### PR TITLE
Fixed lp:1517523 (5.5) ("main.percona_userstat fails sporadically")

### DIFF
--- a/mysql-test/t/percona_userstat.test
+++ b/mysql-test/t/percona_userstat.test
@@ -35,6 +35,11 @@ connection default;
 
 DROP USER mysqltest_1@localhost;
 
+# Make sure that auxiliary connection "conn1" (initiated by the user
+# "mysqltest_1") is closed and therefore will not add another record
+# to the staistics tables
+--source include/wait_until_count_sessions.inc
+
 # Test that I_S and SHOW queries work with userstat disabled
 SELECT * FROM INFORMATION_SCHEMA.CLIENT_STATISTICS;
 SELECT * FROM INFORMATION_SCHEMA.INDEX_STATISTICS;
@@ -173,5 +178,3 @@ FROM
 ;
 
 SET GLOBAL userstat= @userstat_old;
-
---source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Fixed "SELECT ... FROM INFORMATION_SCHEMA.USER_STATISTICS"
statements for the case when this table has more than one record.
This can happen because whithin this test case statistics is being
collected not only for the default user "root" but for the custom
user "mysqltest_1" as well.
