### PR TITLE
bug#1529885 : use innodb_log_block_size=4K for ALL_O_DIRECT in percona_changed_page_bmp_flush testcase

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush.result
@@ -7,6 +7,7 @@ INSERT INTO t1 VALUES (2, REPEAT("b", 20000));
 ib_modified_log_1
 ib_modified_log_2
 INSERT INTO t1 VALUES (3, REPEAT("c", 20000));
+call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
 ib_modified_log_1
 ib_modified_log_2
 ib_modified_log_3

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush.test
@@ -64,6 +64,8 @@ INSERT INTO t1 VALUES (3, REPEAT("c", 20000));
 # Test innodb_flush_method=ALL_O_DIRECT
 # Check that the previous test produced bitmap data while the server is down.
 #
+call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
+
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --shutdown_server 10
 --source include/wait_until_disconnected.inc
@@ -71,7 +73,8 @@ file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
 --enable_reconnect
---exec echo "restart:--innodb-track-changed-pages=1 --innodb-flush-method=ALL_O_DIRECT" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
+--exec echo "restart:--innodb-track-changed-pages=1 --innodb-log-block-size=4096 --innodb-flush-method=ALL_O_DIRECT" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --source include/wait_until_connected_again.inc
 
 INSERT INTO t1 VALUES (4, REPEAT("d", 20000));
@@ -86,6 +89,7 @@ file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
 --enable_reconnect
+--remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --source include/wait_until_connected_again.inc
 


### PR DESCRIPTION
Bug fix for lp:1529885 : innodb_log_block_size is defined as OS_FILE_LOG_BLOCK_SIZE in 5.5 and 5.6 (but it's not ported to 5.7). ALL_O_DIRECT requires requires buffer to be aligned both in memory and disk to be aligned by physical sector size. The stacktrace in bug report is only possible with 5.7 (unaligned memory buffer inside recv_recovery_from_checkpoint_start log_hdr_buf, but innodb_log_write_ahead_size update is not required, because innodb_log_write_ahead_size=8192 by default.).
