### PR TITLE
Fixed lp:1510953 (5.5) ("SHOW ..." statements update "Rows_fetched" value i…

### DIFF
--- a/mysql-test/r/percona_userstat.result
+++ b/mysql-test/r/percona_userstat.result
@@ -101,4 +101,47 @@ ALTER TABLE t2 MODIFY c1 FLOAT;
 SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS WHERE TABLE_NAME='t2';
 TABLE_SCHEMA	TABLE_NAME	ROWS_READ	ROWS_CHANGED	ROWS_CHANGED_X_INDEXES
 DROP TABLE t2;
+SELECT
+Select_commands, Update_commands, Other_commands, Rows_fetched
+INTO
+@initial_select_commands, @initial_update_commands, @initial_other_commands, @initial_rows_fetched
+FROM
+INFORMATION_SCHEMA.USER_STATISTICS
+;
+SELECT
+Select_commands = @initial_select_commands + 1 AS select_must_be_true_2,
+Update_commands = @initial_update_commands     AS update_must_be_true_2,
+Other_commands  = @initial_other_commands      AS other_must_be_true_2,
+Rows_fetched    = @initial_rows_fetched        AS rows_must_be_true_2
+FROM
+INFORMATION_SCHEMA.USER_STATISTICS
+;
+select_must_be_true_2	update_must_be_true_2	other_must_be_true_2	rows_must_be_true_2
+1	1	1	1
+SELECT 'something';
+something
+something
+SELECT
+Select_commands = @initial_select_commands + 3 AS select_must_be_true_4,
+Update_commands = @initial_update_commands     AS update_must_be_true_4,
+Other_commands  = @initial_other_commands      AS other_must_be_true_4,
+Rows_fetched    = @initial_rows_fetched    + 2 AS rows_must_be_true_4
+FROM
+INFORMATION_SCHEMA.USER_STATISTICS
+;
+select_must_be_true_4	update_must_be_true_4	other_must_be_true_4	rows_must_be_true_4
+1	1	1	1
+SHOW VARIABLES LIKE 'userstat';
+Variable_name	Value
+userstat	ON
+SELECT
+Select_commands = @initial_select_commands + 4 AS select_must_be_true_6,
+Update_commands = @initial_update_commands     AS update_must_be_true_6,
+Other_commands  = @initial_other_commands  + 1 AS other_must_be_true_6,
+Rows_fetched    = @initial_rows_fetched    + 3 AS rows_must_be_true_6
+FROM
+INFORMATION_SCHEMA.USER_STATISTICS
+;
+select_must_be_true_6	update_must_be_true_6	other_must_be_true_6	rows_must_be_true_6
+1	1	1	1
 SET GLOBAL userstat= @userstat_old;

--- a/mysql-test/t/percona_userstat.test
+++ b/mysql-test/t/percona_userstat.test
@@ -114,6 +114,64 @@ SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS WHERE TABLE_NAME='t2';
 
 DROP TABLE t2;
 
+# Bug 1510953 ("SHOW ..." statements update "Rows_fetched" value in "information_schema.user_statistics")
+
+# Capture initial "USER_STATISTICS" values
+# statement (1)
+SELECT
+  Select_commands, Update_commands, Other_commands, Rows_fetched
+INTO
+  @initial_select_commands, @initial_update_commands, @initial_other_commands, @initial_rows_fetched
+FROM
+  INFORMATION_SCHEMA.USER_STATISTICS
+;
+
+# Because of (1) "Select_commands" must increase by 1, "Rows_fetched" must mot
+# change ("SELECT INTO" is executed purely on the server and did not return any
+# data)
+# statement (2)
+SELECT
+  Select_commands = @initial_select_commands + 1 AS select_must_be_true_2,
+  Update_commands = @initial_update_commands     AS update_must_be_true_2,
+  Other_commands  = @initial_other_commands      AS other_must_be_true_2,
+  Rows_fetched    = @initial_rows_fetched        AS rows_must_be_true_2
+FROM
+  INFORMATION_SCHEMA.USER_STATISTICS
+;
+
+# Simple "SELECT" statement with 1 row output
+# statement (3)
+SELECT 'something';
+
+# Because of (2) "Select_commands" must increase by 1, "Rows_fetched" by 1
+# Because of (3) "Select_commands" must increase by 1, "Rows_fetched" by 1
+# statement (4)
+SELECT
+  Select_commands = @initial_select_commands + 3 AS select_must_be_true_4,
+  Update_commands = @initial_update_commands     AS update_must_be_true_4,
+  Other_commands  = @initial_other_commands      AS other_must_be_true_4,
+  Rows_fetched    = @initial_rows_fetched    + 2 AS rows_must_be_true_4
+FROM
+  INFORMATION_SCHEMA.USER_STATISTICS
+;
+
+# Simple "SHOW ..." statement with 1 row output
+# statement (5)
+SHOW VARIABLES LIKE 'userstat';
+
+# Because of (4) "Select_commands" must increase by 1, "Rows_fetched" by 1
+# Because of (5) "Select_commands" must not change, "Other_commands" must 
+# increase by 1, "Rows_fetched" must not change
+# statement (6)
+SELECT
+  Select_commands = @initial_select_commands + 4 AS select_must_be_true_6,
+  Update_commands = @initial_update_commands     AS update_must_be_true_6,
+  Other_commands  = @initial_other_commands  + 1 AS other_must_be_true_6,
+  Rows_fetched    = @initial_rows_fetched    + 3 AS rows_must_be_true_6
+FROM
+  INFORMATION_SCHEMA.USER_STATISTICS
+;
+
 SET GLOBAL userstat= @userstat_old;
 
 --source include/wait_until_count_sessions.inc

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1411,7 +1411,7 @@ void THD::update_stats(bool ran_command)
         if (!sent_row_count_2)
           diff_empty_queries++;
       }
-      else if (!sql_command_flags[lex->sql_command] & CF_STATUS_COMMAND)
+      else if ((sql_command_flags[lex->sql_command] & CF_STATUS_COMMAND) != 0)
       {
         // 'SHOW ' commands become SQLCOM_SELECT.
         diff_other_commands++;


### PR DESCRIPTION
…n "information_schema.user_statistics")

Fixed invalid "if" condition in "THD::update_stats()" logic which
lead to incorrect calculations of "Rows_fetched" in
"information_schema.user_statistics" for "SHOW ..." statements.

"percona_userstat.test" extended to cover this case.
