### PR TITLE
lp1512464 : mysqld got signal 11 while setting tokudb_backup_last_err…

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/tokudb_backup_set_last_error.result
+++ b/mysql-test/suite/tokudb.backup/r/tokudb_backup_set_last_error.result
@@ -1,0 +1,20 @@
+create table t1(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
+set session tokudb_backup_dir='/aint/no/way/this/exists/here';
+ERROR 42000: Variable 'tokudb_backup_dir' can't be set to the value of '/aint/no/way/this/exists/here'
+select @@session.tokudb_backup_last_error;
+@@session.tokudb_backup_last_error
+2
+select @@session.tokudb_backup_last_error_string;
+@@session.tokudb_backup_last_error_string
+Could not get real path for /aint/no/way/this/exists/here
+set session tokudb_backup_last_error_string='this should not crash the server';
+select @@session.tokudb_backup_last_error_string;
+@@session.tokudb_backup_last_error_string
+this should not crash the server
+set session tokudb_backup_dir='/aint/no/way/this/exists/here';
+ERROR 42000: Variable 'tokudb_backup_dir' can't be set to the value of '/aint/no/way/this/exists/here'
+select @@session.tokudb_backup_last_error_string;
+@@session.tokudb_backup_last_error_string
+Could not get real path for /aint/no/way/this/exists/here
+set session tokudb_backup_last_error_string = @old_backup_last_error_string;
+drop table t1;

--- a/mysql-test/suite/tokudb.backup/t/tokudb_backup_set_last_error.test
+++ b/mysql-test/suite/tokudb.backup/t/tokudb_backup_set_last_error.test
@@ -1,0 +1,32 @@
+# This test validates that the plugin will not crash if a user sets
+# tokudb_backup_last_error_string after performing a backup.
+source include/have_tokudb_backup.inc;
+
+disable_query_log;
+
+set @old_backup_last_error_string = @@session.tokudb_backup_last_error_string;
+
+enable_query_log;
+
+create table t1(a INT, b INT, c INT, KEY(a), KEY(b), KEY(c)) engine='tokudb';
+
+# this should fail and set the error string since the dummy directory
+# doesn't exist
+--error ER_WRONG_VALUE_FOR_VAR
+--eval set session tokudb_backup_dir='/aint/no/way/this/exists/here'
+
+select @@session.tokudb_backup_last_error;
+select @@session.tokudb_backup_last_error_string;
+
+set session tokudb_backup_last_error_string='this should not crash the server';
+select @@session.tokudb_backup_last_error_string;
+
+# this should fail again and set the error string since the dummy directory
+# doesn't exist
+--error ER_WRONG_VALUE_FOR_VAR
+--eval set session tokudb_backup_dir='/aint/no/way/this/exists/here'
+select @@session.tokudb_backup_last_error_string;
+
+set session tokudb_backup_last_error_string = @old_backup_last_error_string;
+
+drop table t1;

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -30,36 +30,66 @@
 
 static char *tokudb_backup_plugin_version;
 
-static MYSQL_SYSVAR_STR(plugin_version, tokudb_backup_plugin_version, PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY, "version of the tokudb backup plugin",
-                        NULL, NULL, TOKUDB_BACKUP_PLUGIN_VERSION_STRING);
+static MYSQL_SYSVAR_STR(plugin_version, tokudb_backup_plugin_version,
+    PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
+    "version of the tokudb backup plugin",
+    NULL, NULL, TOKUDB_BACKUP_PLUGIN_VERSION_STRING);
 
 static char *tokudb_backup_version = (char *) tokubackup_version_string;
 
-static MYSQL_SYSVAR_STR(version, tokudb_backup_version, PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY, "version of the tokutek backup library",
-                        NULL, NULL, NULL);
+static MYSQL_SYSVAR_STR(version, tokudb_backup_version,
+    PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
+    "version of the tokutek backup library",
+    NULL, NULL, NULL);
 
-static MYSQL_THDVAR_ULONG(last_error, PLUGIN_VAR_THDLOCAL, "error from the last backup. 0 is success",
-                          NULL, NULL, 0 /*default*/, 0 /*min*/, ~0ULL /*max*/, 1 /*blocksize*/);
+static MYSQL_THDVAR_ULONG(last_error,
+    PLUGIN_VAR_THDLOCAL,
+    "error from the last backup. 0 is success",
+    NULL, NULL, 0, 0, ~0ULL, 1);
 
-static MYSQL_THDVAR_STR(last_error_string, PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC, "error string from the last backup", NULL, NULL, NULL);
+static void tokudb_backup_update_last_error_str(THD* thd,
+                                                struct st_mysql_sys_var* var,
+                                                void* var_ptr, const void* save);
 
-static MYSQL_THDVAR_STR(exclude, PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC, "exclude source file regular expression", NULL, NULL, NULL);
+static MYSQL_THDVAR_STR(last_error_string,
+    PLUGIN_VAR_THDLOCAL,
+    "error string from the last backup",
+    NULL, tokudb_backup_update_last_error_str, NULL);
 
-static int tokudb_backup_check_dir(THD *thd, struct st_mysql_sys_var *var, void *save, struct st_mysql_value *value);
-static void tokudb_backup_update_dir(THD *thd, struct st_mysql_sys_var *var, void *var_ptr, const void *save);
+static MYSQL_THDVAR_STR(exclude,
+    PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC,
+    "exclude source file regular expression",
+    NULL, NULL, NULL);
 
-static MYSQL_THDVAR_STR(dir, PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC, "name of the directory where the backup is stored", tokudb_backup_check_dir, tokudb_backup_update_dir, NULL);
+static int tokudb_backup_check_dir(THD* thd, struct st_mysql_sys_var* var,
+                                   void* save, struct st_mysql_value* value);
 
-static int tokudb_backup_check_throttle(THD *thd, struct st_mysql_sys_var *var, void *save, struct st_mysql_value *value);
-static void tokudb_backup_update_throttle(THD *thd, struct st_mysql_sys_var *var, void *var_ptr, const void *save);
+static void tokudb_backup_update_dir(THD* thd, struct st_mysql_sys_var* var,
+                                     void* var_ptr, const void* save);
 
-static MYSQL_THDVAR_ULONGLONG(throttle, PLUGIN_VAR_THDLOCAL, "backup throttle on write rate in bytes per second",
-                              tokudb_backup_check_throttle, tokudb_backup_update_throttle, ~0ULL /*default*/, 0 /*min*/, ~0ULL /*max*/, 1 /*blocksize*/);
+static MYSQL_THDVAR_STR(dir,
+    PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC,
+    "name of the directory where the backup is stored",
+    tokudb_backup_check_dir, tokudb_backup_update_dir, NULL);
+
+static int tokudb_backup_check_throttle(THD* thd, struct st_mysql_sys_var* var,
+                                        void* save, struct st_mysql_value* value);
+
+static void tokudb_backup_update_throttle(THD* thd, struct st_mysql_sys_var* var,
+                                          void* var_ptr, const void* save);
+
+static MYSQL_THDVAR_ULONGLONG(throttle,
+    PLUGIN_VAR_THDLOCAL,
+    "backup throttle on write rate in bytes per second",
+    tokudb_backup_check_throttle, tokudb_backup_update_throttle,
+    ~0ULL, 0, ~0ULL, 1);
 
 static char *tokudb_backup_allowed_prefix;
 
-static MYSQL_SYSVAR_STR(allowed_prefix, tokudb_backup_allowed_prefix, PLUGIN_VAR_READONLY, "allowed prefix of the destination directory",
-                        NULL, NULL, NULL);
+static MYSQL_SYSVAR_STR(allowed_prefix, tokudb_backup_allowed_prefix,
+    PLUGIN_VAR_READONLY,
+    "allowed prefix of the destination directory",
+    NULL, NULL, NULL);
 
 static struct st_mysql_sys_var *tokudb_backup_system_variables[] = {
     MYSQL_SYSVAR(plugin_version),
@@ -119,8 +149,12 @@ static int tokudb_backup_progress_fun(float progress, const char *progress_strin
 static void tokudb_backup_set_error(THD *thd, int error, const char *error_string) {
     THDVAR(thd, last_error) = error;
     char *old_error_string = THDVAR(thd, last_error_string);
-    THDVAR(thd, last_error_string) = error_string ? my_strdup(error_string, MYF(MY_FAE)) : NULL;
-    my_free(old_error_string);
+    if (error_string)
+        THDVAR(thd, last_error_string) = my_strdup(error_string, MYF(MY_FAE));
+    else
+        THDVAR(thd, last_error_string) = NULL;
+    if (old_error_string)
+        my_free(old_error_string);
 }
 
 static void tokudb_backup_set_error_string(THD *thd, int error, const char *error_fmt, const char *s1, const char *s2, const char *s3) {
@@ -130,6 +164,13 @@ static void tokudb_backup_set_error_string(THD *thd, int error, const char *erro
     assert(0 < r && (size_t)r <= n);
     tokudb_backup_set_error(thd, error, error_string);
     my_free(error_string);
+}
+
+static void tokudb_backup_update_last_error_str(THD* thd,
+                                                struct st_mysql_sys_var* var,
+                                                void* var_ptr, const void* save) {
+    tokudb_backup_set_error(thd, THDVAR(thd, last_error), ((LEX_STRING*)save)->str);
+    *((char**)var_ptr) = THDVAR(thd, last_error_string);
 }
 
 struct tokudb_backup_error_extra {


### PR DESCRIPTION
…or_string variable

tokudb_backup_last_error and tokudb_backup_last_error_string should never have
been variables, but status values. Since it is already done and some
apps/infrastructures may depend on these as they are, it is proper then to just
fix the variable issues.

That being said, fixed up memory management of tokudb_backup_last_error_string
so all allocation/free happens within the plugin and not spread across the
server and plugin.

Also added mtr/tokudb.backup test case that crashed as described in the bug
report and works correctly after the fix.

https://bugs.launchpad.net/percona-server/+bug/1512464

No jenkins since the tokudb.backup suite is currently disabled, but here are local results:

Logging: ./mtr  --mysqld=--loose-tokudb-cache-size=2G --force --retry=0 --retry-failure=0 --max-test-fail=0 --no-warnings --testcase-timeout=120 --suite=tokudb.backup
2015-11-12 13:06:35 0 [Note] /ssd/toku/ST-57094/percona-server-install/bin/mysqld (mysqld 5.6.27-75.0-debug) starting as process 27334 ...
2015-11-12 13:06:35 27334 [Note] Plugin 'FEDERATED' is disabled.
2015-11-12 13:06:35 27334 [Note] Binlog end
2015-11-12 13:06:35 27334 [Note] Shutting down plugin 'CSV'
2015-11-12 13:06:35 27334 [Note] Shutting down plugin 'MyISAM'
MySQL Version 5.6.27
Checking supported features...
- SSL connections supported
- binaries are debug compiled
  Using suites: tokudb.backup
  Collecting tests...
  Checking leftover processes...
  Removing old var directory...
  Creating var directory '/ssd/toku/ST-57094/percona-server-install/mysql-test/var'...
  Installing system database...
# 
## TEST                                      RESULT   TIME (ms) or COMMENT

worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 13000..13009
tokudb.backup.tokudb_backup_exclude      [ pass ]    161
## tokudb.backup.tokudb_backup_set_last_error [ pass ]     10

The servers were restarted 0 times
Spent 0.171 of 7 seconds executing testcases

Completed: All 2 tests were successful.
