### PR TITLE
Fix bug 1233431 ([ERROR] Cannot find index <col> in InnoDB index tran…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_expand_fast_index_creation_innodb.result
+++ b/mysql-test/suite/innodb/r/percona_expand_fast_index_creation_innodb.result
@@ -1,0 +1,31 @@
+SET SESSION expand_fast_index_creation=ON;
+CREATE TEMPORARY TABLE t1 (a INT, b INT, INDEX z(a));
+ALTER TABLE t1 ADD INDEX y(b);
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1(id int auto_increment primary key, a int, index(a)) engine=InnoDB;
+ALTER TABLE t1 ADD j int;
+INSERT INTO t1(a) VALUES (1);
+SELECT * FROM t1 FORCE INDEX (PRIMARY);
+id	a	j
+1	1	NULL
+SELECT * FROM t1 FORCE INDEX (a);
+id	a	j
+1	1	NULL
+DROP TABLE t1;
+#
+# Bug 1529555: InnoDB: Failing assertion: id != srv_tmp_space.space_id() in fsp_space_modify_check
+#
+CREATE TEMPORARY TABLE t1(a CHAR (1), b varchar(1)) ENGINE=InnoDB;
+INSERT INTO t1(a) VALUES ('a'), ('a'), ('a'), ('a'), ('a'), (0);
+ALTER TABLE t1 ADD INDEX (a);
+affected rows: 6
+info: Records: 6  Duplicates: 0  Warnings: 0
+SELECT * FROM t1 FORCE INDEX (a) ORDER BY a;
+a	b
+0	NULL
+a	NULL
+a	NULL
+a	NULL
+a	NULL
+a	NULL
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_expand_fast_index_creation_innodb.test
+++ b/mysql-test/suite/innodb/t/percona_expand_fast_index_creation_innodb.test
@@ -1,0 +1,43 @@
+#
+# InnoDB-related expanded fast index creation tests
+#
+--source include/have_innodb.inc
+
+# Test for Percona Server bug 1133926 (A crash that leaves behind an
+# InnoDB temporary table with indexes results in an unbootable server)
+# https://bugs.launchpad.net/percona-server/+bug/1133926
+
+SET SESSION expand_fast_index_creation=ON;
+
+CREATE TEMPORARY TABLE t1 (a INT, b INT, INDEX z(a));
+
+ALTER TABLE t1 ADD INDEX y(b);
+
+DROP TABLE t1;
+
+# Test for bug 1517757 (expanded fast index creation broken on temporary tables
+# in 5.7)
+
+CREATE TEMPORARY TABLE t1(id int auto_increment primary key, a int, index(a)) engine=InnoDB;
+
+ALTER TABLE t1 ADD j int;
+INSERT INTO t1(a) VALUES (1);
+
+SELECT * FROM t1 FORCE INDEX (PRIMARY);
+
+SELECT * FROM t1 FORCE INDEX (a);
+
+DROP TABLE t1;
+
+--echo #
+--echo # Bug 1529555: InnoDB: Failing assertion: id != srv_tmp_space.space_id() in fsp_space_modify_check
+--echo #
+
+CREATE TEMPORARY TABLE t1(a CHAR (1), b varchar(1)) ENGINE=InnoDB;
+INSERT INTO t1(a) VALUES ('a'), ('a'), ('a'), ('a'), ('a'), (0);
+--enable_info
+ALTER TABLE t1 ADD INDEX (a);
+--disable_info
+SELECT * FROM t1 FORCE INDEX (a) ORDER BY a;
+
+DROP TABLE t1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4463,7 +4463,7 @@ building based on the assumption that there is no concurrent
 index creation/drop and DMLs that requires index lookup. All table
 handle will be closed before the index creation/drop.
 @return TRUE if index translation table built successfully */
-static
+UNIV_INTERN
 ibool
 innobase_build_index_translation(
 /*=============================*/

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -347,3 +347,26 @@ innobase_index_name_is_reserved(
 	ulint		num_of_keys);	/*!< in: Number of indexes to
 					be created. */
 
+/*******************************************************************//**
+This function builds a translation table in INNOBASE_SHARE
+structure for fast index location with mysql array number from its
+table->key_info structure. This also provides the necessary translation
+between the key order in mysql key_info and Innodb ib_table->indexes if
+they are not fully matched with each other.
+Note we do not have any mutex protecting the translation table
+building based on the assumption that there is no concurrent
+index creation/drop and DMLs that requires index lookup. All table
+handle will be closed before the index creation/drop.
+@return TRUE if index translation table built successfully */
+UNIV_INTERN
+ibool
+innobase_build_index_translation(
+/*=============================*/
+	const TABLE*		table,	  /*!< in: table in MySQL data
+					  dictionary */
+	dict_table_t*		ib_table, /*!< in: table in Innodb data
+					  dictionary */
+	INNOBASE_SHARE*		share);	  /*!< in/out: share structure
+					  where index translation table
+					  will be constructed in. */
+

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1082,6 +1082,22 @@ ha_innobase::final_add_index(
 
 	trx_free_for_mysql(trx);
 
+	/* Rebuild index translation table now for temporary tables if we are
+	restoring secondary keys, as ha_innobase::open will not be called for
+	the next access. */
+	if (add->indexed_table == prebuilt->table
+	    && dict_table_is_temporary(prebuilt->table))
+	{
+		if (!innobase_build_index_translation(add_arg->table,
+						      prebuilt->table, share))
+		{
+			/* We don't know whether index translation build failed
+			because of DD mismatch or OOM, return non-specific
+			error code. */
+			err = -1;
+		}
+	}
+
 	/* There might be work for utility threads.*/
 	srv_active_wake_master_thread();
 


### PR DESCRIPTION
…slation table ...)

The issue is that temporary tables also are subject to
expand_fast_index_creation, which results in InnoDB index translation
table being obsoleted during the secondary key delete/re-add. As a later
access to the modified temp table skips ha_innobase::open (which would
happen for a regular not temp table), the translation table rebuild is
skipped as well, resulting in the warning and error of the bug report.

Backport the fix from 5.7: make ha_innobase::final_add_index call
innobase_build_index_translation, which is exported from ha_innodb.cc
for this purpose.

Backport the innodb.percona_expand_fast_index_creation_innodb testcase
from 5.7 and add a testcase for bug 1529555 too (which does not fail
on 5.5).

```
http://jenkins.percona.com/job/percona-server-5.5-param/1198/
```
