### PR TITLE
 Bug 1521474: Server is crashing when we grant privileges to user wit…

### DIFF
--- a/plugin/percona-pam-for-mysql/CMakeLists.txt
+++ b/plugin/percona-pam-for-mysql/CMakeLists.txt
@@ -24,6 +24,8 @@ CHECK_SYMBOL_EXISTS(getgrgid_r "grp.h" HAVE_GETGRGID_R)
 CHECK_INCLUDE_FILES (security/pam_misc.h HAVE_SECURITY_PAM_MISC_H)
 CHECK_INCLUDE_FILES (security/openpam.h HAVE_SECURITY_OPENPAM_H)
 CHECK_INCLUDE_FILES (dlfcn.h HAVE_DLFCN_H)
+ADD_DEFINITIONS(-Dget_tty_password_ext=dialog_mysql_get_tty_password_ext)
+ADD_DEFINITIONS(-Dget_tty_password=dialog_mysql_get_tty_password)
 IF(HAVE_PAM AND HAVE_GETPWNAM_R AND HAVE_GETGRGID_R AND HAVE_DLFCN_H)
   SET(AUTH_PAM_COMMON_SOURCES 
     src/auth_pam_common.c src/lib_auth_pam_client.c src/lib_auth_pam_client.h
@@ -32,6 +34,10 @@ IF(HAVE_PAM AND HAVE_GETPWNAM_R AND HAVE_GETGRGID_R AND HAVE_DLFCN_H)
   SET(AUTH_PAM_COMPAT_SOURCES ${AUTH_PAM_COMMON_SOURCES} src/auth_pam_compat.c)
   MYSQL_ADD_PLUGIN(auth_pam ${AUTH_PAM_SOURCES} LINK_LIBRARIES pam MODULE_ONLY)
   MYSQL_ADD_PLUGIN(auth_pam_compat ${AUTH_PAM_COMPAT_SOURCES} LINK_LIBRARIES pam MODULE_ONLY)
-  MYSQL_ADD_PLUGIN(dialog src/dialog.c LINK_LIBRARIES perconaserverclient MODULE_ONLY)
+  MYSQL_ADD_PLUGIN(dialog
+                   src/dialog.c
+                   ../../client/get_password.c
+                   LINK_LIBRARIES perconaserverclient
+                   MODULE_ONLY)
 ENDIF(HAVE_PAM AND HAVE_GETPWNAM_R AND HAVE_GETGRGID_R)
 ENDIF(WITH_PAM)

--- a/plugin/percona-pam-for-mysql/src/auth_pam.c
+++ b/plugin/percona-pam-for-mysql/src/auth_pam.c
@@ -1,5 +1,5 @@
 /*
-(C) 2012, 2013 Percona LLC and/or its affiliates
+(C) 2012, 2015 Percona LLC and/or its affiliates
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -57,6 +57,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include <string.h>
 #include "auth_pam_common.h"
 #include <my_sys.h>
+#include <stdlib.h>
 
 /** The maximum length of buffered PAM messages, i.e. any messages up to the
     next PAM reply-requiring message. 10K should be more than enough by order
@@ -85,8 +86,8 @@ static char pam_msg_style_to_char (int pam_msg_style)
 int auth_pam_client_talk_init(void **talk_data)
 {
   struct pam_msg_buf *msg_buf= my_malloc(key_memory_pam_msg_buf,
-					 sizeof(struct pam_msg_buf),
-					 MY_ZEROFILL);
+                                         sizeof(struct pam_msg_buf),
+                                         MY_ZEROFILL);
   *talk_data= (void*)msg_buf;
   if (msg_buf != NULL)
   {
@@ -141,7 +142,7 @@ int auth_pam_talk_perform(const struct pam_message *msg,
         < 0)
       return PAM_CONV_ERR;
 
-    resp->resp= my_malloc(key_memory_pam_packet, pkt_len + 1, 0);
+    resp->resp= malloc(pkt_len + 1);
     if (resp->resp == NULL)
       return PAM_BUF_ERR;
 
@@ -172,9 +173,9 @@ static struct st_mysql_auth pam_auth_handler=
   MYSQL_AUTHENTICATION_INTERFACE_VERSION,
   "dialog",
   &authenticate_user_with_pam_server,
-  NULL,
-  NULL,
-  NULL,
+  &auth_pam_generate_auth_string_hash,
+  &auth_pam_validate_auth_string_hash,
+  &auth_pam_set_salt,
   0UL
 };
 

--- a/plugin/percona-pam-for-mysql/src/auth_pam_common.h
+++ b/plugin/percona-pam-for-mysql/src/auth_pam_common.h
@@ -52,9 +52,7 @@ struct pam_conv_data {
 };
 
 extern PSI_memory_key key_memory_pam_mapping_iter;
-extern PSI_memory_key key_memory_pam_packet;
 extern PSI_memory_key key_memory_pam_group_iter;
-extern PSI_memory_key key_memory_pam_response;
 
 void auth_pam_common_init(const char *psi_category);
 
@@ -71,6 +69,19 @@ void auth_pam_client_talk_finalize(void *talk_data);
 
 int authenticate_user_with_pam_server (MYSQL_PLUGIN_VIO *vio,
                                        MYSQL_SERVER_AUTH_INFO *info);
+
+int auth_pam_generate_auth_string_hash(char *outbuf,
+                                       unsigned int *buflen,
+                                       const char *inbuf,
+                                       unsigned int inbuflen);
+
+int auth_pam_validate_auth_string_hash(char* const buf,
+                                       unsigned int len);
+
+int auth_pam_set_salt(const char* password,
+                      unsigned int password_len,
+                      unsigned char* salt,
+                      unsigned char* salt_len);
 
 #ifdef __cplusplus
 }

--- a/plugin/percona-pam-for-mysql/src/auth_pam_compat.c
+++ b/plugin/percona-pam-for-mysql/src/auth_pam_compat.c
@@ -1,5 +1,5 @@
 /*
-(C) 2012, 2013 Percona LLC and/or its affiliates
+(C) 2012, 2015 Percona LLC and/or its affiliates
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -55,6 +55,7 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 #include <string.h>
 #include "auth_pam_common.h"
 #include <my_sys.h>
+#include <stdlib.h>
 
 int auth_pam_client_talk_init(void **talk_data)
 {
@@ -89,7 +90,7 @@ int auth_pam_talk_perform(const struct pam_message *msg,
         < 0)
       return PAM_CONV_ERR;
 
-    resp->resp= my_malloc(key_memory_pam_packet, pkt_len + 1, 0);
+    resp->resp= malloc(pkt_len + 1);
     if (resp->resp == NULL)
       return PAM_BUF_ERR;
 
@@ -121,9 +122,9 @@ static struct st_mysql_auth pam_auth_handler=
   MYSQL_AUTHENTICATION_INTERFACE_VERSION,
   "mysql_clear_password",
   &authenticate_user_with_pam_server,
-  NULL,
-  NULL,
-  NULL,
+  &auth_pam_generate_auth_string_hash,
+  &auth_pam_validate_auth_string_hash,
+  &auth_pam_set_salt,
   0UL
 };
 

--- a/plugin/percona-pam-for-mysql/src/dialog.c
+++ b/plugin/percona-pam-for-mysql/src/dialog.c
@@ -42,6 +42,7 @@
 #include <mysql.h>
 #include <mysql/plugin_auth.h>
 #include <mysql/client_plugin.h>
+#include <mysql/get_password.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -219,18 +220,21 @@ typedef char *(*mysql_authentication_dialog_ask_t)(struct st_mysql *mysql,
 
 static mysql_authentication_dialog_ask_t ask;
 
+
+static char * strdup_func(const char *str, myf flags __attribute__((unused)))
+{
+  return strdup(str);
+}
+
 static char *builtin_ask(MYSQL *mysql __attribute__((unused)),
                          int type __attribute__((unused)),
                          const char *prompt,
                          char *buf, int buf_len)
 {
-  fputs(prompt, stdout);
-  fputc(' ', stdout);
-
   if (type == 2) /* password */
   {
     char *password;
-    password= get_tty_password("");
+    password= get_tty_password_ext(prompt, strdup_func);
     strncpy(buf, password, buf_len-1);
     buf[buf_len-1]= 0;
     free(password);


### PR DESCRIPTION
…h PAM plugin

This patch fixes following issues:
- new callbacks were inroduced in 5.7 which can't be NULL. Stubs are
  implemented instead.
- my_malloc() and my_free() are no logner interchangeable with
  malloc() and free(). Memory which later will be released by PAM
  library has to be allocated with malloc()/calloc(), memory which
  allocated by PAM library has to be released with free().
- get_tty_password() is using my_strdup() which is using
  my_malloc(). The problem is that client dynamic plugin is not able
  to use my_malloc() and my_free() at all (see
  http://bugs.mysql.com/bug.php?id=79710). Solution is to link with
  client/get_password.c and use get_tty_password_ext similar to
  built-in yassl.
