### PR TITLE
Make super_read_only work if enabled in startup params or my.cnf

### DIFF
--- a/mysql-test/include/check-warnings.test
+++ b/mysql-test/include/check-warnings.test
@@ -20,6 +20,9 @@ use mtr;
 # Allow this session to read-write even if server is started
 # with --transaction-read-only
 set session transaction read write;
+# Allow super to write
+set @original_super_read_only = @@global.super_read_only;
+set global super_read_only = 0;
 
 create temporary table error_log (
   row int auto_increment primary key,
@@ -56,6 +59,10 @@ if ($mysql_errno)
 # Call check_warnings to filter out any warning in
 # the error_log table
 call mtr.check_warnings(@result);
+
+# Restore the original value
+set @@global.super_read_only = @original_super_read_only;
+
 if (`select @result = 0`){
   skip OK;
 }

--- a/mysql-test/suite/sys_vars/r/super_read_only_func1.result
+++ b/mysql-test/suite/sys_vars/r/super_read_only_func1.result
@@ -1,0 +1,30 @@
+# startup argument: ro, sro => 1, 0
+select @@global.read_only;
+@@global.read_only
+1
+select @@global.super_read_only;
+@@global.super_read_only
+0
+drop table if exists t1;
+# operations as super user, should succeed
+create table t1(a int);
+insert into t1(a) values(1);
+insert into t1(a) values(2);
+delete from t1 where a = 1;
+select a from t1;
+a
+2
+# create normal user
+create user normal_user;
+# connecting conn with 'normal_user'
+# read table t1, should succeed
+select a from t1;
+a
+2
+# write into table t1, should not succeed
+insert into t1(a) values(3);
+ERROR HY000: The MySQL server is running with the --read-only option so it cannot execute this statement
+drop table t1;
+drop user normal_user;
+set global read_only= 1;
+set global super_read_only= 0;

--- a/mysql-test/suite/sys_vars/r/super_read_only_func2.result
+++ b/mysql-test/suite/sys_vars/r/super_read_only_func2.result
@@ -1,0 +1,13 @@
+# startup argument: ro, sro => 0, 1
+# actual: ro, sro => 1, 1
+select @@global.read_only;
+@@global.read_only
+1
+select @@global.super_read_only;
+@@global.super_read_only
+1
+# should not be able to create table as super user
+create table t1(a int);
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+set global read_only= 0;
+set global super_read_only= 1;

--- a/mysql-test/suite/sys_vars/r/super_read_only_func3.result
+++ b/mysql-test/suite/sys_vars/r/super_read_only_func3.result
@@ -1,0 +1,25 @@
+# startup argument: ro, sro => 1, 1
+select @@global.read_only;
+@@global.read_only
+1
+select @@global.super_read_only;
+@@global.super_read_only
+1
+# should not be able to create table as super user
+create table t1(a int);
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+# set super_read_only to 0
+set global super_read_only=0;
+# ro, sro => 1, 0
+select @@global.read_only;
+@@global.read_only
+1
+select @@global.super_read_only;
+@@global.super_read_only
+0
+drop table if exists t1;
+# should be able to create table as super user this time
+create table t1(a int);
+drop table t1;
+set global read_only= 1;
+set global super_read_only= 1;

--- a/mysql-test/suite/sys_vars/t/super_read_only_func1-master.opt
+++ b/mysql-test/suite/sys_vars/t/super_read_only_func1-master.opt
@@ -1,0 +1,2 @@
+--super_read_only=0
+--read_only=1

--- a/mysql-test/suite/sys_vars/t/super_read_only_func1.test
+++ b/mysql-test/suite/sys_vars/t/super_read_only_func1.test
@@ -1,0 +1,36 @@
+--source include/not_embedded.inc
+
+--echo # startup argument: ro, sro => 1, 0
+select @@global.read_only;
+select @@global.super_read_only;
+
+--disable_warnings
+drop table if exists t1;
+--enable_warnings
+
+--echo # operations as super user, should succeed
+create table t1(a int);
+insert into t1(a) values(1);
+insert into t1(a) values(2);
+delete from t1 where a = 1;
+select a from t1;
+
+--echo # create normal user
+create user normal_user;
+--echo # connecting conn with 'normal_user'
+connect (conn,localhost,normal_user,,);
+
+--echo # read table t1, should succeed
+select a from t1;
+--echo # write into table t1, should not succeed
+--Error ER_OPTION_PREVENTS_STATEMENT
+insert into t1(a) values(3);
+
+connection default;
+drop table t1;
+disconnect conn;
+drop user normal_user;
+
+# Restore the original values
+set global read_only= 1;
+set global super_read_only= 0;

--- a/mysql-test/suite/sys_vars/t/super_read_only_func2-master.opt
+++ b/mysql-test/suite/sys_vars/t/super_read_only_func2-master.opt
@@ -1,0 +1,2 @@
+--super_read_only=1
+--read_only=0

--- a/mysql-test/suite/sys_vars/t/super_read_only_func2.test
+++ b/mysql-test/suite/sys_vars/t/super_read_only_func2.test
@@ -1,0 +1,14 @@
+--source include/not_embedded.inc
+
+--echo # startup argument: ro, sro => 0, 1
+--echo # actual: ro, sro => 1, 1
+select @@global.read_only;
+select @@global.super_read_only;
+
+--echo # should not be able to create table as super user
+--Error ER_OPTION_PREVENTS_STATEMENT
+create table t1(a int);
+
+# Restore the original values
+set global read_only= 0;
+set global super_read_only= 1;

--- a/mysql-test/suite/sys_vars/t/super_read_only_func3-master.opt
+++ b/mysql-test/suite/sys_vars/t/super_read_only_func3-master.opt
@@ -1,0 +1,2 @@
+--super_read_only=1
+--read_only=1

--- a/mysql-test/suite/sys_vars/t/super_read_only_func3.test
+++ b/mysql-test/suite/sys_vars/t/super_read_only_func3.test
@@ -1,0 +1,29 @@
+--source include/not_embedded.inc
+
+--echo # startup argument: ro, sro => 1, 1
+select @@global.read_only;
+select @@global.super_read_only;
+
+--echo # should not be able to create table as super user
+--Error ER_OPTION_PREVENTS_STATEMENT
+create table t1(a int);
+
+--echo # set super_read_only to 0
+set global super_read_only=0;
+--echo # ro, sro => 1, 0
+select @@global.read_only;
+select @@global.super_read_only;
+
+--disable_warnings
+drop table if exists t1;
+--enable_warnings
+
+--echo # should be able to create table as super user this time
+create table t1(a int);
+
+drop table t1;
+
+
+# Restore the original values
+set global read_only= 1;
+set global super_read_only= 1;


### PR DESCRIPTION
Cherry-pick and squash c70dd2f4c7897734109d62f46f22751cddbb5d9a and
54340034f2416e34286a566f09f08470dfd01579 from Facebook MySQL 5.6 patch.

Summary: If super_read_only is enabled in startup params or my.cnf, read_only will be enabled as well, no matter it's enabled or disabled previously. Users could not write to the database under this circumstance.

Test Plan:
Design three unit test cases to test the super_read_only system variable when setting via startup params:
- super_read_only_func1.test: super_read_only = 0, read_only = 1.
  super user has write previlege while normal user doesn't have.
- super_read_only_func2.test: super_read_only = 1, read_only = 0.
  read_only should be automatically fixed to 1.
- super_read_only_func3.test: super_read_only = 1, read_only = 1.
  super_read_only should be able to set back to 0 by super user.

Reviewers: pengt

Reviewed By: pengt

```
http://jenkins.percona.com/job/percona-server-5.6-param/955/
```
