### PR TITLE
DB-917 : Assertion `Handlerton: kc_info->cp_info[keynr] == NULL ' fai…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/db917.result
+++ b/mysql-test/suite/tokudb.bugs/r/db917.result
@@ -1,0 +1,14 @@
+drop table if exists t1;
+set @orig_table_open_cache = @@global.table_open_cache;
+create table t1(a int) engine = tokudb partition by key(a) partitions 2 (partition p0 engine = tokudb, partition p1 engine = tokudb);
+lock tables t1 read;
+set @@global.table_open_cache = 1;
+begin;
+insert into t1 values(1),(1);
+select * from t1 where c like _ucs2 0x039C0025 collate ucs2_unicode_ci;
+ERROR 42S22: Unknown column 'c' in 'where clause'
+create table t1(c1 binary (1), c2 varbinary(1));
+ERROR 42S01: Table 't1' already exists
+unlock tables;
+drop table t1;
+set @@global.table_open_cache = @orig_table_open_cache;

--- a/mysql-test/suite/tokudb.bugs/t/db917.test
+++ b/mysql-test/suite/tokudb.bugs/t/db917.test
@@ -1,0 +1,22 @@
+# test DB-917
+# test that table/share open lock timeout does not crash the server on subsequent access
+source include/have_tokudb.inc;
+disable_warnings;
+drop table if exists t1;
+enable_warnings;
+set @orig_table_open_cache = @@global.table_open_cache;
+create table t1(a int) engine = tokudb partition by key(a) partitions 2 (partition p0 engine = tokudb, partition p1 engine = tokudb);
+lock tables t1 read;
+set @@global.table_open_cache = 1;
+begin;
+insert into t1 values(1),(1);
+# when the bug is present, this results in a lock wait timeout
+--error ER_BAD_FIELD_ERROR
+select * from t1 where c like _ucs2 0x039C0025 collate ucs2_unicode_ci;
+# when the bug exists, this results in the assertion
+# kc_info->cp_info[keynr] == NULL in tokudb/ha_tokudb.cc initialize_col_pack_info
+--error ER_TABLE_EXISTS_ERROR
+create table t1(c1 binary (1), c2 varbinary(1));
+unlock tables;
+drop table t1;
+set @@global.table_open_cache = @orig_table_open_cache;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -161,6 +161,15 @@ void TOKUDB_SHARE::static_init() {
 void TOKUDB_SHARE::static_destroy() {
     my_hash_free(&_open_tables);
 }
+const char* TOKUDB_SHARE::get_state_string(share_state_t state) {
+    static const char* state_string[] = {
+        "CLOSED",
+        "OPENED",
+        "ERROR"
+    };
+    assert_always(state == CLOSED || state == OPENED || state == ERROR);
+    return state_string[state];
+}
 void* TOKUDB_SHARE::operator new(size_t sz) {
     return tokudb::memory::malloc(sz, MYF(MY_WME|MY_ZEROFILL|MY_FAE));
 }
@@ -186,12 +195,24 @@ void TOKUDB_SHARE::init(const char* table_name) {
         _database_name,
         _table_name,
         tmp_dictionary_name);
+
+    TOKUDB_SHARE_DBUG_ENTER("file[%s]:state[%s]:use_count[%d]",
+        _full_table_name.ptr(),
+        get_state_string(_state),
+        _use_count);
+    TOKUDB_SHARE_DBUG_VOID_RETURN();
 }
 void TOKUDB_SHARE::destroy() {
+    TOKUDB_SHARE_DBUG_ENTER("file[%s]:state[%s]:use_count[%d]",
+        _full_table_name.ptr(),
+        get_state_string(_state),
+        _use_count);
+
     assert_always(_use_count == 0);
     assert_always(
         _state == TOKUDB_SHARE::CLOSED || _state == TOKUDB_SHARE::ERROR);
     thr_lock_delete(&_thr_lock);
+    TOKUDB_SHARE_DBUG_VOID_RETURN();
 }
 TOKUDB_SHARE* TOKUDB_SHARE::get_share(
     const char* table_name,
@@ -207,6 +228,14 @@ TOKUDB_SHARE* TOKUDB_SHARE::get_share(
             &_open_tables,
             (uchar*)table_name,
             length);
+
+    TOKUDB_TRACE_FOR_FLAGS(
+        TOKUDB_DEBUG_SHARE,
+        "existing share[%s] %s:share[%p]",
+        table_name,
+        share == NULL ? "not found" : "found",
+        share);
+
     if (!share) {
         if (create_new == false)
             goto exit;
@@ -237,25 +266,41 @@ exit:
     return share;
 }
 void TOKUDB_SHARE::drop_share(TOKUDB_SHARE* share) {
+    TOKUDB_TRACE_FOR_FLAGS(
+        TOKUDB_DEBUG_SHARE,
+        "share[%p]:file[%s]:state[%s]:use_count[%d]",
+        share,
+        share->_full_table_name.ptr(),
+        get_state_string(share->_state),
+        share->_use_count);
+
     _open_tables_mutex.lock();
     my_hash_delete(&_open_tables, (uchar*)share);
     _open_tables_mutex.unlock();
 }
 TOKUDB_SHARE::share_state_t TOKUDB_SHARE::addref() {
+    TOKUDB_SHARE_TRACE_FOR_FLAGS((TOKUDB_DEBUG_ENTER & TOKUDB_DEBUG_SHARE),
+        "file[%s]:state[%s]:use_count[%d]",
+        _full_table_name.ptr(),
+        get_state_string(_state),
+        _use_count);
+
     lock();
     _use_count++;
-
-    DBUG_PRINT("info", ("0x%p share->_use_count %u", this, _use_count));
 
     return _state;
 }
 int TOKUDB_SHARE::release() {
+    TOKUDB_SHARE_DBUG_ENTER("file[%s]:state[%s]:use_count[%d]",
+        _full_table_name.ptr(),
+        get_state_string(_state),
+        _use_count);
+
     int error, result = 0;
 
     _mutex.lock();
     assert_always(_use_count != 0);
     _use_count--;
-    DBUG_PRINT("info", ("0x%p share->_use_count %u", this, _use_count));
     if (_use_count == 0 && _state == TOKUDB_SHARE::OPENED) {
         // number of open DB's may not be equal to number of keys we have
         // because add_index may have added some. So, we loop through entire
@@ -299,7 +344,7 @@ int TOKUDB_SHARE::release() {
     }
     _mutex.unlock();
 
-    return result;
+    TOKUDB_SHARE_DBUG_RETURN(result);
 }
 void TOKUDB_SHARE::update_row_count(
     THD* thd,
@@ -1901,6 +1946,7 @@ int ha_tokudb::open(const char *name, int mode, uint test_if_locked) {
         if (ret_val == 0) {
             share->set_state(TOKUDB_SHARE::OPENED);
         } else {
+            free_key_and_col_info(&share->kc_info);
             share->set_state(TOKUDB_SHARE::ERROR);
         }
         share->unlock();

--- a/storage/tokudb/tokudb_debug.h
+++ b/storage/tokudb/tokudb_debug.h
@@ -50,6 +50,7 @@ static void tokudb_backtrace(void);
 #define TOKUDB_DEBUG_UPSERT                 (1<<12)
 #define TOKUDB_DEBUG_CHECK                  (1<<13)
 #define TOKUDB_DEBUG_ANALYZE                (1<<14)
+#define TOKUDB_DEBUG_SHARE                  (1<<16)
 
 #define TOKUDB_TRACE(_fmt, ...) { \
     fprintf(stderr, "%u %s:%u %s " _fmt "\n", tokudb::thread::my_tid(), \
@@ -124,13 +125,67 @@ static void tokudb_backtrace(void);
     DBUG_RETURN(r); \
 }
 
-
 #define TOKUDB_HANDLER_DBUG_VOID_RETURN { \
     if (TOKUDB_UNLIKELY(tokudb::sysvars::debug & TOKUDB_DEBUG_RETURN)) { \
         TOKUDB_HANDLER_TRACE("return");       \
     } \
     DBUG_VOID_RETURN; \
 }
+
+#define TOKUDB_SHARE_TRACE(_fmt, ...) \
+    fprintf(stderr, "%u %p %s:%u TOUDB_SHARE::%s " _fmt "\n", \
+            tokudb::thread::my_tid(), this, __FILE__, __LINE__, \
+            __FUNCTION__, ##__VA_ARGS__);
+
+#define TOKUDB_SHARE_TRACE_FOR_FLAGS(_flags, _fmt, ...) { \
+    if (TOKUDB_UNLIKELY(TOKUDB_DEBUG_FLAGS(_flags))) { \
+        TOKUDB_SHARE_TRACE(_fmt, ##__VA_ARGS__); \
+    } \
+}
+
+#define TOKUDB_SHARE_DBUG_ENTER(_fmt, ...) { \
+    if (TOKUDB_UNLIKELY((tokudb::sysvars::debug & TOKUDB_DEBUG_ENTER) || \
+        (tokudb::sysvars::debug & TOKUDB_DEBUG_SHARE))) { \
+        TOKUDB_SHARE_TRACE(_fmt, ##__VA_ARGS__); \
+    } \
+} \
+    DBUG_ENTER(__FUNCTION__);
+
+#define TOKUDB_SHARE_DBUG_RETURN(r) { \
+    int rr = (r); \
+    if (TOKUDB_UNLIKELY((tokudb::sysvars::debug & TOKUDB_DEBUG_RETURN) || \
+        (tokudb::sysvars::debug & TOKUDB_DEBUG_SHARE) || \
+        (rr != 0 && (tokudb::sysvars::debug & TOKUDB_DEBUG_ERROR)))) { \
+        TOKUDB_SHARE_TRACE("return %d", rr); \
+    } \
+    DBUG_RETURN(rr); \
+}
+
+#define TOKUDB_SHARE_DBUG_RETURN_DOUBLE(r) { \
+    double rr = (r); \
+    if (TOKUDB_UNLIKELY((tokudb::sysvars::debug & TOKUDB_DEBUG_RETURN) || \
+        (tokudb::sysvars::debug & TOKUDB_DEBUG_SHARE))) { \
+        TOKUDB_SHARE_TRACE("return %f", rr); \
+    } \
+    DBUG_RETURN(rr); \
+}
+
+#define TOKUDB_SHARE_DBUG_RETURN_PTR(r) { \
+    if (TOKUDB_UNLIKELY((tokudb::sysvars::debug & TOKUDB_DEBUG_RETURN) || \
+        (tokudb::sysvars::debug & TOKUDB_DEBUG_SHARE))) { \
+        TOKUDB_SHARE_TRACE("return 0x%p", r); \
+    } \
+    DBUG_RETURN(r); \
+}
+
+#define TOKUDB_SHARE_DBUG_VOID_RETURN() { \
+    if (TOKUDB_UNLIKELY((tokudb::sysvars::debug & TOKUDB_DEBUG_RETURN) || \
+        (tokudb::sysvars::debug & TOKUDB_DEBUG_SHARE))) { \
+        TOKUDB_SHARE_TRACE("return");       \
+    } \
+    DBUG_VOID_RETURN; \
+}
+
 
 #define TOKUDB_DBUG_DUMP(s, p, len) \
 { \


### PR DESCRIPTION
…led in tokudb/ha_tokudb.cc:1441 initialize_col_pack_info
- Added new TOKUDB_DEBUG_SHARE (1<<16) debug flag and TOKUDB_SHARE_DBUG macros.
- Instrumented TOKUDB_SHARE functions.
- If there is any kind of error (like say some lock timeout) during the TOKUDB_SHARE initialization for a specific table after the key_and_column_info has been allocated, it is not freed and cleared as the TOKUDB_SHARE is released back. Then the next time it is attempted to be initialized, it asserts because it rightfully finds previous data where it expected none.
- Added call to release/clear allocated data if initialize_share fails.
