### PR TITLE
5.5 Add BUILD_CONFIG=mysql_release in debian rules (bug1433980)

### DIFF
--- a/build-ps/debian/rules
+++ b/build-ps/debian/rules
@@ -71,8 +71,9 @@ ifeq ($(SKIP_DEBUG_BINARY),)
 	    	CFLAGS=$${MYSQL_BUILD_CFLAGS:-"-g -fno-strict-aliasing"} \
 	    	CXX=$${MYSQL_BUILD_CXX:-g++} \
 	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-g -felide-constructors -fno-exceptions -fno-rtti -fno-strict-aliasing"} \
-	    cmake -DCMAKE_INSTALL_PREFIX=/usr \
+	    cmake -DBUILD_CONFIG=mysql_release \
 		\
+		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DMYSQL_UNIX_ADDR=/var/run/mysqld/mysqld.sock \
 		-DCMAKE_BUILD_TYPE=Debug \
 		-DENABLE_DTRACE=OFF \
@@ -97,8 +98,9 @@ endif
 	    	CFLAGS=$${MYSQL_BUILD_CFLAGS:-"-O2 -g -fno-strict-aliasing"} \
 	    	CXX=$${MYSQL_BUILD_CXX:-g++} \
 	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-O3 -g -felide-constructors -fno-exceptions -fno-rtti -fno-strict-aliasing"} \
-	    cmake -DCMAKE_INSTALL_PREFIX=/usr \
+	    cmake -DBUILD_CONFIG=mysql_release \
 		\
+		-DCMAKE_INSTALL_PREFIX=/usr \
 		-DMYSQL_UNIX_ADDR=/var/run/mysqld/mysqld.sock \
 		-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 		-DENABLE_DTRACE=OFF \


### PR DESCRIPTION
We use BUILD_CONFIG=mysql_release in our rpm builds and in build-binary for binary tarball build which sets option WITH_FAST_MUTEXES to ON.
It was noticed in customer issue 50047 that we don't use FAST_MUTEX option in our debian builds and that is causing some performance issues in some cases so this is to add BUILD_CONFIG=mysql_release to debian releases also to make it more uniform.

Bug link:
https://bugs.launchpad.net/percona-server/+bug/1433980

Test builds:
5.5 build:
http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.5-debian-binary/139/
5.6 build:
http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.6-debian-binary/133/
http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.6-debian-binary-32/118/
