### PR TITLE
Fixed vcs-bzr field in debian control file (bld-379)

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -23,7 +23,7 @@ Build-Depends: bison,
                g++ (>= 4.4)
 Standards-Version: 3.9.4
 Homepage: http://www.percona.com/software/percona-server/
-Vcs-Bzr: https://github.com/percona/percona-server
+Vcs-Git: git://github.com/percona/percona-server.git -b 5.7
 
 Package: percona-server-tokudb-5.7
 Section: database

--- a/build-ps/debian/control.notokudb
+++ b/build-ps/debian/control.notokudb
@@ -23,7 +23,7 @@ Build-Depends: bison,
                g++ (>= 4.4)
 Standards-Version: 3.9.4
 Homepage: http://www.percona.com/software/percona-server/
-Vcs-Bzr: https://github.com/percona/percona-server
+Vcs-Git: git://github.com/percona/percona-server.git -b 5.7
 
 Package: libperconaserverclient20
 Architecture: any


### PR DESCRIPTION
This is a leftover from:
https://github.com/percona/percona-server/pull/271

The format is as per:
"In the case of Git, the value consists of a URL, optionally followed by the word -b and the name of a branch in the indicated repository, following the syntax of the git clone command."
From here: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-VCS-fields
