### PR TITLE
Bug 1416582: Slow query log is rotated before it should when using ma…

### DIFF
--- a/mysql-test/r/percona_bug1416582.result
+++ b/mysql-test/r/percona_bug1416582.result
@@ -1,0 +1,21 @@
+SET @old_max_slowlog_size = @@global.max_slowlog_size;
+SET @old_slow_query_log = @@global.slow_query_log;
+SET @old_slow_query_log_file = @@global.slow_query_log_file;
+SET @old_long_query_time = @@long_query_time;
+SET GLOBAL max_slowlog_size=10240000;
+SET long_query_time=0;
+SET GLOBAL slow_query_log_file='MYSQLTEST_VARDIR/abcd';
+SET GLOBAL slow_query_log=1;
+SET GLOBAL slow_query_log=0;
+SET GLOBAL slow_query_log=1;
+SET GLOBAL slow_query_log=0;
+SET GLOBAL slow_query_log=1;
+FLUSH LOGS;
+FLUSH LOGS;
+FLUSH LOGS;
+slow query log files count:
+1
+SET @@global.max_slowlog_size = @old_max_slowlog_size;
+SET @@global.slow_query_log = @old_slow_query_log;
+SET @@global.slow_query_log_file = @old_slow_query_log_file;
+SET @@long_query_time = @old_long_query_time;

--- a/mysql-test/t/percona_bug1416582.test
+++ b/mysql-test/t/percona_bug1416582.test
@@ -1,0 +1,38 @@
+#
+# Bug 1416582: Slow query log is rotated before it should
+#              when using max_slowlog_size
+#
+
+SET @old_max_slowlog_size = @@global.max_slowlog_size;
+SET @old_slow_query_log = @@global.slow_query_log;
+SET @old_slow_query_log_file = @@global.slow_query_log_file;
+SET @old_long_query_time = @@long_query_time;
+SET GLOBAL max_slowlog_size=10240000;
+SET long_query_time=0;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+eval SET GLOBAL slow_query_log_file='$MYSQLTEST_VARDIR/abcd';
+
+# start/stop slog log should not cause log number increment
+SET GLOBAL slow_query_log=1;
+SET GLOBAL slow_query_log=0;
+SET GLOBAL slow_query_log=1;
+SET GLOBAL slow_query_log=0;
+SET GLOBAL slow_query_log=1;
+
+# FLUSH LOGS should not cause log number increment
+FLUSH LOGS;
+FLUSH LOGS;
+FLUSH LOGS;
+
+--echo slow query log files count:
+perl;
+my @files = <$ENV{'MYSQLTEST_VARDIR'}/abcd*>;
+printf "%d\n", scalar(@files);
+EOF
+
+
+SET @@global.max_slowlog_size = @old_max_slowlog_size;
+SET @@global.slow_query_log = @old_slow_query_log;
+SET @@global.slow_query_log_file = @old_slow_query_log_file;
+SET @@long_query_time = @old_long_query_time;

--- a/sql/log.h
+++ b/sql/log.h
@@ -262,20 +262,18 @@ public:
             const char *log_name,
             enum_log_type log_type,
             const char *new_name,
-            enum cache_type io_cache_type_arg,
-            bool unique);
+            enum cache_type io_cache_type_arg);
   bool init_and_set_log_file_name(const char *log_name,
                                   const char *new_name,
                                   enum_log_type log_type_arg,
-                                  enum cache_type io_cache_type_arg,
-                                  bool unique);
+                                  enum cache_type io_cache_type_arg);
   void init(enum_log_type log_type_arg,
             enum cache_type io_cache_type_arg);
   void close(uint exiting);
   inline bool is_open() { return log_state != LOG_CLOSED; }
   const char *generate_name(const char *log_name, const char *suffix,
                             bool strip_ext, char *buff);
-  int generate_new_name(char *new_name, const char *log_name, bool unique);
+  int generate_new_name(char *new_name, const char *log_name);
  protected:
   /* LOCK_log is inited by init_pthread_objects() */
   mysql_mutex_t LOCK_log;
@@ -317,7 +315,7 @@ public:
                 key_file_slow_log,
 #endif
                 generate_name(log_name, "-slow.log", 0, buf),
-                LOG_NORMAL, 0, WRITE_CACHE, max_slowlog_size > 0);
+                LOG_NORMAL, 0, WRITE_CACHE);
   }
   bool open_query_log(const char *log_name)
   {
@@ -327,7 +325,7 @@ public:
                 key_file_query_log,
 #endif
                 generate_name(log_name, ".log", 0, buf),
-                LOG_NORMAL, 0, WRITE_CACHE, false);
+                LOG_NORMAL, 0, WRITE_CACHE);
   }
   int rotate(ulong max_size, bool *need_purge);
   int new_file();


### PR DESCRIPTION
…x_slowlog_size

Every time slow log file opened with max_slowlog_size > 0, new name
with next sequence number were generated.

Fix:
1. Open the last log file every time
2. Invoke rotate before actual write into slow log. This will prevent
   server from writing into overflown file.
3. Since FLUSH LOGS is essentially close and reopen, FLUSH LOGS will
   not start new slow log file.
