### PR TITLE
5.6 - Fix for custom socket location on centos 7 (#1534825)

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -75,9 +75,20 @@ pinger () {
     # Wait for ping to answer to signal startup completed,
     # might take a while in case of e.g. crash recovery
     # MySQL systemd service will timeout script if no answer
+    datadir=$(parse_cnf datadir server mysqld)
+    if [[ -z ${datadir:-} ]]; then
+        datadir="/var/lib/mysql"
+    fi
+    socket=$(parse_cnf socket server mysqld)
+    case $socket in
+        /*) adminsocket="$socket" ;;
+        "") adminsocket="$datadir/mysql.sock" ;;
+        *) adminsocket="$datadir/$socket" ;;
+    esac
+
     while /bin/true ; do
         sleep 1
-        mysqladmin ping >/dev/null 2>&1 && break
+        mysqladmin --no-defaults --socket="$adminsocket" --user=UNKNOWN_MYSQL_USER ping >/dev/null 2>&1 && break
     done
     exit 0
 }


### PR DESCRIPTION
**BUG:**
systemctl start mysqld fails with timeout if custom path for socket specified
https://bugs.launchpad.net/percona-server/+bug/1534825

**TEST BUILD:**
http://jenkins.percona.com/job/percona-server-5.5-redhat-binary/179/
http://jenkins.percona.com/job/percona-server-5.6-redhat-binary/64/

**TEST:**
_DEFAULT SOCKET SPECIFIED_

```
[vagrant@t-centos7-64 ~]$ cat /etc/my.cnf |grep socket
socket=/var/lib/mysql/mysql.sock

[vagrant@t-centos7-64 ~]$ sudo systemctl start mysql

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Percona Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: active (running) since Sri 2016-02-10 08:38:07 CET; 6s ago
  Process: 3655 ExecStartPost=/usr/bin/mysql-systemd post (code=exited, status=0/SUCCESS)
  Process: 3623 ExecStartPre=/usr/bin/mysql-systemd pre (code=exited, status=0/SUCCESS)
 Main PID: 3653 (mysqld_safe)
   CGroup: /system.slice/mysqld.service
           ├─3653 /bin/sh /usr/bin/mysqld_safe
           └─3809 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib64/mysql/plugin --user=mysql --log-error=/var/log/mysqld.log --pid-file=/var/run/mysqld/mysqld.pid --socket=/var/lib/mysql/mysql.soc...

Vel 10 08:37:57 t-centos7-64 mysqld_safe[3653]: 160210 08:37:57 mysqld_safe Logging to '/var/log/mysqld.log'.
Vel 10 08:37:57 t-centos7-64 mysqld_safe[3653]: 160210 08:37:57 mysqld_safe Starting mysqld daemon with databases from /var/lib/mysql
Vel 10 08:38:07 t-centos7-64 systemd[1]: Started MySQL Percona Server.
```

_CUSTOM SOCKET SPECIFIED_

```
[vagrant@t-centos7-64 ~]$ sudo systemctl start mysql

[vagrant@t-centos7-64 ~]$ cat /etc/my.cnf |grep socket
socket=/tmp/mysql.sock

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Percona Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: active (running) since Sri 2016-02-10 08:39:29 CET; 13s ago
  Process: 3889 ExecStartPost=/usr/bin/mysql-systemd post (code=exited, status=0/SUCCESS)
  Process: 3859 ExecStartPre=/usr/bin/mysql-systemd pre (code=exited, status=0/SUCCESS)
 Main PID: 3888 (mysqld_safe)
   CGroup: /system.slice/mysqld.service
           ├─3888 /bin/sh /usr/bin/mysqld_safe
           └─4044 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib64/mysql/plugin --user=mysql --log-error=/var/log/mysqld.log --pid-file=/var/run/mysqld/mysqld.pid --socket=/tmp/mysql.sock

Vel 10 08:39:23 t-centos7-64 mysqld_safe[3888]: 160210 08:39:23 mysqld_safe Logging to '/var/log/mysqld.log'.
Vel 10 08:39:23 t-centos7-64 mysqld_safe[3888]: 160210 08:39:23 mysqld_safe Starting mysqld daemon with databases from /var/lib/mysql
Vel 10 08:39:29 t-centos7-64 systemd[1]: Started MySQL Percona Server.
```

_NO SOCKET SPECIFIED_

```
[vagrant@t-centos7-64 ~]$ cat /etc/my.cnf |grep socket

[vagrant@t-centos7-64 ~]$ sudo systemctl start mysql

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Percona Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: active (running) since Sri 2016-02-10 08:41:12 CET; 6s ago
  Process: 4122 ExecStartPost=/usr/bin/mysql-systemd post (code=exited, status=0/SUCCESS)
  Process: 4092 ExecStartPre=/usr/bin/mysql-systemd pre (code=exited, status=0/SUCCESS)
 Main PID: 4121 (mysqld_safe)
   CGroup: /system.slice/mysqld.service
           ├─4121 /bin/sh /usr/bin/mysqld_safe
           └─4262 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib64/mysql/plugin --user=mysql --log-error=/var/log/mysqld.log --pid-file=/var/run/mysqld/mysqld.pid

Vel 10 08:41:07 t-centos7-64 mysqld_safe[4121]: 160210 08:41:07 mysqld_safe Logging to '/var/log/mysqld.log'.
Vel 10 08:41:07 t-centos7-64 mysqld_safe[4121]: 160210 08:41:07 mysqld_safe Starting mysqld daemon with databases from /var/lib/mysql
Vel 10 08:41:12 t-centos7-64 systemd[1]: Started MySQL Percona Server.
```
