### PR TITLE
Fix bug 1420303 (binlog cache I/O error might be reported twice).

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -6185,9 +6185,9 @@ bool MYSQL_BIN_LOG::write_cache(THD *thd, binlog_cache_data *cache_data)
 
 err:
   if (!write_error)
-    write_error= 1;
   {
     char errbuf[MYSYS_STRERROR_SIZE];
+    write_error= 1;
     sql_print_error(ER(ER_ERROR_ON_WRITE), name,
                     errno, my_strerror(errbuf, sizeof(errbuf), errno));
   }


### PR DESCRIPTION
MYSQL_BIN_LOG::write_cache jumps to err with write_error set in the
case the error exit path should not call sql_print_error, presumably
because it has been called already. This has been broken with the
initial 5.6 port which made sql_print_error call unconditional. Fix by
restoring the original behavior. This is tested by
rpl.rpl_semi_sync_group_commit_deadlock testcase.
