### PR TITLE
Fix TokuDB tests not skipping themselves in case TokuDB was not built…

### DIFF
--- a/mysql-test/suite/tokudb.alter_table/t/frm_discover.test
+++ b/mysql-test/suite/tokudb.alter_table/t/frm_discover.test
@@ -1,4 +1,5 @@
 # test that tokudb discover on simple tables works when there is an frm mismatch
+--source include/have_tokudb.inc
 
 --disable_warnings
 DROP TABLE IF EXISTS foo, bar;

--- a/mysql-test/suite/tokudb.bugs/t/db788-optimize-index-name.test
+++ b/mysql-test/suite/tokudb.bugs/t/db788-optimize-index-name.test
@@ -1,6 +1,6 @@
+--source include/have_tokudb.inc
 # test tokudb_optimize_index_name session variable
 set default_storage_engine='tokudb';
-source include/have_tokudb.inc;
 disable_warnings;
 drop table if exists t;
 enable_warnings;

--- a/mysql-test/suite/tokudb/t/tokudb_support_xa.test
+++ b/mysql-test/suite/tokudb/t/tokudb_support_xa.test
@@ -1,3 +1,4 @@
+--source include/have_tokudb.inc
 --source include/load_sysvars.inc
 let $engine=TokuDB;
 


### PR DESCRIPTION
… (DB-878)

Add missing --source include/have_tokudb.inc as required, or in one
case, move it to the top of the testcase.
