### PR TITLE
Fixed bug 1435606: Installation of audit_log plugin crashes mysql server (5.5)

### DIFF
--- a/mysql-test/r/audit_log_install_bug1435606.result
+++ b/mysql-test/r/audit_log_install_bug1435606.result
@@ -1,0 +1,4 @@
+call mtr.add_suppression("Plugin 'audit_log' init function returned error");
+call mtr.add_suppression("Plugin 'audit_log' registration as a AUDIT failed");
+INSTALL PLUGIN audit_log SONAME 'audit_log.<expected_extension>';
+ERROR HY000: File '/path/does/not/exist/audit.log' not found (Errcode: 2)

--- a/mysql-test/t/audit_log_install_bug1435606-master.opt
+++ b/mysql-test/t/audit_log_install_bug1435606-master.opt
@@ -1,0 +1,1 @@
+$AUDIT_LOG_OPT $AUDIT_LOG_LOAD --audit_log_file=/path/does/not/exist/audit.log

--- a/mysql-test/t/audit_log_install_bug1435606.test
+++ b/mysql-test/t/audit_log_install_bug1435606.test
@@ -1,0 +1,18 @@
+# Bug1435606: server crashes if audit log plugin cannot create file
+
+--source include/not_embedded.inc
+
+call mtr.add_suppression("Plugin 'audit_log' init function returned error");
+call mtr.add_suppression("Plugin 'audit_log' registration as a AUDIT failed");
+
+# Adjustment to the OS dependent extension of shared libraries.
+let $expected_extension= so;
+if(`SELECT CONVERT(@@version_compile_os USING latin1)
+           IN ("Win32","Win64","Windows")`)
+{
+   let $expected_extension= dll;
+}
+
+--replace_result $expected_extension <expected_extension>
+--error 29
+eval INSTALL PLUGIN audit_log SONAME 'audit_log.$expected_extension';

--- a/plugin/audit_log/audit_file.c
+++ b/plugin/audit_log/audit_file.c
@@ -95,9 +95,9 @@ audit_handler_t *audit_handler_file_open(audit_handler_file_config_t *opts)
     handler->set_option= audit_handler_file_set_option;
     goto success;
 error:
-    if (data->use_buffer)
+    if (data->buffer)
     {
-      free(data->buffer);
+      audit_log_buffer_shutdown(data->buffer);
     }
     free(handler);
     handler= NULL;

--- a/plugin/audit_log/audit_handler.h
+++ b/plugin/audit_log/audit_handler.h
@@ -69,7 +69,7 @@ struct audit_handler_syslog_config_struct
 static inline
 int audit_handler_write(audit_handler_t *handler, const char *buf, size_t len)
 {
-  if (handler->write != NULL)
+  if (handler != NULL && handler->write != NULL)
   {
     return handler->write(handler, buf, len);
   }
@@ -79,7 +79,7 @@ int audit_handler_write(audit_handler_t *handler, const char *buf, size_t len)
 static inline
 int audit_handler_flush(audit_handler_t *handler)
 {
-  if (handler->flush != NULL)
+  if (handler != NULL && handler->flush != NULL)
   {
     return handler->flush(handler);
   }
@@ -89,7 +89,7 @@ int audit_handler_flush(audit_handler_t *handler)
 static inline
 int audit_handler_close(audit_handler_t *handler)
 {
-  if (handler->close != NULL)
+  if (handler != NULL && handler->close != NULL)
   {
     return handler->close(handler);
   }
@@ -100,7 +100,7 @@ static inline
 void audit_handler_set_option(audit_handler_t *handler,
                               audit_handler_option_t opt, void *val)
 {
-  if (handler->set_option != NULL)
+  if (handler != NULL && handler->set_option != NULL)
   {
     handler->set_option(handler, opt, val);
   }

--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -273,22 +273,19 @@ void audit_log_write(const char *buf, size_t len)
 {
   static int write_error= 0;
 
-  if (log_handler != NULL)
+  if (audit_handler_write(log_handler, buf, len) < 0)
   {
-    if (audit_handler_write(log_handler, buf, len) < 0)
+    if (!write_error)
     {
-      if (!write_error)
-      {
-        write_error= 1;
-        fprintf_timestamp(stderr);
-        fprintf(stderr, "Error writing to file %s. ", audit_log_file);
-        perror("Error: ");
-      }
+      write_error= 1;
+      fprintf_timestamp(stderr);
+      fprintf(stderr, "Error writing to file %s. ", audit_log_file);
+      perror("Error: ");
     }
-    else
-    {
-      write_error= 0;
-    }
+  }
+  else
+  {
+    write_error= 0;
   }
 }
 
@@ -618,15 +615,12 @@ int init_new_log_file()
 static
 int reopen_log_file()
 {
-  if (log_handler != NULL)
+  if (audit_handler_flush(log_handler))
   {
-    if (audit_handler_flush(log_handler))
-    {
-      fprintf_timestamp(stderr);
-      fprintf(stderr, "Cannot open file %s. ", audit_log_file);
-      perror("Error: ");
-      return(1);
-    }
+    fprintf_timestamp(stderr);
+    fprintf(stderr, "Cannot open file %s. ", audit_log_file);
+    perror("Error: ");
+    return(1);
   }
 
   return(0);
@@ -818,8 +812,7 @@ void audit_log_rotate_on_size_update(
 {
   ulonglong new_val= *(ulonglong *)(save);
 
-  if (log_handler != NULL)
-    audit_handler_set_option(log_handler, OPT_ROTATE_ON_SIZE, &new_val);
+  audit_handler_set_option(log_handler, OPT_ROTATE_ON_SIZE, &new_val);
 
   audit_log_rotate_on_size= new_val;
 }
@@ -838,8 +831,7 @@ void audit_log_rotations_update(
 {
   ulonglong new_val= *(ulonglong *)(save);
 
-  if (log_handler != NULL)
-    audit_handler_set_option(log_handler, OPT_ROTATIONS, &new_val);
+  audit_handler_set_option(log_handler, OPT_ROTATIONS, &new_val);
 
   audit_log_rotations= new_val;
 }


### PR DESCRIPTION
When for some reason plugin can not open audit log file, it returns
NULL as file handler. This handler was not checked for NULL when
plugin tried to close it. Also instead of just deallocating the
buffer we must properly shut it down.
