### PR TITLE
5.7 - Fixed on debian that tokudb 5.7 package replaces tokudb 5.6 on upgrade

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -29,6 +29,8 @@ Package: percona-server-tokudb-5.7
 Section: database
 Architecture: any
 Depends: percona-server-server-5.7 (= ${binary:Version}), libjemalloc1 (>= 3.3.0), ${misc:Depends}
+Breaks: percona-server-tokudb-5.6
+Replaces: percona-server-tokudb-5.6
 Description: TokuDB engine plugin for Percona Server
  .
  TokuDB is a storage engine for MySQL and MariaDB that is specifically


### PR DESCRIPTION
**BUG:**
tokudb upgrade fails during the 5.6 -> 5.7 upgrade
https://bugs.launchpad.net/percona-server/+bug/1533580

**INFO**
Although in the related bug the bigger issue is the transparent huge pages which cannot be set if not root (which is fixed in the bug 1527535) the tokudb 5.7 debian package should also Break/Replace the 5.6 package as server/client and other packages also do (so that part was missing and is corrected now).

**TEST BUILD**
http://jenkins.percona.com/job/percona-server-5.7-debian-binary/28/

**TESTING**
_STATUS BEFORE UPGRADE_

```
vagrant@t-ubuntu1404-64:~$ sudo service mysql status
 * /usr/bin/mysqladmin  Ver 8.42 Distrib 5.6.28-76.1, for debian-linux-gnu on x86_64
Copyright (c) 2009-2015 Percona LLC and/or its affiliates
Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Server version          5.6.28-76.1
Protocol version        10
Connection              Localhost via UNIX socket
UNIX socket             /var/run/mysqld/mysqld.sock
Uptime:                 7 min 22 sec

Threads: 1  Questions: 932  Slow queries: 0  Opens: 275  Flush tables: 2  Open tables: 80  Queries per second avg: 2.108


mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
+-------------------------------+----------+--------------------+--------------+---------+
```

_UPGRADE_

```
vagrant@t-ubuntu1404-64:~$ sudo apt-get install percona-server-server-5.7 percona-server-tokudb-5.7
Reading package lists... Done
Building dependency tree        
Reading state information... Done
The following packages were automatically installed and are no longer required:
  libdbd-mysql-perl libdbi-perl libmysqlclient18 libperconaserverclient18.1
  percona-server-common-5.6
Use 'apt-get autoremove' to remove them.
The following extra packages will be installed:
  percona-server-client-5.7 percona-server-common-5.7
The following packages will be REMOVED:
  percona-server-client-5.6 percona-server-server-5.6
  percona-server-tokudb-5.6
The following NEW packages will be installed:
  percona-server-client-5.7 percona-server-common-5.7
  percona-server-server-5.7 percona-server-tokudb-5.7
0 upgraded, 4 newly installed, 3 to remove and 207 not upgraded.
Need to get 21.2 MB of archives.
After this operation, 41.7 MB of additional disk space will be used.
Do you want to continue? [Y/n] 

Get:1 http://repo.percona.com/apt/ trusty/experimental percona-server-common-5.7 amd64 5.7.10-1rc1-1.trusty [204 kB]
Get:2 http://repo.percona.com/apt/ trusty/experimental percona-server-client-5.7 amd64 5.7.10-1rc1-1.trusty [1,526 kB]
Get:3 http://repo.percona.com/apt/ trusty/experimental percona-server-server-5.7 amd64 5.7.10-1rc1-1.trusty [16.9 MB]
Get:4 http://repo.percona.com/apt/ trusty/experimental percona-server-tokudb-5.7 amd64 5.7.10-1rc1-1.trusty [2,609 kB]
Fetched 21.2 MB in 29s (728 kB/s)                                              
Preconfiguring packages ...
(Reading database ... 104058 files and directories currently installed.)

Removing percona-server-tokudb-5.6 (5.6.28-76.1-1.trusty) ...
Removing percona-server-server-5.6 (5.6.28-76.1-1.trusty) ...
 * Stopping MySQL (Percona Server) mysqld
   ...done.
Removing percona-server-client-5.6 (5.6.28-76.1-1.trusty) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
Selecting previously unselected package percona-server-common-5.7.
(Reading database ... 103795 files and directories currently installed.)
Preparing to unpack .../percona-server-common-5.7_5.7.10-1rc1-1.trusty_amd64.deb ...
Unpacking percona-server-common-5.7 (5.7.10-1rc1-1.trusty) ...
Selecting previously unselected package percona-server-client-5.7.
Preparing to unpack .../percona-server-client-5.7_5.7.10-1rc1-1.trusty_amd64.deb ...
Unpacking percona-server-client-5.7 (5.7.10-1rc1-1.trusty) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
Setting up percona-server-common-5.7 (5.7.10-1rc1-1.trusty) ...
Selecting previously unselected package percona-server-server-5.7.
(Reading database ... 103912 files and directories currently installed.)
Preparing to unpack .../percona-server-server-5.7_5.7.10-1rc1-1.trusty_amd64.deb ...
.
Unpacking percona-server-server-5.7 (5.7.10-1rc1-1.trusty) ...
Selecting previously unselected package percona-server-tokudb-5.7.
Preparing to unpack .../percona-server-tokudb-5.7_5.7.10-1rc1-1.trusty_amd64.deb ...
Unpacking percona-server-tokudb-5.7 (5.7.10-1rc1-1.trusty) ...
Processing triggers for ureadahead (0.100.0-16) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
Setting up percona-server-client-5.7 (5.7.10-1rc1-1.trusty) ...
Setting up percona-server-server-5.7 (5.7.10-1rc1-1.trusty) ...
Installing new version of config file /etc/default/mysql ...
Installing new version of config file /etc/init.d/mysql ...


 * Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
 * Run the following commands to create these functions:

        mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
        mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
        mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"

 * See http://www.percona.com/doc/percona-server/5.7/management/udf_percona_toolkit.html for more details


..
 * Percona Server 5.7.10-1rc1 is started
Processing triggers for ureadahead (0.100.0-16) ...
Setting up percona-server-tokudb-5.7 (5.7.10-1rc1-1.trusty) ...


 * This release of Percona Server is distributed with TokuDB storage engine.
 * Run the following script to enable the TokuDB storage engine in Percona Server:

        ps_tokudb_admin --enable -u <mysql_admin_user> -p[mysql_admin_pass] [-S <socket>] [-h <host> -P <port>]

 * See http://www.percona.com/doc/percona-server/5.7/tokudb/tokudb_installation.html for more installation details

 * See http://www.percona.com/doc/percona-server/5.7/tokudb/tokudb_intro.html for an introduction to TokuDB
```

_STATUS AFTER UPGRADE_

```
mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so | GPL     |
+-------------------------------+----------+--------------------+--------------+---------+
```
