### PR TITLE
Fix lp:1179451 (5.5) "innodb_show_verbose_locks and innodb_show_locks_held untested in MTR"

### DIFF
--- a/mysql-test/suite/innodb/include/percona_extended_innodb_status.inc
+++ b/mysql-test/suite/innodb/include/percona_extended_innodb_status.inc
@@ -1,0 +1,80 @@
+# starting a transaction in the "default" connection
+connection default;
+START TRANSACTION;
+# execute a statement which locks a record
+UPDATE t SET value = 1 WHERE id = 3;
+
+# creating another connection
+connect (con1,localhost,root,,);
+--echo connection con1
+
+# identify this connection ID
+--let $blocked_connection_id = `SELECT CONNECTION_ID()`
+
+# make sure the upcoming blocked update will not time out
+SET innodb_lock_wait_timeout = 1073741824;
+
+# starting a transaction in this connection
+START TRANSACTION;
+# execute a statement which tries to update the same record
+# this statement will hang until the privious transaction finishes
+--send UPDATE t SET value = 1 WHERE id = 3
+
+connection default;
+--echo connection default
+
+# wait until the second transaction switches to "LOCK WAIT" state
+let $wait_condition = SELECT trx_state = 'LOCK WAIT'
+  FROM information_schema.innodb_trx
+  WHERE trx_mysql_thread_id = $blocked_connection_id;
+--source include/wait_condition.inc
+
+# executing "SHOW ENGINE INNODB STATUS" in the "default" connection
+# saving the output into "STATUS" environment variable
+--let STATUS = query_get_value(SHOW ENGINE INNODB STATUS, Status, 1)
+
+# When "innodb_show_verbose_locks" is enabled the output should also include
+# something similar to the following:
+#
+# Record lock, heap no 2 PHYSICAL RECORD: n_fields 4; compact format; info bits 0
+#  0: len 4; hex 80000001; asc     ;;
+#  1: len 6; hex 000000000d07; asc       ;;
+#  2: len 7; hex 14000001bc0110; asc        ;;
+#  3: len 4; hex 80000001; asc     ;;
+
+# using perl script to analyze the ouput from the "STATUS" environment
+# variable
+perl;
+  use strict;
+  use warnings;
+
+  my $output = $ENV{'STATUS'};
+  if ($output =~ /^Record lock, heap no \d+ PHYSICAL RECORD: n_fields \d+; compact format; info bits \d+$/m)
+  {
+    print "\"Record lock\" found\n";
+    my $records = () = $output =~ /^\s*\d+: len \d+; hex [[:xdigit:]]+; asc .*;;$/gm;
+    print "n = $records\n";
+  }
+  else
+  {
+    print "\"Record lock\" not found\n";
+  }
+  if($output =~ /^TOO MANY LOCKS PRINTED FOR THIS TRX: SUPPRESSING FURTHER PRINTS$/m)
+  {
+    print "too many locks printed\n";
+  }
+EOF
+
+# rolling back the first transaction
+ROLLBACK;
+
+# rolling back the second transaction
+connection con1;
+--echo connection con1
+--reap
+ROLLBACK;
+
+# closing auxiliary connection
+connection default;
+--echo connection default
+disconnect con1;

--- a/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
+++ b/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
@@ -1,0 +1,77 @@
+SET @innodb_show_verbose_locks_save = @@global.innodb_show_verbose_locks;
+SET @innodb_show_locks_held_save = @@global.innodb_show_locks_held;
+CREATE TABLE t (id INT PRIMARY KEY, value INT NOT NULL DEFAULT 0) ENGINE=InnoDB;
+INSERT INTO t(id) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+SET GLOBAL innodb_show_verbose_locks = 0;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection con1
+SET innodb_lock_wait_timeout = 1073741824;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection default
+"Record lock" not found
+ROLLBACK;
+connection con1
+ROLLBACK;
+connection default
+SET GLOBAL innodb_show_verbose_locks = 1;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection con1
+SET innodb_lock_wait_timeout = 1073741824;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection default
+"Record lock" found
+n = 4
+ROLLBACK;
+connection con1
+ROLLBACK;
+connection default
+CREATE TABLE innodb_lock_monitor (a INT) ENGINE=InnoDB;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection con1
+SET innodb_lock_wait_timeout = 1073741824;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection default
+"Record lock" found
+n = 12
+ROLLBACK;
+connection con1
+ROLLBACK;
+connection default
+SET GLOBAL innodb_show_locks_held = 1;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection con1
+SET innodb_lock_wait_timeout = 1073741824;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection default
+"Record lock" found
+n = 4
+too many locks printed
+ROLLBACK;
+connection con1
+ROLLBACK;
+connection default
+SET GLOBAL innodb_show_locks_held = 0;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection con1
+SET innodb_lock_wait_timeout = 1073741824;
+START TRANSACTION;
+UPDATE t SET value = 1 WHERE id = 3;
+connection default
+"Record lock" found
+n = 4
+ROLLBACK;
+connection con1
+ROLLBACK;
+connection default
+SET GLOBAL innodb_show_verbose_locks = @innodb_show_verbose_locks_save;
+SET GLOBAL innodb_show_locks_held = @innodb_show_locks_held_save;
+DROP TABLE innodb_lock_monitor, t;

--- a/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
+++ b/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
@@ -1,0 +1,46 @@
+--source include/have_innodb.inc
+
+--source include/count_sessions.inc
+
+# saving global variables which will be changed in this test
+SET @innodb_show_verbose_locks_save = @@global.innodb_show_verbose_locks;
+SET @innodb_show_locks_held_save = @@global.innodb_show_locks_held;
+
+# create a simple table and fill it with 10 records
+CREATE TABLE t (id INT PRIMARY KEY, value INT NOT NULL DEFAULT 0) ENGINE=InnoDB;
+INSERT INTO t(id) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+
+# check "SHOW ENGINE INNODB STATUS" output when there are transactions
+# blocked by locked records
+
+# first, check regular output with monitor turned off
+SET GLOBAL innodb_show_verbose_locks = 0;
+--source suite/innodb/include/percona_extended_innodb_status.inc
+
+# then, verbose output with monitor turned off
+SET GLOBAL innodb_show_verbose_locks = 1;
+--source suite/innodb/include/percona_extended_innodb_status.inc
+
+# create monitor table
+CREATE TABLE innodb_lock_monitor (a INT) ENGINE=InnoDB;
+
+# after that, verbose output with monitor turned on
+--source suite/innodb/include/percona_extended_innodb_status.inc
+
+# and finally, verbose output with monitor turned on and record limit set to 1
+SET GLOBAL innodb_show_locks_held = 1;
+--source suite/innodb/include/percona_extended_innodb_status.inc
+
+# in addition, setting record limit to 0 should act as verbose output with
+# monitor turned off
+SET GLOBAL innodb_show_locks_held = 0;
+--source suite/innodb/include/percona_extended_innodb_status.inc
+
+# wait until all additional connections close
+--source include/wait_until_count_sessions.inc
+
+# restoring affected global variables
+SET GLOBAL innodb_show_verbose_locks = @innodb_show_verbose_locks_save;
+SET GLOBAL innodb_show_locks_held = @innodb_show_locks_held_save;
+
+DROP TABLE innodb_lock_monitor, t;


### PR DESCRIPTION
Added a new MTR test case "innodb.percona_extended_innodb_status.test"
which checks "Extended 'SHOW ENGINE InnoDB STATUS'" functionality.
