### PR TITLE
Fix bug 1484432 (Setting innodb_log_archive crashes --innodb-read-only

### DIFF
--- a/mysql-test/suite/innodb/r/percona_log_archive_ro.result
+++ b/mysql-test/suite/innodb/r/percona_log_archive_ro.result
@@ -1,0 +1,2 @@
+SET GLOBAL innodb_log_archive=ON;
+SET GLOBAL innodb_log_archive=OFF;

--- a/mysql-test/suite/innodb/t/percona_log_archive_ro-master.opt
+++ b/mysql-test/suite/innodb/t/percona_log_archive_ro-master.opt
@@ -1,0 +1,1 @@
+--innodb-read-only

--- a/mysql-test/suite/innodb/t/percona_log_archive_ro.test
+++ b/mysql-test/suite/innodb/t/percona_log_archive_ro.test
@@ -1,0 +1,8 @@
+#
+# Test that innodb_log_archive runtime updating does not crash an --innodb-read-only server
+# (bug 1484432)
+#
+--source include/have_innodb.inc
+
+SET GLOBAL innodb_log_archive=ON;
+SET GLOBAL innodb_log_archive=OFF;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -14761,6 +14761,9 @@ innodb_log_archive_update(
 	void*				var_ptr,
 	const void*			save)
 {
+	if (srv_read_only_mode)
+		return;
+
 	my_bool	in_val = *static_cast<const my_bool*>(save);
 
 	if (in_val) {

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -3225,6 +3225,7 @@ ulint
 log_archive_noarchivelog(void)
 /*==========================*/
 {
+	ut_ad(!srv_read_only_mode);
 loop:
 	mutex_enter(&(log_sys->mutex));
 
@@ -3257,6 +3258,8 @@ ulint
 log_archive_archivelog(void)
 /*========================*/
 {
+	ut_ad(!srv_read_only_mode);
+
 	mutex_enter(&(log_sys->mutex));
 
 	if (log_sys->archiving_state == LOG_ARCH_OFF) {

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2650,24 +2650,25 @@ files_checked:
 	}
 
 #ifdef UNIV_LOG_ARCHIVE
-	/* Archiving is always off under MySQL */
-	if (!srv_log_archive_on) {
-		ut_a(DB_SUCCESS == log_archive_noarchivelog());
-	} else {
-		bool	start_archive;
+	if (!srv_read_only_mode) {
+		if (!srv_log_archive_on) {
+			ut_a(DB_SUCCESS == log_archive_noarchivelog());
+		} else {
+			bool	start_archive;
 
-		mutex_enter(&(log_sys->mutex));
+			mutex_enter(&(log_sys->mutex));
 
-		start_archive = FALSE;
+			start_archive = false;
 
-		if (log_sys->archiving_state == LOG_ARCH_OFF) {
-			start_archive = TRUE;
-		}
+			if (log_sys->archiving_state == LOG_ARCH_OFF) {
+				start_archive = true;
+			}
 
-		mutex_exit(&(log_sys->mutex));
+			mutex_exit(&(log_sys->mutex));
 
-		if (start_archive) {
-			ut_a(DB_SUCCESS == log_archive_archivelog());
+			if (start_archive) {
+				ut_a(DB_SUCCESS == log_archive_archivelog());
+			}
 		}
 	}
 #endif /* UNIV_LOG_ARCHIVE */


### PR DESCRIPTION
server | InnoDB: Failing assertion: !srv_read_only_mode in log0log.cc
line 2192).

Fix by making any log archiving state changes no-ops for
innodb-read-only servers. Add a testcase.

http://jenkins.percona.com/job/percona-server-5.6-param/920/#showFailuresLink
