### PR TITLE
5.5 Added variable for distribution name in tarball from build-binary (bug1172916)

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -161,7 +161,7 @@ else
     REVISION=""
 fi
 PRODUCT_FULL="Percona-Server-$MYSQL_VERSION-$PERCONA_SERVER_VERSION"
-PRODUCT_FULL="$PRODUCT_FULL${BUILD_COMMENT:-}-$TAG$(uname -s).$TARGET"
+PRODUCT_FULL="$PRODUCT_FULL${BUILD_COMMENT:-}-$TAG$(uname -s)${DIST_NAME:-}.$TARGET"
 COMMENT="Percona Server (GPL), Release ${MYSQL_VERSION_EXTRA#-}"
 COMMENT="$COMMENT, Revision $REVISION${BUILD_COMMENT:-}"
 
@@ -247,6 +247,10 @@ fi
     (
         cd "$JEMALLOCDIR"
 
+        unset CFLAGS
+        unset CXXFLAGS
+
+        ./autogen.sh
         ./configure --prefix="/usr/local/$PRODUCT_FULL/" \
                 --libdir="/usr/local/$PRODUCT_FULL/lib/mysql/"
         make $MAKE_JFLAG


### PR DESCRIPTION
Since in bug https://bugs.launchpad.net/percona-server/+bug/1172916
it was concluded that we will have more then one binary tarball because of linking with openssl this change is to add variable in build-binary.sh so that it can reflect the distribution in which it was build.
If it's not set distribution name will not be in the tarball name.
The other part of change is in our jenkins release job which will be changed after this gets merged.

For 5.5 only there's also a change in jemalloc build (unsetting of PS build flags and usage of jemalloc defaults) which was done for 5.6 before - it was missed to be done for 5.5.

As noted in the bug - builds should be used as following:
- debian7 - for all debian/ubuntu except squeeze/lucid
  (libssl.so.1.0.0 => /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007f2e389a5000))
- debian6 - only for squeeze and ubuntu lucid (which is irrelevant since it's EOL is 04/2015)
  (libssl.so.0.9.8 => /usr/lib/libssl.so.0.9.8 (0x00007f9b30db6000))
- centos6 - for centos6 and centos7
  (libssl.so.10 => /usr/lib64/libssl.so.10 (0x00007facbe8c4000))
- centos5 - to be used only for centos5
  (libssl.so.6 => /lib64/libssl.so.6 (0x00002aed5b64d000))

Test builds:
http://jenkins.percona.com/view/TEST/job/percona-server-5.5-binary-tarballs-test/2/
http://jenkins.percona.com/view/TEST/job/percona-server-5.6-binaries-release-test/16/

For all builds for which there is ldd output there was a test run to check that mysqld actually does run.
From 32bit builds the test was done only for Ubuntu Trusty.

5.5 LINK TEST:
CENTOS5 WITH CENTOD5 BUILD - 64BIT
[vagrant@t-centos5-64 Percona-Server-5.5.41-rel37.0-Linux.CentOS5.x86_64]$ ldd bin/mysqld
...
        libssl.so.6 => /lib64/libssl.so.6 (0x00002b3e15e0b000)
        libcrypto.so.6 => /lib64/libcrypto.so.6 (0x00002b3e1605a000)

CENTOS6 WITH CENTOS6 BUILD
[vagrant@t-centos6-64 Percona-Server-5.5.41-rel37.0-Linux.CentOS6.x86_64]$ ldd bin/mysqld
...
        libssl.so.10 => /usr/lib64/libssl.so.10 (0x00007fe91d936000)
        libcrypto.so.10 => /usr/lib64/libcrypto.so.10 (0x00007fe91d557000)

CENTOS7 WITH CENTOS6 BUILD
[vagrant@t-centos7-64 Percona-Server-5.5.41-rel37.0-Linux.CentOS6.x86_64]$ ldd bin/mysql
...
        libssl.so.10 => /lib64/libssl.so.10 (0x00007f04fe9fc000)
        libcrypto.so.10 => /lib64/libcrypto.so.10 (0x00007f04fe617000)

DEBIAN6 WITH BUILD FROM DEBIAN6
vagrant@t-debian6-64:~/Percona-Server-5.5.41-rel37.0-Linux.Debian6.x86_64$ ldd bin/mysqld
...
        libssl.so.0.9.8 => /usr/lib/libssl.so.0.9.8 (0x00007f055defa000)
        libcrypto.so.0.9.8 => /usr/lib/libcrypto.so.0.9.8 (0x00007f055db59000)

DEBIAN7 WITH DEBIAN7 BUILD
vagrant@t-debian7-64:~/Percona-Server-5.5.41-rel37.0-Linux.Debian7.x86_64$ ldd bin/mysqld
...
        libssl.so.1.0.0 => /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007f3f9d037000)
        libcrypto.so.1.0.0 => /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f3f9cc53000)

UBUNTU LUCID WITH BUILD FROM DEBIAN 6
vagrant@t-ubuntu1004-64:~/Percona-Server-5.5.41-rel37.0-Linux.Debian6.x86_64$ ldd bin/mysqld
...
        libssl.so.0.9.8 => /lib/libssl.so.0.9.8 (0x00007f75ff2b4000)
        libcrypto.so.0.9.8 => /lib/libcrypto.so.0.9.8 (0x00007f75fef23000)

UBUNTU PRECISE WITH BUILD FROM DEBIAN7
vagrant@t-ubuntu1204-64:~/Percona-Server-5.5.41-rel37.0-Linux.Debian7.x86_64$ ldd bin/mysqld
...
        libssl.so.1.0.0 => /lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007fb6f3d22000)
        libcrypto.so.1.0.0 => /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007fb6f395a000)

UBUNTU TRUSTY WITH BUILD FROM DEBIAN7
vagrant@t-ubuntu1404-64:~/Percona-Server-5.5.41-rel37.0-Linux.Debian7.x86_64$ ldd bin/mysqld
...
        libssl.so.1.0.0 => /lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007f56d2c0d000)
        libcrypto.so.1.0.0 => /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f56d2833000)

UBUNTU UTOPIC WITH BUILD FROM DEBIAN7
vagrant@t-ubuntu1410-64:~/Percona-Server-5.5.41-rel37.0-Linux.Debian7.x86_64$ ldd bin/mysqld
...
        libssl.so.1.0.0 => /lib/x86_64-linux-gnu/libssl.so.1.0.0 (0x00007f9057c73000)
        libcrypto.so.1.0.0 => /lib/x86_64-linux-gnu/libcrypto.so.1.0.0 (0x00007f9057890000)

UBUNTU TRUSTY 32BIT WITH BUILD FROM DEBIAN7 32BIT
vagrant@t-ubuntu1404-32:~/Percona-Server-5.5.41-rel37.0-Linux.Debian7.i686$ ldd bin/mysqld
...
        libssl.so.1.0.0 => /lib/i386-linux-gnu/libssl.so.1.0.0 (0xb770d000)
        libcrypto.so.1.0.0 => /lib/i386-linux-gnu/libcrypto.so.1.0.0 (0xb7561000)
