### PR TITLE
Fix bitmap files being opened with O_DIRECT, failing on some filesystems

### DIFF
--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -119,6 +119,10 @@ log. */
 #define OS_FILE_READ_ONLY		333
 #define	OS_FILE_READ_WRITE		444
 #define	OS_FILE_READ_ALLOW_DELETE	555	/* for ibbackup */
+#define OS_FILE_READ_WRITE_CACHED	666	/* OS_FILE_READ_WRITE but never
+					O_DIRECT. Only for
+					os_file_create_simple_no_error_handling
+				        currently. */
 
 /* Options for file_create */
 #define	OS_FILE_AIO			61
@@ -505,9 +509,10 @@ os_file_create_simple_no_error_handling_func(
 				OS_FILE_CREATE if a new file is created
 				(if exists, error) */
 	ulint		access_type,/*!< in: OS_FILE_READ_ONLY,
-				OS_FILE_READ_WRITE, or
-				OS_FILE_READ_ALLOW_DELETE; the last option is
-				used by a backup program reading the file */
+				OS_FILE_READ_WRITE, OS_FILE_READ_ALLOW_DELETE
+				(used by a backup program reading the file), or
+				OS_FILE_READ_WRITE_CACHED (disable O_DIRECT if
+				it would be enabled otherwise). */
 	ibool*		success);/*!< out: TRUE if succeed, FALSE if error */
 /****************************************************************//**
 Tries to disable OS caching on an opened file descriptor. */

--- a/storage/innobase/log/log0online.c
+++ b/storage/innobase/log/log0online.c
@@ -544,7 +544,7 @@ log_online_start_bitmap_file(void)
 							innodb_file_bmp_key,
 							log_bmp_sys->out.name,
 							OS_FILE_CREATE,
-							OS_FILE_READ_WRITE,
+							OS_FILE_READ_WRITE_CACHED,
 							&success);
 	}
 	if (UNIV_UNLIKELY(!success)) {
@@ -704,7 +704,7 @@ log_online_read_init(void)
 	log_bmp_sys->out.file
 		= os_file_create_simple_no_error_handling
 		(innodb_file_bmp_key, log_bmp_sys->out.name, OS_FILE_OPEN,
-		 OS_FILE_READ_WRITE, &success);
+		 OS_FILE_READ_WRITE_CACHED, &success);
 
 	if (!success) {
 

--- a/storage/innobase/os/os0file.c
+++ b/storage/innobase/os/os0file.c
@@ -1231,9 +1231,10 @@ os_file_create_simple_no_error_handling_func(
 				OS_FILE_CREATE if a new file is created
 				(if exists, error) */
 	ulint		access_type,/*!< in: OS_FILE_READ_ONLY,
-				OS_FILE_READ_WRITE, or
-				OS_FILE_READ_ALLOW_DELETE; the last option is
-				used by a backup program reading the file */
+				OS_FILE_READ_WRITE, OS_FILE_READ_ALLOW_DELETE
+				(used by a backup program reading the file), or
+				OS_FILE_READ_WRITE_CACHED (disable O_DIRECT if
+				it would be enabled otherwise). */
 	ibool*		success)/*!< out: TRUE if succeed, FALSE if error */
 {
 #ifdef __WIN__
@@ -1256,7 +1257,8 @@ os_file_create_simple_no_error_handling_func(
 
 	if (access_type == OS_FILE_READ_ONLY) {
 		access = GENERIC_READ;
-	} else if (access_type == OS_FILE_READ_WRITE) {
+	} else if (access_type == OS_FILE_READ_WRITE
+		   || access_type == OS_FILE_READ_WRITE_CACHED) {
 		access = GENERIC_READ | GENERIC_WRITE;
 	} else if (access_type == OS_FILE_READ_ALLOW_DELETE) {
 		access = GENERIC_READ;
@@ -1317,7 +1319,8 @@ os_file_create_simple_no_error_handling_func(
 	if (file == -1) {
 		*success = FALSE;
 #ifdef USE_FILE_LOCK
-	} else if (access_type == OS_FILE_READ_WRITE
+	} else if ((access_type == OS_FILE_READ_WRITE
+		    || access_type == OS_FILE_READ_WRITE_CACHED)
 		   && os_file_lock(file, name)) {
 		*success = FALSE;
 		close(file);
@@ -1330,7 +1333,9 @@ os_file_create_simple_no_error_handling_func(
 		disable OS caching (O_DIRECT) here as we do in
 		os_file_create_func(), so we open the same file in the same
 		mode, see man page of open(2). */
-		if (srv_unix_file_flush_method == SRV_UNIX_O_DIRECT) {
+		if ((srv_unix_file_flush_method == SRV_UNIX_O_DIRECT
+		    || srv_unix_file_flush_method == SRV_UNIX_ALL_O_DIRECT)
+		    && access_type != OS_FILE_READ_WRITE_CACHED) {
 			os_file_set_nocache(file, name, mode_str);
 		}
 	}


### PR DESCRIPTION
This fixes
- bug 1498891 (percona_changed_page_bmp_flush fails with "File
  (unknown): 'read' returned OS error 122. Cannot continue operation);
- bug 1500720 (mysql will not start with changed page tracking and
  O_DIRECT)
  and at the same time
- bug 1500741 (Upstream bug 76627 not fixed for the ALL_O_DIRECT case).

For the first two bugs the problem is the upstream commit b4daac2,
which fixed http://bugs.mysql.com/bug.php?id=76627 and made
os_file_create_simple_no_error_handling apply O_DIRECT on opened
files. This fix was merged as-is and resulted in bitmap files being
opened with O_DIRECT.

Fix by introducing new flag for
os_file_create_simple_no_error_handling access_type arg:
OS_FILE_READ_WRITE_CACHED, and using it for bitmap file opening.

The as-is merge of the same upstream commit resulted in bug 1500741:
it was not adapted to handle ALL_O_DIRECT, effectively leaving 76627
unfixed for this case. Fixed trivially.

http://jenkins.percona.com/job/percona-server-5.5-param/1174/#showFailuresLink
