### PR TITLE
- bug#1382745 : CREATE table .. SELECT * from <table> fails if destin…

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -88,7 +88,8 @@ SELECT ROWS_CHANGED INTO @table_rows_changed_1 FROM INFORMATION_SCHEMA.TABLE_STA
 SELECT ROWS_CHANGED_X_INDEXES INTO @table_rows_changed_x_indexes_1 FROM INFORMATION_SCHEMA.TABLE_STATISTICS WHERE TABLE_SCHEMA LIKE 'test' AND TABLE_NAME LIKE 't1';
 SET innodb_fake_changes=1;
 SELECT * FROM t1;
-ERROR HY000: Got error 131 during COMMIT
+a	b
+1	1
 INSERT INTO t1 VALUES (2,2);
 ERROR HY000: Got error 131 during COMMIT
 UPDATE t1 SET a=0 where b=1;
@@ -198,7 +199,8 @@ SELECT ROWS_CHANGED INTO @table_rows_changed_1 FROM INFORMATION_SCHEMA.TABLE_STA
 SELECT ROWS_CHANGED_X_INDEXES INTO @table_rows_changed_x_indexes_1 FROM INFORMATION_SCHEMA.TABLE_STATISTICS WHERE TABLE_SCHEMA LIKE 'test' AND TABLE_NAME LIKE 't2';
 SET innodb_fake_changes=1;
 SELECT * FROM t2;
-ERROR HY000: Got error 131 during COMMIT
+a	b
+1	1
 INSERT INTO t2 VALUES (2,2);
 ERROR HY000: Got error 131 during COMMIT
 UPDATE t2 SET b=0 where a=1;
@@ -333,7 +335,8 @@ SELECT ROWS_CHANGED INTO @table_rows_changed_1 FROM INFORMATION_SCHEMA.TABLE_STA
 SELECT ROWS_CHANGED_X_INDEXES INTO @table_rows_changed_x_indexes_1 FROM INFORMATION_SCHEMA.TABLE_STATISTICS WHERE TABLE_SCHEMA LIKE 'test' AND TABLE_NAME LIKE 't3';
 SET innodb_fake_changes=1;
 SELECT * FROM t3;
-ERROR HY000: Got error 131 during COMMIT
+a	B
+1	
 INSERT INTO t3 VALUES (2,lpad('a',10000, 'b'));
 ERROR HY000: Got error 131 during COMMIT
 UPDATE t3 SET a=0 where a=1;
@@ -615,4 +618,60 @@ rename table t2 to t1;
 ERROR 42000: This version of MySQL doesn't yet support 'ALTER TABLE'
 set innodb_fake_changes = 0;
 drop table t2;
+create table t1 (i int) engine=innodb;
+insert into t1 values (1), (2);
+set session innodb_fake_changes = 1;
+select * from t1;
+i
+1
+2
+set @@session.default_storage_engine=innodb;
+create table t3 select * from t1;
+ERROR HY000: Can't create table 'test.t3' (errno: 131)
+set @@session.default_storage_engine=myisam;
+create table t2 select * from t1;
+show create table t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `i` int(11) DEFAULT NULL
+) ENGINE=MyISAM DEFAULT CHARSET=latin1
+select * from t2;
+i
+1
+2
+drop table t2;
+set session innodb_fake_changes = 0;
+set @@session.default_storage_engine=InnoDB;
+drop table t1;
+use test;
+create table t1 (i int, j int) engine=innodb;
+insert into t1 values (1, 10), (2, 20), (3, 30);
+select * from t1;
+i	j
+1	10
+2	20
+3	30
+set session innodb_fake_changes = 1;
+select * from t1;
+i	j
+1	10
+2	20
+3	30
+begin;
+select * from t1;
+i	j
+1	10
+2	20
+3	30
+commit;
+ERROR HY000: Got error 131 during COMMIT
+insert into t1 select * from t1;
+ERROR HY000: Got error 131 during COMMIT
+select * from t1;
+i	j
+1	10
+2	20
+3	30
+set session innodb_fake_changes = 0;
+drop table t1;
 SET @@GLOBAL.userstat= default;

--- a/mysql-test/suite/binlog/r/binlog_percona_fake_changes.result
+++ b/mysql-test/suite/binlog/r/binlog_percona_fake_changes.result
@@ -11,11 +11,14 @@ INSERT INTO t3 VALUES (1,'');
 RESET MASTER;
 SET innodb_fake_changes=1;
 SELECT * FROM t1;
-ERROR HY000: Got error 131 during COMMIT
+a	b
+1	1
 SELECT * FROM t2;
-ERROR HY000: Got error 131 during COMMIT
+a	b
+1	1
 SELECT * FROM t3;
-ERROR HY000: Got error 131 during COMMIT
+a	b
+1	
 INSERT INTO t1 VALUES (2,2);
 ERROR HY000: Got error 131 during COMMIT
 INSERT INTO t2 VALUES (2,2);

--- a/mysql-test/suite/binlog/t/binlog_percona_fake_changes.test
+++ b/mysql-test/suite/binlog/t/binlog_percona_fake_changes.test
@@ -30,11 +30,8 @@ let $binlog_pos_1= query_get_value("SHOW MASTER STATUS", Position, 1);
 
 SET innodb_fake_changes=1;
 
---error ER_ERROR_DURING_COMMIT
 SELECT * FROM t1;
---error ER_ERROR_DURING_COMMIT
 SELECT * FROM t2;
---error ER_ERROR_DURING_COMMIT
 SELECT * FROM t3;
 
 --error ER_ERROR_DURING_COMMIT

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -49,7 +49,6 @@ INSERT INTO t1 VALUES (1,1);
 --source include/start_fake_changes.inc
 
 # Test with autocommit
---error ER_ERROR_DURING_COMMIT
 SELECT * FROM t1;
 --error ER_ERROR_DURING_COMMIT
 INSERT INTO t1 VALUES (2,2);
@@ -141,7 +140,6 @@ INSERT INTO t2 VALUES (1, 1);
 --source include/start_fake_changes.inc
 
 # Test with autocommit
---error ER_ERROR_DURING_COMMIT
 SELECT * FROM t2;
 --error ER_ERROR_DURING_COMMIT
 INSERT INTO t2 VALUES (2,2);
@@ -258,7 +256,6 @@ INSERT INTO t3 VALUES (1, '');
 --source include/start_fake_changes.inc
 
 # Test with autocommit
---error ER_ERROR_DURING_COMMIT
 SELECT * FROM t3;
 --error ER_ERROR_DURING_COMMIT
 INSERT INTO t3 VALUES (2,lpad('a',10000, 'b'));
@@ -445,6 +442,54 @@ rename table t2 to t1;
 #
 set innodb_fake_changes = 0;
 drop table t2;
+
+#-------------------------------------------------------------------------------
+#
+# Scenario is meant to check following scenarios:
+# SELECT is allowed to function normally if fake_changes = ON as it is readonly
+# CREATE...SELECT * from <table>; is allowed to work if CREATE is done using
+# other SE but SELECT may be working on InnoDB.
+#
+create table t1 (i int) engine=innodb;
+insert into t1 values (1), (2);
+set session innodb_fake_changes = 1;
+#
+select * from t1;
+let save_session_engine = `select @@session.default_storage_engine`;
+set @@session.default_storage_engine=innodb;
+--error ER_CANT_CREATE_TABLE
+create table t3 select * from t1;
+#
+set @@session.default_storage_engine=myisam;
+create table t2 select * from t1;
+show create table t2;
+select * from t2;
+drop table t2;
+#
+set session innodb_fake_changes = 0;
+eval set @@session.default_storage_engine=$save_session_engine;
+drop table t1;
+#
+#
+use test;
+create table t1 (i int, j int) engine=innodb;
+insert into t1 values (1, 10), (2, 20), (3, 30);
+select * from t1;
+#
+set session innodb_fake_changes = 1;
+select * from t1;
+#
+begin;
+select * from t1;
+--error ER_ERROR_DURING_COMMIT
+commit;
+#
+--error ER_ERROR_DURING_COMMIT
+insert into t1 select * from t1;
+#
+select * from t1;
+set session innodb_fake_changes = 0;
+drop table t1;
 
 #-------------------------------------------------------------------------------
 #


### PR DESCRIPTION
…ation table

  is from other SE that is not aware of fake-changes

  Creating table in InnoDB with fake-change mode enable is semantically blocked
  and accordingly ha_innobase::create would return an error.

  What if such table exist in other SE that is not aware of fake-changes and
  table is being created and loaded using CREATE TABLE .... SELECT \* FROM;

  Due to restrictive/blocked SELECT execution (in autocommit mode) it would
  fail which eventually would result in catastrophic error as SELECT statement
  will never fail at commit stage (especially being readonly workload).

  SELECT is readonly so it could be allowed to execute even if fake-changes are
  enabled. Especially SELECT with auto-commit that use to fail before.
  SELECT inside a transaction is already allowed but commit will fail.
  Infact, a transaction without any other modifying DML statement has nothing
  to commit. Also, SELECT being executed as part of CREATE TABLE .... SELECT
  should be allowed too.
