### PR TITLE
Fix clang build warnings and errors on Mac (DB-502 and DB-876).

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -288,7 +288,7 @@ static int free_share(TOKUDB_SHARE * share) {
     }
 
 const char *ha_tokudb::table_type() const {
-    extern const char * const tokudb_hton_name;
+    extern const char *tokudb_hton_name;
     return tokudb_hton_name;
 } 
 
@@ -630,21 +630,6 @@ static ulonglong retrieve_auto_increment(uint16 type, uint32 offset,const uchar 
 
     return autoinc_type == unsigned_type ?  
            unsigned_autoinc : (ulonglong) signed_autoinc;
-}
-
-static inline bool
-is_null_field( TABLE* table, Field* field, const uchar* record) {
-    uint null_offset;
-    bool ret_val;
-    if (!field->real_maybe_null()) {
-        ret_val = false;
-        goto exitpt;
-    }
-    null_offset = get_null_offset(table,field);
-    ret_val = (record[null_offset] & field->null_bit) ? true: false;
-
-exitpt:
-    return ret_val;
 }
 
 static inline ulong field_offset(Field* field, TABLE* table) {

--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -131,7 +131,7 @@ int ha_tokudb::analyze(THD *thd, HA_CHECK_OPT *check_opt) {
                 TOKUDB_HANDLER_TRACE("%.*s rows %" PRIu64 " deleted %" PRIu64,
                                      namelen, name, rows, deleted_rows);
                 for (uint j = 0; j < num_key_parts; j++)
-                    TOKUDB_HANDLER_TRACE("%lu", rec_per_key[total_key_parts+j]);
+                    TOKUDB_HANDLER_TRACE("%" PRIu64, rec_per_key[total_key_parts+j]);
             }
             total_key_parts += num_key_parts;
         } 

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1026,7 +1026,7 @@ static int create_toku_key_descriptor_for_key(KEY* key, uchar* buf) {
         // The second byte for each field is the type
         //
         TOKU_TYPE type = mysql_to_toku_type(field);
-        assert (type < 256);
+        assert ((int)type < 256);
         *pos = (uchar)(type & 255);
         pos++;
 

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -199,7 +199,7 @@ static char *tokudb_log_dir;
 // static long tokudb_lock_scan_time = 0;
 // static ulong tokudb_region_size = 0;
 // static ulong tokudb_cache_parts = 1;
-const char *tokudb_hton_name = "TokuDB";
+const char * tokudb_hton_name = "TokuDB";
 static uint32_t tokudb_checkpointing_period;
 static uint32_t tokudb_fsync_log_period;
 uint32_t tokudb_write_status_frequency;

--- a/storage/tokudb/tokudb_update_fun.cc
+++ b/storage/tokudb/tokudb_update_fun.cc
@@ -424,7 +424,10 @@ static int tokudb_hcad_update_fun(
         max_num_bytes, 
         MYF(MY_FAE)
         );
-    if (new_val_data == NULL) { goto cleanup; }
+    if (new_val_data == NULL) {
+        error = ENOMEM;
+        goto cleanup;
+    }
 
     old_fixed_field_ptr = (uchar *) old_val->data;
     old_fixed_field_ptr += old_num_null_bytes;


### PR DESCRIPTION
- Remove unused function is_null_field in ha_tokudb.cc.
- Use portable printf format specifier for uint64_t in
  ha_tokudb::analyze.
- Avoid "[enum] val always compares to less than 256" warning by
  casting the enum to int in
  hatoku_cmp.cc:create_toku_key_descriptor_for_key.
- Adjust tokudb_hton_name to be const char \* consistently everywhere.
- Fix tokudb_hcad_update_fun returning uninitilised error in case of
  OOM. Return ENOMEM instead.

http://jenkins.percona.com/job/percona-server-5.6-param/967/
