### PR TITLE
5.7 - Rename the service on centos 6 back to mysql and on centos 7 systemd put alias for mysql.service (BLD-398)

### DIFF
--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -427,7 +427,7 @@ install -D -m 0644 $MBD/%{src_dir}/build-ps/rpm/my.cnf %{buildroot}%{_sysconfdir
 install -d %{buildroot}%{_sysconfdir}/my.cnf.d
 %if 0%{?systemd}
 %else
-install -D -m 0755 $MBD/%{src_dir}/build-ps/rpm/mysql.init %{buildroot}%{_sysconfdir}/init.d/mysqld
+install -D -m 0755 $MBD/%{src_dir}/build-ps/rpm/mysql.init %{buildroot}%{_sysconfdir}/init.d/mysql
 %endif
 
 # Add libdir to linker
@@ -492,7 +492,7 @@ datadir=$(/usr/bin/my_print_defaults server mysqld | grep '^--datadir=' | sed -n
 %systemd_post mysqld.service
 /usr/bin/systemctl enable mysqld >/dev/null 2>&1 || :
 %else
-/sbin/chkconfig --add mysqld
+/sbin/chkconfig --add mysql
 %endif
 
 echo "Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit."
@@ -507,8 +507,8 @@ echo "See http://www.percona.com/doc/percona-server/5.7/management/udf_percona_t
 %systemd_preun mysqld.service
 %else
 if [ "$1" = 0 ]; then
-    /sbin/service mysqld stop >/dev/null 2>&1 || :
-    /sbin/chkconfig --del mysqld
+    /sbin/service mysql stop >/dev/null 2>&1 || :
+    /sbin/chkconfig --del mysql
 fi
 %endif
 
@@ -517,7 +517,7 @@ fi
 %systemd_postun_with_restart mysqld.service
 %else
 if [ $1 -ge 1 ]; then
-    /sbin/service mysqld condrestart >/dev/null 2>&1 || :
+    /sbin/service mysql condrestart >/dev/null 2>&1 || :
 fi
 %endif
 
@@ -692,7 +692,7 @@ fi
 %attr(644, root, root) %{_unitdir}/mysqld.service
 %attr(644, root, root) %{_prefix}/lib/tmpfiles.d/mysql.conf
 %else
-%attr(755, root, root) %{_sysconfdir}/init.d/mysqld
+%attr(755, root, root) %{_sysconfdir}/init.d/mysql
 %endif
 %attr(644, root, root) %config(noreplace,missingok) %{_sysconfdir}/logrotate.d/mysql
 %dir %attr(751, mysql, mysql) /var/lib/mysql

--- a/scripts/systemd/mysqld.service.in
+++ b/scripts/systemd/mysqld.service.in
@@ -23,6 +23,7 @@ After=syslog.target
 
 [Install]
 WantedBy=multi-user.target
+Alias=mysql.service
 
 [Service]
 User=@MYSQLD_USER@


### PR DESCRIPTION
**TICKET:** BLD-398
https://bugs.launchpad.net/percona-server/+bug/1542332

**INFO:**
Oracle Mysql uses "mysqld" service name on centos, but we had "mysql" before on centos6 and mysqld with mysql alias on centos 7.
It was decided that we will use the same as 5.6 on centos 6/7 so this change is to make the service name "mysql" on centos 6 and put an alias for mysql in centos 7.

**TEST:**
_CENTOS6:_

```
[vagrant@t-centos6-64 ~]$ sudo service mysql start
Initializing MySQL database:  2016-02-04T14:27:27.932767Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2016-02-04T14:27:28.208267Z 0 [Warning] InnoDB: New log files created, LSN=45790
2016-02-04T14:27:28.242467Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
2016-02-04T14:27:28.302291Z 0 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 6b0327fc-cb4b-11e5-a9c7-08002773bf1c.
2016-02-04T14:27:28.305633Z 0 [Warning] Gtid table is not ready to be used. Table 'mysql.gtid_executed' cannot be opened.
2016-02-04T14:27:28.651066Z 0 [Warning] CA certificate ca.pem is self signed.
2016-02-04T14:27:28.773523Z 1 [Note] A temporary password is generated for root@localhost: /qYfh1K6gpw*
                                                           [  OK  ]
Starting mysqld:                                           [  OK  ]

[vagrant@t-centos6-64 ~]$ sudo service mysql status
mysqld (pid  3271) is running...

[vagrant@t-centos6-64 ~]$ sudo service mysqld status
mysqld: unrecognized service

[vagrant@t-centos6-64 ~]$ sudo service mysql restart
Stopping mysqld:                                           [  OK  ]
Starting mysqld:                                           [  OK  ]

[vagrant@t-centos6-64 ~]$ sudo service mysql status
mysqld (pid  3592) is running...

[vagrant@t-centos6-64 ~]$ sudo service mysql stop
Stopping mysqld:                                           [  OK  ]

[vagrant@t-centos6-64 ~]$ sudo service mysql status
mysqld is stopped
```

_CENTOS7:_

```
[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: inactive (dead)

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysqld
mysqld.service - MySQL Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: inactive (dead)

[vagrant@t-centos7-64 ~]$ sudo systemctl start mysqld

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysqld
mysqld.service - MySQL Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: active (running) since Čet 2016-02-04 15:34:59 CET; 2s ago
  Process: 3622 ExecStart=/usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid $MYSQLD_OPTS (code=exited, status=0/SUCCESS)
  Process: 3574 ExecStartPre=/usr/bin/mysqld_pre_systemd (code=exited, status=0/SUCCESS)
 Main PID: 3624 (mysqld)
   CGroup: /system.slice/mysqld.service
           └─3624 /usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid

Vel 04 15:34:59 t-centos7-64 systemd[1]: Started MySQL Server.

[vagrant@t-centos7-64 ~]$ sudo systemctl stop mysqld

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysqld
mysqld.service - MySQL Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: inactive (dead) since Čet 2016-02-04 15:35:10 CET; 1s ago
  Process: 3622 ExecStart=/usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid $MYSQLD_OPTS (code=exited, status=0/SUCCESS)
  Process: 3574 ExecStartPre=/usr/bin/mysqld_pre_systemd (code=exited, status=0/SUCCESS)
 Main PID: 3624 (code=exited, status=0/SUCCESS)

Vel 04 15:34:59 t-centos7-64 systemd[1]: Started MySQL Server.
Vel 04 15:35:09 t-centos7-64 systemd[1]: Stopping MySQL Server...
Vel 04 15:35:10 t-centos7-64 systemd[1]: Stopped MySQL Server.

[vagrant@t-centos7-64 ~]$ sudo systemctl start mysql

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: active (running) since Čet 2016-02-04 15:35:19 CET; 2s ago
  Process: 3681 ExecStart=/usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid $MYSQLD_OPTS (code=exited, status=0/SUCCESS)
  Process: 3664 ExecStartPre=/usr/bin/mysqld_pre_systemd (code=exited, status=0/SUCCESS)
 Main PID: 3683 (mysqld)
   CGroup: /system.slice/mysqld.service
           └─3683 /usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid

Vel 04 15:35:18 t-centos7-64 systemd[1]: Starting MySQL Server...
Vel 04 15:35:19 t-centos7-64 systemd[1]: Started MySQL Server.

[vagrant@t-centos7-64 ~]$ sudo systemctl stop mysql

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: inactive (dead) since Čet 2016-02-04 15:35:32 CET; 1s ago
  Process: 3681 ExecStart=/usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid $MYSQLD_OPTS (code=exited, status=0/SUCCESS)
  Process: 3664 ExecStartPre=/usr/bin/mysqld_pre_systemd (code=exited, status=0/SUCCESS)
 Main PID: 3683 (code=exited, status=0/SUCCESS)

Vel 04 15:35:18 t-centos7-64 systemd[1]: Starting MySQL Server...
Vel 04 15:35:19 t-centos7-64 systemd[1]: Started MySQL Server.
Vel 04 15:35:31 t-centos7-64 systemd[1]: Stopping MySQL Server...
Vel 04 15:35:32 t-centos7-64 systemd[1]: Stopped MySQL Server.
```
