### PR TITLE
5.7 - ps_tokudb_admin changes for running server without mysqld_safe (BLD-386)

### DIFF
--- a/build-ps/debian/percona-server-tokudb-5.7.install
+++ b/build-ps/debian/percona-server-tokudb-5.7.install
@@ -3,8 +3,8 @@ usr/lib/mysql/plugin/debug/ha_tokudb.so
 usr/bin/tokuftdump
 usr/bin/ps_tokudb_admin
 usr/bin/tokuft_logprint
-#usr/lib/*/libHotBackup.so
+usr/lib/*/libHotBackup.so
 usr/bin/tokuft_logprint
-#usr/lib/mysql/plugin/tokudb_backup.so
-#usr/lib/mysql/plugin/debug/tokudb_backup.so
-#usr/include/backup.h
+usr/lib/mysql/plugin/tokudb_backup.so
+usr/lib/mysql/plugin/debug/tokudb_backup.so
+usr/include/backup.h

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -866,10 +866,10 @@ fi
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/ha_tokudb.so
 %attr(755, root, root) %{_bindir}/ps_tokudb_admin
 %attr(755, root, root) %{_bindir}/tokuft_logprint
-#%attr(755, root, root) %{_libdir}/mysql/plugin/tokudb_backup.so
-#%attr(755, root, root) %{_libdir}/mysql/plugin/debug/tokudb_backup.so
-#%attr(755, root, root) %{_libdir}/libHotBackup.so
-#%{_includedir}/backup.h
+%attr(755, root, root) %{_libdir}/mysql/plugin/tokudb_backup.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/debug/tokudb_backup.so
+%attr(755, root, root) %{_libdir}/mysql/libHotBackup.so
+%{_includedir}/backup.h
 %endif
 
 %changelog

--- a/build-ps/rpm/mysql-5.7-sharedlib-rename.patch
+++ b/build-ps/rpm/mysql-5.7-sharedlib-rename.patch
@@ -1,6 +1,6 @@
 diff -rup old/client/base/CMakeLists.txt new/client/base/CMakeLists.txt
---- old/client/base/CMakeLists.txt	2015-12-10 18:15:42.000000000 +0100
-+++ new/client/base/CMakeLists.txt	2015-12-10 23:05:14.813915920 +0100
+--- old/client/base/CMakeLists.txt	2016-01-22 11:43:36.000000000 +0100
++++ new/client/base/CMakeLists.txt	2016-01-22 16:02:00.134744489 +0100
 @@ -52,7 +52,7 @@ ADD_COMPILE_FLAGS(
    COMPILE_FLAGS -I${BOOST_PATCHES_DIR} -I${BOOST_INCLUDE_DIR}
  )
@@ -11,8 +11,8 @@ diff -rup old/client/base/CMakeLists.txt new/client/base/CMakeLists.txt
  # Do not build library unless it is needed by some other target.
  SET_PROPERTY(TARGET client_base PROPERTY EXCLUDE_FROM_ALL TRUE)
 diff -rup old/client/CMakeLists.txt new/client/CMakeLists.txt
---- old/client/CMakeLists.txt	2015-12-10 18:15:42.000000000 +0100
-+++ new/client/CMakeLists.txt	2015-12-10 23:05:14.813915920 +0100
+--- old/client/CMakeLists.txt	2016-01-22 11:43:36.000000000 +0100
++++ new/client/CMakeLists.txt	2016-01-22 16:02:00.134744489 +0100
 @@ -116,7 +116,7 @@ ENDIF()
  
  ADD_DEFINITIONS(${SSL_DEFINES})
@@ -94,8 +94,8 @@ diff -rup old/client/CMakeLists.txt new/client/CMakeLists.txt
      auth_utils.cc mysql_install_db.cc
      COMPILE_FLAGS "-I${CMAKE_SOURCE_DIR}/sql/auth"
 diff -rup old/client/dump/CMakeLists.txt new/client/dump/CMakeLists.txt
---- old/client/dump/CMakeLists.txt	2015-12-10 18:15:42.000000000 +0100
-+++ new/client/dump/CMakeLists.txt	2015-12-10 23:05:14.813915920 +0100
+--- old/client/dump/CMakeLists.txt	2016-01-22 11:43:36.000000000 +0100
++++ new/client/dump/CMakeLists.txt	2016-01-22 16:02:00.134744489 +0100
 @@ -145,7 +145,7 @@ IF (NOT (CMAKE_CXX_COMPILER_ID STREQUAL
  
    # Store the executable in our parent directory.
@@ -106,8 +106,8 @@ diff -rup old/client/dump/CMakeLists.txt new/client/dump/CMakeLists.txt
      SET_TARGET_PROPERTIES(mysqlpump
        PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/client)
 diff -rup old/cmake/libutils.cmake new/cmake/libutils.cmake
---- old/cmake/libutils.cmake	2015-12-10 18:15:42.000000000 +0100
-+++ new/cmake/libutils.cmake	2015-12-10 23:05:14.813915920 +0100
+--- old/cmake/libutils.cmake	2016-01-22 11:43:36.000000000 +0100
++++ new/cmake/libutils.cmake	2016-01-22 16:02:00.134744489 +0100
 @@ -28,8 +28,8 @@
  # excessive recompiles.
  
@@ -129,8 +129,8 @@ diff -rup old/cmake/libutils.cmake new/cmake/libutils.cmake
  MACRO(MERGE_STATIC_LIBS TARGET OUTPUT_NAME LIBS_TO_MERGE)
    # To produce a library we need at least one source file.
 diff -rup old/include/mysql.h new/include/mysql.h
---- old/include/mysql.h	2015-12-10 18:15:42.000000000 +0100
-+++ new/include/mysql.h	2015-12-10 23:05:14.817915920 +0100
+--- old/include/mysql.h	2016-01-22 11:43:36.000000000 +0100
++++ new/include/mysql.h	2016-01-22 16:02:00.138744489 +0100
 @@ -15,7 +15,7 @@
  
  /*
@@ -156,8 +156,8 @@ diff -rup old/include/mysql.h new/include/mysql.h
  */
  #define mysql_library_init mysql_server_init
 diff -rup old/libmysql/CMakeLists.txt new/libmysql/CMakeLists.txt
---- old/libmysql/CMakeLists.txt	2015-12-10 18:15:42.000000000 +0100
-+++ new/libmysql/CMakeLists.txt	2015-12-10 23:05:14.817915920 +0100
+--- old/libmysql/CMakeLists.txt	2016-01-22 11:43:36.000000000 +0100
++++ new/libmysql/CMakeLists.txt	2016-01-22 16:02:00.138744489 +0100
 @@ -214,12 +214,12 @@ IF(WIN32)
    LIST(APPEND LIBS auth_win_client)
  ENDIF()
@@ -207,8 +207,8 @@ diff -rup old/libmysql/CMakeLists.txt new/libmysql/CMakeLists.txt
  
    ENDIF()
 diff -rup old/libmysql/libmysql.map new/libmysql/libmysql.map
---- old/libmysql/libmysql.map	2015-12-10 13:43:58.000000000 +0100
-+++ new/libmysql/libmysql.map	2015-12-10 23:05:14.817915920 +0100
+--- old/libmysql/libmysql.map	2016-01-21 13:10:05.000000000 +0100
++++ new/libmysql/libmysql.map	2016-01-22 16:02:00.138744489 +0100
 @@ -1,5 +1,5 @@
  # symbols exported from mysql 5.1
 -libperconaserverclient_16 {
@@ -244,8 +244,8 @@ diff -rup old/libmysql/libmysql.map new/libmysql/libmysql.map
  	get_tty_password;
  };
 diff -rup old/libmysql/libmysql.ver.in new/libmysql/libmysql.ver.in
---- old/libmysql/libmysql.ver.in	2015-12-10 18:15:42.000000000 +0100
-+++ new/libmysql/libmysql.ver.in	2015-12-10 23:07:56.001918534 +0100
+--- old/libmysql/libmysql.ver.in	2016-01-22 11:43:36.000000000 +0100
++++ new/libmysql/libmysql.ver.in	2016-01-22 16:02:00.138744489 +0100
 @@ -14,5 +14,5 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA */
  
@@ -254,19 +254,20 @@ diff -rup old/libmysql/libmysql.ver.in new/libmysql/libmysql.ver.in
 +libmysqlclient_@SHARED_LIB_MAJOR_VERSION@.@SHARED_LIB_MINOR_VERSION@
  { global: ${CLIENT_API_FUNCTIONS};${CLIENT_API_FUNCTIONS_UNDOCUMENTED}; local: *; };
 diff -rup old/plugin/percona-pam-for-mysql/CMakeLists.txt new/plugin/percona-pam-for-mysql/CMakeLists.txt
---- old/plugin/percona-pam-for-mysql/CMakeLists.txt	2015-12-10 18:15:43.000000000 +0100
-+++ new/plugin/percona-pam-for-mysql/CMakeLists.txt	2015-12-10 23:05:14.817915920 +0100
-@@ -32,6 +32,6 @@ IF(HAVE_PAM AND HAVE_GETPWNAM_R AND HAVE
-   SET(AUTH_PAM_COMPAT_SOURCES ${AUTH_PAM_COMMON_SOURCES} src/auth_pam_compat.c)
-   MYSQL_ADD_PLUGIN(auth_pam ${AUTH_PAM_SOURCES} LINK_LIBRARIES pam MODULE_ONLY)
-   MYSQL_ADD_PLUGIN(auth_pam_compat ${AUTH_PAM_COMPAT_SOURCES} LINK_LIBRARIES pam MODULE_ONLY)
--  MYSQL_ADD_PLUGIN(dialog src/dialog.c LINK_LIBRARIES perconaserverclient MODULE_ONLY)
-+  MYSQL_ADD_PLUGIN(dialog src/dialog.c LINK_LIBRARIES mysqlclient MODULE_ONLY)
+--- old/plugin/percona-pam-for-mysql/CMakeLists.txt	2016-01-22 11:43:38.000000000 +0100
++++ new/plugin/percona-pam-for-mysql/CMakeLists.txt	2016-01-22 16:07:38.234749970 +0100
+@@ -37,7 +37,7 @@ IF(HAVE_PAM AND HAVE_GETPWNAM_R AND HAVE
+   MYSQL_ADD_PLUGIN(dialog
+                    src/dialog.c
+                    ../../client/get_password.c
+-                   LINK_LIBRARIES perconaserverclient
++                   LINK_LIBRARIES mysqlclient
+                    MODULE_ONLY)
  ENDIF(HAVE_PAM AND HAVE_GETPWNAM_R AND HAVE_GETGRGID_R)
  ENDIF(WITH_PAM)
 diff -rup old/scripts/CMakeLists.txt new/scripts/CMakeLists.txt
---- old/scripts/CMakeLists.txt	2015-12-10 18:15:43.000000000 +0100
-+++ new/scripts/CMakeLists.txt	2015-12-10 23:05:14.821915921 +0100
+--- old/scripts/CMakeLists.txt	2016-01-22 11:43:38.000000000 +0100
++++ new/scripts/CMakeLists.txt	2016-01-22 16:02:00.138744489 +0100
 @@ -319,7 +319,7 @@ ELSE()
  ENDIF()
  
@@ -295,8 +296,8 @@ diff -rup old/scripts/CMakeLists.txt new/scripts/CMakeLists.txt
    GET_TARGET_PROPERTY(LIBMYSQL_OS_SHLIB_VERSION libmysql VERSION)
    GET_TARGET_PROPERTY(LIBMYSQL_OS_OUTPUT_NAME libmysql OUTPUT_NAME)
 diff -rup old/sql/auth/password.c new/sql/auth/password.c
---- old/sql/auth/password.c	2015-12-10 18:15:43.000000000 +0100
-+++ new/sql/auth/password.c	2015-12-10 23:05:14.821915921 +0100
+--- old/sql/auth/password.c	2016-01-22 11:43:38.000000000 +0100
++++ new/sql/auth/password.c	2016-01-22 16:02:00.138744489 +0100
 @@ -29,7 +29,7 @@
    The password is saved (in user.password) by using the PASSWORD() function in
    mysql.
@@ -307,8 +308,8 @@ diff -rup old/sql/auth/password.c new/sql/auth/password.c
    Example:
      update user set password=PASSWORD("hello") where user="test"
 diff -rup old/storage/ndb/ndbapi-examples/mgmapi_logevent/Makefile new/storage/ndb/ndbapi-examples/mgmapi_logevent/Makefile
---- old/storage/ndb/ndbapi-examples/mgmapi_logevent/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/mgmapi_logevent/Makefile	2015-12-10 23:05:14.821915921 +0100
+--- old/storage/ndb/ndbapi-examples/mgmapi_logevent/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/mgmapi_logevent/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -319,8 +320,8 @@ diff -rup old/storage/ndb/ndbapi-examples/mgmapi_logevent/Makefile new/storage/n
  $(OBJS): $(SRCS)
  	$(CXX) $(CFLAGS) -I$(TOP_SRCDIR)/include -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/mgmapi  -I$(INCLUDE_DIR)/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/mgmapi_logevent2/Makefile new/storage/ndb/ndbapi-examples/mgmapi_logevent2/Makefile
---- old/storage/ndb/ndbapi-examples/mgmapi_logevent2/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/mgmapi_logevent2/Makefile	2015-12-10 23:05:14.821915921 +0100
+--- old/storage/ndb/ndbapi-examples/mgmapi_logevent2/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/mgmapi_logevent2/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -331,8 +332,8 @@ diff -rup old/storage/ndb/ndbapi-examples/mgmapi_logevent2/Makefile new/storage/
  $(OBJS): $(SRCS)
  	$(CXX) $(CFLAGS) -I$(TOP_SRCDIR)/include -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/mgmapi  -I$(INCLUDE_DIR)/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_async/Makefile new/storage/ndb/ndbapi-examples/ndbapi_async/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_async/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_async/Makefile	2015-12-10 23:05:14.821915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_async/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_async/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -343,8 +344,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_async/Makefile new/storage/ndb/
  $(TARGET).o: $(SRCS)
  	$(CXX) $(CFLAGS) -I$(INCLUDE_DIR)/include -I$(INCLUDE_DIR)/storage/ndb/include -I$(INCLUDE_DIR)/storage/ndb/include/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_async1/Makefile new/storage/ndb/ndbapi-examples/ndbapi_async1/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_async1/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_async1/Makefile	2015-12-10 23:05:14.821915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_async1/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_async1/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -28,7 +28,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -355,8 +356,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_async1/Makefile new/storage/ndb
  $(TARGET).o: $(SRCS)
  	$(CXX) $(CFLAGS) -I$(TOP_SRCDIR)/include -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_blob/Makefile new/storage/ndb/ndbapi-examples/ndbapi_blob/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_blob/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_blob/Makefile	2015-12-10 23:05:14.821915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_blob/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_blob/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -367,8 +368,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_blob/Makefile new/storage/ndb/n
  $(TARGET).o: $(SRCS)
  	$(CXX) $(CFLAGS) -I$(INCLUDE_DIR)/include -I$(INCLUDE_DIR)/storage/ndb/include -I$(INCLUDE_DIR)/storage/ndb/include/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_blob_ndbrecord/Makefile new/storage/ndb/ndbapi-examples/ndbapi_blob_ndbrecord/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_blob_ndbrecord/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_blob_ndbrecord/Makefile	2015-12-10 23:05:14.821915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_blob_ndbrecord/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_blob_ndbrecord/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -379,8 +380,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_blob_ndbrecord/Makefile new/sto
  $(OBJS): $(SRCS)
  	$(CXX) $(CFLAGS) -I$(INCLUDE_DIR)/include -I$(INCLUDE_DIR)/storage/ndb/include -I$(INCLUDE_DIR)/storage/ndb/include/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_event/Makefile new/storage/ndb/ndbapi-examples/ndbapi_event/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_event/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_event/Makefile	2015-12-10 23:05:14.821915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_event/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_event/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -391,8 +392,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_event/Makefile new/storage/ndb/
  $(TARGET).o: $(SRCS) Makefile
  	$(CXX) $(CFLAGS) $(DEBUG) -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/ndbapi -I$(TOP_SRCDIR)/include $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_recattr_vs_record/Makefile new/storage/ndb/ndbapi-examples/ndbapi_recattr_vs_record/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_recattr_vs_record/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_recattr_vs_record/Makefile	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_recattr_vs_record/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_recattr_vs_record/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -403,8 +404,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_recattr_vs_record/Makefile new/
  $(OBJS): $(SRCS)
  	$(CXX) $(CFLAGS) -I$(INCLUDE_DIR)/include -I$(INCLUDE_DIR)/storage/ndb/include -I$(INCLUDE_DIR)/storage/ndb/include/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_retries/Makefile new/storage/ndb/ndbapi-examples/ndbapi_retries/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_retries/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_retries/Makefile	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_retries/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_retries/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -28,7 +28,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -415,8 +416,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_retries/Makefile new/storage/nd
  $(TARGET).o: $(SRCS)
  	$(CXX) $(CFLAGS)  -I$(TOP_SRCDIR)/include -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_scan/Makefile new/storage/ndb/ndbapi-examples/ndbapi_scan/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_scan/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_scan/Makefile	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_scan/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_scan/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -427,8 +428,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_scan/Makefile new/storage/ndb/n
  $(TARGET).o: $(SRCS)
  	$(CXX) $(CFLAGS) -I$(INCLUDE_DIR)/include -I$(INCLUDE_DIR)/storage/ndb/include -I$(INCLUDE_DIR)/storage/ndb/include/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_simple/Makefile new/storage/ndb/ndbapi-examples/ndbapi_simple/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_simple/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_simple/Makefile	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_simple/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_simple/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -439,8 +440,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_simple/Makefile new/storage/ndb
  $(TARGET).o: $(SRCS)
  	$(CXX) $(CFLAGS) -I$(TOP_SRCDIR)/include -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_simple_dual/Makefile new/storage/ndb/ndbapi-examples/ndbapi_simple_dual/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_simple_dual/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_simple_dual/Makefile	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_simple_dual/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_simple_dual/Makefile	2016-01-22 16:02:00.142744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -451,8 +452,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_simple_dual/Makefile new/storag
  $(OBJS): $(SRCS)
  	$(CXX) $(CFLAGS) -I$(TOP_SRCDIR)/include -I$(INCLUDE_DIR) -I$(INCLUDE_DIR)/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_simple_index/Makefile new/storage/ndb/ndbapi-examples/ndbapi_simple_index/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_simple_index/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_simple_index/Makefile	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_simple_index/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_simple_index/Makefile	2016-01-22 16:02:00.146744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -463,8 +464,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_simple_index/Makefile new/stora
  $(OBJS): $(SRCS)
  	$(CXX) $(CFLAGS) -I$(INCLUDE_DIR)/include -I$(INCLUDE_DIR)/storage/ndb/include -I$(INCLUDE_DIR)/storage/ndb/include/ndbapi $(SRCS)
 diff -rup old/storage/ndb/ndbapi-examples/ndbapi_s_i_ndbrecord/Makefile new/storage/ndb/ndbapi-examples/ndbapi_s_i_ndbrecord/Makefile
---- old/storage/ndb/ndbapi-examples/ndbapi_s_i_ndbrecord/Makefile	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/ndbapi-examples/ndbapi_s_i_ndbrecord/Makefile	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/ndbapi-examples/ndbapi_s_i_ndbrecord/Makefile	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/ndbapi-examples/ndbapi_s_i_ndbrecord/Makefile	2016-01-22 16:02:00.146744489 +0100
 @@ -29,7 +29,7 @@ LIB_DIR = -L$(TOP_SRCDIR)/storage/ndb/sr
  SYS_LIB = 
  
@@ -475,8 +476,8 @@ diff -rup old/storage/ndb/ndbapi-examples/ndbapi_s_i_ndbrecord/Makefile new/stor
  $(OBJS): $(SRCS)
  	$(CXX) $(CFLAGS) -I$(INCLUDE_DIR)/include -I$(INCLUDE_DIR)/storage/ndb/include -I$(INCLUDE_DIR)/storage/ndb/include/ndbapi $(SRCS)
 diff -rup old/storage/ndb/test/run-test/CMakeLists.txt new/storage/ndb/test/run-test/CMakeLists.txt
---- old/storage/ndb/test/run-test/CMakeLists.txt	2015-12-10 18:15:45.000000000 +0100
-+++ new/storage/ndb/test/run-test/CMakeLists.txt	2015-12-10 23:05:14.825915921 +0100
+--- old/storage/ndb/test/run-test/CMakeLists.txt	2016-01-22 11:43:40.000000000 +0100
++++ new/storage/ndb/test/run-test/CMakeLists.txt	2016-01-22 16:02:00.146744489 +0100
 @@ -32,7 +32,7 @@ IF(NOT WIN32)
    ADD_DEFINITIONS(-DDEFAULT_PREFIX=\"${CMAKE_INSTALL_PREFIX}\")
  ENDIF()
@@ -487,8 +488,8 @@ diff -rup old/storage/ndb/test/run-test/CMakeLists.txt new/storage/ndb/test/run-
  FILE(GLOB testcase_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*-tests.txt")
  ADD_TEST(NAME check_testcase_files
 diff -rup old/support-files/MySQL-shared-compat.spec.sh new/support-files/MySQL-shared-compat.spec.sh
---- old/support-files/MySQL-shared-compat.spec.sh	2015-12-10 13:44:03.000000000 +0100
-+++ new/support-files/MySQL-shared-compat.spec.sh	2015-12-10 23:05:14.825915921 +0100
+--- old/support-files/MySQL-shared-compat.spec.sh	2015-12-30 14:29:22.000000000 +0100
++++ new/support-files/MySQL-shared-compat.spec.sh	2016-01-22 16:02:00.146744489 +0100
 @@ -82,7 +82,7 @@ rpm2cpio %{SOURCE3} | cpio -iv --make-di
  
  %files
@@ -499,8 +500,8 @@ diff -rup old/support-files/MySQL-shared-compat.spec.sh new/support-files/MySQL-
  # The spec file changelog only includes changes made to the spec file
  # itself - note that they must be ordered by date (important when
 diff -rup old/testclients/CMakeLists.txt new/testclients/CMakeLists.txt
---- old/testclients/CMakeLists.txt	2015-12-10 18:15:46.000000000 +0100
-+++ new/testclients/CMakeLists.txt	2015-12-10 23:05:14.825915921 +0100
+--- old/testclients/CMakeLists.txt	2016-01-22 11:43:40.000000000 +0100
++++ new/testclients/CMakeLists.txt	2016-01-22 16:02:00.146744489 +0100
 @@ -18,12 +18,12 @@ ADD_DEFINITIONS("-DMYSQL_CLIENT")
  INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)
  

--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -516,7 +516,7 @@ fi
 #
 if test $load_hotbackup -eq 1
 then
-  for libhb in "${MY_BASEDIR_VERSION}/lib" "/usr/lib64" "/usr/lib/x86_64-linux-gnu" "/usr/lib"; do
+  for libhb in "${MY_BASEDIR_VERSION}/lib" "/usr/lib64" "/usr/lib/x86_64-linux-gnu" "/usr/lib" "${MY_BASEDIR_VERSION}/lib/mysql" "/usr/lib64/mysql" "/usr/lib/x86_64-linux-gnu/mysql" "/usr/lib/mysql"; do
     if [ -r "$libhb/libHotBackup.so" ]; then
       add_mysqld_ld_preload "$libhb/libHotBackup.so"
       break

--- a/scripts/ps_tokudb_admin.sh
+++ b/scripts/ps_tokudb_admin.sh
@@ -21,20 +21,27 @@ ENABLE_TOKUBACKUP=0
 DISABLE_TOKUBACKUP=0
 STATUS_HOTBACKUP_MYCNF=0
 STATUS_HOTBACKUP_PLUGIN=0
+STATUS_JEMALLOC_CONFIG=0
 MYCNF_LOCATION=""
 DEFAULTS_FILE_OPTION=""
 MYSQLD_SAFE_STATUS=0
 LIBHOTBACKUP_STATUS=0
+FULL_SYSTEMD_MODE=0
+JEMALLOC_LOCATION=""
+HOTBACKUP_LOCATION=""
+FORCE_MYCNF=0
+FORCE_ENVFILE=0
 
 SCRIPT_PWD=$(cd `dirname $0` && pwd)
 MYSQL_CLIENT_BIN="${SCRIPT_PWD}/mysql"
 MYSQL_DEFAULTS_BIN="${SCRIPT_PWD}/my_print_defaults"
+SYSTEMD_ENV_FILE="/etc/sysconfig/mysql"
 
 # Check if we have a functional getopt(1)
 if ! getopt --test
   then
-  go_out="$(getopt --options=u:p::S:h:P:edbr \
-  --longoptions=user:,password::,socket:,host:,port:,enable,disable,enable-backup,disable-backup,help,defaults-file: \
+  go_out="$(getopt --options=u:p::S:h:P:edbrfm \
+  --longoptions=user:,password::,socket:,host:,port:,enable,disable,enable-backup,disable-backup,help,defaults-file:,force-envfile,force-mycnf \
   --name="$(basename "$0")" -- "$@")"
   test $? -eq 0 || exit 1
   eval set -- $go_out
@@ -101,6 +108,14 @@ do
     shift
     DISABLE_TOKUBACKUP=1
     ;;
+    -m | --force-mycnf )
+    shift
+    FORCE_MYCNF=1
+    ;;
+    -f | --force-envfile )
+    shift
+    FORCE_ENVFILE=1
+    ;;
     --help )
     printf "This script is used for installing and uninstalling TokuDB plugin for Percona Server 5.7.\n"
     printf "It can also be used to install or uninstall the Percona TokuBackup plugin (requires mysql server restart).\n"
@@ -112,13 +127,17 @@ do
     printf "  --socket=path, -S path\t\t the socket file to use for connection\n"
     printf "  --host=host_name, -h host_name\t connect to given host\n"
     printf "  --port=port_num, -P port_num\t\t port number to use for connection\n"
-    printf "  --defaults-file=file \t\t specify defaults file instead of guessing\n"
+    printf "  --defaults-file=file \t\t\t specify defaults file instead of guessing\n"
     printf "  --enable, -e\t\t\t\t enable TokuDB plugin and disable transparent huge pages in my.cnf\n"
     printf "  --enable-backup, -b\t\t\t enable Percona TokuBackup and add preload-hotbackup option to my.cnf\n"
     printf "\t\t\t\t\t (this option includes --enable option)\n"
     printf "  --disable, d\t\t\t\t disable TokuDB plugin and remove thp-setting=never option in my.cnf\n"
     printf "\t\t\t\t\t (this option includes --disable-backup option)\n"
     printf "  --disable-backup, r\t\t\t disable Percona TokuBackup and remove preload-hotbackup option in my.cnf\n"
+    printf "  --force-envfile, f\t\t\t force usage of /etc/sysconfig/mysql instead of my.cnf\n"
+    printf "\t\t\t\t\t (use if autodetect doesn't work on distro with systemd and without mysqld_safe)\n"
+    printf "  --force-mycnf, m\t\t\t force usage of my.cnf instead of /etc/sysconfig/mysql\n"
+    printf "\t\t\t\t\t (use if autodetect doesn't work where mysqld_safe is used for running server)\n"
     printf "  --help\t\t\t\t show this help\n\n"
     printf "For TokuDB requirements and manual steps for installation please visit this webpage:\n"
     printf "http://www.percona.com/doc/percona-server/5.7/tokudb/tokudb_installation.html\n\n"
@@ -161,6 +180,13 @@ if [ -n "$(which sestatus)" ]; then
   fi
 fi
 
+# List plugins
+LIST_ENGINE=$($MYSQL_CLIENT_BIN -e "select CONCAT(PLUGIN_NAME,'#') from information_schema.plugins where PLUGIN_NAME like 'TokuDB%';" -u $USER $PASSWORD $SOCKET $HOST $PORT 2>/dev/null)
+if [ $? -ne 0 ]; then
+  printf "ERROR: Failed to list mysql plugins! Please check username, password and other options for connecting to server...\n";
+  exit 1
+fi
+
 # Get PID number for checking preloads
 if [ $ENABLE = 1 -o $ENABLE_TOKUBACKUP = 1 ]; then
   PID_LIST=$($MYSQL_CLIENT_BIN -e "show variables like 'pid_file';" -u $USER $PASSWORD $SOCKET $HOST $PORT 2>/tmp/ps_tokudb_admin.err)
@@ -180,31 +206,61 @@ if [ $ENABLE = 1 -o $ENABLE_TOKUBACKUP = 1 ]; then
   PID_NUM=$(cat ${PID_LOCATION})
 fi
 
-# List plugins
-LIST_ENGINE=$($MYSQL_CLIENT_BIN -e "select CONCAT(PLUGIN_NAME,'#') from information_schema.plugins where PLUGIN_NAME like 'TokuDB%';" -u $USER $PASSWORD $SOCKET $HOST $PORT 2>/dev/null)
-if [ $? -ne 0 ]; then
-  printf "ERROR: Failed to list mysql plugins! Please check username, password and other options...\n";
-  exit 1
+# Check if we're running in environment without mysqld_safe in which case we want to set
+# LD_PRELOAD and THP_SETTING in /etc/sysconfig/mysql
+if [ $FORCE_ENVFILE = 1 ]; then
+  FULL_SYSTEMD_MODE=1
+elif [ $FORCE_MYCNF = 1 ]; then
+  FULL_SYSTEMD_MODE=0
+else
+  ps acx|grep mysqld_safe >null 2>&1
+  FULL_SYSTEMD_MODE=$?
 fi
 
-# Check if server is running with jemalloc - if not warn that restart is needed
-if [ $ENABLE = 1 ]; then
-  printf "Checking if Percona Server is running with jemalloc enabled...\n"
-  cat /proc/${PID_NUM}/environ >null 2>&1
-  if [ $? = 0 ]; then
-    grep -qc jemalloc /proc/${PID_NUM}/environ || ldd $(which mysqld) | grep -qc jemalloc
-    JEMALLOC_STATUS=$?
-    if [ $JEMALLOC_STATUS = 1 ]; then
-      printf "ERROR: Percona Server is not running with jemalloc, please restart mysql service to enable it and then run this script...\n\n";
-      exit 1
-    else
-      printf "INFO: Percona Server is running with jemalloc enabled.\n\n";
+# Check location for libjemalloc.so.1
+if [ $FULL_SYSTEMD_MODE = 1 -a $ENABLE = 1 ]; then
+  printf "Checking location of jemalloc library ...\n"
+  for libjemall in "${SCRIPT_PWD}/lib/mysql" "/usr/lib64" "/usr/lib/x86_64-linux-gnu" "/usr/lib"; do
+    if [ -r "$libjemall/libjemalloc.so.1" ]; then
+      JEMALLOC_LOCATION="$libjemall/libjemalloc.so.1"
+      break
     fi
+  done
+  if [ -z $JEMALLOC_LOCATION ]; then
+    printf "ERROR: Cannot find libjemalloc.so.1 library. Make sure you have libjemalloc1 on debian|ubuntu or jemalloc on centos package installed.\n\n";
+    exit 1
   else
-    printf "WARNING: The file /proc/${PID_NUM}/environ is not readable so impossible to check LD_PRELOAD for jemalloc.\n";
-    printf "         Possibly running inside container so assuming jemalloc is preloaded and continuing...\n";
-    printf "         If there will be an error during plugin installation try to restart mysql service and run this script again.\n\n";
-    JEMALLOC_STATUS=0
+    printf "INFO: Using jemalloc library from $JEMALLOC_LOCATION\n\n";
+  fi
+fi
+
+# Check location for libHotBackup.so
+if [ $FULL_SYSTEMD_MODE = 1 -a $ENABLE_TOKUBACKUP = 1 ]; then
+  printf "Checking location of TokuBackup library ...\n"
+  for libhotbackup in "${SCRIPT_PWD}/lib" "/usr/lib64" "/usr/lib/x86_64-linux-gnu" "/usr/lib" "${SCRIPT_PWD}/lib/mysql" "/usr/lib64/mysql" "/usr/lib/x86_64-linux-gnu/mysql" "/usr/lib/mysql"; do
+    if [ -r "$libhotbackup/libHotBackup.so" ]; then
+      HOTBACKUP_LOCATION="$libhotbackup/libHotBackup.so"
+      break
+    fi
+  done
+  if [ -z $HOTBACKUP_LOCATION ]; then
+    printf "ERROR: Cannot find libHotBackup.so library. Make sure you have tokudb package installed.\n\n";
+    exit 1
+  else
+    printf "INFO: Using TokuBackup library from $HOTBACKUP_LOCATION\n\n";
+  fi
+fi
+
+# Check if server is running with jemalloc - if not warn that restart is needed (only when running with mysqld_safe)
+if [ $ENABLE = 1 -a $FULL_SYSTEMD_MODE = 0 ]; then
+  printf "Checking if Percona Server is running with jemalloc enabled...\n"
+  grep -qc jemalloc /proc/${PID_NUM}/environ || ldd $(which mysqld) | grep -qc jemalloc
+  JEMALLOC_STATUS=$?
+  if [ $JEMALLOC_STATUS = 1 ]; then
+    printf "ERROR: Percona Server is not running with jemalloc, please restart mysql service to enable it and then run this script...\n\n";
+    exit 1
+  else
+    printf "INFO: Percona Server is running with jemalloc enabled.\n\n";
   fi
 fi
 
@@ -223,48 +279,93 @@ if [ $ENABLE = 1 -o $DISABLE = 1 ]; then
 fi
 
 # Check location of my.cnf
-if [ -z $MYCNF_LOCATION ]; then
-  if [ -f /etc/my.cnf ]; then
-    MYCNF_LOCATION=/etc/my.cnf
-  elif [ -f /etc/mysql/my.cnf ]; then
-    MYCNF_LOCATION=/etc/mysql/my.cnf
-  elif [ -f /usr/etc/my.cnf ]; then
-    MYCNF_LOCATION=/usr/etc/my.cnf
-  else
-    if [ -d /etc/mysql ]; then
-      MYCNF_LOCATION=/etc/mysql/my.cnf
-    else
+if [ $FULL_SYSTEMD_MODE = 0  ]; then
+  if [ -z $MYCNF_LOCATION ]; then
+    if [ -f /etc/my.cnf ]; then
       MYCNF_LOCATION=/etc/my.cnf
+    elif [ -f /etc/mysql/my.cnf ]; then
+      MYCNF_LOCATION=/etc/mysql/my.cnf
+    elif [ -f /usr/etc/my.cnf ]; then
+      MYCNF_LOCATION=/usr/etc/my.cnf
+    else
+      if [ -d /etc/mysql ]; then
+        MYCNF_LOCATION=/etc/mysql/my.cnf
+      else
+        MYCNF_LOCATION=/etc/my.cnf
+      fi
+      echo -n "" >> ${MYCNF_LOCATION}
     fi
-    echo -n "" >> ${MYCNF_LOCATION}
-  fi
-else
-  if [ ! -f $MYCNF_LOCATION ]; then
-    printf "ERROR: Specified defaults file cannot be found!\n\n"
-    exit 1
+  else
+    if [ ! -f $MYCNF_LOCATION ]; then
+      printf "ERROR: Specified defaults file cannot be found!\n\n"
+      exit 1
+    fi
   fi
 fi
 
-# Check thp-setting=never option in my.cnf
+# Check thp-setting=never option in my.cnf or THP_SETTING variable in /etc/sysconfig/mysql
 if [ $ENABLE = 1 -o $DISABLE = 1 ]; then
-  printf "Checking if thp-setting=never option is already set in config file...\n"
-  STATUS_THP_MYCNF=$($MYSQL_DEFAULTS_BIN server mysqld mysqld_safe $DEFAULTS_FILE_OPTION|grep -c thp-setting=never)
-  if [ $STATUS_THP_MYCNF = 0 ]; then
-    printf "INFO: Option thp-setting=never is not set in the config file.\n"
-    printf "      (needed only if THP is not disabled permanently on the system)\n\n"
+  if [ $FULL_SYSTEMD_MODE = 0  ]; then
+    printf "Checking if thp-setting=never option is already set in config file...\n"
+    STATUS_THP_MYCNF=$($MYSQL_DEFAULTS_BIN mysqld_safe $DEFAULTS_FILE_OPTION|grep -c thp-setting=never)
+    if [ $STATUS_THP_MYCNF = 0 ]; then
+      printf "INFO: Option thp-setting=never is not set in the config file.\n"
+      printf "      (needed only if THP is not disabled permanently on the system)\n\n"
+    else
+      printf "INFO: Option thp-setting=never is set in the config file.\n\n"
+    fi
   else
-    printf "INFO: Option thp-setting=never is set in the config file.\n\n"
+    printf "Checking if THP_SETTING variable is set to never or madvise in /etc/sysconfig/mysql...\n"
+    if [ -f $SYSTEMD_ENV_FILE ]; then
+      STATUS_THP_MYCNF=$(cat $SYSTEMD_ENV_FILE|grep -c -e "THP_SETTING=never\|THP_SETTING=madvise")
+    else
+      STATUS_THP_MYCNF=0
+    fi
+    if [ $STATUS_THP_MYCNF = 0 ]; then
+      printf "INFO: Variable THP_SETTING is not set to never or madvise in $SYSTEMD_ENV_FILE.\n\n"
+    else
+      printf "INFO: Variable THP_SETTING is set in $SYSTEMD_ENV_FILE.\n\n"
+    fi
   fi
 fi
 
-# Check preload-hotbackup option in my.cnf
-if [ $ENABLE_TOKUBACKUP = 1 -o $DISABLE_TOKUBACKUP = 1 ]; then
-  printf "Checking if preload-hotbackup option is already set in config file...\n"
-  STATUS_HOTBACKUP_MYCNF=$($MYSQL_DEFAULTS_BIN server mysqld mysqld_safe $DEFAULTS_FILE_OPTION|grep -c preload-hotbackup)
-  if [ $STATUS_HOTBACKUP_MYCNF = 0 ]; then
-    printf "INFO: Option preload-hotbackup is not set in the config file.\n\n"
+# Check if we have variable for preloading jemalloc in /etc/sysconfig/mysql
+if [ $FULL_SYSTEMD_MODE = 1 ]; then
+  printf "Checking if LD_PRELOAD variable is set for libjemalloc.so.1 in $SYSTEMD_ENV_FILE...\n"
+  if [ -f $SYSTEMD_ENV_FILE ]; then
+    STATUS_JEMALLOC_CONFIG=$(cat $SYSTEMD_ENV_FILE|grep -c -e "LD_PRELOAD=.*libjemalloc.so.1")
   else
-    printf "INFO: Option preload-hotbackup is set in the config file.\n\n"
+    STATUS_JEMALLOC_CONFIG=0
+  fi
+  if [ $STATUS_JEMALLOC_CONFIG = 0 ]; then
+    printf "INFO: Variable LD_PRELOAD for libjemalloc.so.1 is not set in $SYSTEMD_ENV_FILE.\n\n"
+  else
+    printf "INFO: Variable LD_PRELOAD for libjemalloc.so.1 is set in $SYSTEMD_ENV_FILE.\n\n"
+  fi
+fi
+
+# Check if we have options for preloading libHotBackup.so
+if [ $ENABLE_TOKUBACKUP = 1 -o $DISABLE_TOKUBACKUP = 1 ]; then
+  if [ $FULL_SYSTEMD_MODE = 0  ]; then
+    printf "Checking if preload-hotbackup option is already set in config file...\n"
+    STATUS_HOTBACKUP_MYCNF=$($MYSQL_DEFAULTS_BIN mysqld_safe $DEFAULTS_FILE_OPTION|grep -c preload-hotbackup)
+    if [ $STATUS_HOTBACKUP_MYCNF = 0 ]; then
+      printf "INFO: Option preload-hotbackup is not set in the config file.\n\n"
+    else
+      printf "INFO: Option preload-hotbackup is set in the config file.\n\n"
+    fi
+  else
+    printf "Checking if LD_PRELOAD variable is set for libHotBackup.so in $SYSTEMD_ENV_FILE...\n"
+    if [ -f $SYSTEMD_ENV_FILE ]; then
+      STATUS_HOTBACKUP_MYCNF=$(cat $SYSTEMD_ENV_FILE|grep -c -e "LD_PRELOAD=.*libHotBackup.so")
+    else
+      STATUS_HOTBACKUP_MYCNF=0
+    fi
+    if [ $STATUS_HOTBACKUP_MYCNF = 0 ]; then
+      printf "INFO: Variable LD_PRELOAD for libHotBackup.so is not set in $SYSTEMD_ENV_FILE.\n\n"
+    else
+      printf "INFO: Variable LD_PRELOAD for libHotBackup.so is set in $SYSTEMD_ENV_FILE.\n\n"
+    fi
   fi
 fi
 
@@ -293,28 +394,62 @@ if [ $ENABLE_TOKUBACKUP = 1 -o $DISABLE_TOKUBACKUP = 1 ]; then
   fi
 fi
 
-# Add option to preload libHotBackup.so into my.cnf
-if [ $ENABLE_TOKUBACKUP = 1 -a $STATUS_HOTBACKUP_MYCNF = 0 ]; then
-  printf "Adding preload-hotbackup option into $MYCNF_LOCATION\n"
-  for MYCNF_SECTION in mysqld_safe MYSQLD_SAFE
-  do
-    MYSQLD_SAFE_STATUS=$(grep -c "^\[${MYCNF_SECTION}\]$" $MYCNF_LOCATION)
-    if [ $MYSQLD_SAFE_STATUS != 0 ]; then
-      MYSQLD_SAFE_SECTION=${MYCNF_SECTION}
-      break
+# Add option to preload libHotBackup.so into my.cnf or LD_PRELOAD
+# for jemalloc and libHotBackup.so into /etc/sysconfig/mysql
+if [ $FULL_SYSTEMD_MODE = 0  ]; then
+  if [ $ENABLE_TOKUBACKUP = 1 -a $STATUS_HOTBACKUP_MYCNF = 0 ]; then
+    printf "Adding preload-hotbackup option into $MYCNF_LOCATION\n"
+    for MYCNF_SECTION in mysqld_safe MYSQLD_SAFE
+    do
+      MYSQLD_SAFE_STATUS=$(grep -c "^\[${MYCNF_SECTION}\]$" $MYCNF_LOCATION)
+      if [ $MYSQLD_SAFE_STATUS != 0 ]; then
+        MYSQLD_SAFE_SECTION=${MYCNF_SECTION}
+        break
+      fi
+    done
+    if [ $MYSQLD_SAFE_STATUS = 0 ]; then
+      echo -e "\n[mysqld_safe]\npreload-hotbackup" >> $MYCNF_LOCATION
+    else
+      sed -i "/^\[${MYSQLD_SAFE_SECTION}\]$/a preload-hotbackup" $MYCNF_LOCATION
     fi
-  done
-  if [ $MYSQLD_SAFE_STATUS = 0 ]; then
-    echo -e "\n[mysqld_safe]\npreload-hotbackup" >> $MYCNF_LOCATION
-  else
-    sed -i "/^\[${MYSQLD_SAFE_SECTION}\]$/a preload-hotbackup" $MYCNF_LOCATION
+    if [ $? -eq 0 ]; then
+      printf "INFO: Successfully added preload-hotbackup option into $MYCNF_LOCATION\n";
+      printf "PLEASE RESTART MYSQL SERVICE AND RUN THIS SCRIPT AGAIN TO FINISH INSTALLATION!\n\n";
+      exit 0
+    else
+      printf "ERROR: Failed to add preload-hotbackup option into $MYCNF_LOCATION\n\n";
+      exit 1
+    fi
   fi
+elif [ $ENABLE = 1 -a $STATUS_JEMALLOC_CONFIG = 0 ] || [ $ENABLE_TOKUBACKUP = 1 -a $STATUS_HOTBACKUP_MYCNF = 0 ]; then
+  printf "Adding LD_PRELOAD variable into $SYSTEMD_ENV_FILE\n"
+  NEW_LD_PRELOAD=""
+  FILE_ADD=""
+  if [ $ENABLE = 1 -a $STATUS_JEMALLOC_CONFIG = 0 ] && [ $ENABLE_TOKUBACKUP = 1 -a $STATUS_HOTBACKUP_MYCNF = 0 ]; then
+    NEW_LD_PRELOAD="${JEMALLOC_LOCATION} ${HOTBACKUP_LOCATION}"
+    FILE_ADD="libjemalloc.so.1 and libHotBackup.so"
+  elif [ $ENABLE = 1 -a $STATUS_JEMALLOC_CONFIG = 0 ]; then
+    NEW_LD_PRELOAD="${JEMALLOC_LOCATION}"
+    FILE_ADD="libjemalloc.so.1"
+  elif [ $ENABLE_TOKUBACKUP = 1 -a $STATUS_HOTBACKUP_MYCNF = 0 ]; then
+    NEW_LD_PRELOAD="${HOTBACKUP_LOCATION}"
+    FILE_ADD="libHotBackup.so"
+  fi
+  # Add desired LD_PRELOAD into config file
+  if [ ! -f $SYSTEMD_ENV_FILE ]; then
+    echo "LD_PRELOAD=${NEW_LD_PRELOAD}" > $SYSTEMD_ENV_FILE
+  elif [ $(grep -c LD_PRELOAD /etc/sysconfig/mysql) = 0 ]; then
+    echo "LD_PRELOAD=${NEW_LD_PRELOAD}" >> $SYSTEMD_ENV_FILE
+  else
+    sed -i '/^LD_PRELOAD=/ s:$: '"${NEW_LD_PRELOAD}"':' $SYSTEMD_ENV_FILE
+  fi
+  # Print status
   if [ $? -eq 0 ]; then
-    printf "INFO: Successfully added preload-hotbackup option into $MYCNF_LOCATION\n";
+    printf "INFO: Successfully added LD_PRELOAD variable for $FILE_ADD into $SYSTEMD_ENV_FILE\n\n";
     printf "PLEASE RESTART MYSQL SERVICE AND RUN THIS SCRIPT AGAIN TO FINISH INSTALLATION!\n\n";
     exit 0
   else
-    printf "ERROR: Failed to add preload-hotbackup option into $MYCNF_LOCATION\n\n";
+    printf "ERROR: Failed to add LD_PRELOAD variable for $FILE_ADD into $SYSTEMD_ENV_FILE\n\n";
     exit 1
   fi
 fi
@@ -322,21 +457,12 @@ fi
 # Check if server is running with libHotBackup.so preloaded - if not warn that restart is needed
 if [ $ENABLE_TOKUBACKUP = 1 ]; then
   printf "Checking if Percona Server is running with libHotBackup.so preloaded...\n"
-  cat /proc/${PID_NUM}/environ >null 2>&1
-  if [ $? = 0 ]; then
-    grep -qc libHotBackup.so /proc/${PID_NUM}/environ
-    LIBHOTBACKUP_STATUS=$?
-    if [ $LIBHOTBACKUP_STATUS = 1 ]; then
-      printf "ERROR: Percona Server is not running with libHotBackup.so preloaded, please restart mysql service to enable it and then run this script again...\n\n";
-      exit 1
-    else
-      printf "INFO: Percona Server is running with libHotBackup.so preloaded.\n\n";
-    fi
+  LIBHOTBACKUP_STATUS=$(grep -c libHotBackup.so /proc/${PID_NUM}/environ)
+  if [ $LIBHOTBACKUP_STATUS = 0 ]; then
+    printf "ERROR: Percona Server is not running with libHotBackup.so preloaded, please restart mysql service to enable it and then run this script again...\n\n";
+    exit 1
   else
-    printf "WARNING: The file /proc/${PID_NUM}/environ is not readable so impossible to check LD_PRELOAD for libHotBackup.so.\n";
-    printf "         Possibly running inside container so assuming libHotBackup.so is preloaded and continuing.\n";
-    printf "         If there will be an error during plugin installation try to restart mysql service and run this script again.\n\n";
-    LIBHOTBACKUP_STATUS=0
+    printf "INFO: Percona Server is running with libHotBackup.so preloaded.\n\n";
   fi
 fi
 
@@ -360,50 +486,99 @@ fi
 
 # Add option to disable transparent huge pages into my.cnf
 if [ $ENABLE = 1 -a $STATUS_THP_MYCNF = 0 ]; then
-  printf "Adding thp-setting=never option into $MYCNF_LOCATION\n"
-  for MYCNF_SECTION in mysqld_safe MYSQLD_SAFE
-  do
-    MYSQLD_SAFE_STATUS=$(grep -c "^\[${MYCNF_SECTION}\]$" $MYCNF_LOCATION)
-    if [ $MYSQLD_SAFE_STATUS != 0 ]; then
-      MYSQLD_SAFE_SECTION=${MYCNF_SECTION}
-      break
+  if [ $FULL_SYSTEMD_MODE = 0 ]; then
+    printf "Adding thp-setting=never option into $MYCNF_LOCATION\n"
+    for MYCNF_SECTION in mysqld_safe MYSQLD_SAFE
+    do
+      MYSQLD_SAFE_STATUS=$(grep -c "^\[${MYCNF_SECTION}\]$" $MYCNF_LOCATION)
+      if [ $MYSQLD_SAFE_STATUS != 0 ]; then
+        MYSQLD_SAFE_SECTION=${MYCNF_SECTION}
+        break
+      fi
+    done
+    if [ $MYSQLD_SAFE_STATUS = 0 ]; then
+      echo -e "\n[mysqld_safe]\nthp-setting=never" >> $MYCNF_LOCATION
+    else
+      sed -i "/^\[${MYSQLD_SAFE_SECTION}\]$/a thp-setting=never" $MYCNF_LOCATION
     fi
-  done
-  if [ $MYSQLD_SAFE_STATUS = 0 ]; then
-    echo -e "\n[mysqld_safe]\nthp-setting=never" >> $MYCNF_LOCATION
+    if [ $? -eq 0 ]; then
+      printf "INFO: Successfully added thp-setting=never option into $MYCNF_LOCATION\n\n";
+    else
+      printf "ERROR: Failed to add thp-setting=never option into $MYCNF_LOCATION\n\n";
+      exit 1
+    fi
   else
-    sed -i "/^\[${MYSQLD_SAFE_SECTION}\]$/a thp-setting=never" $MYCNF_LOCATION
-  fi
-  if [ $? -eq 0 ]; then
-    printf "INFO: Successfully added thp-setting=never option into $MYCNF_LOCATION\n\n";
-  else
-    printf "ERROR: Failed to add thp-setting=never option into $MYCNF_LOCATION\n\n";
-    exit 1
+    printf "Adding THP_SETTING=never variable into $SYSTEMD_ENV_FILE\n"
+    echo -e "THP_SETTING=never" >> $SYSTEMD_ENV_FILE
+    if [ $? -eq 0 ]; then
+      printf "INFO: Successfully added THP_SETTING=never option into $SYSTEMD_ENV_FILE\n\n";
+    else
+      printf "ERROR: Failed to add THP_SETTING=never option into $SYSTEMD_ENV_FILE\n\n";
+      exit 1
+    fi
   fi
 fi
 
-# Remove option for disabling transparent huge pages from my.cnf
+# Remove option for disabling transparent huge pages from config files
 if [ $DISABLE = 1 -a $STATUS_THP_MYCNF = 1 ]; then
-  printf "Removing thp-setting=never option from $MYCNF_LOCATION\n"
-  sed -i '/^thp-setting=never$/d' $MYCNF_LOCATION
-  if [ $? -eq 0 ]; then
-    printf "INFO: Successfully removed thp-setting=never option from $MYCNF_LOCATION\n\n";
+  if [ $FULL_SYSTEMD_MODE = 0  ]; then
+    printf "Removing thp-setting=never option from $MYCNF_LOCATION\n"
+    sed -i '/^thp-setting=never$/d' $MYCNF_LOCATION
+    if [ $? -eq 0 ]; then
+      printf "INFO: Successfully removed thp-setting=never option from $MYCNF_LOCATION\n\n";
+    else
+      printf "ERROR: Failed to remove thp-setting=never option from $MYCNF_LOCATION\n\n";
+      exit 1
+    fi
   else
-    printf "ERROR: Failed to remove thp-setting=never option from $MYCNF_LOCATION\n\n";
-    exit 1
+    printf "Removing THP_SETTING variable from $SYSTEMD_ENV_FILE\n"
+    sed -i '/^THP_SETTING=/d' $SYSTEMD_ENV_FILE
+    if [ $? -eq 0 ]; then
+      printf "INFO: Successfully removed THP_SETTING variable from $SYSTEMD_ENV_FILE\n\n";
+    else
+      printf "ERROR: Failed to remove THP_SETTING variable from $SYSTEMD_ENV_FILE\n\n";
+      exit 1
+    fi
   fi
 fi
 
-# Remove option for preloading libHotBackup.so from my.cnf
-if [ $DISABLE_TOKUBACKUP = 1 -a $STATUS_HOTBACKUP_MYCNF = 1 ]; then
-  printf "Removing preload-hotbackup option from $MYCNF_LOCATION\n"
-  sed -i '/^preload-hotbackup$/d' $MYCNF_LOCATION
-  if [ $? -eq 0 ]; then
-    printf "INFO: Successfully removed preload-hotbackup option from $MYCNF_LOCATION\n\n";
-  else
-    printf "ERROR: Failed to remove preload-hotbackup option from $MYCNF_LOCATION\n\n";
-    exit 1
+# Remove option for preloading libHotBackup.so and jemalloc from config files
+if [ $FULL_SYSTEMD_MODE = 0  ]; then
+  if [ $DISABLE_TOKUBACKUP = 1 -a $STATUS_HOTBACKUP_MYCNF = 1 ]; then
+    printf "Removing preload-hotbackup option from $MYCNF_LOCATION\n"
+    sed -i '/^preload-hotbackup$/d' $MYCNF_LOCATION
+    if [ $? -eq 0 ]; then
+      printf "INFO: Successfully removed preload-hotbackup option from $MYCNF_LOCATION\n\n";
+    else
+      printf "ERROR: Failed to remove preload-hotbackup option from $MYCNF_LOCATION\n\n";
+      exit 1
+    fi
   fi
+elif [ $DISABLE = 1 -o $DISABLE_TOKUBACKUP = 1 ]; then
+  printf "Removing LD_PRELOAD option from $SYSTEMD_ENV_FILE\n"
+  if [ $DISABLE = 1 -a $DISABLE_TOKUBACKUP = 1 ]; then
+    sed -i '/^LD_PRELOAD/d' $SYSTEMD_ENV_FILE
+    FILE_REMOVE="libjemalloc.so.1 and libHotBackup.so"
+  else
+    NEW_LD_PRELOAD=""
+    if [ $DISABLE = 1 ]; then
+      FILE_REMOVE="libjemalloc.so.1"
+    else
+      FILE_REMOVE="libHotBackup.so"
+    fi
+    for file in $(cat $SYSTEMD_ENV_FILE|awk -v var="$FILE_REMOVE" -F ' ' '/LD_PRELOAD/{for(i=1;i<=NF;++i)if($i !~ var)print $i}'|sed 's/LD_PRELOAD=//')
+    do
+      NEW_LD_PRELOAD="${file} "
+    done
+    NEW_LD_PRELOAD=$(echo "LD_PRELOAD=${NEW_LD_PRELOAD}"|sed 's/[ ]*$//')
+    sed -i 's:^LD_PRELOAD=.*:'"${NEW_LD_PRELOAD}"':' $SYSTEMD_ENV_FILE
+  fi
+    if [ $? -eq 0 ]; then
+      printf "INFO: Successfully removed LD_PRELOAD option for $FILE_REMOVE from $SYSTEMD_ENV_FILE\n\n";
+    else
+      printf "ERROR: Failed to remove LD_PRELOAD option for $FILE_REMOVE from $SYSTEMD_ENV_FILE\n\n";
+      exit 1
+    fi
 fi
 
 # Installing TokuDB engine plugin

--- a/scripts/systemd/mysqld_pre_systemd.in
+++ b/scripts/systemd/mysqld_pre_systemd.in
@@ -41,6 +41,15 @@ install_validate_password_sql_file () {
     echo $initfile
 }
 
+fix_thp_setting() {
+    # If no THP_SETTING variable specified in /etc/sysconfig/mysql don't do anything
+    if [ ! -z "${THP_SETTING}" ]; then
+      # Set whatever option is specified in environment file
+      echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/defrag
+      echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/enabled
+    fi
+}
+
 install_db () {
     # Note: something different than datadir=/var/lib/mysql requires SELinux policy changes (in enforcing mode)
     datadir=$(get_option mysqld datadir "@MYSQL_DATADIR@")
@@ -73,6 +82,7 @@ install_db () {
     fi
     exit 0
 }
+fix_thp_setting
 install_db
 
 exit 0


### PR DESCRIPTION
**ISSUE:**
PS 5.7 - centos7 tokudb usage issues (BLD-386)

**INFO:**
5.7 on centos 7 runs with systemd unit files and it doesn't run the mysqld_safe but invokes mysqld directly.
So this is a change in ps_tokudb_admin to use environment file /etc/sysconfig/mysql to setup LD_PRELOAD for jemalloc and libHotBackup and also to set appropriate THP_SETTING variable for disabling transparent huge pages.
On systems which run the server with mysqld_safe (sysvinit and systemd) ps_tokudb_admin should run as before (modifying my.cnf instead of /etc/sysconfig/mysql).

**Changed files:**
- ps_tokudb_admin.sh - as noted above
- mysqld_pre_systemd.in - for reading THP_SETTING variable and disabling THP if needed
- mysqld_safe.sh - small change to accompany different locations of libHotBackup.so
- mysql-5.7-sharedlib-rename.patch - just refresh of the existing patch so that packages for centos can be built (there was a small change in plugin/percona-pam-for-mysql/CMakeLists.txt so the patch was failing)
- percona-server.spec - added TokuBackup files since George fixed the build
- percona-server-tokudb-5.7.install - same as above

**TESTING:**
Some testing done on:
- centos 7 (systemd with running mysqld directly)
- centos 6 (sysvinit with mysqld_safe)
- ubuntu trusty (sysvinit with mysqld_safe)
- ubuntu vivid (systemd with mysqld_safe)

**CENTOS7:**
_INSTALL:_

```
[vagrant@t-centos7-64 ~]$ sudo ps_tokudb_admin --enable --enable-backup -uroot -p
Enter password:

Checking SELinux status...
INFO: SELinux is disabled.

Checking location of jemalloc library ...
INFO: Using jemalloc library from /usr/lib64/libjemalloc.so.1

Checking location of TokuBackup library ...
INFO: Using TokuBackup library from /usr/lib64/mysql/libHotBackup.so

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are enabled (should be disabled).

Checking if THP_SETTING variable is set to never or madvise in /etc/sysconfig/mysql...
INFO: Variable THP_SETTING is not set to never or madvise in /etc/sysconfig/mysql.

Checking if LD_PRELOAD variable is set for libjemalloc.so.1 in /etc/sysconfig/mysql...
INFO: Variable LD_PRELOAD for libjemalloc.so.1 is not set in /etc/sysconfig/mysql.

Checking if LD_PRELOAD variable is set for libHotBackup.so in /etc/sysconfig/mysql...
INFO: Variable LD_PRELOAD for libHotBackup.so is not set in /etc/sysconfig/mysql.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Adding LD_PRELOAD variable into /etc/sysconfig/mysql
INFO: Successfully added LD_PRELOAD variable for libjemalloc.so.1 and libHotBackup.so into /etc/sysconfig/mysql

PLEASE RESTART MYSQL SERVICE AND RUN THIS SCRIPT AGAIN TO FINISH INSTALLATION!

[vagrant@t-centos7-64 ~]$ sudo systemctl restart mysqld

[vagrant@t-centos7-64 ~]$ sudo ps_tokudb_admin --enable --enable-backup -uroot -p
Enter password:

Checking SELinux status...
INFO: SELinux is disabled.

Checking location of jemalloc library ...
INFO: Using jemalloc library from /usr/lib64/libjemalloc.so.1

Checking location of TokuBackup library ...
INFO: Using TokuBackup library from /usr/lib64/mysql/libHotBackup.so

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are enabled (should be disabled).

Checking if THP_SETTING variable is set to never or madvise in /etc/sysconfig/mysql...
INFO: Variable THP_SETTING is not set to never or madvise in /etc/sysconfig/mysql.

Checking if LD_PRELOAD variable is set for libjemalloc.so.1 in /etc/sysconfig/mysql...
INFO: Variable LD_PRELOAD for libjemalloc.so.1 is set in /etc/sysconfig/mysql.

Checking if LD_PRELOAD variable is set for libHotBackup.so in /etc/sysconfig/mysql...
INFO: Variable LD_PRELOAD for libHotBackup.so is set in /etc/sysconfig/mysql.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Checking if Percona Server is running with libHotBackup.so preloaded...
INFO: Percona Server is running with libHotBackup.so preloaded.

Disabling transparent huge pages for the current session...
INFO: Successfully disabled transparent huge pages for this session.

Adding THP_SETTING=never variable into /etc/sysconfig/mysql
INFO: Successfully added THP_SETTING=never option into /etc/sysconfig/mysql

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

Installing TokuBackup plugin...
INFO: Successfully installed TokuBackup plugin.

mysql> show engines;
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| Engine             | Support | Comment                                                                    | Transactions | XA   | Savepoints |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| TokuDB             | YES     | Percona TokuDB Storage Engine with Fractal Tree(tm) Technology             | YES          | YES  | YES        |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+

mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so         | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| tokudb_backup                 | ACTIVE   | DAEMON             | tokudb_backup.so     | GPL     |
+-------------------------------+----------+--------------------+----------------------+---------+

[vagrant@t-centos7-64 ~]$ sudo cat /etc/sysconfig/mysql
LD_PRELOAD=/usr/lib64/libjemalloc.so.1 /usr/lib64/mysql/libHotBackup.so
THP_SETTING=never
```

_UNINSTALL:_

```
[vagrant@t-centos7-64 ~]$ sudo ps_tokudb_admin --disable -uroot -p
Enter password:

Checking SELinux status...
INFO: SELinux is disabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if THP_SETTING variable is set to never or madvise in /etc/sysconfig/mysql...
INFO: Variable THP_SETTING is set in /etc/sysconfig/mysql.

Checking if LD_PRELOAD variable is set for libjemalloc.so.1 in /etc/sysconfig/mysql...
INFO: Variable LD_PRELOAD for libjemalloc.so.1 is set in /etc/sysconfig/mysql.

Checking if LD_PRELOAD variable is set for libHotBackup.so in /etc/sysconfig/mysql...
INFO: Variable LD_PRELOAD for libHotBackup.so is set in /etc/sysconfig/mysql.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is installed.

Removing THP_SETTING variable from /etc/sysconfig/mysql
INFO: Successfully removed THP_SETTING variable from /etc/sysconfig/mysql

Removing LD_PRELOAD option from /etc/sysconfig/mysql
INFO: Successfully removed LD_PRELOAD option for libjemalloc.so.1 and libHotBackup.so from /etc/sysconfig/mysql

Uninstalling TokuBackup plugin...
INFO: Successfully uninstalled TokuBackup plugin.

Uninstalling TokuDB engine plugin...
INFO: Successfully uninstalled TokuDB engine plugin.

[vagrant@t-centos7-64 ~]$ cat /etc/sysconfig/mysql
[vagrant@t-centos7-64 ~]$

> Show engines and plugins show no traces of TokuDB.
```

**CENTOS6:**
_INSTALL:_

```
[vagrant@t-centos6-64 ~]$ sudo ps_tokudb_admin --enable --enable-backup -uroot -p
Enter password:

Checking SELinux status...
INFO: SELinux is disabled.

Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is not set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Adding preload-hotbackup option into /etc/my.cnf
INFO: Successfully added preload-hotbackup option into /etc/my.cnf
PLEASE RESTART MYSQL SERVICE AND RUN THIS SCRIPT AGAIN TO FINISH INSTALLATION!

[vagrant@t-centos6-64 ~]$ sudo service mysqld restart
Stopping mysqld:                                           [  OK  ]
Starting mysqld:                                           [  OK  ]

[vagrant@t-centos6-64 ~]$ sudo ps_tokudb_admin --enable --enable-backup -uroot -p
Enter password:

Checking SELinux status...
INFO: SELinux is disabled.

Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Checking if Percona Server is running with libHotBackup.so preloaded...
INFO: Percona Server is running with libHotBackup.so preloaded.

Adding thp-setting=never option into /etc/my.cnf
INFO: Successfully added thp-setting=never option into /etc/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

Installing TokuBackup plugin...
INFO: Successfully installed TokuBackup plugin.

[vagrant@t-centos6-64 ~]$ cat /etc/sysconfig/mysql
cat: /etc/sysconfig/mysql: No such file or directory

[vagrant@t-centos6-64 ~]$ cat /etc/my.cnf |grep hotbackup
preload-hotbackup

mysql> show engines;
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| Engine             | Support | Comment                                                                    | Transactions | XA   | Savepoints |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| TokuDB             | YES     | Percona TokuDB Storage Engine with Fractal Tree(tm) Technology             | YES          | YES  | YES        |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+

mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so         | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so         | GPL     |
| tokudb_backup                 | ACTIVE   | DAEMON             | tokudb_backup.so     | GPL     |
+-------------------------------+----------+--------------------+----------------------+---------+
```

_UNINSTALL_

```
[vagrant@t-centos6-64 ~]$ sudo ps_tokudb_admin --disable -uroot -p
Enter password:

Checking SELinux status...
INFO: SELinux is disabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is set in the config file.

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is installed.

Removing thp-setting=never option from /etc/my.cnf
INFO: Successfully removed thp-setting=never option from /etc/my.cnf

Removing preload-hotbackup option from /etc/my.cnf
INFO: Successfully removed preload-hotbackup option from /etc/my.cnf

Uninstalling TokuBackup plugin...
INFO: Successfully uninstalled TokuBackup plugin.

Uninstalling TokuDB engine plugin...
INFO: Successfully uninstalled TokuDB engine plugin.

[vagrant@t-centos6-64 ~]$ cat /etc/my.cnf |grep hotbackup
[vagrant@t-centos6-64 ~]$ 

> Show engines and plugins show no traces of TokuDB.
```

**UBUNTU TRUSTY:**
_INSTALL_

```
vagrant@t-ubuntu1404-64:~$ sudo ps_tokudb_admin --enable --enable-backup
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is not set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Adding preload-hotbackup option into /etc/mysql/my.cnf
INFO: Successfully added preload-hotbackup option into /etc/mysql/my.cnf
PLEASE RESTART MYSQL SERVICE AND RUN THIS SCRIPT AGAIN TO FINISH INSTALLATION!

vagrant@t-ubuntu1404-64:~$ sudo service mysql restart
 * Stopping Percona Server 5.7.10-1rc1
...
 * Percona Server 5.7.10-1rc1 is stopped
 * Re-starting Percona Server 5.7.10-1rc1
..
 * Percona Server 5.7.10-1rc1 is started

vagrant@t-ubuntu1404-64:~$ sudo ps_tokudb_admin --enable --enable-backup
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Checking if Percona Server is running with libHotBackup.so preloaded...
INFO: Percona Server is running with libHotBackup.so preloaded.

Adding thp-setting=never option into /etc/mysql/my.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

Installing TokuBackup plugin...
INFO: Successfully installed TokuBackup plugin.

vagrant@t-ubuntu1404-64:~$ cat /etc/mysql/my.cnf|grep hotbackup
preload-hotbackup

mysql> show engines;
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| Engine             | Support | Comment                                                                    | Transactions | XA   | Savepoints |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| TokuDB             | YES     | Percona TokuDB Storage Engine with Fractal Tree(tm) Technology             | YES          | YES  | YES        |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+

mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so     | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| tokudb_backup                 | ACTIVE   | DAEMON             | tokudb_backup.so | GPL     |
+-------------------------------+----------+--------------------+------------------+---------+
```

_UNINSTALL:_

```
vagrant@t-ubuntu1404-64:~$ sudo ps_tokudb_admin --disable
Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is set in the config file.

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is installed.

Removing thp-setting=never option from /etc/mysql/my.cnf
INFO: Successfully removed thp-setting=never option from /etc/mysql/my.cnf

Removing preload-hotbackup option from /etc/mysql/my.cnf
INFO: Successfully removed preload-hotbackup option from /etc/mysql/my.cnf

Uninstalling TokuBackup plugin...
INFO: Successfully uninstalled TokuBackup plugin.

Uninstalling TokuDB engine plugin...
INFO: Successfully uninstalled TokuDB engine plugin.

vagrant@t-ubuntu1404-64:~$ cat /etc/mysql/my.cnf|grep hotbackup
vagrant@t-ubuntu1404-64:~$ 

> Show engines and plugins show no traces of TokuDB.
```

**VIVID**
_INSTALL_

```
vagrant@vagrant-ubuntu-vivid-64:~$ sudo ps_tokudb_admin --enable --enable-backup
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is not set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Adding preload-hotbackup option into /etc/mysql/my.cnf
INFO: Successfully added preload-hotbackup option into /etc/mysql/my.cnf
PLEASE RESTART MYSQL SERVICE AND RUN THIS SCRIPT AGAIN TO FINISH INSTALLATION!

vagrant@vagrant-ubuntu-vivid-64:~$ sudo systemctl restart mysql

vagrant@vagrant-ubuntu-vivid-64:~$ sudo ps_tokudb_admin --enable --enable-backup
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is not installed.

Checking if Percona Server is running with libHotBackup.so preloaded...
INFO: Percona Server is running with libHotBackup.so preloaded.

Adding thp-setting=never option into /etc/mysql/my.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

Installing TokuBackup plugin...
INFO: Successfully installed TokuBackup plugin.

vagrant@vagrant-ubuntu-vivid-64:~$ sudo cat /etc/mysql/my.cnf|grep hotbackup
preload-hotbackup

mysql> show engines;
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| Engine             | Support | Comment                                                                    | Transactions | XA   | Savepoints |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+
| TokuDB             | YES     | Percona TokuDB Storage Engine with Fractal Tree(tm) Technology             | YES          | YES  | YES        |
+--------------------+---------+----------------------------------------------------------------------------+--------------+------+------------+

mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so     | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so     | GPL     |
| tokudb_backup                 | ACTIVE   | DAEMON             | tokudb_backup.so | GPL     |
+-------------------------------+----------+--------------------+------------------+---------+
```

_UNINSTALL_

```
vagrant@vagrant-ubuntu-vivid-64:~$ sudo ps_tokudb_admin --disable
Checking transparent huge pages status on the system...
INFO: Transparent huge pages are currently disabled on the system.

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is set in the config file.

Checking if preload-hotbackup option is already set in config file...
INFO: Option preload-hotbackup is set in the config file.

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is installed.

Checking TokuBackup plugin status...
INFO: TokuBackup plugin is installed.

Removing thp-setting=never option from /etc/mysql/my.cnf
INFO: Successfully removed thp-setting=never option from /etc/mysql/my.cnf

Removing preload-hotbackup option from /etc/mysql/my.cnf
INFO: Successfully removed preload-hotbackup option from /etc/mysql/my.cnf

Uninstalling TokuBackup plugin...
INFO: Successfully uninstalled TokuBackup plugin.

Uninstalling TokuDB engine plugin...
INFO: Successfully uninstalled TokuDB engine plugin.

vagrant@vagrant-ubuntu-vivid-64:~$ sudo cat /etc/mysql/my.cnf|grep hotbackup
vagrant@vagrant-ubuntu-vivid-64:~$
```
