### PR TITLE
Fix bug lp:1521905 Avoid deadlock with backoff empty free list algorithm

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_empty_free_list_algorithm_small_bp.result
+++ b/mysql-test/suite/innodb/r/innodb_empty_free_list_algorithm_small_bp.result
@@ -1,0 +1,11 @@
+SET @start_value = @@GLOBAL.innodb_empty_free_list_algorithm;
+SELECT @@GLOBAL.innodb_empty_free_list_algorithm;
+@@GLOBAL.innodb_empty_free_list_algorithm
+legacy
+call mtr.add_suppression("InnoDB: innodb_empty_free_list_algorithm = 'backoff' requires at least 20MB buffer pool.");
+SET GLOBAL innodb_empty_free_list_algorithm='backoff';
+ERROR 42000: Variable 'innodb_empty_free_list_algorithm' can't be set to the value of 'backoff'
+SELECT @@GLOBAL.innodb_empty_free_list_algorithm;
+@@GLOBAL.innodb_empty_free_list_algorithm
+legacy
+SET GLOBAL innodb_empty_free_list_algorithm = @start_value;

--- a/mysql-test/suite/innodb/t/innodb_empty_free_list_algorithm_small_bp-master.opt
+++ b/mysql-test/suite/innodb/t/innodb_empty_free_list_algorithm_small_bp-master.opt
@@ -1,0 +1,1 @@
+--innodb-buffer-pool-size=5M --innodb_empty_free_list_algorithm='backoff'

--- a/mysql-test/suite/innodb/t/innodb_empty_free_list_algorithm_small_bp.test
+++ b/mysql-test/suite/innodb/t/innodb_empty_free_list_algorithm_small_bp.test
@@ -1,0 +1,12 @@
+--source include/have_innodb.inc
+
+SET @start_value = @@GLOBAL.innodb_empty_free_list_algorithm;
+
+SELECT @@GLOBAL.innodb_empty_free_list_algorithm;
+
+call mtr.add_suppression("InnoDB: innodb_empty_free_list_algorithm = 'backoff' requires at least 20MB buffer pool.");
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_empty_free_list_algorithm='backoff';
+SELECT @@GLOBAL.innodb_empty_free_list_algorithm;
+
+SET GLOBAL innodb_empty_free_list_algorithm = @start_value;

--- a/mysql-test/suite/sys_vars/t/innodb_empty_free_list_algorithm_basic-master.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_empty_free_list_algorithm_basic-master.opt
@@ -1,0 +1,1 @@
+--innodb-buffer-pool-size=20M

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -67,12 +67,6 @@ UNIV_INTERN mysql_pfs_key_t buf_page_cleaner_thread_key;
 UNIV_INTERN mysql_pfs_key_t buf_lru_manager_thread_key;
 #endif /* UNIV_PFS_THREAD */
 
-/** If LRU list of a buf_pool is less than this size then LRU eviction
-should not happen. This is because when we do LRU flushing we also put
-the blocks on free list. If LRU list is very small then we can end up
-in thrashing. */
-#define BUF_LRU_MIN_LEN		256
-
 /* @} */
 
 /** Handled page counters for a single flush */

--- a/storage/innobase/include/buf0flu.h
+++ b/storage/innobase/include/buf0flu.h
@@ -303,6 +303,12 @@ buf_flush_flush_list_in_progress(void)
 /*==================================*/
 	__attribute__((warn_unused_result));
 
+/** If LRU list of a buf_pool is less than this size then LRU eviction
+should not happen. This is because when we do LRU flushing we also put
+the blocks on free list. If LRU list is very small then we can end up
+in thrashing. */
+#define BUF_LRU_MIN_LEN		256
+
 #ifndef UNIV_NONINL
 #include "buf0flu.ic"
 #endif


### PR DESCRIPTION
by disabling it on small buffer pools

```
innodb empty free list algorithm backoff requires free pages from LRU for
best performance. buf_LRU_buf_pool_running_out cancels query if 1/4 of
    buffer pool belongs to LRU or freelist.
At the same time buf_flush_LRU_list_batch keep up to BUF_LRU_MIN_LEN in LRU.
    In order to avoid deadlock baclkoff requires buffer pool to be at least
4*BUF_LRU_MIN_LEN, but flush peformance is bad because of trashing
and additional BUF_LRU_MIN_LEN pages are requested.
```
