### PR TITLE
5.5 - Remove metapackages from debian packaging

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -182,35 +182,6 @@ Description: Percona Server database server binaries
  .
  This package includes the server binaries.
 
-Package: percona-server-server
-Section: database
-Architecture: any
-Depends: percona-server-server-5.5, ${misc:Depends}
-Description: Percona Server database server
- (metapackage depending on the latest version)
- This is an empty package that depends on the current "best" version of
- percona-server-server (currently percona-server-server-5.5), as determined 
- by the Percona Server maintainers. Install this package if in doubt 
- about which Percona Server version you need. That will install the version 
- recommended by the package maintainers.
- .
- Percona Server is a fast, stable and true multi-user, multi-threaded SQL
- database server. SQL (Structured Query Language) is the most popular database
- query language in the world. The main goals of Percona Server are speed,
- robustness and ease of use.
-
-Package: percona-server-client
-Section: database
-Architecture: any
-Depends: percona-server-client-5.5, ${misc:Depends}
-Description: Percona Server database client
- (metapackage depending on the latest version)
- This is an empty package that depends on the current "best" version of
- percona-server-client (currently percona-server-client-5.5), as determined 
- by the Percona Server maintainers.  Install this package if in doubt 
- about which Percona Server version you want, as this is the one we consider 
- to be in the best shape.
-
 Package: percona-server-test-5.5
 Architecture: any
 Depends: percona-server-client-5.5 (>= ${source:Version}), percona-server-server-5.5 (>= ${source:Version}), ${misc:Depends}, ${shlibs:Depends}


### PR DESCRIPTION
TICKET: https://jira.percona.com/browse/BLD-324
BUGS:
https://bugs.launchpad.net/percona-server/+bug/1292517
https://bugs.launchpad.net/percona-server/+bug/1328799

Short info: We have same package names "percona-server-server" and "percona-server-client" for 5.5 and for 5.6 which is not good since we have only one repo.
So when we have release for 5.5 the packages for 5.5 get pushed into repo and when we have 5.6 release the ones for 5.6 get pushed.
So it's decided that we will remove the ones for 5.5 and just stick to 5.6 as default until some day 5.7 becomes default.
More info is in the BLD-324 ticket.
