### PR TITLE
searchs for libjemalloc.so in $basedir/lib/mysql

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -524,7 +524,7 @@ parse_arguments PICK-ARGS-FROM-ARGV "$@"
 #
 if test $load_jemalloc -eq 1
 then
-  for libjemall in "/usr/lib64" "/usr/lib/x86_64-linux-gnu" "/usr/lib"; do
+  for libjemall in "${MY_BASEDIR_VERSION}/lib/mysql" "/usr/lib64" "/usr/lib/x86_64-linux-gnu" "/usr/lib"; do
     if [ -r "$libjemall/libjemalloc.so.1" ]; then
       add_mysqld_ld_preload "$libjemall/libjemalloc.so.1"
       break


### PR DESCRIPTION
libjemalloc.so is needed by tokudb. The jemalloc library is contained into the percona server distribution, but the mysql_safe script searches it in some system directories.
This simple patch modifies mysql_safe script so that mysqld_safe script searches for libjemalloc.so.1 also into the $basedir directory.  
