### PR TITLE
Bug 1454441: Hanging "System Lock" when executing "flush table ... fo…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug1454441.result
+++ b/mysql-test/suite/innodb/r/percona_bug1454441.result
@@ -1,0 +1,48 @@
+SET @save_debug= @@global.debug;
+SET GLOBAL innodb_file_per_table= 1;
+SET GLOBAL innodb_monitor_enable= ibuf_size;
+DROP DATABASE IF EXISTS test_1454441;
+Warnings:
+Note	1008	Can't drop database 'test_1454441'; database doesn't exist
+CREATE DATABASE test_1454441;
+CREATE TABLE test_1454441.t1 (
+c1 BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+c2 BIGINT,
+c3 VARCHAR(2048),
+c4 VARCHAR(2048),
+INDEX idx1(c2),
+INDEX idx2(c3(512)),
+INDEX idx3(c4(512))) Engine=InnoDB;
+CREATE TABLE test_1454441.t2 (c1 INT) Engine=InnoDB;
+SET GLOBAL innodb_purge_stop_now=ON;
+SET GLOBAL innodb_disable_background_merge=ON;
+INSERT INTO test_1454441.t1(c2, c3, c4) VALUES
+(1, REPEAT('a', 2048), REPEAT('a', 2048)),
+(2, REPEAT('b', 2048), REPEAT('b', 2048)),
+(3, REPEAT('c', 2048), REPEAT('c', 2048)),
+(4, REPEAT('d', 2048), REPEAT('d', 2048));
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+DELETE FROM test_1454441.t1 WHERE c2 = 1;
+UPDATE test_1454441.t1 SET c2 = c2 + c1;
+FLUSH TABLES test_1454441.t2 FOR EXPORT;
+UNLOCK TABLES;
+FLUSH TABLES test_1454441.t1 FOR EXPORT;
+UNLOCK TABLES;
+SELECT name, count
+FROM information_schema.innodb_metrics
+WHERE name = 'ibuf_size';
+name	count
+ibuf_size	1
+DROP DATABASE test_1454441;
+SET GLOBAL innodb_purge_run_now=ON;
+SET GLOBAL INNODB_FILE_PER_TABLE= 1;
+SET GLOBAL innodb_disable_background_merge= OFF;
+SET GLOBAL innodb_purge_stop_now= OFF;
+SET GLOBAL debug= @save_debug;
+SET GLOBAL innodb_monitor_enable = default;
+Warnings:
+Warning	1230	Default value is not defined for this set option. Please specify correct counter or module name.

--- a/mysql-test/suite/innodb/t/percona_bug1454441.test
+++ b/mysql-test/suite/innodb/t/percona_bug1454441.test
@@ -1,0 +1,88 @@
+#
+# Bug 1454441: Hanging "System Lock" when executing "flush table ... for export"
+# 
+
+--source include/not_embedded.inc
+--source include/have_debug.inc
+--source include/have_innodb.inc
+
+let MYSQLD_DATADIR=`SELECT @@datadir`;
+let $innodb_file_per_table= `SELECT @@innodb_file_per_table`;
+
+SET @save_debug= @@global.debug;
+
+SET GLOBAL innodb_file_per_table= 1;
+
+SET GLOBAL innodb_monitor_enable= ibuf_size;
+
+DROP DATABASE IF EXISTS test_1454441;
+CREATE DATABASE test_1454441;
+
+#
+# Create a large table with delete marked records, disable purge during
+# the update so that we can test the IMPORT purge code.
+#
+CREATE TABLE test_1454441.t1 (
+	c1 BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+	c2 BIGINT,
+	c3 VARCHAR(2048),
+	c4 VARCHAR(2048),
+	INDEX idx1(c2),
+	INDEX idx2(c3(512)),
+	INDEX idx3(c4(512))) Engine=InnoDB;
+
+# create simple empty table
+CREATE TABLE test_1454441.t2 (c1 INT) Engine=InnoDB;
+
+# Stop purge so that it doesn't remove the delete marked entries.
+SET GLOBAL innodb_purge_stop_now=ON;
+
+# Disable change buffer merge from the master thread, additionally
+# enable aggressive flushing so that more changes are buffered.
+SET GLOBAL innodb_disable_background_merge=ON;
+
+INSERT INTO test_1454441.t1(c2, c3, c4) VALUES
+	(1, REPEAT('a', 2048), REPEAT('a', 2048)),
+	(2, REPEAT('b', 2048), REPEAT('b', 2048)),
+	(3, REPEAT('c', 2048), REPEAT('c', 2048)),
+	(4, REPEAT('d', 2048), REPEAT('d', 2048));
+
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+INSERT INTO test_1454441.t1(c2, c3, c4) SELECT c2, c3, c4 FROM test_1454441.t1;
+
+DELETE FROM test_1454441.t1 WHERE c2 = 1;
+
+UPDATE test_1454441.t1 SET c2 = c2 + c1;
+
+# Bug 1454441: FLUSH TABLE t2 FOR EXPORT hangs when there
+# are buffered changes for t1
+FLUSH TABLES test_1454441.t2 FOR EXPORT;
+UNLOCK TABLES;
+
+FLUSH TABLES test_1454441.t1 FOR EXPORT;
+UNLOCK TABLES;
+
+# IBUF size should become 1
+SELECT name, count
+  FROM information_schema.innodb_metrics
+  WHERE name = 'ibuf_size';
+
+# cleanup
+
+DROP DATABASE test_1454441;
+
+SET GLOBAL innodb_purge_run_now=ON;
+
+eval SET GLOBAL INNODB_FILE_PER_TABLE= $innodb_file_per_table;
+
+SET GLOBAL innodb_disable_background_merge= OFF;
+SET GLOBAL innodb_purge_stop_now= OFF;
+SET GLOBAL debug= @save_debug;
+SET GLOBAL innodb_monitor_enable = default;
+
+--disable_query_log
+call mtr.add_suppression("Monitor ibuf_size is already enabled");
+--enable_query_log

--- a/storage/innobase/dict/dict0stats_bg.cc
+++ b/storage/innobase/dict/dict0stats_bg.cc
@@ -352,6 +352,14 @@ DECLARE_THREAD(dict_stats_thread)(
 			break;
 		}
 
+#if defined UNIV_DEBUG || defined UNIV_IBUF_DEBUG
+		if (srv_ibuf_disable_background_merge) {
+			usleep(100000);
+			os_event_reset(dict_stats_event);
+			continue;
+		}
+#endif
+
 		dict_stats_process_entry_from_recalc_pool();
 
 		os_event_reset(dict_stats_event);

--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -2734,7 +2734,9 @@ ibuf_merge_space(
 			&pages[0], &spaces[0], &versions[0], n_pages,
 			&mtr);
 
-		++sum_sizes;
+		if (*n_pages > 0) {
+			++sum_sizes;
+		}
 	}
 
 	ibuf_mtr_commit(&mtr);


### PR DESCRIPTION
…r export"

ibuf_merge_space returns non-zero value for "volume to be merged"
even if there were no pages found in change buffer for given table
space.

Caller function rely on this value to know when to stop change buffer
merge for given table space.

As a result, FLUSH TABLE FOR EXPORT wait until change buffer becomes
empty.

ibuf_get_merge_pages can return 0 even if there are pages to merge
(*n_pages > 0). It was the reason for increment sum_sizes.

The fix is to increment "sum_sizes" only when pages were found to
merge (*n_pages > 0).
