### PR TITLE
Fix bug 1475107 (DROP TABLE IF EXISTS may brake replication if slave has replication filters)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_bug77684.result
+++ b/mysql-test/suite/rpl/r/rpl_bug77684.result
@@ -1,0 +1,17 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE DATABASE db1;
+CREATE TABLE db1.t1a (ID bigint(20) primary key) ENGINE=InnoDB;
+CREATE TABLE db1.t2a (ID bigint(20) NOT NULL AUTO_INCREMENT, DIVISION_ID bigint(20) DEFAULT NULL, PRIMARY KEY (ID), KEY FK_T1A (DIVISION_ID), CONSTRAINT FK_T1A FOREIGN KEY (DIVISION_ID) REFERENCES db1.t1a (ID) ON DELETE CASCADE) ENGINE=InnoDB;
+DROP TABLE IF EXISTS db1.t1a;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
+USE db1;
+CREATE TABLE t1b (ID bigint(20) primary key) ENGINE=InnoDB;
+CREATE TABLE t2b (ID bigint(20) NOT NULL AUTO_INCREMENT, DIVISION_ID bigint(20) DEFAULT NULL, PRIMARY KEY (ID), KEY FK_T1B (DIVISION_ID), CONSTRAINT FK_T1B FOREIGN KEY (DIVISION_ID) REFERENCES t1b (ID) ON DELETE CASCADE) ENGINE=InnoDB;
+DROP TABLE IF EXISTS t1b;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
+DROP DATABASE db1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_bug77684-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_bug77684-slave.opt
@@ -1,0 +1,1 @@
+--replicate-ignore-db=db1 --replicate-wild-ignore-table=db1.%

--- a/mysql-test/suite/rpl/t/rpl_bug77684.test
+++ b/mysql-test/suite/rpl/t/rpl_bug77684.test
@@ -1,0 +1,34 @@
+# Test case for bug #77684 (DROP TABLE IF EXISTS may brake replication if slave has replication filters)
+--source include/master-slave.inc
+--source include/have_innodb.inc
+
+# Test A (using fully-qualified table names) 
+--connection master
+CREATE DATABASE db1;
+
+CREATE TABLE db1.t1a (ID bigint(20) primary key) ENGINE=InnoDB;
+
+CREATE TABLE db1.t2a (ID bigint(20) NOT NULL AUTO_INCREMENT, DIVISION_ID bigint(20) DEFAULT NULL, PRIMARY KEY (ID), KEY FK_T1A (DIVISION_ID), CONSTRAINT FK_T1A FOREIGN KEY (DIVISION_ID) REFERENCES db1.t1a (ID) ON DELETE CASCADE) ENGINE=InnoDB;
+
+--error ER_ROW_IS_REFERENCED
+DROP TABLE IF EXISTS db1.t1a;
+
+--sync_slave_with_master
+
+# Test B (using "USE" statement)
+--connection master
+USE db1;
+
+CREATE TABLE t1b (ID bigint(20) primary key) ENGINE=InnoDB;
+
+CREATE TABLE t2b (ID bigint(20) NOT NULL AUTO_INCREMENT, DIVISION_ID bigint(20) DEFAULT NULL, PRIMARY KEY (ID), KEY FK_T1B (DIVISION_ID), CONSTRAINT FK_T1B FOREIGN KEY (DIVISION_ID) REFERENCES t1b (ID) ON DELETE CASCADE) ENGINE=InnoDB;
+
+--error ER_ROW_IS_REFERENCED
+DROP TABLE IF EXISTS t1b;
+
+--sync_slave_with_master
+
+--connection master
+DROP DATABASE db1;
+
+--source include/rpl_end.inc

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2701,7 +2701,11 @@ mysql_execute_command(THD *thd)
         lex->sql_command != SQLCOM_ROLLBACK &&
         lex->sql_command != SQLCOM_ROLLBACK_TO_SAVEPOINT &&
         !rpl_filter->db_ok(thd->db))
+    {
+      /* we warn the slave SQL thread */
+      my_message(ER_SLAVE_IGNORED_TABLE, ER(ER_SLAVE_IGNORED_TABLE), MYF(0));
       DBUG_RETURN(0);
+    }
 
     if (lex->sql_command == SQLCOM_DROP_TRIGGER)
     {


### PR DESCRIPTION
Fixed problem introduced in commit 45424a3 with "mysql_execute_command()" returning immediately
without setting errno to ER_SLAVE_IGNORED_TABLE in case when database name is in the replication ignore list.

Jenkins build reference
http://jenkins.percona.com/job/percona-server-5.6-param/940/
