### PR TITLE
- bug#1204443 : Assorted fake changes 5.6 port code review bugs

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -775,5 +775,16 @@ rename table t2 to t1;
 ERROR 42000: This version of MySQL doesn't yet support 'ALTER TABLE'
 set innodb_fake_changes = 0;
 drop table t2;
+use test;
+create table t1 (i int, b blob, primary key pk(i)) engine=innodb;
+set innodb_fake_changes=1;
+insert into t1 values (1, repeat('a', 20000));
+ERROR HY000: Got error 131 during COMMIT
+insert into t1 values (2, repeat('b', 20000));
+ERROR HY000: Got error 131 during COMMIT
+update t1 set b = repeat('c', 20000);
+ERROR HY000: Got error 131 during COMMIT
+set innodb_fake_changes=0;
+drop table t1;
 SET @@GLOBAL.userstat= default;
 SET @@GLOBAL.innodb_stats_transient_sample_pages=default;

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -515,6 +515,22 @@ drop table t2;
 
 #-------------------------------------------------------------------------------
 #
+# Big-record based insertion and update use-case under fake-change mode.
+#
+use test;
+create table t1 (i int, b blob, primary key pk(i)) engine=innodb;
+set innodb_fake_changes=1;
+--error ER_ERROR_DURING_COMMIT
+insert into t1 values (1, repeat('a', 20000));
+--error ER_ERROR_DURING_COMMIT
+insert into t1 values (2, repeat('b', 20000));
+--error ER_ERROR_DURING_COMMIT
+update t1 set b = repeat('c', 20000);
+set innodb_fake_changes=0;
+drop table t1;
+
+#-------------------------------------------------------------------------------
+#
 # cleanup test bed
 #
 SET @@GLOBAL.userstat= default;

--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -1388,9 +1388,6 @@ btr_cur_optimistic_insert(
 	}
 #endif /* UNIV_DEBUG */
 
-	ut_ad((thr && thr_get_trx(thr)->fake_changes)
-	      || mtr_memo_contains(mtr, block, MTR_MEMO_PAGE_X_FIX));
-
 	leaf = page_is_leaf(page);
 
 	/* Calculate the record size when entry is converted to a record */

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -2343,6 +2343,7 @@ row_upd_clust_step(
 	ut_a(pcur->rel_pos == BTR_PCUR_ON);
 
 	ulint	mode;
+	ulint	search_mode;
 
 #ifdef UNIV_DEBUG
 	/* Work around Bug#14626800 ASSERTION FAILURE IN DEBUG_SYNC().
@@ -2354,17 +2355,29 @@ row_upd_clust_step(
 	}
 #endif /* UNIV_DEBUG */
 
+	/* If running with fake_changes mode on then switch from modify to
+	search so that code takes only s-latch and not x-latch.
+	For dry-run (fake-changes) s-latch is acceptable. Taking x-latch will
+	make it more restrictive and will block real changes/workflow. */
 	if (UNIV_UNLIKELY(thr_get_trx(thr)->fake_changes)) {
-		mode = BTR_SEARCH_LEAF;
-	} else if (dict_index_is_online_ddl(index)) {
-		ut_ad(node->table->id != DICT_INDEXES_ID);
-		mode = BTR_MODIFY_LEAF | BTR_ALREADY_S_LATCHED;
-		mtr_s_lock(dict_index_get_lock(index), &mtr);
+		mode = BTR_MODIFY_LEAF;
+		search_mode = BTR_SEARCH_LEAF;
 	} else {
 		mode = BTR_MODIFY_LEAF;
+		search_mode = BTR_MODIFY_LEAF;
 	}
 
-	success = btr_pcur_restore_position(mode, pcur, &mtr);
+	if (dict_index_is_online_ddl(index)) {
+
+		ut_ad(node->table->id != DICT_INDEXES_ID);
+
+		mode |= BTR_ALREADY_S_LATCHED;
+		search_mode |= BTR_ALREADY_S_LATCHED;
+
+		mtr_s_lock(dict_index_get_lock(index), &mtr);
+	}
+
+	success = btr_pcur_restore_position(search_mode, pcur, &mtr);
 
 	if (!success) {
 		err = DB_RECORD_NOT_FOUND;
@@ -2381,6 +2394,10 @@ row_upd_clust_step(
 	if (node->is_delete && node->table->id == DICT_INDEXES_ID) {
 
 		ut_ad(!dict_index_is_online_ddl(index));
+
+		/* Action in fake change mode shouldn't cause changes
+		in system tables. */
+		ut_ad(UNIV_LIKELY(!thr_get_trx(thr)->fake_changes));
 
 		dict_drop_index_tree(btr_pcur_get_rec(pcur), &mtr);
 
@@ -2413,6 +2430,8 @@ row_upd_clust_step(
 		}
 	}
 
+	/* This check passes as the function manipulates x-lock to s-lock
+	if operating in fake-change mode. */
 	ut_ad(lock_trx_has_rec_x_lock(thr_get_trx(thr), index->table,
 				      btr_pcur_get_block(pcur),
 				      page_rec_get_heap_no(rec)));


### PR DESCRIPTION
  Bug is about spread out changes in fake_changes code path.
  a. correct the memory freeing logic if big-records are involved.
  b. removed duplicate assert validation
  c. update case with online-ddl was not covering fake-change latching logic.

  Added test-cases for missing scenarios.
