### PR TITLE
Fixed lp:1425480 ("virtual void MYSQL_BIN_LOG::xlock(): Assertion '!s…

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -7615,9 +7615,9 @@ void MYSQL_BIN_LOG::set_status_variables(THD *thd)
 
 void MYSQL_BIN_LOG::xlock(void)
 {
-  DBUG_ASSERT(!snapshot_lock_acquired);
-
   mysql_mutex_lock(&LOCK_log);
+
+  DBUG_ASSERT(!snapshot_lock_acquired);
 
   /*
     We must ensure that no writes to binlog and no commits to storage engines


### PR DESCRIPTION
…napshot_lock_acquired' failed in sql/binlog.cc:7566")

Fixed problem with asserting "!snapshot_lock_acquired" outside of "LOCK_log" mutex lock.
