### PR TITLE
Temporarily disable savepoints in triggers and stored functions

### DIFF
--- a/mysql-test/r/savepoint_functions.result
+++ b/mysql-test/r/savepoint_functions.result
@@ -1,0 +1,19 @@
+SAVEPOINT in a stored function should be forbidden
+CREATE FUNCTION f1 () RETURNS INT BEGIN
+SAVEPOINT s;
+RETURN 1;
+END|
+SELECT f1();
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
+DROP FUNCTION f1;
+ROLLBACK TO SAVEPOINT in a stored function should be forbidden
+CREATE FUNCTION f2 () RETURNS INT BEGIN
+ROLLBACK TO SAVEPOINT s;
+RETURN 1;
+END|
+BEGIN;
+SAVEPOINT s;
+SELECT f2();
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
+COMMIT;
+DROP FUNCTION f2;

--- a/mysql-test/r/savepoint_triggers.result
+++ b/mysql-test/r/savepoint_triggers.result
@@ -1,0 +1,119 @@
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+Direct SAVEPOINT in a trigger should be forbidden
+CREATE TRIGGER i1_t1 BEFORE INSERT ON t1 FOR EACH ROW SAVEPOINT s;
+INSERT INTO t1 VALUES (1);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER i1_t1;
+CREATE TRIGGER i2_t1 AFTER INSERT ON t1 FOR EACH ROW SAVEPOINT s;
+INSERT INTO t1 VALUES (2);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER i2_t1;
+INSERT INTO t1 VALUES (3);
+CREATE TRIGGER u1_t1 BEFORE UPDATE ON t1 FOR EACH ROW SAVEPOINT s;
+UPDATE t1 SET a=4 WHERE a=3;
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER u1_t1;
+CREATE TRIGGER u2_t1 AFTER UPDATE ON t1 FOR EACH ROW SAVEPOINT s;
+UPDATE t1 SET a=4 WHERE a=3;
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER u2_t1;
+CREATE TRIGGER d1_t1 BEFORE DELETE ON t1 FOR EACH ROW SAVEPOINT s;
+DELETE FROM t1;
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER d1_t1;
+CREATE TRIGGER d1_t1 AFTER DELETE ON t1 FOR EACH ROW SAVEPOINT s;
+DELETE FROM t1;
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER d1_t1;
+SAVEPOINT in a compound statement in a trigger should be forbidden
+CREATE TRIGGER i3_t1 BEFORE INSERT ON t1 FOR EACH ROW BEGIN
+SAVEPOINT s;
+END|
+INSERT INTO t1 VALUES (5);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER i3_t1;
+SAVEPOINT in a PS call in a trigger should be forbidden
+CREATE TRIGGER i4_t1 BEFORE INSERT ON t1 FOR EACH ROW BEGIN
+PREPARE set_savepoint FROM "SAVEPOINT s";
+EXECUTE set_savepoint;
+DEALLOCATE PREPARE set_savepoint;
+END|
+ERROR 0A000: Dynamic SQL is not allowed in stored function or trigger
+SAVEPOINT in SP called from a trigger should be forbidden
+CREATE PROCEDURE p1() BEGIN
+SAVEPOINT s;
+END|
+CREATE TRIGGER i5_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p1;
+INSERT INTO t1 VALUES (6);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER i5_t1;
+SAVEPOINT in a SP called from a PS called from a trigger be forbidden
+PREPARE call_p1 FROM "CALL p1";
+CREATE TRIGGER i6_t1 BEFORE INSERT ON t1 FOR EACH ROW EXECUTE call_p1;
+ERROR 0A000: Dynamic SQL is not allowed in stored function or trigger
+SAVEPOINT in a function called from a trigger should be forbidden
+CREATE FUNCTION f1 () RETURNS INT BEGIN
+SAVEPOINT s;
+RETURN 1;
+END|
+CREATE TRIGGER i7_t1 BEFORE INSERT ON t1 FOR EACH ROW SET @foo = f1();
+INSERT INTO t1 VALUES (7);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER i7_t1;
+SAVEPOINT in a SP called from a SP called from a trigger should be forbidden
+CREATE PROCEDURE p2() BEGIN
+CALL p1();
+END|
+CREATE TRIGGER i8_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p2;
+INSERT INTO t1 VALUES (8);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER i8_t1;
+SAVEPOINT in a SP called from a trigger called from a SP should be forbidden
+CREATE TRIGGER i9_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p1;
+CREATE PROCEDURE p3() BEGIN
+INSERT INTO t1 VALUES (9);
+END|
+CALL p3();
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+DROP TRIGGER i9_t1;
+ROLLBACK TO SAVEPOINT in trigger as a trivial statement should be forbidden
+CREATE TRIGGER i4_t1 BEFORE INSERT ON t1 FOR EACH ROW ROLLBACK TO SAVEPOINT s;
+BEGIN;
+SAVEPOINT s;
+INSERT INTO t1 VALUES (5);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+COMMIT;
+DROP TRIGGER i4_t1;
+ROLLBACK TO SAVEPOINT in a trigger in a SP call should be forbidden
+CREATE PROCEDURE p4() BEGIN
+ROLLBACK TO SAVEPOINT s;
+END|
+CREATE TRIGGER i5_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p4;
+BEGIN;
+SAVEPOINT s;
+INSERT INTO t1 VALUES (6);
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
+COMMIT;
+DROP TRIGGER i5_t1;
+SAVEPOINT in a SP next to a trigger should work
+CREATE TRIGGER i6_t1 BEFORE INSERT ON t1 FOR EACH ROW SET NEW.a = NEW.a + 1;
+CREATE PROCEDURE p5() BEGIN
+SAVEPOINT s;
+INSERT INTO t1 VALUES (10);
+ROLLBACK TO SAVEPOINT s;
+END|
+BEGIN;
+CALL p5();
+COMMIT;
+DROP TRIGGER i6_t1;
+SELECT * FROM t1;
+a
+3
+DROP TABLE t1;
+DEALLOCATE PREPARE call_p1;
+DROP PROCEDURE p1;
+DROP PROCEDURE p2;
+DROP PROCEDURE p3;
+DROP PROCEDURE p4;
+DROP PROCEDURE p5;
+DROP FUNCTION f1;

--- a/mysql-test/r/sp_trans.result
+++ b/mysql-test/r/sp_trans.result
@@ -261,40 +261,37 @@ begin |
 insert into t1 values (1)|
 savepoint x|
 set @a:= bug13825_0()|
-ERROR 42000: SAVEPOINT x does not exist
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 insert into t2 values (2)|
-ERROR 42000: SAVEPOINT x does not exist
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
 set @a:= bug13825_1()|
 ERROR 42000: SAVEPOINT x does not exist
 update t2 set i = 2|
 ERROR 42000: SAVEPOINT x does not exist
 set @a:= bug13825_2()|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
 1
-2
-4
 rollback to savepoint x|
 select * from t1|
 i
 1
 delete from t2|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
 select * from t1|
 i
 1
-2
-4
 rollback to savepoint x|
 select * from t1|
 i
 1
 release savepoint x|
 set @a:= bug13825_2()|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
 1
-2
-4
 rollback to savepoint x|
 ERROR 42000: SAVEPOINT x does not exist
 delete from t1|
@@ -322,26 +319,20 @@ delete from t1|
 commit|
 set autocommit= 1|
 select bug13825_3(0)|
-bug13825_3(0)
-0
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
-1
-2
-3
 delete from t1|
 select bug13825_3(1)|
-bug13825_3(1)
-1
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
-1
-3
 delete from t1|
 set autocommit= 0|
 begin|
 insert into t1 values (1)|
 set @a:= bug13825_4()|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
 1
@@ -351,14 +342,11 @@ set autocommit= 1|
 drop table t2|
 create table t2 (i int) engine=innodb|
 insert into t1 values (1), (bug13825_5(2)), (3)|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
-1
-2
-3
 select * from t2|
 i
-3
 drop function bug13825_0|
 drop function bug13825_1|
 drop function bug13825_2|

--- a/mysql-test/suite/rpl/t/disabled.def
+++ b/mysql-test/suite/rpl/t/disabled.def
@@ -13,3 +13,7 @@
 rpl_row_create_table      : Bug#11759274 2010-02-27 andrei failed different way than earlier with bug#45576
 rpl_delayed_slave         : Bug#11764654 2010-11-09 andrei rpl_delayed_slave fails sporadically in pb
 rpl_row_binlog_max_cache_size : BUG#14126780 May 29 2012 Vasil Dimov timeout if est number of rows is 3 instead of 4
+bug-lp1464468 : percona testcase disabled until savepoints in triggers and stored functions fixed
+rpl_bug1438990_mix : percona testcase disabled until savepoints in triggers and stored functions fixed
+rpl_bug1438990_row : percona testcase disabled until savepoints in triggers and stored functions fixed
+rpl_bug1438990_stmt : percona testcase disabled until savepoints in triggers and stored functions fixed

--- a/mysql-test/t/savepoint_functions.test
+++ b/mysql-test/t/savepoint_functions.test
@@ -1,0 +1,28 @@
+--echo SAVEPOINT in a stored function should be forbidden
+--delimiter |
+CREATE FUNCTION f1 () RETURNS INT BEGIN
+       SAVEPOINT s;
+       RETURN 1;
+END|
+--delimiter ;
+
+--error ER_NOT_SUPPORTED_YET
+SELECT f1();
+
+DROP FUNCTION f1;
+
+--echo ROLLBACK TO SAVEPOINT in a stored function should be forbidden
+--delimiter |
+CREATE FUNCTION f2 () RETURNS INT BEGIN
+       ROLLBACK TO SAVEPOINT s;
+       RETURN 1;
+END|
+--delimiter ;
+
+BEGIN;
+SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+SELECT f2();
+COMMIT;
+
+DROP FUNCTION f2;

--- a/mysql-test/t/savepoint_triggers.test
+++ b/mysql-test/t/savepoint_triggers.test
@@ -1,0 +1,159 @@
+--source include/have_innodb.inc
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+
+--echo Direct SAVEPOINT in a trigger should be forbidden
+CREATE TRIGGER i1_t1 BEFORE INSERT ON t1 FOR EACH ROW SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (1);
+DROP TRIGGER i1_t1;
+
+CREATE TRIGGER i2_t1 AFTER INSERT ON t1 FOR EACH ROW SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (2);
+DROP TRIGGER i2_t1;
+
+INSERT INTO t1 VALUES (3);
+CREATE TRIGGER u1_t1 BEFORE UPDATE ON t1 FOR EACH ROW SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+UPDATE t1 SET a=4 WHERE a=3;
+DROP TRIGGER u1_t1;
+
+CREATE TRIGGER u2_t1 AFTER UPDATE ON t1 FOR EACH ROW SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+UPDATE t1 SET a=4 WHERE a=3;
+DROP TRIGGER u2_t1;
+
+CREATE TRIGGER d1_t1 BEFORE DELETE ON t1 FOR EACH ROW SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+DELETE FROM t1;
+DROP TRIGGER d1_t1;
+
+CREATE TRIGGER d1_t1 AFTER DELETE ON t1 FOR EACH ROW SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+DELETE FROM t1;
+DROP TRIGGER d1_t1;
+
+--echo SAVEPOINT in a compound statement in a trigger should be forbidden
+--delimiter |
+CREATE TRIGGER i3_t1 BEFORE INSERT ON t1 FOR EACH ROW BEGIN
+       SAVEPOINT s;
+END|
+--delimiter ;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (5);
+DROP TRIGGER i3_t1;
+
+--echo SAVEPOINT in a PS call in a trigger should be forbidden
+# echo handled by SAVEPOINT forbidden in PS
+--delimiter |
+--error ER_STMT_NOT_ALLOWED_IN_SF_OR_TRG
+CREATE TRIGGER i4_t1 BEFORE INSERT ON t1 FOR EACH ROW BEGIN
+       PREPARE set_savepoint FROM "SAVEPOINT s";
+       EXECUTE set_savepoint;
+       DEALLOCATE PREPARE set_savepoint;
+END|
+--delimiter ;
+
+--echo SAVEPOINT in SP called from a trigger should be forbidden
+--delimiter |
+CREATE PROCEDURE p1() BEGIN
+       SAVEPOINT s;
+END|
+--delimiter ;
+CREATE TRIGGER i5_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p1;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (6);
+DROP TRIGGER i5_t1;
+
+--echo SAVEPOINT in a SP called from a PS called from a trigger be forbidden
+# echo handled by SAVEPOINT forbidden in PS
+PREPARE call_p1 FROM "CALL p1";
+--error ER_STMT_NOT_ALLOWED_IN_SF_OR_TRG
+CREATE TRIGGER i6_t1 BEFORE INSERT ON t1 FOR EACH ROW EXECUTE call_p1;
+
+--echo SAVEPOINT in a function called from a trigger should be forbidden
+--delimiter |
+CREATE FUNCTION f1 () RETURNS INT BEGIN
+       SAVEPOINT s;
+       RETURN 1;
+END|
+--delimiter ;
+CREATE TRIGGER i7_t1 BEFORE INSERT ON t1 FOR EACH ROW SET @foo = f1();
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (7);
+DROP TRIGGER i7_t1;
+
+--echo SAVEPOINT in a SP called from a SP called from a trigger should be forbidden
+--delimiter |
+CREATE PROCEDURE p2() BEGIN
+       CALL p1();
+END|
+--delimiter ;
+CREATE TRIGGER i8_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p2;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (8);
+DROP TRIGGER i8_t1;
+
+--echo SAVEPOINT in a SP called from a trigger called from a SP should be forbidden
+CREATE TRIGGER i9_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p1;
+--delimiter |
+CREATE PROCEDURE p3() BEGIN
+       INSERT INTO t1 VALUES (9);
+END|
+--delimiter ;
+--error ER_NOT_SUPPORTED_YET
+CALL p3();
+DROP TRIGGER i9_t1;
+
+--echo ROLLBACK TO SAVEPOINT in trigger as a trivial statement should be forbidden
+# Trigger activation creates a new savepoint level, making the earlier levels
+# inaccessible. Thus forbidding SAVEPOINT should be enough as then there is
+# no valid savepoint to pass to ROLLBACK TO SAVEPOINT, but we forbid it once
+# more just in case.
+CREATE TRIGGER i4_t1 BEFORE INSERT ON t1 FOR EACH ROW ROLLBACK TO SAVEPOINT s;
+BEGIN;
+SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (5);
+COMMIT;
+DROP TRIGGER i4_t1;
+
+--echo ROLLBACK TO SAVEPOINT in a trigger in a SP call should be forbidden
+--delimiter |
+CREATE PROCEDURE p4() BEGIN
+       ROLLBACK TO SAVEPOINT s;
+END|
+--delimiter ;
+CREATE TRIGGER i5_t1 BEFORE INSERT ON t1 FOR EACH ROW CALL p4;
+BEGIN;
+SAVEPOINT s;
+--error ER_NOT_SUPPORTED_YET
+INSERT INTO t1 VALUES (6);
+COMMIT;
+DROP TRIGGER i5_t1;
+
+--echo SAVEPOINT in a SP next to a trigger should work
+CREATE TRIGGER i6_t1 BEFORE INSERT ON t1 FOR EACH ROW SET NEW.a = NEW.a + 1;
+--delimiter |
+CREATE PROCEDURE p5() BEGIN
+       SAVEPOINT s;
+       INSERT INTO t1 VALUES (10);
+       ROLLBACK TO SAVEPOINT s;
+END|
+--delimiter ;
+BEGIN;
+CALL p5();
+COMMIT;
+DROP TRIGGER i6_t1;
+
+SELECT * FROM t1;
+
+DROP TABLE t1;
+DEALLOCATE PREPARE call_p1;
+DROP PROCEDURE p1;
+DROP PROCEDURE p2;
+DROP PROCEDURE p3;
+DROP PROCEDURE p4;
+DROP PROCEDURE p5;
+DROP FUNCTION f1;

--- a/mysql-test/t/sp_trans.test
+++ b/mysql-test/t/sp_trans.test
@@ -281,24 +281,27 @@ set autocommit= 0|
 begin |
 insert into t1 values (1)|
 savepoint x|
---error ER_SP_DOES_NOT_EXIST
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_0()|
---error ER_SP_DOES_NOT_EXIST
+--error ER_NOT_SUPPORTED_YET
 insert into t2 values (2)|
 --error ER_SP_DOES_NOT_EXIST
 set @a:= bug13825_1()|
 --error ER_SP_DOES_NOT_EXIST
 update t2 set i = 2|
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_2()|
 select * from t1|
 rollback to savepoint x|
 select * from t1|
+--error ER_NOT_SUPPORTED_YET
 delete from t2|
 select * from t1|
 rollback to savepoint x|
 select * from t1|
 # Of course savepoints set in function should not be visible from its caller
 release savepoint x|
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_2()|
 select * from t1|
 --error ER_SP_DOES_NOT_EXIST
@@ -325,9 +328,11 @@ commit|
 set autocommit= 1|
 # Let us test that savepoints work inside of functions
 # even in auto-commit mode
+--error ER_NOT_SUPPORTED_YET
 select bug13825_3(0)|
 select * from t1|
 delete from t1|
+--error ER_NOT_SUPPORTED_YET
 select bug13825_3(1)|
 select * from t1|
 delete from t1|
@@ -336,6 +341,7 @@ delete from t1|
 set autocommit= 0|
 begin|
 insert into t1 values (1)|
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_4()|
 select * from t1|
 delete from t1|
@@ -344,6 +350,7 @@ set autocommit= 1|
 # Other curious case: savepoint in the middle of statement
 drop table t2|
 create table t2 (i int) engine=innodb|
+--error ER_NOT_SUPPORTED_YET
 insert into t1 values (1), (bug13825_5(2)), (3)|
 select * from t1|
 select * from t2|

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -7672,7 +7672,7 @@ void register_binlog_handler(THD *thd, bool trx)
     if the binary log is set as read/write.
   */
   binlog_cache_mngr *cache_mngr= thd_get_cache_mngr(thd);
-  if (cache_mngr && cache_mngr->trx_cache.get_prev_position() == MY_OFF_T_UNDEF)
+  if (cache_mngr->trx_cache.get_prev_position() == MY_OFF_T_UNDEF)
   {
     /*
       Set an implicit savepoint in order to be able to truncate a trx-cache.

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -50,8 +50,6 @@ using std::min;
 using std::max;
 using std::list;
 
-static int write_locked_table_maps(THD *thd, bool force= false);
-
 // This is a temporary backporting fix.
 #ifndef HAVE_LOG2
 /*
@@ -2138,14 +2136,6 @@ int ha_rollback_to_savepoint(THD *thd, SAVEPOINT *sv)
     status_var_increment(thd->status_var.ha_savepoint_rollback_count);
     trans->no_2pc|= ht->prepare == 0;
   }
-
-  /*
-    Write tables map once more for trigger as it will be wiped out in
-    Query_log_event::do_apply_event() on slave.
-  */
-  if (thd->in_sub_stmt == SUB_STMT_TRIGGER)
-    error= write_locked_table_maps(thd, true);
-
   /*
     rolling back the transaction in all storage engines that were not part of
     the transaction when the savepoint was set
@@ -2220,12 +2210,8 @@ int ha_savepoint(THD *thd, SAVEPOINT *sv)
   int error=0;
   THD_TRANS *trans= (thd->in_sub_stmt ? &thd->transaction.stmt :
                                         &thd->transaction.all);
-  DBUG_ENTER("ha_savepoint");
-
-  if (mysql_bin_log.is_open())
-    register_binlog_handler(thd, thd->in_multi_stmt_transaction_mode());
-
   Ha_trx_info *ha_info= trans->ha_list;
+  DBUG_ENTER("ha_savepoint");
 
   for (; ha_info; ha_info= ha_info->next())
   {
@@ -2245,14 +2231,6 @@ int ha_savepoint(THD *thd, SAVEPOINT *sv)
     }
     status_var_increment(thd->status_var.ha_savepoint_count);
   }
-
-  /*
-     Write tables map once more for trigger as it will be wiped out in
-     Query_log_event::do_apply_event() on slave.
-   */
-   if (thd->in_sub_stmt == SUB_STMT_TRIGGER)
-     error= write_locked_table_maps(thd, true);
-
   /*
     Remember the list of registered storage engines. All new
     engines are prepended to the beginning of the list.
@@ -7499,7 +7477,7 @@ static bool check_table_binlog_row_based(THD *thd, TABLE *table)
        THD::lock
 */
 
-static int write_locked_table_maps(THD *thd, bool force)
+static int write_locked_table_maps(THD *thd)
 {
   DBUG_ENTER("write_locked_table_maps");
   DBUG_PRINT("enter", ("thd: 0x%lx  thd->lock: 0x%lx "
@@ -7508,7 +7486,7 @@ static int write_locked_table_maps(THD *thd, bool force)
 
   DBUG_PRINT("debug", ("get_binlog_table_maps(): %d", thd->get_binlog_table_maps()));
 
-  if (force || (thd->get_binlog_table_maps() == 0))
+  if (thd->get_binlog_table_maps() == 0)
   {
     MYSQL_LOCK *locks[2];
     locks[0]= thd->extra_lock;

--- a/sql/transaction.cc
+++ b/sql/transaction.cc
@@ -535,6 +535,20 @@ bool trans_savepoint(THD *thd, LEX_STRING name)
       !opt_using_transactions)
     DBUG_RETURN(FALSE);
 
+  if (unlikely(thd->in_sub_stmt & SUB_STMT_TRIGGER))
+  {
+    my_error(ER_NOT_SUPPORTED_YET, MYF(0), "savepoints in triggers");
+    DBUG_RETURN(TRUE);
+  }
+
+  if (unlikely(thd->in_sub_stmt & SUB_STMT_FUNCTION))
+  {
+    my_error(ER_NOT_SUPPORTED_YET, MYF(0), "savepoints in functions");
+    DBUG_RETURN(TRUE);
+  }
+
+  DBUG_ASSERT(!thd->in_sub_stmt);
+
   enum xa_states xa_state= thd->transaction.xid_state.xa_state;
   if (xa_state != XA_NOTR && xa_state != XA_ACTIVE)
   {
@@ -618,6 +632,20 @@ bool trans_rollback_to_savepoint(THD *thd, LEX_STRING name)
   thd->transaction.stmt.dbug_unsafe_rollback_flags("stmt");
   thd->transaction.all.dbug_unsafe_rollback_flags("all");
 #endif
+
+  if (unlikely(thd->in_sub_stmt & SUB_STMT_TRIGGER))
+  {
+    my_error(ER_NOT_SUPPORTED_YET, MYF(0), "savepoints in triggers");
+    DBUG_RETURN(TRUE);
+  }
+
+  if (unlikely(thd->in_sub_stmt & SUB_STMT_FUNCTION))
+  {
+    my_error(ER_NOT_SUPPORTED_YET, MYF(0), "savepoints in functions");
+    DBUG_RETURN(TRUE);
+  }
+
+  DBUG_ASSERT(!thd->in_sub_stmt);
 
   if (sv == NULL)
   {


### PR DESCRIPTION
This implements blueprint
https://blueprints.launchpad.net/percona-server/+spec/temp-savepoint-in-triggers-functions-disable.

The reason is that even having fixed bug 1438990 and bug 1464468 we
have found more cases where savepoints in triggers break binary
logging and replication, resulting in server crashes and broken
slaves. As the feature seems to be rarely used, disable it until the
above issues are resolved properly.

Disable by returning ER_NOT_SUPPORTED_YET from trans_savepoint and
trans_rollback_to_savepoint if either is called from a trigger or a
stored function. At the same time revert the code changes for bug
1438990 and bug 1464468 while keeping but disabling their
testcases. Add savepoint_triggers and savepoint_functions testcases to
test the disabling.

http://jenkins.percona.com/job/percona-server-5.6-param/942/
