### PR TITLE
Added libnuma-dev and numactl-devel as build dependency for packages

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -25,7 +25,8 @@ Build-Depends: libtool (>= 1.4.2-7),
                g++ (>= 4.4),
                libaio-dev[linux-any],
                libpam-dev,
-               libssl-dev
+               libssl-dev,
+               libnuma-dev
 Standards-Version: 3.9.4
 Homepage: http://www.percona.com/software/percona-server/
 Vcs-Bzr: lp:percona-server/5.6

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -265,7 +265,7 @@ URL:            http://www.percona.com/
 Packager:       Percona MySQL Development Team <mysqldev@percona.com>
 Vendor:         %{percona_server_vendor}
 Provides:       mysql-server
-BuildRequires:  %{distro_buildreq} pam-devel openssl-devel
+BuildRequires:  %{distro_buildreq} pam-devel openssl-devel numactl-devel
 %if 0%{?systemd}
 BuildRequires:  systemd
 %endif


### PR DESCRIPTION
Last release (5.6.27-75.0) needs numaif.h included so for building it's needed to have libnuma-dev (debian/ubuntu) or numactl-devel (centos) installed on the system.
