### PR TITLE
Merge branch '5.5-ps-bug1364315' into 5.6-ps-bug1364315

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_1364315.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_1364315.result
@@ -1,0 +1,5 @@
+1st restart
+select count(*) > 1 from information_schema.innodb_changed_pages;
+count(*) > 1
+1
+2nd restart

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_1364315.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_1364315.test
@@ -1,0 +1,30 @@
+#
+# Test that I_S.INNODB_CHANGED_PAGES works if a trailing path separator
+# omitted in innodb_data_home_dir (bug 1364315)
+
+--source include/have_innodb.inc
+
+--let $TMPDATADIR= $MYSQLTEST_VARDIR/tmpdatadir_1364315
+
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--shutdown_server 10
+--source include/wait_until_disconnected.inc
+--mkdir $TMPDATADIR
+--enable_reconnect
+--echo 1st restart
+--exec echo "restart:--innodb-data-home-dir=$TMPDATADIR --innodb_log_group_home_dir=$TMPDATADIR --innodb_track_changed_pages=1 --innodb_changed_pages=FORCE" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+
+select count(*) > 1 from information_schema.innodb_changed_pages;
+
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--shutdown_server 10
+--source include/wait_until_disconnected.inc
+
+--remove_files_wildcard $TMPDATADIR *
+--rmdir $TMPDATADIR
+
+--enable_reconnect
+--echo 2nd restart
+--exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc

--- a/storage/innobase/log/log0online.c
+++ b/storage/innobase/log/log0online.c
@@ -1494,10 +1494,20 @@ log_online_open_bitmap_file_read_only(
 	ibool	success	= FALSE;
 	ulint	size_low;
 	ulint	size_high;
+	size_t  srv_data_home_len;
 
 	ut_ad(name[0] != '\0');
 
-	ut_snprintf(bitmap_file->name, FN_REFLEN, "%s%s", srv_data_home, name);
+	srv_data_home_len = strlen(srv_data_home);
+	if (srv_data_home_len
+			&& srv_data_home[srv_data_home_len-1]
+			!= SRV_PATH_SEPARATOR) {
+		ut_snprintf(bitmap_file->name, FN_REFLEN, "%s%c%s",
+				srv_data_home, SRV_PATH_SEPARATOR, name);
+	} else {
+		ut_snprintf(bitmap_file->name, FN_REFLEN, "%s%s",
+				srv_data_home, name);
+	}
 	bitmap_file->file
 		= os_file_create_simple_no_error_handling(innodb_file_bmp_key,
 							  bitmap_file->name,


### PR DESCRIPTION
Fix bug 1364315 / I_S.INNODB_CHANGED_PAGES unavailable if a trailing path separator omitted in innodb_data_home_dir

http://jenkins.percona.com/job/percona-server-5.6-param/981
