### PR TITLE
Bug fix for lp:768038

### DIFF
--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -264,7 +264,6 @@ extern ulint	srv_ibuf_active_contract;
 extern ulint	srv_ibuf_accel_rate;
 extern ulint	srv_checkpoint_age_target;
 extern ulint	srv_flush_neighbor_pages;
-extern ulint	srv_enable_unsafe_group_commit;
 extern ulint	srv_read_ahead;
 extern ulint	srv_adaptive_flushing_method;
 

--- a/storage/innobase/srv/srv0srv.c
+++ b/storage/innobase/srv/srv0srv.c
@@ -427,7 +427,6 @@ UNIV_INTERN ulint	srv_ibuf_accel_rate = 100;
 UNIV_INTERN ulint	srv_checkpoint_age_target = 0;
 UNIV_INTERN ulint	srv_flush_neighbor_pages = 1; /* 0:disable 1:area 2:contiguous */
 
-UNIV_INTERN ulint	srv_enable_unsafe_group_commit = 0; /* 0:disable 1:enable */
 UNIV_INTERN ulint	srv_read_ahead = 3; /* 1: random  2: linear  3: Both */
 UNIV_INTERN ulint	srv_adaptive_flushing_method = 0; /* 0: native  1: estimate  2: keep_average */
 


### PR DESCRIPTION
Removed unused variable 'srv_enable_unsafe_group_commit' in 5.5 branch.
