### PR TITLE
Fix bug 1530102 (rpl.rpl_bug68490 fails under Valgrind in Jenkins)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_bug68490.result
+++ b/mysql-test/suite/rpl/r/rpl_bug68490.result
@@ -1,8 +1,9 @@
 include/master-slave.inc
 [connection master]
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, payload MEDIUMBLOB NOT NULL);
 include/rpl_restart_server.inc [server_number=1]
+include/stop_slave.inc
+include/start_slave.inc
 INSERT INTO t1(payload) VALUES(REPEAT('a',1468872));
 DROP TABLE t1;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_bug68490.test
+++ b/mysql-test/suite/rpl/t/rpl_bug68490.test
@@ -1,16 +1,15 @@
 --source include/have_binlog_format_row.inc 
 --source include/master-slave.inc
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
-sync_slave_with_master;
---enable_warnings
-
 connection master;
 CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, payload MEDIUMBLOB NOT NULL);
 
 --let $rpl_server_number= 1
 --source include/rpl_restart_server.inc
+--connection slave
+--source include/stop_slave.inc
+--source include/start_slave.inc
+--connection master
 
 INSERT INTO t1(payload) VALUES(REPEAT('a',1468872));
 sync_slave_with_master;


### PR DESCRIPTION
Under Valgrind, the slave might fail to reconnect to the restarted
master server due to timeout. Fix by adding an explicit slave restart
after the master server restart. At the same time remove redundant
testsuite cleanup at the start.

```
http://jenkins.percona.com/job/percona-server-5.5-param/1197/
http://jenkins.percona.com/view/PS%205.5/job/percona-server-5.5-valgrind-param/8/
```
