### PR TITLE
Fix owner of mysql_upgrade_info file in debian (BLD-297)

### DIFF
--- a/build-ps/debian/percona-server-server-5.6.mysql.init
+++ b/build-ps/debian/percona-server-server-5.6.mysql.init
@@ -122,6 +122,10 @@ case "${1:-''}" in
 	        # Now start mysqlcheck or whatever the admin wants.
 	        output=$(/etc/mysql/debian-start)
 		[ -n "$output" ] && log_action_msg "$output"
+		# Set mysql as owner of mysql_upgrade_info file - TokuBackup needs this to work (BLD-297)
+		# Needed here because debian-start runs mysql_upgrade
+		datadir=`mysqld_get_param datadir`
+		if [ -f "$datadir/mysql_upgrade_info" ]; then chown mysql:mysql "$datadir/mysql_upgrade_info"; fi
 	    else
 	        log_end_msg 1
 		log_failure_msg "Please take a look at the syslog"


### PR DESCRIPTION
This is to fix mysql_upgrade_info file permissions in datadirectory since on debian it get's created as non readable by mysql user (owner/group is root without read permissions for others) which makes problems for TokuBackup.
The change is in init script since it calls debian-start which runs mysql_upgrade be it an upgrade or not which then creates a mysql_upgrade_info file.
