### PR TITLE
Fix bitmap files being opened with O_DIRECT, failing on some filesystems

### DIFF
--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -132,6 +132,10 @@ enum os_file_create_t {
 #define OS_FILE_READ_ONLY		333
 #define	OS_FILE_READ_WRITE		444
 #define	OS_FILE_READ_ALLOW_DELETE	555	/* for mysqlbackup */
+#define OS_FILE_READ_WRITE_CACHED	666	/* OS_FILE_READ_WRITE but never
+						O_DIRECT. Only for
+						os_file_create_simple_no_error_handling
+						currently. */
 
 /* Options for file_create */
 #define	OS_FILE_AIO			61
@@ -540,9 +544,11 @@ os_file_create_simple_no_error_handling_func(
 				null-terminated string */
 	ulint		create_mode,/*!< in: create mode */
 	ulint		access_type,/*!< in: OS_FILE_READ_ONLY,
-				OS_FILE_READ_WRITE, or
-				OS_FILE_READ_ALLOW_DELETE; the last option is
-				used by a backup program reading the file */
+				OS_FILE_READ_WRITE,
+				OS_FILE_READ_ALLOW_DELETE (used by a backup
+				program reading the file), or
+				OS_FILE_READ_WRITE_CACHED (disable O_DIRECT
+				if it would be enabled otherwise) */
 	ibool*		success)/*!< out: TRUE if succeed, FALSE if error */
 	__attribute__((nonnull, warn_unused_result));
 /****************************************************************//**

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -546,7 +546,7 @@ log_online_start_bitmap_file(void)
 							innodb_file_bmp_key,
 							log_bmp_sys->out.name,
 							OS_FILE_CREATE,
-							OS_FILE_READ_WRITE,
+							OS_FILE_READ_WRITE_CACHED,
 							&success);
 	}
 	if (UNIV_UNLIKELY(!success)) {
@@ -707,7 +707,7 @@ log_online_read_init(void)
 	log_bmp_sys->out.file
 		= os_file_create_simple_no_error_handling
 		(innodb_file_bmp_key, log_bmp_sys->out.name, OS_FILE_OPEN,
-		 OS_FILE_READ_WRITE, &success);
+		 OS_FILE_READ_WRITE_CACHED, &success);
 
 	if (!success) {
 


### PR DESCRIPTION
This fixes
- bug 1498891 (percona_changed_page_bmp_flush fails with "File
  (unknown): 'read' returned OS error 122. Cannot continue operation);
- bug 1500720 (mysql will not start with changed page tracking and
  O_DIRECT)
  and at the same time
- bug 1500741 (Upstream bug 76627 not fixed for the ALL_O_DIRECT case).

For the first two bugs the problem is the upstream commit b4daac2,
which fixed http://bugs.mysql.com/bug.php?id=76627 and made
os_file_create_simple_no_error_handling apply O_DIRECT on opened
files. This fix was merged as-is and resulted in bitmap files being
opened with O_DIRECT.

Fix by introducing new flag for
os_file_create_simple_no_error_handling access_type arg:
OS_FILE_READ_WRITE_CACHED, and using it for bitmap file opening.

The as-is merge of the same upstream commit resulted in bug 1500741:
it was not adapted to handle ALL_O_DIRECT, effectively leaving 76627
unfixed for this case. Fixed trivially.

```
http://jenkins.percona.com/job/percona-server-5.6-param/989/
```
