### PR TITLE
- bug#1372219: Failing assertion: discard.n_recs == 1 in file row0imp…

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -708,5 +708,14 @@ ERROR HY000: Got error 131 during COMMIT
 set session innodb_fake_changes = 0;
 drop procedure populate_t1;
 drop table t1;
+set global innodb_file_per_table = 1;
+use test;
+create table t1 (i int, key(i)) engine=innodb;
+set innodb_fake_changes = 1;
+alter table t1 discard tablespace;
+ERROR HY000: Table storage engine for 't1' doesn't have this option
+set innodb_fake_changes = 0;
+drop table t1;
+set global innodb_file_per_table = 1;
 SET @@GLOBAL.userstat= default;
 SET @@GLOBAL.innodb_stats_transient_sample_pages=default;

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -421,6 +421,24 @@ drop table t1;
 
 #-------------------------------------------------------------------------------
 #
+# Scenario that try to discard tablespace with fake_change one.
+# Discard tablespace is DDL operation which is blocked in fake_change mode.
+#
+let save_file_per_table = `select @@innodb_file_per_table`;
+set global innodb_file_per_table = 1;
+#
+use test;
+create table t1 (i int, key(i)) engine=innodb;
+set innodb_fake_changes = 1;
+--error ER_ILLEGAL_HA
+alter table t1 discard tablespace;
+set innodb_fake_changes = 0;
+drop table t1;
+#
+eval set global innodb_file_per_table = $save_file_per_table;
+
+#-------------------------------------------------------------------------------
+#
 # cleanup test bed
 #
 SET @@GLOBAL.userstat= default;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -10617,6 +10617,10 @@ ha_innobase::discard_or_import_tablespace(
 		DBUG_RETURN(HA_ERR_TABLE_READONLY);
 	}
 
+	if (UNIV_UNLIKELY(prebuilt->trx->fake_changes)) {
+		DBUG_RETURN(HA_ERR_WRONG_COMMAND);
+	}
+
 	dict_table = prebuilt->table;
 
 	if (dict_table->space == TRX_SYS_SPACE) {


### PR DESCRIPTION
…ort.cc

  line 3453 | abort (sig=6) in row_import_update_discarded_flag

  Fake change is dry-run operation which is not suppose to make any change
  to database. Alter table discard tablespace is DDL operation and any
  DDL operation by defintiion of fake-change is not allowed or in other
  word suppose to generate an error.

 Check for blocking ALTER TABLE DISCARD was missing.
