### PR TITLE
Apply a patch that has a high probability of fixing bug 1467760, which

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -937,11 +937,11 @@ buf_flush_write_block_low(
 	case BUF_BLOCK_ZIP_DIRTY:
 		frame = bpage->zip.data;
 
-		ut_a(page_zip_verify_checksum(frame, zip_size));
-
 		mach_write_to_8(frame + FIL_PAGE_LSN,
 				bpage->newest_modification);
 		memset(frame + FIL_PAGE_FILE_FLUSH_LSN, 0, 8);
+
+		ut_a(page_zip_verify_checksum(frame, zip_size));
 		break;
 	case BUF_BLOCK_FILE_PAGE:
 		frame = bpage->zip.data;


### PR DESCRIPTION
is an unhandled case of http://bugs.mysql.com/bug.php?id=73689: a
compressed page, which happens to checksum to zero, and whose LSN
field is still zero, would fail checksum validation. Fix by writing
LSN to the page before validating its checksum. Patch by Justin
Tolmer.

http://jenkins.percona.com/job/percona-server-5.6-param/875/
