### PR TITLE
Fixed BLD-360 (build errors on Ubuntu Wily) (5.5)

### DIFF
--- a/storage/innobase/dict/dict0crea.c
+++ b/storage/innobase/dict/dict0crea.c
@@ -1255,7 +1255,7 @@ dict_create_index_step(
 			>= DICT_TF_FORMAT_ZIP);
 
 		node->index = dict_index_get_if_in_cache_low(index_id);
-		ut_a(!node->index == (err != DB_SUCCESS));
+		ut_a((node->index == 0) == (err != DB_SUCCESS));
 
 		if (err != DB_SUCCESS) {
 

--- a/storage/innobase/log/log0recv.c
+++ b/storage/innobase/log/log0recv.c
@@ -1833,7 +1833,7 @@ loop:
 		goto loop;
 	}
 
-	ut_ad(!allow_ibuf == mutex_own(&log_sys->mutex));
+	ut_ad((allow_ibuf == 0) == (mutex_own(&log_sys->mutex) != 0));
 
 	if (!allow_ibuf) {
 		recv_no_ibuf_operations = TRUE;


### PR DESCRIPTION
Rewritten several complex "ut_ad" assertions producing warnings on
recent GCC compilers.
