### PR TITLE
- Bug#1426610: mtr is not committed if detect corruption in

### DIFF
--- a/mysql-test/suite/innodb/r/percona_corrupt_table_action-debug.result
+++ b/mysql-test/suite/innodb/r/percona_corrupt_table_action-debug.result
@@ -1,0 +1,23 @@
+use test;
+set global innodb_corrupt_table_action=1;
+select @@innodb_corrupt_table_action;
+@@innodb_corrupt_table_action
+warn
+create table t1 (
+a int, b char(100), primary key pk(a)) engine=innodb;
+create procedure populate_t1()
+begin
+declare i int default 1;
+while (i <= 200) DO
+insert into t1 values (i, 'a');
+set i = i + 1;
+end while;
+end|
+set session debug="+d,ib_corrupt_page_while_stats_calc";
+begin;
+call populate_t1();
+commit;
+set session debug="-d,ib_corrupt_page_while_stats_calc";
+drop procedure populate_t1;
+drop table t1;
+set global innodb_corrupt_table_action = assert;

--- a/mysql-test/suite/innodb/t/percona_corrupt_table_action-debug.test
+++ b/mysql-test/suite/innodb/t/percona_corrupt_table_action-debug.test
@@ -1,0 +1,55 @@
+# This test-case is meant to test and validate corrupt table action feature.
+# This feature allows user to control what action server takes if corrupt
+# table is found.
+
+--source include/have_innodb.inc
+--source include/have_debug.inc
+
+
+#------------------------------------------------------------------------------
+#
+# Scenarios:
+# 1. Check if injected corruption of pages during stats calculation is handled
+#
+
+#------------------------------------------------------------------------------
+#
+# Setup test environment
+#
+let save_corrupt_table_action_state = `select @@innodb_corrupt_table_action`;
+
+#------------------------------------------------------------------------------
+#
+# 1. Check if injected corruption of pages during stats calculation is handled
+#
+use test;
+set global innodb_corrupt_table_action=1;
+select @@innodb_corrupt_table_action;
+#
+create table t1 (
+	a int, b char(100), primary key pk(a)) engine=innodb;
+#
+delimiter |;
+create procedure populate_t1()
+begin
+        declare i int default 1;
+        while (i <= 200) DO
+                insert into t1 values (i, 'a');
+                set i = i + 1;
+        end while;
+end|
+delimiter ;|
+#
+set session debug="+d,ib_corrupt_page_while_stats_calc";
+begin;
+call populate_t1();
+commit;
+set session debug="-d,ib_corrupt_page_while_stats_calc";
+drop procedure populate_t1;
+drop table t1;
+
+#------------------------------------------------------------------------------
+#
+# Clearup test environment
+#
+eval set global innodb_corrupt_table_action = $save_corrupt_table_action_state;

--- a/storage/innobase/btr/btr0cur.c
+++ b/storage/innobase/btr/btr0cur.c
@@ -3882,7 +3882,14 @@ btr_estimate_number_of_different_key_vals(
 
 		page = btr_cur_get_page(&cursor);
 
-		SRV_CORRUPT_TABLE_CHECK(page, goto exit_loop;);
+		DBUG_EXECUTE_IF("ib_corrupt_page_while_stats_calc",
+				page = NULL;);
+
+		SRV_CORRUPT_TABLE_CHECK(page,
+		{
+			mtr_commit(&mtr);
+			goto exit_loop;
+		});
 
 		rec = page_rec_get_next(page_get_infimum_rec(page));
 


### PR DESCRIPTION
  btr_estimate_number_of_different_key_vals

  Starting 5.5 percona server has an option to define what happens if server
  encounters a corrupted page. (Assert/Warn/Salvage)
  (Configurable through innodb_corrupt_table_action)

  If user has configured server to Warn/Salvage then loop to estimate stats
  make a safe exit if it encounters a corrupt page.
  This safe exit path failed to close (commit) and open (started)
  mtr which would then lead to an issue while closing transaction.
