### PR TITLE
Bug 1379582: tmp->start_utime > now_utime impossibility leading to ne…

### DIFF
--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2048,7 +2048,7 @@ int fill_schema_processlist(THD* thd, TABLE_LIST* tables, COND* cond)
       mysql_mutex_unlock(&tmp->LOCK_thd_data);
 
       /* TIME_MS */
-      table->field[8]->store(((tmp->start_utime ?
+      table->field[8]->store(((tmp->start_utime < now_utime ?
                                now_utime - tmp->start_utime : 0)/ 1000));
 
       mysql_mutex_lock(&tmp->LOCK_thd_data);


### PR DESCRIPTION
…gative TIME_MS values in processlist

fill_schema_processlist works as following:
1. Remember current time in now_utime
2. Lock LOCK_thd_remove, so threads will not be removed from the list
   of threads, but new threads can be added
3. For each thread calculate TIME_MS as now_utime - tmp->start_utime
4. Unlock LOCK_thd_remove

It is possible for the new thread to be created while we
doing 3. Natural fix would be to set TIME_MS=0 when now_utime <
tmp->start_utime.
