### PR TITLE
Add a variable named by read_binlog_speed_limit to limit the speed of  reading binlog from Master.

### DIFF
--- a/include/my_global.h
+++ b/include/my_global.h
@@ -119,6 +119,7 @@
 #include <process.h>  /* getpid() */
 
 #define sleep(a) Sleep((a)*1000)
+#define usleep(a) Sleep((a)/1000)
 
 /* Define missing access() modes. */
 #define F_OK 0

--- a/sql/rpl_slave.h
+++ b/sql/rpl_slave.h
@@ -244,6 +244,7 @@ extern my_bool opt_skip_slave_start, opt_reckless_slave;
 extern my_bool opt_log_slave_updates;
 extern char *opt_slave_skip_errors;
 extern ulonglong relay_log_space_limit;
+extern ulonglong opt_read_binlog_speed_limit;
 
 extern const char *relay_log_index;
 extern const char *relay_log_basename;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4582,6 +4582,12 @@ static Sys_var_ulonglong Sys_relay_log_space_limit(
        READ_ONLY GLOBAL_VAR(relay_log_space_limit), CMD_LINE(REQUIRED_ARG),
        VALID_RANGE(0, ULONG_MAX), DEFAULT(0), BLOCK_SIZE(1));
 
+static Sys_var_ulonglong Sys_read_binlog_speed_limit(
+       "read_binlog_speed_limit", "Maximum speed(KB/s) to read binlog from"
+       " master (0 = no limit)",
+       GLOBAL_VAR(opt_read_binlog_speed_limit), CMD_LINE(OPT_ARG),
+       VALID_RANGE(0, ULONG_MAX), DEFAULT(0), BLOCK_SIZE(1));
+
 static Sys_var_uint Sys_sync_relaylog_period(
        "sync_relay_log", "Synchronously flush relay log to disk after "
        "every #th event. Use 0 to disable synchronous flushing",


### PR DESCRIPTION
In some situation(such as one master and many slaves), we want to limit the speed of reading binlog form master, so I add this feature. It's very simple and easy to understand. 
