### PR TITLE
Fixed RPMs assumes that .pid file is located in datadir (bug1201896)

### DIFF
--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -635,11 +635,17 @@ rm -rf $RBR%{_sysconfdir}/init.d/mysql
 if [ -x %{_bindir}/my_print_defaults ]
 then
   mysql_datadir=`%{_bindir}/my_print_defaults server mysqld | grep '^--datadir=' | sed -n 's/--datadir=//p' | tail -n 1`
+  PID_FILE_PATT=`%{_bindir}/my_print_defaults server mysqld | grep '^--pid-file=' | sed -n 's/--pid-file=//p'`
 fi
 if [ -z "$mysql_datadir" ]
 then
   mysql_datadir=%{mysqldatadir}
 fi
+if [ -z "$PID_FILE_PATT" ]
+then
+  PID_FILE_PATT="$mysql_datadir/*.pid"
+fi
+
 # Check if we can safely upgrade.  An upgrade is only safe if it's from one
 # of our RPMs in the same version family.
 
@@ -717,7 +723,7 @@ fi
 
 # We assume that if there is exactly one ".pid" file,
 # it contains the valid PID of a running MySQL server.
-NR_PID_FILES=`ls $mysql_datadir/*.pid 2>/dev/null | wc -l`
+NR_PID_FILES=`ls -1 $PID_FILE_PATT 2>/dev/null | wc -l`
 case $NR_PID_FILES in
 	0 ) SERVER_TO_START=''  ;;  # No "*.pid" file == no running server
 	1 ) SERVER_TO_START='true' ;;
@@ -739,8 +745,8 @@ if [ -f $STATUS_FILE ]; then
 	echo "before repeating the MySQL upgrade."
 	exit 1
 elif [ -n "$SEVERAL_PID_FILES" ] ; then
-	echo "Your MySQL directory '$mysql_datadir' has more than one PID file:"
-	ls -ld $mysql_datadir/*.pid
+	echo "You have more than one PID file:"
+	ls -ld $PID_FILE_PATT
 	echo "Please check which one (if any) corresponds to a running server"
 	echo "and delete all others before repeating the MySQL upgrade."
 	exit 1
@@ -754,28 +760,31 @@ if [ -d $mysql_datadir ] ; then
 	echo "MySQL RPM upgrade to version $NEW_VERSION"  > $STATUS_FILE
 	echo "'pre' step running at `date`"          >> $STATUS_FILE
 	echo                                         >> $STATUS_FILE
-	echo "ERR file(s):"                          >> $STATUS_FILE
-	ls -ltr $mysql_datadir/*.err                 >> $STATUS_FILE
-	echo                                         >> $STATUS_FILE
-	echo "Latest 'Version' line in latest file:" >> $STATUS_FILE
-	grep '^Version' `ls -tr $mysql_datadir/*.err | tail -1` | \
-		tail -1                              >> $STATUS_FILE
-	echo                                         >> $STATUS_FILE
+	fcount=`ls -ltr $mysql_datadir/*.err 2>/dev/null | wc -l`
+	if [ $fcount -gt 0 ] ; then
+		echo "ERR file(s):"                          >> $STATUS_FILE
+		ls -ltr $mysql_datadir/*.err                 >> $STATUS_FILE
+		echo                                         >> $STATUS_FILE
+		echo "Latest 'Version' line in latest file:" >> $STATUS_FILE
+		grep '^Version' `ls -tr $mysql_datadir/*.err | tail -1` | \
+			tail -1                              >> $STATUS_FILE
+		echo                                         >> $STATUS_FILE
+	fi
 
 	if [ -n "$SERVER_TO_START" ] ; then
 		# There is only one PID file, race possibility ignored
 		echo "PID file:"                           >> $STATUS_FILE
-		ls -l   $mysql_datadir/*.pid               >> $STATUS_FILE
-		cat     $mysql_datadir/*.pid               >> $STATUS_FILE
+		ls -l   $PID_FILE_PATT                     >> $STATUS_FILE
+		cat     $PID_FILE_PATT                     >> $STATUS_FILE
 		echo                                       >> $STATUS_FILE
 		echo "Server process:"                     >> $STATUS_FILE
-		ps -fp `cat $mysql_datadir/*.pid`          >> $STATUS_FILE
+		ps -fp `cat $PID_FILE_PATT`                >> $STATUS_FILE
 		echo                                       >> $STATUS_FILE
 		echo "SERVER_TO_START=$SERVER_TO_START"    >> $STATUS_FILE
 	else
 		# Take a note we checked it ...
 		echo "PID file:"                           >> $STATUS_FILE
-		ls -l   $mysql_datadir/*.pid               >> $STATUS_FILE 2>&1
+		ls -l   $PID_FILE_PATT                     >> $STATUS_FILE 2>&1
 	fi
 fi
 


### PR DESCRIPTION
If the user had pid file located in directory other than datadir when upgrading the server didn't automatically start if it was started before - reported in bugs 1201896, 1311840 and probably also 1378944.
Also when installing there was this listing which doesn't look nice and it's fixed now to print err files only if they exist (suggested in one of the bug comments):
db-02: ls: cannot access /var/lib/mysql//_.err: No such file or directory
db-02: ls: cannot access /var/lib/mysql//_.err: No such file or directory

TEST PACKAGES:
http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.5-redhat-binary/148/
http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.6-redhat-binary/133/
## 5.6 INSTALL TEST:

Transaction Test Succeeded
Running Transaction
  Installing : Percona-Server-shared-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  1/3 
  Installing : Percona-Server-client-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  2/3 
  Installing : Percona-Server-server-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  3/3 
2015-02-26 01:36:46 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2015-02-26 01:36:46 2556 [Note] InnoDB: Using atomics to ref count buffer pool pages
2015-02-26 01:36:46 2556 [Note] InnoDB: The InnoDB memory heap is disabled
2015-02-26 01:36:46 2556 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
2015-02-26 01:36:46 2556 [Note] InnoDB: Memory barrier is not used
2015-02-26 01:36:46 2556 [Note] InnoDB: Compressed tables use zlib 1.2.3
2015-02-26 01:36:46 2556 [Note] InnoDB: Using Linux native AIO
2015-02-26 01:36:46 2556 [Note] InnoDB: Not using CPU crc32 instructions
2015-02-26 01:36:46 2556 [Note] InnoDB: Initializing buffer pool, size = 128.0M
2015-02-26 01:36:46 2556 [Note] InnoDB: Completed initialization of buffer pool
2015-02-26 01:36:46 2556 [Note] InnoDB: The first specified data file ./ibdata1 did not exist: a new database to be created!
2015-02-26 01:36:46 2556 [Note] InnoDB: Setting file ./ibdata1 size to 12 MB
2015-02-26 01:36:46 2556 [Note] InnoDB: Database physically writes the file full: wait...
2015-02-26 01:36:46 2556 [Note] InnoDB: Setting log file ./ib_logfile101 size to 48 MB
2015-02-26 01:36:46 2556 [Note] InnoDB: Setting log file ./ib_logfile1 size to 48 MB
2015-02-26 01:36:47 2556 [Note] InnoDB: Renaming log file ./ib_logfile101 to ./ib_logfile0
2015-02-26 01:36:47 2556 [Warning] InnoDB: New log files created, LSN=45781
2015-02-26 01:36:47 2556 [Note] InnoDB: Doublewrite buffer not found: creating new
2015-02-26 01:36:47 2556 [Note] InnoDB: Doublewrite buffer created
2015-02-26 01:36:47 2556 [Note] InnoDB: 128 rollback segment(s) are active.
2015-02-26 01:36:47 2556 [Warning] InnoDB: Creating foreign key constraint system tables.
2015-02-26 01:36:47 2556 [Note] InnoDB: Foreign key constraint system tables created
2015-02-26 01:36:47 2556 [Note] InnoDB: Creating tablespace and datafile system tables.
2015-02-26 01:36:47 2556 [Note] InnoDB: Tablespace and datafile system tables created.
2015-02-26 01:36:47 2556 [Note] InnoDB: Waiting for purge to start
2015-02-26 01:36:47 2556 [Note] InnoDB:  Percona XtraDB (http://www.percona.com) 5.6.22-72.0 started; log sequence number 0
2015-02-26 01:36:47 2556 [Note] RSA private key file not found: /var/lib/mysql//private_key.pem. Some authentication plugins will not work.
2015-02-26 01:36:47 2556 [Note] RSA public key file not found: /var/lib/mysql//public_key.pem. Some authentication plugins will not work.
2015-02-26 01:36:47 2556 [Note] Binlog end
2015-02-26 01:36:47 2556 [Note] InnoDB: FTS optimize thread exiting.
2015-02-26 01:36:47 2556 [Note] InnoDB: Starting shutdown...

PLEASE REMEMBER TO SET A PASSWORD FOR THE MySQL root USER !
To do so, start the server, then issue the following commands:

  /usr/bin/mysqladmin -u root password 'new-password'
  /usr/bin/mysqladmin -u root -h t-centos6-64 password 'new-password'

Alternatively you can run:

  /usr/bin/mysql_secure_installation

which will also give you the option of removing the test
databases and anonymous user created by default.  This is
strongly recommended for production servers.

See the manual for more instructions.

Please report any problems at
 https://bugs.launchpad.net/percona-server/+filebug

The latest information about Percona Server is available on the web at
  http://www.percona.com/software/percona-server

Support Percona by buying support at
 http://www.percona.com/products/mysql-support

WARNING: Default config file /etc/my.cnf exists on the system
This file will be read by default by the MySQL server
If you do not want to use this, either remove it, or use the
--defaults-file argument to mysqld_safe when starting the server

Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
Run the following commands to create these functions:
mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"
See http://www.percona.com/doc/percona-server/5.6/management/udf_percona_toolkit.html for more details
  Verifying  : Percona-Server-server-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  1/3 
  Verifying  : Percona-Server-shared-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  2/3 
  Verifying  : Percona-Server-client-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  3/3 

Installed:
  Percona-Server-client-56.x86_64 0:5.6.22-rel72.0.el6                        Percona-Server-server-56.x86_64 0:5.6.22-rel72.0.el6                        Percona-Server-shared-56.x86_64 0:5.6.22-rel72.0.el6                       

Complete!
### STATUS AFTER INSTALL

[vagrant@t-centos6-64 ~]$ sudo service mysql start
Starting MySQL (Percona Server). SUCCESS! 
[vagrant@t-centos6-64 ~]$ sudo service mysql status
 SUCCESS! MySQL (Percona Server) running (2793)
[vagrant@t-centos6-64 ~]$ ls /var/lib/mysql/_.pid
/var/lib/mysql/t-centos6-64.pid
[vagrant@t-centos6-64 ~]$ ls /var/lib/mysql/_.sock
/var/lib/mysql/mysql.sock
## 5.6 UPGRADE TEST WHEN PID FILE IS IN DATADIR:
### STATUS BEFORE:

[vagrant@t-centos6-64 ~]$ sudo service mysql status
 SUCCESS! MySQL (Percona Server) running (1361)
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.pid
/var/lib/mysql/t-centos6-64.pid
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.sock
/var/lib/mysql/mysql.sock
### UPGRADE:

...
Upgrade       3 Package(s)

Total size: 123 M
Is this ok [y/N]: y
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Updating   : Percona-Server-shared-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  1/6 
  Updating   : Percona-Server-client-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  2/6 
  Updating   : Percona-Server-server-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  3/6 
Giving mysqld 5 seconds to exit nicely
Starting MySQL (Percona Server). SUCCESS! 
Giving mysqld 5 seconds to start
Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
Run the following commands to create these functions:
mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"
See http://www.percona.com/doc/percona-server/5.6/management/udf_percona_toolkit.html for more details
  Cleanup    : Percona-Server-server-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  4/6 
  Cleanup    : Percona-Server-client-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  5/6 
  Cleanup    : Percona-Server-shared-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  6/6 
  Verifying  : Percona-Server-server-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  1/6 
  Verifying  : Percona-Server-shared-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  2/6 
  Verifying  : Percona-Server-client-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  3/6 
  Verifying  : Percona-Server-server-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  4/6 
  Verifying  : Percona-Server-client-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  5/6 
  Verifying  : Percona-Server-shared-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  6/6 

Updated:
  Percona-Server-client-56.x86_64 0:5.6.22-rel72.0.el6                        Percona-Server-server-56.x86_64 0:5.6.22-rel72.0.el6                        Percona-Server-shared-56.x86_64 0:5.6.22-rel72.0.el6                       

Complete!
### STATUS AFTER UPGRADE:

[vagrant@t-centos6-64 ~]$ sudo service mysql status
 SUCCESS! MySQL (Percona Server) running (2494)
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.pid
/var/lib/mysql/t-centos6-64.pid
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.sock
/var/lib/mysql/mysql.sock
## 5.6 UPGRADE TEST WHEN PID FILE IS NOT IN DATADIR:
### STATUS BEFORE:

[vagrant@t-centos6-64 ~]$ sudo service mysql status
 SUCCESS! MySQL (Percona Server) running (2470)
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.pid
ls: cannot access /var/lib/mysql/_.pid: No such file or directory
[vagrant@t-centos6-64 ~]$ sudo ls /tmp _.pid
/tmp/mysqld.pid
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.sock
/var/lib/mysql/mysql.sock
### UPGRADE:

Upgrade       3 Package(s)

Total size: 123 M
Is this ok [y/N]: y
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Updating   : Percona-Server-shared-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  1/6 
  Updating   : Percona-Server-client-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  2/6 
  Updating   : Percona-Server-server-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  3/6 
Giving mysqld 5 seconds to exit nicely
Starting MySQL (Percona Server). SUCCESS! 
Giving mysqld 5 seconds to start
Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
Run the following commands to create these functions:
mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"
See http://www.percona.com/doc/percona-server/5.6/management/udf_percona_toolkit.html for more details
  Cleanup    : Percona-Server-server-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  4/6 
  Cleanup    : Percona-Server-client-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  5/6 
  Cleanup    : Percona-Server-shared-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  6/6 
  Verifying  : Percona-Server-server-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  1/6 
  Verifying  : Percona-Server-shared-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  2/6 
  Verifying  : Percona-Server-client-56-5.6.22-rel72.0.el6.x86_64                                                                                                                                                                  3/6 
  Verifying  : Percona-Server-server-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  4/6 
  Verifying  : Percona-Server-client-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  5/6 
  Verifying  : Percona-Server-shared-56-5.6.22-rel71.0.el6.x86_64                                                                                                                                                                  6/6 

Updated:
  Percona-Server-client-56.x86_64 0:5.6.22-rel72.0.el6                        Percona-Server-server-56.x86_64 0:5.6.22-rel72.0.el6                        Percona-Server-shared-56.x86_64 0:5.6.22-rel72.0.el6                       

Complete!
### STATUS AFTER UPGRADE:

[vagrant@t-centos6-64 ~]$ sudo service mysql status
 SUCCESS! MySQL (Percona Server) running (2785)
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.pid
ls: cannot access /var/lib/mysql/_.pid: No such file or directory
mysqld.pid  script.sh
[vagrant@t-centos6-64 ~]$ sudo ls /tmp/_.pid
/tmp/mysqld.pid
[vagrant@t-centos6-64 ~]$ sudo ls /var/lib/mysql/_.sock
/var/lib/mysql/mysql.sock
