### PR TITLE
plugin/qrt/qrt.cc: fix for launchpad bug 1453277

### DIFF
--- a/plugin/query_response_time/query_response_time.cc
+++ b/plugin/query_response_time/query_response_time.cc
@@ -303,6 +303,7 @@ static collector g_collector;
 
 void query_response_time_init()
 {
+  query_response_time_flush();
 }
 
 void query_response_time_free()


### PR DESCRIPTION
If query_response_time_range_base is set as a command line option or in a configuration file, its value does not take effect until the first flush is made. Call flush during plugin init so that any configured value takes effect upon start up.
