### PR TITLE
- bug#1395706 : Failing assertion: update->n_fields == 0 in row0ins.c…

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -557,4 +557,14 @@ SELECT @table_rows_changed_x_indexes_2 - @table_rows_changed_x_indexes_1 AS shou
 should_be_0
 0
 DROP TABLE t1, t3;
+use test;
+create table t1 (a int, primary key pk(a));
+alter table t1 add column b char;
+create index bx on t1(b);
+insert into t1 values (1, 0x41), (2, 0x41);
+set innodb_fake_changes=1;
+update t1 set a = upper(a), b = lower(b);
+ERROR HY000: Got error 131 during COMMIT
+set innodb_fake_changes=0;
+drop table t1;
 SET @@GLOBAL.userstat= default;

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -14,9 +14,14 @@ SET innodb_fake_changes=default;
 SHOW VARIABLES LIKE 'innodb_fake_changes';
 SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.SESSION_VARIABLES WHERE VARIABLE_NAME='innodb_fake_changes';
 
+#-------------------------------------------------------------------------------
+#
+# create test bed
+#
 --echo # Explicit COMMIT should fail when innodb_fake_changes is enabled
 --echo # DML should be fine
 SET @@GLOBAL.userstat=TRUE;
+
 CREATE TABLE t1 (a INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 
@@ -365,4 +370,26 @@ COMMIT;
 
 DROP TABLE t1, t3;
 
+#-------------------------------------------------------------------------------
+#
+# Scenario to exercise update such that it causes ordering change in clustered
+# index key initiating delete + insertion action to complete update.
+# For fake-change record is not actually delete marked but assumed to be
+# delete marked and path is choosen accordingly.
+#
+use test;
+create table t1 (a int, primary key pk(a));
+alter table t1 add column b char;
+create index bx on t1(b);
+insert into t1 values (1, 0x41), (2, 0x41);
+set innodb_fake_changes=1;
+--error ER_ERROR_DURING_COMMIT
+update t1 set a = upper(a), b = lower(b);
+set innodb_fake_changes=0;
+drop table t1;
+
+#-------------------------------------------------------------------------------
+#
+# cleanup test bed
+#
 SET @@GLOBAL.userstat= default;

--- a/storage/innobase/row/row0ins.c
+++ b/storage/innobase/row/row0ins.c
@@ -247,8 +247,9 @@ row_ins_sec_index_entry_by_modify(
 	rec = btr_cur_get_rec(cursor);
 
 	ut_ad(!dict_index_is_clust(cursor->index));
-	ut_ad(rec_get_deleted_flag(rec,
-				   dict_table_is_comp(cursor->index->table)));
+	ut_ad(UNIV_UNLIKELY(thr_get_trx(thr)->fake_changes)
+	      || rec_get_deleted_flag(rec,
+			dict_table_is_comp(cursor->index->table)));
 
 	/* We know that in the alphabetical ordering, entry and rec are
 	identified. But in their binary form there may be differences if


### PR DESCRIPTION
…c line 276

  In fake-change mode database records are not actually modified but the
  modification is assumed and accordingly the path is selected/forced.

  For workload involving ordering change update will be executed as series
  of delete + insert action. Given that fake-change mode is enabled
  actual delete will never happen but path will be selected assuming that
  it took place. Well this can cause to hit some asserts in the forced
  path as the state is not marked. Relax such asserts if fake-change mode
  is enabled.

  One such path that assumed record is marked as deleted when it is not
  is fixed by this patch.
  (rec-del-mark) -> (fake-change || rec-del-mark)
