### PR TITLE
Fix bug 1519094 (MySQL hangs randomly)

### DIFF
--- a/storage/innobase/include/os0sync.h
+++ b/storage/innobase/include/os0sync.h
@@ -41,6 +41,7 @@ Created 9/6/1995 Heikki Tuuri
     || defined _M_X64 || defined __WIN__
 
 #define IB_STRONG_MEMORY_MODEL
+#undef HAVE_IB_GCC_ATOMIC_TEST_AND_SET // Quick-and-dirty fix for bug 1519094
 
 #endif /* __i386__ || __x86_64__ || _M_IX86 || M_X64 || __WIN__ */
 


### PR DESCRIPTION
The issue is incorrect upstream fix for
https://bugs.mysql.com/bug.php?id=76135. On x86, it replaced full
memory barriers at mutex lock/unlock with acquire/release ones. This
broke synchronisation between mutex lock_word and waiters flag,
resulting in missed waiting thread wakeups. These, in combination with
error monitor thread trying to acquire the mutex with a missed wakeup,
result in a server hang.

Fix by restoring previous behavior of full memory barriers on x86_64.

http://jenkins.percona.com/job/percona-server-5.5-param/1178/
