### PR TITLE
Adjust TokuDB testcases for Percona Server having disabled savepoints…

### DIFF
--- a/mysql-test/suite/tokudb/r/savepoint-3.result
+++ b/mysql-test/suite/tokudb/r/savepoint-3.result
@@ -86,40 +86,37 @@ begin |
 insert into t1 values (1)|
 savepoint x|
 set @a:= bug13825_0()|
-ERROR 42000: SAVEPOINT x does not exist
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 insert into t2 values (2)|
-ERROR 42000: SAVEPOINT x does not exist
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
 set @a:= bug13825_1()|
 ERROR 42000: SAVEPOINT x does not exist
 update t2 set i = 2|
 ERROR 42000: SAVEPOINT x does not exist
 set @a:= bug13825_2()|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
 1
-2
-4
 rollback to savepoint x|
 select * from t1|
 i
 1
 delete from t2|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in triggers'
 select * from t1|
 i
 1
-2
-4
 rollback to savepoint x|
 select * from t1|
 i
 1
 release savepoint x|
 set @a:= bug13825_2()|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
 1
-2
-4
 rollback to savepoint x|
 ERROR 42000: SAVEPOINT x does not exist
 delete from t1|
@@ -147,26 +144,20 @@ delete from t1|
 commit|
 set autocommit= 1|
 select bug13825_3(0)|
-bug13825_3(0)
-0
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
-1
-2
-3
 delete from t1|
 select bug13825_3(1)|
-bug13825_3(1)
-1
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
-1
-3
 delete from t1|
 set autocommit= 0|
 begin|
 insert into t1 values (1)|
 set @a:= bug13825_4()|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
 1
@@ -176,14 +167,11 @@ set autocommit= 1|
 drop table t2|
 create table t2 (i int) |
 insert into t1 values (1), (bug13825_5(2)), (3)|
+ERROR 42000: This version of MySQL doesn't yet support 'savepoints in functions'
 select * from t1|
 i
-1
-2
-3
 select * from t2|
 i
-3
 drop function bug13825_0|
 drop function bug13825_1|
 drop function bug13825_2|

--- a/mysql-test/suite/tokudb/t/disabled.def
+++ b/mysql-test/suite/tokudb/t/disabled.def
@@ -3,3 +3,4 @@ mvcc-20: tokutek
 mvcc-27: tokutek
 storage_engine_default: tokudb is not the default storage engine
 cluster_key_part : https://tokutek.atlassian.net/browse/DB-720
+savepoint-4 : percona testcase disabled until savepoints in triggers and stored functions fixed

--- a/mysql-test/suite/tokudb/t/savepoint-3.test
+++ b/mysql-test/suite/tokudb/t/savepoint-3.test
@@ -104,24 +104,27 @@ set autocommit= 0|
 begin |
 insert into t1 values (1)|
 savepoint x|
---error ER_SP_DOES_NOT_EXIST
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_0()|
---error ER_SP_DOES_NOT_EXIST
+--error ER_NOT_SUPPORTED_YET
 insert into t2 values (2)|
 --error ER_SP_DOES_NOT_EXIST
 set @a:= bug13825_1()|
 --error ER_SP_DOES_NOT_EXIST
 update t2 set i = 2|
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_2()|
 select * from t1|
 rollback to savepoint x|
 select * from t1|
+--error ER_NOT_SUPPORTED_YET
 delete from t2|
 select * from t1|
 rollback to savepoint x|
 select * from t1|
 # Of course savepoints set in function should not be visible from its caller
 release savepoint x|
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_2()|
 select * from t1|
 --error ER_SP_DOES_NOT_EXIST
@@ -148,9 +151,11 @@ commit|
 set autocommit= 1|
 # Let us test that savepoints work inside of functions
 # even in auto-commit mode
+--error ER_NOT_SUPPORTED_YET
 select bug13825_3(0)|
 select * from t1|
 delete from t1|
+--error ER_NOT_SUPPORTED_YET
 select bug13825_3(1)|
 select * from t1|
 delete from t1|
@@ -159,6 +164,7 @@ delete from t1|
 set autocommit= 0|
 begin|
 insert into t1 values (1)|
+--error ER_NOT_SUPPORTED_YET
 set @a:= bug13825_4()|
 select * from t1|
 delete from t1|
@@ -167,6 +173,7 @@ set autocommit= 1|
 # Other curious case: savepoint in the middle of statement
 drop table t2|
 create table t2 (i int) |
+--error ER_NOT_SUPPORTED_YET
 insert into t1 values (1), (bug13825_5(2)), (3)|
 select * from t1|
 select * from t2|


### PR DESCRIPTION
… in triggers and stored functions

This is TokuDB-specific part of
https://blueprints.launchpad.net/percona-server/+spec/temp-savepoint-in-triggers-functions-disable,
which disabled SAVEPOINT and ROLLBACK TO SAVEPOINT in triggers and
stored functions. It is expected that this change will be reverted
soon.

For tokudb.savepoint-3, adjust the testcase for the error code
returned. For tokudb.savepoint-4, disable it as the disabled
functionality is central to the testcase.

http://jenkins.percona.com/job/percona-server-5.6-param/971/
