### PR TITLE
Partial fix for small buffer pool 100% cpu usage lp:1433432

### DIFF
--- a/storage/innobase/include/buf0flu.h
+++ b/storage/innobase/include/buf0flu.h
@@ -202,9 +202,10 @@ Clears up tail of the LRU lists:
 * Put replaceable pages at the tail of LRU to the free list
 * Flush dirty pages at the tail of LRU to the disk
 The depth to which we scan each buffer pool is controlled by dynamic
-config parameter innodb_LRU_scan_depth. */
+config parameter innodb_LRU_scan_depth.
+@return number of pages flushed */
 UNIV_INTERN
-void
+ulint
 buf_flush_LRU_tail(void);
 /*====================*/
 /*********************************************************************//**


### PR DESCRIPTION
https://bugs.launchpad.net/percona-server/+bug/1433432

http://jenkins.percona.com/job/percona-server-5.6-param/1034/

Using --innodb_empty_free_list_algorithm=legacy to avoid deadlock
Increase lru page cleaner sleep time if free lists filled less than 1% and previous clean batch had nothing to clean
