### PR TITLE
Fix bug 1549196 (Some TokuDB testcases not properly skipped for Valgr…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/t/xa-3.test
+++ b/mysql-test/suite/tokudb.bugs/t/xa-3.test
@@ -1,6 +1,12 @@
 -- source include/have_innodb.inc
 -- source include/have_tokudb.inc
 -- source include/have_debug.inc
+# Valgrind would report memory leaks on the intentional crashes
+-- source include/not_valgrind.inc
+# Embedded server does not support crashing
+-- source include/not_embedded.inc
+# Avoid CrashReporter popup on Mac
+-- source include/not_crashrep.inc
 
 --disable_warnings
 drop table if exists t1, t2;

--- a/mysql-test/suite/tokudb.bugs/t/xa-4.test
+++ b/mysql-test/suite/tokudb.bugs/t/xa-4.test
@@ -1,6 +1,12 @@
 -- source include/have_innodb.inc
 -- source include/have_tokudb.inc
 -- source include/have_debug.inc
+# Valgrind would report memory leaks on the intentional crashes
+-- source include/not_valgrind.inc
+# Embedded server does not support crashing
+-- source include/not_embedded.inc
+# Avoid CrashReporter popup on Mac
+-- source include/not_crashrep.inc
 
 --disable_warnings
 drop table if exists t1, t2;

--- a/mysql-test/suite/tokudb.bugs/t/xa-6.test
+++ b/mysql-test/suite/tokudb.bugs/t/xa-6.test
@@ -1,5 +1,11 @@
 --source include/have_tokudb.inc
 --source include/have_debug.inc
+# Valgrind would report memory leaks on the intentional crashes
+-- source include/not_valgrind.inc
+# Embedded server does not support crashing
+-- source include/not_embedded.inc
+# Avoid CrashReporter popup on Mac
+-- source include/not_crashrep.inc
 
 --disable_warnings
 drop table if exists t1;


### PR DESCRIPTION
…ind)

Crashing testcases have to be skipped for Valgrind or all allocated
memory at the crash time will be reported as a leak. The affected
testcases are:
tokudb.bugs.xa-3
tokudb.bugs.xa-4
tokudb.bugs.xa-6

Fix by adding include/not_valgrind.inc. At the same add
include/not_embedded.inc (crashing is not supported for an embedded
server) and include/not_crashrep.inc (avoid crash popups on Mac) too.

```
http://jenkins.percona.com/job/percona-server-5.6-param/1081/
```
