### PR TITLE
5.5 - Changed package name for cpack from mysql to percona-server (BLD-309)

### DIFF
--- a/cmake/package_name.cmake
+++ b/cmake/package_name.cmake
@@ -128,7 +128,7 @@ IF(NOT VERSION)
     STRING(REGEX REPLACE "^.*-ndb-" "" NDBVERSION "${VERSION}")
     SET(package_name "mysql-cluster${PRODUCT_TAG}-${NDBVERSION}-${SYSTEM_NAME_AND_PROCESSOR}")
   ELSE()
-    SET(package_name "mysql${PRODUCT_TAG}-${VERSION}-${SYSTEM_NAME_AND_PROCESSOR}")
+    SET(package_name "percona-server${PRODUCT_TAG}-${VERSION}-${SYSTEM_NAME_AND_PROCESSOR}")
   ENDIF()
 
   MESSAGE(STATUS "Packaging as: ${package_name}")


### PR DESCRIPTION
**TICKETS: BLD-309, BLD-387**
https://bugs.launchpad.net/percona-server/+bug/1540385

This is just a cpack package name from mysql to percona-server so that when using make_binary_distribution we get tarballs like percona-server-...

**TEST:**
_5.5:_
vagrant@b-ubuntu1404-64:~/build-flash/ps/test/percona-server/build$ scripts/make_binary_distribution 
CPack: Create package using TGZ
CPack: Install projects
CPack: - Run preinstall target for: MySQL
CPack: - Install project: MySQL
CPack: Create package
CPack: - package: /home/vagrant/build-flash/ps/test/percona-server/build/percona-server-5.5.46-37.6-linux-x86_64.tar.gz generated.

_5.6:_
vagrant@b-ubuntu1404-64:~/build-flash/ps/test/percona-server/build$ scripts/make_binary_distribution 
CPack: Create package using TGZ
CPack: Install projects
CPack: - Run preinstall target for: MySQL
CPack: - Install project: MySQL
CPack: Create package
CPack: - package: /home/vagrant/build-flash/ps/test/percona-server/build/percona-server-5.6.27-76.0-linux-x86_64.tar.gz generated.

_5.7:_
vagrant@b-ubuntu1404-64:~/build-flash/ps/test/percona-server/build$ scripts/make_binary_distribution 
CPack: Create package using TGZ
CPack: Install projects
CPack: - Run preinstall target for: MySQL
CPack: - Install project: MySQL
CPack: Create package
CPack: - package: /home/vagrant/build-flash/ps/test/percona-server/build/percona-server-5.7.10-1rc1-linux-x86_64.tar.gz generated.

_while running cmake I see following output:_
-- Packaging as: percona-server-5.5.46-37.6-Linux-x86_64
-- Packaging as: percona-server-5.6.27-76.0-Linux-x86_64
-- Packaging as: percona-server-5.7.10-1rc1-Linux-x86_64

_Subdirectory names inside tarball:_
percona-server-5.7.10-1rc1-linux-x86_64
percona-server-5.6.27-76.0-linux-x86_64
percona-server-5.5.46-37.6-linux-x86_64
