### PR TITLE
Bug #1409652: While selecting wrong pos with SHOW BINLOG EVENTS, it

### DIFF
--- a/mysql-test/suite/rpl/r/percona_bug1409652.result
+++ b/mysql-test/suite/rpl/r/percona_bug1409652.result
@@ -1,0 +1,14 @@
+include/master-slave.inc
+[connection master]
+CREATE TABLE t (a INT, b INT);
+INSERT INTO t (a, b) VALUES (1, 1);
+INSERT INTO t (a, b) VALUES (2, 2);
+INSERT INTO t (a, b) VALUES (3, 3);
+INSERT INTO t (a, b) VALUES (4, 4);
+INSERT INTO t (a, b) VALUES (5, 5);
+INSERT INTO t (a, b) VALUES (6, 6);
+INSERT INTO t (a, b) VALUES (7, 7);
+SHOW BINLOG EVENTS FROM 5;
+ERROR HY000: Error when executing command SHOW BINLOG EVENTS: Wrong offset or I/O error
+DROP TABLE t;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/percona_bug1409652.test
+++ b/mysql-test/suite/rpl/t/percona_bug1409652.test
@@ -1,0 +1,27 @@
+# without fix this test will fail with
+# 'Found warnings/errors in server log file!' error
+
+source include/master-slave.inc;
+
+connection master;
+
+CREATE TABLE t (a INT, b INT);
+
+INSERT INTO t (a, b) VALUES (1, 1);
+INSERT INTO t (a, b) VALUES (2, 2);
+INSERT INTO t (a, b) VALUES (3, 3);
+INSERT INTO t (a, b) VALUES (4, 4);
+INSERT INTO t (a, b) VALUES (5, 5);
+INSERT INTO t (a, b) VALUES (6, 6);
+INSERT INTO t (a, b) VALUES (7, 7);
+
+sync_slave_with_master;
+
+--error 1220
+SHOW BINLOG EVENTS FROM 5;
+
+connection master;
+
+DROP TABLE t;
+
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1200,9 +1200,18 @@ err:
   if (!res)
   {
     DBUG_ASSERT(error != 0);
-    sql_print_error("Error in Log_event::read_log_event(): "
-                    "'%s', data_len: %d, event_type: %d",
-		    error,data_len,head[EVENT_TYPE_OFFSET]);
+    /* Don't log error if read_log_event invoked from SHOW BINLOG EVENTS */
+#ifdef MYSQL_SERVER
+    THD *thd= current_thd;
+    if (!(thd && thd->lex &&
+          thd->lex->sql_command == SQLCOM_SHOW_BINLOG_EVENTS)) {
+#endif
+      sql_print_error("Error in Log_event::read_log_event(): "
+                      "'%s', data_len: %d, event_type: %d",
+		      error,data_len,head[EVENT_TYPE_OFFSET]);
+#ifdef MYSQL_SERVER
+    }
+#endif
     my_free(buf);
     /*
       The SQL slave thread will check if file->error<0 to know


### PR DESCRIPTION
fails and does give error to client and log to error log

Misleading error message logged into mysql error log when
SHOW BINLOG EVENTS invoked with wrong offset.

Fix is don't log error if read_log_event invoked from SHOW BINLOG
EVENTS
