### PR TITLE
- bug#1395579: Failing assertion: mode != LOCK_X ||

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -567,4 +567,52 @@ update t1 set a = upper(a), b = lower(b);
 ERROR HY000: Got error 131 during COMMIT
 set innodb_fake_changes=0;
 drop table t1;
+use test;
+create table t1 (c1 int);
+insert into t1 values (10);
+select * from t1;
+c1
+10
+set innodb_fake_changes = 1;
+begin;
+insert into t1 values (10);
+select * from t1;
+c1
+10
+set innodb_fake_changes = 0;
+replace into t1(c1) values (10);
+commit;
+ERROR HY000: Got error 131 during COMMIT
+select * from t1;
+c1
+10
+begin;
+insert into t1 values (11);
+insert into t1 values (12);
+set innodb_fake_changes = 1;
+commit;
+set innodb_fake_changes = 0;
+select * from t1;
+c1
+10
+11
+12
+begin;
+set innodb_fake_changes = 1;
+insert into t1 values (11);
+insert into t1 values (12);
+commit;
+ERROR HY000: Got error 131 during COMMIT
+set innodb_fake_changes = 0;
+drop table t1;
+use test;
+create table t1 (i int) engine=innodb;
+rename table t1 to t2;
+select * from t2;
+i
+set innodb_fake_changes = 1;
+rename table t2 to t1;
+ERROR 42000: This version of MySQL doesn't yet support 'ALTER TABLE'
+set innodb_fake_changes = 0;
+drop table t2;
 SET @@GLOBAL.userstat= default;

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -390,6 +390,64 @@ drop table t1;
 
 #-------------------------------------------------------------------------------
 #
+# If fake-change mode is set to on or off after transaction starts then
+# transaction shouldn't honor the change instead it transaction should always
+# operate honoring the setting while it started.
+#
+use test;
+create table t1 (c1 int);
+insert into t1 values (10);
+select * from t1;
+set innodb_fake_changes = 1;
+begin;
+insert into t1 values (10);
+select * from t1;
+set innodb_fake_changes = 0;
+replace into t1(c1) values (10);
+# this should fail as trx has register fake-change = 1 while starting.
+--error ER_ERROR_DURING_COMMIT
+commit;
+select * from t1;
+#
+begin;
+insert into t1 values (11);
+insert into t1 values (12);
+set innodb_fake_changes = 1;
+# this should pass as trx has register fake-change = 0 while starting.
+commit;
+set innodb_fake_changes = 0;
+select * from t1;
+#
+begin;
+set innodb_fake_changes = 1;
+insert into t1 values (11);
+insert into t1 values (12);
+# this should fail as trx has register fake-change = 1 while starting.
+# note: begin doesn't start a transaction but insert does.
+--error ER_ERROR_DURING_COMMIT
+commit;
+#
+set innodb_fake_changes = 0;
+drop table t1;
+
+#-------------------------------------------------------------------------------
+#
+# Rename of table is blocked with fake-change enabled.
+#
+use test;
+create table t1 (i int) engine=innodb;
+rename table t1 to t2;
+select * from t2;
+#
+set innodb_fake_changes = 1;
+--error ER_NOT_SUPPORTED_YET
+rename table t2 to t1;
+#
+set innodb_fake_changes = 0;
+drop table t2;
+
+#-------------------------------------------------------------------------------
+#
 # cleanup test bed
 #
 SET @@GLOBAL.userstat= default;

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -268,6 +268,16 @@ thd_supports_xa(
 			the global innodb_supports_xa */
 
 /******************************************************************//**
+Check the status of fake changes mode (innodb_fake_changes)
+@return	true	if fake change mode is enabled. */
+
+ibool
+thd_fake_changes(
+/*=============*/
+	void*	thd);	/*!< in: thread handle, or NULL to query
+			the global innodb_supports_xa */
+
+/******************************************************************//**
 Returns the lock wait timeout for the current connection.
 @return	the lock wait timeout, in seconds */
 

--- a/storage/innobase/trx/trx0trx.c
+++ b/storage/innobase/trx/trx0trx.c
@@ -881,6 +881,12 @@ trx_start_low(
 
 	trx->no = IB_ULONGLONG_MAX;
 
+	/* Cache the state of fake_changes that transaction will use for
+	lifetime. Any change in session/global fake_changes configuration during
+	lifetime of transaction will not be honored by already started
+	transaction. */
+	trx->fake_changes = thd_fake_changes(trx->mysql_thd);
+
 	trx->rseg = rseg;
 
 	trx->state = TRX_ACTIVE;


### PR DESCRIPTION
  lock_table_has(thr_get_trx(thr), index->table, LOCK_IX) in- bug#

  As per the semantics of fake_changes
  "The effective unit is each transaction. The behavior is decided at the start
  of the each one and never changed during the transaction"

  Due to the bug in the logic this semantics was not being honored and so change
  in innodb_fake_changes value during lifetime of transaction use to affect
  the current active transactions too. This effectively meant some of your
  statements from a transaction went in dry-run format w/o making any change
  to DB and follow-up statements from same transaction are executing with
  fake_change mode off there-by making changes to DB.
  First, this is violating the semantics and second with half-cooked
  transaction it is taking DB to an in-consistent state there-by causing
  validation checks to fail.

  Patch fixes the issue by making sure that the semantics is honored.
  While starting any new transaction state of fake_changes is cached
  and it is not updated/refreshed till the transaction is active
  (COMMIT/ROLLBACK). There are some non-transactional APIs that uses
  transactional object more like a data-carrier. If non-active transaction
  object is being used for such non-transactional APIs then fake_changes
  state is refresh before using it (as part of innobase_trx_init).
