### PR TITLE
Fix bug 1206008 (Failing assertion: state == TRX_STATE_NOT_STARTED in file trx0trx.ic line 60)

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2141,8 +2141,7 @@ rescan_idle:
 		mutex_enter(&trx_sys->mutex);
 		trx = UT_LIST_GET_FIRST(trx_sys->mysql_trx_list);
 		while (trx) {
-			if (!trx_state_eq(trx, TRX_STATE_NOT_STARTED)
-			    && trx_state_eq(trx, TRX_STATE_ACTIVE)
+			if (trx->state == TRX_STATE_ACTIVE
 			    && trx->mysql_thd
 			    && innobase_thd_is_idle(trx->mysql_thd)) {
 				ib_int64_t	start_time = innobase_thd_get_start_time(trx->mysql_thd);


### PR DESCRIPTION
Fixed double-checking of transaction state in "srv_error_monitor_thread" loop.

Jenkins build reference
http://jenkins.percona.com/job/percona-server-5.6-param/930/
