### PR TITLE
Bug 1379582: tmp->start_utime > now_utime impossibility leading to ne…

### DIFF
--- a/mysql-test/r/percona_bug1379582.result
+++ b/mysql-test/r/percona_bug1379582.result
@@ -1,0 +1,10 @@
+SET GLOBAL DEBUG='+d,after_thread_setup';
+SET DEBUG_SYNC='before_fill_schema_processlist
+                            SIGNAL fill_schema_processlist
+                            WAIT_FOR thread_setup';
+SELECT count(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE TIME_MS > 999999999999999;
+SET DEBUG_SYNC='now WAIT_FOR fill_schema_processlist';
+count(*)
+0
+SET DEBUG_SYNC='RESET';
+SET GLOBAL DEBUG='';

--- a/mysql-test/t/percona_bug1379582.test
+++ b/mysql-test/t/percona_bug1379582.test
@@ -1,0 +1,35 @@
+#
+# bug 1379582: tmp->start_utime > now_utime impossibility
+#              leading to negative TIME_MS values in processlist
+#
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+SET GLOBAL DEBUG='+d,after_thread_setup';
+
+connect(con_ps,localhost,root,,test);
+
+SET DEBUG_SYNC='before_fill_schema_processlist
+                            SIGNAL fill_schema_processlist
+                            WAIT_FOR thread_setup';
+
+--send SELECT count(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE TIME_MS > 999999999999999
+
+connection default;
+
+SET DEBUG_SYNC='now WAIT_FOR fill_schema_processlist';
+
+connect(con1,localhost,root,,test);
+
+connection con_ps;
+
+--reap
+
+connection default;
+
+SET DEBUG_SYNC='RESET';
+SET GLOBAL DEBUG='';
+
+disconnect con1;
+disconnect con_ps;

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -37,6 +37,7 @@
                       // reset_host_errors
 #include "sql_acl.h"  // acl_getroot, NO_ACCESS, SUPER_ACL
 #include "sql_callback.h"
+#include "debug_sync.h"
 
 
 #if defined(HAVE_OPENSSL) && !defined(EMBEDDED_LIBRARY)
@@ -1390,6 +1391,14 @@ void do_handle_one_connection(THD *thd_arg)
   thd->thread_stack= (char*) &thd;
   if (setup_connection_thread_globals(thd))
     return;
+
+  DBUG_EXECUTE_IF("after_thread_setup",
+                  {
+                  const char act[]=
+                  "now signal thread_setup";
+                  DBUG_ASSERT(!debug_sync_set_action(current_thd,
+                                                     STRING_WITH_LEN(act)));
+                  };);
 
   for (;;)
   {

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1947,6 +1947,8 @@ int fill_schema_processlist(THD* thd, TABLE_LIST* tables, COND* cond)
   ulonglong now_utime= my_micro_time_and_time(&now);
   DBUG_ENTER("fill_process_list");
 
+  DEBUG_SYNC(thd, "before_fill_schema_processlist");
+
   user= thd->security_ctx->master_access & PROCESS_ACL ?
         NullS : thd->security_ctx->priv_user;
 
@@ -2045,13 +2047,12 @@ int fill_schema_processlist(THD* thd, TABLE_LIST* tables, COND* cond)
                                    tmp->query_length()), cs);
         table->field[7]->set_notnull();
       }
-      mysql_mutex_unlock(&tmp->LOCK_thd_data);
 
       /* TIME_MS */
-      table->field[8]->store(((tmp->start_utime ?
-                               now_utime - tmp->start_utime : 0)/ 1000));
+      ulonglong tmp_start_utime= tmp->start_utime;
+      table->field[8]->store(((tmp_start_utime < now_utime ?
+                               now_utime - tmp_start_utime : 0)/ 1000));
 
-      mysql_mutex_lock(&tmp->LOCK_thd_data);
       /* ROWS_SENT */
       table->field[9]->store((ulonglong) tmp->sent_row_count);
       /* ROWS_EXAMINED */


### PR DESCRIPTION
…gative TIME_MS values in processlist

fill_schema_processlist works as following:
1. Remember current time in now_utime
2. Lock LOCK_thd_remove, so threads will not be removed from the list
   of threads, but new threads can be added
3. For each thread calculate TIME_MS as now_utime - tmp->start_utime
4. Unlock LOCK_thd_remove

It is possible for the new thread to be created while we
doing 3. Natural fix would be to set TIME_MS=0 when now_utime <
tmp->start_utime.
