### PR TITLE
Fixed bug lp:1497942 (percona_slow_query_log_rate fails sporadically) (5.5)

### DIFF
--- a/mysql-test/include/percona_slow_query_log_rate.inc
+++ b/mysql-test/include/percona_slow_query_log_rate.inc
@@ -28,10 +28,16 @@ dec $i;
 }
 
 --connection default
---source include/log_stop.inc
 --disconnect connection_one
 --disconnect connection_two
 --disconnect connection_three
 --source include/wait_until_count_sessions.inc
+# we disable slow query log AFTER disconnects here to make sure that all
+# "SELECT 'connection_xxx'" statements are 100% processed (including logging
+# slow queries) and we do not close slow query log file in one connection
+# while other ones, althought already send the result back to the client,
+# may still need to finish remaining tasks (like writing
+# to slog)
+--source include/log_stop.inc
 --let log_slow_rate_test=1
 --source include/log_grep.inc

--- a/mysql-test/r/percona_slow_query_log_rate.result
+++ b/mysql-test/r/percona_slow_query_log_rate.result
@@ -1,4 +1,3 @@
-SET @old_debug=@@global.debug;
 SET GLOBAL debug="+d,seed_slow_log_random";
 SET GLOBAL long_query_time=0;
 SET GLOBAL log_slow_rate_type='session';

--- a/mysql-test/t/percona_slow_query_log_rate.test
+++ b/mysql-test/t/percona_slow_query_log_rate.test
@@ -9,7 +9,7 @@ let $old_log_slow_rate_limit=`SELECT @@global.log_slow_rate_limit`;
 let $old_slow_query_log_always_write_time=`SELECT @@global.slow_query_log_always_write_time`;
 
 # Force deterministic random pattern of slow log filter for new connections
-SET @old_debug=@@global.debug;
+let $old_debug=`SELECT @@global.debug`;
 SET GLOBAL debug="+d,seed_slow_log_random";
 
 SET GLOBAL long_query_time=0;
@@ -32,7 +32,7 @@ SET GLOBAL log_slow_rate_limit=2;
 --source include/percona_slow_query_log_rate.inc
 
 --disable_query_log
-SET GLOBAL debug=@old_debug;
+eval SET GLOBAL debug='$old_debug';
 eval SET GLOBAL long_query_time=$old_long_query_time;
 eval SET GLOBAL log_slow_rate_type=$old_log_slow_rate_type;
 eval SET GLOBAL log_slow_rate_limit=$old_log_slow_rate_limit;


### PR DESCRIPTION
Fixed problem with "percona_slow_query_log_rate.test" not properly restoring
"debug" global variable after server restart.
Running "./mtr percona_slow_query_log_rate --debug" does not fail any more.

Fixed problem with potential disabling slow query log in primary connection
while other ones (executing "SELECT 'something_xxx'"), although already sent
the result back to the client, have not written these statements to the slog
yet.

Jenkins build link
http://jenkins.percona.com/job/percona-server-5.5-param/1164/
