### PR TITLE
Fix lp:1441259 (5.6) "super_read_only mode breaks replication with some queries"

### DIFF
--- a/mysql-test/suite/rpl/r/percona_bug1441259.result
+++ b/mysql-test/suite/rpl/r/percona_bug1441259.result
@@ -1,0 +1,27 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1 (
+id INT NOT NULL PRIMARY KEY,
+val INT NOT NULL
+);
+CREATE TABLE t2 (
+id INT NOT NULL PRIMARY KEY,
+val INT NOT NULL
+);
+INSERT INTO t1 VALUES (1, 1);
+INSERT INTO t2 VALUES (1, 2);
+include/sync_slave_sql_with_master.inc
+SET @read_only_save = @@global.read_only;
+SET @super_read_only_save = @@global.super_read_only;
+SET GLOBAL read_only = 1;
+SET GLOBAL super_read_only = 1;
+UPDATE t1 LEFT JOIN t2 USING(id) SET t1.val = 42;
+include/sync_slave_sql_with_master.inc
+DROP TABLE t1, t2;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL read_only = @read_only_save;
+SET GLOBAL super_read_only = @super_read_only_save;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/percona_bug1441259.test
+++ b/mysql-test/suite/rpl/t/percona_bug1441259.test
@@ -1,0 +1,39 @@
+#
+# Bug lp:1441259 "super_read_only mode breaks replication with some queries"
+#
+--source include/have_binlog_format_mixed_or_statement.inc
+--source include/master-slave.inc
+
+# creating a few tables and fill them with some data
+connection master;
+CREATE TABLE t1 (
+  id INT NOT NULL PRIMARY KEY,
+  val INT NOT NULL
+);
+CREATE TABLE t2 (
+  id INT NOT NULL PRIMARY KEY,
+  val INT NOT NULL
+);
+INSERT INTO t1 VALUES (1, 1);
+INSERT INTO t2 VALUES (1, 2);
+--source include/sync_slave_sql_with_master.inc
+
+SET @read_only_save = @@global.read_only;
+SET @super_read_only_save = @@global.super_read_only;
+SET GLOBAL read_only = 1;
+SET GLOBAL super_read_only = 1;
+
+# executing a multitable update
+connection master;
+UPDATE t1 LEFT JOIN t2 USING(id) SET t1.val = 42;
+--source include/sync_slave_sql_with_master.inc
+
+# cleaning up
+connection master;
+DROP TABLE t1, t2;
+--source include/sync_slave_sql_with_master.inc
+SET GLOBAL read_only = @read_only_save;
+SET GLOBAL super_read_only = @super_read_only_save;
+
+--source include/rpl_end.inc
+

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3787,9 +3787,9 @@ end_with_restore_list:
 
 #ifdef HAVE_REPLICATION
     /* Check slave filtering rules */
-    if (unlikely(thd->slave_thread && !have_table_map_for_update))
+    if (unlikely(thd->slave_thread))
     {
-      if (all_tables_not_ok(thd, all_tables))
+      if (!have_table_map_for_update && all_tables_not_ok(thd, all_tables))
       {
         if (res!= 0)
         {
@@ -3817,6 +3817,7 @@ end_with_restore_list:
       {
         my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0),
                  opt_super_readonly ? "--read-only (super)" : "--read-only");
+        break;
       }
 #ifdef HAVE_REPLICATION
     }  /* unlikely */


### PR DESCRIPTION
Fixed problem introduced in commit 78e1f5d "Cherry picking patch for BUG#37051".

BUG#37051 "Replication rules not evaluated correctly"
(https://bugs.mysql.com/bug.php?id=37051).

"!have_table_map_for_update" was added by mistake to "if (unlikely(thd->slave_thread))"
condition. Instead, it should have been added inside the "slave" branch.

Added missing "break;" statement which was not included in commit 519bc81
"Port --super-read-only option from WebScaleSQL, implementing".
Original WebScaleSQL implementation has it
(https://github.com/webscalesql/webscalesql-5.6/commit/73fe122dd4b7f1a0fa79f338a7a0c4e5809389e2).

Added new MTR test case "rpl.percona_bug1441259" which checks
replication of the multitable update statements.
