### PR TITLE
DB-926 : Assertion `used_keyparts <= key->u ser_defined_key_parts' fa…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash.result
@@ -17,5 +17,5 @@ test.t	analyze	status	OK
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	6	NULL	NULL		BTREE		
-t	1	x	1	x	A	6	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	2	NULL	NULL	YES	BTREE		
 drop table t;

--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1.result
@@ -16,5 +16,5 @@ test.t	analyze	status	OK
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	4	NULL	NULL		BTREE		
-t	1	x	1	x	A	4	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	1	NULL	NULL	YES	BTREE		
 drop table t;

--- a/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
+++ b/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
@@ -46,5 +46,5 @@ show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	9	NULL	NULL		BTREE		
 t	1	x	1	x	A	9	NULL	NULL	YES	BTREE		
-t	1	y	1	y	A	5	NULL	NULL	YES	BTREE		
+t	1	y	1	y	A	2	NULL	NULL	YES	BTREE		
 drop table t;

--- a/mysql-test/suite/tokudb.sys_vars/r/tokudb_cardinality_scale_percent_basic.result
+++ b/mysql-test/suite/tokudb.sys_vars/r/tokudb_cardinality_scale_percent_basic.result
@@ -1,7 +1,7 @@
 SET @orig_global = @@global.tokudb_cardinality_scale_percent;
 SELECT @orig_global;
 @orig_global
-50
+100
 SET GLOBAL tokudb_cardinality_scale_percent = 10;
 SELECT @@global.tokudb_cardinality_scale_percent;
 @@global.tokudb_cardinality_scale_percent
@@ -13,12 +13,12 @@ SELECT @@global.tokudb_cardinality_scale_percent;
 SET GLOBAL tokudb_cardinality_scale_percent = DEFAULT;
 SELECT @@global.tokudb_cardinality_scale_percent;
 @@global.tokudb_cardinality_scale_percent
-50
+100
 SET GLOBAL tokudb_cardinality_scale_percent = 'foobar';
 ERROR 42000: Incorrect argument type to variable 'tokudb_cardinality_scale_percent'
 SELECT @@global.tokudb_cardinality_scale_percent;
 @@global.tokudb_cardinality_scale_percent
-50
+100
 SET GLOBAL tokudb_cardinality_scale_percent = 12;
 SET SESSION tokudb_cardinality_scale_percent = 13;
 ERROR HY000: Variable 'tokudb_cardinality_scale_percent' is a GLOBAL variable and should be set with SET GLOBAL
@@ -33,4 +33,4 @@ tokudb_cardinality_scale_percent	12
 SET GLOBAL tokudb_cardinality_scale_percent = @orig_global;
 SELECT @@global.tokudb_cardinality_scale_percent;
 @@global.tokudb_cardinality_scale_percent
-50
+100

--- a/mysql-test/suite/tokudb/r/card_add_drop.result
+++ b/mysql-test/suite/tokudb/r/card_add_drop.result
@@ -13,13 +13,13 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	1	a	1	a	A	4	NULL	NULL	YES	BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
 alter table tt drop key b, add key (d);
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	1	a	1	a	A	4	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
 tt	1	d	1	d	A	4	NULL	NULL	YES	BTREE		
 analyze table tt;
 Table	Op	Msg_type	Msg_text
@@ -27,12 +27,12 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	1	a	1	a	A	4	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
-tt	1	d	1	d	A	2	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
+tt	1	d	1	d	A	1	NULL	NULL	YES	BTREE		
 flush tables;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	1	a	1	a	A	4	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
-tt	1	d	1	d	A	2	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
+tt	1	d	1	d	A	1	NULL	NULL	YES	BTREE		
 drop table tt;

--- a/mysql-test/suite/tokudb/r/card_add_index.result
+++ b/mysql-test/suite/tokudb/r/card_add_index.result
@@ -22,12 +22,12 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
 alter table tt add key (c);
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
 tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
 analyze table tt;
 Table	Op	Msg_type	Msg_text
@@ -35,12 +35,12 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
 flush tables;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
 drop table tt;

--- a/mysql-test/suite/tokudb/r/card_drop_index.result
+++ b/mysql-test/suite/tokudb/r/card_drop_index.result
@@ -13,13 +13,13 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
 alter table tt drop key b;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
 alter table tt drop key c;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb/r/card_drop_index_2.result
+++ b/mysql-test/suite/tokudb/r/card_drop_index_2.result
@@ -140,13 +140,13 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	500	NULL	NULL		BTREE		
-tt	1	b	1	b	A	250	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	125	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	1	NULL	NULL	YES	BTREE		
 alter table tt drop key b;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	500	NULL	NULL		BTREE		
-tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	1	NULL	NULL	YES	BTREE		
 alter table tt drop key c;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb/r/card_drop_pk.result
+++ b/mysql-test/suite/tokudb/r/card_drop_pk.result
@@ -13,8 +13,8 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
-tt	1	c	1	c	A	4	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
+tt	1	c	1	c	A	2	NULL	NULL	YES	BTREE		
 alter table tt drop primary key;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb/r/card_pk_2.result
+++ b/mysql-test/suite/tokudb/r/card_pk_2.result
@@ -11,11 +11,11 @@ Table	Op	Msg_type	Msg_text
 test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
-tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
+tt	0	PRIMARY	1	a	A	2	NULL	NULL		BTREE		
 tt	0	PRIMARY	2	b	A	4	NULL	NULL		BTREE		
 flush tables;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
-tt	0	PRIMARY	1	a	A	4	NULL	NULL		BTREE		
+tt	0	PRIMARY	1	a	A	2	NULL	NULL		BTREE		
 tt	0	PRIMARY	2	b	A	4	NULL	NULL		BTREE		
 drop table tt;

--- a/mysql-test/suite/tokudb/r/card_pk_sk.result
+++ b/mysql-test/suite/tokudb/r/card_pk_sk.result
@@ -2029,10 +2029,10 @@ test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4000	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
 flush tables;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 tt	0	PRIMARY	1	a	A	4000	NULL	NULL		BTREE		
-tt	1	b	1	b	A	2	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	1	NULL	NULL	YES	BTREE		
 drop table tt;

--- a/mysql-test/suite/tokudb/r/card_sk.result
+++ b/mysql-test/suite/tokudb/r/card_sk.result
@@ -11,9 +11,9 @@ Table	Op	Msg_type	Msg_text
 test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
-tt	1	b	1	b	A	8	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	4	NULL	NULL	YES	BTREE		
 flush tables;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
-tt	1	b	1	b	A	8	NULL	NULL	YES	BTREE		
+tt	1	b	1	b	A	4	NULL	NULL	YES	BTREE		
 drop table tt;

--- a/mysql-test/suite/tokudb/r/card_sk_2.result
+++ b/mysql-test/suite/tokudb/r/card_sk_2.result
@@ -11,11 +11,11 @@ Table	Op	Msg_type	Msg_text
 test.tt	analyze	status	OK
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
-tt	1	a	1	a	A	4	NULL	NULL	YES	BTREE		
+tt	1	a	1	a	A	2	NULL	NULL	YES	BTREE		
 tt	1	a	2	b	A	4	NULL	NULL	YES	BTREE		
 flush tables;
 show indexes from tt;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
-tt	1	a	1	a	A	4	NULL	NULL	YES	BTREE		
+tt	1	a	1	a	A	2	NULL	NULL	YES	BTREE		
 tt	1	a	2	b	A	4	NULL	NULL	YES	BTREE		
 drop table tt;

--- a/storage/tokudb/ha_tokudb_alter_56.cc
+++ b/storage/tokudb/ha_tokudb_alter_56.cc
@@ -678,9 +678,10 @@ int ha_tokudb::alter_table_add_index(
         MYF(MY_WME));
     for (uint i = 0; i < ha_alter_info->index_add_count; i++) {
         KEY *key = &key_info[i];
-        *key = ha_alter_info->key_info_buffer[ha_alter_info->index_add_buffer[i]];
+        *key =
+            ha_alter_info->key_info_buffer[ha_alter_info->index_add_buffer[i]];
         for (KEY_PART_INFO* key_part = key->key_part;
-             key_part < key->key_part + get_key_parts(key);
+             key_part < key->key_part + key->user_defined_key_parts;
              key_part++) {
             key_part->field = table->field[key_part->fieldnr];
         }
@@ -1123,7 +1124,7 @@ int ha_tokudb::alter_table_expand_varchar_offsets(
 
 // Return true if a field is part of a key
 static bool field_in_key(KEY *key, Field *field) {
-    for (uint i = 0; i < get_key_parts(key); i++) {
+    for (uint i = 0; i < key->user_defined_key_parts; i++) {
         KEY_PART_INFO *key_part = &key->key_part[i];
         if (strcmp(key_part->field->field_name, field->field_name) == 0)
             return true;

--- a/storage/tokudb/ha_tokudb_alter_common.cc
+++ b/storage/tokudb/ha_tokudb_alter_common.cc
@@ -75,8 +75,8 @@ static bool tables_have_same_keys(
             if (print_error) {
                 sql_print_error(
                     "keys disagree on if they are clustering, %d, %d",
-                    get_key_parts(curr_orig_key),
-                    get_key_parts(curr_altered_key));
+                    curr_orig_key->user_defined_key_parts,
+                    curr_altered_key->user_defined_key_parts);
             }
             retval = false;
             goto cleanup;
@@ -86,18 +86,19 @@ static bool tables_have_same_keys(
             if (print_error) {
                 sql_print_error(
                     "keys disagree on if they are unique, %d, %d",
-                    get_key_parts(curr_orig_key),
-                    get_key_parts(curr_altered_key));
+                    curr_orig_key->user_defined_key_parts,
+                    curr_altered_key->user_defined_key_parts);
             }
             retval = false;
             goto cleanup;
         }
-        if (get_key_parts(curr_orig_key) != get_key_parts(curr_altered_key)) {
+        if (curr_orig_key->user_defined_key_parts !=
+            curr_altered_key->user_defined_key_parts) {
             if (print_error) {
                 sql_print_error(
                     "keys have different number of parts, %d, %d",
-                    get_key_parts(curr_orig_key),
-                    get_key_parts(curr_altered_key));
+                    curr_orig_key->user_defined_key_parts,
+                    curr_altered_key->user_defined_key_parts);
             }
             retval = false;
             goto cleanup;
@@ -105,7 +106,7 @@ static bool tables_have_same_keys(
         //
         // now verify that each field in the key is the same
         //
-        for (uint32_t j = 0; j < get_key_parts(curr_orig_key); j++) {
+        for (uint32_t j = 0; j < curr_orig_key->user_defined_key_parts; j++) {
             KEY_PART_INFO* curr_orig_part = &curr_orig_key->key_part[j];
             KEY_PART_INFO* curr_altered_part = &curr_altered_key->key_part[j];
             Field* curr_orig_field = curr_orig_part->field;

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1012,7 +1012,7 @@ static int create_toku_key_descriptor_for_key(KEY* key, uchar* buf) {
     uchar* pos = buf;
     uint32_t num_bytes_in_field = 0;
     uint32_t charset_num = 0;
-    for (uint i = 0; i < get_key_parts(key); i++){
+    for (uint i = 0; i < key->user_defined_key_parts; i++){
         Field* field = key->key_part[i].field;
         //
         // The first byte states if there is a null byte
@@ -1883,7 +1883,7 @@ static uint32_t pack_desc_pk_offset_info(
 
     bool is_constant_offset = true;
     uint32_t offset = 0;
-    for (uint i = 0; i < get_key_parts(prim_key); i++) {
+    for (uint i = 0; i < prim_key->user_defined_key_parts; i++) {
         KEY_PART_INFO curr = prim_key->key_part[i];
         uint16 curr_field_index = curr.field->field_index;
 
@@ -2505,8 +2505,8 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
         //
         // store number of parts
         //
-        assert_always(get_key_parts(prim_key) < 128);
-        pos[0] = 2 * get_key_parts(prim_key);
+        assert_always(prim_key->user_defined_key_parts < 128);
+        pos[0] = 2 * prim_key->user_defined_key_parts;
         pos++;
         //
         // for each part, store if it is a fixed field or var field
@@ -2516,7 +2516,7 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
         //
         pk_info = pos;
         uchar* tmp = pos;
-        for (uint i = 0; i < get_key_parts(prim_key); i++) {
+        for (uint i = 0; i < prim_key->user_defined_key_parts; i++) {
             tmp += pack_desc_pk_info(
                 tmp,
                 kc_info,
@@ -2527,11 +2527,11 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
         //
         // asserting that we moved forward as much as we think we have
         //
-        assert_always(tmp - pos == (2 * get_key_parts(prim_key)));
+        assert_always(tmp - pos == (2 * prim_key->user_defined_key_parts));
         pos = tmp;
     }
 
-    for (uint i = 0; i < get_key_parts(key_info); i++) {
+    for (uint i = 0; i < key_info->user_defined_key_parts; i++) {
         KEY_PART_INFO curr_kpi = key_info->key_part[i];
         uint16 field_index = curr_kpi.field->field_index;
         Field* field = table_share->field[field_index];

--- a/storage/tokudb/hatoku_hton.h
+++ b/storage/tokudb/hatoku_hton.h
@@ -199,14 +199,4 @@ void tokudb_pretty_left_key(const DB* db, const DBT* key, String* out);
 void tokudb_pretty_right_key(const DB* db, const DBT* key, String* out);
 const char *tokudb_get_index_name(DB* db);
 
-inline uint get_key_parts(const KEY *key) {
-#if (50609 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50699) || \
-    (50700 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50799) || \
-    (100009 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100099)
-    return key->user_defined_key_parts;
-#else
-    return key->key_parts;
-#endif
-}
-
 #endif //#ifdef _HATOKU_HTON

--- a/storage/tokudb/tokudb_card.h
+++ b/storage/tokudb/tokudb_card.h
@@ -27,7 +27,7 @@ namespace tokudb {
     uint compute_total_key_parts(TABLE_SHARE *table_share) {
         uint total_key_parts = 0;
         for (uint i = 0; i < table_share->keys; i++) {
-            total_key_parts += get_key_parts(&table_share->key_info[i]);
+            total_key_parts += table_share->key_info[i].user_defined_key_parts;
         }
         return total_key_parts;
     }
@@ -156,13 +156,14 @@ namespace tokudb {
         uint orig_key_parts = 0;
         for (uint i = 0; i < table_share->keys; i++) {
             orig_key_offset[i] = orig_key_parts;
-            orig_key_parts += get_key_parts(&table_share->key_info[i]);
+            orig_key_parts += table_share->key_info[i].user_defined_key_parts;
         }
         // if orig card data exists, then use it to compute new card data
         if (error == 0) {
             uint next_key_parts = 0;
             for (uint i = 0; error == 0 && i < altered_table_share->keys; i++) {
-                uint ith_key_parts = get_key_parts(&altered_table_share->key_info[i]);
+                uint ith_key_parts =
+                    altered_table_share->key_info[i].user_defined_key_parts;
                 uint orig_key_index;
                 if (find_index_of_key(
                         altered_table_share->key_info[i].name,

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -109,7 +109,7 @@ static MYSQL_SYSVAR_INT(
     "index cardinality scale percentage",
     NULL,
     NULL,
-    50,
+    100,
     0,
     100,
     0);


### PR DESCRIPTION
…iled in sql/opt_statistics.cc:51
- 5.7 added new cardinality tracking as float instead of int. Without populating this value, the optimizer takes a strange path and eventually asserts.
- Added new cardinality tracking logic.
- Removed version dependent key parts and changed to using proper value from KEY.
- Changed the tokudb_cardinality_scale_percent default from 50% to 100% similar to InnoDB changes.
- Re-evaluated now failing cardinality tests and cmpared/verified results with InnoDB in same situation. Fixed up results where appropriate.
