### PR TITLE
Fix bug 1113388 (field.cc:3822: virtual longlong

### DIFF
--- a/mysql-test/r/percona_bug1113388.result
+++ b/mysql-test/r/percona_bug1113388.result
@@ -1,0 +1,13 @@
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+SET DEBUG_SYNC= 'after_copy_data_between_tables SIGNAL optimize_ready WAIT_FOR i_s_stopped_1';
+OPTIMIZE TABLE t1;
+SET DEBUG_SYNC= 'now WAIT_FOR optimize_ready';
+SET DEBUG_SYNC= 'fill_global_temporary_tables_before_storing_rec SIGNAL i_s_stopped_1';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+COUNT(*)
+1
+DROP TABLE t1;

--- a/mysql-test/t/percona_bug1113388.test
+++ b/mysql-test/t/percona_bug1113388.test
@@ -1,0 +1,29 @@
+#
+# Test for bug 1113388: field.cc:3822: virtual longlong Field_long::val_int(): Assertion `table->in_use == _current_thd()' failed
+#
+--source include/have_innodb.inc
+--source include/have_debug_sync.inc
+
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+SET DEBUG_SYNC= 'after_copy_data_between_tables SIGNAL optimize_ready WAIT_FOR i_s_stopped_1';
+send OPTIMIZE TABLE t1;
+
+connect (conn2,localhost,root,,);
+connection conn2;
+
+SET DEBUG_SYNC= 'now WAIT_FOR optimize_ready';
+SET DEBUG_SYNC= 'fill_global_temporary_tables_before_storing_rec SIGNAL i_s_stopped_1';
+send SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+
+connection default;
+reap;
+
+connection conn2;
+reap;
+
+disconnect conn2;
+connection default;
+
+DROP TABLE t1;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2286,6 +2286,10 @@ handler *handler::clone(const char *name, MEM_ROOT *mem_root)
      !(new_handler->ref= (uchar*) alloc_root(mem_root,
                                              ALIGN_SIZE(ref_length)*2)))
     new_handler= NULL;
+
+  if (new_handler)
+    new_handler->cloned= true;
+
   /*
     TODO: Implement a more efficient way to have more than one index open for
     the same table instance. The ha_open call is not cachable for clone.
@@ -2313,6 +2317,8 @@ void **handler::ha_data(THD *thd) const
 
 THD *handler::ha_thd(void) const
 {
+  if (unlikely(cloned))
+    return current_thd;
   DBUG_ASSERT(!table || !table->in_use || table->in_use == current_thd);
   return (table && table->in_use) ? table->in_use : current_thd;
 }

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1397,7 +1397,8 @@ public:
     locked(FALSE), implicit_emptied(0),
     pushed_cond(0), rows_read(0), rows_changed(0), next_insert_id(0), insert_id_for_cur_row(0),
     auto_inc_intervals_count(0),
-    m_psi(NULL)
+    m_psi(NULL),
+    cloned(false)
     {
       memset(index_rows_read, 0, sizeof(index_rows_read));
     }
@@ -2293,6 +2294,13 @@ private:
   { return HA_ERR_WRONG_COMMAND; }
   virtual int rename_partitions(const char *path)
   { return HA_ERR_WRONG_COMMAND; }
+
+private:
+  /**
+    If true, the current handler is a clone. In that case certain invariants
+    such as table->in_use == current_thd are relaxed to support cloning a
+    handler belonging to a different thread. */
+  bool cloned;
 };
 
 

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -3947,17 +3947,14 @@ static int fill_global_temporary_tables(THD *thd, TABLE_LIST *tables, COND *cond
       }
 #endif
 
-      THD *t= tmp->in_use;
-      tmp->in_use= thd;
+      DEBUG_SYNC(thd, "fill_global_temporary_tables_before_storing_rec");
 
       if (store_temporary_table_record(thd_item, tables->table, tmp, thd->lex->select_lex.db, table_names_only)) {
-        tmp->in_use= t;
         mysql_mutex_unlock(&thd_item->LOCK_temporary_tables);
         mysql_mutex_unlock(&LOCK_thread_count); 
         DBUG_RETURN(1);
       }
 
-      tmp->in_use= t;
     }
     mysql_mutex_unlock(&thd_item->LOCK_temporary_tables);
   }


### PR DESCRIPTION
Field_long::val_int(): Assertion `table->in_use == _current_thd()'
failed).

The problem is that INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES query
iterates through temporary tables belonging to a different thread, and
patches their in_use fields to point to the current thread
temporarily. This patching happens without any synchronizing with the
owner thread.

The fix is to stop patching in_use field for temporary tables. But
that by itself will cause asserts in the GLOBAL_TEMPORARY_TABLES
thread trying to clone and query the handler. Thus additionally
introduce a flag indicating that the handler is a clone and relax
handler::ha_thd assert in case it is.

http://jenkins.percona.com/job/percona-server-5.5-param/1133/
