### PR TITLE
Bug 1432846: add option to entirely skip slow logging of stored proce…

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -288,10 +288,12 @@ The following options may be given as the first argument:
  query log. [session, query]
  --log-slow-slave-statements 
  Log queries replayed be the slave SQL thread
- --log-slow-sp-statements 
- Log slow statements executed by stored procedure to the
- slow log if it is open.
- (Defaults to on; use --skip-log-slow-sp-statements to disable.)
+ --log-slow-sp-statements[=name] 
+ Choice between logging slow CALL statements, logging
+ individual slow statements inside stored procedures or
+ skipping the logging of stored procedures into the slow
+ log entirely. Values are OFF, ON and OFF_NO_CALLS
+ respectively.
  --log-slow-verbosity=name 
  Choose how verbose the messages to your slow log will be.
  Multiple flags allowed in a comma-separated string.
@@ -932,7 +934,7 @@ log-slow-filter
 log-slow-rate-limit 1
 log-slow-rate-type session
 log-slow-slave-statements FALSE
-log-slow-sp-statements TRUE
+log-slow-sp-statements ON
 log-slow-verbosity 
 log-tc tc.log
 log-tc-size 24576

--- a/mysql-test/r/percona_log_slow_sp_statements.result
+++ b/mysql-test/r/percona_log_slow_sp_statements.result
@@ -15,6 +15,9 @@ END^
 PREPARE stmt FROM "CALL test_outer()";
 SET GLOBAL log_slow_sp_statements=ON;
 [log_start.inc] percona.slow_extended.sp1
+SELECT "log_always";
+log_always
+log_always
 CALL test_outer();
 1
 1
@@ -26,6 +29,8 @@ EXECUTE stmt;
 2
 2
 [log_stop.inc] percona.slow_extended.sp1
+[log_grep.inc] file: percona.slow_extended.sp1 pattern: log_always
+[log_grep.inc] lines:   1
 [log_grep.inc] file: percona.slow_extended.sp1 pattern: SELECT 1;
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.sp1 pattern: SELECT 2;
@@ -38,6 +43,9 @@ EXECUTE stmt;
 [log_grep.inc] lines:   2
 SET GLOBAL log_slow_sp_statements=OFF;
 [log_start.inc] percona.slow_extended.sp2
+SELECT "log_always";
+log_always
+log_always
 CALL test_outer();
 1
 1
@@ -49,6 +57,8 @@ EXECUTE stmt;
 2
 2
 [log_stop.inc] percona.slow_extended.sp2
+[log_grep.inc] file: percona.slow_extended.sp2 pattern: log_always
+[log_grep.inc] lines:   1
 [log_grep.inc] file: percona.slow_extended.sp2 pattern: SELECT 1;
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.sp2 pattern: SELECT 2;
@@ -56,6 +66,32 @@ EXECUTE stmt;
 [log_grep.inc] file: percona.slow_extended.sp2 pattern: CALL test_
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.sp2 pattern: # Stored_routine: test.test_
+[log_grep.inc] lines:   0
+SET GLOBAL log_slow_sp_statements=OFF_NO_CALLS;
+[log_start.inc] percona.slow_extended.sp3
+SELECT "log_always";
+log_always
+log_always
+CALL test_outer();
+1
+1
+2
+2
+EXECUTE stmt;
+1
+1
+2
+2
+[log_stop.inc] percona.slow_extended.sp3
+[log_grep.inc] file: percona.slow_extended.sp3 pattern: log_always
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.sp3 pattern: SELECT 1;
+[log_grep.inc] lines:   0
+[log_grep.inc] file: percona.slow_extended.sp3 pattern: SELECT 2;
+[log_grep.inc] lines:   0
+[log_grep.inc] file: percona.slow_extended.sp3 pattern: CALL test_
+[log_grep.inc] lines:   0
+[log_grep.inc] file: percona.slow_extended.sp3 pattern: # Stored_routine: test.test_
 [log_grep.inc] lines:   0
 DROP PROCEDURE test_outer;
 DROP PROCEDURE test_inner;

--- a/mysql-test/suite/sys_vars/r/log_slow_sp_statements_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_sp_statements_basic.result
@@ -1,3 +1,32 @@
+default
 SELECT @@global.log_slow_sp_statements;
 @@global.log_slow_sp_statements
-1
+ON
+SET GLOBAL log_slow_sp_statements = ON;
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+ON
+SET GLOBAL log_slow_sp_statements = OFF;
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+OFF
+SET GLOBAL log_slow_sp_statements = OFF_NO_CALLS;
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+OFF_NO_CALLS
+SET GLOBAL log_slow_sp_statements = FALSE;
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+OFF
+SET GLOBAL log_slow_sp_statements = TRUE;
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+ON
+SET GLOBAL log_slow_sp_statements = 0;
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+OFF
+SET GLOBAL log_slow_sp_statements = 1;
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+ON

--- a/mysql-test/suite/sys_vars/r/log_slow_sp_statements_set.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_sp_statements_set.result
@@ -1,0 +1,3 @@
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+ON

--- a/mysql-test/suite/sys_vars/r/log_slow_sp_statements_skip.result
+++ b/mysql-test/suite/sys_vars/r/log_slow_sp_statements_skip.result
@@ -1,0 +1,3 @@
+SELECT @@global.log_slow_sp_statements;
+@@global.log_slow_sp_statements
+OFF

--- a/mysql-test/suite/sys_vars/t/log_slow_sp_statements_basic.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_sp_statements_basic.test
@@ -1,1 +1,23 @@
+--echo default
+SELECT @@global.log_slow_sp_statements;
+
+SET GLOBAL log_slow_sp_statements = ON;
+SELECT @@global.log_slow_sp_statements;
+
+SET GLOBAL log_slow_sp_statements = OFF;
+SELECT @@global.log_slow_sp_statements;
+
+SET GLOBAL log_slow_sp_statements = OFF_NO_CALLS;
+SELECT @@global.log_slow_sp_statements;
+
+SET GLOBAL log_slow_sp_statements = FALSE;
+SELECT @@global.log_slow_sp_statements;
+
+SET GLOBAL log_slow_sp_statements = TRUE;
+SELECT @@global.log_slow_sp_statements;
+
+SET GLOBAL log_slow_sp_statements = 0;
+SELECT @@global.log_slow_sp_statements;
+
+SET GLOBAL log_slow_sp_statements = 1;
 SELECT @@global.log_slow_sp_statements;

--- a/mysql-test/suite/sys_vars/t/log_slow_sp_statements_set-master.opt
+++ b/mysql-test/suite/sys_vars/t/log_slow_sp_statements_set-master.opt
@@ -1,0 +1,1 @@
+--log-slow-sp-statements

--- a/mysql-test/suite/sys_vars/t/log_slow_sp_statements_set.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_sp_statements_set.test
@@ -1,0 +1,1 @@
+SELECT @@global.log_slow_sp_statements;

--- a/mysql-test/suite/sys_vars/t/log_slow_sp_statements_skip-master.opt
+++ b/mysql-test/suite/sys_vars/t/log_slow_sp_statements_skip-master.opt
@@ -1,0 +1,1 @@
+--skip-log-slow-sp-statements

--- a/mysql-test/suite/sys_vars/t/log_slow_sp_statements_skip.test
+++ b/mysql-test/suite/sys_vars/t/log_slow_sp_statements_skip.test
@@ -1,0 +1,1 @@
+SELECT @@global.log_slow_sp_statements;

--- a/mysql-test/t/percona_log_slow_sp_statements.test
+++ b/mysql-test/t/percona_log_slow_sp_statements.test
@@ -30,9 +30,12 @@ PREPARE stmt FROM "CALL test_outer()";
 SET GLOBAL log_slow_sp_statements=ON;
 --let log_file=percona.slow_extended.sp1
 --source include/log_start.inc
+SELECT "log_always";
 CALL test_outer();
 EXECUTE stmt;
 --source include/log_stop.inc
+--let grep_pattern=log_always
+--source include/log_grep.inc
 --let grep_pattern=SELECT 1;
 --source include/log_grep.inc
 --let grep_pattern=SELECT 2;
@@ -47,9 +50,30 @@ EXECUTE stmt;
 SET GLOBAL log_slow_sp_statements=OFF;
 --let log_file=percona.slow_extended.sp2
 --source include/log_start.inc
+SELECT "log_always";
 CALL test_outer();
 EXECUTE stmt;
 --source include/log_stop.inc
+--let grep_pattern=log_always
+--source include/log_grep.inc
+--let grep_pattern=SELECT 1;
+--source include/log_grep.inc
+--let grep_pattern=SELECT 2;
+--source include/log_grep.inc
+--let grep_pattern=CALL test_
+--source include/log_grep.inc
+--let grep_pattern=# Stored_routine: test.test_
+--source include/log_grep.inc
+
+SET GLOBAL log_slow_sp_statements=OFF_NO_CALLS;
+--let log_file=percona.slow_extended.sp3
+--source include/log_start.inc
+SELECT "log_always";
+CALL test_outer();
+EXECUTE stmt;
+--source include/log_stop.inc
+--let grep_pattern=log_always
+--source include/log_grep.inc
 --let grep_pattern=SELECT 1;
 --source include/log_grep.inc
 --let grep_pattern=SELECT 2;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2830,7 +2830,7 @@ bool MYSQL_QUERY_LOG::write(THD *thd, ulonglong current_utime,
     if (my_b_write(&log_file, (uchar*) "\n", 1))
         tmp_errno= errno;
 
-    if (opt_log_slow_sp_statements &&
+    if (opt_log_slow_sp_statements == 1 &&
         thd->spcont &&
         my_b_printf(&log_file,
                     "# Stored_routine: %s\n",

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -436,7 +436,7 @@ char* opt_secure_file_priv= NULL;
 my_bool opt_secure_file_priv_noarg= FALSE;
 my_bool opt_log_slow_admin_statements= 0;
 my_bool opt_log_slow_slave_statements= 0;
-my_bool opt_log_slow_sp_statements= 0;
+ulong opt_log_slow_sp_statements= 0;
 my_bool opt_slow_query_log_timestamp_always= 0;
 ulonglong opt_slow_query_log_use_global_control= 0;
 ulong opt_slow_query_log_timestamp_precision= 0;
@@ -7600,6 +7600,7 @@ C_MODE_END
 /* defined in sys_vars.cc */
 extern void init_log_slow_verbosity();
 extern void init_slow_query_log_use_global_control();
+extern void init_log_slow_sp_statements();
 
 /**
   Get server options from the command line,
@@ -7752,6 +7753,7 @@ static int get_options(int *argc_ptr, char ***argv_ptr)
 
   init_log_slow_verbosity();
   init_slow_query_log_use_global_control();
+  init_log_slow_sp_statements();
   if (opt_short_log_format)
     opt_specialflag|= SPECIAL_SHORT_LOG_FORMAT;
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -124,7 +124,7 @@ extern char* opt_secure_file_priv;
 extern char* opt_secure_backup_file_priv;
 extern size_t opt_secure_backup_file_priv_len;
 extern my_bool opt_log_slow_admin_statements, opt_log_slow_slave_statements;
-extern my_bool opt_log_slow_sp_statements;
+extern ulong opt_log_slow_sp_statements;
 extern my_bool opt_slow_query_log_timestamp_always;
 extern ulonglong opt_slow_query_log_use_global_control;
 extern ulong opt_slow_query_log_timestamp_precision;

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -2165,7 +2165,8 @@ sp_head::execute_procedure(THD *thd, List<Item> *args)
     DBUG_PRINT("info",(" %.*s: eval args done", (int) m_name.length, 
                        m_name.str));
   }
-  if (!(m_flags & LOG_SLOW_STATEMENTS || opt_log_slow_sp_statements) && thd->enable_slow_log)
+  if (!(m_flags & LOG_SLOW_STATEMENTS || opt_log_slow_sp_statements == 1)
+      && thd->enable_slow_log)
   {
     DBUG_PRINT("info", ("Disabling slow log for the execution"));
     save_enable_slow_log= true;

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1585,7 +1585,7 @@ void log_slow_statement(THD *thd)
     This code should be run after query_response_time_collect(...)
     function to avoid influence on query_response_time_stats logic.
   */
-  if (opt_log_slow_sp_statements &&
+  if (opt_log_slow_sp_statements > 0 &&
       thd->lex)
   {
     if (thd->lex->sql_command == SQLCOM_CALL)

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3369,11 +3369,31 @@ static Sys_var_mybool Sys_log_slow_admin_statements(
        " to the slow log if it is open.",
        GLOBAL_VAR(opt_log_slow_admin_statements), CMD_LINE(OPT_ARG),
        DEFAULT(FALSE));
-static Sys_var_mybool Sys_log_slow_sp_statements(
+static const char *log_slow_sp_statements_names[]=
+  {"OFF", "ON", "OFF_NO_CALLS", "FALSE", "TRUE", "0", "1", 0};
+static bool fix_log_slow_sp_statements(sys_var */*self*/, THD */*thd*/,
+                                       enum_var_type /*type*/)
+{
+  if(opt_log_slow_sp_statements > 2)
+  {
+    opt_log_slow_sp_statements= (opt_log_slow_sp_statements - 3) % 2;
+  }
+  return false;
+}
+void init_log_slow_sp_statements()
+{
+  fix_log_slow_sp_statements(NULL, NULL, OPT_GLOBAL);
+}
+static Sys_var_enum Sys_log_slow_sp_statements(
        "log_slow_sp_statements",
-       "Log slow statements executed by stored procedure to the slow log if it is open.",
+       "Choice between logging slow CALL statements, logging individual slow "
+       "statements inside stored procedures or skipping the logging of stored "
+       "procedures into the slow log entirely. Values are OFF, ON and "
+       "OFF_NO_CALLS respectively.",
        GLOBAL_VAR(opt_log_slow_sp_statements), CMD_LINE(OPT_ARG),
-       DEFAULT(TRUE));
+       log_slow_sp_statements_names, DEFAULT(1),
+       NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
+       ON_UPDATE(fix_log_slow_sp_statements));
 static Sys_var_mybool Sys_slow_query_log_timestamp_always(
        "slow_query_log_timestamp_always",
        "Timestamp is printed for all records of the slow log even if they are same time.",


### PR DESCRIPTION
…dures

log_slow_sp_statements changed from boolean to enum with values

OFF  - log slow CALL statements
ON   - log slow individual statements inside stored procedure
SKIP - skip logging of stored procedures entirely
