### PR TITLE
Add TokuDB HotBackup library to ld_preload (BLD-280)

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -18,6 +18,7 @@ niceness=0
 mysqld_ld_preload=
 mysqld_ld_library_path=
 load_jemalloc=1
+load_hotbackup=1
 flush_caches=0
 numa_interleave=0
 # Change (disable) transparent huge pages (TokuDB requirement)
@@ -529,6 +530,19 @@ then
       add_mysqld_ld_preload "$libjemall/libjemalloc.so.1"
       break
     fi  
+  done
+fi
+
+#
+# Add TokuDB HotBackup library to ld_preload
+#
+if test $load_hotbackup -eq 1
+then
+  for libhb in "${MY_BASEDIR_VERSION}/lib" "/usr/lib64" "/usr/lib/x86_64-linux-gnu" "/usr/lib"; do
+    if [ -r "$libhb/libHotBackup.so" ]; then
+      add_mysqld_ld_preload "$libhb/libHotBackup.so"
+      break
+    fi
   done
 fi
 


### PR DESCRIPTION
**Ticket:**
Merge ld_preload change for libHotBackup.so into mysqld_safe
https://jira.percona.com/browse/BLD-280

**Test build:**
http://jenkins.percona.com/view/Percona-RELEASES/job/percona-server-5.6-binaries-release/111/

**TEST WITHOUT LIBRARY IN THE PLACE:**
**RESULT:** mysqld_safe loads only libjemalloc.so.1 and tokudb installs normally

[vagrant@t-centos6-64 mysql]$ sudo bin/mysqld_safe --user=mysql &
[1] 3012
[vagrant@t-centos6-64 mysql]$ 150619 08:03:02 mysqld_safe Adding '/usr/local/Percona-Server-5.6.24-rel72.2-Linux.x86_64.ssl101/lib/mysql/libjemalloc.so.1' to LD_PRELOAD for mysqld
150619 08:03:02 mysqld_safe Logging to '/usr/local/Percona-Server-5.6.24-rel72.2-Linux.x86_64.ssl101/data/t-centos6-64.err'.
150619 08:03:02 mysqld_safe Starting mysqld daemon with databases from /usr/local/Percona-Server-5.6.24-rel72.2-Linux.x86_64.ssl101/data

[vagrant@t-centos6-64 mysql]$ bin/mysql -u root
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.6.24-72.2 Percona Server (GPL), Release 72.2, Revision 7da4adc

Copyright (c) 2009-2015 Percona LLC and/or its affiliates
Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> INSTALL PLUGIN tokudb SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.27 sec)

mysql> INSTALL PLUGIN tokudb_file_map SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.01 sec)

mysql> INSTALL PLUGIN tokudb_fractal_tree_info SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_fractal_tree_block_map SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_trx SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_locks SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_lock_waits SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

**TEST WITH LIBRARY IN PLACE:**
**RESULT:** mysqld_safe loads libjemalloc.so.1 and libHotBackup.so, tokudb and tokudb_backup.so install normally, backup runs

[vagrant@t-centos6-64 mysql]$ sudo bin/mysqld_safe --user=mysql &
[1] 3068
[vagrant@t-centos6-64 mysql]$ 150619 08:14:04 mysqld_safe Adding '/usr/local/Percona-Server-5.6.24-rel72.2-Linux.x86_64.ssl101/lib/mysql/libjemalloc.so.1' to LD_PRELOAD for mysqld
150619 08:14:04 mysqld_safe Adding '/usr/local/Percona-Server-5.6.24-rel72.2-Linux.x86_64.ssl101/lib/libHotBackup.so' to LD_PRELOAD for mysqld
150619 08:14:04 mysqld_safe Logging to '/usr/local/Percona-Server-5.6.24-rel72.2-Linux.x86_64.ssl101/data/t-centos6-64.err'.
150619 08:14:04 mysqld_safe Starting mysqld daemon with databases from /usr/local/Percona-Server-5.6.24-rel72.2-Linux.x86_64.ssl101/data

[vagrant@t-centos6-64 mysql]$ bin/mysql -u root
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 2
Server version: 5.6.24-72.2 Percona Server (GPL), Release 72.2, Revision 7da4adc

Copyright (c) 2009-2015 Percona LLC and/or its affiliates
Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> INSTALL PLUGIN tokudb SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.25 sec)

mysql> INSTALL PLUGIN tokudb_file_map SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.02 sec)

mysql> INSTALL PLUGIN tokudb_fractal_tree_info SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_fractal_tree_block_map SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_trx SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_locks SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> INSTALL PLUGIN tokudb_lock_waits SONAME 'ha_tokudb.so';
Query OK, 0 rows affected (0.00 sec)

mysql> install plugin tokudb_backup soname 'tokudb_backup.so';
Query OK, 0 rows affected (0.01 sec)

mysql> set tokudb_backup_dir='/tmp';
Query OK, 0 rows affected (0.46 sec)

mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so     | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| tokudb_backup                 | ACTIVE   | DAEMON             | tokudb_backup.so | GPL     |
+-------------------------------+----------+--------------------+------------------+---------+
