### PR TITLE
lp:1438990 Abort in slave if SAVEPOINT is in trigger.

### DIFF
--- a/mysql-test/suite/rpl/include/rpl_bug1438990.inc
+++ b/mysql-test/suite/rpl/include/rpl_bug1438990.inc
@@ -1,0 +1,85 @@
+# Bug lp:1438990
+# "SAVEPOINT", "ROLLBACK TO savepoint" wipe out table map
+# on slave during execution binary log events. For trigger
+# the map is written to binary log once for all trigger body
+# and if trigger contains "SAVEPOINT" or "ROLLBACK TO savepoint"
+# statements any trigger's events after these statements will not
+# have table map.
+#
+# Run it for all types of replication to be sure
+# the fix did not break anything.
+#
+
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY);
+
+DELIMITER |;
+
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+        DECLARE EXIT HANDLER FOR SQLEXCEPTION
+                BEGIN
+                        ROLLBACK TO event_logging_1;
+                        INSERT t3 VALUES (1);
+                END;       
+        
+        SAVEPOINT event_logging_1;
+
+        INSERT INTO t2 VALUES (1);
+
+        RELEASE SAVEPOINT event_logging_1;
+
+END|
+DELIMITER ;|
+
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+
+--source include/show_binlog_events.inc
+
+--sync_slave_with_master
+
+--connection master
+
+DROP TRIGGER tr1;
+DELETE FROM t1;
+DELETE FROM t2;
+DELETE FROM t3;
+
+DELIMITER |;
+
+CREATE PROCEDURE p1()
+BEGIN
+        DECLARE EXIT HANDLER FOR SQLEXCEPTION
+                BEGIN
+                        ROLLBACK TO event_logging_2;
+                        INSERT t3 VALUES (3);
+                END;
+
+        SAVEPOINT event_logging_2;
+
+        INSERT INTO t2 VALUES (1);
+
+        RELEASE SAVEPOINT event_logging_2;
+END|
+
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW CALL p1()|
+
+DELIMITER ;|
+
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+
+--source include/show_binlog_events.inc
+
+--sync_slave_with_master
+
+--connection master
+
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+
+DROP PROCEDURE p1;
+--source include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_bug1438990_mix.result
+++ b/mysql-test/suite/rpl/r/rpl_bug1438990_mix.result
@@ -1,0 +1,116 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY);
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END|
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t2 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t3 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t2 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+DROP TRIGGER tr1;
+DELETE FROM t1;
+DELETE FROM t2;
+DELETE FROM t3;
+CREATE PROCEDURE p1()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_2;
+INSERT t3 VALUES (3);
+END;
+SAVEPOINT event_logging_2;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_2;
+END|
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW CALL p1()|
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t2 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t3 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t2 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; DROP TRIGGER tr1
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; DELETE FROM t1
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; DELETE FROM t2
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; DELETE FROM t3
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` PROCEDURE `p1`()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_2;
+INSERT t3 VALUES (3);
+END;
+SAVEPOINT event_logging_2;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_2;
+END
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW CALL p1()
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t2 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP PROCEDURE p1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_bug1438990_row.result
+++ b/mysql-test/suite/rpl/r/rpl_bug1438990_row.result
@@ -1,0 +1,146 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY);
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END|
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t2 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t3 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
+master-bin.000001	#	Write_rows	#	#	table_id: #
+master-bin.000001	#	Query	#	#	SAVEPOINT `event_logging_1`
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+DROP TRIGGER tr1;
+DELETE FROM t1;
+DELETE FROM t2;
+DELETE FROM t3;
+CREATE PROCEDURE p1()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_2;
+INSERT t3 VALUES (3);
+END;
+SAVEPOINT event_logging_2;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_2;
+END|
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW CALL p1()|
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t2 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t3 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
+master-bin.000001	#	Write_rows	#	#	table_id: #
+master-bin.000001	#	Query	#	#	SAVEPOINT `event_logging_1`
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; DROP TRIGGER tr1
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Delete_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Delete_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
+master-bin.000001	#	Delete_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` PROCEDURE `p1`()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_2;
+INSERT t3 VALUES (3);
+END;
+SAVEPOINT event_logging_2;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_2;
+END
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW CALL p1()
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
+master-bin.000001	#	Write_rows	#	#	table_id: #
+master-bin.000001	#	Query	#	#	SAVEPOINT `event_logging_2`
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t1)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t2)
+master-bin.000001	#	Table_map	#	#	table_id: # (test.t3)
+master-bin.000001	#	Write_rows	#	#	table_id: # flags: STMT_END_F
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP PROCEDURE p1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_bug1438990_stmt.result
+++ b/mysql-test/suite/rpl/r/rpl_bug1438990_stmt.result
@@ -1,0 +1,116 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t2 (f1 INTEGER PRIMARY KEY);
+CREATE TABLE t3 (f1 INTEGER PRIMARY KEY);
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END|
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t2 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t3 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t2 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+DROP TRIGGER tr1;
+DELETE FROM t1;
+DELETE FROM t2;
+DELETE FROM t3;
+CREATE PROCEDURE p1()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_2;
+INSERT t3 VALUES (3);
+END;
+SAVEPOINT event_logging_2;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_2;
+END|
+CREATE TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW CALL p1()|
+INSERT INTO t2 VALUES (1);
+INSERT INTO t1 VALUES (1);
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t1 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t2 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE TABLE t3 (f1 INTEGER PRIMARY KEY)
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_1;
+INSERT t3 VALUES (1);
+END;       
+SAVEPOINT event_logging_1;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_1;
+END
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t2 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; DROP TRIGGER tr1
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; DELETE FROM t1
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; DELETE FROM t2
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; DELETE FROM t3
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` PROCEDURE `p1`()
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+ROLLBACK TO event_logging_2;
+INSERT t3 VALUES (3);
+END;
+SAVEPOINT event_logging_2;
+INSERT INTO t2 VALUES (1);
+RELEASE SAVEPOINT event_logging_2;
+END
+master-bin.000001	#	Query	#	#	use `test`; CREATE DEFINER=`root`@`localhost` TRIGGER tr1 AFTER INSERT ON t1 FOR EACH ROW CALL p1()
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t2 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t1 VALUES (1)
+master-bin.000001	#	Xid	#	#	COMMIT /* XID */
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP PROCEDURE p1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_bug1438990_mix.test
+++ b/mysql-test/suite/rpl/t/rpl_bug1438990_mix.test
@@ -1,0 +1,5 @@
+--source include/have_innodb.inc
+--source include/master-slave.inc
+--source include/have_binlog_format_mixed.inc
+
+--source suite/rpl/include/rpl_bug1438990.inc

--- a/mysql-test/suite/rpl/t/rpl_bug1438990_row.test
+++ b/mysql-test/suite/rpl/t/rpl_bug1438990_row.test
@@ -1,0 +1,5 @@
+--source include/have_innodb.inc
+--source include/master-slave.inc
+--source include/have_binlog_format_row.inc
+
+--source suite/rpl/include/rpl_bug1438990.inc

--- a/mysql-test/suite/rpl/t/rpl_bug1438990_stmt.test
+++ b/mysql-test/suite/rpl/t/rpl_bug1438990_stmt.test
@@ -1,0 +1,5 @@
+--source include/have_innodb.inc
+--source include/master-slave.inc
+--source include/have_binlog_format_statement.inc
+
+--source suite/rpl/include/rpl_bug1438990.inc

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -50,6 +50,8 @@ using std::min;
 using std::max;
 using std::list;
 
+static int write_locked_table_maps(THD *thd, bool force= false);
+
 // This is a temporary backporting fix.
 #ifndef HAVE_LOG2
 /*
@@ -2136,6 +2138,14 @@ int ha_rollback_to_savepoint(THD *thd, SAVEPOINT *sv)
     status_var_increment(thd->status_var.ha_savepoint_rollback_count);
     trans->no_2pc|= ht->prepare == 0;
   }
+
+  /*
+    Write tables map once more for trigger as it will be wiped out in
+    Write_rows_log_event::write_row() on slave.
+  */
+  if (thd->in_sub_stmt == SUB_STMT_TRIGGER)
+    error= write_locked_table_maps(thd, true);
+
   /*
     rolling back the transaction in all storage engines that were not part of
     the transaction when the savepoint was set
@@ -2231,6 +2241,14 @@ int ha_savepoint(THD *thd, SAVEPOINT *sv)
     }
     status_var_increment(thd->status_var.ha_savepoint_count);
   }
+
+  /*
+     Write tables map once more for trigger as it will be wiped out in
+     Write_rows_log_event::write_row() on slave.
+   */
+   if (thd->in_sub_stmt == SUB_STMT_TRIGGER)
+     error= write_locked_table_maps(thd, true);
+
   /*
     Remember the list of registered storage engines. All new
     engines are prepended to the beginning of the list.
@@ -7413,6 +7431,8 @@ static bool check_table_binlog_row_based(THD *thd, TABLE *table)
    SYNOPSIS
      write_locked_table_maps()
        thd     Pointer to THD structure
+       force   if true write table map even it was written earlier,
+               default value is false
 
    DESCRIPTION
        This function will generate and write table maps for all tables
@@ -7426,7 +7446,7 @@ static bool check_table_binlog_row_based(THD *thd, TABLE *table)
        THD::lock
 */
 
-static int write_locked_table_maps(THD *thd)
+static int write_locked_table_maps(THD *thd, bool force)
 {
   DBUG_ENTER("write_locked_table_maps");
   DBUG_PRINT("enter", ("thd: 0x%lx  thd->lock: 0x%lx "
@@ -7435,7 +7455,7 @@ static int write_locked_table_maps(THD *thd)
 
   DBUG_PRINT("debug", ("get_binlog_table_maps(): %d", thd->get_binlog_table_maps()));
 
-  if (thd->get_binlog_table_maps() == 0)
+  if (force || (thd->get_binlog_table_maps() == 0))
   {
     MYSQL_LOCK *locks[2];
     locks[0]= thd->extra_lock;


### PR DESCRIPTION
1. Why does the crash take place?

The crash happens in Write_rows_log_event::write_row()  when row field is unpacked. The stack in the following

Relay_log_info::get_table_data()
unpack_row()
unpack_current_row()
Write_rows_log_event::write_row()

Relay_log_info::get_table_data() contains the following code:

  bool get_table_data(TABLE *table_arg, table_def tabledef_var, TABLE conv_table_var) const
  {
     ...
    for (TABLE_LIST *ptr= tables_to_lock ; ptr != NULL ; ptr= ptr->next_global)
      if (ptr->table == table_arg)
      {
         ...
         return true;
      }
     return false;
   }

Relay_log_info::tables_to_lock is NULL, Relay_log_info::get_table_data() returns false and unpack_row() is aborted by assert.
1. Why Relay_log_info::tables_to_lock is NULL.?

Because it was cleared in Query_log_event::do_apply_event()->Relay_log_info::slave_close_thread_tables()->Relay_log_info::clear_tables_to_lock() when log event for "SAVEPOINT" is executed"
1. How table map is written for trigger?

It is written once for the whole trigger body:

a) Table is added to thd->lex->query_tables in open_table_entry_fini() <- the function for opening tables for triggers which are specified for the table which takes part in query

b) thd->lock is filled from lock_tables() with thd->lex->query_tables . lock_tables .

c) binlog_log_row()->write_locked_table_maps() writes table maps to binlog and invoke THD::binlog_write_table_map() which increases THD::binlog_table_maps.

d) when write_locked_table_maps() is invoked for the next statement in trigger it writes map to binlog only if THD::binlog_table_maps is zero, but it is not zero as it was changed in (c).

Trigger is parsed and executed before DML execution and all tables which take part in query are added into list of open tables.
1. The fix:

SAVEPOINT, ROLLBACK TO SAVEPOINT(as well as BEGIN, COMMIT, ROLLBACK, but they are forbidden for triggers) statements are logged into binary log as Query_log_event. Query_log_event::do_apply_event() wipes out table map.  And we can not recognize on slave if we are inside of trigger or not as only modification events are written to binary log and there is not event for trigger boddy call. But we can recognize it in master. The idea is to write tables map into binary log after each SAVEPOINT, ROLLBACK TO SAVEPOINT execution on master if it happens inside of trigger.

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/838/
