### PR TITLE
Fix bug 1418996 (InnoDB lock monitor output is printed even if not

### DIFF
--- a/storage/innobase/lock/lock0lock.c
+++ b/storage/innobase/lock/lock0lock.c
@@ -4720,7 +4720,7 @@ loop:
 		}
 	}
 
-        if (!srv_print_innodb_lock_monitor && !srv_show_locks_held) {
+	if (!srv_print_innodb_lock_monitor || !srv_show_locks_held) {
 		nth_trx++;
 		goto loop;
 	}


### PR DESCRIPTION
requested).

Currently lock_print_info_all_transactions prints lock info if either
innodb lock monitor is on, either innodb_show_locks_held is greater
than zero (the default value is ten). It should be printed when both
conditions hold instead.
