### PR TITLE
Bug #1428331 fix. CRASH IN BTR_CUR_LATCH_LEAVES

### DIFF
--- a/storage/innobase/btr/btr0cur.c
+++ b/storage/innobase/btr/btr0cur.c
@@ -249,6 +249,7 @@ btr_cur_latch_leaves(
 	ulint		left_page_no;
 	ulint		right_page_no;
 	buf_block_t*	get_block;
+	buf_block_t*	get_block_left= NULL;
 
 	ut_ad(page && mtr);
 
@@ -281,15 +282,10 @@ btr_cur_latch_leaves(
 			get_block = btr_block_get(
 				space, zip_size, left_page_no,
 				sibling_mode, cursor->index, mtr);
+			get_block_left= get_block;
 
 			SRV_CORRUPT_TABLE_CHECK(get_block, return;);
 
-#ifdef UNIV_BTR_DEBUG
-			ut_a(page_is_comp(get_block->frame)
-			     == page_is_comp(page));
-			ut_a(btr_page_get_next(get_block->frame, mtr)
-			     == page_get_page_no(page));
-#endif /* UNIV_BTR_DEBUG */
 			if (sibling_mode == RW_NO_LATCH) {
 				/* btr_block_get() called with RW_NO_LATCH will
 				fix the read block in the buffer.  This serves
@@ -309,6 +305,13 @@ btr_cur_latch_leaves(
 		SRV_CORRUPT_TABLE_CHECK(get_block, return;);
 
 #ifdef UNIV_BTR_DEBUG
+		/* Sanity check only after both the blocks are latched. */
+		if (get_block_left) {
+			ut_a(page_is_comp(get_block_left->frame) ==
+				page_is_comp(page));
+			ut_a(btr_page_get_next(get_block_left->frame, mtr) ==
+				page_get_page_no(page));
+		}
 		ut_a(page_is_comp(get_block->frame) == page_is_comp(page));
 #endif /* UNIV_BTR_DEBUG */
 		get_block->check_index_page_at_flush = TRUE;


### PR DESCRIPTION
Bug #1428331 fix. CRASH IN BTR_CUR_LATCH_LEAVES

Check the state of page only after the page is latched.
There could be in-consistency if page state is accessed w/o latching it.

The original code can be found here:
https://github.com/mysql/mysql-server/commit/777bf2aab05fb58fad7838aed4ef307b50722786
