### PR TITLE
row_fomat=tokudb_default is recognized by sql grammar

### DIFF
--- a/sql/handler.h
+++ b/sql/handler.h
@@ -405,7 +405,7 @@ enum row_type { ROW_TYPE_NOT_USED=-1, ROW_TYPE_DEFAULT, ROW_TYPE_FIXED,
                 ROW_TYPE_PAGE,
                 ROW_TYPE_TOKU_UNCOMPRESSED, ROW_TYPE_TOKU_ZLIB,
                 ROW_TYPE_TOKU_QUICKLZ, ROW_TYPE_TOKU_LZMA,
-                ROW_TYPE_TOKU_FAST, ROW_TYPE_TOKU_SMALL };
+                ROW_TYPE_TOKU_FAST, ROW_TYPE_TOKU_SMALL, ROW_TYPE_TOKU_DEFAULT };
 
 /* Specifies data storage format for individual columns */
 enum column_format_type {

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -405,7 +405,7 @@ enum row_type { ROW_TYPE_NOT_USED=-1, ROW_TYPE_DEFAULT, ROW_TYPE_FIXED,
                 ROW_TYPE_PAGE,
                 ROW_TYPE_TOKU_UNCOMPRESSED, ROW_TYPE_TOKU_ZLIB,
                 ROW_TYPE_TOKU_QUICKLZ, ROW_TYPE_TOKU_LZMA,
-                ROW_TYPE_TOKU_FAST, ROW_TYPE_TOKU_SMALL, ROW_TYPE_TOKU_DEFAULT };
+                ROW_TYPE_TOKU_FAST, ROW_TYPE_TOKU_SMALL };
 
 /* Specifies data storage format for individual columns */
 enum column_format_type {

--- a/sql/lex.h
+++ b/sql/lex.h
@@ -604,6 +604,7 @@ static SYMBOL symbols[] = {
   { "TOKUDB_LZMA",             SYM(TOKU_LZMA_SYM)},
   { "TOKUDB_FAST",             SYM(TOKU_FAST_SYM)},
   { "TOKUDB_SMALL",            SYM(TOKU_SMALL_SYM)},
+  { "TOKUDB_DEFAULT",          SYM(TOKU_DEFAULT_SYM)},
   { "TRAILING",		SYM(TRAILING)},
   { "TRANSACTION",	SYM(TRANSACTION_SYM)},
   { "TRIGGER",          SYM(TRIGGER_SYM)},

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -6290,7 +6290,7 @@ row_types:
         | TOKU_LZMA_SYM         { $$= ROW_TYPE_TOKU_LZMA; }
         | TOKU_FAST_SYM         { $$= ROW_TYPE_TOKU_FAST; }
         | TOKU_SMALL_SYM        { $$= ROW_TYPE_TOKU_SMALL; }
-        | TOKU_DEFAULT_SYM      { $$= ROW_TYPE_TOKU_ZLIB; }
+        | TOKU_DEFAULT_SYM      { $$= ROW_TYPE_DEFAULT; }
         ;
 
 merge_insert_types:

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1623,6 +1623,7 @@ bool my_yyoverflow(short **a, YYSTYPE **b, ulong *yystacksize);
 %token  TOKU_LZMA_SYM
 %token  TOKU_FAST_SYM
 %token  TOKU_SMALL_SYM
+%token  TOKU_DEFAULT_SYM
 %token  TRAILING                      /* SQL-2003-R */
 %token  TRANSACTION_SYM
 %token  TRIGGERS_SYM
@@ -6289,6 +6290,7 @@ row_types:
         | TOKU_LZMA_SYM         { $$= ROW_TYPE_TOKU_LZMA; }
         | TOKU_FAST_SYM         { $$= ROW_TYPE_TOKU_FAST; }
         | TOKU_SMALL_SYM        { $$= ROW_TYPE_TOKU_SMALL; }
+        | TOKU_DEFAULT_SYM      { $$= ROW_TYPE_TOKU_ZLIB; }
         ;
 
 merge_insert_types:


### PR DESCRIPTION
When a table with the `tokudb_default` format is specified a syntax error is generated. For example:

```
mysql> create table test.t (i int) engine=tokudb row_format=tokudb_default;
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'tokudb_default' at line 1
mysql> create table test.t (i int) engine=tokudb row_format=tokudb_zlib;
Query OK, 0 rows affected (0.09 sec)

mysql> select version();
+-------------+
| version()   |
+-------------+
| 5.6.23-72.1 |
+-------------+
1 row in set (0.00 sec)
```

The [documentation](http://docs.tokutek.com/tokudb/tokudb-index-using-tokudb.html) states that the `tokudb_default` is an alias for tokudb_zlib format. The patch adds a token `tokudb_default` to the grammar. When the yacc parser recognizes `tokudb_default` it evaluated to `ROW_TYPE_DEFAULT` value.

After the patch:

```
mysql> create table t (i int) engine=tokudb row_format=tokudb_default;
Query OK, 0 rows affected (0.02 sec)

mysql> alter table t row_format=tokudb_uncompressed;
Query OK, 0 rows affected (0.02 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> select table_name, row_format from information_schema.tables where table_schema='test'; 
+------------+---------------------+
| table_name | row_format          |
+------------+---------------------+
| t          | tokudb_uncompressed |
+------------+---------------------+
1 row in set (0.00 sec)

mysql> alter table t row_format=tokudb_default;
Query OK, 0 rows affected (0.03 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> select table_name, row_format from information_schema.tables where table_schema='test'; 
+------------+-------------+
| table_name | row_format  |
+------------+-------------+
| t          | tokudb_zlib |
+------------+-------------+
1 row in set (0.00 sec)
```
