### PR TITLE
DB-898 : mtr failed with wrong errno 1399: 'XAER_RMFAIL: The command …

### DIFF
--- a/storage/tokudb/tokudb_debug.h
+++ b/storage/tokudb/tokudb_debug.h
@@ -50,6 +50,7 @@ static void tokudb_backtrace(void);
 #define TOKUDB_DEBUG_UPSERT                 (1<<12)
 #define TOKUDB_DEBUG_CHECK                  (1<<13)
 #define TOKUDB_DEBUG_ANALYZE                (1<<14)
+#define TOKUDB_DEBUG_XA                     (1<<15)
 
 #define TOKUDB_TRACE(_fmt, ...) { \
     fprintf(stderr, "%u %s:%u %s " _fmt "\n", tokudb::thread::my_tid(), \


### PR DESCRIPTION
…cannot be executed when global transaction is in the  PREPARED state', instead of 1397...
- This occurred in Percona Server 5.7.10 mtr testing and revealed an opportunity to enhance the TOKUDB_DEBUG_ to include a new XA category. Since the change is minimal and useful everywhere I have originated it in 5.6 first.
- Added new TOKUDB_DEBUG_XA (1<<15) debug flag
- Instrumented xa specific handlerton functions with enter/exit logging.
- Converted existing TOKUDB_DEBUG_TXN logging within the XA functions to TOKUDB_DEBUG_XA.
