### PR TITLE
- bug#1410410: innodb_fake_changes cause unknown error code 1000

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -678,5 +678,35 @@ SHOW INDEXES IN t3;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t3	0	PRIMARY	1	a	A	1	NULL	NULL		BTREE		
 DROP TABLE t1, t3;
+use test;
+create table t1 (i int, j blob, primary key pk(i)) engine=innodb;
+insert into t1 values (1, repeat('a', 8000));
+insert into t1 values (2, repeat('b', 8000));
+set session innodb_fake_changes = 1;
+insert into t1 values (3, repeat('c', 8000));
+ERROR HY000: Got error 131 during COMMIT
+set session innodb_fake_changes = 0;
+drop table t1;
+use test;
+create table t1 (
+i int, j varchar(500), primary key pk(i), unique index sk(j)
+) engine=innodb;
+create procedure populate_t1()
+begin
+declare i int default 1;
+while (i <= 36) DO
+insert into t1 values (i, repeat(i, 250));
+set i = i + 1;
+end while;
+end|
+begin;
+call populate_t1();
+commit;
+set session innodb_fake_changes = 1;
+insert into t1 values (37, repeat(37, 250));
+ERROR HY000: Got error 131 during COMMIT
+set session innodb_fake_changes = 0;
+drop procedure populate_t1;
+drop table t1;
 SET @@GLOBAL.userstat= default;
 SET @@GLOBAL.innodb_stats_transient_sample_pages=default;

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -14,6 +14,10 @@ SET innodb_fake_changes=default;
 SHOW VARIABLES LIKE 'innodb_fake_changes';
 SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_VARIABLES WHERE VARIABLE_NAME='innodb_fake_changes';
 
+#-------------------------------------------------------------------------------
+#
+# create test bed
+#
 --echo # Explicit COMMIT should fail when innodb_fake_changes is enabled
 --echo # DML should be fine
 SET @@GLOBAL.userstat=TRUE;
@@ -368,5 +372,56 @@ COMMIT;
 
 DROP TABLE t1, t3;
 
+#-------------------------------------------------------------------------------
+#
+# Scenario will try to insert data that will cause split of a node something
+# which will not happen in real if fake_changes = 1.
+# Note: test-case below will exercise pessmisitic insert case for 16K page
+# size but for 4K and 8K will not exercise pessmisitic insert with fake change
+# enabled but even the normal insert fail for fake_change mode.
+#
+
+# clustered index split
+use test;
+create table t1 (i int, j blob, primary key pk(i)) engine=innodb;
+insert into t1 values (1, repeat('a', 8000));
+insert into t1 values (2, repeat('b', 8000));
+set session innodb_fake_changes = 1;
+--error ER_ERROR_DURING_COMMIT
+insert into t1 values (3, repeat('c', 8000));
+set session innodb_fake_changes = 0;
+drop table t1;
+#
+#
+
+# secondary index split
+use test;
+create table t1 (
+	i int, j varchar(500), primary key pk(i), unique index sk(j)
+	) engine=innodb;
+#
+delimiter |;
+create procedure populate_t1()
+begin
+	declare i int default 1;
+	while (i <= 36) DO
+	insert into t1 values (i, repeat(i, 250));
+	set i = i + 1;
+end while;
+end|
+delimiter ;|
+#
+begin; call populate_t1(); commit;
+set session innodb_fake_changes = 1;
+--error ER_ERROR_DURING_COMMIT
+insert into t1 values (37, repeat(37, 250));
+set session innodb_fake_changes = 0;
+drop procedure populate_t1;
+drop table t1;
+
+#-------------------------------------------------------------------------------
+#
+# cleanup test bed
+#
 SET @@GLOBAL.userstat= default;
 SET @@GLOBAL.innodb_stats_transient_sample_pages=default;

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -2327,24 +2327,34 @@ row_ins_clust_index_entry_low(
 	big_rec_t*	big_rec		= NULL;
 	mtr_t		mtr;
 	mem_heap_t*	offsets_heap	= NULL;
+	ulint		search_mode;
 
 	ut_ad(dict_index_is_clust(index));
 	ut_ad(!dict_index_is_unique(index)
 	      || n_uniq == dict_index_get_n_unique(index));
 	ut_ad(!n_uniq || n_uniq == dict_index_get_n_unique(index));
 
+	/* If running with fake_changes mode on then switch from modify to
+	search so that code takes only s-latch and not x-latch.
+	For dry-run (fake-changes) s-latch is acceptable. Taking x-latch will
+	make it more restrictive and will block real changes/workflow. */
+	if (UNIV_UNLIKELY(thr_get_trx(thr)->fake_changes)) {
+		search_mode = (mode & BTR_MODIFY_TREE)
+			      ? BTR_SEARCH_TREE : BTR_SEARCH_LEAF;
+	} else {
+		search_mode = mode;
+	}
+
 	mtr_start(&mtr);
 
 	if (mode == BTR_MODIFY_LEAF && dict_index_is_online_ddl(index)) {
-		if (UNIV_UNLIKELY(thr_get_trx(thr)->fake_changes)) {
-			mode = BTR_SEARCH_LEAF | BTR_ALREADY_S_LATCHED;
-		} else {
-			mode = BTR_MODIFY_LEAF | BTR_ALREADY_S_LATCHED;
-		}
+
+		/* We really don't need to OR mode but will leave it for
+		code consistency. */
+		mode |= BTR_ALREADY_S_LATCHED;
+		search_mode |= BTR_ALREADY_S_LATCHED;
+
 		mtr_s_lock(dict_index_get_lock(index), &mtr);
-	} else if (UNIV_UNLIKELY(thr_get_trx(thr)->fake_changes)) {
-		mode = (mode & BTR_MODIFY_TREE)
-			? BTR_SEARCH_TREE : BTR_SEARCH_LEAF;
 	}
 
 	cursor.thr = thr;
@@ -2353,7 +2363,7 @@ row_ins_clust_index_entry_low(
 	the function will return in both low_match and up_match of the
 	cursor sensible values */
 
-	btr_cur_search_to_nth_level(index, 0, entry, PAGE_CUR_LE, mode,
+	btr_cur_search_to_nth_level(index, 0, entry, PAGE_CUR_LE, search_mode,
 				    &cursor, 0, __FILE__, __LINE__, &mtr);
 
 #ifdef UNIV_DEBUG
@@ -2624,7 +2634,7 @@ row_ins_sec_index_entry_low(
 	que_thr_t*	thr)	/*!< in: query thread */
 {
 	btr_cur_t	cursor;
-	ulint		search_mode	= mode | BTR_INSERT;
+	ulint		search_mode;
 	dberr_t		err		= DB_SUCCESS;
 	ulint		n_unique;
 	mtr_t		mtr;
@@ -2637,6 +2647,18 @@ row_ins_sec_index_entry_low(
 	ut_ad(thr_get_trx(thr)->id);
 	mtr_start(&mtr);
 
+	/* If running with fake_changes mode on then avoid using insert buffer
+	and also switch from modify to search so that code takes only s-latch
+	and not x-latch. For dry-run (fake-changes) s-latch is acceptable.
+	Taking x-latch will make it more restrictive and will block real
+	changes/workflow. */
+	if (UNIV_UNLIKELY(thr_get_trx(thr)->fake_changes)) {
+		search_mode = (mode & BTR_MODIFY_TREE)
+			      ? BTR_SEARCH_TREE : BTR_SEARCH_LEAF;
+	} else {
+		search_mode = mode | BTR_INSERT;
+	}
+
 	/* Ensure that we acquire index->lock when inserting into an
 	index with index->online_status == ONLINE_INDEX_COMPLETE, but
 	could still be subject to rollback_inplace_alter_table().
@@ -2644,11 +2666,24 @@ row_ins_sec_index_entry_low(
 	The memory object cannot be freed as long as we have an open
 	reference to the table, or index->table->n_ref_count > 0. */
 	const bool check = *index->name == TEMP_INDEX_PREFIX;
+
 	if (check) {
+
 		DEBUG_SYNC_C("row_ins_sec_index_enter");
-		if (mode == BTR_MODIFY_LEAF) {
+
+		/* mode = MODIFY_LEAF is synonymous to search_mode = SEARCH_LEAF
+		search_mode = SEARCH_TREE suggest operation in fake_change mode
+		so continue to s-latch in this mode too. */
+
+		if (mode == BTR_MODIFY_LEAF || search_mode == BTR_SEARCH_TREE) {
+
+			ut_ad((search_mode == BTR_SEARCH_TREE
+			       && thr_get_trx(thr)->fake_changes)
+			      || mode == BTR_MODIFY_LEAF);
+
 			search_mode |= BTR_ALREADY_S_LATCHED;
 			mtr_s_lock(dict_index_get_lock(index), &mtr);
+
 		} else {
 			mtr_x_lock(dict_index_get_lock(index), &mtr);
 		}
@@ -2659,14 +2694,13 @@ row_ins_sec_index_entry_low(
 		}
 	}
 
-	/* Note that we use PAGE_CUR_LE as the search mode, because then
-	the function will return in both low_match and up_match of the
-	cursor sensible values */
-
 	if (!thr_get_trx(thr)->check_unique_secondary) {
 		search_mode |= BTR_IGNORE_SEC_UNIQUE;
 	}
 
+	/* Note that we use PAGE_CUR_LE as the search mode, because then
+	the function will return in both low_match and up_match of the
+	cursor sensible values */
 	btr_cur_search_to_nth_level(index, 0, entry, PAGE_CUR_LE,
 				    search_mode,
 				    &cursor, 0, __FILE__, __LINE__, &mtr);
@@ -2746,10 +2780,7 @@ row_ins_sec_index_entry_low(
 
 		btr_cur_search_to_nth_level(
 			index, 0, entry, PAGE_CUR_LE,
-			UNIV_UNLIKELY(thr_get_trx(thr)->fake_changes)
-			? BTR_SEARCH_LEAF
-			: (btr_latch_mode)
-			(search_mode & ~(BTR_INSERT | BTR_IGNORE_SEC_UNIQUE)),
+			search_mode & ~(BTR_INSERT | BTR_IGNORE_SEC_UNIQUE),
 			&cursor, 0, __FILE__, __LINE__, &mtr);
 	}
 


### PR DESCRIPTION
  innodb_fake_changes allows user to dry run the workload.
  Dry run will execute the query part but will not make any modifications
  to DB there-by helping in warmup the cache. This feature eventually helps
  newly added slave to catch-up with replication faster.

  To faciliate this, search mode in-case of pessimistic insert is modified
  from BTR_MODIFY_TREE to BTR_SEARCH_TREE (newly added for this purpose).
  This mode switch takes S-latch instead of X-latch as S-latch is less
  restrictive and so is acceptable for dry-run workload requirement.

  Same search mode was used for insert too but without special handling
  in insert part and so even though pessimistic mode was invoked it caused
  optimistic insert to execute
    if (mode != BTR_MODIFY_TREE) {
        optimistic
    } else {
        pessimistic
    }

  with mode = BTR_SEARCH_TREE it defaulted to optimistic.

  We made the code consistent with previous revision to ensure that
  search_mode and mode (used for insert) are segregated to avoid re-use.
