### PR TITLE
- bug#1160960 : bug54330.test missing have_innodb check

### DIFF
--- a/mysql-test/suite/innodb/t/bug54330.test
+++ b/mysql-test/suite/innodb/t/bug54330.test
@@ -1,5 +1,7 @@
 # Testcase for MySQL bug #54330 - broken fast index creation
 
+--source include/have_innodb.inc
+
 --disable_warnings
 DROP TABLE IF EXISTS t1;
 --enable_warnings


### PR DESCRIPTION
  TC was missing innodb se check which is must if TC involves use
  of innodb storage engine.
