### PR TITLE
DB-935 : Enable default background analyze table for 5.7

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists t;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists t;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1_pick.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_1_pick.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists t;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_2.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_2.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists t;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_2_pick.result
+++ b/mysql-test/suite/tokudb.bugs/r/db756_card_part_hash_2_pick.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists t;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment

--- a/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
+++ b/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists t;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table t (id int, x int, y int, primary key (id), key (x), key (y)) 
 partition by range(id) 
 ( partition p0 values less than (10), partition p1 values less than maxvalue);

--- a/mysql-test/suite/tokudb.bugs/r/simple_icp.result
+++ b/mysql-test/suite/tokudb.bugs/r/simple_icp.result
@@ -121,7 +121,7 @@ Variable_name	Value
 Handler_read_prev	0
 explain select * from foo where a > 19 and c=10;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	foo	NULL	range	a	a	5	NA	1713	10.00	Using where
+1	SIMPLE	foo	NULL	range	a	a	5	NA	1402	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`foo`.`a` AS `a`,`test`.`foo`.`b` AS `b`,`test`.`foo`.`c` AS `c`,`test`.`foo`.`d` AS `d`,`test`.`foo`.`e` AS `e` from `test`.`foo` where ((`test`.`foo`.`c` = 10) and (`test`.`foo`.`a` > 19))
 select * from foo where a > 19 and c=10 order by a desc;

--- a/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash.test
+++ b/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash.test
@@ -5,6 +5,12 @@ set default_storage_engine='tokudb';
 disable_warnings;
 drop table if exists t;
 enable_warnings;
+
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 insert into t values (1,1),(3,1),(5,1);

--- a/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_1.test
+++ b/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_1.test
@@ -5,6 +5,12 @@ set default_storage_engine='tokudb';
 disable_warnings;
 drop table if exists t;
 enable_warnings;
+
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 insert into t values (1,1),(3,1),(5,1);

--- a/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_1_pick.test
+++ b/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_1_pick.test
@@ -5,6 +5,12 @@ set default_storage_engine='tokudb';
 disable_warnings;
 drop table if exists t;
 enable_warnings;
+
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 insert into t values (1,1),(3,2),(5,3);

--- a/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_2.test
+++ b/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_2.test
@@ -5,6 +5,12 @@ set default_storage_engine='tokudb';
 disable_warnings;
 drop table if exists t;
 enable_warnings;
+
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 insert into t values (2,1),(4,1),(6,1);

--- a/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_2_pick.test
+++ b/mysql-test/suite/tokudb.bugs/t/db756_card_part_hash_2_pick.test
@@ -5,6 +5,12 @@ set default_storage_engine='tokudb';
 disable_warnings;
 drop table if exists t;
 enable_warnings;
+
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table t (id int, x int, primary key (id), key (x)) partition by hash(id) partitions 2;
 show indexes from t;
 insert into t values (1,1),(3,2),(5,3),(7,4);

--- a/mysql-test/suite/tokudb.bugs/t/db757_part_alter_analyze.test
+++ b/mysql-test/suite/tokudb.bugs/t/db757_part_alter_analyze.test
@@ -5,6 +5,11 @@ disable_warnings;
 drop table if exists t;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table t (id int, x int, y int, primary key (id), key (x), key (y)) 
 partition by range(id) 
 ( partition p0 values less than (10), partition p1 values less than maxvalue);

--- a/mysql-test/suite/tokudb.bugs/t/simple_icp.test
+++ b/mysql-test/suite/tokudb.bugs/t/simple_icp.test
@@ -16,6 +16,12 @@ create table foo (a int, b int, c int, d int, e int, key(a,b,c)) engine=TokuDB;
 
 insert into foo (a,b,c) select * from a,b,c;
 
+# wait for the bjm queue to empty
+-- disable_query_log
+let $wait_condition=select count(*)=0 from information_schema.tokudb_background_job_status;
+-- source include/wait_condition.inc
+-- enable_query_log
+
 flush status;
 show status like '%Handler_read_next%';
 replace_column 9 NA;

--- a/mysql-test/suite/tokudb.parts/t/suite.opt
+++ b/mysql-test/suite/tokudb.parts/t/suite.opt
@@ -1,1 +1,1 @@
-$TOKUDB_OPT $TOKUDB_LOAD_ADD --loose-tokudb-check-jemalloc=0
+$TOKUDB_OPT $TOKUDB_LOAD_ADD --loose-tokudb-check-jemalloc=0 --loose-tokudb-auto-analyze=0 --loose-tokudb-analyze-in-background=0

--- a/mysql-test/suite/tokudb.sys_vars/r/tokudb_analyze_in_background_basic.result
+++ b/mysql-test/suite/tokudb.sys_vars/r/tokudb_analyze_in_background_basic.result
@@ -1,11 +1,11 @@
 SET @orig_global = @@global.tokudb_analyze_in_background;
 SELECT @orig_global;
 @orig_global
-0
+1
 SET @orig_session = @@session.tokudb_analyze_in_background;
 SELECT @orig_session;
 @orig_session
-0
+1
 SET GLOBAL tokudb_analyze_in_background = 0;
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
@@ -17,7 +17,7 @@ SELECT @@global.tokudb_analyze_in_background;
 SET GLOBAL tokudb_analyze_in_background = DEFAULT;
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
-0
+1
 SET GLOBAL tokudb_analyze_in_background = -6;
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
@@ -92,8 +92,8 @@ tokudb_analyze_in_background	ON
 SET SESSION tokudb_analyze_in_background = @orig_session;
 SELECT @@session.tokudb_analyze_in_background;
 @@session.tokudb_analyze_in_background
-0
+1
 SET GLOBAL tokudb_analyze_in_background = @orig_global;
 SELECT @@global.tokudb_analyze_in_background;
 @@global.tokudb_analyze_in_background
-0
+1

--- a/mysql-test/suite/tokudb.sys_vars/r/tokudb_auto_analyze.result
+++ b/mysql-test/suite/tokudb.sys_vars/r/tokudb_auto_analyze.result
@@ -1,11 +1,11 @@
 SET @orig_global = @@global.tokudb_auto_analyze;
 SELECT @orig_global;
 @orig_global
-0
+30
 SET @orig_session = @@session.tokudb_auto_analyze;
 SELECT @orig_session;
 @orig_session
-0
+30
 SET GLOBAL tokudb_auto_analyze = 10;
 SELECT @@global.tokudb_auto_analyze;
 @@global.tokudb_auto_analyze
@@ -17,12 +17,12 @@ SELECT @@global.tokudb_auto_analyze;
 SET GLOBAL tokudb_auto_analyze = DEFAULT;
 SELECT @@global.tokudb_auto_analyze;
 @@global.tokudb_auto_analyze
-0
+30
 SET GLOBAL tokudb_auto_analyze = 'foobar';
 ERROR 42000: Incorrect argument type to variable 'tokudb_auto_analyze'
 SELECT @@global.tokudb_auto_analyze;
 @@global.tokudb_auto_analyze
-0
+30
 SET SESSION tokudb_auto_analyze = 10;
 SELECT @@session.tokudb_auto_analyze;
 @@session.tokudb_auto_analyze
@@ -34,12 +34,12 @@ SELECT @@session.tokudb_auto_analyze;
 SET SESSION tokudb_auto_analyze = DEFAULT;
 SELECT @@session.tokudb_auto_analyze;
 @@session.tokudb_auto_analyze
-0
+30
 SET SESSION tokudb_auto_analyze = 'foobar';
 ERROR 42000: Incorrect argument type to variable 'tokudb_auto_analyze'
 SELECT @@session.tokudb_auto_analyze;
 @@session.tokudb_auto_analyze
-0
+30
 SET GLOBAL tokudb_auto_analyze = 12;
 SET SESSION tokudb_auto_analyze = 13;
 SELECT @@global.tokudb_auto_analyze;
@@ -54,8 +54,8 @@ tokudb_auto_analyze	13
 SET SESSION tokudb_auto_analyze = @orig_session;
 SELECT @@session.tokudb_auto_analyze;
 @@session.tokudb_auto_analyze
-0
+30
 SET GLOBAL tokudb_auto_analyze = @orig_global;
 SELECT @@global.tokudb_auto_analyze;
 @@global.tokudb_auto_analyze
-0
+30

--- a/mysql-test/suite/tokudb/r/card_add_drop.result
+++ b/mysql-test/suite/tokudb/r/card_add_drop.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, c int, d int, key(a), key(b), key(c));
 insert into tt values (0,0,0,0),(1,0,0,0),(2,0,1,0),(3,0,1,0);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_add_index.result
+++ b/mysql-test/suite/tokudb/r/card_add_index.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, c int, primary key(a));
 insert into tt values (1,0,0),(2,0,0),(3,0,1),(4,0,1);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_drop_index.result
+++ b/mysql-test/suite/tokudb/r/card_drop_index.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, c int, key(b), key(c), primary key(a));
 insert into tt values (1,0,0),(2,0,0),(3,0,1),(4,0,1);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_drop_index_2.result
+++ b/mysql-test/suite/tokudb/r/card_drop_index_2.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, c int, primary key(a), key(b), key(c));
 insert into tt values (0, 0, 0), (0+1, 0, 0), (0+2, 0, 0), (0+3, 0, 0);
 insert into tt values (4, 4, 0), (4+1, 4, 0), (4+2, 4, 0), (4+3, 4, 0);

--- a/mysql-test/suite/tokudb/r/card_drop_pk.result
+++ b/mysql-test/suite/tokudb/r/card_drop_pk.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, c int, key(b), key(c), primary key(a));
 insert into tt values (1,0,0),(2,0,0),(3,0,1),(4,0,1);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_no_keys.result
+++ b/mysql-test/suite/tokudb/r/card_no_keys.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int);
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_pk.result
+++ b/mysql-test/suite/tokudb/r/card_pk.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, primary key(a));
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_pk_2.result
+++ b/mysql-test/suite/tokudb/r/card_pk_2.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, primary key(a,b));
 insert into tt values (0,0),(0,1),(1,0),(1,1);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_sk.result
+++ b/mysql-test/suite/tokudb/r/card_sk.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, key(b));
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 insert into tt values (5,0),(6,1),(7,2),(8,3);

--- a/mysql-test/suite/tokudb/r/card_sk_2.result
+++ b/mysql-test/suite/tokudb/r/card_sk_2.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, key(a,b));
 insert into tt values (0,0),(0,1),(1,0),(1,1);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/r/card_unique_sk.result
+++ b/mysql-test/suite/tokudb/r/card_unique_sk.result
@@ -1,5 +1,7 @@
 set default_storage_engine='tokudb';
 drop table if exists tt;
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
 create table tt (a int, b int, unique key(a));
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/t/card_add_drop.test
+++ b/mysql-test/suite/tokudb/t/card_add_drop.test
@@ -7,6 +7,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, c int, d int, key(a), key(b), key(c));
 insert into tt values (0,0,0,0),(1,0,0,0),(2,0,1,0),(3,0,1,0);
 

--- a/mysql-test/suite/tokudb/t/card_add_index.test
+++ b/mysql-test/suite/tokudb/t/card_add_index.test
@@ -7,6 +7,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, c int, primary key(a));
 insert into tt values (1,0,0),(2,0,0),(3,0,1),(4,0,1);
 

--- a/mysql-test/suite/tokudb/t/card_drop_index.test
+++ b/mysql-test/suite/tokudb/t/card_drop_index.test
@@ -7,6 +7,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, c int, key(b), key(c), primary key(a));
 insert into tt values (1,0,0),(2,0,0),(3,0,1),(4,0,1);
 

--- a/mysql-test/suite/tokudb/t/card_drop_index_2.test
+++ b/mysql-test/suite/tokudb/t/card_drop_index_2.test
@@ -7,6 +7,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, c int, primary key(a), key(b), key(c));
 let $a=0;
 while ($a < 500) {

--- a/mysql-test/suite/tokudb/t/card_drop_pk.test
+++ b/mysql-test/suite/tokudb/t/card_drop_pk.test
@@ -7,6 +7,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, c int, key(b), key(c), primary key(a));
 insert into tt values (1,0,0),(2,0,0),(3,0,1),(4,0,1);
 

--- a/mysql-test/suite/tokudb/t/card_no_keys.test
+++ b/mysql-test/suite/tokudb/t/card_no_keys.test
@@ -5,6 +5,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int);
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 show indexes from tt;

--- a/mysql-test/suite/tokudb/t/card_pk.test
+++ b/mysql-test/suite/tokudb/t/card_pk.test
@@ -5,6 +5,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, primary key(a));
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 

--- a/mysql-test/suite/tokudb/t/card_pk_2.test
+++ b/mysql-test/suite/tokudb/t/card_pk_2.test
@@ -5,6 +5,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, primary key(a,b));
 insert into tt values (0,0),(0,1),(1,0),(1,1);
 

--- a/mysql-test/suite/tokudb/t/card_pk_sk.test
+++ b/mysql-test/suite/tokudb/t/card_pk_sk.test
@@ -13,9 +13,23 @@ while ($i < 1000) {
     inc $i;
 }
 
-# test that analyze computes the correct cardinality for the keys
+# wait for the bjm queue to empty
+-- disable_query_log
+let $wait_condition=select count(*)=0 from information_schema.tokudb_background_job_status;
+-- source include/wait_condition.inc
+-- enable_query_log
+
 show indexes from tt;
+
+# test that analyze computes the correct cardinality for the keys
 analyze table tt;
+
+# wait for the bjm queue to empty
+-- disable_query_log
+let $wait_condition=select count(*)=0 from information_schema.tokudb_background_job_status;
+-- source include/wait_condition.inc
+-- enable_query_log
+
 show indexes from tt;
 
 # test that cardinality is persistent
@@ -32,9 +46,23 @@ while ($i < 1000) {
     inc $i;
 }
 
-# test that analyze computes the correct cardinality for the keys
+# wait for the bjm queue to empty
+-- disable_query_log
+let $wait_condition=select count(*)=0 from information_schema.tokudb_background_job_status;
+-- source include/wait_condition.inc
+-- enable_query_log
+
 show indexes from tt;
+
+# test that analyze computes the correct cardinality for the keys
 analyze table tt;
+
+# wait for the bjm queue to empty
+-- disable_query_log
+let $wait_condition=select count(*)=0 from information_schema.tokudb_background_job_status;
+-- source include/wait_condition.inc
+-- enable_query_log
+
 show indexes from tt;
 
 # test that cardinality is persistent
@@ -42,5 +70,3 @@ flush tables;
 show indexes from tt;
 
 drop table tt;
-
-

--- a/mysql-test/suite/tokudb/t/card_scale_percent.test
+++ b/mysql-test/suite/tokudb/t/card_scale_percent.test
@@ -2,8 +2,11 @@
 
 -- disable_query_log
 
-set @orig_throttle = @@session.tokudb_analyze_throttle;
-set @orig_time = @@session.tokudb_analyze_time;
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 set @orig_scale_percent = @@global.tokudb_cardinality_scale_percent;
 
 create table tt (a int, b int, c int, d int, primary key(a), key(b), key(c), key(d)) engine=tokudb;
@@ -49,8 +52,6 @@ show indexes from tt;
 -- disable_query_log
 
 drop table tt;
-set session tokudb_analyze_throttle = @orig_throttle;
-set session tokudb_analyze_time = @orig_time;
 set global tokudb_cardinality_scale_percent = @orig_scale_percent;
 
 -- enable_query_log

--- a/mysql-test/suite/tokudb/t/card_sk.test
+++ b/mysql-test/suite/tokudb/t/card_sk.test
@@ -5,6 +5,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, key(b));
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 insert into tt values (5,0),(6,1),(7,2),(8,3);

--- a/mysql-test/suite/tokudb/t/card_sk_2.test
+++ b/mysql-test/suite/tokudb/t/card_sk_2.test
@@ -5,6 +5,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, key(a,b));
 insert into tt values (0,0),(0,1),(1,0),(1,1);
 

--- a/mysql-test/suite/tokudb/t/card_unique_sk.test
+++ b/mysql-test/suite/tokudb/t/card_unique_sk.test
@@ -5,6 +5,11 @@ disable_warnings;
 drop table if exists tt;
 enable_warnings;
 
+# this test is explicitly testing analyze functionality so we need to disable
+# the auto and background analysis (on by default in 5.7) for this test
+set session tokudb_auto_analyze = 0;
+set session tokudb_analyze_in_background = 0;
+
 create table tt (a int, b int, unique key(a));
 insert into tt values (1,0),(2,1),(3,2),(4,3);
 

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -459,7 +459,7 @@ static MYSQL_THDVAR_BOOL(
     "dispatch ANALYZE TABLE to background job.",
     NULL,
     NULL,
-    false);
+    true);
 
 const char* srv_analyze_mode_names[] = {
     "TOKUDB_ANALYZE_STANDARD",
@@ -515,7 +515,7 @@ static MYSQL_THDVAR_ULONGLONG(
     "auto analyze threshold (percent)",
     NULL,
     NULL,
-    0,
+    30,
     0,
     ~0U,
     1);


### PR DESCRIPTION
- Enabled tokudb_auto_analyze to 30% by default from 0 (disabled) and enabled tokudb_analyze_in_background by default from off/false.
- Corrected cardinality/analysis related test cases that expect this to be all disabled by default.
