### PR TITLE
BACKUP-125 : Unclear error if backup process found mysqld_safe.pid(ow…

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/tokudb_backup_exclude.result
+++ b/mysql-test/suite/tokudb.backup/r/tokudb_backup_exclude.result
@@ -9,7 +9,7 @@ select @@session.tokudb_backup_last_error_string;
 @@session.tokudb_backup_last_error_string
 NULL
 20
-set session tokudb_backup_exclude='(t1a|t1c)+';
+set session tokudb_backup_exclude='(t1a|t1c|mysqld_safe\.pid)+';
 select @@session.tokudb_backup_last_error;
 @@session.tokudb_backup_last_error
 0
@@ -17,7 +17,7 @@ select @@session.tokudb_backup_last_error_string;
 @@session.tokudb_backup_last_error_string
 NULL
 10
-set session tokudb_backup_exclude='t1[abc]+';
+set session tokudb_backup_exclude='(t1[abc]|mysqld_safe\.pid)+';
 select @@session.tokudb_backup_last_error;
 @@session.tokudb_backup_last_error
 0

--- a/mysql-test/suite/tokudb.backup/t/tokudb_backup_exclude.test
+++ b/mysql-test/suite/tokudb.backup/t/tokudb_backup_exclude.test
@@ -32,7 +32,7 @@ select @@session.tokudb_backup_last_error_string;
 
 
 # This should filter all files for the t1a and t1c tables
-set session tokudb_backup_exclude='(t1a|t1c)+';
+set session tokudb_backup_exclude='(t1a|t1c|mysqld_safe\.pid)+';
 
 disable_query_log;
 --exec mkdir $MYSQLTEST_VARDIR/tmp/backup
@@ -48,7 +48,7 @@ select @@session.tokudb_backup_last_error_string;
 --exec rm -rf $MYSQLTEST_VARDIR/tmp/backup
 
 # This should filter all files for the t1a, t1b, and t1c tables
-set session tokudb_backup_exclude='t1[abc]+';
+set session tokudb_backup_exclude='(t1[abc]|mysqld_safe\.pid)+';
 
 disable_query_log;
 --exec mkdir $MYSQLTEST_VARDIR/tmp/backup

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -28,7 +28,8 @@
 #define TOKUDB_BACKUP_PLUGIN_VERSION_STRING NULL
 #endif
 
-static char *tokudb_backup_plugin_version;
+static char* tokudb_backup_plugin_version;
+static const char* tokudb_backup_exclude_default="(mysqld_safe\\.pid)+";
 
 // This is just a place holder for now and must be replaced soon with a proper
 // PSI key for this plugin.
@@ -63,7 +64,7 @@ static MYSQL_THDVAR_STR(last_error_string,
 static MYSQL_THDVAR_STR(exclude,
     PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC,
     "exclude source file regular expression",
-    NULL, NULL, NULL);
+    NULL, NULL, tokudb_backup_exclude_default);
 
 static int tokudb_backup_check_dir(THD* thd, struct st_mysql_sys_var* var,
                                    void* save, struct st_mysql_value* value);


### PR DESCRIPTION
…ned by root) inside datadir
- Added a default value for tokudb_backup_exclude to be "(mysqld_safe\.pid)+"
- Users that use this feature will need to add this same value to their exclude values if they encounder the problem.
- Updated and re-recorded the tokudb.backup.tokudb_backup_exclude test and result to capture the new default value.
