### PR TITLE
Fix lp:1368552 (5.6) "InnoDB: Failing assertion: purge_sys->state == PURGE_STATE_RUN"

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug1368552.result
+++ b/mysql-test/suite/innodb/r/percona_bug1368552.result
@@ -1,0 +1,3 @@
+SET GLOBAL innodb_purge_stop_now = ON;
+SET GLOBAL innodb_sched_priority_purge = 5;
+SET GLOBAL innodb_purge_run_now = ON;

--- a/mysql-test/suite/innodb/t/percona_bug1368552.test
+++ b/mysql-test/suite/innodb/t/percona_bug1368552.test
@@ -1,0 +1,18 @@
+# Bug lp:1368552
+# "InnoDB: Failing assertion: purge_sys->state == PURGE_STATE_RUN |
+# abort (sig=6) in innodb_sched_priority_purge_update"
+
+--source include/have_debug.inc
+--source include/have_innodb.inc
+--source include/linux.inc
+
+SET GLOBAL innodb_purge_stop_now = ON;
+
+SET GLOBAL innodb_sched_priority_purge = 5;
+
+SET GLOBAL innodb_purge_run_now = ON;
+
+# As elevated privileges may be required to restore
+# "innodb_sched_priority_purge" it is easier to just restart the
+# server rather than save/restore this variable
+--source include/restart_mysqld.inc

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -16267,7 +16267,6 @@ innodb_sched_priority_purge_update(
 		return;
 	}
 
-	ut_ad(purge_sys->state == PURGE_STATE_RUN);
 	for (ulint i = 0; i < srv_n_purge_threads; i++) {
 
 		ulint actual_priority


### PR DESCRIPTION
Removed "ut_ad(purge_sys->state == PURGE_STATE_RUN);" assertion
from the "innodb_sched_priority_purge_update()" to make sure that
it is safe to change "innodb_sched_priority_purge" variable when
purge threads are disabled.
