### PR TITLE
Backport fix for #16906827 https://github.com/mysql/mysql-server/comm…

### DIFF
--- a/mysql-test/r/query_cache_disabled.result
+++ b/mysql-test/r/query_cache_disabled.result
@@ -12,3 +12,23 @@ SHOW GLOBAL VARIABLES LIKE 'query_cache_size';
 Variable_name	Value
 query_cache_size	1048576
 SET GLOBAL query_cache_size=DEFAULT;
+#
+# BUG#16906827 - CAN'T SET QUERY_CACHE_TYPE TO 0 WHEN IT IS ALREADY 0
+#
+SHOW GLOBAL VARIABLES LIKE 'query_cache_type';
+Variable_name	Value
+query_cache_type	OFF
+# This statement will pass if run with the fix and fail with 
+# ER_QUERY_CACHE_DISABLED if run without the fix.
+SET GLOBAL query_cache_type=OFF;
+SET GLOBAL query_cache_type=ON;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
+SET GLOBAL query_cache_type=DEMAND;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
+# This statement will pass if run with the fix and fail with 
+# ER_QUERY_CACHE_DISABLED if run without the fix.
+SET SESSION query_cache_type=OFF;
+SET SESSION query_cache_type=ON;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
+SET SESSION query_cache_type=DEMAND;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it

--- a/mysql-test/t/query_cache_disabled.test
+++ b/mysql-test/t/query_cache_disabled.test
@@ -12,3 +12,21 @@ SET GLOBAL query_cache_type=OFF;
 SET GLOBAL query_cache_size=1024*1024;
 SHOW GLOBAL VARIABLES LIKE 'query_cache_size';
 SET GLOBAL query_cache_size=DEFAULT;
+--echo #
+--echo # BUG#16906827 - CAN'T SET QUERY_CACHE_TYPE TO 0 WHEN IT IS ALREADY 0
+--echo #
+SHOW GLOBAL VARIABLES LIKE 'query_cache_type';
+--echo # This statement will pass if run with the fix and fail with 
+--echo # ER_QUERY_CACHE_DISABLED if run without the fix.
+SET GLOBAL query_cache_type=OFF;
+--error ER_QUERY_CACHE_DISABLED
+SET GLOBAL query_cache_type=ON;
+--error ER_QUERY_CACHE_DISABLED
+SET GLOBAL query_cache_type=DEMAND;
+--echo # This statement will pass if run with the fix and fail with 
+--echo # ER_QUERY_CACHE_DISABLED if run without the fix.
+SET SESSION query_cache_type=OFF;
+--error ER_QUERY_CACHE_DISABLED
+SET SESSION query_cache_type=ON;
+--error ER_QUERY_CACHE_DISABLED
+SET SESSION query_cache_type=DEMAND;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2747,7 +2747,9 @@ static Sys_var_ulong Sys_query_cache_min_res_unit(
 static const char *query_cache_type_names[]= { "OFF", "ON", "DEMAND", 0 };
 static bool check_query_cache_type(sys_var *self, THD *thd, set_var *var)
 {
-  if (query_cache.is_disabled())
+  if (var->save_result.ulonglong_value == 0)
+    return false;
+  else if (query_cache.is_disabled())
   {
     my_error(ER_QUERY_CACHE_DISABLED, MYF(0));
     return true;


### PR DESCRIPTION
When you start percona-server with the option 
  query_cache_type=0
And then you execute a 
  set global query_cache_type=0;
The server answer with error 1651.

This is a problem because some automation tools try to set variables at evry run. The first run will be OK, but the next will fail.

This is fixed in mainstream mysql-server
