### PR TITLE
Fixed tarball name and revision number in build-binary.sh (JEN-318)

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -153,15 +153,15 @@ PRODUCT="Percona-Server-$MYSQL_VERSION-$PERCONA_SERVER_VERSION"
 # Build information
 if test -e "$SOURCEDIR/Docs/INFO_SRC"
 then
-    REVISION="$(cd "$SOURCEDIR"; grep '^revno: ' Docs/INFO_SRC |sed -e 's/revno: //')"
-elif test -e "$SOURCEDIR/.bzr/branch/last-revision"
+    REVISION="$(cd "$SOURCEDIR"; grep '^short: ' Docs/INFO_SRC |sed -e 's/short: //')"
+elif [ -n "$(which git)" -a -d "$SOURCEDIR/.git" ];
 then
-    REVISION="$(cd "$SOURCEDIR"; cat .bzr/branch/last-revision | awk -F ' ' '{print $1}')"
+    REVISION="$(git rev-parse --short HEAD)"
 else
     REVISION=""
 fi
 PRODUCT_FULL="Percona-Server-$MYSQL_VERSION-$PERCONA_SERVER_VERSION"
-PRODUCT_FULL="$PRODUCT_FULL-$REVISION${BUILD_COMMENT:-}$TAG.$(uname -s).$TARGET"
+PRODUCT_FULL="$PRODUCT_FULL${BUILD_COMMENT:-}-$TAG$(uname -s).$TARGET"
 COMMENT="Percona Server (GPL), Release ${MYSQL_VERSION_EXTRA#-}"
 COMMENT="$COMMENT, Revision $REVISION${BUILD_COMMENT:-}"
 


### PR DESCRIPTION
It was reported in JEN-318 that tarball name in jenkins jobs that use build-binary is not good after git migration.
Looked like this: Percona-Server-5.6.22-rel72.0-.Linux.i686.tar.gz
Means it lost revision number and there was just a dash and dot so this is to fix it. As noted in JEN-318 this is independent of versioning and package names for nightly/custom builds so it should be fixed before the release.

Here's some testing:
### TEST BUILDS:
- 5.5 builds:
  http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.5-binary-tarballs/121/
  http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.5-binaries-opt-yassl/25/
- 5.6 builds:
  http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.6-binaries-release/93/
  http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.6-binaries-opt-yassl/266/
### Created test script just to print variable names out of build-binary.sh to see how the string look so here's output:
- 5.5 normal build:
  
  > plavi@zoidberg:build-ps (5.5-ps-jen-318*) $ ./test2.sh build
  > TARNAME=Percona-Server-5.5.40-rel36.1-Linux.x86_64.tar.gz
  > COMMENT=Percona Server (GPL), Release 36.1, Revision 84ae2d2
  > REVISION=84ae2d2
- 5.5 debug build:
  
  > plavi@zoidberg:build-ps (5.5-ps-jen-318*) $ ./test2.sh build --debug
  > TARNAME=Percona-Server-5.5.40-rel36.1-debug-Linux.x86_64.tar.gz
  > COMMENT=Percona Server (GPL), Release 36.1, Revision 84ae2d2-debug
  > REVISION=84ae2d2
- 5.6 normal build:
  
  > plavi@zoidberg:build-ps (5.6-ps-jen-318*) $ ./test3.sh build  
  > TARNAME=Percona-Server-5.6.22-rel72.0-Linux.x86_64.tar.gz
  > TARTOKUDB=Percona-Server-5.6.22-rel72.0-TokuDB.Linux.x86_64
  > COMMENT=Percona Server (GPL), Release 72.0, Revision 791293e
  > REVISION=791293e
- 5.6 debug build:
  
  > plavi@zoidberg:build-ps (5.6-ps-jen-318*) $ ./test3.sh build --debug
  > TARNAME=Percona-Server-5.6.22-rel72.0-debug-Linux.x86_64.tar.gz
  > TARTOKUDB=Percona-Server-5.6.22-rel72.0-debug-TokuDB.Linux.x86_64
  > COMMENT=Percona Server (GPL), Release 72.0, Revision 791293e-debug
  > REVISION=791293e
