### PR TITLE
- bug#1204422 : Suboptimal fake changes handling in online ALTER stor…

### DIFF
--- a/mysql-test/r/percona_innodb_fake_changes.result
+++ b/mysql-test/r/percona_innodb_fake_changes.result
@@ -716,6 +716,12 @@ create table t1 (i int, key(i)) engine=innodb;
 set session innodb_fake_changes = 1;
 alter table t1 discard tablespace;
 ERROR HY000: Table storage engine for 't1' doesn't have this option
+alter table t1 add column b char;
+ERROR HY000: Got error 131 during COMMIT
+alter table t1 add column b char, algorithm=copy;
+ERROR HY000: Table storage engine for '#sql-temporary' doesn't have this option
+alter table t1 add column b char, algorithm=default;
+ERROR HY000: Got error 131 during COMMIT
 set session innodb_fake_changes = 0;
 drop table t1;
 set global innodb_file_per_table = 1;

--- a/mysql-test/t/percona_innodb_fake_changes.test
+++ b/mysql-test/t/percona_innodb_fake_changes.test
@@ -419,6 +419,7 @@ drop table t1;
 #
 # Scenario that try to discard tablespace with fake_change one.
 # Discard tablespace is DDL operation which is blocked in fake_change mode.
+# Scenario also test other variants of alter table.
 #
 let save_file_per_table = `select @@innodb_file_per_table`;
 set global innodb_file_per_table = 1;
@@ -428,6 +429,13 @@ create table t1 (i int, key(i)) engine=innodb;
 set session innodb_fake_changes = 1;
 --error ER_ILLEGAL_HA
 alter table t1 discard tablespace;
+--error ER_ERROR_DURING_COMMIT
+alter table t1 add column b char;
+--replace_regex /#sql-[0-9a-f_]*'/#sql-temporary'/
+--error ER_ILLEGAL_HA
+alter table t1 add column b char, algorithm=copy;
+--error ER_ERROR_DURING_COMMIT
+alter table t1 add column b char, algorithm=default;
 set session innodb_fake_changes = 0;
 drop table t1;
 #

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -2600,14 +2600,9 @@ prepare_inplace_alter_table_dict(
 	/* Create a background transaction for the operations on
 	the data dictionary tables. */
 	ctx->trx = innobase_trx_allocate(ctx->prebuilt->trx->mysql_thd);
-
-	if (UNIV_UNLIKELY(ctx->trx->fake_changes)) {
-		trx_rollback_to_savepoint(ctx->trx, NULL);
-		trx_free_for_mysql(ctx->trx);
-		DBUG_RETURN(HA_ERR_WRONG_COMMAND);
-	}
-
 	trx_start_for_ddl(ctx->trx, TRX_DICT_OP_INDEX);
+
+	DBUG_ASSERT(!ctx->trx->fake_changes);
 
 	/* Create table containing all indexes to be built in this
 	ALTER TABLE ADD INDEX so that they are in the correct order


### PR DESCRIPTION
…age engine API

  Removal of dead-code.
  ALTER Table is blocked at higher level and so the lower level API doesn't need
  to block it as control is never expected to reach there.
  Replaced the dead-code with DEBUG ASSERT for safe check.
