### PR TITLE
Fix bug 1534114 (Busy server prefers LRU flushing over flush list flu…

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3385,7 +3385,13 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 
 		n_flushed = n_processed_lru;
 
-		if (ut_time_ms() > next_loop_time)
+		if (ut_time_ms() > next_loop_time
+		    && ret_sleep != OS_SYNC_TIME_EXCEEDED)
+
+			/* If our LRU flush took too long, skip the rest only
+			if the last iteration completed in time, otherwise we'd
+			be LRU flushing all the time, even if e.g. a sync flush
+			is waiting. */
 			ret_sleep = OS_SYNC_TIME_EXCEEDED;
 		else if (ret_sleep != OS_SYNC_TIME_EXCEEDED
 		    && srv_flush_sync


### PR DESCRIPTION
…shing too strongly)

With the current 5.7 version of the fix for
https://bugs.launchpad.net/percona-server/+bug/1234562 /
http://bugs.mysql.com/bug.php?id=70500, the main cleaner coordinator
thread loop looks like

... /\* Flush LRU: _/
  pc_flush(0, 0, &n_processed_lru, &n_flushed_list);
  ut_ad(n_flushed_list == 0);
... /_ LRU iteration took too long _/
  if (ut_time_ms() > next_loop_time)
   ret_sleep = OS_SYNC_TIME_EXCEEDED;
... /_ Sync flush? _/
  else if (ret_sleep != OS_SYNC_TIME_EXCEEDED
      && srv_flush_sync
      && buf_flush_sync_lsn > 0) {
... /_ adaptive flush? _/
  } else if (srv_check_activity(last_activity)) {
... /_ idle flush? _/
  } else if (ret_sleep == OS_SYNC_TIME_EXCEEDED) {
...
  } else {
   /_ no activity, but woken up by event */
  }

Thus, if LRU took too long, we won't go into sync flush, even if that
is requested, in which case it will cause performance degradation.

Fix by going to the "LRU iteration took too long" branch only if the
previous cleaner loop iteration did not take too long.

http://jenkins.percona.com/job/mysql-5.7-param/73/
