### PR TITLE
Bug fix in stop case of Debian init script

### DIFF
--- a/build-ps/debian/percona-server-server-5.6.mysql.init
+++ b/build-ps/debian/percona-server-server-5.6.mysql.init
@@ -22,8 +22,7 @@ test -x "${PERCONA_PREFIX}"/sbin/mysqld || exit 0
 
 . /lib/lsb/init-functions
 
-SELF=$(cd $(dirname $0); pwd -P)/$(basename $0)
-CONF=/etc/mysql/my.cnf
+SELF=$(cd "$(dirname "$0")"; pwd -P)/$(basename "$0")
 MYADMIN="${PERCONA_PREFIX}/bin/mysqladmin --defaults-file=/etc/mysql/debian.cnf"
 
 # priority can be overriden and "-s" adds output to stderr
@@ -59,8 +58,8 @@ sanity_checks() {
   #fi
 
   # check for diskspace shortage
-  if LC_ALL=C BLOCKSIZE= df --portability $datadir/. | tail -n 1 | awk '{ exit ($4>4096) }'; then
   datadir=$(mysqld_get_param datadir)
+  if LC_ALL=C BLOCKSIZE= df --portability "$datadir"/. | tail -n 1 | awk '{ exit ($4>4096) }'; then
     log_failure_msg "$0: ERROR: The partition with $datadir is too full!"
     echo                "ERROR: The partition with $datadir is too full!" | $ERR_LOGGER
     exit 1
@@ -77,8 +76,8 @@ mysqld_status () {
     ping_output=$($MYADMIN ping 2>&1); ping_alive=$(( ! $? ))
 
     ps_alive=0
-    if [ -f "$pidfile" ] && ps `cat $pidfile` >/dev/null 2>&1; then ps_alive=1; fi
     pidfile=$(mysqld_get_param pid-file)
+    if [ -f "$pidfile" ] && ps "$(cat "$pidfile")" >/dev/null 2>&1; then ps_alive=1; fi
     
     if [ "$1" = "check_alive"  -a  $ping_alive = 1 ] ||
        [ "$1" = "check_dead"   -a  $ping_alive = 0  -a  $ps_alive = 0 ]; then

--- a/build-ps/debian/percona-server-server-5.6.mysql.init
+++ b/build-ps/debian/percona-server-server-5.6.mysql.init
@@ -59,8 +59,8 @@ sanity_checks() {
   #fi
 
   # check for diskspace shortage
-  datadir=`mysqld_get_param datadir`
   if LC_ALL=C BLOCKSIZE= df --portability $datadir/. | tail -n 1 | awk '{ exit ($4>4096) }'; then
+  datadir=$(mysqld_get_param datadir)
     log_failure_msg "$0: ERROR: The partition with $datadir is too full!"
     echo                "ERROR: The partition with $datadir is too full!" | $ERR_LOGGER
     exit 1
@@ -74,11 +74,11 @@ sanity_checks() {
 #
 # Usage: boolean mysqld_status [check_alive|check_dead] [warn|nowarn]
 mysqld_status () {
-    ping_output=`$MYADMIN ping 2>&1`; ping_alive=$(( ! $? ))
+    ping_output=$($MYADMIN ping 2>&1); ping_alive=$(( ! $? ))
 
     ps_alive=0
-    pidfile=`mysqld_get_param pid-file`
     if [ -f "$pidfile" ] && ps `cat $pidfile` >/dev/null 2>&1; then ps_alive=1; fi
+    pidfile=$(mysqld_get_param pid-file)
     
     if [ "$1" = "check_alive"  -a  $ping_alive = 1 ] ||
        [ "$1" = "check_dead"   -a  $ping_alive = 0  -a  $ps_alive = 0 ]; then
@@ -137,7 +137,7 @@ case "${1:-''}" in
 	log_daemon_msg "Stopping MySQL (Percona Server)" "mysqld"
 	if ! mysqld_status check_dead nowarn; then
 	  set +e
-	  shutdown_out=`$MYADMIN shutdown 2>&1`; r=$?
+	  shutdown_out=$($MYADMIN shutdown 2>&1); r=$?
 	  set -e
 	  if [ "$r" -ne 0 ]; then
 	    log_end_msg 1

--- a/build-ps/debian/percona-server-server-5.6.mysql.init
+++ b/build-ps/debian/percona-server-server-5.6.mysql.init
@@ -152,6 +152,15 @@ case "${1:-''}" in
 	  fi
         fi
 
+	if ! mysqld_status check_dead nowarn && ! mysqld_status check_alive nowarn; then
+	  # mysql is going down...
+	  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+	    if mysqld_status check_dead nowarn; then break; fi
+	    sleep 1
+            echo -n " ."
+	  done
+	fi
+
         if ! mysqld_status check_dead warn; then
 	  log_end_msg 1
 	  log_failure_msg "Please stop MySQL (Percona Server) manually and read /usr/share/doc/percona-server-server-5.6/README.Debian.gz!"


### PR DESCRIPTION
## Some syntax fixes +
## Bug fix in stop case of init script (wrong FAIL status)

Debian GNU/Linux 7.8 (wheezy):
- Before:
  root@server:# /etc/init.d/mysql start
  [ ok ] Starting MySQL (Percona Server) database server: mysqld ..
  [info] Checking for corrupt, not cleanly closed and upgrade needing tables..
  root@server:# /etc/init.d/mysql stop
  [FAIL] Stopping MySQL (Percona Server): mysqld failed!
- After:
  root@server:# /etc/init.d/mysql start
  [ ok ] Starting MySQL (Percona Server) database server: mysqld ..
  [info] Checking for corrupt, not cleanly closed and upgrade needing tables..
  root@server:# /etc/init.d/mysql stop
  [ ok ] Stopping MySQL (Percona Server): mysqld . . ..
