### PR TITLE
5.6 - Create default file for debian init script timeout params (bug1434022)

### DIFF
--- a/build-ps/debian/additions/default-mysql
+++ b/build-ps/debian/additions/default-mysql
@@ -1,0 +1,3 @@
+# defaults file for percona server
+startup_timeout=900
+stop_timeout=300

--- a/build-ps/debian/percona-server-server-5.5.files
+++ b/build-ps/debian/percona-server-server-5.5.files
@@ -54,3 +54,4 @@ usr/share/man/man8/mysqld.8
 usr/share/mysql
 etc/mysql/debian-start
 usr/share/mysql/debian-start.inc.sh
+etc/default/mysql

--- a/build-ps/debian/percona-server-server-5.5.mysql.init
+++ b/build-ps/debian/percona-server-server-5.5.mysql.init
@@ -20,6 +20,11 @@ PERCONA_PREFIX=/usr
 
 test -x "${PERCONA_PREFIX}"/sbin/mysqld || exit 0
 
+# read default file
+startup_timeout=900
+stop_timeout=300
+[ -e /etc/default/mysql ] && . /etc/default/mysql || true
+
 . /lib/lsb/init-functions
 
 SELF=$(cd $(dirname $0); pwd -P)/$(basename $0)
@@ -109,8 +114,8 @@ case "${1:-''}" in
 	    while true; do
                 sleep 1
 	        if mysqld_status check_alive nowarn ; then break; fi
-		# wait 10sec before start checking if pid file created or server is dead
-		if [ $dead_check_counter -lt 10 ]; then
+		# wait before start checking if pid file created or server is dead
+		if [ $dead_check_counter -lt $startup_timeout ]; then
 			dead_check_counter=$(( dead_check_counter + 1 ))
 		else
 			if mysqld_status check_dead nowarn; then break; fi
@@ -145,7 +150,7 @@ case "${1:-''}" in
 	    log_daemon_msg "Killing MySQL (Percona Server) by signal" "mysqld"
 	    killall -15 mysqld
             server_down=
-	    for i in 1 2 3 4 5 6 7 8 9 10; do
+	    for i in `seq 1 $stop_timeout`; do
               sleep 1
               if mysqld_status check_dead nowarn; then server_down=1; break; fi
             done

--- a/build-ps/debian/rules
+++ b/build-ps/debian/rules
@@ -247,6 +247,9 @@ install: build
 	# FIXME install -m 0755 debian/additions/echo_stderr $(TMP)/usr/share/mysql/
 	install -m 0755 debian/additions/debian-start $(TMP)/etc/mysql/
 	install -m 0755 debian/additions/debian-start.inc.sh $(TMP)/usr/share/mysql/
+	# install default file for init script timeout params
+	install -d $(TMP)/etc/default
+	install -m 0644 debian/additions/default-mysql $(TMP)/etc/default/mysql
 
 	# install AppArmor profile
 	# FIXME install -D -m 644 debian/apparmor-profile $(TMP)/etc/apparmor.d/usr.sbin.mysqld


### PR DESCRIPTION
**BUG:**
https://bugs.launchpad.net/percona-server/+bug/1434022

So this is basically to create a /etc/default/mysql file with two variables that user can change if the defaults don't work for him (eg. large buffer pools).
startup_timeout=900
stop_timeout=300
The defaults file is sourced from the init script.

**TEST BUILDS:**
http://jenkins.percona.com/job/percona-server-5.5-debian-binary/151/
http://jenkins.percona.com/job/percona-server-5.6-debian-binary/58/
http://jenkins.percona.com/job/percona-server-5.6-debian-binary-notokudb/26/

**5.5 TEST UBUNTU TRUSTY:**
_INSTALL:_

```
vagrant@t-ubuntu1404-64:~$ sudo dpkg -i libperconaserverclient18_5.5.45-rel37.4-1.trusty_amd64.deb percona-server-common-5.5_5.5.45-rel37.4-1.trusty_amd64.deb percona-server-client-5.5_5.5.45-rel37.4-1.trusty_amd64.deb percona-server-server-5.5_5.5.45-rel37.4-1.trusty_amd64.deb 
(Reading database ... 103818 files and directories currently installed.)
Preparing to unpack libperconaserverclient18_5.5.45-rel37.4-1.trusty_amd64.deb ...
Unpacking libperconaserverclient18 (5.5.45-rel37.4-1.trusty) over (5.5.45-rel37.4-1.trusty) ...
Preparing to unpack percona-server-common-5.5_5.5.45-rel37.4-1.trusty_amd64.deb ...
Unpacking percona-server-common-5.5 (5.5.45-rel37.4-1.trusty) over (5.5.45-rel37.4-1.trusty) ...
Preparing to unpack percona-server-client-5.5_5.5.45-rel37.4-1.trusty_amd64.deb ...
Unpacking percona-server-client-5.5 (5.5.45-rel37.4-1.trusty) over (5.5.45-rel37.4-1.trusty) ...
Preparing to unpack percona-server-server-5.5_5.5.45-rel37.4-1.trusty_amd64.deb ...
Unpacking percona-server-server-5.5 (5.5.45-rel37.4-1.trusty) ...
Setting up percona-server-common-5.5 (5.5.45-rel37.4-1.trusty) ...
Setting up libperconaserverclient18 (5.5.45-rel37.4-1.trusty) ...
Setting up percona-server-client-5.5 (5.5.45-rel37.4-1.trusty) ...
Setting up percona-server-server-5.5 (5.5.45-rel37.4-1.trusty) ...
 * Stopping MySQL (Percona Server) mysqld
   ...done.


 * Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
 * Run the following commands to create these functions:

        mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
        mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
        mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"

 * See http://www.percona.com/doc/percona-server/5.5/management/udf_percona_toolkit.html for more details


 * Starting MySQL (Percona Server) database server mysqld
   ...done.
 * Checking for corrupt, not cleanly closed and upgrade needing tables.
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
Processing triggers for ureadahead (0.100.0-16) ...
ureadahead will be reprofiled on next reboot
Processing triggers for libc-bin (2.19-0ubuntu6.4) ...
```

_SERVICE STOP/START:_

```
vagrant@t-ubuntu1404-64:~$ sudo service mysql stop
 * Stopping MySQL (Percona Server) mysqld
   ...done.
vagrant@t-ubuntu1404-64:~$ sudo service mysql start
 * Starting MySQL (Percona Server) database server mysqld
   ...done.
 * Checking for corrupt, not cleanly closed and upgrade needing tables.
vagrant@t-ubuntu1404-64:~$ sudo service mysql status
 * /usr/bin/mysqladmin  Ver 8.42 Distrib 5.5.45-37.4, for debian-linux-gnu on x86_64
Copyright (c) 2009-2015 Percona LLC and/or its affiliates
Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Server version          5.5.45-37.4
Protocol version        10
Connection              Localhost via UNIX socket
UNIX socket             /var/run/mysqld/mysqld.sock
Uptime:                 7 sec

Threads: 1  Questions: 110  Slow queries: 0  Opens: 48  Flush tables: 1  Open tables: 41  Queries per second avg: 15.714

vagrant@t-ubuntu1404-64:~$ sudo cat /etc/default/mysql 
# defaults file for percona server
startup_timeout=900
stop_timeout=300
```

**5.6 TEST ON UBUNTU TRUSTY**

```
vagrant@t-ubuntu1404-64:~$ sudo service mysql stop
 * Stopping MySQL (Percona Server) mysqld
   ...done.

vagrant@t-ubuntu1404-64:~$ sudo service mysql start
 * Starting MySQL (Percona Server) database server mysqld
   ...done.
 * Checking for corrupt, not cleanly closed and upgrade needing tables.

vagrant@t-ubuntu1404-64:~$ sudo cat /etc/default/mysql
# defaults file for percona server
startup_timeout=900
stop_timeout=300

vagrant@t-ubuntu1404-64:~$ sudo service mysql status
 * /usr/bin/mysqladmin  Ver 8.42 Distrib 5.6.27-74.1, for debian-linux-gnu on x86_64
Copyright (c) 2009-2015 Percona LLC and/or its affiliates
Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Server version          5.6.27-74.1
Protocol version        10
Connection              Localhost via UNIX socket
UNIX socket             /var/run/mysqld/mysqld.sock
Uptime:                 1 min 15 sec

Threads: 1  Questions: 111  Slow queries: 0  Opens: 87  Flush tables: 1  Open tables: 80  Queries per second avg: 1.480
```

Actually had a problem on 5.6 with:
2015-11-02 03:21:43 1930 [ERROR] /usr/sbin/mysqld: unknown variable 'innodb-numa-interleave=1'
2015-11-02 03:21:43 1930 [ERROR] Aborting
But that's because of some upstream merge and the server had actually waited for 15min to timeout while starting which is ok.
