### PR TITLE
Implement a multithreaded asynchronous LRU flusher

### DIFF
--- a/mysql-test/suite/perfschema/r/threads_innodb.result
+++ b/mysql-test/suite/perfschema/r/threads_innodb.result
@@ -6,6 +6,7 @@ WHERE name LIKE 'thread/innodb/%'
 GROUP BY name;
 name	type	processlist_user	processlist_host	processlist_db	processlist_command	processlist_time	processlist_state	processlist_info	parent_thread_id	role	instrumented
 thread/innodb/buf_dump_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
+thread/innodb/buf_lru_manager_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/dict_stats_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/io_ibuf_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES
 thread/innodb/io_log_thread	BACKGROUND	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	YES

--- a/mysql-test/suite/sys_vars/r/innodb_empty_free_list_algorithm_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_empty_free_list_algorithm_basic.result
@@ -1,7 +1,7 @@
 SET @start_value = @@GLOBAL.innodb_empty_free_list_algorithm;
 SELECT @@GLOBAL.innodb_empty_free_list_algorithm;
 @@GLOBAL.innodb_empty_free_list_algorithm
-legacy
+backoff
 SELECT @@SESSION.innodb_empty_free_list_algorithm;
 ERROR HY000: Variable 'innodb_empty_free_list_algorithm' is a GLOBAL variable
 SET GLOBAL innodb_empty_free_list_algorithm='legacy';

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -75,6 +75,9 @@ need to protect it by a mutex. It is only ever read by the thread
 doing the shutdown */
 bool buf_page_cleaner_is_active = false;
 
+/** Flag indicating if the lru_manager is in active state. */
+bool buf_lru_manager_is_active = false;
+
 /** Factor for scan length to determine n_pages for intended oldest LSN
 progress */
 static ulint buf_flush_lsn_scan_factor = 3;
@@ -87,6 +90,7 @@ static lsn_t buf_flush_sync_lsn = 0;
 
 #ifdef UNIV_PFS_THREAD
 mysql_pfs_key_t page_cleaner_thread_key;
+mysql_pfs_key_t	buf_lru_manager_thread_key;
 #endif /* UNIV_PFS_THREAD */
 
 /** Event to synchronise with the flushing. */
@@ -114,8 +118,8 @@ struct page_cleaner_slot_t {
 					protected by page_cleaner_t::mutex
 					if the worker thread got the slot and
 					set to PAGE_CLEANER_STATE_FLUSHING,
-					n_flushed_lru and n_flushed_list can be
-					updated only by the worker thread */
+					n_flushed_list can be updated only by
+					the worker thread */
 	/* This value is set during state==PAGE_CLEANER_STATE_NONE */
 	ulint			n_pages_requested;
 					/*!< number of requested pages
@@ -123,9 +127,6 @@ struct page_cleaner_slot_t {
 	/* These values are updated during state==PAGE_CLEANER_STATE_FLUSHING,
 	and commited with state==PAGE_CLEANER_STATE_FINISHED.
 	The consistency is protected by the 'state' */
-	ulint			n_flushed_lru;
-					/*!< number of flushed and evicted
-					pages by LRU scan flushing */
 
 	ulint			n_flushed_list;
 					/*!< number of flushed pages
@@ -133,13 +134,9 @@ struct page_cleaner_slot_t {
 	bool			succeeded_list;
 					/*!< true if flush_list flushing
 					succeeded. */
-	ulint			flush_lru_time;
-					/*!< elapsed time for LRU flushing */
 	ulint			flush_list_time;
 					/*!< elapsed time for flush_list
 					flushing */
-	ulint			flush_lru_pass;
-					/*!< count to attempt LRU flushing */
 	ulint			flush_list_pass;
 					/*!< count to attempt flush_list
 					flushing */
@@ -1939,26 +1936,6 @@ buf_flush_batch(
 }
 
 /******************************************************************//**
-Gather the aggregated stats for both flush list and LRU list flushing.
-@param page_count_flush	number of pages flushed from the end of the flush_list
-@param page_count_LRU	number of pages flushed from the end of the LRU list
-*/
-static
-void
-buf_flush_stats(
-/*============*/
-	ulint		page_count_flush,
-	ulint		page_count_LRU)
-{
-	DBUG_PRINT("ib_buf", ("flush completed, from flush_list %u pages, "
-			      "from LRU_list %u pages",
-			      unsigned(page_count_flush),
-			      unsigned(page_count_LRU)));
-
-	srv_stats.buf_pool_flushed.add(page_count_flush + page_count_LRU);
-}
-
-/******************************************************************//**
 Start a buffer flush batch for LRU or flush list */
 static
 ibool
@@ -2217,7 +2194,7 @@ buf_flush_lists(
 	}
 
 	if (n_flushed) {
-		buf_flush_stats(n_flushed, 0);
+		srv_stats.buf_pool_flushed.add(n_flushed);
 	}
 
 	if (n_processed) {
@@ -2378,7 +2355,7 @@ buf_flush_LRU_lists(void)
 	}
 
 	if (n_flushed) {
-		buf_flush_stats(0, n_flushed);
+		srv_stats.buf_pool_flushed.add(n_flushed);
 	}
 
 	return(n_flushed);
@@ -2575,9 +2552,7 @@ page_cleaner_flush_pages_recommendation(
 		page_cleaner->flush_time = 0;
 		page_cleaner->flush_pass = 0;
 
-		ulint	lru_tm = 0;
 		ulint	list_tm = 0;
-		ulint	lru_pass = 0;
 		ulint	list_pass = 0;
 
 		for (ulint i = 0; i < page_cleaner->n_slots; i++) {
@@ -2585,13 +2560,9 @@ page_cleaner_flush_pages_recommendation(
 
 			slot = &page_cleaner->slots[i];
 
-			lru_tm    += slot->flush_lru_time;
-			lru_pass  += slot->flush_lru_pass;
 			list_tm   += slot->flush_list_time;
 			list_pass += slot->flush_list_pass;
 
-			slot->flush_lru_time  = 0;
-			slot->flush_lru_pass  = 0;
 			slot->flush_list_time = 0;
 			slot->flush_list_pass = 0;
 		}
@@ -2599,9 +2570,6 @@ page_cleaner_flush_pages_recommendation(
 		mutex_exit(&page_cleaner->mutex);
 
 		/* minimum values are 1, to avoid dividing by zero. */
-		if (lru_tm < 1) {
-			lru_tm = 1;
-		}
 		if (list_tm < 1) {
 			list_tm = 1;
 		}
@@ -2609,9 +2577,6 @@ page_cleaner_flush_pages_recommendation(
 			flush_tm = 1;
 		}
 
-		if (lru_pass < 1) {
-			lru_pass = 1;
-		}
 		if (list_pass < 1) {
 			list_pass = 1;
 		}
@@ -2621,25 +2586,16 @@ page_cleaner_flush_pages_recommendation(
 
 		MONITOR_SET(MONITOR_FLUSH_ADAPTIVE_AVG_TIME_SLOT,
 			    list_tm / list_pass);
-		MONITOR_SET(MONITOR_LRU_BATCH_FLUSH_AVG_TIME_SLOT,
-			    lru_tm  / lru_pass);
 
 		MONITOR_SET(MONITOR_FLUSH_ADAPTIVE_AVG_TIME_THREAD,
 			    list_tm / (srv_n_page_cleaners * flush_pass));
-		MONITOR_SET(MONITOR_LRU_BATCH_FLUSH_AVG_TIME_THREAD,
-			    lru_tm / (srv_n_page_cleaners * flush_pass));
 		MONITOR_SET(MONITOR_FLUSH_ADAPTIVE_AVG_TIME_EST,
 			    flush_tm * list_tm / flush_pass
-			    / (list_tm + lru_tm));
-		MONITOR_SET(MONITOR_LRU_BATCH_FLUSH_AVG_TIME_EST,
-			    flush_tm * lru_tm / flush_pass
-			    / (list_tm + lru_tm));
+			    / list_tm);
 		MONITOR_SET(MONITOR_FLUSH_AVG_TIME, flush_tm / flush_pass);
 
 		MONITOR_SET(MONITOR_FLUSH_ADAPTIVE_AVG_PASS,
 			    list_pass / page_cleaner->n_slots);
-		MONITOR_SET(MONITOR_LRU_BATCH_FLUSH_AVG_PASS,
-			    lru_pass / page_cleaner->n_slots);
 		MONITOR_SET(MONITOR_FLUSH_AVG_PASS, flush_pass);
 
 		prev_lsn = cur_lsn;
@@ -2888,9 +2844,7 @@ static
 ulint
 pc_flush_slot(void)
 {
-	ulint	lru_tm = 0;
 	ulint	list_tm = 0;
-	int	lru_pass = 0;
 	int	list_pass = 0;
 
 	mutex_enter(&page_cleaner->mutex);
@@ -2922,25 +2876,11 @@ pc_flush_slot(void)
 		}
 
 		if (!page_cleaner->is_running) {
-			slot->n_flushed_lru = 0;
 			slot->n_flushed_list = 0;
 			goto finish_mutex;
 		}
 
 		mutex_exit(&page_cleaner->mutex);
-
-		lru_tm = ut_time_ms();
-
-		/* Flush pages from end of LRU if required */
-		slot->n_flushed_lru = buf_flush_LRU_list(buf_pool);
-
-		lru_tm = ut_time_ms() - lru_tm;
-		lru_pass++;
-
-		if (!page_cleaner->is_running) {
-			slot->n_flushed_list = 0;
-			goto finish;
-		}
 
 		/* Flush pages from flush_list if required */
 		if (page_cleaner->requested) {
@@ -2959,16 +2899,13 @@ pc_flush_slot(void)
 			slot->n_flushed_list = 0;
 			slot->succeeded_list = true;
 		}
-finish:
 		mutex_enter(&page_cleaner->mutex);
 finish_mutex:
 		page_cleaner->n_slots_flushing--;
 		page_cleaner->n_slots_finished++;
 		slot->state = PAGE_CLEANER_STATE_FINISHED;
 
-		slot->flush_lru_time += lru_tm;
 		slot->flush_list_time += list_tm;
-		slot->flush_lru_pass += lru_pass;
 		slot->flush_list_pass += list_pass;
 
 		if (page_cleaner->n_slots_requested == 0
@@ -2986,20 +2923,16 @@ finish_mutex:
 
 /**
 Wait until all flush requests are finished.
-@param n_flushed_lru	number of pages flushed and evicted from the end of the
-                        LRU list.
 @param n_flushed_list	number of pages flushed from the end of the
 			flush_list.
 @return			true if all flush_list flushing batch were success. */
 static
 bool
 pc_wait_finished(
-	ulint*	n_flushed_lru,
 	ulint*	n_flushed_list)
 {
 	bool	all_succeeded = true;
 
-	*n_flushed_lru = 0;
 	*n_flushed_list = 0;
 
 	os_event_wait(page_cleaner->is_finished);
@@ -3015,7 +2948,6 @@ pc_wait_finished(
 
 		ut_ad(slot->state == PAGE_CLEANER_STATE_FINISHED);
 
-		*n_flushed_lru += slot->n_flushed_lru;
 		*n_flushed_list += slot->n_flushed_list;
 		all_succeeded &= slot->succeeded_list;
 
@@ -3031,67 +2963,6 @@ pc_wait_finished(
 	mutex_exit(&page_cleaner->mutex);
 
 	return(all_succeeded);
-}
-
-/**
-Uses all available threads on all buffer pool instances to flush LRU up to max
-scan depth and to flush the flush lists according to the input args. If both
-input args are zero, only LRU flush is performed.
-@param[in]	min_n	wished minimum number of flush list blocks flushed (it
-                        is not guaranteed that the actual number is that big)
-@param[in]	lsn_limit all blocks on flush lists whose oldest_modification
-                        is smaller than this should be flushed (if their number
-                        does not exceed min_n), otherwise ignored
-@param[out]	n_processed_lru number of processed (flushed and evicted)
-                        blocks on LRU lists
-@param[out]	n_flushed_list number of flushed blocks on flust lists
-*/
-static
-void
-pc_flush(
-	ulint	min_n,
-	ulint	lsn_limit,
-	ulint*  n_processed_lru,
-	ulint*  n_flushed_list)
-{
-	/* Request flushing for threads */
-	pc_request(min_n, lsn_limit);
-
-	ulint tm = ut_time_ms();
-
-	/* Coordinator also treats requests */
-	while (pc_flush_slot() > 0) {}
-
-	/* only coordinator is using these counters,
-	so no need to protect by lock. */
-	page_cleaner->flush_time += ut_time_ms() - tm;
-	page_cleaner->flush_pass++;
-
-	/* Wait for all slots to be finished */
-	*n_processed_lru = 0;
-	*n_flushed_list = 0;
-	pc_wait_finished(n_processed_lru, n_flushed_list);
-	ut_ad((min_n && lsn_limit) || (*n_flushed_list == 0));
-
-	if (*n_flushed_list || *n_processed_lru) {
-		buf_flush_stats(*n_flushed_list, *n_processed_lru);
-	}
-
-	if (*n_processed_lru) {
-		MONITOR_INC_VALUE_CUMULATIVE(
-			MONITOR_LRU_BATCH_FLUSH_TOTAL_PAGE,
-			MONITOR_LRU_BATCH_FLUSH_COUNT,
-			MONITOR_LRU_BATCH_FLUSH_PAGES,
-			*n_processed_lru);
-	}
-
-	if (*n_flushed_list) {
-		MONITOR_INC_VALUE_CUMULATIVE(
-			MONITOR_FLUSH_ADAPTIVE_TOTAL_PAGE,
-			MONITOR_FLUSH_ADAPTIVE_COUNT,
-			MONITOR_FLUSH_ADAPTIVE_PAGES,
-			*n_flushed_list);
-	}
 }
 
 #ifdef UNIV_LINUX
@@ -3276,7 +3147,6 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 	       && srv_shutdown_state == SRV_SHUTDOWN_NONE
 	       && recv_sys->heap != NULL) {
 		/* treat flushing requests during recovery. */
-		ulint	n_flushed_lru = 0;
 		ulint	n_flushed_list = 0;
 
 		os_event_wait(recv_sys->flush_start);
@@ -3286,26 +3156,11 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 			break;
 		}
 
-		switch (recv_sys->flush_type) {
-		case BUF_FLUSH_LRU:
-			/* Flush pages from end of LRU if required */
-			pc_request(0, LSN_MAX);
-			while (pc_flush_slot() > 0) {}
-			pc_wait_finished(&n_flushed_lru, &n_flushed_list);
-			break;
-
-		case BUF_FLUSH_LIST:
-			/* Flush all pages */
-			do {
-				pc_request(ULINT_MAX, LSN_MAX);
-				while (pc_flush_slot() > 0) {}
-			} while (!pc_wait_finished(&n_flushed_lru,
-						   &n_flushed_list));
-			break;
-
-		default:
-			ut_ad(0);
-		}
+		/* Flush all pages */
+		do {
+		    pc_request(ULINT_MAX, LSN_MAX);
+		    while (pc_flush_slot() > 0) {}
+		} while (!pc_wait_finished(&n_flushed_list));
 
 		os_event_reset(recv_sys->flush_start);
 		os_event_set(recv_sys->flush_end);
@@ -3314,7 +3169,6 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 	os_event_wait(buf_flush_event);
 
 	ulint		ret_sleep = 0;
-	ulint		n_evicted = 0;
 	ulint		n_flushed_last = 0;
 	ulint		warn_interval = 1;
 	ulint		warn_count = 0;
@@ -3355,8 +3209,6 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 						<< "ms. The settings might not"
 						" be optimal. (flushed="
 						<< n_flushed_last
-						<< " and evicted="
-						<< n_evicted
 						<< ", during the time.)";
 					if (warn_interval > 300) {
 						warn_interval = 600;
@@ -3375,15 +3227,8 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 			}
 
 			next_loop_time = curr_time + 1000;
-			n_flushed_last = n_evicted = 0;
+			n_flushed_last = 0;
 		}
-
-		ulint	n_processed_lru = 0;
-		ulint	n_flushed_list = 0;
-		pc_flush(0, 0, &n_processed_lru, &n_flushed_list);
-		ut_ad(n_flushed_list == 0);
-
-		n_flushed = n_processed_lru;
 
 		if (ut_time_ms() > next_loop_time
 		    && ret_sleep != OS_SYNC_TIME_EXCEEDED)
@@ -3416,21 +3261,20 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 			page_cleaner->flush_pass++;
 
 			/* Wait for all slots to be finished */
-			ulint	n_flushed_lru = 0;
 			ulint	n_flushed_list = 0;
-			pc_wait_finished(&n_flushed_lru, &n_flushed_list);
+			pc_wait_finished(&n_flushed_list);
 
-			if (n_flushed_list > 0 || n_flushed_lru > 0) {
-				buf_flush_stats(n_flushed_list, n_flushed_lru);
+			if (n_flushed_list > 0) {
+				srv_stats.buf_pool_flushed.add(n_flushed_list);
 
 				MONITOR_INC_VALUE_CUMULATIVE(
 					MONITOR_FLUSH_SYNC_TOTAL_PAGE,
 					MONITOR_FLUSH_SYNC_COUNT,
 					MONITOR_FLUSH_SYNC_PAGES,
-					n_flushed_lru + n_flushed_list);
+					n_flushed_list);
 			}
 
-			n_flushed = n_flushed_lru + n_flushed_list;
+			n_flushed = n_flushed_list;
 
 		} else if (srv_check_activity(last_activity)) {
 			ulint	n_to_flush;
@@ -3446,17 +3290,41 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 				n_to_flush = 0;
 			}
 
-			pc_flush(n_to_flush, lsn_limit, &n_processed_lru,
-				 &n_flushed_list);
+			/* Request flushing for threads */
+			pc_request(n_to_flush, lsn_limit);
+
+			ulint tm = ut_time_ms();
+
+			/* Coordinator also treats requests */
+			while (pc_flush_slot() > 0) {}
+
+			/* only coordinator is using these counters,
+			so no need to protect by lock. */
+			page_cleaner->flush_time += ut_time_ms() - tm;
+			page_cleaner->flush_pass++;
+
+			/* Wait for all slots to be finished */
+			ulint	n_flushed_list = 0;
+
+			pc_wait_finished(&n_flushed_list);
+
+			if (n_flushed_list) {
+				srv_stats.buf_pool_flushed.add(n_flushed_list);
+
+				MONITOR_INC_VALUE_CUMULATIVE(
+					MONITOR_FLUSH_ADAPTIVE_TOTAL_PAGE,
+					MONITOR_FLUSH_ADAPTIVE_COUNT,
+					MONITOR_FLUSH_ADAPTIVE_PAGES,
+					n_flushed_list);
+			}
 
 			if (ret_sleep == OS_SYNC_TIME_EXCEEDED) {
 				last_pages = n_flushed_list;
 			}
 
-			n_evicted += n_processed_lru;
 			n_flushed_last += n_flushed_list;
 
-			n_flushed = n_processed_lru + n_flushed_list;
+			n_flushed = n_flushed_list;
 
 		} else if (ret_sleep == OS_SYNC_TIME_EXCEEDED) {
 			/* no activity, slept enough */
@@ -3506,11 +3374,10 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 
 		while (pc_flush_slot() > 0) {}
 
-		ulint	n_flushed_lru = 0;
 		ulint	n_flushed_list = 0;
-		pc_wait_finished(&n_flushed_lru, &n_flushed_list);
+		pc_wait_finished(&n_flushed_list);
 
-		n_flushed = n_flushed_lru + n_flushed_list;
+		n_flushed = n_flushed_list;
 
 		/* We sleep only if there are no pages to flush */
 		if (n_flushed == 0) {
@@ -3531,7 +3398,6 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 	sweep and we'll come out of the loop leaving behind dirty pages
 	in the flush_list */
 	buf_flush_wait_batch_end(NULL, BUF_FLUSH_LIST);
-	buf_flush_wait_LRU_batch_end();
 
 	bool	success;
 
@@ -3540,14 +3406,12 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 
 		while (pc_flush_slot() > 0) {}
 
-		ulint	n_flushed_lru = 0;
 		ulint	n_flushed_list = 0;
-		success = pc_wait_finished(&n_flushed_lru, &n_flushed_list);
+		success = pc_wait_finished(&n_flushed_list);
 
-		n_flushed = n_flushed_lru + n_flushed_list;
+		n_flushed = n_flushed_list;
 
 		buf_flush_wait_batch_end(NULL, BUF_FLUSH_LIST);
-		buf_flush_wait_LRU_batch_end();
 
 	} while (!success || n_flushed > 0);
 
@@ -3636,6 +3500,138 @@ DECLARE_THREAD(buf_flush_page_cleaner_worker)(
 
 	OS_THREAD_DUMMY_RETURN;
 }
+
+/** Make a LRU manager thread sleep until the passed target time, if it's not
+already in the past.
+@param[in]	next_loop_time	desired wake up time */
+static
+void
+buf_lru_manager_sleep_if_needed(
+	ulint	next_loop_time)
+{
+	ulint	cur_time	= ut_time_ms();
+
+	if (next_loop_time > cur_time) {
+		/* Get sleep interval in micro seconds. We use
+		ut_min() to avoid long sleep in case of
+		wrap around. */
+		os_thread_sleep(std::min(1000000UL,
+					 (next_loop_time - cur_time)
+					 * 1000));
+	}
+}
+
+/** Adjust the LRU manager thread sleep time based on the free list length and
+the last flush result
+@param[in]	buf_pool	buffer pool whom we are flushing
+@param[in]	lru_n_flushed	last LRU flush page count
+@param[in,out]	lru_sleep_time	LRU manager thread sleep time */
+static
+void
+buf_lru_manager_adapt_sleep_time(
+	const buf_pool_t*	buf_pool,
+	ulint			lru_n_flushed,
+	ulint*			lru_sleep_time)
+{
+	const ulint free_len = UT_LIST_GET_LEN(buf_pool->free);
+	const ulint max_free_len = srv_LRU_scan_depth;
+
+	if (free_len < max_free_len / 100 && lru_n_flushed) {
+
+		/* Free list filled less than 1% and the last iteration was
+		able to flush, no sleep */
+		*lru_sleep_time = 0;
+	} else if (free_len > max_free_len / 5
+		   || (free_len < max_free_len / 100 && lru_n_flushed == 0)) {
+
+		/* Free list filled more than 20% or no pages flushed in the
+		previous batch, sleep a bit more */
+		*lru_sleep_time += 50;
+		if (*lru_sleep_time > srv_cleaner_max_lru_time)
+			*lru_sleep_time = srv_cleaner_max_lru_time;
+	} else if (free_len < max_free_len / 20 && *lru_sleep_time >= 50) {
+
+		/* Free list filled less than 5%, sleep a bit less */
+		*lru_sleep_time -= 50;
+	} else {
+
+		/* Free lists filled between 5% and 20%, no change */
+	}
+}
+
+/** LRU manager thread for performing LRU flushed and evictions for buffer pool
+free list refill. One thread is created for each buffer pool instace.
+@param[in]	arg	buffer pool instance number for this thread
+@return a dummy value */
+extern "C"
+os_thread_ret_t
+DECLARE_THREAD(buf_lru_manager)(
+	void*	arg)
+{
+	my_thread_init();
+
+#ifdef UNIV_PFS_THREAD
+	pfs_register_thread(buf_lru_manager_thread_key);
+#endif /* UNIV_PFS_THREAD */
+
+#ifdef UNIV_DEBUG_THREAD_CREATION
+	ib::info() << "lru_manager thread running, id "
+		   << os_thread_pf(os_thread_get_curr_id());
+#endif /* UNIV_DEBUG_THREAD_CREATION */
+
+#ifdef UNIV_LINUX
+	/* linux might be able to set different setting for each thread
+	worth to try to set high priority for page cleaner threads */
+	if (buf_flush_page_cleaner_set_priority(
+		    buf_flush_page_cleaner_priority)) {
+
+		ib::info() << "lru_manager worker priority: "
+			   << buf_flush_page_cleaner_priority;
+	}
+#endif /* UNIV_LINUX */
+
+	ulong	i = reinterpret_cast<ulong>(arg);
+	ut_ad(i < srv_buf_pool_instances);
+
+	buf_pool_t*	buf_pool = buf_pool_from_array(i);
+
+	ulint	lru_sleep_time	= 1000;
+	ulint	next_loop_time	= ut_time_ms() + lru_sleep_time;
+	ulint	lru_n_flushed	= 1;
+
+	/* On server shutdown, the LRU manager thread runs through cleanup
+	phase to provide free pages for the master and purge threads.  */
+	while (srv_shutdown_state == SRV_SHUTDOWN_NONE
+	       || srv_shutdown_state == SRV_SHUTDOWN_CLEANUP) {
+
+		buf_lru_manager_sleep_if_needed(next_loop_time);
+
+		buf_lru_manager_adapt_sleep_time(buf_pool, lru_n_flushed,
+						 &lru_sleep_time);
+
+		next_loop_time = ut_time_ms() + lru_sleep_time;
+
+		lru_n_flushed = buf_flush_LRU_list(buf_pool);
+
+		buf_flush_wait_batch_end(buf_pool, BUF_FLUSH_LRU);
+
+		if (lru_n_flushed) {
+			srv_stats.buf_pool_flushed.add(lru_n_flushed);
+
+			MONITOR_INC_VALUE_CUMULATIVE(
+				MONITOR_LRU_BATCH_FLUSH_TOTAL_PAGE,
+				MONITOR_LRU_BATCH_FLUSH_COUNT,
+				MONITOR_LRU_BATCH_FLUSH_PAGES,
+				lru_n_flushed);
+		}
+	}
+	my_thread_end();
+
+	os_thread_exit(NULL);
+
+	OS_THREAD_DUMMY_RETURN;
+}
+
 
 /*******************************************************************//**
 Synchronously flush dirty blocks from the end of the flush list of all buffer

--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -1399,7 +1399,7 @@ loop:
 	freed = false;
 
 	if (srv_empty_free_list_algorithm == SRV_EMPTY_FREE_LIST_BACKOFF
-	    && buf_page_cleaner_is_active
+	    && buf_lru_manager_is_active
 	    && (srv_shutdown_state == SRV_SHUTDOWN_NONE
 		|| srv_shutdown_state == SRV_SHUTDOWN_CLEANUP)) {
 
@@ -1443,11 +1443,11 @@ loop:
 		goto loop;
 	} else {
 
-		/* The LRU manager is not running or Oracle MySQL 5.6 algorithm
+		/* The LRU manager is not running or Oracle MySQL 5.7 algorithm
 		was requested, will perform a single page flush  */
 		ut_ad((srv_empty_free_list_algorithm
 		       == SRV_EMPTY_FREE_LIST_LEGACY)
-		      || !buf_page_cleaner_is_active
+		      || !buf_lru_manager_is_active
 		      || (srv_shutdown_state != SRV_SHUTDOWN_NONE
 			  && srv_shutdown_state != SRV_SHUTDOWN_CLEANUP));
 	}

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -435,7 +435,6 @@ static PSI_mutex_info all_innodb_mutexes[] = {
 	PSI_KEY(page_zip_stat_per_index_mutex),
 	PSI_KEY(purge_sys_pq_mutex),
 	PSI_KEY(recv_sys_mutex),
-	PSI_KEY(recv_writer_mutex),
 	PSI_KEY(redo_rseg_mutex),
 	PSI_KEY(noredo_rseg_mutex),
 #  ifdef UNIV_DEBUG
@@ -513,7 +512,7 @@ static PSI_thread_info	all_innodb_threads[] = {
 	PSI_KEY(io_read_thread),
 	PSI_KEY(io_write_thread),
 	PSI_KEY(page_cleaner_thread),
-	PSI_KEY(recv_writer_thread),
+	PSI_KEY(buf_lru_manager_thread),
 	PSI_KEY(srv_error_monitor_thread),
 	PSI_KEY(srv_lock_timeout_thread),
 	PSI_KEY(srv_master_thread),
@@ -19790,11 +19789,8 @@ static MYSQL_SYSVAR_ENUM(empty_free_list_algorithm,
   "The algorithm to use for empty free list handling.  Allowed values: "
   "LEGACY: (default) Original Oracle MySQL 5.6 handling with single page flushes; "
   "BACKOFF: Wait until cleaner produces a free page.",
-  innodb_srv_empty_free_list_algorithm_validate, NULL, SRV_EMPTY_FREE_LIST_LEGACY,
-  // Default changed until separate LRU flusher is merged. With a single page
-  // cleaner otherwise it is possible to loop forever in a query
-  // thread while the cleaner is waiting for the page latch held by that
-  // thread. See sys_vars.log_slow_admin_statements_func in 5.7.5.
+  innodb_srv_empty_free_list_algorithm_validate, NULL,
+  SRV_EMPTY_FREE_LIST_BACKOFF,
   &innodb_empty_free_list_algorithm_typelib);
 
 static MYSQL_SYSVAR_ULONG(buffer_pool_instances, srv_buf_pool_instances,

--- a/storage/innobase/include/buf0flu.h
+++ b/storage/innobase/include/buf0flu.h
@@ -35,6 +35,9 @@ Created 11/5/1995 Heikki Tuuri
 /** Flag indicating if the page_cleaner is in active state. */
 extern bool buf_page_cleaner_is_active;
 
+/** Flag indicating if the lru_manager is in active state. */
+extern bool buf_lru_manager_is_active;
+
 #ifdef UNIV_DEBUG
 
 /** Value of MySQL global variable used to disable page cleaner. */
@@ -248,6 +251,15 @@ DECLARE_THREAD(buf_flush_page_cleaner_worker)(
 /*==========================================*/
 	void*	arg);		/*!< in: a dummy parameter required by
 				os_thread_create */
+
+/** LRU manager thread
+@param[in]	arg	buffer pool instance number for this thread
+@return a dummy value */
+extern "C"
+os_thread_ret_t
+DECLARE_THREAD(buf_lru_manager)(
+	void*	arg);
+
 /******************************************************************//**
 Initialize page_cleaner. */
 void

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -335,16 +335,10 @@ struct recv_sys_t{
 	ib_mutex_t		mutex;	/*!< mutex protecting the fields apply_log_recs,
 				n_addrs, and the state field in each recv_addr
 				struct */
-	ib_mutex_t		writer_mutex;/*!< mutex coordinating
-				flushing between recv_writer_thread and
-				the recovery thread. */
 	os_event_t		flush_start;/*!< event to acticate
 				page cleaner threads */
 	os_event_t		flush_end;/*!< event to signal that the page
 				cleaner has finished the request */
-	buf_flush_t		flush_type;/*!< type of the flush request.
-				BUF_FLUSH_LRU: flush end of LRU, keeping free blocks.
-				BUF_FLUSH_LIST: flush all of blocks. */
 #endif /* !UNIV_HOTBACKUP */
 	ibool		apply_log_recs;
 				/*!< this is TRUE when log rec application to
@@ -432,11 +426,6 @@ extern bool		recv_lsn_checks_on;
 /** TRUE when the redo log is being backed up */
 extern bool		recv_is_making_a_backup;
 #endif /* UNIV_HOTBACKUP */
-
-#ifndef UNIV_HOTBACKUP
-/** Flag indicating if recv_writer thread is active. */
-extern volatile bool	recv_writer_thread_active;
-#endif /* !UNIV_HOTBACKUP */
 
 /** Size of the parsing buffer; it must accommodate RECV_SCAN_SIZE many
 times! */

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -561,7 +561,7 @@ extern mysql_pfs_key_t	io_log_thread_key;
 extern mysql_pfs_key_t	io_read_thread_key;
 extern mysql_pfs_key_t	io_write_thread_key;
 extern mysql_pfs_key_t	page_cleaner_thread_key;
-extern mysql_pfs_key_t	recv_writer_thread_key;
+extern mysql_pfs_key_t	buf_lru_manager_thread_key;
 extern mysql_pfs_key_t	srv_error_monitor_thread_key;
 extern mysql_pfs_key_t	srv_lock_timeout_thread_key;
 extern mysql_pfs_key_t	srv_master_thread_key;

--- a/storage/innobase/include/sync0sync.h
+++ b/storage/innobase/include/sync0sync.h
@@ -82,7 +82,6 @@ extern mysql_pfs_key_t	recalc_pool_mutex_key;
 extern mysql_pfs_key_t	page_cleaner_mutex_key;
 extern mysql_pfs_key_t	purge_sys_pq_mutex_key;
 extern mysql_pfs_key_t	recv_sys_mutex_key;
-extern mysql_pfs_key_t	recv_writer_mutex_key;
 extern mysql_pfs_key_t	rtr_active_mutex_key;
 extern mysql_pfs_key_t	rtr_match_mutex_key;
 extern mysql_pfs_key_t	rtr_path_mutex_key;

--- a/storage/innobase/include/sync0types.h
+++ b/storage/innobase/include/sync0types.h
@@ -289,8 +289,6 @@ enum latch_level_t {
 
 	SYNC_TRX_I_S_RWLOCK,
 
-	SYNC_RECV_WRITER,
-
 	/** Level is varying. Only used with buffer pool page locks, which
 	do not have a fixed level, but instead have their level set after
 	the page is locked; see e.g.  ibuf_bitmap_get_map_page(). */
@@ -340,7 +338,6 @@ enum latch_id_t {
 	LATCH_ID_PURGE_SYS_PQ,
 	LATCH_ID_RECALC_POOL,
 	LATCH_ID_RECV_SYS,
-	LATCH_ID_RECV_WRITER,
 	LATCH_ID_REDO_RSEG,
 	LATCH_ID_NOREDO_RSEG,
 	LATCH_ID_RW_LOCK_DEBUG,
@@ -1156,8 +1153,6 @@ struct dict_sync_check : public sync_check_functor_t {
 		    || (level != SYNC_DICT
 			&& level != SYNC_DICT_OPERATION
 			&& level != SYNC_FTS_CACHE
-			/* This only happens in recv_apply_hashed_log_recs. */
-			&& level != SYNC_RECV_WRITER
 			&& level != SYNC_NO_ORDER_CHECK)) {
 
 			m_result = true;

--- a/storage/innobase/srv/srv0mon.cc
+++ b/storage/innobase/srv/srv0mon.cc
@@ -367,7 +367,8 @@ static monitor_info_t	innodb_counter_info[] =
 	 MONITOR_DEFAULT_START, MONITOR_FLUSH_ADAPTIVE_AVG_TIME_SLOT},
 
 	{"buffer_LRU_batch_flush_avg_time_slot", "buffer",
-	 "Avg time (ms) spent for LRU batch flushing recently per slot.",
+	 "Avg time (ms) spent for LRU batch flushing recently per slot. "
+	 "Always 0 in XtraDB.",
 	 MONITOR_NONE,
 	 MONITOR_DEFAULT_START, MONITOR_LRU_BATCH_FLUSH_AVG_TIME_SLOT},
 
@@ -377,7 +378,8 @@ static monitor_info_t	innodb_counter_info[] =
 	 MONITOR_DEFAULT_START, MONITOR_FLUSH_ADAPTIVE_AVG_TIME_THREAD},
 
 	{"buffer_LRU_batch_flush_avg_time_thread", "buffer",
-	 "Avg time (ms) spent for LRU batch flushing recently per thread.",
+	 "Avg time (ms) spent for LRU batch flushing recently per thread."
+	 "Always 0 in XtraDB.",
 	 MONITOR_NONE,
 	 MONITOR_DEFAULT_START, MONITOR_LRU_BATCH_FLUSH_AVG_TIME_THREAD},
 
@@ -387,7 +389,8 @@ static monitor_info_t	innodb_counter_info[] =
 	 MONITOR_DEFAULT_START, MONITOR_FLUSH_ADAPTIVE_AVG_TIME_EST},
 
 	{"buffer_LRU_batch_flush_avg_time_est", "buffer",
-	 "Estimated time (ms) spent for LRU batch flushing recently.",
+	 "Estimated time (ms) spent for LRU batch flushing recently."
+	 "Always 0 in XtraDB.",
 	 MONITOR_NONE,
 	 MONITOR_DEFAULT_START, MONITOR_LRU_BATCH_FLUSH_AVG_TIME_EST},
 
@@ -402,7 +405,8 @@ static monitor_info_t	innodb_counter_info[] =
 	 MONITOR_DEFAULT_START, MONITOR_FLUSH_ADAPTIVE_AVG_PASS},
 
 	{"buffer_LRU_batch_flush_avg_pass", "buffer",
-	 "Number of LRU batch flushes passed during the recent Avg period.",
+	 "Number of LRU batch flushes passed during the recent Avg period."
+	 "Always 0 in XtraDB.",
 	 MONITOR_NONE,
 	 MONITOR_DEFAULT_START, MONITOR_LRU_BATCH_FLUSH_AVG_PASS},
 

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1648,7 +1648,6 @@ innobase_start_or_create_for_mysql(void)
 			    + 1 /* buf_dump_thread */
 			    + 1 /* dict_stats_thread */
 			    + 1 /* fts_optimize_thread */
-			    + 1 /* recv_writer_thread */
 			    + 1 /* trx_rollback_or_clean_all_recovered */
 			    + 128 /* added as margin, for use of
 				  InnoDB Memcached etc. */
@@ -1880,6 +1879,13 @@ innobase_start_or_create_for_mysql(void)
 		os_thread_create(buf_flush_page_cleaner_worker,
 				 NULL, NULL);
 	}
+
+	for (i = 0; i < srv_buf_pool_instances; i++) {
+		os_thread_create(buf_lru_manager, reinterpret_cast<void *>(i),
+				 NULL);
+	}
+
+	buf_lru_manager_is_active = true;
 
 	/* Make sure page cleaner is active. */
 	while (!buf_page_cleaner_is_active) {

--- a/storage/innobase/sync/sync0debug.cc
+++ b/storage/innobase/sync/sync0debug.cc
@@ -531,7 +531,6 @@ LatchDebug::LatchDebug()
 	LEVEL_MAP_INSERT(SYNC_FILE_FORMAT_TAG);
 	LEVEL_MAP_INSERT(SYNC_TRX_I_S_LAST_READ);
 	LEVEL_MAP_INSERT(SYNC_TRX_I_S_RWLOCK);
-	LEVEL_MAP_INSERT(SYNC_RECV_WRITER);
 	LEVEL_MAP_INSERT(SYNC_LEVEL_VARYING);
 	LEVEL_MAP_INSERT(SYNC_NO_ORDER_CHECK);
 
@@ -796,7 +795,6 @@ LatchDebug::check_order(
 	case SYNC_STATS_AUTO_RECALC:
 	case SYNC_POOL:
 	case SYNC_POOL_MANAGER:
-	case SYNC_RECV_WRITER:
 
 		basic_check(latches, level, level);
 		break;
@@ -1415,8 +1413,6 @@ sync_latch_meta_init()
 		  recalc_pool_mutex_key);
 
 	LATCH_ADD(RECV_SYS, SYNC_RECV, recv_sys_mutex_key);
-
-	LATCH_ADD(RECV_WRITER, SYNC_RECV_WRITER, recv_writer_mutex_key);
 
 	LATCH_ADD(REDO_RSEG, SYNC_REDO_RSEG, redo_rseg_mutex_key);
 

--- a/storage/innobase/sync/sync0sync.cc
+++ b/storage/innobase/sync/sync0sync.cc
@@ -67,7 +67,6 @@ mysql_pfs_key_t	recalc_pool_mutex_key;
 mysql_pfs_key_t	page_cleaner_mutex_key;
 mysql_pfs_key_t	purge_sys_pq_mutex_key;
 mysql_pfs_key_t	recv_sys_mutex_key;
-mysql_pfs_key_t	recv_writer_mutex_key;
 mysql_pfs_key_t	redo_rseg_mutex_key;
 mysql_pfs_key_t	noredo_rseg_mutex_key;
 mysql_pfs_key_t page_zip_stat_per_index_mutex_key;


### PR DESCRIPTION
This implements a blueprint
https://blueprints.launchpad.net/percona-server/+spec/mt-lru.
- New per-buffer pool instance server background thread
  buf_flush_lru_monitor, that, in a loop, flushes its assigned
  instance in a LRU mode, while server is in crash recovery, regular
  operation or in shutdown cleanup (i.e. purge) phases. It has two new
  helper functions, buf_lru_manager_sleep_if_needed and
  buf_lru_manager_adapt_sleep_time. It is registered for Performance
  Schema instrumentation.
- New flag buf_lru_manager_is_active, check it instead of
  buf_page_cleaner_is_active in buf_LRU_get_free_block.
- Change innodb_empty_free_list_algorithm server variable default
  value to "backoff."
- Remove LRU flushing related fields and code from struct
  page_cleaner_slot_t, page_cleaner_flush_pages_recommendation,
  pc_flush_slot, pc_wait_finished, buf_flush_page_cleaner_coordinator.
  Remove buf_flush_stats and pc_flush entirely.
- Do not update the following InnoDB
  metrics: buffer_LRU_batch_flush_avg_time_slot,
  buffer_LRU_batch_flush_avg_pass,
  buffer_LRU_batch_flush_avg_time_thread, and
  buffer_LRU_batch_flush_avg_time_est.
- Remove any LRU-specific flushing logic from crash recovery as the
  LRU manager threads are started early enough to treat those requests
  too. This consists of PSI_KEY(recv_writer_mutex),
  PSI_KEY(recv_writer_thread), recv_sys_t::writer_mutex,
  recv_writer_thread_active, recv_writer_thread_key,
  recv_writer_mutex_key, SYNC_RECV_WRITER, LATCH_ID_RECV_WRITER,
  recv_writer_thread. Consequently remove recv_sys_t::flush_type field
  (as it can be assumed to have BUF_FLUSH_LIST value unconditionally),
  simplify buf_flush_page_cleaner_coordinator accordingly.

http://jenkins.percona.com/job/mysql-5.7-param/89/#showFailuresLink
