### PR TITLE
Fix for setting transparent huge pages in ubuntu and debian (BLD-399)

### DIFF
--- a/build-ps/debian/extra/mysql-systemd-start
+++ b/build-ps/debian/extra/mysql-systemd-start
@@ -18,6 +18,15 @@ pinger () {
 	done
 }
 
+fix_thp_setting() {
+	THP_SETTING=$(my_print_defaults mysqld_safe | grep thp-setting | cut -d= -f2)
+	if [ ! -z "${THP_SETTING}" ]; then
+		# Set whatever option is specified in config file
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/defrag
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/enabled
+	fi
+}
+
 sanity () {
 	MYSQLRUN=/var/run/mysqld
 	MYSQLDATA=$(get_path datadir)
@@ -81,6 +90,9 @@ sanity () {
 		echo "Percona Server configuration not found at /etc/mysql/my.cnf. Please install one using update-alternatives."
 		exit 1
 	fi
+
+	# Needed because of TokuDB
+	fix_thp_setting
 }
 
 case $1 in

--- a/build-ps/debian/percona-server-server-5.7.mysql.init
+++ b/build-ps/debian/percona-server-server-5.7.mysql.init
@@ -50,6 +50,15 @@ get_mysql_option() {
 	echo $RESULT
 }
 
+fix_thp_setting() {
+	THP_SETTING=$(get_mysql_option mysqld_safe thp-setting "")
+	if [ ! -z "${THP_SETTING}" ]; then
+	# Set whatever option is specified in config file
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/defrag
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/enabled
+	fi
+}
+
 get_running () {
 	PIDFILE=$(get_mysql_option mysqld_safe pid-file "")
 	if [ -z "$PIDFILE" ];
@@ -157,7 +166,10 @@ case "$1" in
 			chmod 755 ${MYSQLRUN}
 		fi
 
-		mysqld_safe > /dev/null &
+		# Needed because of TokuDB
+		fix_thp_setting
+
+		su - mysql -s /bin/bash -c "mysqld_safe > /dev/null &"
 		verify_server start
 		if [ "$?" -eq 0 ];
 		then

--- a/build-ps/ubuntu/extra/mysql-systemd-start
+++ b/build-ps/ubuntu/extra/mysql-systemd-start
@@ -18,6 +18,15 @@ pinger () {
 	done
 }
 
+fix_thp_setting() {
+	THP_SETTING=$(my_print_defaults mysqld_safe | grep thp-setting | cut -d= -f2)
+	if [ ! -z "${THP_SETTING}" ]; then
+		# Set whatever option is specified in config file
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/defrag
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/enabled
+	fi
+}
+
 sanity () {
 	MYSQLRUN=/var/run/mysqld
 	MYSQLDATA=$(get_path datadir)
@@ -81,6 +90,9 @@ sanity () {
 		echo "Percona Server configuration not found at /etc/mysql/my.cnf. Please install one using update-alternatives."
 		exit 1
 	fi
+
+	# Needed because of TokuDB
+	fix_thp_setting
 }
 
 case $1 in

--- a/build-ps/ubuntu/percona-server-server-5.7.mysql.init
+++ b/build-ps/ubuntu/percona-server-server-5.7.mysql.init
@@ -50,6 +50,15 @@ get_mysql_option() {
 	echo $RESULT
 }
 
+fix_thp_setting() {
+	THP_SETTING=$(get_mysql_option mysqld_safe thp-setting "")
+	if [ ! -z "${THP_SETTING}" ]; then
+	# Set whatever option is specified in config file
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/defrag
+		echo "${THP_SETTING}" > /sys/kernel/mm/transparent_hugepage/enabled
+	fi
+}
+
 get_running () {
 	PIDFILE=$(get_mysql_option mysqld_safe pid-file "")
 	if [ -z "$PIDFILE" ];
@@ -157,7 +166,10 @@ case "$1" in
 			chmod 755 ${MYSQLRUN}
 		fi
 
-		mysqld_safe > /dev/null &
+		# Needed because of TokuDB
+		fix_thp_setting
+
+		su - mysql -s /bin/bash -c "mysqld_safe > /dev/null &"
 		verify_server start
 		if [ "$?" -eq 0 ];
 		then

--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -851,10 +851,7 @@ fi
 # Change transparent huge pages setting if thp-setting option specified
 if [ -n "$thp_setting" ]
 then
-  if [ $(id -u) -ne 0 ]; then
-    log_error "mysqld_safe must be run as root for setting transparent huge pages!"
-    exit 1
-  elif [ $thp_setting != "always" -a $thp_setting != "madvise" -a $thp_setting != "never" ]; then
+  if [ $thp_setting != "always" -a $thp_setting != "madvise" -a $thp_setting != "never" ]; then
     log_error "Invalid value for thp-setting=$thp_setting in config file. Valid values are: always, madvise or never"
     exit 1
   else
@@ -867,6 +864,9 @@ then
     fi
     if [ $STATUS_THP -eq 0 ]; then
       log_notice "Transparent huge pages are already set to: ${thp_setting}."
+    elif [ $(id -u) -ne 0 ]; then
+      log_error "mysqld_safe must be run as root for setting transparent huge pages!"
+      exit 1
     else
       if [ -f /sys/kernel/mm/transparent_hugepage/defrag ]; then
         echo $thp_setting > /sys/kernel/mm/transparent_hugepage/defrag


### PR DESCRIPTION
**TICKETS:**
https://bugs.launchpad.net/percona-server/+bug/1527535/
BLD-399

**ISSUE:**
In the #300 we have fixed the issue by changing that the mysqld_safe is run as root on ubuntu/debian with sysvinit - but we didn't fix the issue for systemd.
Since I don't want to run mysqld_safe as root on systemd as well I have found another solution and reverted the change from PR #300 (should have done it in the first place)
The change here is that mysqld_safe checks if it's run as root only if the thp-setting config option is set and different then the one on the system (change needed). In the init scripts (pre mysqld_safe running) for sysvinit and systemd I have added that we check for thp-setting option and if set make a change (that part is always running as root so it's not a problem).

**TEST BUILD:**
http://jenkins.percona.com/job/percona-server-5.7-debian-binary/50/
(the build is currently in experimental repository)

**TEST:**
_TRUSTY:_

```
vagrant@t-ubuntu1404-64:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never

vagrant@t-ubuntu1404-64:~$ sudo ps_tokudb_admin --enable
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are enabled (should be disabled).

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Disabling transparent huge pages for the current session...
INFO: Successfully disabled transparent huge pages for this session.

Adding thp-setting=never option into /etc/mysql/my.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.


root@t-ubuntu1404-64:~# echo always > /sys/kernel/mm/transparent_hugepage/enabled

vagrant@t-ubuntu1404-64:~$ sudo service mysql stop
....
 * Percona Server 5.7.10-2rc2 is stopped

vagrant@t-ubuntu1404-64:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never

vagrant@t-ubuntu1404-64:~$ cat /sys/kernel/mm/transparent_hugepage/defrag
[always] madvise never

vagrant@t-ubuntu1404-64:~$ sudo service mysql start
..
 * Percona Server 5.7.10-2rc2 is started

mysql> show plugins;
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so   | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
+-------------------------------+----------+--------------------+----------------+---------+

vagrant@t-ubuntu1404-64:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]

vagrant@t-ubuntu1404-64:~$ cat /sys/kernel/mm/transparent_hugepage/defrag
always madvise [never]

vagrant@t-ubuntu1404-64:~$ ps aux|grep mysql
mysql      928  0.0  0.1   4444   748 ?        S    15:25   0:00 /bin/sh /usr/bin/mysqld_safe
mysql     1206  1.8 42.1 1166644 211560 ?      Sl   15:25   0:00 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --log-error=/var/log/mysql/error.log --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306
```

_JESSIE:_

```
root@t-debian8-64:~# echo always > /sys/kernel/mm/transparent_hugepage/defrag
root@t-debian8-64:~# echo always > /sys/kernel/mm/transparent_hugepage/enabled

vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never

vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/defrag
[always] madvise never

vagrant@t-debian8-64:~$ sudo ps_tokudb_admin --enable
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are enabled (should be disabled).

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Disabling transparent huge pages for the current session...
INFO: Successfully disabled transparent huge pages for this session.

Adding thp-setting=never option into /etc/mysql/my.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/my.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/defrag
always madvise [never]

vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]

vagrant@t-debian8-64:~$ sudo systemctl stop mysql

root@t-debian8-64:~# echo always > /sys/kernel/mm/transparent_hugepage/defrag
root@t-debian8-64:~# echo always > /sys/kernel/mm/transparent_hugepage/enabled

vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never

vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/defrag
[always] madvise never
vagrant@t-debian8-64:~$ sudo systemctl start mysql

vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/defrag                                                                                                                                                                 
always madvise [never]
vagrant@t-debian8-64:~$ cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]

vagrant@t-debian8-64:~$ sudo mysql -uroot -e "show plugins;"
...
| TokuDB                        | ACTIVE   | STORAGE ENGINE     | ha_tokudb.so   | GPL     |
| TokuDB_background_job_status  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_file_map               | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_fractal_tree_block_map | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_fractal_tree_info      | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_locks                  | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_lock_waits             | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
| TokuDB_trx                    | ACTIVE   | INFORMATION SCHEMA | ha_tokudb.so   | GPL     |
+-------------------------------+----------+--------------------+----------------+---------+

vagrant@t-debian8-64:~$ ps aux|grep mysql
mysql     3542  0.0  0.3   4328  1600 ?        Ss   23:21   0:00 /bin/sh /usr/bin/mysqld_safe
mysql     3818  0.1 43.9 1166768 222688 ?      Sl   23:21   0:00 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --log-error=/var/log/mysql/error.log --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306
```

_WILY:_

```
root@vagrant-ubuntu-wily-64:~# echo always > /sys/kernel/mm/transparent_hugepage/defrag
root@vagrant-ubuntu-wily-64:~# echo always > /sys/kernel/mm/transparent_hugepage/enabled
root@vagrant-ubuntu-wily-64:~# ps_tokudb_admin --enable
Checking if Percona Server is running with jemalloc enabled...
INFO: Percona Server is running with jemalloc enabled.

Checking transparent huge pages status on the system...
INFO: Transparent huge pages are enabled (should be disabled).

Checking if thp-setting=never option is already set in config file...
INFO: Option thp-setting=never is not set in the config file.
      (needed only if THP is not disabled permanently on the system)

Checking TokuDB engine plugin status...
INFO: TokuDB engine plugin is not installed.

Disabling transparent huge pages for the current session...
INFO: Successfully disabled transparent huge pages for this session.

Adding thp-setting=never option into /etc/mysql/percona-server.conf.d/mysqld_safe.cnf
INFO: Successfully added thp-setting=never option into /etc/mysql/percona-server.conf.d/mysqld_safe.cnf

Installing TokuDB engine...
INFO: Successfully installed TokuDB engine plugin.

root@vagrant-ubuntu-wily-64:~# mysql -uroot -e "show plugins;"|grep TokuDB                                                                                                                                                             
TokuDB  ACTIVE  STORAGE ENGINE  ha_tokudb.so    GPL
TokuDB_file_map ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_fractal_tree_info        ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_fractal_tree_block_map   ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_trx      ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_locks    ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_lock_waits       ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_background_job_status    ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/defrag
always madvise [never]

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]

root@vagrant-ubuntu-wily-64:~# echo always > /sys/kernel/mm/transparent_hugepage/enabled

root@vagrant-ubuntu-wily-64:~# echo always > /sys/kernel/mm/transparent_hugepage/defrag

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/defrag
[always] madvise never

root@vagrant-ubuntu-wily-64:~# systemctl stop mysql

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/defrag
[always] madvise never

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/enabled
[always] madvise never

root@vagrant-ubuntu-wily-64:~# systemctl start mysql

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/defrag
always madvise [never]

root@vagrant-ubuntu-wily-64:~# cat /sys/kernel/mm/transparent_hugepage/enabled
always madvise [never]

root@vagrant-ubuntu-wily-64:~# mysql -uroot -e "show plugins;"|grep TokuDB                                                                                                                                                             
TokuDB  ACTIVE  STORAGE ENGINE  ha_tokudb.so    GPL
TokuDB_background_job_status    ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_file_map ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_fractal_tree_block_map   ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_fractal_tree_info        ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_locks    ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_lock_waits       ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
TokuDB_trx      ACTIVE  INFORMATION SCHEMA      ha_tokudb.so    GPL
```
