### PR TITLE
DB-925 : REGRESSION: cardinality of partitioned tables became inaccur…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1_pick.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1_pick.result
@@ -17,5 +17,5 @@ test.t	analyze	status	OK
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	7	NULL	NULL		BTREE		
-t	1	x	1	x	A	7	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	3	NULL	NULL	YES	BTREE		
 drop table t;

--- a/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
+++ b/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
@@ -15,7 +15,7 @@ test.t	analyze	status	OK
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	5	NULL	NULL		BTREE		
-t	1	x	1	x	A	5	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	2	NULL	NULL	YES	BTREE		
 t	1	y	1	y	A	5	NULL	NULL	YES	BTREE		
 alter table t analyze partition p1;
 Table	Op	Msg_type	Msg_text
@@ -23,13 +23,13 @@ test.t	analyze	status	OK
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	5	NULL	NULL		BTREE		
-t	1	x	1	x	A	5	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	2	NULL	NULL	YES	BTREE		
 t	1	y	1	y	A	5	NULL	NULL	YES	BTREE		
 insert into t values (100,1,1),(200,2,1),(300,3,1),(400,4,1),(500,5,1);
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	9	NULL	NULL		BTREE		
-t	1	x	1	x	A	9	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	4	NULL	NULL	YES	BTREE		
 t	1	y	1	y	A	9	NULL	NULL	YES	BTREE		
 alter table t analyze partition p0;
 Table	Op	Msg_type	Msg_text

--- a/mysql-test/suite/tokudb/r/truncate_row_count.result
+++ b/mysql-test/suite/tokudb/r/truncate_row_count.result
@@ -14,5 +14,5 @@ select * from t;
 a	b
 select TABLE_ROWS from information_schema.tables where table_schema='test' and table_name='t';
 TABLE_ROWS
-1
+0
 drop table t;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -350,34 +350,32 @@ void TOKUDB_SHARE::update_row_count(
     unlock();
 }
 void TOKUDB_SHARE::set_cardinality_counts_in_table(TABLE* table) {
-    // if there is nothing new to report, just skip it.
-    if (_card_changed) {
-        lock();
-        uint32_t next_key_part = 0;
-        for (uint32_t i = 0; i < table->s->keys; i++) {
-            bool is_unique_key =
-                (i == table->s->primary_key) ||
-                (table->key_info[i].flags & HA_NOSAME);
+    lock();
+    uint32_t next_key_part = 0;
+    for (uint32_t i = 0; i < table->s->keys; i++) {
+        KEY* key = &table->key_info[i];
+        bool is_unique_key =
+            (i == table->s->primary_key) || (key->flags & HA_NOSAME);
 
-            uint32_t num_key_parts = get_key_parts(&table->key_info[i]);
-            for (uint32_t j = 0; j < num_key_parts; j++) {
-                assert_always(next_key_part < _rec_per_keys);
-                ulong val = _rec_per_key[next_key_part++];
-                if (is_unique_key && j == num_key_parts-1) {
-                    val = 1;
-                } else {
-                    val =
-                        (val*tokudb::sysvars::cardinality_scale_percent)/100;
-                    if (val == 0)
-                        val = 1;
-                }
-
-                table->key_info[i].rec_per_key[j] = val;
+        for (uint32_t j = 0; j < key->actual_key_parts; j++) {
+            if (j >= key->user_defined_key_parts) {
+                // MySQL 'hidden' keys, really needs deeper investigation
+                // into MySQL hidden keys vs TokuDB hidden keys
+                key->rec_per_key[j] = 1;
+                continue;
             }
+
+            assert_always(next_key_part < _rec_per_keys);
+            ulong val = _rec_per_key[next_key_part++];
+            val = (val * tokudb::sysvars::cardinality_scale_percent) / 100;
+            if (val == 0 || _rows == 0 ||
+                (is_unique_key && j == key->actual_key_parts - 1)) {
+                val = 1;
+            }
+            key->rec_per_key[j] = val;
         }
-        _card_changed = false;
-        unlock();
     }
+    unlock();
 }
 
 #define HANDLE_INVALID_CURSOR() \
@@ -771,29 +769,36 @@ static int filter_key_part_compare (const void* left, const void* right) {
 // if key, table have proper info set. I had to verify by checking
 // in the debugger.
 //
-void set_key_filter(MY_BITMAP* key_filter, KEY* key, TABLE* table, bool get_offset_from_keypart) {
+void set_key_filter(
+    MY_BITMAP* key_filter,
+    KEY* key,
+    TABLE* table,
+    bool get_offset_from_keypart) {
+
     FILTER_KEY_PART_INFO parts[MAX_REF_PARTS];
     uint curr_skip_index = 0;
 
-    for (uint i = 0; i < get_key_parts(key); i++) {
+    for (uint i = 0; i < key->user_defined_key_parts; i++) {
         //
         // horrendous hack due to bugs in mysql, basically
         // we cannot always reliably get the offset from the same source
         //
-        parts[i].offset = get_offset_from_keypart ? key->key_part[i].offset : field_offset(key->key_part[i].field, table);
+        parts[i].offset =
+            get_offset_from_keypart ?
+                key->key_part[i].offset :
+                field_offset(key->key_part[i].field, table);
         parts[i].part_index = i;
     }
     qsort(
         parts, // start of array
-        get_key_parts(key), //num elements
+        key->user_defined_key_parts, //num elements
         sizeof(*parts), //size of each element
-        filter_key_part_compare
-        );
+        filter_key_part_compare);
 
     for (uint i = 0; i < table->s->fields; i++) {
         Field* field = table->field[i];
         uint curr_field_offset = field_offset(field, table);
-        if (curr_skip_index < get_key_parts(key)) {
+        if (curr_skip_index < key->user_defined_key_parts) {
             uint curr_skip_offset = 0;
             curr_skip_offset = parts[curr_skip_index].offset;
             if (curr_skip_offset == curr_field_offset) {
@@ -1595,7 +1600,11 @@ exit:
     return error;
 }
 
-bool ha_tokudb::can_replace_into_be_fast(TABLE_SHARE* table_share, KEY_AND_COL_INFO* kc_info, uint pk) {
+bool ha_tokudb::can_replace_into_be_fast(
+    TABLE_SHARE* table_share,
+    KEY_AND_COL_INFO* kc_info,
+    uint pk) {
+
     uint curr_num_DBs = table_share->keys + tokudb_test(hidden_primary_key);
     bool ret_val;
     if (curr_num_DBs == 1) {
@@ -1606,7 +1615,7 @@ bool ha_tokudb::can_replace_into_be_fast(TABLE_SHARE* table_share, KEY_AND_COL_I
     for (uint curr_index = 0; curr_index < table_share->keys; curr_index++) {
         if (curr_index == pk) continue;
         KEY* curr_key_info = &table_share->key_info[curr_index];
-        for (uint i = 0; i < get_key_parts(curr_key_info); i++) {
+        for (uint i = 0; i < curr_key_info->user_defined_key_parts; i++) {
             uint16 curr_field_index = curr_key_info->key_part[i].field->field_index;
             if (!bitmap_is_set(&kc_info->key_filters[curr_index],curr_field_index)) {
                 ret_val = false;
@@ -1692,7 +1701,8 @@ int ha_tokudb::initialize_share(const char* name, int mode) {
 
     /* Open other keys;  These are part of the share structure */
     for (uint i = 0; i < table_share->keys; i++) {
-        share->_key_descriptors[i]._parts = get_key_parts(&table_share->key_info[i]);
+        share->_key_descriptors[i]._parts =
+            table_share->key_info[i].user_defined_key_parts;
         if (i == primary_key) {
             share->_key_descriptors[i]._is_unique = true;
             share->_key_descriptors[i]._name = tokudb::memory::strdup("primary", 0);
@@ -1732,8 +1742,9 @@ int ha_tokudb::initialize_share(const char* name, int mode) {
         // the "infinity byte" in keys, and for placing the DBT size in the first four bytes
         //
         ref_length = sizeof(uint32_t) + sizeof(uchar);
-        KEY_PART_INFO *key_part = table->key_info[primary_key].key_part;
-        KEY_PART_INFO *end = key_part + get_key_parts(&table->key_info[primary_key]);
+        KEY_PART_INFO* key_part = table->key_info[primary_key].key_part;
+        KEY_PART_INFO* end =
+            key_part + table->key_info[primary_key].user_defined_key_parts;
         for (; key_part != end; key_part++) {
             ref_length += key_part->field->max_packed_col_length(key_part->length);
             TOKU_TYPE toku_type = mysql_to_toku_type(key_part->field);
@@ -2616,13 +2627,13 @@ exit:
 }
 
 uint32_t ha_tokudb::place_key_into_mysql_buff(
-    KEY* key_info, 
-    uchar * record, 
-    uchar* data
-    ) 
-{
-    KEY_PART_INFO *key_part = key_info->key_part, *end = key_part + get_key_parts(key_info);
-    uchar *pos = data;
+    KEY* key_info,
+    uchar* record,
+    uchar* data) {
+
+    KEY_PART_INFO* key_part = key_info->key_part;
+    KEY_PART_INFO* end = key_part + key_info->user_defined_key_parts;
+    uchar* pos = data;
 
     for (; key_part != end; key_part++) {
         if (key_part->field->null_bit) {
@@ -2682,15 +2693,14 @@ void ha_tokudb::unpack_key(uchar * record, DBT const *key, uint index) {
 }
 
 uint32_t ha_tokudb::place_key_into_dbt_buff(
-    KEY* key_info, 
-    uchar * buff, 
-    const uchar * record, 
-    bool* has_null, 
-    int key_length
-    ) 
-{
-    KEY_PART_INFO *key_part = key_info->key_part;
-    KEY_PART_INFO *end = key_part + get_key_parts(key_info);
+    KEY* key_info,
+    uchar* buff,
+    const uchar* record,
+    bool* has_null,
+    int key_length) {
+
+    KEY_PART_INFO* key_part = key_info->key_part;
+    KEY_PART_INFO* end = key_part + key_info->user_defined_key_parts;
     uchar* curr_buff = buff;
     *has_null = false;
     for (; key_part != end && key_length > 0; key_part++) {
@@ -2870,25 +2880,29 @@ DBT* ha_tokudb::create_dbt_key_for_lookup(
 // Returns:
 //      the parameter key
 //
-DBT *ha_tokudb::pack_key(
-    DBT * key, 
-    uint keynr, 
-    uchar * buff, 
-    const uchar * key_ptr, 
-    uint key_length, 
-    int8_t inf_byte
-    ) 
-{
-    TOKUDB_HANDLER_DBUG_ENTER("key %p %u:%2.2x inf=%d", key_ptr, key_length, key_length > 0 ? key_ptr[0] : 0, inf_byte);
+DBT* ha_tokudb::pack_key(
+    DBT* key,
+    uint keynr,
+    uchar* buff,
+    const uchar* key_ptr,
+    uint key_length,
+    int8_t inf_byte) {
+
+    TOKUDB_HANDLER_DBUG_ENTER(
+        "key %p %u:%2.2x inf=%d",
+        key_ptr,
+        key_length,
+        key_length > 0 ? key_ptr[0] : 0,
+        inf_byte);
 #if TOKU_INCLUDE_EXTENDED_KEYS
     if (keynr != primary_key && !tokudb_test(hidden_primary_key)) {
         DBUG_RETURN(pack_ext_key(key, keynr, buff, key_ptr, key_length, inf_byte));
     }
 #endif
-    KEY *key_info = &table->key_info[keynr];
-    KEY_PART_INFO *key_part = key_info->key_part;
-    KEY_PART_INFO *end = key_part + get_key_parts(key_info);
-    my_bitmap_map *old_map = dbug_tmp_use_all_columns(table, table->write_set);
+    KEY* key_info = &table->key_info[keynr];
+    KEY_PART_INFO* key_part = key_info->key_part;
+    KEY_PART_INFO* end = key_part + key_info->user_defined_key_parts;
+    my_bitmap_map* old_map = dbug_tmp_use_all_columns(table, table->write_set);
 
     memset((void *) key, 0, sizeof(*key));
     key->data = buff;
@@ -2930,31 +2944,30 @@ DBT *ha_tokudb::pack_key(
 }
 
 #if TOKU_INCLUDE_EXTENDED_KEYS
-DBT *ha_tokudb::pack_ext_key(
-    DBT * key, 
-    uint keynr, 
-    uchar * buff, 
-    const uchar * key_ptr, 
-    uint key_length, 
-    int8_t inf_byte
-    ) 
-{
+DBT* ha_tokudb::pack_ext_key(
+    DBT* key,
+    uint keynr,
+    uchar* buff,
+    const uchar* key_ptr,
+    uint key_length,
+    int8_t inf_byte) {
+
     TOKUDB_HANDLER_DBUG_ENTER("");
 
     // build a list of PK parts that are in the SK.  we will use this list to build the
     // extended key if necessary. 
-    KEY *pk_key_info = &table->key_info[primary_key];
-    uint pk_parts = get_key_parts(pk_key_info);
+    KEY* pk_key_info = &table->key_info[primary_key];
+    uint pk_parts = pk_key_info->user_defined_key_parts;
     uint pk_next = 0;
     struct {
         const uchar *key_ptr;
         KEY_PART_INFO *key_part;
     } pk_info[pk_parts];
 
-    KEY *key_info = &table->key_info[keynr];
-    KEY_PART_INFO *key_part = key_info->key_part;
-    KEY_PART_INFO *end = key_part + get_key_parts(key_info);
-    my_bitmap_map *old_map = dbug_tmp_use_all_columns(table, table->write_set);
+    KEY* key_info = &table->key_info[keynr];
+    KEY_PART_INFO* key_part = key_info->key_part;
+    KEY_PART_INFO* end = key_part + key_info->user_defined_key_parts;
+    my_bitmap_map* old_map = dbug_tmp_use_all_columns(table, table->write_set);
 
     memset((void *) key, 0, sizeof(*key));
     key->data = buff;
@@ -4439,11 +4452,16 @@ cleanup:
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
 
-static bool index_key_is_null(TABLE *table, uint keynr, const uchar *key, uint key_len) {
+static bool index_key_is_null(
+    TABLE* table,
+    uint keynr,
+    const uchar* key,
+    uint key_len) {
+
     bool key_can_be_null = false;
-    KEY *key_info = &table->key_info[keynr];
-    KEY_PART_INFO *key_part = key_info->key_part;
-    KEY_PART_INFO *end = key_part + get_key_parts(key_info);
+    KEY* key_info = &table->key_info[keynr];
+    KEY_PART_INFO* key_part = key_info->key_part;
+    KEY_PART_INFO* end = key_part + key_info->user_defined_key_parts;
     for (; key_part != end; key_part++) {
         if (key_part->null_bit) {
             key_can_be_null = true;
@@ -5979,11 +5997,7 @@ int ha_tokudb::info(uint flag) {
 #endif
     DB_TXN* txn = NULL;
     if (flag & HA_STATUS_VARIABLE) {
-        // Just to get optimizations right
         stats.records = share->row_count() + share->rows_from_locked_table;
-        if (stats.records == 0) {
-            stats.records++;
-        }
         stats.deleted = 0;
         if (!(flag & HA_STATUS_NO_LOCK)) {
             uint64_t num_rows = 0;
@@ -6002,9 +6016,6 @@ int ha_tokudb::info(uint flag) {
             if (error == 0) {
                 share->set_row_count(num_rows, false);
                 stats.records = num_rows;
-                if (stats.records == 0) {
-                    stats.records++;
-                }
             } else {
                 goto cleanup;
             }
@@ -6084,6 +6095,22 @@ int ha_tokudb::info(uint flag) {
                 }
                 stats.delete_length += frag_info.unused_bytes;
             }
+        }
+
+        /*
+        The following comment and logic has been taken from InnoDB and 
+        an old hack was removed that forced to always set stats.records > 0
+        ---
+        The MySQL optimizer seems to assume in a left join that n_rows
+        is an accurate estimate if it is zero. Of course, it is not,
+        since we do not have any locks on the rows yet at this phase.
+        Since SHOW TABLE STATUS seems to call this function with the
+        HA_STATUS_TIME flag set, while the left join optimizer does not
+        set that flag, we add one to a zero value if the flag is not
+        set. That way SHOW TABLE STATUS will show the best estimate,
+        while the optimizer never sees the table empty. */
+        if (stats.records == 0 && !(flag & HA_STATUS_TIME)) {
+            stats.records++;
         }
     }
     if ((flag & HA_STATUS_CONST)) {
@@ -6785,9 +6812,9 @@ void ha_tokudb::trace_create_table_info(const char *name, TABLE * form) {
                 "key:%d:%s:%d",
                 i,
                 key->name,
-                get_key_parts(key));
+                key->user_defined_key_parts);
             uint p;
-            for (p = 0; p < get_key_parts(key); p++) {
+            for (p = 0; p < key->user_defined_key_parts; p++) {
                 KEY_PART_INFO* key_part = &key->key_part[p];
                 Field* field = key_part->field;
                 TOKUDB_HANDLER_TRACE(

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -306,7 +306,6 @@ private:
     // cardinality counts
     uint32_t _rec_per_keys;
     uint64_t* _rec_per_key;
-    bool _card_changed;
 
     void init(const char* table_name);
     void destroy();
@@ -371,7 +370,6 @@ inline void TOKUDB_SHARE::init_cardinality_counts(
     assert_always(_rec_per_key == NULL && _rec_per_keys == 0);
     _rec_per_keys = rec_per_keys;
     _rec_per_key = rec_per_key;
-    _card_changed = true;
 }
 inline void TOKUDB_SHARE::update_cardinality_counts(
     uint32_t rec_per_keys,
@@ -382,7 +380,6 @@ inline void TOKUDB_SHARE::update_cardinality_counts(
     assert_always(rec_per_keys == _rec_per_keys);
     assert_always(rec_per_key != NULL);
     memcpy(_rec_per_key, rec_per_key, _rec_per_keys * sizeof(uint64_t));
-    _card_changed = true;
 }
 inline void TOKUDB_SHARE::disallow_auto_analysis() {
     assert_debug(_mutex.is_owned_by_me());

--- a/storage/tokudb/ha_tokudb_alter_56.cc
+++ b/storage/tokudb/ha_tokudb_alter_56.cc
@@ -680,7 +680,7 @@ int ha_tokudb::alter_table_add_index(
         KEY *key = &key_info[i];
         *key = ha_alter_info->key_info_buffer[ha_alter_info->index_add_buffer[i]];
         for (KEY_PART_INFO* key_part = key->key_part;
-             key_part < key->key_part + get_key_parts(key);
+             key_part < key->key_part + key->user_defined_key_parts;
              key_part++) {
             key_part->field = table->field[key_part->fieldnr];
         }
@@ -1123,7 +1123,7 @@ int ha_tokudb::alter_table_expand_varchar_offsets(
 
 // Return true if a field is part of a key
 static bool field_in_key(KEY *key, Field *field) {
-    for (uint i = 0; i < get_key_parts(key); i++) {
+    for (uint i = 0; i < key->user_defined_key_parts; i++) {
         KEY_PART_INFO *key_part = &key->key_part[i];
         if (strcmp(key_part->field->field_name, field->field_name) == 0)
             return true;

--- a/storage/tokudb/ha_tokudb_alter_common.cc
+++ b/storage/tokudb/ha_tokudb_alter_common.cc
@@ -75,8 +75,8 @@ static bool tables_have_same_keys(
             if (print_error) {
                 sql_print_error(
                     "keys disagree on if they are clustering, %d, %d",
-                    get_key_parts(curr_orig_key),
-                    get_key_parts(curr_altered_key));
+                    curr_orig_key->user_defined_key_parts,
+                    curr_altered_key->user_defined_key_parts);
             }
             retval = false;
             goto cleanup;
@@ -86,18 +86,19 @@ static bool tables_have_same_keys(
             if (print_error) {
                 sql_print_error(
                     "keys disagree on if they are unique, %d, %d",
-                    get_key_parts(curr_orig_key),
-                    get_key_parts(curr_altered_key));
+                    curr_orig_key->user_defined_key_parts,
+                    curr_altered_key->user_defined_key_parts);
             }
             retval = false;
             goto cleanup;
         }
-        if (get_key_parts(curr_orig_key) != get_key_parts(curr_altered_key)) {
+        if (curr_orig_key->user_defined_key_parts !=
+            curr_altered_key->user_defined_key_parts) {
             if (print_error) {
                 sql_print_error(
                     "keys have different number of parts, %d, %d",
-                    get_key_parts(curr_orig_key),
-                    get_key_parts(curr_altered_key));
+                    curr_orig_key->user_defined_key_parts,
+                    curr_altered_key->user_defined_key_parts);
             }
             retval = false;
             goto cleanup;
@@ -105,7 +106,7 @@ static bool tables_have_same_keys(
         //
         // now verify that each field in the key is the same
         //
-        for (uint32_t j = 0; j < get_key_parts(curr_orig_key); j++) {
+        for (uint32_t j = 0; j < curr_orig_key->user_defined_key_parts; j++) {
             KEY_PART_INFO* curr_orig_part = &curr_orig_key->key_part[j];
             KEY_PART_INFO* curr_altered_part = &curr_altered_key->key_part[j];
             Field* curr_orig_field = curr_orig_part->field;

--- a/storage/tokudb/ha_tokudb_update.cc
+++ b/storage/tokudb/ha_tokudb_update.cc
@@ -453,7 +453,7 @@ static bool check_all_update_expressions(
 static bool full_field_in_key(TABLE* table, Field* field) {
     assert_always(table->s->primary_key < table->s->keys);
     KEY* key = &table->s->key_info[table->s->primary_key];
-    for (uint i = 0; i < get_key_parts(key); i++) {
+    for (uint i = 0; i < key->user_defined_key_parts; i++) {
         KEY_PART_INFO* key_part = &key->key_part[i];
         if (strcmp(field->field_name, key_part->field->field_name) == 0) {
             return key_part->length == field->field_length;
@@ -519,7 +519,7 @@ static bool check_point_update(Item* conds, TABLE* table) {
     if (bitmap_init(&pk_fields, NULL, table->s->fields, FALSE)) // 1 -> failure
         return false;
     KEY *key = &table->s->key_info[table->s->primary_key];
-    for (uint i = 0; i < get_key_parts(key); i++) 
+    for (uint i = 0; i < key->user_defined_key_parts; i++)
         bitmap_set_bit(&pk_fields, key->key_part[i].field->field_index);
 
     switch (conds->type()) {

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1010,7 +1010,7 @@ static int create_toku_key_descriptor_for_key(KEY* key, uchar* buf) {
     uchar* pos = buf;
     uint32_t num_bytes_in_field = 0;
     uint32_t charset_num = 0;
-    for (uint i = 0; i < get_key_parts(key); i++){
+    for (uint i = 0; i < key->user_defined_key_parts; i++) {
         Field* field = key->key_part[i].field;
         //
         // The first byte states if there is a null byte
@@ -1881,7 +1881,7 @@ static uint32_t pack_desc_pk_offset_info(
 
     bool is_constant_offset = true;
     uint32_t offset = 0;
-    for (uint i = 0; i < get_key_parts(prim_key); i++) {
+    for (uint i = 0; i < prim_key->user_defined_key_parts; i++) {
         KEY_PART_INFO curr = prim_key->key_part[i];
         uint16 curr_field_index = curr.field->field_index;
 
@@ -2503,8 +2503,8 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
         //
         // store number of parts
         //
-        assert_always(get_key_parts(prim_key) < 128);
-        pos[0] = 2 * get_key_parts(prim_key);
+        assert_always(prim_key->user_defined_key_parts < 128);
+        pos[0] = 2 * prim_key->user_defined_key_parts;
         pos++;
         //
         // for each part, store if it is a fixed field or var field
@@ -2514,7 +2514,7 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
         //
         pk_info = pos;
         uchar* tmp = pos;
-        for (uint i = 0; i < get_key_parts(prim_key); i++) {
+        for (uint i = 0; i < prim_key->user_defined_key_parts; i++) {
             tmp += pack_desc_pk_info(
                 tmp,
                 kc_info,
@@ -2525,11 +2525,11 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
         //
         // asserting that we moved forward as much as we think we have
         //
-        assert_always(tmp - pos == (2 * get_key_parts(prim_key)));
+        assert_always(tmp - pos == (2 * prim_key->user_defined_key_parts));
         pos = tmp;
     }
 
-    for (uint i = 0; i < get_key_parts(key_info); i++) {
+    for (uint i = 0; i < key_info->user_defined_key_parts; i++) {
         KEY_PART_INFO curr_kpi = key_info->key_part[i];
         uint16 field_index = curr_kpi.field->field_index;
         Field* field = table_share->field[field_index];

--- a/storage/tokudb/hatoku_hton.h
+++ b/storage/tokudb/hatoku_hton.h
@@ -199,14 +199,4 @@ void tokudb_pretty_left_key(const DB* db, const DBT* key, String* out);
 void tokudb_pretty_right_key(const DB* db, const DBT* key, String* out);
 const char *tokudb_get_index_name(DB* db);
 
-inline uint get_key_parts(const KEY *key) {
-#if (50609 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50699) || \
-    (50700 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50799) || \
-    (100009 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100099)
-    return key->user_defined_key_parts;
-#else
-    return key->key_parts;
-#endif
-}
-
 #endif //#ifdef _HATOKU_HTON

--- a/storage/tokudb/tokudb_card.h
+++ b/storage/tokudb/tokudb_card.h
@@ -27,7 +27,7 @@ namespace tokudb {
     uint compute_total_key_parts(TABLE_SHARE *table_share) {
         uint total_key_parts = 0;
         for (uint i = 0; i < table_share->keys; i++) {
-            total_key_parts += get_key_parts(&table_share->key_info[i]);
+            total_key_parts += table_share->key_info[i].user_defined_key_parts;
         }
         return total_key_parts;
     }
@@ -156,13 +156,14 @@ namespace tokudb {
         uint orig_key_parts = 0;
         for (uint i = 0; i < table_share->keys; i++) {
             orig_key_offset[i] = orig_key_parts;
-            orig_key_parts += get_key_parts(&table_share->key_info[i]);
+            orig_key_parts += table_share->key_info[i].user_defined_key_parts;
         }
         // if orig card data exists, then use it to compute new card data
         if (error == 0) {
             uint next_key_parts = 0;
             for (uint i = 0; error == 0 && i < altered_table_share->keys; i++) {
-                uint ith_key_parts = get_key_parts(&altered_table_share->key_info[i]);
+                uint ith_key_parts =
+                    altered_table_share->key_info[i].user_defined_key_parts;
                 uint orig_key_index;
                 if (find_index_of_key(
                         altered_table_share->key_info[i].name,


### PR DESCRIPTION
…ate after the changes introduced by DB-848
- Issue is due to a bad optimization added during the cardinality rework from https://blueprints.launchpad.net/percona-server/+spec/tokudb-background-auto-analyze
- This only happenes with partitioned tables. There were cases where the optimizer and/or partition handler would call the handler to update the shared key record count structures multiple times and it would 'clear' the values in between calls. There was an optimization added in TokuDB that would not update the record count values if it knew that the cardinality had not changed since the last call, thus leaving all of the record counts in the 'cleared' state.
- Removed this optimization, re-recorded affected tests and validated the results against the same conditions in InnoDB.
- Removed 6 year old hack that was wrong in the first place to fix a '0' record count and replaced with logic matching InnoDB.
