### PR TITLE
Fixed "tokudb.parts" MTR test suite.

### DIFF
--- a/mysql-test/suite/tokudb.parts/r/partition_alter1_1_2_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter1_1_2_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 
@@ -68,8 +70,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -246,6 +248,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -258,6 +262,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -560,8 +566,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -738,6 +744,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -750,6 +758,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1060,8 +1070,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -1245,6 +1255,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1257,6 +1269,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1565,8 +1579,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -1746,6 +1760,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1758,6 +1774,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2064,8 +2082,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -2245,6 +2263,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2257,6 +2277,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2567,8 +2589,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -2755,6 +2777,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2767,6 +2791,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3077,8 +3103,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -3267,6 +3293,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3279,6 +3307,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3585,8 +3615,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -3767,6 +3797,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3779,6 +3811,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4082,8 +4116,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4260,6 +4294,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4272,6 +4308,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4574,8 +4612,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4752,6 +4790,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4764,6 +4804,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5074,8 +5116,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5259,6 +5301,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5271,6 +5315,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5579,8 +5625,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5760,6 +5806,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5772,6 +5820,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6078,8 +6128,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6259,6 +6309,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6271,6 +6323,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6581,8 +6635,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6769,6 +6823,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6781,6 +6837,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7091,8 +7149,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7281,6 +7339,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7293,6 +7353,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7599,8 +7661,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7781,6 +7843,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7793,6 +7857,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8291,6 +8357,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8303,6 +8371,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8799,6 +8869,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8811,6 +8883,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9322,6 +9396,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9334,6 +9410,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9839,6 +9917,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9851,6 +9931,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10354,6 +10436,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10366,6 +10450,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10880,6 +10966,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10892,6 +10980,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11408,6 +11498,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11420,6 +11512,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11924,6 +12018,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11936,6 +12032,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12433,6 +12531,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12445,6 +12545,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12941,6 +13043,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12953,6 +13057,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13464,6 +13570,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13476,6 +13584,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13981,6 +14091,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13993,6 +14105,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14496,6 +14610,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14508,6 +14624,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15022,6 +15140,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15034,6 +15154,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15550,6 +15672,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15562,6 +15686,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16066,6 +16192,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16078,6 +16206,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16382,8 +16512,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -16561,6 +16691,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16573,6 +16705,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16875,8 +17009,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -17054,6 +17188,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17066,6 +17202,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17376,8 +17514,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -17562,6 +17700,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17574,6 +17714,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17882,8 +18024,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -18064,6 +18206,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18076,6 +18220,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18382,8 +18528,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -18564,6 +18710,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18576,6 +18724,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18886,8 +19036,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -19075,6 +19225,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19087,6 +19239,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19397,8 +19551,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -19588,6 +19742,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19600,6 +19756,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19906,8 +20064,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -20089,6 +20247,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -20101,6 +20261,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -20404,8 +20566,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -20583,6 +20745,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -20595,6 +20759,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -20897,8 +21063,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -21076,6 +21242,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -21088,6 +21256,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -21398,8 +21568,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -21584,6 +21754,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -21596,6 +21768,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -21904,8 +22078,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -22086,6 +22260,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -22098,6 +22274,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -22404,8 +22582,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -22586,6 +22764,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -22598,6 +22778,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -22908,8 +23090,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -23097,6 +23279,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -23109,6 +23293,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -23419,8 +23605,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -23610,6 +23796,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -23622,6 +23810,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -23928,8 +24118,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -24111,6 +24301,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -24123,6 +24315,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -24426,8 +24620,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -24605,6 +24799,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -24617,6 +24813,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -24919,8 +25117,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -25098,6 +25296,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -25110,6 +25310,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -25420,8 +25622,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -25606,6 +25808,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -25618,6 +25822,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -25926,8 +26132,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -26108,6 +26314,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -26120,6 +26328,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -26426,8 +26636,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -26608,6 +26818,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -26620,6 +26832,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -26930,8 +27144,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -27119,6 +27333,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -27131,6 +27347,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -27441,8 +27659,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -27632,6 +27850,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -27644,6 +27864,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -27950,8 +28172,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -28133,6 +28355,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -28145,6 +28369,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;

--- a/mysql-test/suite/tokudb.parts/r/partition_alter1_1_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter1_1_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 
@@ -386,8 +388,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -564,6 +566,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -576,6 +580,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -878,8 +884,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -1056,6 +1062,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1068,6 +1076,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1378,8 +1388,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -1563,6 +1573,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1575,6 +1587,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1883,8 +1897,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -2064,6 +2078,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2076,6 +2092,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2382,8 +2400,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -2565,6 +2583,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2577,6 +2597,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2887,8 +2909,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -3075,6 +3097,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3087,6 +3111,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3397,8 +3423,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -3587,6 +3613,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3599,6 +3627,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3905,8 +3935,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4087,6 +4117,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4099,6 +4131,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4402,8 +4436,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4580,6 +4614,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4592,6 +4628,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4894,8 +4932,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5072,6 +5110,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5084,6 +5124,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5394,8 +5436,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5579,6 +5621,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5591,6 +5635,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5899,8 +5945,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6080,6 +6126,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6092,6 +6140,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6398,8 +6448,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6581,6 +6631,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6593,6 +6645,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6903,8 +6957,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7091,6 +7145,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7103,6 +7159,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7413,8 +7471,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7603,6 +7661,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7615,6 +7675,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7921,8 +7983,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8103,6 +8165,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8115,6 +8179,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8613,6 +8679,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8625,6 +8693,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9121,6 +9191,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9133,6 +9205,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9644,6 +9718,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9656,6 +9732,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10161,6 +10239,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10173,6 +10253,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10678,6 +10760,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10690,6 +10774,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11204,6 +11290,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11216,6 +11304,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11732,6 +11822,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11744,6 +11836,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12248,6 +12342,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12260,6 +12356,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12757,6 +12855,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12769,6 +12869,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13265,6 +13367,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13277,6 +13381,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13788,6 +13894,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13800,6 +13908,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14305,6 +14415,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14317,6 +14429,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14822,6 +14936,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14834,6 +14950,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15348,6 +15466,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15360,6 +15480,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15876,6 +15998,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15888,6 +16012,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16392,6 +16518,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16404,6 +16532,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;

--- a/mysql-test/suite/tokudb.parts/r/partition_alter1_2_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter1_2_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 
@@ -67,8 +69,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -193,6 +195,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -205,6 +209,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -507,8 +513,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -633,6 +639,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -645,6 +653,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -955,8 +965,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -1088,6 +1098,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1100,6 +1112,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1408,8 +1422,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -1537,6 +1551,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1549,6 +1565,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1855,8 +1873,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -1986,6 +2004,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1998,6 +2018,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2308,8 +2330,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -2444,6 +2466,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2456,6 +2480,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2766,8 +2792,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -2904,6 +2930,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2916,6 +2944,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3222,8 +3252,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -3352,6 +3382,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3364,6 +3396,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3667,8 +3701,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -3793,6 +3827,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3805,6 +3841,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4107,8 +4145,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -4233,6 +4271,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4245,6 +4285,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4555,8 +4597,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -4688,6 +4730,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4700,6 +4744,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5008,8 +5054,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -5137,6 +5183,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5149,6 +5197,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5455,8 +5505,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -5586,6 +5636,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5598,6 +5650,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5908,8 +5962,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -6044,6 +6098,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6056,6 +6112,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6366,8 +6424,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -6504,6 +6562,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6516,6 +6576,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6822,8 +6884,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -6952,6 +7014,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6964,6 +7028,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7409,6 +7475,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7421,6 +7489,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7865,6 +7935,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7877,6 +7949,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8336,6 +8410,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8348,6 +8424,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8801,6 +8879,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8813,6 +8893,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9266,6 +9348,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9278,6 +9362,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9740,6 +9826,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9752,6 +9840,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10216,6 +10306,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10228,6 +10320,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10680,6 +10774,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10692,6 +10788,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10999,8 +11097,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -11125,6 +11223,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11137,6 +11237,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11439,8 +11541,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -11565,6 +11667,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11577,6 +11681,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11887,8 +11993,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -12020,6 +12126,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12032,6 +12140,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12340,8 +12450,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -12469,6 +12579,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12481,6 +12593,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12787,8 +12901,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -12916,6 +13030,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12928,6 +13044,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13238,8 +13356,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -13374,6 +13492,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13386,6 +13506,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13696,8 +13818,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -13834,6 +13956,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13846,6 +13970,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14152,8 +14278,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -14282,6 +14408,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14294,6 +14422,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14597,8 +14727,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -14723,6 +14853,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14735,6 +14867,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15037,8 +15171,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -15163,6 +15297,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15175,6 +15311,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15485,8 +15623,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -15618,6 +15756,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15630,6 +15770,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15938,8 +16080,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -16067,6 +16209,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16079,6 +16223,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16385,8 +16531,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -16514,6 +16660,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16526,6 +16674,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16836,8 +16986,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -16972,6 +17122,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16984,6 +17136,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17294,8 +17448,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -17432,6 +17586,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17444,6 +17600,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17750,8 +17908,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -17880,6 +18038,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17892,6 +18052,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18338,6 +18500,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18350,6 +18514,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18794,6 +18960,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18806,6 +18974,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19265,6 +19435,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19277,6 +19449,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19730,6 +19904,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19742,6 +19918,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -20193,6 +20371,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -20205,6 +20385,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -20667,6 +20849,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -20679,6 +20863,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -21143,6 +21329,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -21155,6 +21343,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -21607,6 +21797,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -21619,6 +21811,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -22064,6 +22258,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -22076,6 +22272,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -22520,6 +22718,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -22532,6 +22732,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -22991,6 +23193,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -23003,6 +23207,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -23456,6 +23662,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -23468,6 +23676,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -23919,6 +24129,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -23931,6 +24143,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -24393,6 +24607,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -24405,6 +24621,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -24869,6 +25087,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -24881,6 +25101,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -25333,6 +25555,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -25345,6 +25569,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -25649,8 +25875,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -25775,6 +26001,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -25787,6 +26015,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -26089,8 +26319,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -26215,6 +26445,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -26227,6 +26459,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -26537,8 +26771,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -26670,6 +26904,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -26682,6 +26918,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -26990,8 +27228,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -27119,6 +27357,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -27131,6 +27371,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -27437,8 +27679,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -27566,6 +27808,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -27578,6 +27822,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -27888,8 +28134,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -28024,6 +28270,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -28036,6 +28284,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -28346,8 +28596,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -28484,6 +28734,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -28496,6 +28748,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -28802,8 +29056,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -28932,6 +29186,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -28944,6 +29200,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -29247,8 +29505,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -29373,6 +29631,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -29385,6 +29645,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -29687,8 +29949,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -29813,6 +30075,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -29825,6 +30089,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -30135,8 +30401,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -30268,6 +30534,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -30280,6 +30548,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -30588,8 +30858,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -30717,6 +30987,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -30729,6 +31001,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -31035,8 +31309,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -31164,6 +31438,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -31176,6 +31452,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -31486,8 +31764,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -31622,6 +31900,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -31634,6 +31914,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -31944,8 +32226,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -32082,6 +32364,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -32094,6 +32378,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -32400,8 +32686,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL
@@ -32530,6 +32816,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -32542,6 +32830,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -32987,6 +33277,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -32999,6 +33291,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -33443,6 +33737,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -33455,6 +33751,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -33914,6 +34212,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -33926,6 +34226,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -34379,6 +34681,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -34391,6 +34695,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -34842,6 +35148,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -34854,6 +35162,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -35316,6 +35626,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -35328,6 +35640,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -35792,6 +36106,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -35804,6 +36120,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -36256,6 +36574,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -36268,6 +36588,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -36548,6 +36870,176 @@ TRUNCATE t1;
 # check TRUNCATE success: 	1
 # check layout success:    1
 # End usability test (inc/partition_check.inc)
+DROP TABLE t1;
+
+#========================================================================
+#  3.    ALTER TABLE "ALTER"(DROP + ADD) PRIMARY KEY
+#        mleich: I think that an ALTER TABLE statement where a PRIMARY
+#            KEY is dropped and recreated (with different layout) might
+#            be of interest, if the tree containing the table data has
+#            to be reorganized during this operation.
+#========================================================================
+#------------------------------------------------------------------------
+#  3.1   Partitioning function uses the PRIMARY/UNIQUE KEY
+#------------------------------------------------------------------------
+#  3.1.1 DROP and CREATE PRIMARY KEY on different column
+DROP TABLE IF EXISTS t1;
+#----------- PARTITION BY KEY
+CREATE TABLE t1 (
+f_int1 INTEGER NOT NULL,
+f_int2 INTEGER NOT NULL,
+f_char1 CHAR(20),
+f_char2 CHAR(20),
+f_charbig VARCHAR(1000)
+, PRIMARY KEY(f_int1)
+)
+PARTITION BY KEY() PARTITIONS 5;
+INSERT INTO t1(f_int1, f_int2) values(100, 200);
+INSERT INTO t1(f_int1, f_int2) values(200, 300);
+INSERT INTO t1(f_int1, f_int2) values(300, 400);
+INSERT INTO t1(f_int1, f_int2) values(400, 500);
+INSERT INTO t1(f_int1, f_int2) values(500, 100);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+Execute ALTER: Expect Success
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(f_int2, f_int1);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
+  `f_char1` char(20) DEFAULT NULL,
+  `f_char2` char(20) DEFAULT NULL,
+  `f_charbig` varchar(1000) DEFAULT NULL,
+  PRIMARY KEY (`f_int2`,`f_int1`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1
+/*!50100 PARTITION BY KEY ()
+PARTITIONS 5 */
+DROP TABLE t1;
+#  3.1.2 Negative test: Try DROP and CREATE PRIMARY KEY INPLACE
+# Expect error for INPLACE ALTER
+DROP TABLE IF EXISTS t1;
+#----------- PARTITION BY KEY
+CREATE TABLE t1 (
+f_int1 INTEGER NOT NULL,
+f_int2 INTEGER NOT NULL,
+f_char1 CHAR(20),
+f_char2 CHAR(20),
+f_charbig VARCHAR(1000)
+, PRIMARY KEY(f_int1)
+)
+PARTITION BY KEY() PARTITIONS 5;
+INSERT INTO t1(f_int1, f_int2) values(100, 200);
+INSERT INTO t1(f_int1, f_int2) values(200, 300);
+INSERT INTO t1(f_int1, f_int2) values(300, 400);
+INSERT INTO t1(f_int1, f_int2) values(400, 500);
+INSERT INTO t1(f_int1, f_int2) values(500, 100);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+Execute ALTER: Expect Error 1845
+ALTER TABLE t1 DROP PRIMARY KEY, ADD PRIMARY KEY(f_int2, f_int1),
+ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
+  `f_char1` char(20) DEFAULT NULL,
+  `f_char2` char(20) DEFAULT NULL,
+  `f_charbig` varchar(1000) DEFAULT NULL,
+  PRIMARY KEY (`f_int1`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1
+/*!50100 PARTITION BY KEY ()
+PARTITIONS 5 */
+DROP TABLE t1;
+#  3.1.3 DROP and CREATE UNIQUE KEY on different column
+DROP TABLE IF EXISTS t1;
+#----------- PARTITION BY KEY
+CREATE TABLE t1 (
+f_int1 INTEGER NOT NULL,
+f_int2 INTEGER NOT NULL,
+f_char1 CHAR(20),
+f_char2 CHAR(20),
+f_charbig VARCHAR(1000)
+, UNIQUE KEY ukey1(f_int1)
+)
+PARTITION BY KEY() PARTITIONS 5;
+INSERT INTO t1(f_int1, f_int2) values(100, 200);
+INSERT INTO t1(f_int1, f_int2) values(200, 300);
+INSERT INTO t1(f_int1, f_int2) values(300, 400);
+INSERT INTO t1(f_int1, f_int2) values(400, 500);
+INSERT INTO t1(f_int1, f_int2) values(500, 100);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+Execute ALTER: Expect Success
+ALTER TABLE t1 DROP KEY ukey1, ADD UNIQUE KEY
+ukey2(f_int2, f_int1);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
+  `f_char1` char(20) DEFAULT NULL,
+  `f_char2` char(20) DEFAULT NULL,
+  `f_charbig` varchar(1000) DEFAULT NULL,
+  UNIQUE KEY `ukey2` (`f_int2`,`f_int1`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1
+/*!50100 PARTITION BY KEY ()
+PARTITIONS 5 */
+DROP TABLE t1;
+#  3.1.4 Negative test: Try DROP and CREATE UNIQUE KEY INPLACE
+# Expect error for INPLACE ALTER
+DROP TABLE IF EXISTS t1;
+#----------- PARTITION BY KEY
+CREATE TABLE t1 (
+f_int1 INTEGER NOT NULL,
+f_int2 INTEGER NOT NULL,
+f_char1 CHAR(20),
+f_char2 CHAR(20),
+f_charbig VARCHAR(1000)
+, UNIQUE KEY ukey1(f_int1)
+)
+PARTITION BY KEY() PARTITIONS 5;
+INSERT INTO t1(f_int1, f_int2) values(100, 200);
+INSERT INTO t1(f_int1, f_int2) values(200, 300);
+INSERT INTO t1(f_int1, f_int2) values(300, 400);
+INSERT INTO t1(f_int1, f_int2) values(400, 500);
+INSERT INTO t1(f_int1, f_int2) values(500, 100);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+Execute ALTER: Expect Error 1845
+ALTER TABLE t1 DROP KEY ukey1, ADD UNIQUE KEY
+ukey2(f_int2, f_int1), ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
+  `f_char1` char(20) DEFAULT NULL,
+  `f_char2` char(20) DEFAULT NULL,
+  `f_charbig` varchar(1000) DEFAULT NULL,
+  UNIQUE KEY `ukey1` (`f_int1`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1
+/*!50100 PARTITION BY KEY ()
+PARTITIONS 5 */
 DROP TABLE t1;
 DROP VIEW  IF EXISTS v1;
 DROP TABLE IF EXISTS t1;

--- a/mysql-test/suite/tokudb.parts/r/partition_alter2_1_1_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter2_1_1_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 
@@ -210,6 +212,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -222,6 +226,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -666,6 +672,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -678,6 +686,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1137,6 +1147,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1149,6 +1161,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1602,6 +1616,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1614,6 +1630,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2067,6 +2085,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2079,6 +2099,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2541,6 +2563,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2553,6 +2577,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3017,6 +3043,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3029,6 +3057,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3481,6 +3511,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3493,6 +3525,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3797,8 +3831,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -3975,6 +4009,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3987,6 +4023,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4289,8 +4327,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4467,6 +4505,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4479,6 +4519,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4789,8 +4831,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4974,6 +5016,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4986,6 +5030,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5294,8 +5340,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5475,6 +5521,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5487,6 +5535,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5793,8 +5843,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5976,6 +6026,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5988,6 +6040,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6298,8 +6352,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6486,6 +6540,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6498,6 +6554,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6808,8 +6866,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6998,6 +7056,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7010,6 +7070,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7316,8 +7378,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7498,6 +7560,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7510,6 +7574,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7813,8 +7879,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7991,6 +8057,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8003,6 +8071,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8305,8 +8375,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8483,6 +8553,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8495,6 +8567,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8805,8 +8879,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8990,6 +9064,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9002,6 +9078,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9310,8 +9388,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9491,6 +9569,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9503,6 +9583,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9809,8 +9891,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9992,6 +10074,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10004,6 +10088,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10314,8 +10400,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10502,6 +10588,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10514,6 +10602,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10824,8 +10914,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11014,6 +11104,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11026,6 +11118,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11332,8 +11426,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11514,6 +11608,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11526,6 +11622,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12024,6 +12122,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12036,6 +12136,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12532,6 +12634,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12544,6 +12648,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13055,6 +13161,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13067,6 +13175,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13572,6 +13682,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13584,6 +13696,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14089,6 +14203,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14101,6 +14217,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14615,6 +14733,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14627,6 +14747,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15143,6 +15265,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15155,6 +15279,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15659,6 +15785,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15671,6 +15799,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16168,6 +16298,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16180,6 +16312,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16676,6 +16810,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16688,6 +16824,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17199,6 +17337,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17211,6 +17351,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17716,6 +17858,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17728,6 +17872,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18233,6 +18379,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18245,6 +18393,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18759,6 +18909,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18771,6 +18923,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19287,6 +19441,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19299,6 +19455,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19803,6 +19961,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19815,6 +19975,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;

--- a/mysql-test/suite/tokudb.parts/r/partition_alter2_1_2_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter2_1_2_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 #------------------------------------------------------------------------
@@ -206,6 +208,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -218,6 +222,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -662,6 +668,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -674,6 +682,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1133,6 +1143,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1145,6 +1157,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1598,6 +1612,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1610,6 +1626,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2061,6 +2079,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2073,6 +2093,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2535,6 +2557,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2547,6 +2571,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3011,6 +3037,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3023,6 +3051,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3475,6 +3505,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3487,6 +3519,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3791,8 +3825,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -3969,6 +4003,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3981,6 +4017,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4283,8 +4321,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4461,6 +4499,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4473,6 +4513,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4783,8 +4825,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4968,6 +5010,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4980,6 +5024,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5288,8 +5334,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5469,6 +5515,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5481,6 +5529,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5787,8 +5837,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5968,6 +6018,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5980,6 +6032,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6290,8 +6344,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6478,6 +6532,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6490,6 +6546,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6800,8 +6858,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6990,6 +7048,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7002,6 +7062,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7308,8 +7370,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7490,6 +7552,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7502,6 +7566,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7805,8 +7871,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7983,6 +8049,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7995,6 +8063,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8297,8 +8367,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8475,6 +8545,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8487,6 +8559,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8797,8 +8871,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8982,6 +9056,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8994,6 +9070,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9302,8 +9380,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9483,6 +9561,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9495,6 +9575,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9801,8 +9883,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9982,6 +10064,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9994,6 +10078,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10304,8 +10390,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10492,6 +10578,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10504,6 +10592,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10814,8 +10904,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11004,6 +11094,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11016,6 +11108,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11322,8 +11416,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` bigint(20) NOT NULL DEFAULT '0',
-  `f_int2` bigint(20) NOT NULL DEFAULT '0',
+  `f_int1` bigint(20) NOT NULL,
+  `f_int2` bigint(20) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11504,6 +11598,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11516,6 +11612,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12014,6 +12112,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12026,6 +12126,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12522,6 +12624,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12534,6 +12638,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13045,6 +13151,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13057,6 +13165,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13562,6 +13672,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13574,6 +13686,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14077,6 +14191,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14089,6 +14205,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14603,6 +14721,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14615,6 +14735,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15131,6 +15253,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15143,6 +15267,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15647,6 +15773,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15659,6 +15787,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16156,6 +16286,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16168,6 +16300,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16664,6 +16798,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16676,6 +16812,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17187,6 +17325,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17199,6 +17339,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17704,6 +17846,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17716,6 +17860,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18219,6 +18365,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18231,6 +18379,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18745,6 +18895,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18757,6 +18909,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19273,6 +19427,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19285,6 +19441,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19789,6 +19947,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19801,6 +19961,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;

--- a/mysql-test/suite/tokudb.parts/r/partition_alter2_2_1_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter2_2_1_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 
@@ -212,6 +214,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -224,6 +228,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -670,6 +676,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -682,6 +690,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1143,6 +1153,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1155,6 +1167,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1608,6 +1622,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1620,6 +1636,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2075,6 +2093,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2087,6 +2107,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2549,6 +2571,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2561,6 +2585,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3027,6 +3053,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3039,6 +3067,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3493,6 +3523,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3505,6 +3537,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3808,8 +3842,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -3988,6 +4022,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4000,6 +4036,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4302,8 +4340,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4482,6 +4520,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4494,6 +4534,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4804,8 +4846,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4991,6 +5033,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5003,6 +5047,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5311,8 +5357,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5492,6 +5538,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5504,6 +5552,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5810,8 +5860,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5995,6 +6045,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6007,6 +6059,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6317,8 +6371,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6505,6 +6559,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6517,6 +6573,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6827,8 +6885,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7019,6 +7077,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7031,6 +7091,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7337,8 +7399,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7521,6 +7583,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7533,6 +7597,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7836,8 +7902,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8016,6 +8082,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8028,6 +8096,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8330,8 +8400,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8510,6 +8580,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8522,6 +8594,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8832,8 +8906,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9019,6 +9093,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9031,6 +9107,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9339,8 +9417,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9520,6 +9598,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9532,6 +9612,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9838,8 +9920,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10023,6 +10105,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10035,6 +10119,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10345,8 +10431,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10533,6 +10619,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10545,6 +10633,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10855,8 +10945,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11047,6 +11137,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11059,6 +11151,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11365,8 +11459,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11549,6 +11643,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11561,6 +11657,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12061,6 +12159,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12073,6 +12173,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12571,6 +12673,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12583,6 +12687,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13096,6 +13202,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13108,6 +13216,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13613,6 +13723,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13625,6 +13737,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14132,6 +14246,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14144,6 +14260,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14658,6 +14776,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14670,6 +14790,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15188,6 +15310,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15200,6 +15324,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15706,6 +15832,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15718,6 +15846,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16217,6 +16347,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16229,6 +16361,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16727,6 +16861,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16739,6 +16875,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17252,6 +17390,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17264,6 +17404,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17769,6 +17911,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17781,6 +17925,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18288,6 +18434,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18300,6 +18448,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18814,6 +18964,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18826,6 +18978,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19344,6 +19498,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19356,6 +19512,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19862,6 +20020,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19874,6 +20034,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;

--- a/mysql-test/suite/tokudb.parts/r/partition_alter2_2_2_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter2_2_2_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 #------------------------------------------------------------------------
@@ -208,6 +210,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -220,6 +224,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -667,6 +673,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -679,6 +687,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1141,6 +1151,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1153,6 +1165,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1611,6 +1625,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1623,6 +1639,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2079,6 +2097,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2091,6 +2111,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2558,6 +2580,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2570,6 +2594,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3037,6 +3063,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3049,6 +3077,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3504,6 +3534,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3516,6 +3548,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3820,8 +3854,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4001,6 +4035,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4013,6 +4049,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4315,8 +4353,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -4496,6 +4534,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4508,6 +4548,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4818,8 +4860,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5006,6 +5048,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5018,6 +5062,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5326,8 +5372,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -5512,6 +5558,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5524,6 +5572,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5830,8 +5880,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6016,6 +6066,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6028,6 +6080,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6338,8 +6392,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -6531,6 +6585,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6543,6 +6599,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6853,8 +6911,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7046,6 +7104,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7058,6 +7118,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7364,8 +7426,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7549,6 +7611,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7561,6 +7625,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7864,8 +7930,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8045,6 +8111,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8057,6 +8125,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8359,8 +8429,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8540,6 +8610,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8552,6 +8624,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8862,8 +8936,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9050,6 +9124,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9062,6 +9138,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9370,8 +9448,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9556,6 +9634,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9568,6 +9648,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9874,8 +9956,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10060,6 +10142,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10072,6 +10156,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10382,8 +10468,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10575,6 +10661,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10587,6 +10675,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10897,8 +10987,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11090,6 +11180,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11102,6 +11194,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11408,8 +11502,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` mediumint(9) NOT NULL DEFAULT '0',
-  `f_int2` mediumint(9) NOT NULL DEFAULT '0',
+  `f_int1` mediumint(9) NOT NULL,
+  `f_int2` mediumint(9) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11593,6 +11687,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11605,6 +11701,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12106,6 +12204,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12118,6 +12218,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12617,6 +12719,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12629,6 +12733,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13143,6 +13249,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13155,6 +13263,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13665,6 +13775,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13677,6 +13789,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14185,6 +14299,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14197,6 +14313,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14716,6 +14834,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14728,6 +14848,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15247,6 +15369,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15259,6 +15383,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15766,6 +15892,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15778,6 +15906,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16278,6 +16408,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16290,6 +16422,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16789,6 +16923,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16801,6 +16937,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17315,6 +17453,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17327,6 +17467,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17837,6 +17979,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17849,6 +17993,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18357,6 +18503,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18369,6 +18517,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18888,6 +19038,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18900,6 +19052,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19419,6 +19573,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19431,6 +19587,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19938,6 +20096,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19950,6 +20110,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;

--- a/mysql-test/suite/tokudb.parts/r/partition_alter3_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter3_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 
@@ -58,8 +60,11 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -81,8 +86,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -99,8 +107,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -115,8 +126,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -140,8 +154,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	part1	ALL	NULL	NULL	NULL	NULL	7	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	part1	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -164,8 +181,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	5	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -189,8 +209,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	3	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -225,8 +248,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p6	ALL	NULL	NULL	NULL	NULL	3	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p6	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -247,8 +273,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p4	ALL	NULL	NULL	NULL	NULL	4	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p4	ALL	NULL	NULL	NULL	NULL	4	25.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -268,8 +297,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	4	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	4	25.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -288,8 +320,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	5	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -307,8 +342,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	part1	ALL	NULL	NULL	NULL	NULL	7	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	part1	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -325,8 +363,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	10	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	10	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -342,8 +383,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -360,8 +404,11 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (`test`.`t1`.`f_date` = '1000-02-10')
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -400,8 +447,11 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -424,8 +474,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -452,8 +505,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	7	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -476,8 +532,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	5	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -504,8 +563,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p6	ALL	NULL	NULL	NULL	NULL	3	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p6	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -538,8 +600,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	4	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	4	25.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -563,8 +628,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	3	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -587,8 +655,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p4	ALL	NULL	NULL	NULL	NULL	10	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p4	ALL	NULL	NULL	NULL	NULL	10	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -610,8 +681,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	5	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -632,8 +706,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	7	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -653,8 +730,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	10	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	10	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -673,8 +753,11 @@ t1	CREATE TABLE `t1` (
 t1.frm
 t1.par
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1
@@ -694,8 +777,11 @@ t1	CREATE TABLE `t1` (
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
-id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	Using where
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
+Warnings:
+Warning	1681	'PARTITIONS' is deprecated and will be removed in a future release.
+Note	1003	/* select#1 */ select (count(0) <> 1) AS `COUNT(*) <> 1` from `test`.`t1` where (`test`.`t1`.`f_int1` = 3)
 # check read single success: 1
 # check read all success: 1
 # check read row by row success: 1

--- a/mysql-test/suite/tokudb.parts/r/partition_basic_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_basic_tokudb.result
@@ -35,6 +35,8 @@ f_charbig VARCHAR(1000) )
 ENGINE = MEMORY;
 SET AUTOCOMMIT= 1;
 SET @@session.sql_mode= '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 # End of basic preparations needed for all tests
 #-----------------------------------------------
 
@@ -213,6 +215,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -225,6 +229,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -668,6 +674,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -680,6 +688,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1138,6 +1148,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1150,6 +1162,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -1602,6 +1616,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -1614,6 +1630,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2066,6 +2084,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2078,6 +2098,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -2539,6 +2561,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -2551,6 +2575,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3018,6 +3044,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3030,6 +3058,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3481,6 +3511,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3493,6 +3525,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -3938,6 +3972,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -3950,6 +3986,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4393,6 +4431,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4405,6 +4445,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -4863,6 +4905,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -4875,6 +4919,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5327,6 +5373,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5339,6 +5387,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -5789,6 +5839,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -5801,6 +5853,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6262,6 +6316,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6274,6 +6330,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -6737,6 +6795,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -6749,6 +6809,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7200,6 +7262,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7212,6 +7276,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -7515,8 +7581,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -7698,6 +7764,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -7710,6 +7778,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8007,8 +8077,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8190,6 +8260,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8202,6 +8274,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -8507,8 +8581,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -8697,6 +8771,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -8709,6 +8785,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9012,8 +9090,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9198,6 +9276,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9210,6 +9290,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -9511,8 +9593,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -9699,6 +9781,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -9711,6 +9795,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10016,8 +10102,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10209,6 +10295,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10221,6 +10309,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -10530,8 +10620,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -10725,6 +10815,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -10737,6 +10829,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11038,8 +11132,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11225,6 +11319,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11237,6 +11333,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -11535,8 +11633,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -11718,6 +11816,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -11730,6 +11830,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12027,8 +12129,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -12210,6 +12312,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12222,6 +12326,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -12527,8 +12633,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -12717,6 +12823,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -12729,6 +12837,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13032,8 +13142,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -13218,6 +13328,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13230,6 +13342,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -13531,8 +13645,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -13719,6 +13833,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -13731,6 +13847,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14036,8 +14154,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -14229,6 +14347,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14241,6 +14361,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -14550,8 +14672,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -14745,6 +14867,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -14757,6 +14881,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15058,8 +15184,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -15245,6 +15371,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15257,6 +15385,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -15754,6 +15884,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -15766,6 +15898,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16262,6 +16396,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16274,6 +16410,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -16785,6 +16923,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -16797,6 +16937,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17302,6 +17444,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17314,6 +17458,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -17819,6 +17965,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -17831,6 +17979,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18345,6 +18495,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18357,6 +18509,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -18877,6 +19031,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -18889,6 +19045,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19393,6 +19551,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19405,6 +19565,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -19708,8 +19870,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -19891,6 +20053,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -19903,6 +20067,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -20200,8 +20366,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -20383,6 +20549,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -20395,6 +20563,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -20700,8 +20870,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -20890,6 +21060,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -20902,6 +21074,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -21205,8 +21379,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -21391,6 +21565,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -21403,6 +21579,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -21704,8 +21882,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -21890,6 +22068,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -21902,6 +22082,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -22207,8 +22389,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -22400,6 +22582,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -22412,6 +22596,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -22717,8 +22903,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -22912,6 +23098,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -22924,6 +23112,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -23225,8 +23415,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -23412,6 +23602,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -23424,6 +23616,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -23722,8 +23916,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -23905,6 +24099,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -23917,6 +24113,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -24214,8 +24412,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -24397,6 +24595,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -24409,6 +24609,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -24714,8 +24916,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -24904,6 +25106,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -24916,6 +25120,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -25219,8 +25425,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -25405,6 +25611,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -25417,6 +25625,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -25718,8 +25928,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -25904,6 +26114,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -25916,6 +26128,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -26221,8 +26435,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -26414,6 +26628,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -26426,6 +26642,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -26731,8 +26949,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -26926,6 +27144,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -26938,6 +27158,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -27239,8 +27461,8 @@ create_command
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `f_int1` int(11) NOT NULL DEFAULT '0',
-  `f_int2` int(11) NOT NULL DEFAULT '0',
+  `f_int1` int(11) NOT NULL,
+  `f_int2` int(11) NOT NULL,
   `f_char1` char(20) DEFAULT NULL,
   `f_char2` char(20) DEFAULT NULL,
   `f_charbig` varchar(1000) DEFAULT NULL,
@@ -27426,6 +27648,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -27438,6 +27662,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -27935,6 +28161,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -27947,6 +28175,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -28443,6 +28673,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -28455,6 +28687,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -28966,6 +29200,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -28978,6 +29214,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -29483,6 +29721,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -29495,6 +29735,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -29998,6 +30240,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -30010,6 +30254,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -30524,6 +30770,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -30536,6 +30784,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -31052,6 +31302,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -31064,6 +31316,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
@@ -31568,6 +31822,8 @@ COMMIT;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;
 SET @@session.sql_mode = 'traditional';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SELECT @max_row_div2 + @max_row_div4 - @max_row_div4 + 1 INTO @exp_inserted_rows;
 INSERT INTO t1 (f_int1, f_int2, f_char1, f_char2, f_charbig)
 SELECT IF(f_int1 = @max_row_div2,f_int1 / 0,f_int1),f_int1,
@@ -31580,6 +31836,8 @@ COMMIT;
 # INFO: Storage engine used for t1 seems to be able to revert
 #       changes made by the failing statement.
 SET @@session.sql_mode = '';
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
 SET AUTOCOMMIT= 1;
 DELETE FROM t1 WHERE f_charbig = 'was inserted';
 COMMIT WORK;

--- a/mysql-test/suite/tokudb.parts/r/partition_debug_sync_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_debug_sync_tokudb.result
@@ -64,7 +64,7 @@ WHERE TABLE_NAME = 't1' AND TABLE_SCHEMA = 'test';
 SET DEBUG_SYNC = 'now WAIT_FOR parked';
 # When waiting for the name lock in get_all_tables in sql_show.cc
 # this will not be concurrent any more, thus the TIMEOUT
-SET DEBUG_SYNC = 'before_rename_partitions SIGNAL open WAIT_FOR alter TIMEOUT 1';
+SET DEBUG_SYNC = 'before_handle_alter_part_end SIGNAL open WAIT_FOR alter TIMEOUT 1';
 # Needs to be executed twice, since first is this 'SET DEBUG_SYNC ...'
 SET DEBUG_SYNC = 'before_close_thread_tables SIGNAL finish EXECUTE 2';
 ALTER TABLE t1 REORGANIZE PARTITION p0 INTO

--- a/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb.test
@@ -71,7 +71,7 @@ connect (con1, localhost, root,,);
 SET DEBUG_SYNC = 'now WAIT_FOR parked';
 --echo # When waiting for the name lock in get_all_tables in sql_show.cc
 --echo # this will not be concurrent any more, thus the TIMEOUT
-SET DEBUG_SYNC = 'before_rename_partitions SIGNAL open WAIT_FOR alter TIMEOUT 1';
+SET DEBUG_SYNC = 'before_handle_alter_part_end SIGNAL open WAIT_FOR alter TIMEOUT 1';
 --echo # Needs to be executed twice, since first is this 'SET DEBUG_SYNC ...'
 SET DEBUG_SYNC = 'before_close_thread_tables SIGNAL finish EXECUTE 2';
 --error 0,ER_TABLE_EXISTS_ERROR

--- a/mysql-test/suite/tokudb.parts/t/partition_max_parts_hash_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_parts_hash_tokudb.test
@@ -21,4 +21,6 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
---source suite/parts/inc/partition_max_parts_hash.inc
+let $mysql_needed_max_files=32768;
+
+--source suite/max_parts/inc/partition_max_parts_hash.inc

--- a/mysql-test/suite/tokudb.parts/t/partition_max_parts_inv_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_parts_inv_tokudb.test
@@ -21,4 +21,6 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
---source suite/parts/inc/partition_max_parts_inv.inc
+let $mysql_needed_max_files=32768;
+
+--source suite/max_parts/inc/partition_max_parts_inv.inc

--- a/mysql-test/suite/tokudb.parts/t/partition_max_parts_key_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_parts_key_tokudb.test
@@ -22,4 +22,6 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
---source suite/parts/inc/partition_max_parts_key.inc
+let $mysql_needed_max_files=32768;
+
+--source suite/max_parts/inc/partition_max_parts_key.inc

--- a/mysql-test/suite/tokudb.parts/t/partition_max_parts_list_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_parts_list_tokudb.test
@@ -21,4 +21,6 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
---source suite/parts/inc/partition_max_parts_list.inc
+let $mysql_needed_max_files=32768;
+
+--source suite/max_parts/inc/partition_max_parts_list.inc

--- a/mysql-test/suite/tokudb.parts/t/partition_max_parts_range_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_parts_range_tokudb.test
@@ -21,4 +21,6 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
---source suite/parts/inc/partition_max_parts_range.inc
+let $mysql_needed_max_files=32768;
+
+--source suite/max_parts/inc/partition_max_parts_range.inc

--- a/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_key_list_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_key_list_tokudb.test
@@ -22,5 +22,7 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
---source suite/parts/inc/partition_max_sub_parts_key_list.inc
+let $mysql_needed_max_files=32768;
+
+--source suite/max_parts/inc/partition_max_sub_parts_key_list.inc
 

--- a/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_key_range_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_key_range_tokudb.test
@@ -22,4 +22,6 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
---source suite/parts/inc/partition_max_sub_parts_key_range.inc
+let $mysql_needed_max_files=32768;
+
+--source suite/max_parts/inc/partition_max_sub_parts_key_range.inc

--- a/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_list_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_list_tokudb.test
@@ -22,9 +22,11 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
+let $mysql_needed_max_files=32768;
+
 #SET @save_tokudb_file_per_table= @@global.tokudb_file_per_table;
 #SET @@global.tokudb_file_per_table= OFF;
 
---source suite/parts/inc/partition_max_sub_parts_list.inc
+--source suite/max_parts/inc/partition_max_sub_parts_list.inc
 
 #SET @@global.tokudb_file_per_table= @save_tokudb_file_per_table;

--- a/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_range_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_max_sub_parts_range_tokudb.test
@@ -21,9 +21,11 @@
 ##### Storage engine to be tested
 let $engine= 'TokuDB';
 
+let $mysql_needed_max_files=32768;
+
 #SET @save_tokudb_file_per_table= @@global.tokudb_file_per_table;
 #SET @@global.tokudb_file_per_table= OFF;
 
---source suite/parts/inc/partition_max_sub_parts_range.inc
+--source suite/max_parts/inc/partition_max_sub_parts_range.inc
 
 #SET @@global.tokudb_file_per_table= @save_tokudb_file_per_table;


### PR DESCRIPTION
Fixed invalid DEBUG_SYNC point name in "partition_debug_sync_tokudb.test" as it has
been renamed from "before_rename_partitions" to "before_handle_alter_part_end".

Fixed invalid "--source suite/parts/inc/partition_max_<xxx>.inc" directives, as these
files have been moved to "suite/max_parts/inc/partition_max_<xxx>.inc".

Re-recorded test results files as widly used "SET sql_mode =''" in 5.7 generates warnings.

Please notice, that some "tokudb.parts" tests require max number of OS's open files to be
no less than 32768.
When MTR is invoked in parallel mode, say, with "--parallel=4", then this value must
be increased even more to 32768 \* 4 = 131072.

To configure these values on CentOS 7 use the following instructions:
https://naveensnayak.wordpress.com/2015/09/17/increasing-file-descriptors-and-open-files-limit-centos-7/

To sum up:

In /etc/sysctl.conf
fs.file-max = 131072

In /etc/security/limits.conf
- soft nproc 32768
- hard nproc 32768
- soft nofile 32768
- hard nofile 32768

Then invoke
sysctl -p
