### PR TITLE
Fix bug 1524763 (Some issues with audit log testcases)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3069,3 +3069,4 @@ Docs/INFO_SRC
 Testing
 FilesCopied
 source_downloads
+mysql-test/test_results.subunit

--- a/mysql-test/r/audit_log_csv.result
+++ b/mysql-test/r/audit_log_csv.result
@@ -1,3 +1,5 @@
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_flush=ON;
 CREATE TABLE t1 (c1 INT, c2 CHAR(20));
 CREATE TABLE t1
 (c1 INT,

--- a/mysql-test/r/audit_log_json.result
+++ b/mysql-test/r/audit_log_json.result
@@ -1,3 +1,5 @@
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_flush=ON;
 CREATE TABLE t1 (c1 INT, c2 CHAR(20));
 CREATE TABLE t1
 (c1 INT,

--- a/mysql-test/r/audit_log_new.result
+++ b/mysql-test/r/audit_log_new.result
@@ -1,3 +1,5 @@
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_flush=ON;
 CREATE TABLE t1 (c1 INT, c2 CHAR(20));
 CREATE TABLE t1
 (c1 INT,

--- a/mysql-test/r/audit_log_old.result
+++ b/mysql-test/r/audit_log_old.result
@@ -1,3 +1,5 @@
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_flush=ON;
 CREATE TABLE t1 (c1 INT, c2 CHAR(20));
 CREATE TABLE t1
 (c1 INT,

--- a/mysql-test/r/audit_log_threadpool.result
+++ b/mysql-test/r/audit_log_threadpool.result
@@ -1,4 +1,5 @@
 set global audit_log_flush= ON;
+set global audit_log_flush= ON;
 select 1;
 1
 1

--- a/mysql-test/t/audit_log_csv.test
+++ b/mysql-test/t/audit_log_csv.test
@@ -3,6 +3,10 @@
 let $MYSQLD_DATADIR= `select @@datadir`;
 let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
+SET GLOBAL audit_log_flush=ON;
+--remove_file $MYSQLD_DATADIR/test_audit.log
+SET GLOBAL audit_log_flush=ON;
+
 --source include/audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_csv.log
@@ -18,3 +22,4 @@ perl;
   close $file;
 EOF
 --remove_file $MYSQLD_DATADIR/test_audit.log
+--remove_file $MYSQLD_DATADIR/test_audit_csv.log

--- a/mysql-test/t/audit_log_json.test
+++ b/mysql-test/t/audit_log_json.test
@@ -3,6 +3,10 @@
 let $MYSQLD_DATADIR= `select @@datadir`;
 let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
+SET GLOBAL audit_log_flush=ON;
+--remove_file $MYSQLD_DATADIR/test_audit.log
+SET GLOBAL audit_log_flush=ON;
+
 --source include/audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_json.log
@@ -16,3 +20,4 @@ perl;
   close $file;
 EOF
 --remove_file $MYSQLD_DATADIR/test_audit.log
+--remove_file $MYSQLD_DATADIR/test_audit_json.log

--- a/mysql-test/t/audit_log_new.test
+++ b/mysql-test/t/audit_log_new.test
@@ -3,6 +3,10 @@
 let $MYSQLD_DATADIR= `select @@datadir`;
 let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
+SET GLOBAL audit_log_flush=ON;
+--remove_file $MYSQLD_DATADIR/test_audit.log
+SET GLOBAL audit_log_flush=ON;
+
 --source include/audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_new.log
@@ -13,3 +17,4 @@ perl;
   $p->parsefile($ENV{'MYSQLD_DATADIR'} . '/test_audit_new.log');
 EOF
 --remove_file $MYSQLD_DATADIR/test_audit.log
+--remove_file $MYSQLD_DATADIR/test_audit_new.log

--- a/mysql-test/t/audit_log_old.test
+++ b/mysql-test/t/audit_log_old.test
@@ -3,6 +3,10 @@
 let $MYSQLD_DATADIR= `select @@datadir`;
 let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
+SET GLOBAL audit_log_flush=ON;
+--remove_file $MYSQLD_DATADIR/test_audit.log
+SET GLOBAL audit_log_flush=ON;
+
 --source include/audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_old.log
@@ -13,3 +17,4 @@ perl;
   $p->parsefile($ENV{'MYSQLD_DATADIR'} . '/test_audit_old.log');
 EOF
 --remove_file $MYSQLD_DATADIR/test_audit.log
+--remove_file $MYSQLD_DATADIR/test_audit_old.log

--- a/mysql-test/t/audit_log_rotate-master.opt
+++ b/mysql-test/t/audit_log_rotate-master.opt
@@ -2,7 +2,7 @@ $AUDIT_LOG_OPT
 $AUDIT_LOG_LOAD
 --audit_log_file=test_audit.log
 --audit_log_format=JSON
---audit_log_strategy=ASYNCHRONOUS
+--audit_log_strategy=SEMISYNCHRONOUS
 --audit_log_rotate_on_size=4096
 --audit_log_buffer_size=5000
 --audit_log_rotations=10

--- a/mysql-test/t/audit_log_rotate.test
+++ b/mysql-test/t/audit_log_rotate.test
@@ -14,7 +14,7 @@ let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
 perl;
   eval "use JSON qw(decode_json); 1" or exit 0;
-  my @files = glob ($ENV{'MYSQLD_DATADIR'} . "/test_audit.log.*");
+  my @files = glob ($ENV{'MYSQLD_DATADIR'} . "/test_audit.log.[0-9][0-9]");
   foreach (@files) {
     open my $file, $_ or die "Could not open log: $!";
     while (my $line = <$file>) {
@@ -22,7 +22,7 @@ perl;
     }
     close $file;
   }
-  die "Rotation doesn't wrok!" unless scalar(@files) > 1
+  die "Rotation doesn't work!" unless scalar(@files) > 1
 EOF
 --remove_files_wildcard $MYSQLD_DATADIR test_audit.log*
 

--- a/mysql-test/t/audit_log_threadpool.test
+++ b/mysql-test/t/audit_log_threadpool.test
@@ -3,7 +3,8 @@
 let $MYSQLD_DATADIR= `select @@datadir`;
 let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
---move_file $MYSQLD_DATADIR/test_audit_threadpool.log $MYSQLD_DATADIR/test_audit_threadpool_garbage.log
+set global audit_log_flush= ON;
+--remove_file $MYSQLD_DATADIR/test_audit_threadpool.log
 set global audit_log_flush= ON;
 
 --source include/count_sessions.inc
@@ -36,5 +37,4 @@ perl;
 EOF
 
 --remove_file $MYSQLD_DATADIR/test_audit_threadpool.log
---remove_file $MYSQLD_DATADIR/test_audit_threadpool_garbage.log
 --remove_file $MYSQLD_DATADIR/test_audit_threadpool_done.log


### PR DESCRIPTION
Fix by:
- Flushing the audit log, removing its file, and flushing the log
  again at the start of each testcase. This way the testcase will have
  an empty audit log regardless of whether its file was present before
  or not, or even if deleted but still opened. The exception is
  audit_log_rotate where we don't care about previous audit log contents.
- Deleting all the log files at the end of testcases.
- Changing audit_log_rotate log write strategy to semisynchronous so that
  writing the log for the server workload is serialized with counting the
  resulting log files.
- Narrowing audit_log_rotate filename glob pattern so that only numeric
  two-digit suffixes are accepted.
  
  http://jenkins.percona.com/job/percona-server-5.5-param/1190/
