### PR TITLE
Implements blueprint https://blueprints.launchpad.net/percona-server/…

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -278,7 +278,7 @@ int TOKUDB_SHARE::release() {
             }
         }
 
-        error = tokudb::close_status(&status_block);
+        error = tokudb::metadata::close(&status_block);
         assert_always(error == 0);
 
         free_key_and_col_info(&kc_info);
@@ -1305,7 +1305,7 @@ static int open_status_dictionary(DB** ptr, const char* name, DB_TXN* txn) {
     make_name(newname, newname_len, name, "status");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_OPEN, "open:%s", newname);
 
-    error = tokudb::open_status(db_env, ptr, newname, txn);
+    error = tokudb::metadata::open(db_env, ptr, newname, txn);
 cleanup:
     tokudb::memory::free(newname);
     return error;
@@ -7165,7 +7165,7 @@ int ha_tokudb::create(
     /* Create status.tokudb and save relevant metadata */
     make_name(newname, newname_len, name, "status");
 
-    error = tokudb::create_status(db_env, &status_block, newname, txn);
+    error = tokudb::metadata::create(db_env, &status_block, newname, txn);
     if (error) { goto cleanup; }
 
     version = HA_TOKU_VERSION;    
@@ -7266,7 +7266,7 @@ int ha_tokudb::create(
     error = 0;
 cleanup:
     if (status_block != NULL) {
-        int r = tokudb::close_status(&status_block); 
+        int r = tokudb::metadata::close(&status_block);
         assert_always(r==0);
     }
     free_key_and_col_info(&kc_info);

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -610,6 +610,15 @@ static int tokudb_init_func(void *p) {
     init_tree(&tokudb_map, 0, 0, 0, tokudb_map_pair_cmp, true, NULL, NULL);
 #endif
 
+    if (tokudb::sysvars::strip_frm_data) {
+        r = tokudb::metadata::strip_frm_data(db_env);
+        if (r) {
+            DBUG_PRINT("info", ("env->open %d", r));
+            handle_ydb_error(r);
+            goto error;
+        }
+    }
+
     //3938: succeeded, set the init status flag and unlock
     tokudb_hton_initialized = 1;
     tokudb_hton_initialized_lock.unlock();

--- a/storage/tokudb/tokudb_card.h
+++ b/storage/tokudb/tokudb_card.h
@@ -50,7 +50,7 @@ namespace tokudb {
         }
         // write cardinality to status
         int error =
-            write_to_status(
+            tokudb::metadata::write(
                 status_db,
                 hatoku_cardinality,
                 b.data(),
@@ -60,10 +60,21 @@ namespace tokudb {
     }
 
     // Get the cardinality counters from the status dictionary.
-    int get_card_from_status(DB *status_db, DB_TXN *txn, uint rec_per_keys, uint64_t rec_per_key[]) {
+    int get_card_from_status(
+        DB* status_db,
+        DB_TXN* txn,
+        uint rec_per_keys,
+        uint64_t rec_per_key[]) {
+
         // read cardinality from status
-        void *buf = 0; size_t buf_size = 0;
-        int error = get_status_realloc(status_db, txn, hatoku_cardinality, &buf, &buf_size);
+        void* buf = 0; size_t buf_size = 0;
+        int error =
+            tokudb::metadata::read_realloc(
+                status_db,
+                txn,
+                hatoku_cardinality,
+                &buf,
+                &buf_size);
         if (error == 0) {
             // decode cardinality from the buffer
             tokudb::buffer b(buf, 0, buf_size);
@@ -88,12 +99,17 @@ namespace tokudb {
     }
 
     // Delete the cardinality counters from the status dictionary.
-    int delete_card_from_status(DB *status_db, DB_TXN *txn) {
-        int error = remove_from_status(status_db, hatoku_cardinality, txn);
+    int delete_card_from_status(DB* status_db, DB_TXN* txn) {
+        int error =
+            tokudb::metadata::remove(status_db, hatoku_cardinality, txn);
         return error;
     }
 
-    bool find_index_of_key(const char *key_name, TABLE_SHARE *table_share, uint *index_offset_ptr) {
+    bool find_index_of_key(
+        const char* key_name,
+        TABLE_SHARE* table_share,
+        uint* index_offset_ptr) {
+
         for (uint i = 0; i < table_share->keys; i++) {
             if (strcmp(key_name, table_share->key_info[i].name) == 0) {
                 *index_offset_ptr = i;
@@ -108,16 +124,30 @@ namespace tokudb {
             dest[i] = src[i];
     }
 
-    // Altered table cardinality = select cardinality data from current table cardinality for keys that exist 
+    // Altered table cardinality = select cardinality data from current table
+    // cardinality for keys that exist
     // in the altered table and the current table.
-    int alter_card(DB *status_db, DB_TXN *txn, TABLE_SHARE *table_share, TABLE_SHARE *altered_table_share) {
+    int alter_card(
+        DB* status_db,
+        DB_TXN *txn,
+        TABLE_SHARE* table_share,
+        TABLE_SHARE* altered_table_share) {
+
         int error;
         // read existing cardinality data from status
-        uint table_total_key_parts = tokudb::compute_total_key_parts(table_share);
+        uint table_total_key_parts =
+            tokudb::compute_total_key_parts(table_share);
+
         uint64_t rec_per_key[table_total_key_parts];
-        error = get_card_from_status(status_db, txn, table_total_key_parts, rec_per_key);
+        error =
+            get_card_from_status(
+                status_db,
+                txn,
+                table_total_key_parts,
+                rec_per_key);
         // set altered records per key to unknown
-        uint altered_table_total_key_parts = tokudb::compute_total_key_parts(altered_table_share);
+        uint altered_table_total_key_parts =
+            tokudb::compute_total_key_parts(altered_table_share);
         uint64_t altered_rec_per_key[altered_table_total_key_parts];
         for (uint i = 0; i < altered_table_total_key_parts; i++)
             altered_rec_per_key[i] = 0;
@@ -134,16 +164,28 @@ namespace tokudb {
             for (uint i = 0; error == 0 && i < altered_table_share->keys; i++) {
                 uint ith_key_parts = get_key_parts(&altered_table_share->key_info[i]);
                 uint orig_key_index;
-                if (find_index_of_key(altered_table_share->key_info[i].name, table_share, &orig_key_index)) {
-                    copy_card(&altered_rec_per_key[next_key_parts], &rec_per_key[orig_key_offset[orig_key_index]], ith_key_parts);
+                if (find_index_of_key(
+                        altered_table_share->key_info[i].name,
+                        table_share,
+                        &orig_key_index)) {
+                    copy_card(
+                        &altered_rec_per_key[next_key_parts],
+                        &rec_per_key[orig_key_offset[orig_key_index]],
+                        ith_key_parts);
                 }
                 next_key_parts += ith_key_parts;
             }
         }
-        if (error == 0)
-            error = set_card_in_status(status_db, txn, altered_table_total_key_parts, altered_rec_per_key);
-        else
+        if (error == 0) {
+            error =
+                set_card_in_status(
+                    status_db,
+                    txn,
+                    altered_table_total_key_parts,
+                    altered_rec_per_key);
+        } else {
             error = delete_card_from_status(status_db, txn);
+        }
         return error;
     }
 }

--- a/storage/tokudb/tokudb_status.h
+++ b/storage/tokudb/tokudb_status.h
@@ -43,118 +43,374 @@ typedef ulonglong HA_METADATA_KEY;
 #define status_dict_pagesize 1024
 
 namespace tokudb {
+namespace metadata {
 
-    // get the value for a given key in the status dictionary. copy the value to the supplied buffer.
-    // returns 0 if successful.
-    int get_status(DB *status_db, DB_TXN *txn, HA_METADATA_KEY k, void *p, size_t s, size_t *sp) {
-        DBT key = {}; key.data = &k; key.size = sizeof k;
-        DBT val = {}; val.data = p; val.ulen = (uint32_t) s; val.flags = DB_DBT_USERMEM;
-        int error = status_db->get(status_db, txn, &key, &val, 0);
-        if (error == 0) {
-            *sp = val.size;
-        }
-        return error;
+// get the value for a given key in the status dictionary.
+// copy the value to the supplied buffer.
+// returns 0 if successful.
+int read(
+    DB* status_db,
+    DB_TXN* txn,
+    HA_METADATA_KEY k,
+    void* p,
+    size_t s,
+    size_t* sp) {
+
+    DBT key = {};
+    key.data = &k;
+    key.size = sizeof(k);
+    DBT val = {};
+    val.data = p;
+    val.ulen = (uint32_t)s;
+    val.flags = DB_DBT_USERMEM;
+    int error = status_db->get(status_db, txn, &key, &val, 0);
+    if (error == 0) {
+        *sp = val.size;
     }
-
-    // get the value for a given key in the status dictionary. put the value in a realloced buffer.
-    // returns 0 if successful.
-    int get_status_realloc(DB *status_db, DB_TXN *txn, HA_METADATA_KEY k, void **pp, size_t *sp) {
-        DBT key = {}; key.data = &k; key.size = sizeof k;
-        DBT val = {}; val.data = *pp; val.size = (uint32_t) *sp; val.flags = DB_DBT_REALLOC;
-        int error = status_db->get(status_db, txn, &key, &val, 0);
-        if (error == 0) {
-            *pp = val.data;
-            *sp = val.size;
-        }
-        return error;
-    }
-
-    // write a key value pair into the status dictionary, overwriting the previous value if any.
-    // auto create a txn if necessary.
-    // returns 0 if successful.
-    int write_metadata(DB *status_db, void *key_data, uint key_size, void* val_data, uint val_size, DB_TXN *txn) {
-        DBT key = {}; key.data = key_data; key.size = key_size;
-        DBT value = {}; value.data = val_data; value.size = val_size;
-        int error = status_db->put(status_db, txn, &key, &value, 0);
-        return error;
-    }
-
-    // write a key value pair into the status dictionary, overwriting the previous value if any.
-    // the key must be a HA_METADATA_KEY.
-    // returns 0 if successful.
-    int write_to_status(DB *status_db, HA_METADATA_KEY curr_key_data, void *val, size_t val_size, DB_TXN *txn) {
-        return write_metadata(status_db, &curr_key_data, sizeof curr_key_data, val, val_size, txn);
-    }
-
-    // remove a key from the status dictionary.
-    // auto create a txn if necessary.
-    // returns 0 if successful.
-    int remove_metadata(DB *status_db, void *key_data, uint key_size, DB_TXN *txn) {
-        DBT key = {}; key.data = key_data; key.size = key_size;
-        int error = status_db->del(status_db, txn, &key, DB_DELETE_ANY);
-        return error;
-    }
-
-    // remove a key from the status dictionary.
-    // the key must be a HA_METADATA_KEY
-    // returns 0 if successful.
-    int remove_from_status(DB *status_db, HA_METADATA_KEY curr_key_data, DB_TXN *txn) {
-        return remove_metadata(status_db, &curr_key_data, sizeof curr_key_data, txn);
-    }
-
-    int close_status(DB **status_db_ptr) {
-        int error = 0;
-        DB *status_db = *status_db_ptr;
-        if (status_db) {
-            error = status_db->close(status_db, 0);
-            if (error == 0)
-                *status_db_ptr = NULL;
-        }
-        return error;
-    }
-
-    int create_status(DB_ENV *env, DB **status_db_ptr, const char *name, DB_TXN *txn) {
-        int error;
-        DB *status_db = NULL;
-
-        error = db_create(&status_db, env, 0);
-        if (error == 0) {
-            error = status_db->set_pagesize(status_db, status_dict_pagesize);
-        }
-        if (error == 0) {
-            error = status_db->open(status_db, txn, name, NULL, DB_BTREE, DB_CREATE | DB_EXCL, 0);
-        }
-        if (error == 0) {
-            *status_db_ptr = status_db;
-        } else {
-            int r = close_status(&status_db);
-            assert_always(r == 0);
-        }
-        return error;
-    }
-
-    int open_status(DB_ENV *env, DB **status_db_ptr, const char *name, DB_TXN *txn) {
-        int error = 0;
-        DB *status_db = NULL;
-        error = db_create(&status_db, env, 0);
-        if (error == 0) {
-            error = status_db->open(status_db, txn, name, NULL, DB_BTREE, DB_THREAD, 0);
-        }
-        if (error == 0) {
-            uint32_t pagesize = 0;
-            error = status_db->get_pagesize(status_db, &pagesize);                
-            if (error == 0 && pagesize > status_dict_pagesize) {
-                error = status_db->change_pagesize(status_db, status_dict_pagesize);
-            }
-        }
-        if (error == 0) {
-            *status_db_ptr = status_db;
-        } else {
-            int r = close_status(&status_db);
-            assert_always(r == 0);
-        }
-        return error;
-    }
+    return error;
 }
 
+// get the value for a given key in the status dictionary.
+// put the value in a realloced buffer.
+// returns 0 if successful.
+int read_realloc(
+    DB* status_db,
+    DB_TXN* txn,
+    HA_METADATA_KEY k,
+    void** pp,
+    size_t* sp) {
+
+    DBT key = {};
+    key.data = &k;
+    key.size = sizeof(k);
+    DBT val = {};
+    val.data = *pp;
+    val.size = (uint32_t)*sp;
+    val.flags = DB_DBT_REALLOC;
+    int error = status_db->get(status_db, txn, &key, &val, 0);
+    if (error == 0) {
+        *pp = val.data;
+        *sp = val.size;
+    }
+    return error;
+}
+
+// write a key value pair into the status dictionary,
+// overwriting the previous value if any.
+// auto create a txn if necessary.
+// returns 0 if successful.
+int write_low(
+    DB* status_db,
+    void* key_data,
+    uint key_size,
+    void* val_data,
+    uint val_size,
+    DB_TXN *txn) {
+
+    DBT key = {};
+    key.data = key_data;
+    key.size = key_size;
+    DBT value = {};
+    value.data = val_data;
+    value.size = val_size;
+    int error = status_db->put(status_db, txn, &key, &value, 0);
+    return error;
+}
+
+// write a key value pair into the status dictionary,
+// overwriting the previous value if any.
+// the key must be a HA_METADATA_KEY.
+// returns 0 if successful.
+int write(
+    DB* status_db,
+    HA_METADATA_KEY curr_key_data,
+    void* val,
+    size_t val_size,
+    DB_TXN* txn) {
+
+    return
+        tokudb::metadata::write_low(
+            status_db,
+            &curr_key_data,
+            sizeof(curr_key_data),
+            val,
+            val_size,
+            txn);
+}
+
+// remove a key from the status dictionary.
+// auto create a txn if necessary.
+// returns 0 if successful.
+int remove_low(
+    DB* status_db,
+    void* key_data,
+    uint key_size,
+    DB_TXN* txn) {
+
+    DBT key = {};
+    key.data = key_data;
+    key.size = key_size;
+    int error = status_db->del(status_db, txn, &key, DB_DELETE_ANY);
+    return error;
+}
+
+// remove a key from the status dictionary.
+// the key must be a HA_METADATA_KEY
+// returns 0 if successful.
+int remove(
+    DB* status_db,
+    HA_METADATA_KEY curr_key_data,
+    DB_TXN* txn) {
+    return
+        tokudb::metadata::remove_low(
+            status_db,
+            &curr_key_data,
+            sizeof(curr_key_data),
+            txn);
+}
+
+int close(DB** status_db_ptr) {
+    int error = 0;
+    DB* status_db = *status_db_ptr;
+    if (status_db) {
+        error = status_db->close(status_db, 0);
+        if (error == 0)
+            *status_db_ptr = NULL;
+    }
+    return error;
+}
+
+int create(
+    DB_ENV* env,
+    DB** status_db_ptr,
+    const char* name,
+    DB_TXN* txn) {
+
+    int error;
+    DB *status_db = NULL;
+
+    error = db_create(&status_db, env, 0);
+    if (error == 0) {
+        error = status_db->set_pagesize(status_db, status_dict_pagesize);
+    }
+    if (error == 0) {
+        error =
+            status_db->open(
+                status_db,
+                txn,
+                name,
+                NULL,
+                DB_BTREE, DB_CREATE | DB_EXCL,
+                0);
+    }
+    if (error == 0) {
+        *status_db_ptr = status_db;
+    } else {
+        int r = tokudb::metadata::close(&status_db);
+        assert_always(r == 0);
+    }
+    return error;
+}
+
+int open(
+    DB_ENV* env,
+    DB** status_db_ptr,
+    const char* name,
+    DB_TXN* txn) {
+
+    int error = 0;
+    DB* status_db = NULL;
+    error = db_create(&status_db, env, 0);
+    if (error == 0) {
+        error =
+            status_db->open(
+                status_db,
+                txn,
+                name,
+                NULL,
+                DB_BTREE,
+                DB_THREAD,
+                0);
+    }
+    if (error == 0) {
+        uint32_t pagesize = 0;
+        error = status_db->get_pagesize(status_db, &pagesize);
+        if (error == 0 && pagesize > status_dict_pagesize) {
+            error =
+                status_db->change_pagesize(status_db, status_dict_pagesize);
+        }
+    }
+    if (error == 0) {
+        *status_db_ptr = status_db;
+    } else {
+        int r = tokudb::metadata::close(&status_db);
+        assert_always(r == 0);
+    }
+    return error;
+}
+
+int strip_frm_data(DB_ENV* env) {
+    int r;
+    DB_TXN* txn = NULL;
+
+    fprintf(stderr, "TokuDB strip_frm_data : Beginning stripping process.\n");
+
+    r = db_env->txn_begin(env, NULL, &txn, 0);
+    assert_always(r == 0);
+
+    DBC* c = NULL;
+    r = env->get_cursor_for_directory(env, txn, &c);
+    assert_always(r == 0);
+
+    DBT key = { };
+    key.flags = DB_DBT_REALLOC;
+
+    DBT val = { };
+    val.flags = DB_DBT_REALLOC;
+    while (1) {
+        r = c->c_get(c, &key, &val, DB_NEXT);
+        if (r == DB_NOTFOUND)
+            break;
+        const char* dname = (const char*) key.data;
+        const char* iname = (const char*) val.data;
+        assert_always(r == 0);
+
+        if (strstr(iname, "_status_")) {
+            fprintf(
+                stderr,
+                "TokuDB strip_frm_data : stripping from dname=%s iname=%s\n",
+                dname,
+                iname);
+
+            DB* status_db;
+            r = tokudb::metadata::open(db_env, &status_db, dname, txn);
+            if (r != 0) {
+                fprintf(
+                    stderr,
+                    "TokuDB strip_frm_data : unable to open status file %s, "
+                    "error = %d\n",
+                    dname,
+                    r);
+                continue;
+            }
+
+            // GOL : this is a godawful hack. The inventors of this did not
+            // think it would be a good idea to use some kind of magic
+            // identifier k/v pair so that you can in fact tell a proper status
+            // file from any other file that might have the string _status_ in
+            // it. Out in ha_tokudb::create, when the status file is initially
+            // created, it is immediately populated with:
+            //    uint hatoku_new_version=HA_TOKU_VERSION=4 and
+            //    uint hatoku_capabilities=HA_TOKU_CAP=0
+            // Since I can't count on the fact that these values are/were
+            // _always_ 4 and 0, I can count on the fact that they _must_ be
+            // there and the _must_ be sizeof(uint). That will at least give us
+            // a much better idea that these are in fact status files.
+            void* p = NULL;
+            size_t sz;
+            r =
+                tokudb::metadata::read_realloc(
+                    status_db,
+                    txn,
+                    hatoku_new_version,
+                    &p,
+                    &sz);
+            if (r != 0) {
+                fprintf(
+                    stderr,
+                    "TokuDB strip_frm_data : does not look like a real TokuDB "
+                    "status file, new_verion is missing, leaving alone %s \n",
+                    dname);
+
+                r = tokudb::metadata::close(&status_db);
+                assert_always(r == 0);
+                continue;
+            } else if (sz != sizeof(uint)) {
+                fprintf(
+                    stderr,
+                    "TokuDB strip_frm_data : does not look like a real TokuDB "
+                    "status file, new_verion is the wrong size, "
+                    "leaving alone %s \n",
+                    dname);
+
+                tokudb::memory::free(p);
+                r = tokudb::metadata::close(&status_db);
+                assert_always(r == 0);
+                continue;
+            }
+            tokudb::memory::free(p);
+            p = NULL;
+
+            r =
+                tokudb::metadata::read_realloc(
+                    status_db,
+                    txn,
+                    hatoku_capabilities,
+                    &p,
+                    &sz);
+            if (r != 0) {
+                fprintf(
+                    stderr,
+                    "TokuDB strip_frm_data : does not look like a real TokuDB "
+                    "status file, capabilities is missing, leaving alone %s \n",
+                    dname);
+
+                r = tokudb::metadata::close(&status_db);
+                assert_always(r == 0);
+                continue;
+            } else if (sz != sizeof(uint)) {
+                fprintf(
+                    stderr,
+                    "TokuDB strip_frm_data : does not look like a real TokuDB "
+                    "status file, capabilities is the wrong size, "
+                    "leaving alone %s \n",
+                    dname);
+
+                tokudb::memory::free(p);
+                r = tokudb::metadata::close(&status_db);
+                assert_always(r == 0);
+                continue;
+            }
+            tokudb::memory::free(p);
+
+            // OK, st this point, it is probably a status file, not 100% but
+            // it looks like it :(
+            r = tokudb::metadata::remove(status_db, hatoku_frm_data, txn);
+            if (r != 0) {
+                fprintf(
+                    stderr,
+                    "TokuDB strip_frm_data : unable to find/strip frm data "
+                    "from status file %s, error = %d\n",
+                    dname,
+                    r);
+            }
+
+            r = tokudb::metadata::close(&status_db);
+            assert_always(r == 0);
+        }
+    }
+    tokudb::memory::free(key.data);
+    tokudb::memory::free(val.data);
+
+    fprintf(
+        stderr,
+        "TokuDB strip_frm_data : Stripping process complete, beginning "
+        "commit, this may take some time.\n");
+
+    r = c->c_close(c);
+    assert_always(r == 0);
+
+    r = txn->commit(txn, 0);
+    assert_always(r == 0);
+
+    fprintf(
+        stderr,
+        "TokuDB strip_frm_data : Commit complete, resuming server init "
+        "process.");
+
+    return 0;
+}
+
+} // namespace metadata
+} // namespace tokudb
 #endif

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -63,6 +63,7 @@ uint        fsync_log_period = 0;
 char*       log_dir = NULL;
 ulonglong   max_lock_memory = 0;
 uint        read_status_frequency = 0;
+my_bool     strip_frm_data = FALSE;
 char*       tmp_dir = NULL;
 uint        write_status_frequency = 0;
 char*       version = (char*) TOKUDB_VERSION_STR;
@@ -355,6 +356,15 @@ static MYSQL_SYSVAR_UINT(
     0,
     ~0U,
     0);
+
+static MYSQL_SYSVAR_BOOL(
+    strip_frm_data,
+    strip_frm_data,
+    PLUGIN_VAR_READONLY,
+    "strip .frm data from metadata file(s)",
+    NULL,
+    NULL,
+    FALSE);
 
 static MYSQL_SYSVAR_STR(
     tmp_dir,
@@ -895,6 +905,7 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(log_dir),
     MYSQL_SYSVAR(max_lock_memory),
     MYSQL_SYSVAR(read_status_frequency),
+    MYSQL_SYSVAR(strip_frm_data),
     MYSQL_SYSVAR(tmp_dir),
     MYSQL_SYSVAR(version),
     MYSQL_SYSVAR(write_status_frequency),

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -78,6 +78,7 @@ extern uint         fsync_log_period;
 extern char*        log_dir;
 extern ulonglong    max_lock_memory;
 extern uint         read_status_frequency;
+extern my_bool      strip_frm_data;
 extern char*        tmp_dir;
 extern uint         write_status_frequency;
 extern char*        version;


### PR DESCRIPTION
…+spec/tokudb-strip-frm-data
- New BOOL global read only server option --tokudb-strip-frm-data=TRUE that walks all the _status_ files and removes the embedded .frm metadata.
- Reports status and errors to stderr.
- Also includes some code reformatting and refactoring.

http://jenkins.percona.com/job/percona-server-5.6-param/1031/
