### PR TITLE
Packaging changes for tokutek-merge (BLD-287)

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -28,6 +28,8 @@ TAG=''
 CMAKE_BUILD_TYPE=''
 COMMON_FLAGS=''
 #
+TOKUDB_BACKUP_VERSION='@@TOKUDB_BACKUP_VERSION@@'
+#
 # Some programs that may be overriden
 TAR=${TAR:-tar}
 
@@ -173,7 +175,7 @@ export CXX=${CXX:-g++}
 # TokuDB cmake flags
 if test -d "$SOURCEDIR/storage/tokudb"
 then
-    CMAKE_OPTS="${CMAKE_OPTS:-} -DBUILD_TESTING=OFF -DUSE_GTAGS=OFF -DUSE_CTAGS=OFF -DUSE_ETAGS=OFF -DUSE_CSCOPE=OFF"
+    CMAKE_OPTS="${CMAKE_OPTS:-} -DBUILD_TESTING=OFF -DUSE_GTAGS=OFF -DUSE_CTAGS=OFF -DUSE_ETAGS=OFF -DUSE_CSCOPE=OFF -DTOKUDB_BACKUP_PLUGIN_VERSION=${TOKUDB_BACKUP_VERSION}"
     
     if test "x$CMAKE_BUILD_TYPE" != "xDebug"
     then
@@ -275,17 +277,7 @@ fi
 (
     cd "$INSTALLDIR/usr/local/"
 
-    find $PRODUCT_FULL ! -type d  ! \( -iname '*toku*' -o -iwholename '*/tokudb*/*' \) | sort > $WORKDIR_ABS/tokudb_server.list
-    $TAR --owner=0 --group=0 -czf "$WORKDIR_ABS/$PRODUCT_FULL.tar.gz" -T $WORKDIR_ABS/tokudb_server.list
-    rm -f $WORKDIR_ABS/tokudb_server.list
-
-    if test -e "$PRODUCT_FULL/lib/mysql/plugin/ha_tokudb.so"
-    then
-        TARGETTOKU=$(echo $PRODUCT_FULL | sed 's/-Linux/-TokuDB.Linux/')
-	find $PRODUCT_FULL ! -type d \( -iname '*toku*' -o -iwholename '*/tokudb*/*' \) > $WORKDIR_ABS/tokudb_plugin.list
-        $TAR --owner=0 --group=0 -czf "$WORKDIR_ABS/$TARGETTOKU.tar.gz" -T $WORKDIR_ABS/tokudb_plugin.list
-        rm -f $WORKDIR_ABS/tokudb_plugin.list
-    fi
+    $TAR --owner=0 --group=0 -czf "$WORKDIR_ABS/$PRODUCT_FULL.tar.gz" $PRODUCT_FULL
 )
 
 # Clean up

--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -30,6 +30,20 @@ Standards-Version: 3.9.4
 Homepage: http://www.percona.com/software/percona-server/
 Vcs-Bzr: lp:percona-server/5.6
 
+Package: percona-server-tokudb-5.6
+Section: database
+Architecture: any
+Depends: percona-server-server-5.6 (= ${binary:Version}), libjemalloc1 (>= 3.3.0), ${misc:Depends}
+Description: TokuDB engine plugin for Percona Server 
+ .
+ TokuDB is a storage engine for MySQL and MariaDB that is specifically 
+ designed for high performance on write-intensive workloads. It achieves 
+ this via Fractal Tree indexing. TokuDB is a scalable, ACID and MVCC compliant 
+ storage engine that provides indexing-based query improvements, offers online 
+ schema modifications, and reduces slave lag for both hard disk drives and flash memory.
+ .
+ This package includes the TokuDB plugin library.
+
 Package: libperconaserverclient18.1
 Section: libs
 Architecture: any

--- a/build-ps/debian/control.notokudb
+++ b/build-ps/debian/control.notokudb
@@ -30,20 +30,6 @@ Standards-Version: 3.9.4
 Homepage: http://www.percona.com/software/percona-server/
 Vcs-Bzr: lp:percona-server/5.6
 
-Package: percona-server-tokudb-5.6
-Section: database
-Architecture: any
-Depends: percona-server-server-5.6 (= ${binary:Version}), libjemalloc1 (>= 3.3.0), ${misc:Depends}
-Description: TokuDB engine plugin for Percona Server 
- .
- TokuDB is a storage engine for MySQL and MariaDB that is specifically 
- designed for high performance on write-intensive workloads. It achieves 
- this via Fractal Tree indexing. TokuDB is a scalable, ACID and MVCC compliant 
- storage engine that provides indexing-based query improvements, offers online 
- schema modifications, and reduces slave lag for both hard disk drives and flash memory.
- .
- This package includes the TokuDB plugin library.
-
 Package: libperconaserverclient18.1
 Section: libs
 Architecture: any

--- a/build-ps/debian/percona-server-tokudb-5.6.files
+++ b/build-ps/debian/percona-server-tokudb-5.6.files
@@ -3,3 +3,7 @@ usr/lib/mysql/plugin/debug/ha_tokudb.so
 usr/bin/tokuftdump
 usr/bin/ps_tokudb_admin
 usr/bin/tokuft_logprint
+usr/lib/*/libHotBackup.so
+usr/bin/tokuft_logprint
+usr/lib/mysql/plugin/tokudb_backup.so
+usr/lib/mysql/plugin/debug/tokudb_backup.so

--- a/build-ps/debian/rules
+++ b/build-ps/debian/rules
@@ -8,6 +8,7 @@ PS_VERSION_EXTRA = '@@PERCONA_VERSION_EXTRA@@'
 REVISION = '@@REVISION@@'
 COMPILATION_COMMENT_RELEASE = "Percona Server (GPL), Release $(PS_VERSION_EXTRA), Revision $(REVISION)"
 COMPILATION_COMMENT_DEBUG = "Percona Server - Debug (GPL), Release $(PS_VERSION_EXTRA), Revision $(REVISION)"
+TOKUDB_BACKUP_VERSION = "@@TOKUDB_BACKUP_VERSION@@"
 
 TMP=$(CURDIR)/debian/tmp/
 TMPD=$(CURDIR)/debian/tmp-debug/
@@ -28,6 +29,10 @@ DEB_NOEPOCH_VERSION ?= $(shell echo $(DEB_VERSION) | cut -d: -f2-)
 DEB_UPSTREAM_VERSION ?= $(shell echo $(DEB_NOEPOCH_VERSION) | sed 's/-[^-]*$$//')
 DEB_UPSTREAM_VERSION_MAJOR_MINOR := $(shell echo $(DEB_UPSTREAM_VERSION) | sed -r -n 's/^([0-9]+\.[0-9]+).*/\1/p')
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
+
+TOKUDB_OPTS_DEFAULT ?= -DWITH_VALGRIND=OFF -DUSE_VALGRIND=OFF -DDEBUG_EXTNAME=OFF -DBUILD_TESTING=OFF -DUSE_GTAGS=OFF -DUSE_CTAGS=OFF -DUSE_ETAGS=OFF -DUSE_CSCOPE=OFF -DTOKUDB_BACKUP_PLUGIN_VERSION=$(TOKUDB_BACKUP_VERSION)
+TOKUDB_OPTS_RELEASE ?= $(TOKUDB_OPTS_DEFAULT) -DTOKU_DEBUG_PARANOID=OFF
+TOKUDB_OPTS_DEBUG ?= $(TOKUDB_OPTS_DEFAULT) -DTOKU_DEBUG_PARANOID=ON
 
 EXPORTED_SOURCE_TARBALL = debian/percona-server-source-5.6.tar.gz
 
@@ -70,7 +75,7 @@ ifeq ($(SKIP_DEBUG_BINARY),)
 	    	CC=$${MYSQL_BUILD_CC:-gcc} \
 	    	CFLAGS=$${MYSQL_BUILD_CFLAGS:-"-g -fno-strict-aliasing"} \
 	    	CXX=$${MYSQL_BUILD_CXX:-g++} \
-	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-g -felide-constructors -fno-exceptions -fno-rtti -fno-strict-aliasing"} \
+	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-g -felide-constructors -fexceptions -fno-rtti -fno-strict-aliasing"} \
 	    cmake -DBUILD_CONFIG=mysql_release \
 		\
 		-DCMAKE_INSTALL_PREFIX=/usr \
@@ -90,7 +95,7 @@ ifeq ($(SKIP_DEBUG_BINARY),)
 		-DWITH_BLACKHOLE_STORAGE_ENGINE=ON \
 		-DWITH_FEDERATED_STORAGE_ENGINE=ON \
 		-DWITH_PAM=ON \
-		-DWITH_EXTRA_CHARSETS=all ..'
+		-DWITH_EXTRA_CHARSETS=all $(TOKUDB_OPTS_DEBUG) ..'
 endif
 
 	( test -d $(builddir) || mkdir $(builddir) ) && cd $(builddir) && \
@@ -98,7 +103,7 @@ endif
 	    	CC=$${MYSQL_BUILD_CC:-gcc} \
 	    	CFLAGS=$${MYSQL_BUILD_CFLAGS:-"-O2 -g -fno-strict-aliasing"} \
 	    	CXX=$${MYSQL_BUILD_CXX:-g++} \
-	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-O3 -g -felide-constructors -fno-exceptions -fno-rtti -fno-strict-aliasing"} \
+	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-O3 -g -felide-constructors -fexceptions -fno-rtti -fno-strict-aliasing"} \
 	    cmake -DBUILD_CONFIG=mysql_release \
 		\
 		-DCMAKE_INSTALL_PREFIX=/usr \
@@ -118,7 +123,7 @@ endif
 		-DWITH_BLACKHOLE_STORAGE_ENGINE=ON \
 		-DWITH_FEDERATED_STORAGE_ENGINE=ON \
 		-DWITH_PAM=ON \
-		-DWITH_EXTRA_CHARSETS=all ..'
+		-DWITH_EXTRA_CHARSETS=all $(TOKUDB_OPTS_RELEASE) ..'
 	touch $@
 
 build: build-arch build-indep

--- a/build-ps/debian/rules.notokudb
+++ b/build-ps/debian/rules.notokudb
@@ -70,7 +70,7 @@ ifeq ($(SKIP_DEBUG_BINARY),)
 	    	CC=$${MYSQL_BUILD_CC:-gcc} \
 	    	CFLAGS=$${MYSQL_BUILD_CFLAGS:-"-g -fno-strict-aliasing"} \
 	    	CXX=$${MYSQL_BUILD_CXX:-g++} \
-	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-g -felide-constructors -fno-exceptions -fno-rtti -fno-strict-aliasing"} \
+	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-g -felide-constructors -fexceptions -fno-rtti -fno-strict-aliasing"} \
 	    cmake -DBUILD_CONFIG=mysql_release \
 		\
 		-DCMAKE_INSTALL_PREFIX=/usr \
@@ -89,9 +89,8 @@ ifeq ($(SKIP_DEBUG_BINARY),)
 		-DWITH_ARCHIVE_STORAGE_ENGINE=ON \
 		-DWITH_BLACKHOLE_STORAGE_ENGINE=ON \
 		-DWITH_FEDERATED_STORAGE_ENGINE=ON \
-		-DWITH_PAM=ON -DWITH_EXTRA_CHARSETS=all \
-		-DWITH_VALGRIND=OFF -DUSE_VALGRIND=OFF -DDEBUG_EXTNAME=OFF -DBUILD_TESTING=OFF -DUSE_GTAGS=OFF \
-		-DUSE_CTAGS=OFF -DUSE_ETAGS=OFF -DUSE_CSCOPE=OFF -DTOKU_DEBUG_PARANOID=ON ..'
+		-DWITH_PAM=ON \
+		-DWITH_EXTRA_CHARSETS=all ..'
 endif
 
 	( test -d $(builddir) || mkdir $(builddir) ) && cd $(builddir) && \
@@ -99,7 +98,7 @@ endif
 	    	CC=$${MYSQL_BUILD_CC:-gcc} \
 	    	CFLAGS=$${MYSQL_BUILD_CFLAGS:-"-O2 -g -fno-strict-aliasing"} \
 	    	CXX=$${MYSQL_BUILD_CXX:-g++} \
-	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-O3 -g -felide-constructors -fno-exceptions -fno-rtti -fno-strict-aliasing"} \
+	    	CXXFLAGS=$${MYSQL_BUILD_CXXFLAGS:-"-O3 -g -felide-constructors -fexceptions -fno-rtti -fno-strict-aliasing"} \
 	    cmake -DBUILD_CONFIG=mysql_release \
 		\
 		-DCMAKE_INSTALL_PREFIX=/usr \
@@ -118,10 +117,8 @@ endif
 		-DWITH_ARCHIVE_STORAGE_ENGINE=ON \
 		-DWITH_BLACKHOLE_STORAGE_ENGINE=ON \
 		-DWITH_FEDERATED_STORAGE_ENGINE=ON \
-		-DWITH_PAM=ON -DWITH_EXTRA_CHARSETS=all \
-		-DWITH_VALGRIND=OFF -DUSE_VALGRIND=OFF -DDEBUG_EXTNAME=OFF -DBUILD_TESTING=OFF -DUSE_GTAGS=OFF \
-		-DUSE_CTAGS=OFF -DUSE_ETAGS=OFF -DUSE_CSCOPE=OFF -DTOKU_DEBUG_PARANOID=OFF ..'
-		
+		-DWITH_PAM=ON \
+		-DWITH_EXTRA_CHARSETS=all ..'
 	touch $@
 
 build: build-arch build-indep

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -29,6 +29,7 @@
 %define redhatversion %(lsb_release -rs | awk -F. '{ print $1}')
 %define percona_server_version @@PERCONA_VERSION@@
 %define revision @@REVISION@@
+%define tokudb_backup_version @@TOKUDB_BACKUP_VERSION@@
 
 #
 %bcond_with tokudb
@@ -46,7 +47,7 @@
 
 #
 %if %{with tokudb}
-  %define TOKUDB_FLAGS -DWITH_VALGRIND=OFF -DUSE_VALGRIND=OFF -DDEBUG_EXTNAME=OFF -DBUILD_TESTING=OFF -DUSE_GTAGS=OFF -DUSE_CTAGS=OFF -DUSE_ETAGS=OFF -DUSE_CSCOPE=OFF
+  %define TOKUDB_FLAGS -DWITH_VALGRIND=OFF -DUSE_VALGRIND=OFF -DDEBUG_EXTNAME=OFF -DBUILD_TESTING=OFF -DUSE_GTAGS=OFF -DUSE_CTAGS=OFF -DUSE_ETAGS=OFF -DUSE_CSCOPE=OFF -DTOKUDB_BACKUP_PLUGIN_VERSION=%{tokudb_backup_version}
   %define TOKUDB_DEBUG_ON -DTOKU_DEBUG_PARANOID=ON
   %define TOKUDB_DEBUG_OFF -DTOKU_DEBUG_PARANOID=OFF
 %else
@@ -260,9 +261,6 @@ Release:        %{release}
 Distribution:   %{distro_description}
 License:        Copyright (c) 2000, 2010, %{mysql_vendor}.  All rights reserved.  Use is subject to license terms.  Under %{license_type} license as shown in the Description field.
 Source:         http://www.percona.com/downloads/Percona-Server-5.6/Percona-Server-%{mysql_version}-%{percona_server_version}/source/%{src_dir}.tar.gz
-%if %{with tokudb}
-Source1:        http://www.percona.com/downloads/Percona-Server-5.6/Percona-Server-%{mysql_version}-%{percona_server_version}/source/%{src_dir}.tokudb.tar.gz
-%endif
 URL:            http://www.percona.com/
 Packager:       Percona MySQL Development Team <mysqldev@percona.com>
 Vendor:         %{percona_server_vendor}
@@ -428,9 +426,6 @@ and applications need to dynamically load and use Percona Server.
 ##############################################################################
 %prep
 %setup -n %{src_dir}
-%if %{with tokudb}
-%setup -n %{src_dir} -T -D -b 1
-%endif
 
 %if "%rhel" > "6"
 %patch0 -p1
@@ -619,7 +614,7 @@ install -D -m 0644 $MBD/build-ps/rpm/my.cnf $RBR%{_sysconfdir}/my.cnf
 %endif
 
 #
-%{__rm} -f $RBR/%{_prefix}/README*
+%{__rm} -f $RBR/%{_prefix}/README
 #
 # Delete the symlinks to the libraries from the libdir. These are created by
 # ldconfig(8) afterwards.
@@ -1409,7 +1404,8 @@ fi
 %{_libdir}/mysql/%{shared_lib_pri_name}.a
 %{_libdir}/mysql/%{shared_lib_pri_name}_r.a
 %{_libdir}/mysql/libmysqlservices.a
-%{_libdir}/*.so
+%{_libdir}/%{shared_lib_pri_name}.so
+%{_libdir}/%{shared_lib_pri_name}_r.so
 
 %post -n Percona-Server-devel%{product_suffix}
 # For compatibility after reverting name to libmysql
@@ -1436,6 +1432,14 @@ done
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/ha_tokudb.so
 %attr(755, root, root) %{_bindir}/ps_tokudb_admin
 %attr(755, root, root) %{_bindir}/tokuft_logprint
+%attr(755, root, root) %{_libdir}/mysql/plugin/tokudb_backup.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/debug/tokudb_backup.so
+%attr(755, root, root) %{_libdir}/libHotBackup.so
+%{_includedir}/backup.h
+%doc %{_prefix}/README.md
+%doc %{_prefix}/COPYING.AGPLv3
+%doc %{_prefix}/COPYING.GPLv2
+%doc %{_prefix}/PATENTS
 %endif
 
 # ----------------------------------------------------------------------------

--- a/plugin/tokudb-backup-plugin/CMakeLists.txt
+++ b/plugin/tokudb-backup-plugin/CMakeLists.txt
@@ -1,3 +1,19 @@
+# TokuDB only supports x86-64 and cmake-2.8.9+
+IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" AND
+    NOT CMAKE_VERSION VERSION_LESS "2.8.9" AND
+   NOT WITHOUT_TOKUDB AND NOT WITHOUT_TOKUDB_STORAGE_ENGINE)
+CHECK_CXX_SOURCE_COMPILES(
+"
+struct a {int b; int c; };
+struct a d = { .b=1, .c=2 };
+int main() { return 0; }
+" TOKUDB_OK)
+ENDIF()
+
+IF(NOT TOKUDB_OK)
+  RETURN()
+ENDIF()
+
 # disable -Wvla
 include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
@@ -33,4 +49,9 @@ ELSE()
   MESSAGE(STATUS "tokudb-backup-plugin no backup ${CMAKE_CURRENT_SOURCE_DIR}")
 ENDIF()
 MYSQL_ADD_PLUGIN(tokudb_backup ${TOKUDB_BACKUP_SOURCES} MODULE_ONLY MODULE_OUTPUT_NAME "tokudb_backup")
-INSTALL(FILES README_tokudb_backup DESTINATION ${INSTALL_DOCDIR})
+#
+# RPM installs documentation directly from the source tree
+#
+IF(NOT INSTALL_LAYOUT MATCHES "RPM")
+  INSTALL(FILES README_tokudb_backup DESTINATION ${INSTALL_DOCDIR})
+ENDIF()

--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -18,7 +18,7 @@ niceness=0
 mysqld_ld_preload=
 mysqld_ld_library_path=
 load_jemalloc=1
-load_hotbackup=1
+load_hotbackup=0
 flush_caches=0
 numa_interleave=0
 # Change (disable) transparent huge pages (TokuDB requirement)
@@ -246,6 +246,7 @@ parse_arguments() {
       --open_files_limit=*) open_files="$val" ;;
       --skip-kill-mysqld*) KILL_MYSQLD=0 ;;
       --thp-setting=*) thp_setting="$val" ;;
+      --preload-hotbackup) load_hotbackup=1 ;;
       --syslog) want_syslog=1 ;;
       --skip-syslog) want_syslog=0 ;;
       --syslog-tag=*) syslog_tag="$val" ;;


### PR DESCRIPTION
**TICKET: BLD-287 - TokuDB merge with Percona Server**
Change build and packaging files, param/trunk jobs and release job

Some info:
After tokutek repositories merge it is needed to create one source tarball, one binary tarball BUT the rpm/deb packages stay separate!
We leave tokudb package outside server package for now and add tokudb-hotbackup to it.
Change ps_tokudb_admin script to install hotbackup also and check for selinux status in the system (if in enforcing state report error so that the user knows that it's not going to work).
No static linking of jemalloc for ha_tokudb.so for now so LD_PRELOADS stay.

**Changes in:**
- debian/\* and percona-server.spec files are to apply packaging changes (default debian rules and control files include tokudb package, for no-tokudb version there is rules.notokudb and control.notokudb files)
  - for debian we set "-fexeptions" since the build is not going to work with "-fno-exeptions" and it is used in rpm builds already (the actual error is below)
- plugin/tokudb-backup-plugin/CMakeLists.txt
  - The first change is to disable build of tokudb-backup plugin if TokuDB is not supported on the build platform (that part was copied from PerconaFT/CmakeLists.txt - so it's the same).
  - The second change in that file is because ${INSTALL_DOCDIR} is not defined in RPM layout so we would get error on package builds.
- scripts/ps_tokudb_admin.sh
  - added options for installing TokuBackup (--enable-backup, --disable-backup) - when enabling option "preload-hotbackup" is added to my.cnf which then mysqld_safe picks-up and does LD_PRELOAD of libHotBackup.so for mysqld
  - installation of tokudb_backup plugin is done
  - when doing installation the check is done for selinux status, if in enforcing mode the error is shown
- scripts/mysqld_safe.sh
  - added part for LD_PRELOAD for libHotBackup.so if "preload-hotbackup" option is found in my.cnf, by default it's off
- Percona TokuBackup is included in the tokudbpackage build tokudb_backup.so and libHotBackup.so

**TEST BUILDS:**
RELEASE BUILD (new job): http://jenkins.percona.com/view/TEST/job/percona-server-5.6-RELEASE-new/32/
PARAM BUILD (changed existing job): http://jenkins.percona.com/job/percona-server-5.6-param/953/

**DEBIAN EXCEPTIONS ERROR**
12:55:55 /mnt/workspace/percona-server-5.6-debian-binary-notokudb-new/label_exp/ubuntu-trusty-32bit/percona-server-5.6-5.6.26-73.2/plugin/password_validation/validate_password.cc: In function 'void read_dictionary_file()':
12:55:55 /mnt/workspace/percona-server-5.6-debian-binary-notokudb-new/label_exp/ubuntu-trusty-32bit/percona-server-5.6-5.6.26-73.2/plugin/password_validation/validate_password.cc:183:10: error: exception handling disabled, use -fexceptions to enable
12:55:55    catch (...) // no exceptions !
12:55:55           ^
12:55:55 [ 71%] make[3]: **\* [plugin/password_validation/CMakeFiles/validate_password.dir/validate_password.cc.o] Error 1
12:55:55 make[3]: Leaving directory `/mnt/workspace/percona-server-5.6-debian-binary-notokudb-new/label_exp/ubuntu-trusty-32bit/percona-server-5.6-5.6.26-73.2/debug'
12:55:55 make[2]: **\* [plugin/password_validation/CMakeFiles/validate_password.dir/all] Error 2
12:55:55 make[2]: **\* Waiting for unfinished jobs....

**BASIC INSTALL TEST**
**INSTALL TOKUDB ENGINE:**
[vagrant@t-centos7-64 ~]$ sudo ps_tokudb_admin --enable
Checking SELinux status...
INFO: SELinux is disabled.

Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are enabled (should be disabled).

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Disabling transparent huge pages for the current session...
INFO: Successfully disabled transparent huge pages for this session.

Adding thp-setting=never option into /etc/my.cnf
INFO: Successfully added thp-setting=never option into /etc/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

**INSTALL TOKUBACKUP PLUGIN**
[vagrant@t-centos7-64 ~]$ sudo ps_tokudb_admin --enable-backup
Checking SELinux status...
INFO: SELinux is disabled.
