### PR TITLE
Fixed bug #1402074: mysql_install_db Error in my_thread_global_end(): 1 ...

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4857,6 +4857,12 @@ int mysqld_main(int argc, char **argv)
   if (opt_bootstrap)
   {
     select_thread_in_use= 0;                    // Allow 'kill' to work
+    /* Signal threads waiting for server to be started */
+    mysql_mutex_lock(&LOCK_server_started);
+    mysqld_server_started= 1;
+    mysql_cond_broadcast(&COND_server_started);
+    mysql_mutex_unlock(&LOCK_server_started);
+
     bootstrap(mysql_stdin);
     unireg_abort(bootstrap_error ? 1 : 0);
   }


### PR DESCRIPTION
...threads didn't exit

This is another regression introduced by back porting the fix for
bug 1249193.

mysqld --bootstrap never gets to the point when mysqld_server_started
set to 1. Fixed by setting mysqld_server_started = 1 and signalling
the COND_server_started.

jenkins: http://jenkins.percona.com/view/PS%205.5/job/percona-server-5.5-param/1097/

5.6 version will be null merge
