### PR TITLE
Fix for LP #1371827 and ##1377093

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3137,3 +3137,6 @@ support-files/plugins.files
 storage/perfschema/pfs_lex_token.h
 storage/perfschema/gen_pfs_lex_token
 sql/share/bulgarian
+/GPATH
+/GRTAGS
+/GTAGS

--- a/mysql-test/r/backup_locks.result
+++ b/mysql-test/r/backup_locks.result
@@ -909,6 +909,16 @@ FLUSH TABLES WITH READ LOCK;
 ERROR HY000: Can't execute the query because you have a conflicting backup lock
 UNLOCK TABLES;
 DROP TABLE t1;
+CREATE TABLE t(a int) ENGINE=InnoDB;
+FLUSH TABLES t FOR EXPORT;
+LOCK BINLOG FOR BACKUP;
+UNLOCK TABLES;
+UNLOCK BINLOG;
+DROP TABLE t;
+CREATE TABLE t(a INT);
+LOCK TABLE t READ;
+LOCK BINLOG FOR BACKUP;
+DROP TABLE t;
 #-----------------------------------------------------------------------
 # Cleanup
 #-----------------------------------------------------------------------

--- a/mysql-test/t/backup_locks.test
+++ b/mysql-test/t/backup_locks.test
@@ -1128,6 +1128,43 @@ UNLOCK TABLES;
 
 DROP TABLE t1;
 
+################################################################################
+# Bug #1371827: Sporadic partial-hangup on various queries + related
+#               (same-testcase) crashes/asserts
+################################################################################
+
+CREATE TABLE t(a int) ENGINE=InnoDB;
+
+FLUSH TABLES t FOR EXPORT;
+
+LOCK BINLOG FOR BACKUP;
+
+UNLOCK TABLES;
+
+UNLOCK BINLOG;
+
+DROP TABLE t;
+
+################################################################################
+# Bug #1377093: Assertion `m_lock != __null &&
+#               thd->mdl_context.is_lock_owner(m_namespace, "", "", MDL_SHARED)'
+#               failed. in lock.cc:1140 | abort (sig=6) in
+#               Global_backup_lock::release
+################################################################################
+
+--connect(con,localhost,root,,)
+
+CREATE TABLE t(a INT);
+
+LOCK TABLE t READ;
+
+LOCK BINLOG FOR BACKUP;
+
+--disconnect con
+--connection default
+
+DROP TABLE t;
+
 --echo #-----------------------------------------------------------------------
 --echo # Cleanup
 --echo #-----------------------------------------------------------------------

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -1149,6 +1149,31 @@ void Global_backup_lock::release(THD *thd)
 }
 
 /**
+   Set explicit lock duration for the backup metadata lock.
+
+   @param thd     Reference to connection.
+*/
+
+void Global_backup_lock::set_explicit_lock_duration(THD *thd)
+{
+  DBUG_ENTER("Global_backup_lock::set_explicit_lock_duration");
+
+  if (m_lock)
+  {
+    DBUG_ASSERT(thd->mdl_context.is_lock_owner(m_namespace, "", "",
+                                               MDL_SHARED));
+    thd->mdl_context.set_lock_duration(m_lock, MDL_EXPLICIT);
+  }
+  else
+  {
+    DBUG_ASSERT(!thd->mdl_context.is_lock_owner(m_namespace, "", "",
+                                                MDL_SHARED));
+  }
+
+  DBUG_VOID_RETURN;
+}
+
+/**
    Acquire protection against a global backup lock. Wait if a global backup lock
    is active.
 

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -5015,6 +5015,11 @@ void THD::leave_locked_tables_mode()
       when leaving LTM.
     */
     global_read_lock.set_explicit_lock_duration(this);
+
+    /* Make sure backup locks are not released when leaving LTM */
+    DBUG_ASSERT(!backup_tables_lock.is_acquired());
+    backup_binlog_lock.set_explicit_lock_duration(this);
+
     /* Also ensure that we don't release metadata locks for open HANDLERs. */
     if (handler_tables_hash.records)
       mysql_ha_set_explicit_lock_duration(this);

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2146,6 +2146,8 @@ public:
   bool acquire(THD *thd);
   void release(THD *thd);
 
+  void set_explicit_lock_duration(THD *thd);
+
   bool acquire_protection(THD *thd, enum_mdl_duration duration,
                           ulong lock_wait_timeout);
   void init_protection_request(MDL_request *mdl_request,


### PR DESCRIPTION
Bug #1371827: Sporadic partial-hangup on various queries +
              related (same-testcase) crashes/asserts

Bug #1377093: Assertion `m_lock != __null &&
              thd->mdl_context.is_lock_owner(m_namespace, "", "",
              MDL_SHARED)' failed. in lock.cc:1140 | abort (sig=6) in
              Global_backup_lock::release

Restore explicit lock duration for the BINLOG lock after a call to
MDL_context.set_transaction_duration_for_all_locks() in
THD::leave_locked_tables_mode().
