### PR TITLE
Disable failing TokuDB tests for known bugs

### DIFF
--- a/mysql-test/suite/engines/funcs/t/ai_reset_by_truncate.test
+++ b/mysql-test/suite/engines/funcs/t/ai_reset_by_truncate.test
@@ -1,3 +1,7 @@
+if (`SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.SESSION_VARIABLES WHERE VARIABLE_NAME="storage_engine" AND VARIABLE_VALUE="tokudb"`)
+{
+  --skip Disabled for TokuDB: https://tokutek.atlassian.net/browse/DB-640
+}
 --disable_warnings
 DROP TABLE IF EXISTS t1;
 --enable_warnings

--- a/mysql-test/suite/tokudb.bugs/t/disabled.def
+++ b/mysql-test/suite/tokudb.bugs/t/disabled.def
@@ -11,3 +11,6 @@ checkpoint_lock_2: test can not work when the checkpoint_safe_lock is a fair rwl
 6053: tokudb is not the default storage engine
 1883: tokutek's auto inc singleton patch missing
 3083: no patch to find_shortest_key to prefer PK over CK
+db768 : https://tokutek.atlassian.net/browse/DB-768
+dict_leak_3518 : https://tokutek.atlassian.net/browse/DB-635
+1872 : https://tokutek.atlassian.net/browse/DB-750

--- a/mysql-test/suite/tokudb.parts/t/disabled.def
+++ b/mysql-test/suite/tokudb.parts/t/disabled.def
@@ -1,2 +1,4 @@
 partition_basic_symlink_tokudb : tokudb_file_per_table is not supported
 partition_reorganize_tokudb : tokudb_file_per_table is not supported
+partition_mgm_lc0_tokudb : https://tokutek.atlassian.net/browse/DB-637
+partition_mgm_lc1_tokudb : https://tokutek.atlassian.net/browse/DB-637


### PR DESCRIPTION
Disable the following tests through disabled.def:

tokudb.bugs.db768 : https://tokutek.atlassian.net/browse/DB-768
tokudb.bugs.dict_leak_3518 : https://tokutek.atlassian.net/browse/DB-635
tokudb.bugs.1872 : https://tokutek.atlassian.net/browse/DB-750
tokudb.parts.partition_mgm_lc0_tokudb : https://tokutek.atlassian.net/browse/DB-637
tokudb.parts.partition_mgm_lc1_tokudb : https://tokutek.atlassian.net/browse/DB-637

Disable engines/funcs.ai_reset_by_truncate because of
https://tokutek.atlassian.net/browse/DB-640 directly in the testcase
if it's running with storage_engine == TokuDB. Do not use disabled.def
because we still want the test to run for other storage engines.

http://jenkins.percona.com/job/percona-server-5.6-param/968/
