### PR TITLE
Run mysqld_safe in debian/ubuntu as root (#1527535) - 5.7

### DIFF
--- a/build-ps/debian/percona-server-server-5.7.mysql.init
+++ b/build-ps/debian/percona-server-server-5.7.mysql.init
@@ -157,7 +157,7 @@ case "$1" in
 			chmod 755 ${MYSQLRUN}
 		fi
 
-		su - mysql -s /bin/bash -c "mysqld_safe > /dev/null &"
+		mysqld_safe > /dev/null &
 		verify_server start
 		if [ "$?" -eq 0 ];
 		then


### PR DESCRIPTION
**BUG:**
Percona Server 5.7 can't be restarted after TokuDB has been installed with ps_tokudb_admin
https://bugs.launchpad.net/percona-server/+bug/1527535/

Basically switching in debian init script to run mysqld_safe with root user and it then runs mysqld with mysql user - just like in 5.6.
We need this because of setting transparent huge pages on the system and similar.

**TEST BUILD:**
http://jenkins.percona.com/job/percona-server-5.7-debian-binary/27/
(precise and wily failed here because of libssl-dev dependency missing - opened JEN-436 for that)

**TEST:**

```
root@t-ubuntu1404-64:/home/vagrant# ps aux|grep mysql
root      2372  0.0  0.1   4444   756 pts/0    S    06:12   0:00 /bin/sh /usr/bin/mysqld_safe
mysql     2702  0.4 36.2 1031912 181716 pts/0  Sl   06:12   0:00 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --user=mysql --log-error=/var/log/mysql/error.log --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306

root@t-ubuntu1404-64:/home/vagrant# ps_tokudb_admin --enable
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Adding thp-setting=never option into /etc/mysql/my.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

root@t-ubuntu1404-64:/home/vagrant# service mysql restart
 * Stopping Percona Server 5.7.10-1rc1
...
 * Percona Server 5.7.10-1rc1 is stopped
 * Re-starting Percona Server 5.7.10-1rc1
..
 * Percona Server 5.7.10-1rc1 is started

root@t-ubuntu1404-64:/home/vagrant# mysql -uroot -e "show plugins;"
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so   | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
+-------------------------------+----------+--------------------+----------------+---------+
```
