### PR TITLE
Fix bug 1534874 (Assertion `(old_mh->m_key == key) || (old_mh->m_key …

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9356,8 +9356,6 @@ PSI_memory_key key_memory_userstat_user_stats;
 PSI_memory_key key_memory_userstat_thread_stats;
 PSI_memory_key key_memory_userstat_client_stats;
 
-PSI_memory_key key_memory_per_query_vars;
-
 PSI_memory_key key_memory_thread_pool_connection;
 
 #ifdef HAVE_PSI_INTERFACE
@@ -9419,8 +9417,6 @@ static PSI_memory_info all_server_memory[]=
   { &key_memory_userstat_user_stats, "userstat_user_stats", 0},
   { &key_memory_userstat_thread_stats, "userstat_thread_stats", 0},
   { &key_memory_userstat_client_stats, "userstat_client_stats", 0},
-
-  { &key_memory_per_query_vars, "per_query_variables", 0},
 
   { &key_memory_thread_pool_connection, "thread_pool_connection", 0},
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -567,8 +567,6 @@ extern PSI_memory_key key_memory_userstat_user_stats;
 extern PSI_memory_key key_memory_userstat_thread_stats;
 extern PSI_memory_key key_memory_userstat_client_stats;
 
-extern PSI_memory_key key_memory_per_query_vars;
-
 extern PSI_memory_key key_memory_thread_pool_connection;
 
 extern PSI_memory_key key_memory_Sys_var_charptr_value;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -4166,14 +4166,14 @@ copy_system_variables(const struct system_variables *src,
   DBUG_ASSERT(src);
 
   dst= (struct system_variables *)
-    my_malloc(key_memory_per_query_vars, sizeof(struct system_variables),
+    my_malloc(key_memory_THD_variables, sizeof(struct system_variables),
               MYF(MY_WME | MY_FAE));
   *dst = *src;
 
   if (dst->dynamic_variables_ptr)
   {
     dst->dynamic_variables_ptr=
-      (char *)my_malloc(key_memory_per_query_vars, dst->dynamic_variables_size,
+      (char *)my_malloc(key_memory_THD_variables, dst->dynamic_variables_size,
                         MYF(MY_WME | MY_FAE));
     memcpy(dst->dynamic_variables_ptr,
            src->dynamic_variables_ptr,
@@ -4186,7 +4186,7 @@ copy_system_variables(const struct system_variables *src,
   {
     const char *src_value= (const char *)(i + 1);
     size_t src_length= strlen(src_value) + 1;
-    LIST *dst_el= (LIST *) my_malloc(key_memory_per_query_vars,
+    LIST *dst_el= (LIST *) my_malloc(key_memory_THD_variables,
                                      sizeof(LIST) + src_length,
                                      MYF(MY_WME | MY_FAE));
     memcpy(dst_el + 1, src_value, src_length);


### PR DESCRIPTION
…== 0)' failed in mysys/my_malloc.c:80)

The assert shows that a memory block was allocated with one PFS memory
key (key_memory_per_query_vars), and later reallocated with a
different one (key_memory_THD_variables). The fix is to remove the
key_memory_per_query_vars key completely, as its memory blocks are
interchangeable with key_memory_THD_variables ones, thus it's
incorrect to have a separate memory key.

No testcase as it requires a SET STATEMENT FOR, then expanding global
variables list significantly, then a session variable query.
Expanding global variable list would require e.g. installing more than
one plugin (one plugin, such as Example SE is not sufficient for
reliable reproduction). And installing more than one plugin is not
straightforward in MySQL Test Framework.

http://jenkins.percona.com/job/mysql-5.7-param/85/
