### PR TITLE
TokuDB known issues and limitation fixes

### DIFF
--- a/doc/source/tokudb/tokudb_faq.rst
+++ b/doc/source/tokudb/tokudb_faq.rst
@@ -96,7 +96,8 @@ Backup
 
 **How do I back up a system with TokuDB tables?**
 
-*Taking backups with :ref:`TokuBackup`*
+Taking backups with :ref:`toku_backup`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 |TokuDB| is capable of performing online backups with :ref:`toku_backup`. To perform a backup, execute ``backup to '/path/to/backup';``. This will create backup of the server and return when complete. The backup can be used by another server using a copy of the binaries on the source server. You can view the progress of the backup by executing ``SHOW PROCESSLIST;``. |TokuBackup| produces a copy of your running |MySQL| server that is consistent at the end time of the backup process. The thread copying files from source to destination can be throttled by setting the :variable:`tokudb_backup_throttle` server variable. For more information check :ref:`toku_backup`.
 
@@ -104,7 +105,7 @@ Backup
 
   * Currently, |TokuBackup| only supports tables using the |TokuDB| storage engine and the |MyISAM| tables in the ``mysql`` database. 
 
-    .. warning:: You must disable |InnoDB| asynchronous IO if backing up |InnoDB| tables via |TokuBackup| utility. The appropriate setting is :variable:`innodb_use_native_aio` to ``0``.
+    .. warning:: You must disable |InnoDB| asynchronous IO if backing up |InnoDB| tables via |TokuBackup| utility. Otherwise you will have inconsistent, unrecoverable backups. The appropriate setting is :variable:`innodb_use_native_aio` to ``0``.
 
   * Transactional storage engines (|TokuDB| and |InnoDB|) will perform recovery on the backup copy of the database when it is first started.
 
@@ -120,7 +121,8 @@ Backup
 
   * |TokuBackup| does not follow symbolic links.
 
-*Other options for taking backups*
+Other options for taking backups
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   |TokuDB| tables are represented in the file system with dictionary files, log files, and metadata files. A consistent copy of all of these files must be made during a backup. Copying the files while they may be modified by a running |MySQL| may result in an inconsistent copy of the database.
 

--- a/doc/source/tokudb/tokudb_variables.rst
+++ b/doc/source/tokudb/tokudb_variables.rst
@@ -250,6 +250,8 @@ This variable configures the directory name where the |TokuDB| tables are stored
 
 This variable specifies the directory where the |TokuDB| log files are stored. The default location is the MySQL data directory. Configuring a separate log directory is somewhat involved. Please contact Percona support for more details.
 
+.. warning:: After changing |TokuDB| log directory path, the old |TokuDB| recovery log file should be moved to new directory prior to start of |MySQL| server and log file's owner must be the ``mysql`` user. Otherwise server will fail to initialize the |TokuDB| store engine restart.
+
 .. variable:: tokudb_tmp_dir
 
 This variable specifies the directory where the |TokuDB| bulk loader stores temporary files. The bulk loader can create large temporary files while it is loading a table, so putting these temporary files on a disk separate from the data directory can be useful.


### PR DESCRIPTION
DOC-234 - Fixed by implementing the know issues and limitations list
DOC-221/DOC-222 - Fixed by adding the warning to the issues and
limitations list in tokuback documentation
DOC-218 - Fixed by adding a new information on how to recover backups in
case tokudb_data_dir and tokudb_log_dir are defined
DOC-192 - Fixed by mentioning the correct directory ownership
DOC-219 - Fixed by making a note on incremental backups not being
supported
LP Bug #1538087 - Fixed by making clear that the backup process will
automatically start once the tokudb_backup_dir is defined
DOC-202 - Fixed by adding a comment about requirements after
tokudb_log_dir variable has been changed
