### PR TITLE
Fixed bug 1420606: MTS breaks in after restart

### DIFF
--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -1383,15 +1383,6 @@ public:
 
 #if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)
 
-  /**
-    Re-implement this function for events which should rollback current group,
-    such as "ROLLBACK" statement, format description event or stop event.
-  */
-  virtual bool should_rollback_current_group() const
-  {
-    return false;
-  }
-
 private:
 
   /*
@@ -2669,14 +2660,6 @@ public:
     return START_V3_HEADER_LEN; //no variable-sized part
   }
 
-  /**
-    New log file rolls the current group back if "created" property is set.
-  */
-  virtual bool should_rollback_current_group() const
-  {
-    return created != 0;
-  }
-
 protected:
 #if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)
   virtual int do_apply_event(Relay_log_info const *rli);
@@ -3078,14 +3061,6 @@ public:
   ~Stop_log_event() {}
   Log_event_type get_type_code() { return STOP_EVENT;}
   bool is_valid() const { return 1; }
-
-  /**
-    Always rollback current group
-  */
-  virtual bool should_rollback_current_group() const
-  {
-    return true;
-  }
 
 private:
 #if defined(MYSQL_SERVER) && defined(HAVE_REPLICATION)

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -98,8 +98,7 @@ Relay_log_info::Relay_log_info(bool is_slave_recovery
    mts_group_status(MTS_NOT_IN_GROUP), reported_unsafe_warning(false),
    rli_description_event(NULL),
    sql_delay(0), sql_delay_end(0), m_flags(0), row_stmt_start_timestamp(0),
-   long_find_row_note_printed(false), error_on_rli_init_info(false),
-   rli_next_event(NULL)
+   long_find_row_note_printed(false), error_on_rli_init_info(false)
 {
   DBUG_ENTER("Relay_log_info::Relay_log_info");
 

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -894,22 +894,6 @@ public:
   }
 
   /**
-    Remember next event.
-  */
-  void set_rli_next_event(Log_event *ev)
-  {
-    rli_next_event= ev;
-  }
-
-  /**
-    Return the remembered event.
-  */
-  Log_event *get_rli_next_event() const
-  {
-    return rli_next_event;
-  }
-
-  /**
     adaptation for the slave applier to specific master versions.
   */
   void adapt_to_master_version(Format_description_log_event *fdle);
@@ -981,13 +965,6 @@ private:
     SLAVE must be executed and the problem fixed manually.
    */
   bool error_on_rli_init_info;
-
-  /*
-   This variable is used when we want to inject "ROLLBACK" event just before
-   the real event. The real event is remembered here and is returned by
-   the next call.
-   */
-  Log_event *rli_next_event;
 };
 
 bool mysql_show_relaylog_events(THD* thd);

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -6285,8 +6285,6 @@ llstr(rli->get_group_master_log_pos(), llbuff));
   /* we die so won't remember charset - re-update them on next thread start */
   rli->cached_charset_invalidate();
   rli->save_temporary_tables = thd->temporary_tables;
-  delete rli->get_rli_next_event();
-  rli->set_rli_next_event(NULL);
 
   /*
     TODO: see if we can do this conditionally in next_event() instead
@@ -7477,12 +7475,6 @@ static Log_event* next_event(Relay_log_info* rli)
 
   DBUG_ASSERT(thd != 0);
 
-  if ((ev = rli->get_rli_next_event()) != NULL)
-  {
-    rli->set_rli_next_event(NULL);
-    DBUG_RETURN(ev);
-  }
-
 #ifndef DBUG_OFF
   if (abort_slave_event_count && !rli->events_until_exit--)
     DBUG_RETURN(0);
@@ -7606,36 +7598,6 @@ static Log_event* next_event(Relay_log_info* rli)
                     (force && (rli->checkpoint_seqno <= (rli->checkpoint_group - 1))) ||
                     sql_slave_killed(thd, rli));
         mysql_mutex_lock(&rli->data_lock);
-      }
-      if (rli->is_parallel_exec() && 
-          ev->should_rollback_current_group() &&
-          (rli->curr_group_seen_begin || rli->curr_group_seen_gtid))
-      {
-        /* We reached the end of relay log file and it doesn't end with
-           COMMIT or ROLLBACK. To prevent MTS from stalling we generate
-           ROLLBACK event. Single-treaded slave takes care of such
-           cases (see Format_description_log_event::do_apply_event).
-           When relay_log_recovery is ON, relay log will be redownloaded
-           from the master. */
-        rli->report(WARNING_LEVEL, 0,
-                    "injecting ROLLBACK at the end of cold group");
-        Query_log_event *rollback_event= 
-            new Query_log_event(thd, STRING_WITH_LEN("ROLLBACK"),
-                                TRUE, FALSE, TRUE, 0, FALSE);
-        if (unlikely(!rollback_event))
-        {
-          errmsg= "Slave SQL thread failed to create a ROLLBACK event "
-            "(out of memory?), MTS may stall";
-          goto err;
-        }
-        rollback_event->data_written = 0;
-        rollback_event->db= "";
-        rollback_event->db_len= 0;
-        rollback_event->server_id= 0; // won't be ignored by slave SQL thread
-        rollback_event->set_artificial_event();
-        rollback_event->future_event_relay_log_pos = BIN_LOG_HEADER_SIZE;
-        rli->set_rli_next_event(ev);
-        DBUG_RETURN(rollback_event);
       }
       DBUG_RETURN(ev);
     }


### PR DESCRIPTION
Regression introduced by the fix for bug 1331586. Fix for 1331586 can
be reverted since upstream fixed the same bug differently. Test case
and synchronization points are kept, because upstream test case and
sync points are bit different.
