### PR TITLE
Bug lp:1380985 fix.

### DIFF
--- a/sql/table.cc
+++ b/sql/table.cc
@@ -6175,12 +6175,12 @@ static bool add_derived_key(List<Derived_key> &derived_key_list, Field *field,
   {
     THD *thd= field->table->in_use;
     key++;
-    entry= new (thd->stmt_arena->mem_root) Derived_key();
+    entry= new (thd->mem_root) Derived_key();
     if (!entry)
       return TRUE;
     entry->referenced_by= ref_by_tbl;
     entry->used_fields.clear_all();
-    if (derived_key_list.push_back(entry, thd->stmt_arena->mem_root))
+    if (derived_key_list.push_back(entry, thd->mem_root))
       return TRUE;
     field->table->max_keys++;
   }


### PR DESCRIPTION
The memory leak reason is the following:

1) The instruction (sp_instr_cpush::mem_root) memory root pointer is set to
persistent memory root (sp_head::main_mem_root) during SP compilation

bool sp_head::add_instr(THD _thd, sp_instr *instr)
{
...
  /_
    Memory root of every instruction is designated for permanent
    transformations (optimizations) made on the parsed tree during
    the first execution. It points to the memory root of the
    entire stored procedure, as their life span is equal.
  */
  instr->mem_root= get_persistent_mem_root();
...
}

2) sp_cursor::m_push_instr stores pointer to sp_instr_cpush, see sp_cursor ctor.

3) The pointer to sp_instr_cpush is inflated from sp_cursor and thd->stmt_arena
is set to sp_instr_cpush in sp_inst_copen::execute().

4) add_derived_key() uses thd->stmt_arena->mem_root for allocating, namely it
uses memory root for persistent objects, this memory is not cleared after
instruction execution which leads to constant memory consumption.

It works well outside of SP because thd->stmt_arena points to thd and
thd->mem_root is initialized before each query in THD::init_for_queries() and
cleared after each query in dispatch_command().

But inside of SP there is special mechanism to clear memory after each
instruction. There are local variables execute_mem_root and execute_arena
in sp_head::execute(). thd->mem_root is set pointed to local execute_mem_root
before SP execution and the old pointer is restored after SP execution
(see sp_head::execute()). After each instruction thd->mem_root is cleared.

So we have thd->mem_root which is cleared after statement execution in both
SP and non-SP cases. The fix is in using thd->mem_root instead of
thd->stmt_arena->mem_root for memory alocation in add_derived_key().

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/827/
