### PR TITLE
Fix bug 1419230 (The stored procedure key uses spaces instead of

### DIFF
--- a/mysql-test/r/percona_log_slow_sp_statements.result
+++ b/mysql-test/r/percona_log_slow_sp_statements.result
@@ -32,9 +32,9 @@ EXECUTE stmt;
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.sp1 pattern: CALL test_
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.sp1 pattern: # Stored routine: test.test_outer
+[log_grep.inc] file: percona.slow_extended.sp1 pattern: # Stored_routine: test.test_outer
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.sp1 pattern: # Stored routine: test.test_inner
+[log_grep.inc] file: percona.slow_extended.sp1 pattern: # Stored_routine: test.test_inner
 [log_grep.inc] lines:   2
 SET GLOBAL log_slow_sp_statements=OFF;
 [log_start.inc] percona.slow_extended.sp2
@@ -55,7 +55,7 @@ EXECUTE stmt;
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.sp2 pattern: CALL test_
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.sp2 pattern: # Stored routine: test.test_
+[log_grep.inc] file: percona.slow_extended.sp2 pattern: # Stored_routine: test.test_
 [log_grep.inc] lines:   0
 DROP PROCEDURE test_outer;
 DROP PROCEDURE test_inner;

--- a/mysql-test/t/percona_log_slow_sp_statements.test
+++ b/mysql-test/t/percona_log_slow_sp_statements.test
@@ -39,9 +39,9 @@ EXECUTE stmt;
 --source include/log_grep.inc
 --let grep_pattern=CALL test_
 --source include/log_grep.inc
---let grep_pattern=# Stored routine: test.test_outer
+--let grep_pattern=# Stored_routine: test.test_outer
 --source include/log_grep.inc
---let grep_pattern=# Stored routine: test.test_inner
+--let grep_pattern=# Stored_routine: test.test_inner
 --source include/log_grep.inc
 
 SET GLOBAL log_slow_sp_statements=OFF;
@@ -56,7 +56,7 @@ EXECUTE stmt;
 --source include/log_grep.inc
 --let grep_pattern=CALL test_
 --source include/log_grep.inc
---let grep_pattern=# Stored routine: test.test_
+--let grep_pattern=# Stored_routine: test.test_
 --source include/log_grep.inc
 
 DROP PROCEDURE test_outer;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2833,7 +2833,7 @@ bool MYSQL_QUERY_LOG::write(THD *thd, ulonglong current_utime,
     if (opt_log_slow_sp_statements &&
         thd->spcont &&
         my_b_printf(&log_file,
-                    "# Stored routine: %s\n",
+                    "# Stored_routine: %s\n",
                     thd->spcont->sp->m_qname.str) == (uint) -1)
       tmp_errno= errno;
 


### PR DESCRIPTION
underscores in the extended slow query log).

The stored procedure identifier is logged with a "# Stored procedure:
" key, where as the rest of information use underscores, i.e. "#
QC_Hit: ". Fixed trivially, adjusted the testcase.
