### PR TITLE
5.6 - Change rpm to obsolete mariadb-devel package (BLD-302)

### DIFF
--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -359,6 +359,9 @@ Summary:        Percona Server - Development header files and libraries
 Group:          Applications/Databases
 Provides:       mysql-devel
 Conflicts:      Percona-SQL-devel-50 Percona-Server-devel-51
+%if "%rhel" > "6"
+Obsoletes:      mariadb-devel
+%endif
 
 %description -n Percona-Server-devel%{product_suffix}
 This package contains the development header files and libraries necessary


### PR DESCRIPTION
**TICKETS:**
BLD-302
https://bugs.launchpad.net/percona-server/+bug/1499721

Problem: If mariadb-devel package is installed in centos 7 system the installation of PS 5.5/5.6 will fail because nothing is replacing that package and we replace mariadb-libs on which mariadb-devel depends.
Solution: Put obsoletes for mariadb-devel package so it can be replaced correctly.

**TEST BUILDS:**
5.5: http://jenkins.percona.com/job/percona-server-5.5-redhat-binary/169/label_exp=centos7-64/
5.6: http://jenkins.percona.com/job/percona-server-5.6-redhat-binary/47/label_exp=centos7-64/

**TESTS:**
**OLD 5.5 PACKAGE:**

```
[vagrant@t-centos7-64 old]$ sudo yum install *.rpm
Loaded plugins: fastestmirror
Examining Percona-Server-client-55-5.5.45-rel37.4.el7.x86_64.rpm: Percona-Server-client-55-5.5.45-rel37.4.el7.x86_64
Marking Percona-Server-client-55-5.5.45-rel37.4.el7.x86_64.rpm to be installed
Examining Percona-Server-devel-55-5.5.45-rel37.4.el7.x86_64.rpm: Percona-Server-devel-55-5.5.45-rel37.4.el7.x86_64
Marking Percona-Server-devel-55-5.5.45-rel37.4.el7.x86_64.rpm to be installed
Examining Percona-Server-server-55-5.5.45-rel37.4.el7.x86_64.rpm: Percona-Server-server-55-5.5.45-rel37.4.el7.x86_64
Marking Percona-Server-server-55-5.5.45-rel37.4.el7.x86_64.rpm to be installed
Examining Percona-Server-shared-55-5.5.45-rel37.4.el7.x86_64.rpm: Percona-Server-shared-55-5.5.45-rel37.4.el7.x86_64
Marking Percona-Server-shared-55-5.5.45-rel37.4.el7.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package Percona-Server-client-55.x86_64 0:5.5.45-rel37.4.el7 will be installed
---> Package Percona-Server-devel-55.x86_64 0:5.5.45-rel37.4.el7 will be installed
---> Package Percona-Server-server-55.x86_64 0:5.5.45-rel37.4.el7 will be installed
--> Processing Dependency: perl(Data::Dumper) for package: Percona-Server-server-55-5.5.45-rel37.4.el7.x86_64
Loading mirror speeds from cached hostfile
 * base: mirrors.xgroup.si
 * extras: mirrors.xgroup.si
 * updates: mirrors.xgroup.si
---> Package Percona-Server-shared-55.x86_64 0:5.5.45-rel37.4.el7 will be obsoleting
---> Package mariadb-libs.x86_64 1:5.5.44-1.el7_1 will be obsoleted
--> Processing Dependency: mariadb-libs(x86-64) = 1:5.5.44-1.el7_1 for package: 1:mariadb-devel-5.5.44-1.el7_1.x86_64
--> Running transaction check
---> Package mariadb-libs.x86_64 1:5.5.44-1.el7_1 will be obsoleted
--> Processing Dependency: mariadb-libs(x86-64) = 1:5.5.44-1.el7_1 for package: 1:mariadb-devel-5.5.44-1.el7_1.x86_64
---> Package perl-Data-Dumper.x86_64 0:2.145-3.el7 will be installed
--> Finished Dependency Resolution
Error: Package: 1:mariadb-devel-5.5.44-1.el7_1.x86_64 (@updates)
           Requires: mariadb-libs(x86-64) = 1:5.5.44-1.el7_1
           Removing: 1:mariadb-libs-5.5.44-1.el7_1.x86_64 (@updates)
               mariadb-libs(x86-64) = 1:5.5.44-1.el7_1
           Obsoleted By: Percona-Server-shared-55-5.5.45-rel37.4.el7.x86_64 (/Percona-Server-shared-55-5.5.45-rel37.4.el7.x86_64)
               Not found
           Available: 1:mariadb-libs-5.5.41-2.el7_0.x86_64 (base)
               mariadb-libs(x86-64) = 1:5.5.41-2.el7_0
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```

**NEW 5.5 PACKAGE:**

```
[vagrant@t-centos7-64 new55]$ sudo yum install *.rpm
Loaded plugins: fastestmirror
Examining Percona-Server-client-55-5.5.44-rel37.3.el7.x86_64.rpm: Percona-Server-client-55-5.5.44-rel37.3.el7.x86_64
Marking Percona-Server-client-55-5.5.44-rel37.3.el7.x86_64.rpm to be installed
Examining Percona-Server-devel-55-5.5.44-rel37.3.el7.x86_64.rpm: Percona-Server-devel-55-5.5.44-rel37.3.el7.x86_64
Marking Percona-Server-devel-55-5.5.44-rel37.3.el7.x86_64.rpm to be installed
Examining Percona-Server-server-55-5.5.44-rel37.3.el7.x86_64.rpm: Percona-Server-server-55-5.5.44-rel37.3.el7.x86_64
Marking Percona-Server-server-55-5.5.44-rel37.3.el7.x86_64.rpm to be installed
Examining Percona-Server-shared-55-5.5.44-rel37.3.el7.x86_64.rpm: Percona-Server-shared-55-5.5.44-rel37.3.el7.x86_64
Marking Percona-Server-shared-55-5.5.44-rel37.3.el7.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package Percona-Server-client-55.x86_64 0:5.5.44-rel37.3.el7 will be installed
---> Package Percona-Server-devel-55.x86_64 0:5.5.44-rel37.3.el7 will be obsoleting
---> Package Percona-Server-server-55.x86_64 0:5.5.44-rel37.3.el7 will be installed
--> Processing Dependency: perl(Data::Dumper) for package: Percona-Server-server-55-5.5.44-rel37.3.el7.x86_64
Loading mirror speeds from cached hostfile
 * base: mirrors.prometeus.net
 * extras: centos.muzzy.it
 * updates: centos.muzzy.it
---> Package Percona-Server-shared-55.x86_64 0:5.5.44-rel37.3.el7 will be obsoleting
---> Package mariadb-devel.x86_64 1:5.5.44-1.el7_1 will be obsoleted
---> Package mariadb-libs.x86_64 1:5.5.44-1.el7_1 will be obsoleted
--> Running transaction check
---> Package perl-Data-Dumper.x86_64 0:2.145-3.el7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

=======================================================================================================================================================================================================================================
 Package                                                Arch                                 Version                                           Repository                                                                         Size
=======================================================================================================================================================================================================================================
Installing:
 Percona-Server-client-55                               x86_64                               5.5.44-rel37.3.el7                                /Percona-Server-client-55-5.5.44-rel37.3.el7.x86_64                                30 M
 Percona-Server-devel-55                                x86_64                               5.5.44-rel37.3.el7                                /Percona-Server-devel-55-5.5.44-rel37.3.el7.x86_64                                4.5 M
     replacing  mariadb-devel.x86_64 1:5.5.44-1.el7_1
 Percona-Server-server-55                               x86_64                               5.5.44-rel37.3.el7                                /Percona-Server-server-55-5.5.44-rel37.3.el7.x86_64                                66 M
 Percona-Server-shared-55                               x86_64                               5.5.44-rel37.3.el7                                /Percona-Server-shared-55-5.5.44-rel37.3.el7.x86_64                               3.1 M
     replacing  mariadb-libs.x86_64 1:5.5.44-1.el7_1
Installing for dependencies:
 perl-Data-Dumper                                       x86_64                               2.145-3.el7                                       base                                                                               47 k

Transaction Summary
=======================================================================================================================================================================================================================================
Install  4 Packages (+1 Dependent package)

Total size: 103 M
...
Installed:
  Percona-Server-client-55.x86_64 0:5.5.44-rel37.3.el7     Percona-Server-devel-55.x86_64 0:5.5.44-rel37.3.el7     Percona-Server-server-55.x86_64 0:5.5.44-rel37.3.el7     Percona-Server-shared-55.x86_64 0:5.5.44-rel37.3.el7    

Dependency Installed:
  perl-Data-Dumper.x86_64 0:2.145-3.el7                                                                                                                                                                                                

Replaced:
  mariadb-devel.x86_64 1:5.5.44-1.el7_1                                                                              mariadb-libs.x86_64 1:5.5.44-1.el7_1                                                                             
```

**5.6 OLD PACKAGE**

```
[vagrant@t-centos7-64 old]$ sudo yum install *.rpm
Loaded plugins: fastestmirror
Examining Percona-Server-client-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-client-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-client-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Examining Percona-Server-devel-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-devel-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-devel-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Examining Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Examining Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package Percona-Server-client-56.x86_64 0:5.6.26-rel74.0.el7 will be installed
---> Package Percona-Server-devel-56.x86_64 0:5.6.26-rel74.0.el7 will be installed
---> Package Percona-Server-server-56.x86_64 0:5.6.26-rel74.0.el7 will be installed
--> Processing Dependency: perl(Data::Dumper) for package: Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64
Loading mirror speeds from cached hostfile
 * base: mirrors.xgroup.si
 * extras: mirrors.xgroup.si
 * updates: mirrors.xgroup.si
---> Package Percona-Server-shared-56.x86_64 0:5.6.26-rel74.0.el7 will be obsoleting
---> Package mariadb-libs.x86_64 1:5.5.44-1.el7_1 will be obsoleted
--> Processing Dependency: mariadb-libs(x86-64) = 1:5.5.44-1.el7_1 for package: 1:mariadb-devel-5.5.44-1.el7_1.x86_64
--> Running transaction check
---> Package mariadb-libs.x86_64 1:5.5.44-1.el7_1 will be obsoleted
--> Processing Dependency: mariadb-libs(x86-64) = 1:5.5.44-1.el7_1 for package: 1:mariadb-devel-5.5.44-1.el7_1.x86_64
---> Package perl-Data-Dumper.x86_64 0:2.145-3.el7 will be installed
--> Finished Dependency Resolution
Error: Package: 1:mariadb-devel-5.5.44-1.el7_1.x86_64 (@updates)
           Requires: mariadb-libs(x86-64) = 1:5.5.44-1.el7_1
           Removing: 1:mariadb-libs-5.5.44-1.el7_1.x86_64 (@updates)
               mariadb-libs(x86-64) = 1:5.5.44-1.el7_1
           Obsoleted By: Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64 (/Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64)
               Not found
           Available: 1:mariadb-libs-5.5.41-2.el7_0.x86_64 (base)
               mariadb-libs(x86-64) = 1:5.5.41-2.el7_0
 You could try using --skip-broken to work around the problem
 You could try running: rpm -Va --nofiles --nodigest
```

**5.6 NEW PACKAGE:**

```
[vagrant@t-centos7-64 new]$ sudo yum install *.rpm
Loaded plugins: fastestmirror
Examining Percona-Server-client-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-client-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-client-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Examining Percona-Server-devel-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-devel-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-devel-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Examining Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Examining Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64.rpm: Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64
Marking Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package Percona-Server-client-56.x86_64 0:5.6.26-rel74.0.el7 will be installed
---> Package Percona-Server-devel-56.x86_64 0:5.6.26-rel74.0.el7 will be obsoleting
---> Package Percona-Server-server-56.x86_64 0:5.6.26-rel74.0.el7 will be installed
--> Processing Dependency: perl(Data::Dumper) for package: Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64
Loading mirror speeds from cached hostfile
 * base: mirrors.xgroup.si
 * extras: mirrors.prometeus.net
 * updates: centos.muzzy.it
---> Package Percona-Server-shared-56.x86_64 0:5.6.26-rel74.0.el7 will be obsoleting
---> Package mariadb-devel.x86_64 1:5.5.44-1.el7_1 will be obsoleted
---> Package mariadb-libs.x86_64 1:5.5.44-1.el7_1 will be obsoleted
--> Running transaction check
---> Package perl-Data-Dumper.x86_64 0:2.145-3.el7 will be installed
--> Finished Dependency Resolution

Dependencies Resolved

=======================================================================================================================================================================================================================================
 Package                                                Arch                                 Version                                           Repository                                                                         Size
=======================================================================================================================================================================================================================================
Installing:
 Percona-Server-client-56                               x86_64                               5.6.26-rel74.0.el7                                /Percona-Server-client-56-5.6.26-rel74.0.el7.x86_64                                33 M
 Percona-Server-devel-56                                x86_64                               5.6.26-rel74.0.el7                                /Percona-Server-devel-56-5.6.26-rel74.0.el7.x86_64                                5.0 M
     replacing  mariadb-devel.x86_64 1:5.5.44-1.el7_1
 Percona-Server-server-56                               x86_64                               5.6.26-rel74.0.el7                                /Percona-Server-server-56-5.6.26-rel74.0.el7.x86_64                                88 M
 Percona-Server-shared-56                               x86_64                               5.6.26-rel74.0.el7                                /Percona-Server-shared-56-5.6.26-rel74.0.el7.x86_64                               3.5 M
     replacing  mariadb-libs.x86_64 1:5.5.44-1.el7_1
Installing for dependencies:
 perl-Data-Dumper                                       x86_64                               2.145-3.el7                                       base                                                                               47 k

Transaction Summary
=======================================================================================================================================================================================================================================
Install  4 Packages (+1 Dependent package)

Total size: 129 M
Total download size: 47 k
...
Installed:
  Percona-Server-client-56.x86_64 0:5.6.26-rel74.0.el7     Percona-Server-devel-56.x86_64 0:5.6.26-rel74.0.el7     Percona-Server-server-56.x86_64 0:5.6.26-rel74.0.el7     Percona-Server-shared-56.x86_64 0:5.6.26-rel74.0.el7    

Dependency Installed:
  perl-Data-Dumper.x86_64 0:2.145-3.el7                                                                                                                                                                                                

Replaced:
  mariadb-devel.x86_64 1:5.5.44-1.el7_1                                                                              mariadb-libs.x86_64 1:5.5.44-1.el7_1                                                                             

Complete!
```
