### PR TITLE
DB-928 : 5.7 support_xa needs to be deprecated as it can break replic…

### DIFF
--- a/mysql-test/suite/tokudb/r/tokudb_support_xa.result
+++ b/mysql-test/suite/tokudb/r/tokudb_support_xa.result
@@ -8,29 +8,45 @@ SELECT @global_start_value;
 @global_start_value
 1
 SET @@session.tokudb_support_xa = 0;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases. Only tokudb_support_xa=ON is allowed.
 SET @@session.tokudb_support_xa = DEFAULT;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases.
 SELECT @@session.tokudb_support_xa;
 @@session.tokudb_support_xa
 1
 SET @@global.tokudb_support_xa = 0;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases. Only tokudb_support_xa=ON is allowed.
 SET @@global.tokudb_support_xa = DEFAULT;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases.
 SELECT @@global.tokudb_support_xa;
 @@global.tokudb_support_xa
 1
 '#--------------------case#1 valid set support_xa------------------------#'
 SET @@session.tokudb_support_xa = 0;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases. Only tokudb_support_xa=ON is allowed.
 SELECT @@session.tokudb_support_xa;
 @@session.tokudb_support_xa
-0
+1
 SET @@session.tokudb_support_xa = 1;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases.
 SELECT @@session.tokudb_support_xa;
 @@session.tokudb_support_xa
 1
 SET @@global.tokudb_support_xa = 0;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases. Only tokudb_support_xa=ON is allowed.
 SELECT @@global.tokudb_support_xa;
 @@global.tokudb_support_xa
-0
+1
 SET @@global.tokudb_support_xa = 1;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases.
 SELECT @@global.tokudb_support_xa;
 @@global.tokudb_support_xa
 1
@@ -44,9 +60,11 @@ ERROR 42000: Variable 'tokudb_support_xa' can't be set to the value of 'T'
 SET @@session.tokudb_support_xa = "Y";
 ERROR 42000: Variable 'tokudb_support_xa' can't be set to the value of 'Y'
 SET @@session.tokudb_support_xa = OF;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases. Only tokudb_support_xa=ON is allowed.
 SELECT @@session.tokudb_support_xa;
 @@session.tokudb_support_xa
-0
+1
 SET @@global.tokudb_support_xa = 2;
 ERROR 42000: Variable 'tokudb_support_xa' can't be set to the value of '2'
 SET @@global.tokudb_support_xa = "T";
@@ -56,9 +74,11 @@ ERROR 42000: Variable 'tokudb_support_xa' can't be set to the value of 'Y'
 '#--------------------case#3 xa.test port from tokudb_mariadb/xa.test ------------------------#'
 '#--------------------xa.test with tokudb_support_xa OFF ------------------------#'
 SET @@global.tokudb_support_xa = OFF;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases. Only tokudb_support_xa=ON is allowed.
 SELECT @@global.tokudb_support_xa;
 @@global.tokudb_support_xa
-0
+1
 create table t1 (a int) engine=tokudb;
 xa start 'test1';
 insert t1 values (10);
@@ -124,10 +144,14 @@ t1
 drop table t1;
 '#--------------------end------------------------#'
 SET @@session.tokudb_support_xa = @session_start_value;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases.
 SELECT @@session.tokudb_support_xa;
 @@session.tokudb_support_xa
 1
 SET @@global.tokudb_support_xa = @global_start_value;
+Warnings:
+Warning	131	Using tokudb_support_xa is deprecated and the parameter may be removed in future releases.
 SELECT @@global.tokudb_support_xa;
 @@global.tokudb_support_xa
 1

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -78,7 +78,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_USE_DB_TYPE_TOKUDB 1           // has DB_TYPE_TOKUDB patch
 #define TOKU_INCLUDE_ALTER_56 1
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 1 // has tokudb row format compression patch
-#define TOKU_INCLUDE_XA 1                   // has patch that fixes TC_LOG_MMAP code
 #define TOKU_PARTITION_WRITE_FRM_DATA 0
 #define TOKU_INCLUDE_WRITE_FRM_DATA 0
 #if defined(HTON_SUPPORTS_EXTENDED_KEYS)

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -869,15 +869,34 @@ static MYSQL_THDVAR_BOOL(
     false);
 #endif
 
-#if TOKU_INCLUDE_XA
+static const char* deprecated_tokudb_support_xa =
+    "Using tokudb_support_xa is deprecated and the "
+    "parameter may be removed in future releases.";
+static const char* deprecated_tokudb_support_xa_off =
+    "Using tokudb_support_xa is deprecated and the "
+    "parameter may be removed in future releases. "
+    "Only tokudb_support_xa=ON is allowed.";
+
+static void support_xa_update(
+    THD* thd,
+    st_mysql_sys_var* var,
+    void* var_ptr,
+    const void* save) {
+    my_bool tokudb_support_xa = *static_cast<const my_bool*>(save);
+    push_warning(thd,
+                 Sql_condition::SL_WARNING,
+                 HA_ERR_WRONG_COMMAND,
+                 tokudb_support_xa ? deprecated_tokudb_support_xa :
+                 deprecated_tokudb_support_xa_off);
+}
+
 static MYSQL_THDVAR_BOOL(
     support_xa,
     PLUGIN_VAR_OPCMDARG,
     "Enable TokuDB support for the XA two-phase commit",
     NULL,
-    NULL,
+    support_xa_update,
     true);
-#endif
 
 
 
@@ -963,9 +982,7 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(disable_slow_upsert),
 #endif
 
-#if TOKU_INCLUDE_XA
     MYSQL_SYSVAR(support_xa),
-#endif
 
 #if TOKUDB_DEBUG
    MYSQL_SYSVAR(debug_pause_background_job_manager),


### PR DESCRIPTION
…ation.
- Modified tokudb_support_xa to prevent setting it to anything but on/enabled and print sql warning anytime an attempt is made to change it, just like innodb_support_xa.
- Removed extraneous TOKU_INCLUDE_XA as yes, we will always support XA in 5.7 branch forward.
- Re-recorded tokudb.tokudb_support_xa test to have new warenings and behaviors in the result.
