### PR TITLE
5.7 - Fix for boost download location in cmake (dl from our infrastructure)

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -29,7 +29,7 @@
 SET(BOOST_PACKAGE_NAME "boost_1_59_0")
 SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.gz")
 SET(BOOST_DOWNLOAD_URL
-  "http://sourceforge.net/projects/boost/files/boost/1.59.0/${BOOST_TARBALL}"
+  "http://jenkins.percona.com/downloads/boost/${BOOST_TARBALL}"
   )
 
 SET(OLD_PACKAGE_NAMES "boost_1_55_0 boost_1_56_0 boost_1_57_0 boost_1_58_0")


### PR DESCRIPTION
This is to speedup the builds and avoid timeouts when downloading boost libraries from sourceforge.
Here can be seen how it looks:
http://jenkins.percona.com/job/percona-server-5.7-debian-binary/label_exp=ubuntu-trusty-64bit/11/consoleFull
