### PR TITLE
- bug#1384588 : Failing assertion: result != FTS_INVALID in file fts0…

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -690,7 +690,6 @@ insert into t1 values (3, repeat('c', 8000));
 ERROR HY000: Got error 131 during COMMIT
 set session innodb_fake_changes = 0;
 drop table t1;
-use test;
 create table t1 (
 i int, j varchar(500), primary key pk(i), unique index sk(j)
 ) engine=innodb;
@@ -714,10 +713,10 @@ drop table t1;
 set global innodb_file_per_table = 1;
 use test;
 create table t1 (i int, key(i)) engine=innodb;
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 alter table t1 discard tablespace;
 ERROR HY000: Table storage engine for 't1' doesn't have this option
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 drop table t1;
 set global innodb_file_per_table = 1;
 use test;
@@ -725,10 +724,10 @@ create table t1 (a int, primary key pk(a));
 alter table t1 add column b char;
 create index bx on t1(b);
 insert into t1 values (1, 0x41), (2, 0x41);
-set innodb_fake_changes=1;
+set session innodb_fake_changes=1;
 update t1 set a = upper(a), b = lower(b);
 ERROR HY000: Got error 131 during COMMIT
-set innodb_fake_changes=0;
+set session innodb_fake_changes=0;
 drop table t1;
 use test;
 create table t1 (c1 int);
@@ -736,13 +735,13 @@ insert into t1 values (10);
 select * from t1;
 c1
 10
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 begin;
 insert into t1 values (10);
 select * from t1;
 c1
 10
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 replace into t1(c1) values (10);
 commit;
 ERROR HY000: Got error 131 during COMMIT
@@ -752,42 +751,42 @@ c1
 begin;
 insert into t1 values (11);
 insert into t1 values (12);
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 commit;
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 select * from t1;
 c1
 10
 11
 12
 begin;
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 insert into t1 values (11);
 insert into t1 values (12);
 commit;
 ERROR HY000: Got error 131 during COMMIT
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 drop table t1;
 use test;
 create table t1 (i int) engine=innodb;
 rename table t1 to t2;
 select * from t2;
 i
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 rename table t2 to t1;
 ERROR 42000: This version of MySQL doesn't yet support 'ALTER TABLE'
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 drop table t2;
 use test;
 create table t1 (i int, b blob, primary key pk(i)) engine=innodb;
-set innodb_fake_changes=1;
+set session innodb_fake_changes=1;
 insert into t1 values (1, repeat('a', 20000));
 ERROR HY000: Got error 131 during COMMIT
 insert into t1 values (2, repeat('b', 20000));
 ERROR HY000: Got error 131 during COMMIT
 update t1 set b = repeat('c', 20000);
 ERROR HY000: Got error 131 during COMMIT
-set innodb_fake_changes=0;
+set session innodb_fake_changes=0;
 drop table t1;
 create table t1 (i int) engine=innodb;
 insert into t1 values (1), (2);
@@ -814,7 +813,6 @@ drop table t2;
 set session innodb_fake_changes = 0;
 set @@session.default_storage_engine=InnoDB;
 drop table t1;
-use test;
 create table t1 (i int, j int) engine=innodb;
 insert into t1 values (1, 10), (2, 20), (3, 30);
 select * from t1;
@@ -844,6 +842,39 @@ i	j
 2	20
 3	30
 set session innodb_fake_changes = 0;
+drop table t1;
+use test;
+create table t1 (i int, c char(100), fulltext fts(c)) engine=innodb;
+insert into t1 values (1, 'it is raining outside');
+insert into t1 values (2, 'good to see some rain during rainy season');
+select * from t1;
+i	c
+1	it is raining outside
+2	good to see some rain during rainy season
+set session innodb_fake_changes=1;
+insert into t1 values (3, 'climate has turned really rainy and humid too');
+ERROR HY000: Got error 131 during COMMIT
+select * from t1 where match(c) against ('rainy');
+i	c
+2	good to see some rain during rainy season
+update t1 set c='some test foobar' where match c against ('rain');
+ERROR HY000: Got error 131 during COMMIT
+delete from t1 where MATCH(c) AGAINST ("rainy");
+ERROR HY000: Got error 131 during COMMIT
+select * from t1;
+i	c
+1	it is raining outside
+2	good to see some rain during rainy season
+set session innodb_fake_changes=0;
+drop table t1;
+create table t1 (
+FTS_DOC_ID bigint unsigned key,
+title char(1),
+body text, fulltext(title,body)) engine=innodb;
+set session innodb_fake_changes=1;
+insert into t1 values(1,2,11),(1,2,7);
+ERROR HY000: Got error 131 during COMMIT
+set session innodb_fake_changes=0;
 drop table t1;
 SET @@GLOBAL.userstat= default;
 SET @@GLOBAL.innodb_stats_transient_sample_pages=default;

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -392,7 +392,6 @@ drop table t1;
 #
 
 # secondary index split
-use test;
 create table t1 (
 	i int, j varchar(500), primary key pk(i), unique index sk(j)
 	) engine=innodb;
@@ -426,10 +425,10 @@ set global innodb_file_per_table = 1;
 #
 use test;
 create table t1 (i int, key(i)) engine=innodb;
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 --error ER_ILLEGAL_HA
 alter table t1 discard tablespace;
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 drop table t1;
 #
 eval set global innodb_file_per_table = $save_file_per_table;
@@ -446,10 +445,10 @@ create table t1 (a int, primary key pk(a));
 alter table t1 add column b char;
 create index bx on t1(b);
 insert into t1 values (1, 0x41), (2, 0x41);
-set innodb_fake_changes=1;
+set session innodb_fake_changes=1;
 --error ER_ERROR_DURING_COMMIT
 update t1 set a = upper(a), b = lower(b);
-set innodb_fake_changes=0;
+set session innodb_fake_changes=0;
 drop table t1;
 
 #-------------------------------------------------------------------------------
@@ -462,11 +461,11 @@ use test;
 create table t1 (c1 int);
 insert into t1 values (10);
 select * from t1;
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 begin;
 insert into t1 values (10);
 select * from t1;
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 replace into t1(c1) values (10);
 # this should fail as trx has register fake-change = 1 while starting.
 --error ER_ERROR_DURING_COMMIT
@@ -476,14 +475,14 @@ select * from t1;
 begin;
 insert into t1 values (11);
 insert into t1 values (12);
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 # this should pass as trx has register fake-change = 0 while starting.
 commit;
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 select * from t1;
 #
 begin;
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 insert into t1 values (11);
 insert into t1 values (12);
 # this should fail as trx has register fake-change = 1 while starting.
@@ -491,7 +490,7 @@ insert into t1 values (12);
 --error ER_ERROR_DURING_COMMIT
 commit;
 #
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 drop table t1;
 
 #-------------------------------------------------------------------------------
@@ -503,11 +502,11 @@ create table t1 (i int) engine=innodb;
 rename table t1 to t2;
 select * from t2;
 #
-set innodb_fake_changes = 1;
+set session innodb_fake_changes = 1;
 --error ER_NOT_SUPPORTED_YET
 rename table t2 to t1;
 #
-set innodb_fake_changes = 0;
+set session innodb_fake_changes = 0;
 drop table t2;
 
 #-------------------------------------------------------------------------------
@@ -516,14 +515,14 @@ drop table t2;
 #
 use test;
 create table t1 (i int, b blob, primary key pk(i)) engine=innodb;
-set innodb_fake_changes=1;
+set session innodb_fake_changes=1;
 --error ER_ERROR_DURING_COMMIT
 insert into t1 values (1, repeat('a', 20000));
 --error ER_ERROR_DURING_COMMIT
 insert into t1 values (2, repeat('b', 20000));
 --error ER_ERROR_DURING_COMMIT
 update t1 set b = repeat('c', 20000);
-set innodb_fake_changes=0;
+set session innodb_fake_changes=0;
 drop table t1;
 
 #-------------------------------------------------------------------------------
@@ -533,6 +532,8 @@ drop table t1;
 # CREATE...SELECT * from <table>; is allowed to work if CREATE is done using
 # other SE but SELECT may be working on InnoDB.
 #
+
+# create ... select * from
 create table t1 (i int) engine=innodb;
 insert into t1 values (1), (2);
 set session innodb_fake_changes = 1;
@@ -554,7 +555,8 @@ eval set @@session.default_storage_engine=$save_session_engine;
 drop table t1;
 #
 #
-use test;
+
+# insert into select
 create table t1 (i int, j int) engine=innodb;
 insert into t1 values (1, 10), (2, 20), (3, 30);
 select * from t1;
@@ -572,6 +574,46 @@ insert into t1 select * from t1;
 #
 select * from t1;
 set session innodb_fake_changes = 0;
+drop table t1;
+
+#-------------------------------------------------------------------------------
+#
+# Scenario will test use of fts with fake-change mode enabled.
+#
+
+# fts operation with fake-changes = on
+use test;
+create table t1 (i int, c char(100), fulltext fts(c)) engine=innodb;
+insert into t1 values (1, 'it is raining outside');
+insert into t1 values (2, 'good to see some rain during rainy season');
+select * from t1;
+#
+set session innodb_fake_changes=1;
+--error ER_ERROR_DURING_COMMIT
+insert into t1 values (3, 'climate has turned really rainy and humid too');
+select * from t1 where match(c) against ('rainy');
+#
+--error ER_ERROR_DURING_COMMIT
+update t1 set c='some test foobar' where match c against ('rain');
+--error ER_ERROR_DURING_COMMIT
+delete from t1 where MATCH(c) AGAINST ("rainy");
+select * from t1;
+#
+set session innodb_fake_changes=0;
+drop table t1;
+#
+#
+
+# fts operation with explicit doc-id and fake-changes = on.
+create table t1 (
+	FTS_DOC_ID bigint unsigned key,
+	title char(1),
+	body text, fulltext(title,body)) engine=innodb;
+#
+set session innodb_fake_changes=1;
+--error ER_ERROR_DURING_COMMIT
+insert into t1 values(1,2,11),(1,2,7);
+set session innodb_fake_changes=0;
 drop table t1;
 
 #-------------------------------------------------------------------------------

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -1388,7 +1388,8 @@ error_exit:
 		return(err);
 	}
 
-	if (dict_table_has_fts_index(table)) {
+	if (dict_table_has_fts_index(table)
+	    && UNIV_LIKELY(!thr_get_trx(thr)->fake_changes)) {
 		doc_id_t        doc_id;
 
 		/* Extract the doc id from the hidden FTS column */


### PR DESCRIPTION
…fts.cc line 2224

  While operating in fake-change mode actual changes are not made to DB also the
  commit is forced to fail and so we should avoid updating any of the FTS
  related tables (also known as FTS auxillary tables).

  Existing logic missed this path for insert but had it active for UPDATE
  and DELETE.
