### PR TITLE
Unset PS build flags in build-binary.sh for jemalloc to use defaults

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -254,6 +254,10 @@ fi
     (
         cd "$JEMALLOCDIR"
 
+        unset CFLAGS
+        unset CXXFLAGS
+
+        ./autogen.sh
         ./configure --prefix="/usr/local/$PRODUCT_FULL/" \
                 --libdir="/usr/local/$PRODUCT_FULL/lib/mysql/"
         make $MAKE_JFLAG


### PR DESCRIPTION
This is to fix jemalloc build in build-binary.sh script so that it doesn't use build flags from Percona Server but to use default build flags. It was agreed on percona-tokutek mailing list.

autogen.sh generates configure script and was before in jenkins, but since not everybody runs it like we do it's better for it to be in the script.

Here's the test build:
http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.6-binaries-release/96/
