### PR TITLE
Bug #21086723 PAGE_ZIP_VERIFY_CHECKSUM() RETURNS FALSE FOR A

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -942,8 +942,6 @@ buf_flush_write_block_low(
 		ut_a(page_zip_verify_checksum(frame, zip_size));
 
 		memset(frame + FIL_PAGE_FILE_FLUSH_LSN, 0, 8);
-
-		ut_a(page_zip_verify_checksum(frame, zip_size));
 		break;
 	case BUF_BLOCK_FILE_PAGE:
 		frame = bpage->zip.data;


### PR DESCRIPTION
The previous 5.6.26 merge contains two fixes for this bug:
5b6041b - upstream  fix
c5654b0 - percona's fix

This commit removes percona's fix.
