### PR TITLE
lp1513178 : tokudb-backup exclude.result contains variable results

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/tokudb_backup_exclude.result
+++ b/mysql-test/suite/tokudb.backup/r/tokudb_backup_exclude.result
@@ -2,7 +2,6 @@ create table t1(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
 create table t1a(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
 create table t1b(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
 create table t1c(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
-set session tokudb_backup_dir='/ssd/toku/DB-874/percona-server-install/mysql-test/var/tmp/backup';
 select @@session.tokudb_backup_last_error;
 @@session.tokudb_backup_last_error
 0
@@ -11,7 +10,6 @@ select @@session.tokudb_backup_last_error_string;
 NULL
 20
 set session tokudb_backup_exclude='(t1a|t1c)+';
-set session tokudb_backup_dir='/ssd/toku/DB-874/percona-server-install/mysql-test/var/tmp/backup';
 select @@session.tokudb_backup_last_error;
 @@session.tokudb_backup_last_error
 0
@@ -20,7 +18,6 @@ select @@session.tokudb_backup_last_error_string;
 NULL
 10
 set session tokudb_backup_exclude='t1[abc]+';
-set session tokudb_backup_dir='/ssd/toku/DB-874/percona-server-install/mysql-test/var/tmp/backup';
 select @@session.tokudb_backup_last_error;
 @@session.tokudb_backup_last_error
 0

--- a/mysql-test/suite/tokudb.backup/t/tokudb_backup_exclude.test
+++ b/mysql-test/suite/tokudb.backup/t/tokudb_backup_exclude.test
@@ -17,8 +17,10 @@ create table t1b(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
 create table t1c(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
 
 # This should not filter any files
+disable_query_log;
 --exec mkdir $MYSQLTEST_VARDIR/tmp/backup
 --eval set session tokudb_backup_dir='$MYSQLTEST_VARDIR/tmp/backup'
+enable_query_log;
 
 select @@session.tokudb_backup_last_error;
 select @@session.tokudb_backup_last_error_string;
@@ -32,8 +34,10 @@ select @@session.tokudb_backup_last_error_string;
 # This should filter all files for the t1a and t1c tables
 set session tokudb_backup_exclude='(t1a|t1c)+';
 
+disable_query_log;
 --exec mkdir $MYSQLTEST_VARDIR/tmp/backup
 --eval set session tokudb_backup_dir='$MYSQLTEST_VARDIR/tmp/backup'
+enable_query_log;
 
 select @@session.tokudb_backup_last_error;
 select @@session.tokudb_backup_last_error_string;
@@ -46,8 +50,10 @@ select @@session.tokudb_backup_last_error_string;
 # This should filter all files for the t1a, t1b, and t1c tables
 set session tokudb_backup_exclude='t1[abc]+';
 
+disable_query_log;
 --exec mkdir $MYSQLTEST_VARDIR/tmp/backup
 --eval set session tokudb_backup_dir='$MYSQLTEST_VARDIR/tmp/backup'
+enable_query_log;
 
 select @@session.tokudb_backup_last_error;
 select @@session.tokudb_backup_last_error_string;


### PR DESCRIPTION
Fixed test to disable query log around setting of the tokudd_backup_dir and re-recorded.
