### PR TITLE
- bug#1192898 : InnoDB: Failing assertion: mtr_memo_contains_page(mtr…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug_1192898.result
+++ b/mysql-test/suite/innodb/r/percona_bug_1192898.result
@@ -1,0 +1,10 @@
+set global innodb_limit_optimistic_insert_debug=2;
+use test;
+create table t1 (c1 int, c2 char(5)) engine=innodb;
+insert into t1 values (), (), (), (), (), (), (), (), (), (), (), (), (), (), ();
+set innodb_fake_changes = 1;
+insert into t1(c1) values (2);
+ERROR HY000: Got error 131 during COMMIT
+set innodb_fake_changes = 0;
+drop table t1;
+set global innodb_limit_optimistic_insert_debug = 0;

--- a/mysql-test/suite/innodb/t/percona_bug_1192898.test
+++ b/mysql-test/suite/innodb/t/percona_bug_1192898.test
@@ -1,0 +1,31 @@
+
+
+--source include/have_innodb.inc
+--source include/have_debug.inc
+
+# Test-Case aims at testing sibilings prefetch as part of pessmisitic insert
+# with fake-change mode = ON.
+
+
+
+#-------------------------------------------------------------------------------
+#
+# Create test-bed
+#
+let opt_insert_debug = `select @@innodb_limit_optimistic_insert_debug`;
+set global innodb_limit_optimistic_insert_debug=2;
+
+use test;
+create table t1 (c1 int, c2 char(5)) engine=innodb;
+insert into t1 values (), (), (), (), (), (), (), (), (), (), (), (), (), (), ();
+set innodb_fake_changes = 1;
+--error ER_ERROR_DURING_COMMIT
+insert into t1(c1) values (2);
+set innodb_fake_changes = 0;
+drop table t1;
+
+#-------------------------------------------------------------------------------
+#
+# Remove test-bed
+#
+eval set global innodb_limit_optimistic_insert_debug = $opt_insert_debug;

--- a/storage/innobase/btr/btr0cur.c
+++ b/storage/innobase/btr/btr0cur.c
@@ -287,8 +287,13 @@ btr_cur_latch_leaves(
 #ifdef UNIV_BTR_DEBUG
 			ut_a(page_is_comp(get_block->frame)
 			     == page_is_comp(page));
-			ut_a(btr_page_get_next(get_block->frame, mtr)
-			     == page_get_page_no(page));
+
+			/* For fake_change mode we avoid a detailed validation
+			as it operate in tweaked format where-in validation
+			may fail. */
+			ut_a(sibling_mode == RW_NO_LATCH
+			     || btr_page_get_next(get_block->frame, mtr)
+				== page_get_page_no(page));
 #endif /* UNIV_BTR_DEBUG */
 			if (sibling_mode == RW_NO_LATCH) {
 				/* btr_block_get() called with RW_NO_LATCH will


### PR DESCRIPTION
…, page, 2)

  || mtr_memo_contains_page(mtr, page, 1) in file btr0btr.ic line 169

  In case of fake change operational mode, locking is less restricting.
  For example: If pessmisitic insert is operating in fake-change mode
  sibilings are not locked/latched as the flow doesn't plan to change
  the perform the change action but this contradict with existing validation
  assert that are not meant to handle this situation.

  Relaxed the assert by || it with special consideration for fake-change
  mode operation.
