### PR TITLE
Fixed lp:1515613 ("Valgrind error on repair, merge, mysqlcheck and archive")

### DIFF
--- a/sql/table.cc
+++ b/sql/table.cc
@@ -2368,7 +2368,8 @@ partititon_err:
   outparam->default_column_bitmaps();
 
   /* Fill record with default values */
-  restore_record(outparam, s->default_values);
+  if (outparam->record[0] != outparam->s->default_values)
+    restore_record(outparam, s->default_values);
 
   /* The table struct is now initialized;  Open the table */
   error= 2;


### PR DESCRIPTION
Added condition which prevents "restore_record" (a macro for "memcpy") to be
called with identical "src" and "dst" parameters.
