### PR TITLE
5.7 - ps_tokudb_admin print warning if unable to check LD_PRELOAD for mysqld (#1520890)

### DIFF
--- a/scripts/ps_tokudb_admin.sh
+++ b/scripts/ps_tokudb_admin.sh
@@ -179,13 +179,21 @@ fi
 # Check if server is running with jemalloc - if not warn that restart is needed
 if [ $ENABLE = 1 ]; then
   printf "Checking if Percona Server is running with jemalloc enabled...\n"
-  grep -qc jemalloc /proc/${PID_NUM}/environ || ldd $(which mysqld) | grep -qc jemalloc
-  JEMALLOC_STATUS=$?
-  if [ $JEMALLOC_STATUS = 1 ]; then
-    printf "ERROR: Percona Server is not running with jemalloc, please restart mysql service to enable it and then run this script...\n\n";
-    exit 1
+  cat /proc/${PID_NUM}/environ >null 2>&1
+  if [ $? = 0 ]; then
+    grep -qc jemalloc /proc/${PID_NUM}/environ || ldd $(which mysqld) | grep -qc jemalloc
+    JEMALLOC_STATUS=$?
+    if [ $JEMALLOC_STATUS = 1 ]; then
+      printf "ERROR: Percona Server is not running with jemalloc, please restart mysql service to enable it and then run this script...\n\n";
+      exit 1
+    else
+      printf "INFO: Percona Server is running with jemalloc enabled.\n\n";
+    fi
   else
-    printf "INFO: Percona Server is running with jemalloc enabled.\n\n";
+    printf "WARNING: The file /proc/${PID_NUM}/environ is not readable so impossible to check LD_PRELOAD for jemalloc.\n";
+    printf "         Possibly running inside container so assuming jemalloc is preloaded and continuing...\n";
+    printf "         If there will be an error during plugin installation try to restart mysql service and run this script again.\n\n";
+    JEMALLOC_STATUS=0
   fi
 fi
 
@@ -296,12 +304,21 @@ fi
 # Check if server is running with libHotBackup.so preloaded - if not warn that restart is needed
 if [ $ENABLE_TOKUBACKUP = 1 ]; then
   printf "Checking if Percona Server is running with libHotBackup.so preloaded...\n"
-  LIBHOTBACKUP_STATUS=$(grep -c libHotBackup.so /proc/${PID_NUM}/environ)
-  if [ $LIBHOTBACKUP_STATUS = 0 ]; then
-    printf "ERROR: Percona Server is not running with libHotBackup.so preloaded, please restart mysql service to enable it and then run this script again...\n\n";
-    exit 1
+  cat /proc/${PID_NUM}/environ >null 2>&1
+  if [ $? = 0 ]; then
+    grep -qc libHotBackup.so /proc/${PID_NUM}/environ
+    LIBHOTBACKUP_STATUS=$?
+    if [ $LIBHOTBACKUP_STATUS = 1 ]; then
+      printf "ERROR: Percona Server is not running with libHotBackup.so preloaded, please restart mysql service to enable it and then run this script again...\n\n";
+      exit 1
+    else
+      printf "INFO: Percona Server is running with libHotBackup.so preloaded.\n\n";
+    fi
   else
-    printf "INFO: Percona Server is running with libHotBackup.so preloaded.\n\n";
+    printf "WARNING: The file /proc/${PID_NUM}/environ is not readable so impossible to check LD_PRELOAD for libHotBackup.so.\n";
+    printf "         Possibly running inside container so assuming libHotBackup.so is preloaded and continuing.\n";
+    printf "         If there will be an error during plugin installation try to restart mysql service and run this script again.\n\n";
+    LIBHOTBACKUP_STATUS=0
   fi
 fi
 


### PR DESCRIPTION
**BUG:** Error enabling TokuDB through ps_tokudb_admin
https://bugs.launchpad.net/percona-server/+bug/1520890

Docker container cannot read "/proc/${PID_NUM}/environ" file even with root so decided to put a warning that a check is impossible and continue running instead of exiting so that the script can be used inside docker containers.

**TESTING:**
Done only on 5.6 and on the 5.7 it should work the same but 5.7 version needs more changes and testing in general before GA.

**INSIDE DOCKER CONTAINER:**
(warning is visible)

```
root@master:/# sudo ps_tokudb_admin --enable
Checking if Percona Server is running with jemalloc enabled...
WARNING: The file /proc/424/environ is not readable so impossible to check LD_PRELOAD for jemalloc.
         Possibly running inside container so assuming jemalloc is preloaded and continuing...
         If there will be an error during plugin installation try to restart mysql service and run this script again.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Adding thp-setting=never option into /etc/mysql/my.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

root@master:/# sudo ps_tokudb_admin --enable-backup
Checking if Percona Server is running with jemalloc enabled...
WARNING: The file /proc/1123/environ is not readable so impossible to check LD_PRELOAD for jemalloc.
         Possibly running inside container so assuming jemalloc is preloaded and continuing...
         If there will be an error during plugin installation try to restart mysql service and run this script again.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is set in the config file.

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Checking if Percona Server is running with libHotBackup.so preloaded...
WARNING: The file /proc/1123/environ is not readable so impossible to check LD_PRELOAD for libHotBackup.so.
         Possibly running inside container so assuming libHotBackup.so is preloaded and continuing.
         If there will be an error during plugin installation try to restart mysql service and run this script again.

Installing TokuBackup plugin...
INFO: Successfully installed TokuBackup plugin.


mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so     | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| tokudb_backup                 | ACTIVE   | DAEMON             | tokudb_backup.so | GPL     |
+-------------------------------+----------+--------------------+------------------+---------+
```

**INSIDE NORMAL VM**
(no warning visible)

```
vagrant@t-ubuntu1404-64:~$ sudo ps_tokudb_admin --enable
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Adding thp-setting=never option into /etc/mysql/my.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

vagrant@t-ubuntu1404-64:~$ sudo ps_tokudb_admin --enable-backup
Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is not set in the config file.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Adding preload-hotbackup option into /etc/mysql/my.cnf
INFO: Successfully added preload-hotbackup option into /etc/mysql/my.cnf
PLEASE RESTART MYSQL SERVICE AND RUN THIS SCRIPT AGAIN TO FINISH INSTALLATION!

vagrant@t-ubuntu1404-64:~$ sudo service mysql restart
 * Stopping MySQL (Percona Server) mysqld
   ...done.
 * Starting MySQL (Percona Server) database server mysqld
   ...done.
 * Checking for corrupt, not cleanly closed and upgrade needing tables.
vagrant@t-ubuntu1404-64:~$ sudo ps_tokudb_admin --enable-backup
Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Checking if Percona Server is running with libHotBackup.so preloaded...
INFO: Percona Server is running with libHotBackup.so preloaded.

Installing TokuBackup plugin...
INFO: Successfully installed TokuBackup plugin.

mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so     | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| tokudb_backup                 | ACTIVE   | DAEMON             | tokudb_backup.so | GPL     |
+-------------------------------+----------+--------------------+------------------+---------+
```
