### PR TITLE
Clarified ps_tokudb_admin messages (BLD-258)

### DIFF
--- a/scripts/ps_tokudb_admin.sh
+++ b/scripts/ps_tokudb_admin.sh
@@ -98,15 +98,15 @@ done
 
 # Make sure only root can run this script
 if [ $(id -u) -ne 0 ]; then
-  echo "This script must be run as root!" 1>&2
+  echo "ERROR: This script must be run as root!" 1>&2
   exit 1
 fi
 
 if [ $ENABLE = 1 -a $DISABLE = 1 ]; then
-  printf "Only --enable OR --disable can be specified - not both!\n"
+  printf "ERROR: Only --enable OR --disable can be specified - not both!\n"
   exit 1
 elif [ $ENABLE = 0 -a $DISABLE = 0 ]; then
-  printf "You should specify --enable or --disable option. Use --help for printing options.\n"
+  printf "ERROR: You should specify --enable or --disable option. Use --help for printing options.\n"
   exit 1
 fi
 
@@ -118,21 +118,21 @@ if [ $? -ne 0 ]; then
     cat /tmp/ps_tokudb_admin.err|grep -v "Warning:"
     rm -f /tmp/ps_tokudb_admin.err
   fi
-  printf ">> Error checking pid file location!\n";
+  printf "ERROR: Pid file location unknown!\n";
   exit 1
 fi
 PID_LOCATION=$(echo "${PID_LIST}"|grep pid_file|awk '{print $2}')
 if [ $? -ne 0 ] || [ "${PID_LOCATION}" == "" ]; then
-  printf ">> Error checking pid file location!\n";
+  printf "ERROR: Pid file location unknown!\n";
   exit 1
 fi
 PID_NUM=$(cat ${PID_LOCATION})
 JEMALLOC_STATUS=$(grep -c jemalloc /proc/${PID_NUM}/environ)
 if [ $JEMALLOC_STATUS = 0 ]; then
-  printf ">> Percona server is not running with jemalloc, please restart server to enable it and then run this script...\n\n";
+  printf "ERROR: Percona server is not running with jemalloc, please restart server to enable it and then run this script...\n\n";
   exit 1
 else
-  printf ">> Percona server is running with jemalloc enabled.\n\n";
+  printf "INFO: Percona server is running with jemalloc enabled.\n\n";
 fi
 
 # Check transparent huge pages status on the system
@@ -142,19 +142,19 @@ if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
   STATUS_THP_SYSTEM=$(echo $CONTENT_TRANSHP | grep -cv '\[never\]')
 fi
 if [ $STATUS_THP_SYSTEM = 0 ]; then
-  printf ">> Transparent huge pages are currently disabled on the system.\n\n"
+  printf "INFO: Transparent huge pages are currently disabled on the system.\n\n"
 else
-  printf ">> Transparent huge pages are enabled (should be disabled).\n\n"
+  printf "INFO: Transparent huge pages are enabled (should be disabled).\n\n"
 fi
 
 # Check thp-setting=never option in my.cnf
 printf "Checking if thp-setting=never option is already set in config file...\n"
 STATUS_THP_MYCNF=$(my_print_defaults server mysqld mysqld_safe|grep -c thp-setting=never)
 if [ $STATUS_THP_MYCNF = 0 ]; then
-  printf ">> Option thp-setting=never is not set in the config file.\n"
-  printf ">> (needed only if THP is not disabled permanently on the system)\n\n"
+  printf "INFO: Option thp-setting=never is not set in the config file.\n"
+  printf "      (needed only if THP is not disabled permanently on the system)\n\n"
 else
-  printf ">> Option thp-setting=never is set in the config file.\n\n"
+  printf "INFO: Option thp-setting=never is set in the config file.\n\n"
 fi
 
 # Check location of my.cnf
@@ -177,16 +177,16 @@ fi
 printf "Checking TokuDB plugin status...\n"
 LIST_ENGINE=$(mysql -e "show plugins;" -u $USER $PASSWORD $SOCKET $HOST $PORT 2>/dev/null)
 if [ $? -ne 0 ]; then
-  printf ">> Error checking TokuDB plugin status! Please check username, password and other options...\n";
+  printf "ERROR: Failed to check TokuDB plugin status! Please check username, password and other options...\n";
   exit 1
 fi
 STATUS_PLUGIN=$(echo "$LIST_ENGINE" | grep -c "TokuDB")
 if [ $STATUS_PLUGIN = 0 ]; then
-  printf ">> TokuDB plugin is not installed.\n\n"
+  printf "INFO: TokuDB plugin is not installed.\n\n"
 elif [ $STATUS_PLUGIN = 7 ]; then
-  printf ">> TokuDB plugin is installed.\n\n"
+  printf "INFO: TokuDB plugin is installed.\n\n"
 else
-  printf ">> TokuDB plugin is partially installed. Please cleanup manually.\n\n"
+  printf "ERROR: TokuDB plugin is partially installed. Please cleanup manually.\n\n"
   exit 1
 fi
 
@@ -201,9 +201,9 @@ if [ $ENABLE = 1 -a $STATUS_THP_SYSTEM = 1 ]; then
     echo never > /sys/kernel/mm/transparent_hugepage/enabled
   fi
   if [ $? -eq 0 ]; then
-    printf ">> Successfuly disabled transparent huge pages for this session.\n\n"
+    printf "INFO: Successfully disabled transparent huge pages for this session.\n\n"
   else
-    printf ">> Error disabling transparent huge pages for this session.\n\n"
+    printf "ERROR: Failed to disable transparent huge pages for this session.\n\n"
     exit 1
   fi
 fi
@@ -225,9 +225,9 @@ if [ $ENABLE = 1 -a $STATUS_THP_MYCNF = 0 ]; then
     sed -i "/^\[${MYSQLD_SAFE_SECTION}\]$/a thp-setting=never" $MYCNF_LOCATION
   fi
   if [ $? -eq 0 ]; then
-    printf ">> Successfuly added thp-setting=never option into $MYCNF_LOCATION\n\n";
+    printf "INFO: Successfully added thp-setting=never option into $MYCNF_LOCATION\n\n";
   else
-    printf ">> Error adding thp-setting=never option into $MYCNF_LOCATION\n\n";
+    printf "ERROR: Failed to add thp-setting=never option into $MYCNF_LOCATION\n\n";
     exit 1
   fi
 fi
@@ -237,9 +237,9 @@ if [ $DISABLE = 1 -a $STATUS_THP_MYCNF = 1 ]; then
   printf "Removing thp-setting=never option from $MYCNF_LOCATION\n"
   sed -i '/^thp-setting=never$/d' $MYCNF_LOCATION
   if [ $? -eq 0 ]; then
-    printf ">> Successfuly removed thp-setting=never option from $MYCNF_LOCATION\n\n";
+    printf "INFO: Successfully removed thp-setting=never option from $MYCNF_LOCATION\n\n";
   else
-    printf ">> Error removing thp-setting=never option from $MYCNF_LOCATION\n\n";
+    printf "ERROR: Failed to remove thp-setting=never option from $MYCNF_LOCATION\n\n";
     exit 1
   fi
 fi
@@ -257,9 +257,9 @@ INSTALL PLUGIN tokudb_locks SONAME 'ha_tokudb.so';
 INSTALL PLUGIN tokudb_lock_waits SONAME 'ha_tokudb.so';
 EOFTOKUDBENABLE
   if [ $? -eq 0 ]; then
-    printf ">> Successfuly installed TokuDB plugin.\n\n"
+    printf "INFO: Successfully installed TokuDB plugin.\n\n"
   else
-    printf ">> Error installing TokuDB plugin. Please check error log.\n\n"
+    printf "ERROR: Failed to install TokuDB plugin. Please check error log.\n\n"
     exit 1
   fi
 fi
@@ -277,9 +277,9 @@ UNINSTALL PLUGIN tokudb_locks;
 UNINSTALL PLUGIN tokudb_lock_waits;
 EOFTOKUDBDISABLE
   if [ $? -eq 0 ]; then
-    printf ">> Successfuly uninstalled TokuDB plugin.\n\n"
+    printf "INFO: Successfully uninstalled TokuDB plugin.\n\n"
   else
-    printf ">> Error uninstalling TokuDB plugin. Please check error log.\n\n"
+    printf "ERROR: Failed to uninstall TokuDB plugin. Please check error log.\n\n"
     exit 1
   fi
 fi


### PR DESCRIPTION
The script for installing/uninstalling tokudb in PS (ps_tokudb_admin) prints some info messages and it wasn't clear what was actual error and what was just info/notice.
So this is to clear it up, and some testing was done in jira ticket.
https://jira.percona.com/browse/BLD-258
