### PR TITLE
5.6 - Add --skip-log-bin for bootstrap mode and run mysql_install_db only on upgrade in debian

### DIFF
--- a/build-ps/debian/percona-server-server-5.5.postinst
+++ b/build-ps/debian/percona-server-server-5.5.postinst
@@ -18,7 +18,7 @@ invoke() {
   fi
 }
 
-MYSQL_BOOTSTRAP="/usr/sbin/mysqld --bootstrap --user=mysql --skip-grant-tables"
+MYSQL_BOOTSTRAP="/usr/sbin/mysqld --bootstrap --user=mysql --skip-grant-tables --skip-log-bin"
 
 test_mysql_access() {
        mysql --no-defaults -u root -h localhost </dev/null >/dev/null 2>&1
@@ -139,14 +139,17 @@ EOF
 
     # initiate databases. Output is not allowed by debconf :-(
     # Debian: beware of the bashisms... 
-    # Debian: can safely run on upgrades with existing databases 
-    set +e
-    bash /usr/bin/mysql_install_db --user=mysql --rpm 2>&1 |
-        $ERR_LOGGER
-    if [ "$?" != "0" ]; then
-      echo "ATTENTION: An error has occured. More info is in the syslog!"
+    # Don't run this on upgrades (#1507812, #1457614)
+    if [ -z "$2" ];
+    then
+      set +e
+      bash /usr/bin/mysql_install_db --user=mysql --rpm 2>&1 |
+          $ERR_LOGGER
+      if [ "$?" != "0" ]; then
+        echo "ATTENTION: An error has occured. More info is in the syslog!"
+      fi
+      set -e
     fi
-    set -e
     
     ## On every reconfiguration the maintenance user is recreated.
     #


### PR DESCRIPTION
**BUGS:**
Package upgrade on Ubuntu runs mysql_install_db even though data directory already exists
https://bugs.launchpad.net/percona-server/+bug/1457614
Debian package ignores GTID options when restarts server
https://bugs.launchpad.net/percona-server/+bug/1507812

**INFO:**
It's needed to run mysql_install_db in debian packaging only on install and not on upgrade and also there's a fix for running bootstrap mode with --skip-log-bin so that those statements don't get into bin log without GTID's and mess the numbering. This does not affect 5.7 so it will be only null merge here for 5.7.

**TEST BUILD:**
http://jenkins.percona.com/job/percona-server-5.6-debian-binary/73/

**TEST:**
So it can be seen below that before the upgrade GTID's stopped at 2 and after upgrade and inserting 2 rows they continued at 3 and 4.

_BEFORE UPGRADE:_

```
vagrant@t-ubuntu1404-64:~$ dpkg -l|grep percona
ii  libperconaserverclient18.1          5.6.27-75.0-1.trusty                amd64        Percona Server database client library
ii  percona-server-client-5.6           5.6.27-75.0-1.trusty                amd64        Percona Server database client binaries
ii  percona-server-common-5.6           5.6.27-75.0-1.trusty                amd64        Percona Server database common files (e.g. /etc/mysql/my.cnf)
ii  percona-server-server-5.6           5.6.27-75.0-1.trusty                amd64        Percona Server database server binaries

mysql> use test;
Database changed
mysql> create table test1(age int);
Query OK, 0 rows affected (0.23 sec)

mysql> insert into test1 values (1);
Query OK, 1 row affected (0.00 sec)

mysql> insert into test1 values (2);                                                                                                                                                                                                   
Query OK, 1 row affected (0.01 sec)

root@t-ubuntu1404-64:/var/lib/mysql# mysqlbinlog mysql-bin.000001 |grep GTID
#160217  2:06:00 server id 1  end_log_pos 151 CRC32 0x1c34d999  Previous-GTIDs
#160217  2:06:47 server id 1  end_log_pos 199 CRC32 0xa2b56ad2  GTID [commit=yes]
SET @@SESSION.GTID_NEXT= '9d78f43c-d55d-11e5-bcd8-080027501f8c:1'/*!*/;
#160217  2:08:00 server id 1  end_log_pos 348 CRC32 0x16aa4f41  GTID [commit=yes]
SET @@SESSION.GTID_NEXT= '9d78f43c-d55d-11e5-bcd8-080027501f8c:2'/*!*/;
SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog *//*!*/;

root@t-ubuntu1404-64:/var/lib/mysql# ls -1|grep bin
mysql-bin.000001
mysql-bin.index
```

_UPGRADE:_

```
vagrant@t-ubuntu1404-64:~$ sudo dpkg -i percona-server-server-5.6_5.6.27-76.0-1.trusty_amd64.deb 
(Reading database ... 104073 files and directories currently installed.)
Preparing to unpack percona-server-server-5.6_5.6.27-76.0-1.trusty_amd64.deb ...
 * Stopping MySQL (Percona Server) mysqld
   ...done.
 * Stopping MySQL (Percona Server) mysqld
   ...done.
Unpacking percona-server-server-5.6 (5.6.27-76.0-1.trusty) over (5.6.27-75.0-1.trusty) ...
Setting up percona-server-server-5.6 (5.6.27-76.0-1.trusty) ...
 * Stopping MySQL (Percona Server) mysqld
   ...done.

 * Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit.
 * Run the following commands to create these functions:

        mysql -e "CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'"
        mysql -e "CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'"
        mysql -e "CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'"

 * See http://www.percona.com/doc/percona-server/5.6/management/udf_percona_toolkit.html for more details

 * Starting MySQL (Percona Server) database server mysqld
   ...done.
 * Checking for corrupt, not cleanly closed and upgrade needing tables.
Processing triggers for ureadahead (0.100.0-16) ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...
```

_AFTER UPGRADE AND INSERTING NEW DATA:_

```
mysql> use test;
Database changed

mysql> insert into test1 values (3);                                                                                                                                                                                                   
Query OK, 1 row affected (0.02 sec)

mysql> insert into test1 values (4);                                                                                                                                                                                                   
Query OK, 1 row affected (0.01 sec)

root@t-ubuntu1404-64:/var/lib/mysql# ls -1|grep bin
mysql-bin.000001
mysql-bin.000002
mysql-bin.index

root@t-ubuntu1404-64:/var/lib/mysql# mysqlbinlog mysql-bin.000002|grep GTID
#160217  2:11:50 server id 1  end_log_pos 191 CRC32 0x4558d77f  Previous-GTIDs
#160217  2:13:17 server id 1  end_log_pos 239 CRC32 0xc7610c75  GTID [commit=yes]
SET @@SESSION.GTID_NEXT= '9d78f43c-d55d-11e5-bcd8-080027501f8c:3'/*!*/;
#160217  2:13:19 server id 1  end_log_pos 499 CRC32 0x074afe7c  GTID [commit=yes]
SET @@SESSION.GTID_NEXT= '9d78f43c-d55d-11e5-bcd8-080027501f8c:4'/*!*/;
SET @@SESSION.GTID_NEXT= 'AUTOMATIC' /* added by mysqlbinlog *//*!*/;
```
