### PR TITLE
Fix for writing temp password into logfile on centos 6 (#1541769)

### DIFF
--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -494,6 +494,20 @@ datadir=$(/usr/bin/my_print_defaults server mysqld | grep '^--datadir=' | sed -n
 %else
 /sbin/chkconfig --add mysqld
 %endif
+# We need this because we don't provide my.cnf on centos 6
+# and the default system one doesn't have info needed
+%if 0%{?rhel} < 7
+if [ $1 -eq 1 ]; then
+  cnflog=$(/usr/bin/my_print_defaults mysqld|grep -c log-error)
+  if [ $cnflog = 0 -a -f /etc/my.cnf ]; then
+    sed -i "/^\[mysqld\]$/a log-error=/var/log/mysqld.log" /etc/my.cnf
+  fi
+  cnfpid=$(/usr/bin/my_print_defaults mysqld|grep -c pid-file)
+  if [ $cnfpid = 0 -a -f /etc/my.cnf ]; then
+    sed -i "/^\[mysqld\]$/a pid-file=/var/run/mysqld/mysqld.pid" /etc/my.cnf
+  fi
+fi
+%endif
 
 echo "Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit."
 echo "Run the following commands to create these functions:"

--- a/build-ps/rpm/mysql.init
+++ b/build-ps/rpm/mysql.init
@@ -3,7 +3,7 @@
 # mysqld	This shell script takes care of starting and stopping
 #		the MySQL subsystem (mysqld).
 #
-# chkconfig: - 64 36
+# chkconfig: 345 64 36
 # description:	MySQL database server.
 # processname: mysqld
 # config: /etc/my.cnf
@@ -37,7 +37,7 @@ extra_opts="$@"
 # We use my_print_defaults which prints all options from multiple files,
 # with the more specific ones later; hence take the last match.
 get_mysql_option(){
-	result=`/usr/bin/my_print_defaults "$1" | sed -n "s/^--$2=//p" | tail -n 1`
+	result=$(/usr/bin/my_print_defaults "$1" | sed -n "s/^--$2=//p" | tail -n 1)
 	if [ -z "$result" ]; then
 	    # not found, use default
 	    result="$3"
@@ -61,15 +61,12 @@ esac
 install_validate_password_sql_file () {
     local dir
     local initfile
-    if [ -d /var/lib/mysql-files ]; then
-        dir=/var/lib/mysql-files
-    else
-        dir=/tmp
-    fi
+    dir=/var/lib/mysql
     initfile="$(mktemp $dir/install-validate-password-plugin.XXXXXX.sql)"
     chown mysql:mysql "$initfile"
-    echo "INSERT INTO mysql.plugin (name, dl) VALUES ('validate_password', 'validate_password.so');" > $initfile
-    echo $initfile
+    echo "INSERT INTO mysql.plugin (name, dl) VALUES ('validate_password', 'validate_password.so');" > "$initfile"
+    echo "SHUTDOWN;" >> "$initfile"
+    echo "$initfile"
 }
 
 start(){
@@ -86,9 +83,9 @@ start(){
 	action $"Starting $prog: " /bin/true
 	ret=0
     else
-    	# prepare for start
+	# prepare for start
 	touch "$errlogfile"
-	chown mysql:mysql "$errlogfile" 
+	chown mysql:mysql "$errlogfile"
 	chmod 0640 "$errlogfile"
 	[ -x /sbin/restorecon ] && /sbin/restorecon "$errlogfile"
 	if [ ! -d "$datadir/mysql" ] ; then
@@ -99,19 +96,28 @@ start(){
 	    fi
 	    chown mysql:mysql "$datadir"
 	    chmod 0751 "$datadir"
-	    [ -x /sbin/restorecon ] && /sbin/restorecon "$datadir"
+	    if [ -x /sbin/restorecon ] ; then
+		/sbin/restorecon "$datadir"
+		for dir in /var/lib/mysql-files /var/lib/mysql-keyring ; do
+		    if [ -x /usr/sbin/semanage -a -d /var/lib/mysql -a -d $dir ] ; then
+			/usr/sbin/semanage fcontext -a -e /var/lib/mysql $dir >/dev/null 2>&1
+			/sbin/restorecon $dir
+		    fi
+		done
+	    fi
 	    # Now create the database
-            initfile="$(install_validate_password_sql_file)"
-	    action $"Initializing MySQL database: " /usr/sbin/mysqld --initialize --datadir="$datadir" --user=mysql --init-file="$initfile"
+	    action $"Initializing MySQL database: " /usr/sbin/mysqld --initialize --datadir="$datadir" --user=mysql
 	    ret=$?
-            rm -f "$initfile"
+	    [ $ret -ne 0 ] && return $ret
+	    initfile="$(install_validate_password_sql_file)"
+	    action $"Installing validate password plugin: " /usr/sbin/mysqld --datadir="$datadir" --user=mysql --init-file="$initfile"
+	    ret=$?
+	    rm -f "$initfile"
 	    chown -R mysql:mysql "$datadir"
-            # Generate certs if needed
-            if [ -x /usr/bin/mysql_ssl_rsa_setup -a ! -e "${datadir}/server-key.pem" ] ; then
-                /usr/bin/mysql_ssl_rsa_setup --datadir="$datadir" --uid=mysql >/dev/null 2>&1
-            fi
-	    if [ $ret -ne 0 ] ; then
-		return $ret
+	    [ $ret -ne 0 ] && return $ret
+	    # Generate certs if needed
+	    if [ -x /usr/bin/mysql_ssl_rsa_setup -a ! -e "${datadir}/server-key.pem" ] ; then
+		/usr/bin/mysql_ssl_rsa_setup --datadir="$datadir" --uid=mysql >/dev/null 2>&1
 	    fi
 	fi
 	chown mysql:mysql "$datadir"
@@ -164,7 +170,7 @@ stop(){
 	    action $"Stopping $prog: " /bin/true
 	    return 0
 	fi
-	MYSQLPID=`cat "$mypidfile"`
+	MYSQLPID=$(cat "$mypidfile")
 	if [ -n "$MYSQLPID" ]; then
 	    /bin/kill "$MYSQLPID" >/dev/null 2>&1
 	    ret=$?
@@ -194,7 +200,7 @@ stop(){
 	fi
 	return $ret
 }
- 
+
 restart(){
     stop
     start


### PR DESCRIPTION
**BUG:**
Percona Server 5.7.10-1rc1 doesn't write the initial password into log
https://bugs.launchpad.net/percona-server/+bug/1541769

**INFO:**
On centos 6 the init script doesn't write the temp password into log file. It doesn't do so because log-error
is missing from [mysqld] section of system default my.cnf. So for that the change is made in rpm spec file to
only add this and pid-file if it's initial installation and options are missing.
The changes in the init file for centos 6 are from latest upstream changes, and here's some comments on their latest changes:
- 88be5dd 2016-01-27 | BUG#22600974 - SYSV INITSCRIPT FOR RHEL DON'T ENABLE MYSQLD SERVICE BY DEFAULT [Balasubramanian Kandasamy]
- 6e71a0f 2016-01-18 | Bug#22559624 KEYRING_FILE INITIALIZATION FAILURE WHEN SELINUX ENABLED FROM DISABLED STATE [Balasubramanian Kandasamy]
- 3c9db0a 2015-12-17 | Bug#22286481 UNABLE TO START SERVER/CREATE DB WHEN SELINUX ENABLED WITH ENFORCING Bug#22314098 MYSQL 5.7 SERVER START FAILING AFTER INSTALLATION [Balasubramanian Kandasamy]

**TEST BUILD:**
http://jenkins.percona.com/job/percona-server-5.7-redhat-binary/label_exp=centos6-64/

**TEST:**

_BEFORE CHANGE_

```
[vagrant@t-centos6-64 ~]$ sudo service mysql start
Initializing MySQL database:  2016-02-08T12:24:41.310832Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
2016-02-08T12:24:41.560244Z 0 [Warning] InnoDB: New log files created, LSN=45790
2016-02-08T12:24:41.595247Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
2016-02-08T12:24:41.653873Z 0 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: edcccf57-ce5e-11e5-a836-08002773bf1c.
2016-02-08T12:24:41.657354Z 0 [Warning] Gtid table is not ready to be used. Table 'mysql.gtid_executed' cannot be opened.
2016-02-08T12:24:42.103092Z 0 [Warning] CA certificate ca.pem is self signed.
2016-02-08T12:24:42.166392Z 1 [Note] A temporary password is generated for root@localhost: 9p;yu(;)peUJ
                                                           [  OK  ]
Starting mysqld:                                           [  OK  ]
```

The temp password was displayed on stdout and not in error log.

_AFTER CHANGE_
(notice the service is called mysqld instead of mysql, but that's because the RC2 branch is not merged yet - there will be no conflict with that change)

```
[vagrant@t-centos6-64 ~]$ sudo yum install *.rpm
Loaded plugins: fastestmirror, security
Determining fastest mirrors
 * base: mirror.met.hu
 * extras: mirror.met.hu
 * updates: mirror.met.hu
... 
Setting up Install Process
Examining Percona-Server-client-57-5.7.10-1rc1.1.el6.x86_64.rpm: Percona-Server-client-57-5.7.10-1rc1.1.el6.x86_64
Marking Percona-Server-client-57-5.7.10-1rc1.1.el6.x86_64.rpm to be installed
Examining Percona-Server-server-57-5.7.10-1rc1.1.el6.x86_64.rpm: Percona-Server-server-57-5.7.10-1rc1.1.el6.x86_64
Marking Percona-Server-server-57-5.7.10-1rc1.1.el6.x86_64.rpm to be installed
Examining Percona-Server-shared-57-5.7.10-1rc1.1.el6.x86_64.rpm: Percona-Server-shared-57-5.7.10-1rc1.1.el6.x86_64
Marking Percona-Server-shared-57-5.7.10-1rc1.1.el6.x86_64.rpm to be installed
Resolving Dependencies
--> Running transaction check
---> Package Percona-Server-client-57.x86_64 0:5.7.10-1rc1.1.el6 will be installed
---> Package Percona-Server-server-57.x86_64 0:5.7.10-1rc1.1.el6 will be installed
---> Package Percona-Server-shared-57.x86_64 0:5.7.10-1rc1.1.el6 will be installed
--> Finished Dependency Resolution

Dependencies Resolved
 Package                                                Arch                                 Version                                            Repository                                                                        Size
=======================================================================================================================================================================================================================================
Installing:
 Percona-Server-client-57                               x86_64                               5.7.10-1rc1.1.el6                                  /Percona-Server-client-57-5.7.10-1rc1.1.el6.x86_64                                37 M
 Percona-Server-server-57                               x86_64                               5.7.10-1rc1.1.el6                                  /Percona-Server-server-57-5.7.10-1rc1.1.el6.x86_64                               173 M
 Percona-Server-shared-57                               x86_64                               5.7.10-1rc1.1.el6                                  /Percona-Server-shared-57-5.7.10-1rc1.1.el6.x86_64                               3.7 M

Transaction Summary
=======================================================================================================================================================================================================================================
Install       3 Package(s)

Total size: 213 M
Installed size: 213 M
Is this ok [y/N]: y
Downloading Packages:
Running rpm_check_debug
Running Transaction Test
Transaction Test Succeeded
Running Transaction
  Installing : Percona-Server-shared-57-5.7.10-1rc1.1.el6.x86_64                                                                                                                                                                   1/3 
  Installing : Percona-Server-client-57-5.7.10-1rc1.1.el6.x86_64                                                                                                                                                                   2/3 
  Installing : Percona-Server-server-57-5.7.10-1rc1.1.el6.x86_64                                                                                                                                                                   3/3 
Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
Run the following commands to create these functions:
mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"
See http://www.percona.com/doc/percona-server/5.7/management/udf_percona_toolkit.html for more details
  Verifying  : Percona-Server-shared-57-5.7.10-1rc1.1.el6.x86_64  1/3 
  Verifying  : Percona-Server-server-57-5.7.10-1rc1.1.el6.x86_64  2/3 
  Verifying  : Percona-Server-client-57-5.7.10-1rc1.1.el6.x86_64  3/3 

Installed:
  Percona-Server-client-57.x86_64 0:5.7.10-1rc1.1.el6                         Percona-Server-server-57.x86_64 0:5.7.10-1rc1.1.el6                         Percona-Server-shared-57.x86_64 0:5.7.10-1rc1.1.el6                        

Complete!

[vagrant@t-centos6-64 ~]$ sudo service mysqld start
Initializing MySQL database:                               [  OK  ]
Installing validate password plugin:                       [  OK  ]
Starting mysqld:                                           [  OK  ]

[vagrant@t-centos6-64 ~]$ sudo service mysqld stop
Stopping mysqld:                                           [  OK  ]

[vagrant@t-centos6-64 ~]$ sudo service mysqld start
Starting mysqld:                                           [  OK  ]

[vagrant@t-centos6-64 ~]$ sudo grep 'temporary password' /var/log/mysqld.log
2016-02-08T16:22:06.108971Z 1 [Note] A temporary password is generated for root@localhost: WUFjWN<xH1->

[vagrant@t-centos6-64 ~]$ cat /etc/my.cnf 
[mysqld]
pid-file=/var/run/mysqld/mysqld.pid
log-error=/var/log/mysqld.log
datadir=/var/lib/mysql
socket=/var/lib/mysql/mysql.sock
user=mysql
# Disabling symbolic-links is recommended to prevent assorted security risks
symbolic-links=0

[mysqld_safe]
log-error=/var/log/mysqld.log
pid-file=/var/run/mysqld/mysqld.pid
```
