### PR TITLE
Fix bug 1370002 (virtual THD::~THD(): Assertion `timer == __null'

### DIFF
--- a/mysql-test/r/max_statement_time_func.result
+++ b/mysql-test/r/max_statement_time_func.result
@@ -109,6 +109,13 @@ GET_LOCK('lock', 1)
 SELECT GET_LOCK('lock', 1);
 GET_LOCK('lock', 1)
 NULL
+XA START '';
+SET @@session.max_statement_time=65535;
+LOCK TABLES t WRITE;
+ERROR XAE07: XAER_RMFAIL: The command cannot be executed when global transaction is in the  ACTIVE state
+XA END '';
+XA PREPARE '';
+XA COMMIT '';
 SELECT RELEASE_LOCK('lock');
 RELEASE_LOCK('lock')
 1

--- a/mysql-test/t/max_statement_time_func.test
+++ b/mysql-test/t/max_statement_time_func.test
@@ -1,6 +1,7 @@
 --source include/have_statement_timeout.inc
 --source include/not_embedded.inc
 --source include/have_innodb.inc
+--source include/count_sessions.inc
 
 SET @old_session_max_statement_time = @@SESSION.max_statement_time;
 
@@ -147,8 +148,25 @@ SELECT GET_LOCK('lock', 1);
 connection con1;
 SELECT GET_LOCK('lock', 1);
 
+#
+# Bug 1370002 (virtual THD::~THD(): Assertion `timer == __null' failed in sql_class.cc:1799
+# | abort (sig=6) in THD::~THD)
+#
+
+XA START '';
+SET @@session.max_statement_time=65535;
+--error ER_XAER_RMFAIL
+# Bug case 1: early return from mysql_execute_command case SQLCOM_LOCK_TABLES
+# does not reset the timer
+LOCK TABLES t WRITE;
+XA END '';
+XA PREPARE '';
+XA COMMIT '';
 disconnect con1;
+
 connection default;
 SELECT RELEASE_LOCK('lock');
 DROP TABLE t1;
 SET @@SESSION.max_statement_time = @old_session_max_statement_time;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4198,8 +4198,12 @@ end_with_restore_list:
         Can we commit safely? If not, return to avoid releasing
         transactional metadata locks.
       */
-      if (trans_check_state(thd))
+      if (trans_check_state(thd)) {
+        /* Cannot happen, but still reset this for safety */
+        if (reset_timer)
+          reset_statement_timer(thd);
         DBUG_RETURN(-1);
+      }
       res= trans_commit_implicit(thd);
       thd->locked_tables_list.unlock_locked_tables(thd);
       thd->mdl_context.release_transactional_locks();
@@ -4242,7 +4246,11 @@ end_with_restore_list:
       transactional metadata locks.
     */
     if (trans_check_state(thd))
+    {
+      if (reset_timer)
+        reset_statement_timer(thd);
       DBUG_RETURN(-1);
+    }
     /* We must end the transaction first, regardless of anything */
     res= trans_commit_implicit(thd);
     thd->locked_tables_list.unlock_locked_tables(thd);


### PR DESCRIPTION
failed in sql_class.cc:1799 | abort (sig=6) in THD::~THD) by ensuring
that all early returns from mysql_execute_command after
set_statement_timer call do not bypass reset_statement_timer call.

Add testcase.

http://jenkins.percona.com/job/percona-server-5.6-param/892/#showFailuresLink
