### PR TITLE
Fix to XtraDB flusher thread bugs 1491420 and 1491435

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2209,10 +2209,9 @@ Clears up tail of the LRU lists:
 * Put replaceable pages at the tail of LRU to the free list
 * Flush dirty pages at the tail of LRU to the disk
 The depth to which we scan each buffer pool is controlled by dynamic
-config parameter innodb_LRU_scan_depth.
-@return total pages flushed */
+config parameter innodb_LRU_scan_depth. */
 UNIV_INTERN
-ulint
+void
 buf_flush_LRU_tail(void)
 /*====================*/
 {
@@ -2314,8 +2313,6 @@ buf_flush_LRU_tail(void)
 			MONITOR_LRU_BATCH_PAGES,
 			total_flushed);
 	}
-
-	return(total_flushed);
 }
 
 /*********************************************************************//**
@@ -2725,7 +2722,8 @@ DECLARE_THREAD(buf_flush_page_cleaner_thread)(
 			}
 
 			/* Flush pages from flush_list if required */
-			n_flushed += page_cleaner_flush_pages_if_needed();
+			n_flushed = page_cleaner_flush_pages_if_needed();
+
 		} else {
 			n_flushed = page_cleaner_do_flush_batch(
 							PCT_IO(100),
@@ -2850,8 +2848,6 @@ DECLARE_THREAD(buf_flush_lru_manager_thread)(
 	while (srv_shutdown_state == SRV_SHUTDOWN_NONE
 	       || srv_shutdown_state == SRV_SHUTDOWN_CLEANUP) {
 
-		ulint n_flushed_lru;
-
 		srv_current_thread_priority = srv_cleaner_thread_priority;
 
 		page_cleaner_sleep_if_needed(next_loop_time);
@@ -2860,16 +2856,7 @@ DECLARE_THREAD(buf_flush_lru_manager_thread)(
 
 		next_loop_time = ut_time_ms() + lru_sleep_time;
 
-		n_flushed_lru = buf_flush_LRU_tail();
-
-		if (n_flushed_lru) {
-
-			MONITOR_INC_VALUE_CUMULATIVE(
-				MONITOR_FLUSH_BACKGROUND_TOTAL_PAGE,
-				MONITOR_FLUSH_BACKGROUND_COUNT,
-				MONITOR_FLUSH_BACKGROUND_PAGES,
-				n_flushed_lru);
-		}
+		buf_flush_LRU_tail();
 	}
 
 	buf_lru_manager_is_active = false;

--- a/storage/innobase/include/buf0flu.h
+++ b/storage/innobase/include/buf0flu.h
@@ -202,10 +202,9 @@ Clears up tail of the LRU lists:
 * Put replaceable pages at the tail of LRU to the free list
 * Flush dirty pages at the tail of LRU to the disk
 The depth to which we scan each buffer pool is controlled by dynamic
-config parameter innodb_LRU_scan_depth.
-@return total pages flushed */
+config parameter innodb_LRU_scan_depth. */
 UNIV_INTERN
-ulint
+void
 buf_flush_LRU_tail(void);
 /*====================*/
 /*********************************************************************//**


### PR DESCRIPTION
Bug 1491420 is LRU manager thread flushing being accounted to
buffer_flush_background InnoDB metrics, which is wrong (that counter
is for idle server flush list flushing), and redundant (LRU flushing
is already accounted as buffer_LRU_batches / buffer_LRU_batch_pages /
buffer_LRU_batch_total_pages). Fix by removing the redundant
accounting.

Bug 1491435 is a typo in the cleaner thread loop where n_flushed is
added to, instead of reset, by the idle server flushing. This may
cause a cleaner thread sleep skip on a non-idle server.

http://jenkins.percona.com/job/percona-server-5.6-param/944/
