### PR TITLE
Bug lp:1426345 fix. Crash in qrt plugin if prepared statement is exec…

### DIFF
--- a/plugin/query_response_time/plugin.cc
+++ b/plugin/query_response_time/plugin.cc
@@ -149,7 +149,16 @@ static void query_response_time_audit_notify(MYSQL_THD thd,
       thd->lex->sql_command;
     if (sql_command == SQLCOM_EXECUTE)
     {
-      LEX_STRING *name= &thd->lex->prepared_stmt_name;
+      const LEX_STRING *name=
+        (
+          thd->sp_runtime_ctx &&
+          thd->stmt_arena &&
+          ((sp_lex_instr *)thd->stmt_arena)->get_prepared_stmt_name()
+        )                                                               ?
+        /* If we are inside of SP */
+        ((sp_lex_instr *)thd->stmt_arena)->get_prepared_stmt_name()     :
+        /* otherwise */
+        &thd->lex->prepared_stmt_name;
       Statement *stmt=
         (Statement *)thd->stmt_map.find_by_name(name);
       sql_command= stmt->lex->sql_command;

--- a/plugin/query_response_time/tests/mtr/query_response_time-rw.result
+++ b/plugin/query_response_time/tests/mtr/query_response_time-rw.result
@@ -9,6 +9,18 @@ CREATE PROCEDURE NESTED_PROC()
 BEGIN
 SELECT DML_FUNC();
 END|
+CREATE PROCEDURE PREPARE_EXECUTE_PROC()
+BEGIN
+PREPARE p_stmt_select FROM "SELECT 1";
+PREPARE p_stmt_insert FROM "INSERT INTO t1 (b) VALUES (1), (2)";
+PREPARE p_stmt_update FROM "UPDATE t1 SET b = 1";
+EXECUTE p_stmt_select;
+EXECUTE p_stmt_insert;
+EXECUTE p_stmt_update;
+DEALLOCATE PREPARE p_stmt_select;
+DEALLOCATE PREPARE p_stmt_insert;
+DEALLOCATE PREPARE p_stmt_update;
+END|
 SET default_storage_engine=InnoDB;
 
 ============================
@@ -98,6 +110,33 @@ SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_READ WHERE count != 0;
 TIME	COUNT	TOTAL
       0.000001	1	      0.000000
       1.000000	2	      1.000000
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_WRITE WHERE count != 0;
+TIME	COUNT	TOTAL
+      1.000000	2	      1.000000
+
+==============================================
+= Test for PREPARE-EXECUTE in stored procedure
+==============================================
+
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME WHERE count != 0;
+TIME	COUNT	TOTAL
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_READ WHERE count != 0;
+TIME	COUNT	TOTAL
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_WRITE WHERE count != 0;
+TIME	COUNT	TOTAL
+------------------Test body begin--------------------
+CALL PREPARE_EXECUTE_PROC();
+1
+1
+------------------Test body end----------------------
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME WHERE count != 0;
+TIME	COUNT	TOTAL
+      0.000001	1	      0.000000
+      1.000000	10	      5.000000
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_READ WHERE count != 0;
+TIME	COUNT	TOTAL
+      0.000001	1	      0.000000
+      1.000000	8	      4.000000
 SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_WRITE WHERE count != 0;
 TIME	COUNT	TOTAL
       1.000000	2	      1.000000
@@ -203,10 +242,10 @@ TIME	COUNT	TOTAL
 BEGIN;
 SELECT * FROM t1;
 a	b
-5	1
-6	1
 7	1
 8	1
+9	1
+10	1
 COMMIT;
 ------------------Test body end----------------------
 SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME WHERE count != 0;
@@ -231,12 +270,12 @@ INSERT INTO t1 (b) VALUES (1), (2);
 UPDATE t1 SET b = 1;
 SELECT * FROM t1;
 a	b
-5	1
-6	1
 7	1
 8	1
 9	1
 10	1
+11	1
+12	1
 DELETE FROM t1;
 COMMIT;
 ------------------Test body end----------------------
@@ -479,6 +518,33 @@ SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_WRITE WHERE count != 0;
 TIME	COUNT	TOTAL
       1.000000	2	      1.000000
 
+==============================================
+= Test for PREPARE-EXECUTE in stored procedure
+==============================================
+
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME WHERE count != 0;
+TIME	COUNT	TOTAL
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_READ WHERE count != 0;
+TIME	COUNT	TOTAL
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_WRITE WHERE count != 0;
+TIME	COUNT	TOTAL
+------------------Test body begin--------------------
+CALL PREPARE_EXECUTE_PROC();
+1
+1
+------------------Test body end----------------------
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME WHERE count != 0;
+TIME	COUNT	TOTAL
+      0.000001	1	      0.000000
+      1.000000	10	      5.000000
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_READ WHERE count != 0;
+TIME	COUNT	TOTAL
+      0.000001	1	      0.000000
+      1.000000	8	      4.000000
+SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME_WRITE WHERE count != 0;
+TIME	COUNT	TOTAL
+      1.000000	2	      1.000000
+
 ============================
 = Test for 'PREPARE'
 ============================
@@ -580,10 +646,10 @@ TIME	COUNT	TOTAL
 BEGIN;
 SELECT * FROM t1;
 a	b
-5	1
-6	1
 7	1
 8	1
+9	1
+10	1
 COMMIT;
 ------------------Test body end----------------------
 SELECT * FROM INFORMATION_SCHEMA.QUERY_RESPONSE_TIME WHERE count != 0;
@@ -608,12 +674,12 @@ INSERT INTO t1 (b) VALUES (1), (2);
 UPDATE t1 SET b = 1;
 SELECT * FROM t1;
 a	b
-5	1
-6	1
 7	1
 8	1
 9	1
 10	1
+11	1
+12	1
 DELETE FROM t1;
 COMMIT;
 ------------------Test body end----------------------
@@ -763,3 +829,4 @@ DROP TABLE t2;
 SET default_storage_engine=default;
 DROP FUNCTION DML_FUNC;
 DROP PROCEDURE NESTED_PROC;
+DROP PROCEDURE PREPARE_EXECUTE_PROC;

--- a/plugin/query_response_time/tests/mtr/query_response_time-rw.test
+++ b/plugin/query_response_time/tests/mtr/query_response_time-rw.test
@@ -24,6 +24,23 @@ BEGIN
   SELECT DML_FUNC();
 END|
 
+CREATE PROCEDURE PREPARE_EXECUTE_PROC()
+BEGIN
+
+  PREPARE p_stmt_select FROM "SELECT 1";
+  PREPARE p_stmt_insert FROM "INSERT INTO t1 (b) VALUES (1), (2)";
+  PREPARE p_stmt_update FROM "UPDATE t1 SET b = 1";
+
+  EXECUTE p_stmt_select;
+  EXECUTE p_stmt_insert;
+  EXECUTE p_stmt_update;
+
+  DEALLOCATE PREPARE p_stmt_select;
+  DEALLOCATE PREPARE p_stmt_insert;
+  DEALLOCATE PREPARE p_stmt_update;
+
+END|
+
 --delimiter ;
 
 --let $i=2
@@ -88,7 +105,16 @@ while ($i)
   --source query_response_time-rw-begin.inc
   CALL NESTED_PROC();
   --source query_response_time-rw-end.inc
-  
+
+  --echo
+  --echo ==============================================
+  --echo = Test for PREPARE-EXECUTE in stored procedure
+  --echo ==============================================
+  --echo
+  --source query_response_time-rw-begin.inc
+  CALL PREPARE_EXECUTE_PROC();
+  --source query_response_time-rw-end.inc
+
   --echo
   --echo ============================
   --echo = Test for 'PREPARE'
@@ -199,3 +225,4 @@ while ($i)
 SET default_storage_engine=default;
 DROP FUNCTION DML_FUNC;
 DROP PROCEDURE NESTED_PROC;
+DROP PROCEDURE PREPARE_EXECUTE_PROC;

--- a/sql/sp_instr.h
+++ b/sql/sp_instr.h
@@ -224,6 +224,10 @@ public:
       return m_lex ? m_lex->sql_command : -1;
   }
 
+  const LEX_STRING *get_prepared_stmt_name() const {
+    return m_lex ? &m_lex->prepared_stmt_name : NULL;
+  }
+
 private:
   /**
     Prepare LEX and thread for execution of instruction, if requested open

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -994,7 +994,7 @@ public:
 
   int insert(THD *thd, Statement *statement);
 
-  Statement *find_by_name(LEX_STRING *name)
+  Statement *find_by_name(const LEX_STRING *name) const
   {
     Statement *stmt;
     stmt= (Statement*)my_hash_search(&names_hash, (uchar*)name->str,


### PR DESCRIPTION
…uted in SP

The crash happens in query_response_time_audit_notify() function because
thd->lex->prepared_stmt_name does not contain prepared statement name
if audit callback is invoked from stored procedure.

The fix is in using ((sp_lex_instr *)thd->stmt_arena)->get_prepared_stmt_name()
function for getting prepared statement name if we are inside of SP.

The additional testig is added for the case of using prepared statement inside of
SP.

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/899/
