### PR TITLE
Disable Toku hot backup plugin build on Mac (DB-877)

### DIFF
--- a/plugin/tokudb-backup-plugin/CMakeLists.txt
+++ b/plugin/tokudb-backup-plugin/CMakeLists.txt
@@ -10,7 +10,12 @@ int main() { return 0; }
 " TOKUDB_OK)
 ENDIF()
 
-IF(NOT TOKUDB_OK)
+include(CheckSymbolExists)
+check_symbol_exists(O_DIRECT "fcntl.h" HAVE_O_DIRECT)
+check_symbol_exists(CLOCK_REALTIME "time.h" HAVE_CLOCK_MONOTONIC)
+
+IF(NOT TOKUDB_OK OR NOT HAVE_O_DIRECT OR NOT HAVE_CLOCK_MONOTONIC OR APPLE)
+  MESSAGE(STATUS "Not building tokudb-backup-plugin")
   RETURN()
 ENDIF()
 

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -521,7 +521,7 @@ static void tokudb_backup_run(THD *thd, const char *dest_dir) {
     }
     free(dest_dir_path);
 
-    struct source_dirs sources;
+    source_dirs sources;
     sources.find_and_allocate_dirs(thd);
 
     if (sources.check_dirs_layout(thd) == false) {


### PR DESCRIPTION
Add CMake check to skip the plugin build if we are not Mac, if we are
unable to compile TokuDB, or if we don't have either O_DIRECT or
CLOCK_MONOTONIC.

At the same time fix a compilation warning in tokudb_backup.cc where
struct qualifier was used for a class type.

Jenkins run http://jenkins.percona.com/job/percona-server-5.6-param/964/, tested that backup build is not skipped on any platform where TokuDB itself is built
