### PR TITLE
Fix bug 1100652 (innochecksum always fail to check table files with

### DIFF
--- a/extra/CMakeLists.txt
+++ b/extra/CMakeLists.txt
@@ -71,6 +71,7 @@ MYSQL_ADD_EXECUTABLE(replace replace.c)
 TARGET_LINK_LIBRARIES(replace mysys)
 IF(UNIX)
   MYSQL_ADD_EXECUTABLE(innochecksum innochecksum.c)
+  TARGET_LINK_LIBRARIES(innochecksum ${ZLIB_LIBRARY})
 
   MYSQL_ADD_EXECUTABLE(resolve_stack_dump resolve_stack_dump.c)
   TARGET_LINK_LIBRARIES(resolve_stack_dump mysys)

--- a/extra/innochecksum.c
+++ b/extra/innochecksum.c
@@ -32,6 +32,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <zlib.h>
 
 /* all of these ripped from InnoDB code from MySQL 4.0.22 */
 #define UT_HASH_RANDOM_MASK     1463735687
@@ -42,7 +43,7 @@
 #define FIL_PAGE_DATA       38
 #define FIL_PAGE_END_LSN_OLD_CHKSUM 8
 #define FIL_PAGE_SPACE_OR_CHKSUM 0
-#define UNIV_PAGE_SIZE          (2 * 8192)
+#define FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID  34
 
 #define FIL_PAGE_TYPE           24
 #define FIL_PAGE_TYPE_FSP_HDR   8       /*!< File space header */
@@ -63,7 +64,9 @@
                                                 new BLOB treatment */
 #define DICT_TF_ZSSIZE_SHIFT            1
 #define DICT_TF_ZSSIZE_MASK             (15 << DICT_TF_ZSSIZE_SHIFT)
-#define DICT_TF_ZSSIZE_MAX (UNIV_PAGE_SIZE_SHIFT - PAGE_ZIP_MIN_SIZE_SHIFT + 1)
+
+#define UNIV_PAGE_SIZE_SHIFT_MAX	14
+#define UNIV_PAGE_SIZE_MAX	(1 << UNIV_PAGE_SIZE_SHIFT_MAX)
 
 /* command line argument to do page checks (that's it) */
 /* another argument to specify page ranges... seek to right spot and go from there */
@@ -116,11 +119,13 @@ ut_fold_binary(
     return(fold);
 }
 
+static
 ulint
 buf_calc_page_new_checksum(
 /*=======================*/
                /* out: checksum */
-    uchar*    page) /* in: buffer page */
+    uchar*    page, /* in: buffer page */
+    ulint     page_size)
 {
     ulint checksum;
 
@@ -134,7 +139,7 @@ buf_calc_page_new_checksum(
     checksum= ut_fold_binary(page + FIL_PAGE_OFFSET,
                              FIL_PAGE_FILE_FLUSH_LSN - FIL_PAGE_OFFSET)
             + ut_fold_binary(page + FIL_PAGE_DATA,
-                             UNIV_PAGE_SIZE - FIL_PAGE_DATA
+                             page_size - FIL_PAGE_DATA
                              - FIL_PAGE_END_LSN_OLD_CHKSUM);
     checksum= checksum & 0xFFFFFFFF;
 
@@ -154,6 +159,31 @@ buf_calc_page_old_checksum(
     checksum= checksum & 0xFFFFFFFF;
 
     return(checksum);
+}
+
+/**********************************************************************//**
+Calculate the compressed page checksum.
+@return	page checksum */
+static
+ulint
+page_zip_calc_checksum(
+/*===================*/
+  const void*	data,	/*!< in: compressed page */
+  ulint		size)	/*!< in: size of compressed page */
+{
+  /* Exclude FIL_PAGE_SPACE_OR_CHKSUM, FIL_PAGE_LSN,
+  and FIL_PAGE_FILE_FLUSH_LSN from the checksum. */
+
+  const Bytef* s= data;
+  uLong adler;
+
+  adler= adler32(0L, s + FIL_PAGE_OFFSET,
+		 FIL_PAGE_LSN - FIL_PAGE_OFFSET);
+  adler= adler32(adler, s + FIL_PAGE_TYPE, 2);
+  adler= adler32(adler, s + FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID,
+		 size - FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID);
+
+  return((ulint) adler);
 }
 
 static
@@ -207,15 +237,120 @@ display_format_info(uchar *page)
   }
 }
 
+static
+int lsn_match(uchar* p, ulint page_no, ulint page_size, int compressed,
+	      int debug) {
+  ulint logseq, logseqfield;
+  logseq= mach_read_from_4(p + FIL_PAGE_LSN + 4);
+  logseqfield= mach_read_from_4(p + page_size - FIL_PAGE_END_LSN_OLD_CHKSUM
+				+ 4);
+  if (debug) {
+    printf("page %lu: log sequence number: first = %lu; second = %lu\n",
+	   page_no, logseq, logseqfield);
+    if (compressed && (logseq == logseqfield))
+      printf("WARNING: lsns should not always match for compressed pages!\n");
+  }
+  return logseq == logseqfield;
+}
+
+static
+int checksum_match(uchar* p, ulint page_no, ulint page_size, int compressed,
+		   int debug) {
+  ulint csum, csumfield, oldcsumfield, oldcsum;
+  if (compressed) {
+    csum = page_zip_calc_checksum(p, page_size);
+    csumfield= mach_read_from_4(p + FIL_PAGE_SPACE_OR_CHKSUM);
+    if (debug)
+      printf("page %lu: calculated = %lu; recorded = %lu\n", page_no, csum,
+	     csumfield);
+    return csum == csumfield;
+  } else {
+    /* check the "stored log sequence numbers" */
+    if (!lsn_match(p, page_no, page_size, 0, debug))
+    {
+      return 0;
+    }
+    /* check old method of checksumming */
+    oldcsum= buf_calc_page_old_checksum(p);
+    oldcsumfield= mach_read_from_4(p + page_size
+				   - FIL_PAGE_END_LSN_OLD_CHKSUM);
+    if (debug)
+      printf("page %lu: old style: calculated = %lu; recorded = %lu\n",
+	     page_no, oldcsum, oldcsumfield);
+    if (oldcsumfield != mach_read_from_4(p + FIL_PAGE_LSN) &&
+	oldcsumfield != oldcsum)
+    {
+      return 0;
+    }
+    /* now check the new method */
+    csum= buf_calc_page_new_checksum(p, page_size);
+    csumfield= mach_read_from_4(p + FIL_PAGE_SPACE_OR_CHKSUM);
+    if (debug)
+      printf("page %lu: new style: calculated = %lu; recorded = %lu\n",
+	     page_no, csum, csumfield);
+    if (csumfield != 0 && csum != csumfield)
+    {
+      return 0;
+    }
+    return 1;
+  }
+}
+
+static
+int find_page_size(FILE *f, ulint *page_size, int *compressed, int debug)
+{
+  uchar p[UNIV_PAGE_SIZE_MAX];
+  size_t bytes;
+  ulint flags;
+  ulint zip_ssize;
+  bytes= fread(p, 1, PAGE_ZIP_MIN_SIZE, f);
+  rewind(f);
+  if (bytes != PAGE_ZIP_MIN_SIZE) {
+    fprintf(stderr, "Error in reading the first %d bytes of the ibd file.\n",
+	    PAGE_ZIP_MIN_SIZE);
+    return 0;
+  }
+
+  flags= mach_read_from_4(p + FIL_PAGE_DATA + FSP_SPACE_FLAGS);
+  zip_ssize= (flags & DICT_TF_ZSSIZE_MASK) >> DICT_TF_ZSSIZE_SHIFT;
+  if (zip_ssize) { /* table is compressed */
+    *compressed= 1;
+    *page_size= ((ulint)PAGE_ZIP_MIN_SIZE >> 1) << zip_ssize;
+    return 1;
+  }
+
+  *compressed= 0;
+  *page_size= 16384;
+
+  if (debug)
+    printf("checking if page_size is %lu\n", *page_size);
+  bytes= fread(p, 1, *page_size, f);
+  rewind(f);
+
+  if (bytes != *page_size) {
+    fprintf(stderr, "Error in reading the first %lu bytes of the ibd file.\n",
+	    *page_size);
+    return 0;
+  }
+
+  if (checksum_match(p, 0, *page_size, 0, debug)) {
+    if (debug)
+      printf("table has page size %lu and is uncompressed\n", *page_size);
+    return 1;
+  }
+
+  fprintf(stderr, "Page size can not be determined for the table\n");
+  return 0;
+}
+
 int main(int argc, char **argv)
 {
   FILE *f;                     /* our input file */
   uchar *p;                     /* storage of pages read */
-  int bytes;                   /* bytes read count */
+  size_t bytes;                /* bytes read count */
   ulint ct;                    /* current page number (0 based) */
   int now;                     /* current time */
   int lastt;                   /* last time */
-  ulint oldcsum, oldcsumfield, csum, csumfield, logseq, logseqfield; /* ulints for checksum storage */
   struct stat st;              /* for stat, if you couldn't guess */
   unsigned long long int size; /* size of file (has to be 64 bits) */
   ulint pages;                 /* number of pages in file */
@@ -227,6 +362,8 @@ int main(int argc, char **argv)
   int debug= 0;
   int c;
   int fd;
+  int compressed= 0;
+  ulint page_size= 0;
 
   /* remove arguments */
   while ((c= getopt(argc, argv, "fcvds:e:p:")) != -1)
@@ -292,8 +429,30 @@ int main(int argc, char **argv)
     perror("error statting file");
     return 1;
   }
+
+  /* open the file for reading */
+  f= fopen(argv[optind], "r");
+  if (!f)
+  {
+    perror("error opening file");
+    return 1;
+  }
+
+  if (!find_page_size(f, &page_size, &compressed, debug)) {
+    fprintf(stderr, "error in determining the page size and/or"
+	    " whether the table is in compressed format\n");
+    return 1;
+  }
+
+  if (!display_format)
+  {
+    printf("Table is %s\n", (compressed ? "compressed" : "not compressed"));
+    printf("%s size is %luK\n", (compressed ? "Key block" : "Page"),
+	   page_size >> 10);
+  }
+
   size= st.st_size;
-  pages= size / UNIV_PAGE_SIZE;
+  pages= size / page_size;
   if (just_count)
   {
     printf("%lu\n", pages);
@@ -303,14 +462,6 @@ int main(int argc, char **argv)
   {
     printf("file %s = %llu bytes (%lu pages)...\n", argv[optind], size, pages);
     printf("checking pages in range %lu to %lu\n", start_page, use_end_page ? end_page : (pages - 1));
-  }
-
-  /* open the file for reading */
-  f= fopen(argv[optind], "r");
-  if (!f)
-  {
-    perror("error opening file");
-    return 1;
   }
 
   /* seek to the necessary position, ignore with -f as we only need to read the
@@ -324,7 +475,7 @@ int main(int argc, char **argv)
       return 1;
     }
 
-    offset= (off_t)start_page * (off_t)UNIV_PAGE_SIZE;
+    offset= (off_t)start_page * (off_t)page_size;
 
     if (lseek(fd, offset, SEEK_SET) != offset)
     {
@@ -334,18 +485,20 @@ int main(int argc, char **argv)
   }
 
   /* allocate buffer for reading (so we don't realloc every time) */
-  p= (uchar *)malloc(UNIV_PAGE_SIZE);
+  p= (uchar *)malloc(page_size);
 
   /* main checksumming loop */
   ct= start_page;
   lastt= 0;
   while (!feof(f))
   {
-    bytes= fread(p, 1, UNIV_PAGE_SIZE, f);
+    bytes= fread(p, 1, page_size, f);
     if (!bytes && feof(f)) return 0;
-    if (bytes != UNIV_PAGE_SIZE)
+    if (bytes != page_size)
     {
-      fprintf(stderr, "bytes read (%d) doesn't match universal page size (%d)\n", bytes, UNIV_PAGE_SIZE);
+      fprintf(stderr,
+	      "bytes read (%lu) doesn't match universal page size (%lu)\n",
+	      (unsigned long)bytes, page_size);
       return 1;
     }
 
@@ -356,34 +509,7 @@ int main(int argc, char **argv)
       return 0;
     }
 
-    /* check the "stored log sequence numbers" */
-    logseq= mach_read_from_4(p + FIL_PAGE_LSN + 4);
-    logseqfield= mach_read_from_4(p + UNIV_PAGE_SIZE - FIL_PAGE_END_LSN_OLD_CHKSUM + 4);
-    if (debug)
-      printf("page %lu: log sequence number: first = %lu; second = %lu\n", ct, logseq, logseqfield);
-    if (logseq != logseqfield)
-    {
-      fprintf(stderr, "page %lu invalid (fails log sequence number check)\n", ct);
-      return 1;
-    }
-
-    /* check old method of checksumming */
-    oldcsum= buf_calc_page_old_checksum(p);
-    oldcsumfield= mach_read_from_4(p + UNIV_PAGE_SIZE - FIL_PAGE_END_LSN_OLD_CHKSUM);
-    if (debug)
-      printf("page %lu: old style: calculated = %lu; recorded = %lu\n", ct, oldcsum, oldcsumfield);
-    if (oldcsumfield != mach_read_from_4(p + FIL_PAGE_LSN) && oldcsumfield != oldcsum)
-    {
-      fprintf(stderr, "page %lu invalid (fails old style checksum)\n", ct);
-      return 1;
-    }
-
-    /* now check the new method */
-    csum= buf_calc_page_new_checksum(p);
-    csumfield= mach_read_from_4(p + FIL_PAGE_SPACE_OR_CHKSUM);
-    if (debug)
-      printf("page %lu: new style: calculated = %lu; recorded = %lu\n", ct, csum, csumfield);
-    if (csumfield != 0 && csum != csumfield)
+    if (!checksum_match(p, ct, page_size, compressed, debug))
     {
       fprintf(stderr, "page %lu invalid (fails new style checksum)\n", ct);
       return 1;

--- a/mysql-test/include/shutdown_mysqld.inc
+++ b/mysql-test/include/shutdown_mysqld.inc
@@ -1,0 +1,18 @@
+# This is the first half of include/restart_mysqld.inc.
+if ($rpl_inited)
+{
+  if (!$allow_rpl_inited)
+  {
+    --die ERROR IN TEST: When using the replication test framework (master-slave.inc, rpl_init.inc etc), use rpl_restart_server.inc instead of restart_mysqld.inc. If you know what you are doing and you really have to use restart_mysqld.inc, set allow_rpl_inited=1 before you source restart_mysqld.inc
+  }
+}
+
+# Write file to make mysql-test-run.pl expect the "crash", but don't start it
+--let $_server_id= `SELECT @@server_id`
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
+--exec echo "wait" > $_expect_file_name
+
+# Send shutdown to the connected server
+--shutdown_server
+--source include/wait_until_disconnected.inc
+

--- a/mysql-test/include/start_mysqld.inc
+++ b/mysql-test/include/start_mysqld.inc
@@ -1,0 +1,22 @@
+if (!$restart_parameters)
+{
+  let $restart_parameters = restart;
+}
+
+--echo # $restart_parameters
+
+# Include this script only after using shutdown_mysqld.inc
+# or kill_mysqld.inc
+# where $_expect_file_name was initialized.
+# Write file to make mysql-test-run.pl start up the server again
+--exec echo "$restart_parameters" > $_expect_file_name
+
+# Turn on reconnect
+--enable_reconnect
+
+# Call script that will poll the server waiting for it to be back online again
+--source include/wait_until_connected_again.inc
+
+# Turn off reconnect again
+--disable_reconnect
+

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -2437,6 +2437,15 @@ sub environment_setup {
   $ENV{'MYSQL_MY_PRINT_DEFAULTS'}= native_path($exe_my_print_defaults);
 
   # ----------------------------------------------------
+  # Setup env so childs can execute innochecksum
+  # ----------------------------------------------------
+  my $exe_innochecksum=
+    mtr_exe_exists(vs_config_dirs('extra', 'innochecksum'),
+                   "$path_client_bindir/innochecksum",
+                   "$basedir/extra/innochecksum");
+  $ENV{'INNOCHECKSUM'}= native_path($exe_innochecksum);
+
+  # ----------------------------------------------------
   # Setup env so childs can execute myisampack and myisamchk
   # ----------------------------------------------------
   $ENV{'MYISAMCHK'}= native_path(mtr_exe_exists(

--- a/mysql-test/suite/innodb/r/innodb-wl6045-1.result
+++ b/mysql-test/suite/innodb/r/innodb-wl6045-1.result
@@ -1,0 +1,15 @@
+SET GLOBAL innodb_file_per_table= ON;
+CREATE TABLE tab1(c1 INT PRIMARY KEY,c2 VARCHAR(20)) ENGINE=InnoDB;
+CREATE INDEX idx1 ON tab1(c2(10));
+INSERT INTO tab1 VALUES(1, 'Innochecksum InnoDB1');
+# shutdown the server
+[2]: Test for verbose short option, output from innochecksum
+# Print the verbose output
+Table is not compressed
+Page size is 16K
+file tab1.ibd = 114688 bytes (7 pages)...
+checking pages in range 0 to 6
+# Restart the server
+# restart
+DROP TABLE tab1;
+SET @@GLOBAL.innodb_file_per_table= 0;

--- a/mysql-test/suite/innodb/t/innodb-wl6045-1.test
+++ b/mysql-test/suite/innodb/t/innodb-wl6045-1.test
@@ -1,0 +1,53 @@
+#************************************************************
+# WL6045:Improve Innochecksum
+#************************************************************
+--source include/have_innodb.inc
+
+let MYSQLD_DATADIR= `SELECT @@datadir`;
+let start_innodb_file_per_table= `SELECT @@innodb_file_per_table`;
+SET GLOBAL innodb_file_per_table= ON;
+
+CREATE TABLE tab1(c1 INT PRIMARY KEY,c2 VARCHAR(20)) ENGINE=InnoDB;
+CREATE INDEX idx1 ON tab1(c2(10));
+INSERT INTO tab1 VALUES(1, 'Innochecksum InnoDB1');
+
+--echo # shutdown the server
+--source include/shutdown_mysqld.inc
+
+--echo [2]: Test for verbose short option, output from innochecksum
+--exec $INNOCHECKSUM -v $MYSQLD_DATADIR/test/tab1.ibd >$MYSQLTEST_VARDIR/tmp/ver_output
+
+perl;
+use strict;
+use warnings;
+use File::Copy;
+my $dir = $ENV{'MYSQLTEST_VARDIR'};
+opendir(DIR, $dir) or die $!;
+my $file= 'ver_output';
+# open file in write mode
+open IN_FILE,"<", "$dir/tmp/$file" or die $!;
+open OUT_FILE, ">", "$dir/tmp/tmpfile" or die $!;
+while(<IN_FILE>)
+{
+   unless ($_=~ /^debug.*$/) {
+     $_=~ s/^file.+\/(.+?)\.ibd = /file $1.ibd = /g;
+     print OUT_FILE $_;
+   }
+}
+close(IN_FILE);
+close(OUT_FILE);
+# move the new content from tmp file to the original file.
+move ("$dir/tmp/tmpfile", "$dir/tmp/$file");
+closedir(DIR);
+EOF
+
+--echo # Print the verbose output
+cat_file $MYSQLTEST_VARDIR/tmp/ver_output;
+--remove_file $MYSQLTEST_VARDIR/tmp/ver_output
+
+# Cleanup
+--echo # Restart the server
+--source include/start_mysqld.inc
+
+DROP TABLE tab1;
+eval SET @@GLOBAL.innodb_file_per_table= $start_innodb_file_per_table;

--- a/mysql-test/suite/innodb_zip/include/innodb-wl6045.inc
+++ b/mysql-test/suite/innodb_zip/include/innodb-wl6045.inc
@@ -1,0 +1,16 @@
+--echo ===> Testing  size=$size
+--disable_warnings
+--eval CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255)) ENGINE=INNODB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=$size
+--enable_warnings
+
+insert into t1 values(1,"I");
+insert into t1 values(2,"AM");
+insert into t1 values(3,"COMPRESSED");
+
+--source include/shutdown_mysqld.inc
+
+--exec $INNOCHECKSUM $MYSQLD_DATADIR/test/t1.ibd
+
+--source include/start_mysqld.inc
+select * from t1;
+drop table t1;

--- a/mysql-test/suite/innodb_zip/r/innochecksum_2.result
+++ b/mysql-test/suite/innodb_zip/r/innochecksum_2.result
@@ -1,0 +1,108 @@
+CREATE TABLE t1 (j LONGBLOB) ENGINE = InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=1;
+INSERT INTO t1 VALUES (repeat('abcdefghijklmnopqrstuvwxyz',200));
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+INSERT INTO t1 SELECT * from t1;
+# stop the server
+[2]:# Run the innochecksum when file isn't provided.
+# It will print the innochecksum usage similar to --help option.
+InnoDB offline file checksum utility.
+innochecksum [-c] [-s <start page>] [-e <end page>] [-p <page>] [-v] [-d] <filename>
+	-f	display information about the file format and exit
+	-c	print the count of pages in the file
+	-s n	start on this page number (0 based)
+	-e n	end at this page number (0 based)
+	-p n	check only this page (0 based)
+	-v	verbose (prints progress every 5 seconds)
+	-d	debug mode (prints checksums for each page)
+[3]:# check the short option for "count" and exit
+Table is compressed
+Key block size is #K
+#
+# Restart the DB server
+# restart
+DROP TABLE t1;
+[5]:# Check the innochecksum for compressed table t1 with different key_block_size
+# Test for KEY_BLOCK_SIZE=1
+===> Testing  size=1
+CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255)) ENGINE=INNODB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=1;
+insert into t1 values(1,"I");
+insert into t1 values(2,"AM");
+insert into t1 values(3,"COMPRESSED");
+Table is compressed
+Key block size is 1K
+# restart
+select * from t1;
+id	msg
+1	I
+2	AM
+3	COMPRESSED
+drop table t1;
+# Test for KEY_BLOCK_SIZE=2
+===> Testing  size=2
+CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255)) ENGINE=INNODB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=2;
+insert into t1 values(1,"I");
+insert into t1 values(2,"AM");
+insert into t1 values(3,"COMPRESSED");
+Table is compressed
+Key block size is 2K
+# restart
+select * from t1;
+id	msg
+1	I
+2	AM
+3	COMPRESSED
+drop table t1;
+# Test for for KEY_BLOCK_SIZE=4
+===> Testing  size=4
+CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255)) ENGINE=INNODB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=4;
+insert into t1 values(1,"I");
+insert into t1 values(2,"AM");
+insert into t1 values(3,"COMPRESSED");
+Table is compressed
+Key block size is 4K
+# restart
+select * from t1;
+id	msg
+1	I
+2	AM
+3	COMPRESSED
+drop table t1;
+# Test for for KEY_BLOCK_SIZE=8
+===> Testing  size=8
+CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255)) ENGINE=INNODB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+insert into t1 values(1,"I");
+insert into t1 values(2,"AM");
+insert into t1 values(3,"COMPRESSED");
+Table is compressed
+Key block size is 8K
+# restart
+select * from t1;
+id	msg
+1	I
+2	AM
+3	COMPRESSED
+drop table t1;
+# Test for KEY_BLOCK_SIZE=16
+===> Testing  size=16
+CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, msg VARCHAR(255)) ENGINE=INNODB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=16;
+insert into t1 values(1,"I");
+insert into t1 values(2,"AM");
+insert into t1 values(3,"COMPRESSED");
+Table is compressed
+Key block size is 16K
+# restart
+select * from t1;
+id	msg
+1	I
+2	AM
+3	COMPRESSED
+drop table t1;
+# Test[5] completed

--- a/mysql-test/suite/innodb_zip/t/innochecksum_2-master.opt
+++ b/mysql-test/suite/innodb_zip/t/innochecksum_2-master.opt
@@ -1,0 +1,1 @@
+--innodb-file-per-table --innodb-file-format=Barracuda

--- a/mysql-test/suite/innodb_zip/t/innochecksum_2.test
+++ b/mysql-test/suite/innodb_zip/t/innochecksum_2.test
@@ -1,0 +1,77 @@
+#************************************************************
+# WL6045:Improve Innochecksum
+#************************************************************
+--source include/have_innodb.inc
+
+let MYSQLD_DATADIR= `SELECT @@datadir`;
+
+CREATE TABLE t1 (j LONGBLOB) ENGINE = InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=1;
+INSERT INTO t1 VALUES (repeat('abcdefghijklmnopqrstuvwxyz',200));
+let $i=10;
+while ($i > 0) {
+  INSERT INTO t1 SELECT * from t1;
+  dec $i;
+}
+
+--echo # stop the server
+--source include/shutdown_mysqld.inc
+
+--echo [2]:# Run the innochecksum when file isn't provided.
+--echo # It will print the innochecksum usage similar to --help option.
+--error 1
+--exec $INNOCHECKSUM > $MYSQLTEST_VARDIR/tmp/usage.txt
+
+perl;
+use strict;
+use warnings;
+use File::Copy;
+my $dir = $ENV{'MYSQLTEST_VARDIR'};
+my $file= 'usage.txt';
+# open file in write mode
+open IN_FILE,"<", "$dir/tmp/$file" or die $!;
+open OUT_FILE, ">", "$dir/tmp/tmpfile" or die $!;
+while(<IN_FILE>) {
+ unless ($_=~ /^debug.*$/ || $_=~ /\-#, \-\-debug.*$/ || $_=~ /http:.*html/) {
+    $_=~ s/^usage.*innochecksum/innochecksum/g;
+    print OUT_FILE $_;
+ }
+}
+close(IN_FILE);
+close(OUT_FILE);
+# move the new content from tmp file to the orginal file.
+move ("$dir/tmp/tmpfile", "$dir/tmp/$file");
+EOF
+
+--cat_file $MYSQLTEST_VARDIR/tmp/usage.txt
+--remove_file $MYSQLTEST_VARDIR/tmp/usage.txt
+
+--echo [3]:# check the short option for "count" and exit
+--replace_regex /[0-9]+/#/
+--exec $INNOCHECKSUM -c $MYSQLD_DATADIR/test/t1.ibd
+
+--echo # Restart the DB server
+--source include/start_mysqld.inc
+
+DROP TABLE t1;
+
+--echo [5]:# Check the innochecksum for compressed table t1 with different key_block_size
+--echo # Test for KEY_BLOCK_SIZE=1
+--let $size=1
+--source ../include/innodb-wl6045.inc
+
+--echo # Test for KEY_BLOCK_SIZE=2
+--let $size=2
+--source ../include/innodb-wl6045.inc
+
+--echo # Test for for KEY_BLOCK_SIZE=4
+--let $size=4
+--source ../include/innodb-wl6045.inc
+
+--echo # Test for for KEY_BLOCK_SIZE=8
+--let $size=8
+--source ../include/innodb-wl6045.inc
+
+--echo # Test for KEY_BLOCK_SIZE=16
+--let $size=16
+--source ../include/innodb-wl6045.inc
+--echo # Test[5] completed


### PR DESCRIPTION
KEY_BLOCK_SIZE=4 and ROW_FORMAT=COMPRESSED).

Implement compressed table support for innochecksum by adapting a
similar patch from Facebook MySQL 5.1 at
http://bazaar.launchpad.net/~mysqlatfacebook/mysqlatfacebook/5.1/revision/3813,
and by selective backport of MySQL 5.7 innochecksum MTR tests
(WL #6045).

Changes from the Facebook patch:
- -b option was not added;
- --innodb-fast-checksum support was not added;
- support for different uncompressed InnoDB page sizes was not added;
- compilation warnings have been fixed and other minor code cleanups
  done;
- the display of the detected compression and page size has been
  conditional on -f option not being present, which would print the
  same information again.

http://jenkins.percona.com/job/percona-server-5.5-param/1105/
Also did some local runs with innochecksum debug output enabled.
