### PR TITLE
Fix bug 1532747 (Page cleaner worker threads are not instrumented for…

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3595,6 +3595,10 @@ DECLARE_THREAD(buf_flush_page_cleaner_worker)(
 {
 	my_thread_init();
 
+#ifdef UNIV_PFS_THREAD
+	pfs_register_thread(page_cleaner_thread_key);
+#endif /* UNIV_PFS_THREAD */
+
 	mutex_enter(&page_cleaner->mutex);
 	page_cleaner->n_workers++;
 	mutex_exit(&page_cleaner->mutex);


### PR DESCRIPTION
… performance schema)

Call pfs_register_thread for page cleaner worker threads too. Use the
same key as for the page cleaner coordinator thread.

http://jenkins.percona.com/job/mysql-5.7-param/72/
