### PR TITLE
Fix lp:1488055 (5.6) "ALTER TABLE w/o ENGINE= clause changes table engine…

### DIFF
--- a/mysql-test/include/percona_enforce_storage_engine_alter_table.inc
+++ b/mysql-test/include/percona_enforce_storage_engine_alter_table.inc
@@ -1,0 +1,21 @@
+# OPTIMIZE TABLE must not change table engine
+# This statement will use "ALGORITHM=INPLACE" in both 5.6 and 5.7
+eval OPTIMIZE TABLE $enforce_table;
+
+--echo After OPTIMIZE TABLE statement
+# Make sure table engine hasn't been changed
+# Make sure column definition hasn't been changed
+--let $enforce_engine= InnoDB
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Modify table definition (do not specify "ENGINE")
+# This statement will use "ALGORITHM=COPY" in both 5.6 and 5.7
+eval ALTER TABLE $enforce_table MODIFY a INT;
+
+--echo After ALTER TABLE
+# Make sure table engine hasn't been changed
+# Make sure column definition has been changed
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+

--- a/mysql-test/include/percona_enforce_storage_engine_alter_table_assert.inc
+++ b/mysql-test/include/percona_enforce_storage_engine_alter_table_assert.inc
@@ -1,0 +1,12 @@
+--disable_query_log
+--echo Checking '$enforce_table': Engine = '$enforce_engine'
+eval SELECT Engine = '$enforce_engine' AS engine_match FROM INFORMATION_SCHEMA.TABLES
+  WHERE table_schema = DATABASE() AND table_name ='$enforce_table';
+
+--echo Checking '$enforce_table': Column = '$enforce_column'
+eval SELECT column_type = '$enforce_column' AS column_match
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE table_schema = DATABASE() AND table_name = '$enforce_table' AND column_name='a';
+
+--enable_query_log
+

--- a/mysql-test/include/restart_mysqld.inc
+++ b/mysql-test/include/restart_mysqld.inc
@@ -7,6 +7,11 @@ if ($rpl_inited)
   }
 }
 
+if (!$restart_parameters)
+{
+  let $restart_parameters = restart;
+}
+
 # Write file to make mysql-test-run.pl expect the "crash", but don't start
 # it until it's told to
 --let $_server_id= `SELECT @@server_id`
@@ -18,7 +23,7 @@ if ($rpl_inited)
 shutdown_server 10;
 
 # Write file to make mysql-test-run.pl start up the server again
---exec echo "restart" > $_expect_file_name
+--exec echo "$restart_parameters" > $_expect_file_name
 
 # Turn on reconnect
 --enable_reconnect

--- a/mysql-test/r/percona_enforce_storage_engine_alter_table.result
+++ b/mysql-test/r/percona_enforce_storage_engine_alter_table.result
@@ -1,0 +1,224 @@
+SELECT @@global.enforce_storage_engine IS NULL AS enforce_storage_engine_is_disabled;
+enforce_storage_engine_is_disabled
+1
+CREATE TABLE t1 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t1 VALUES('1');
+CREATE TABLE t2 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t2 VALUES('1');
+CREATE TABLE t3 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t3 VALUES('1');
+CREATE TABLE t4 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t4 VALUES('1');
+CREATE TABLE t5 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t5 VALUES('1');
+CREATE TABLE t6 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t6 VALUES('1');
+CREATE TABLE t7 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t7 VALUES('1');
+CREATE TABLE t8 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t8 VALUES('1');
+CREATE TABLE t9 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t9 VALUES('1');
+CREATE TABLE t10 (a VARCHAR(1)) ENGINE=InnoDB;
+INSERT INTO t10 VALUES('1');
+After CREATE TABLE
+SELECT COUNT(*) = 10 AS engines_match FROM INFORMATION_SCHEMA.TABLES
+WHERE table_schema = DATABASE() AND table_name LIKE 't%';
+engines_match
+1
+After the first restart
+SELECT @@global.enforce_storage_engine = 'MyISAM' AS enforce_storage_engine_is_myisam;
+enforce_storage_engine_is_myisam
+1
+SELECT COUNT(*) = 10 AS engines_match FROM INFORMATION_SCHEMA.TABLES
+WHERE table_schema = DATABASE() AND table_name LIKE 't%';
+engines_match
+1
+SET sql_mode = 'NO_ENGINE_SUBSTITUTION';
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t1	optimize	status	OK
+After OPTIMIZE TABLE statement
+Checking 't1': Engine = 'InnoDB'
+engine_match
+1
+Checking 't1': Column = 'varchar(1)'
+column_match
+1
+ALTER TABLE t1 MODIFY a INT;
+After ALTER TABLE
+Checking 't1': Engine = 'InnoDB'
+engine_match
+1
+Checking 't1': Column = 'int(11)'
+column_match
+1
+ALTER TABLE t1 ENGINE=Memory;
+ERROR 42000: Unknown storage engine 'MEMORY'
+ALTER TABLE t1 MODIFY a INT, ENGINE=Memory;
+ERROR 42000: Unknown storage engine 'MEMORY'
+ALTER TABLE t1 ALTER a SET DEFAULT '0', ENGINE=Memory;
+ERROR 42000: Unknown storage engine 'MEMORY'
+ALTER TABLE t1 ENGINE=InnoDB;
+ERROR 42000: Unknown storage engine 'InnoDB'
+ALTER TABLE t1 MODIFY a INT, ENGINE=InnoDB;
+ERROR 42000: Unknown storage engine 'InnoDB'
+ALTER TABLE t1 ALTER a SET DEFAULT '0', ENGINE=InnoDB;
+ERROR 42000: Unknown storage engine 'InnoDB'
+After unsuccessful ALTER TABLE statements (NO_ENGINE_SUBSTITUTION enabled)
+Checking 't1': Engine = 'InnoDB'
+engine_match
+1
+Checking 't1': Column = 'int(11)'
+column_match
+1
+ALTER TABLE t2 ENGINE=MyISAM;
+Checking 't2': Engine = 'MyISAM'
+engine_match
+1
+Checking 't2': Column = 'varchar(1)'
+column_match
+1
+ALTER TABLE t3 MODIFY a INT, ENGINE=MyISAM;
+Checking 't3': Engine = 'MyISAM'
+engine_match
+1
+Checking 't3': Column = 'int(11)'
+column_match
+1
+SET sql_mode = '';
+OPTIMIZE TABLE t4;
+Table	Op	Msg_type	Msg_text
+test.t4	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t4	optimize	status	OK
+After OPTIMIZE TABLE statement
+Checking 't4': Engine = 'InnoDB'
+engine_match
+1
+Checking 't4': Column = 'varchar(1)'
+column_match
+1
+ALTER TABLE t4 MODIFY a INT;
+After ALTER TABLE
+Checking 't4': Engine = 'InnoDB'
+engine_match
+1
+Checking 't4': Column = 'int(11)'
+column_match
+1
+ALTER TABLE t5 ENGINE=MyISAM;
+Checking 't5': Engine = 'MyISAM'
+engine_match
+1
+Checking 't5': Column = 'varchar(1)'
+column_match
+1
+ALTER TABLE t6 MODIFY a INT, ENGINE=MyISAM;
+Checking 't6': Engine = 'MyISAM'
+engine_match
+1
+Checking 't6': Column = 'int(11)'
+column_match
+1
+ALTER TABLE t7 ENGINE=Memory;
+Warnings:
+Note	1266	Using storage engine MyISAM for table 't7'
+Checking 't7': Engine = 'MyISAM'
+engine_match
+1
+Checking 't7': Column = 'varchar(1)'
+column_match
+1
+ALTER TABLE t8 MODIFY a INT, ENGINE=Memory;
+Warnings:
+Note	1266	Using storage engine MyISAM for table 't8'
+Checking 't8': Engine = 'MyISAM'
+engine_match
+1
+Checking 't8': Column = 'int(11)'
+column_match
+1
+ALTER TABLE t9 ENGINE=InnoDB;
+Warnings:
+Note	1266	Using storage engine MyISAM for table 't9'
+Checking 't9': Engine = 'MyISAM'
+engine_match
+1
+Checking 't9': Column = 'varchar(1)'
+column_match
+1
+ALTER TABLE t10 MODIFY a INT, ENGINE=InnoDB;
+Warnings:
+Note	1266	Using storage engine MyISAM for table 't10'
+Checking 't10': Engine = 'MyISAM'
+engine_match
+1
+Checking 't10': Column = 'int(11)'
+column_match
+1
+After the second restart
+SELECT @@global.enforce_storage_engine IS NULL AS enforce_storage_engine_is_disabled;
+enforce_storage_engine_is_disabled
+1
+Checking 't1': Engine = 'InnoDB'
+engine_match
+1
+Checking 't1': Column = 'int(11)'
+column_match
+1
+Checking 't2': Engine = 'MyISAM'
+engine_match
+1
+Checking 't2': Column = 'varchar(1)'
+column_match
+1
+Checking 't3': Engine = 'MyISAM'
+engine_match
+1
+Checking 't3': Column = 'int(11)'
+column_match
+1
+Checking 't4': Engine = 'InnoDB'
+engine_match
+1
+Checking 't4': Column = 'int(11)'
+column_match
+1
+Checking 't5': Engine = 'MyISAM'
+engine_match
+1
+Checking 't5': Column = 'varchar(1)'
+column_match
+1
+Checking 't6': Engine = 'MyISAM'
+engine_match
+1
+Checking 't6': Column = 'int(11)'
+column_match
+1
+Checking 't7': Engine = 'MyISAM'
+engine_match
+1
+Checking 't7': Column = 'varchar(1)'
+column_match
+1
+Checking 't8': Engine = 'MyISAM'
+engine_match
+1
+Checking 't8': Column = 'int(11)'
+column_match
+1
+Checking 't9': Engine = 'MyISAM'
+engine_match
+1
+Checking 't9': Column = 'varchar(1)'
+column_match
+1
+Checking 't10': Engine = 'MyISAM'
+engine_match
+1
+Checking 't10': Column = 'int(11)'
+column_match
+1
+DROP TABLE t1, t2, t3, t4, t5, t6, t7, t8, t9, t10;

--- a/mysql-test/t/percona_enforce_storage_engine_alter_table.test
+++ b/mysql-test/t/percona_enforce_storage_engine_alter_table.test
@@ -1,0 +1,190 @@
+#
+# Bug lp:1488055 "ALTER TABLE w/o ENGINE= clause changes table engine if enforce_storage_engine active"
+#
+
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+
+--disable_query_log
+call mtr.add_suppression('Default storage engine \\(InnoDB\\) is not the same as enforced storage engine \\(MyISAM\\)');
+--enable_query_log
+
+# Make sure "enforce_storage_engine" is disabled
+SELECT @@global.enforce_storage_engine IS NULL AS enforce_storage_engine_is_disabled;
+
+# Create 10 dummy tables of the same structure with "InnoDB" engine
+--let $i=1
+while($i <=10)
+{
+  --eval CREATE TABLE t$i (a VARCHAR(1)) ENGINE=InnoDB
+  --eval INSERT INTO t$i VALUES('1')
+  --inc $i
+}
+
+# Make sure the tables were indeed created with "InnoDB" engine and have identical
+# structure
+--let $enforce_engine= InnoDB
+--let $enforce_column= varchar(1)
+
+--echo After CREATE TABLE
+# Make sure all 10 tables have been created with "InnoDB" engine
+SELECT COUNT(*) = 10 AS engines_match FROM INFORMATION_SCHEMA.TABLES
+  WHERE table_schema = DATABASE() AND table_name LIKE 't%';
+
+#
+# Restart "mysqld" with "enforce_storage_engine" set to "MyISAM"
+#
+--let $restart_parameters= restart:--enforce_storage_engine=MyISAM
+--source include/restart_mysqld.inc
+
+--echo After the first restart
+
+# Make sure "enforce_storage_engine" is set to "MyISAM"
+SELECT @@global.enforce_storage_engine = 'MyISAM' AS enforce_storage_engine_is_myisam;
+
+# Make sure table engines have not changed
+SELECT COUNT(*) = 10 AS engines_match FROM INFORMATION_SCHEMA.TABLES
+  WHERE table_schema = DATABASE() AND table_name LIKE 't%';
+
+#
+# Tests with 'NO_ENGINE_SUBSTITUTION' in sql_mode
+#
+SET sql_mode = 'NO_ENGINE_SUBSTITUTION';
+--let $enforce_table= t1
+--source include/percona_enforce_storage_engine_alter_table.inc
+
+# Under Enforced SE, when sql_mode includes NO_ENGINE_SUBSTITUTION changing table
+# engine to something other than "@@global.enforce_storage_engine" must generate
+# an error
+--error ER_UNKNOWN_STORAGE_ENGINE
+ALTER TABLE t1 ENGINE=Memory;
+--error ER_UNKNOWN_STORAGE_ENGINE
+ALTER TABLE t1 MODIFY a INT, ENGINE=Memory;
+--error ER_UNKNOWN_STORAGE_ENGINE
+ALTER TABLE t1 ALTER a SET DEFAULT '0', ENGINE=Memory;
+
+# The same error must be generated when we specify the same engine which is
+# currently set to the table if it is not "@@global.enforce_storage_engine"
+--error ER_UNKNOWN_STORAGE_ENGINE
+ALTER TABLE t1 ENGINE=InnoDB;
+--error ER_UNKNOWN_STORAGE_ENGINE
+ALTER TABLE t1 MODIFY a INT, ENGINE=InnoDB;
+--error ER_UNKNOWN_STORAGE_ENGINE
+ALTER TABLE t1 ALTER a SET DEFAULT '0', ENGINE=InnoDB;
+
+# Make sure table engine hasn't been changed
+# Make sure column definition hasn't been changed
+--echo After unsuccessful ALTER TABLE statements (NO_ENGINE_SUBSTITUTION enabled)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Successful alteration with allowed (enforced) engine
+ALTER TABLE t2 ENGINE=MyISAM;
+--let $enforce_table= t2
+--let $enforce_engine= MyISAM
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Successful alteration with allowed (enforced) engine and new column definition
+ALTER TABLE t3 MODIFY a INT, ENGINE=MyISAM;
+--let $enforce_table= t3
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+#
+# Tests without 'NO_ENGINE_SUBSTITUTION' in sql_mode
+#
+SET sql_mode = '';
+--let $enforce_table= t4
+--let $enforce_engine= InnoDB
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table.inc
+
+# Successful alteration with allowed (enforced) engine with SUBSTITUTION
+ALTER TABLE t5 ENGINE=MyISAM;
+--let $enforce_table= t5
+--let $enforce_engine= MyISAM
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Successful alteration with allowed (enforced) engine and new column definition
+# with SUBSTITUTION
+ALTER TABLE t6 MODIFY a INT, ENGINE=MyISAM;
+--let $enforce_table= t6
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Successful alteration with "Memory" engine with SUBSTITUTION
+ALTER TABLE t7 ENGINE=Memory;
+--let $enforce_table= t7
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Successful alteration with "Memory" engine and new column definition
+# with SUBSTITUTION
+ALTER TABLE t8 MODIFY a INT, ENGINE=Memory;
+--let $enforce_table= t8
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Successful alteration with current ("InnoDB") engine with SUBSTITUTION
+ALTER TABLE t9 ENGINE=InnoDB;
+--let $enforce_table= t9
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Successful alteration with current ("InnoDB") engine and new column
+# definition with SUBSTITUTION
+ALTER TABLE t10 MODIFY a INT, ENGINE=InnoDB;
+--let $enforce_table= t10
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+#
+# Restarting "mysqld" with initial options
+#
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--echo After the second restart
+
+# Make sure after the second restart "enforce_storage_engine" is disabled again
+SELECT @@global.enforce_storage_engine IS NULL AS enforce_storage_engine_is_disabled;
+
+# Make sure the table engine is still "InnoDB"
+--let $enforce_table= t1
+--let $enforce_engine= InnoDB
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t2
+--let $enforce_engine= MyISAM
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t3
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t4
+--let $enforce_engine= InnoDB
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t5
+--let $enforce_engine= MyISAM
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t6
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t7
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t8
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t9
+--let $enforce_column= varchar(1)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+--let $enforce_table= t10
+--let $enforce_column= int(11)
+--source include/percona_enforce_storage_engine_alter_table_assert.inc
+
+# Cleaning up
+DROP TABLE t1, t2, t3, t4, t5, t6, t7, t8, t9, t10;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7737,7 +7737,19 @@ static bool check_engine(THD *thd, const char *db_name,
         test(thd->variables.sql_mode & MODE_NO_ENGINE_SUBSTITUTION);
 
   if (!in_bootstrap && !opt_noacl)
-    enf_engine= ha_enforce_handlerton(thd);
+  {
+    /*
+      Storage engine enforcement must be forbidden:
+      1. for "OPTIMIZE TABLE" statements.
+      2. for "ALTER TABLE" statements without explicit "... ENGINE=xxx" part
+    */
+    bool enforcement_forbidden =
+          ((thd->lex->sql_command == SQLCOM_ALTER_TABLE) &&
+          (create_info->used_fields & HA_CREATE_USED_ENGINE) == 0) ||
+          (thd->lex->sql_command == SQLCOM_OPTIMIZE);
+    if (!enforcement_forbidden)
+      enf_engine= ha_enforce_handlerton(thd);
+  }
 
   if (!(*new_engine= ha_checktype(thd, ha_legacy_type(req_engine),
                                   no_substitution, 1)))


### PR DESCRIPTION
… if enforce-storage-engine active"
