### PR TITLE
- bug#1433197: handle_fatal_signal (sig=11) in ha_innobase::check |

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug_1433197.result
+++ b/mysql-test/suite/innodb/r/percona_bug_1433197.result
@@ -1,0 +1,15 @@
+call mtr.add_suppression("InnoDB: Warning: cannot find a free slot for an undo log. Do you have too");
+call mtr.add_suppression("Flagged corruption of PRIMARY in table.*in CHECK TABLE");
+call mtr.add_suppression("Cannot open table test.* from the internal data dictionary");
+use test;
+set global innodb_trx_rseg_n_slots_debug=1;
+create table t1 (a int, primary key pk(a)) engine = innodb;
+truncate table t1;
+ERROR HY000: Got error -1 from storage engine
+insert into t1 select a, b+32 from t1;
+ERROR 42S02: Table 'test.t1' doesn't exist
+check table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	error	Corrupt
+drop table t1;
+set global innodb_trx_rseg_n_slots_debug = 0;

--- a/mysql-test/suite/innodb/t/percona_bug_1433197.test
+++ b/mysql-test/suite/innodb/t/percona_bug_1433197.test
@@ -1,0 +1,41 @@
+
+# Test-case try to exercise truncate operation with limited number of rsegs
+# which then fails and mark table as corrupted. Any operation post this
+# should be blocked with safe exit. (no crash is expected)
+
+--source include/have_innodb.inc
+# we need to limit rsegs so craft a real world situation that is less likely
+# to happen but a rare possibility. limit functionality is debug only.
+--source include/have_debug.inc
+
+call mtr.add_suppression("InnoDB: Warning: cannot find a free slot for an undo log. Do you have too");
+call mtr.add_suppression("Flagged corruption of PRIMARY in table.*in CHECK TABLE");
+call mtr.add_suppression("Cannot open table test.* from the internal data dictionary");
+
+#-------------------------------------------------------------------------------
+#
+# create test-bed
+#
+let existing_rseg_slots = `select @@innodb_trx_rseg_n_slots_debug`;
+
+#-------------------------------------------------------------------------------
+#
+# Try to truncate the table. Truncate at-least need 2 rsegs to operate.
+#
+use test;
+set global innodb_trx_rseg_n_slots_debug=1;
+#
+create table t1 (a int, primary key pk(a)) engine = innodb;
+#
+--error ER_GET_ERRNO
+truncate table t1;
+--error ER_NO_SUCH_TABLE
+insert into t1 select a, b+32 from t1;
+check table t1;
+drop table t1;
+
+#-------------------------------------------------------------------------------
+#
+# cleanup test-bed
+#
+eval set global innodb_trx_rseg_n_slots_debug = $existing_rseg_slots;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12290,8 +12290,8 @@ ha_innobase::check(
 		thd_set_kill_status(user_thd);
 	}
 
-	if (UNIV_UNLIKELY(share->ib_table->is_corrupt)) {
-		return(HA_ADMIN_CORRUPT);
+	if (UNIV_UNLIKELY(prebuilt->table && prebuilt->table->corrupted)) {
+		DBUG_RETURN(HA_ADMIN_CORRUPT);
 	}
 
 	DBUG_RETURN(is_ok ? HA_ADMIN_OK : HA_ADMIN_CORRUPT);


### PR DESCRIPTION
  handler/ha_innodb.cc:12244

  Truncate of table needs at-least 2 free rseg slots.
  If the needed slots are not available then truncate would fail and
  truncate failure is non-recoverable so best it does is to mark the
  table as corrupt.

  If any follow-up api try to access the table assuming it to be
  always present that could lead to an assert.

  Bug test-case highlighted same scenario. check table api was trying
  to access the table through share->ib_table which is set to NULL if
  table is corrupt and so the crash. (Existing cache reference of
  prebuilt->table is still valid which can be used for taking decision.
  Ideally, existing cache reference should be also devalidated by
  server if open for the table fails post truncate.)
