### PR TITLE
5.5 - Fix complaint on duplicate pid file in rpm upgrade (bug1454917)

### DIFF
--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -640,7 +640,7 @@ rm -rf $RBR%{_sysconfdir}/init.d/mysql
 if [ -x %{_bindir}/my_print_defaults ]
 then
   mysql_datadir=`%{_bindir}/my_print_defaults server mysqld | grep '^--datadir=' | sed -n 's/--datadir=//p' | tail -n 1`
-  PID_FILE_PATT=`%{_bindir}/my_print_defaults server mysqld | grep '^--pid-file=' | sed -n 's/--pid-file=//p'`
+  PID_FILE_PATT=`%{_bindir}/my_print_defaults server mysqld | grep '^--pid-file=' | sed -n 's/--pid-file=//p' | sort -u`
 fi
 if [ -z "$mysql_datadir" ]
 then


### PR DESCRIPTION
**PROBLEM:**
In rpm upgrade case if the user has duplicate pid-file options in config files the upgrade will stop with error because it thinks it's the different pid file and it actually is the same one. If the user actually has multiple different pid-files the upgrade will fail so there should be no change there.

**SOLUTION:**
Just do simple sort with removal of duplicates.

**BUGS:**
https://bugs.launchpad.net/percona-server/+bug/1454917
https://bugs.launchpad.net/percona-server/+bug/1499569

**TEST BUILDS:**
5.5: http://jenkins.percona.com/job/percona-server-5.5-redhat-binary/170/
5.6: http://jenkins.percona.com/job/percona-server-5.6-redhat-binary/48/

**OLD BEHAVIOUR**

```
[vagrant@t-centos6-64 ~]$ my_print_defaults server mysqld | grep '^--pid-file=' | sed -n 's/--pid-file=//p'
/tmp/mysqld.pid
/tmp/mysqld.pid
```

_UPGRADE:_

```
Running Transaction
  Updating   : Percona-Server-shared-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  1/8 
  Updating   : Percona-Server-client-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  2/8 
You have more than one PID file:
-rw-rw---- 1 mysql mysql 5 2015-10-01 05:56 /tmp/mysqld.pid
-rw-rw---- 1 mysql mysql 5 2015-10-01 05:56 /tmp/mysqld.pid
Please check which one (if any) corresponds to a running server
and delete all others before repeating the MySQL upgrade.
error: %pre(Percona-Server-server-56-5.6.26-rel74.0.el6.x86_64) scriptlet failed, exit status 1
Error in PREIN scriptlet in rpm package Percona-Server-server-56-5.6.26-rel74.0.el6.x86_64
error:   install: %pre scriptlet failed (2), skipping Percona-Server-server-56-5.6.26-rel74.0.el6
```

**NEW TEST FOR 5.6**

```
[vagrant@t-centos6-64 ~]$ my_print_defaults server mysqld | grep '^--pid-file=' | sed -n 's/--pid-file=//p'|sort -u
/tmp/mysqld.pid

[vagrant@t-centos6-64 ~]$ sudo service mysql status
 SUCCESS! MySQL (Percona Server) running (3135)
```

_UPGRADE:_

```
Resolving Dependencies
--> Running transaction check
---> Package Percona-Server-client-56.x86_64 0:5.6.25-rel73.1.el6 will be updated
---> Package Percona-Server-client-56.x86_64 0:5.6.26-rel74.0.el6 will be an update
---> Package Percona-Server-server-56.x86_64 0:5.6.25-rel73.1.el6 will be updated
---> Package Percona-Server-server-56.x86_64 0:5.6.26-rel74.0.el6 will be an update
---> Package Percona-Server-shared-56.x86_64 0:5.6.25-rel73.1.el6 will be updated
---> Package Percona-Server-shared-56.x86_64 0:5.6.26-rel74.0.el6 will be an update
--> Finished Dependency Resolution

Dependencies Resolved

=======================================================================================================================================================================================================================================
 Package                                                Arch                                 Version                                           Repository                                                                         Size
=======================================================================================================================================================================================================================================
Updating:
 Percona-Server-client-56                               x86_64                               5.6.26-rel74.0.el6                                /Percona-Server-client-56-5.6.26-rel74.0.el6.x86_64                                33 M
 Percona-Server-server-56                               x86_64                               5.6.26-rel74.0.el6                                /Percona-Server-server-56-5.6.26-rel74.0.el6.x86_64                                87 M
 Percona-Server-shared-56                               x86_64                               5.6.26-rel74.0.el6                                /Percona-Server-shared-56-5.6.26-rel74.0.el6.x86_64                               3.4 M

Transaction Summary
=======================================================================================================================================================================================================================================
Upgrade       3 Package(s)

Total size: 123 M
Is this ok [y/N]: y
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Updating   : Percona-Server-shared-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  1/6 
  Updating   : Percona-Server-client-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  2/6 
Giving mysqld 5 seconds to exit nicely
  Updating   : Percona-Server-server-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  3/6 
Starting MySQL (Percona Server). SUCCESS! 
Giving mysqld 5 seconds to start
Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
Run the following commands to create these functions:
mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"
See http://www.percona.com/doc/percona-server/5.6/management/udf_percona_toolkit.html for more details
  Cleanup    : Percona-Server-server-56-5.6.25-rel73.1.el6.x86_64                                                                                                                                                                  4/6 
  Cleanup    : Percona-Server-client-56-5.6.25-rel73.1.el6.x86_64                                                                                                                                                                  5/6 
  Cleanup    : Percona-Server-shared-56-5.6.25-rel73.1.el6.x86_64                                                                                                                                                                  6/6 
  Verifying  : Percona-Server-client-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  1/6 
  Verifying  : Percona-Server-server-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  2/6 
  Verifying  : Percona-Server-shared-56-5.6.26-rel74.0.el6.x86_64                                                                                                                                                                  3/6 
  Verifying  : Percona-Server-server-56-5.6.25-rel73.1.el6.x86_64                                                                                                                                                                  4/6 
  Verifying  : Percona-Server-client-56-5.6.25-rel73.1.el6.x86_64                                                                                                                                                                  5/6 
  Verifying  : Percona-Server-shared-56-5.6.25-rel73.1.el6.x86_64                                                                                                                                                                  6/6 

Updated:
  Percona-Server-client-56.x86_64 0:5.6.26-rel74.0.el6                        Percona-Server-server-56.x86_64 0:5.6.26-rel74.0.el6                        Percona-Server-shared-56.x86_64 0:5.6.26-rel74.0.el6                       

Complete!
[vagrant@t-centos6-64 ~]$ sudo service mysql status
 SUCCESS! MySQL (Percona Server) running (3479)
```
