### PR TITLE
Fix for ubuntu/debian sysvinit script and pid-file option (#1549333)

### DIFF
--- a/build-ps/debian/percona-server-server-5.7.mysql.init
+++ b/build-ps/debian/percona-server-server-5.7.mysql.init
@@ -61,10 +61,15 @@ fix_thp_setting() {
 
 get_running () {
 	PIDFILE=$(get_mysql_option mysqld_safe pid-file "")
+	MYSQLDATA=$(get_mysql_option mysqld datadir "/var/lib/mysql")
 	if [ -z "$PIDFILE" ];
 	then
 		PIDFILE=$(get_mysql_option mysqld pid-file "$MYSQLDATA/$(hostname).pid")
 	fi
+	case $PIDFILE in
+		/*) ;;
+		*) PIDFILE="$MYSQLDATA/$PIDFILE" ;;
+	esac
 	if [ -e "$PIDFILE" ] && [ -d "/proc/$(cat "$PIDFILE")" ];
 	then
 		echo 1

--- a/build-ps/ubuntu/percona-server-server-5.7.mysql.init
+++ b/build-ps/ubuntu/percona-server-server-5.7.mysql.init
@@ -61,10 +61,15 @@ fix_thp_setting() {
 
 get_running () {
 	PIDFILE=$(get_mysql_option mysqld_safe pid-file "")
+	MYSQLDATA=$(get_mysql_option mysqld datadir "/var/lib/mysql")
 	if [ -z "$PIDFILE" ];
 	then
 		PIDFILE=$(get_mysql_option mysqld pid-file "$MYSQLDATA/$(hostname).pid")
 	fi
+	case $PIDFILE in
+		/*) ;;
+		*) PIDFILE="$MYSQLDATA/$PIDFILE" ;;
+	esac
 	if [ -e "$PIDFILE" ] && [ -d "/proc/$(cat "$PIDFILE")" ];
 	then
 		echo 1


### PR DESCRIPTION
**BUG**
PS 5.7 ubuntu/debian sysvinit script doesn't tolerate pid-file option without path specified
https://bugs.launchpad.net/percona-server/+bug/1549333

**TEST BUILD**
http://jenkins.percona.com/job/percona-server-5.7-debian-binary/59/

**INFO**
If pid-file is specified with just a filename without a path then startup script should search it in datadir/filename.
Currently it fails because it's using just that filename and it can't find it.
Also MYSQLDATA variable needs to be specified here because in case "stop" is used it didn't work in all cases because the variable is set only in "start" function.
This affects ubuntu/debian distributions that use sysvinit (wheezy/precise/trusty).

_CASE1: pid-file with path_

```
vagrant@t-ubuntu1404-64:~$ sudo cat /etc/mysql/my.cnf|grep pid-file                                                                                                                                                                   
pid-file        = /var/lib/mysql/mysqld.pid

vagrant@t-ubuntu1404-64:~$ sudo service mysql start
..
 * Percona Server 5.7.10-3 is started

vagrant@t-ubuntu1404-64:~$ ps aux|grep mysql
mysql     4636  0.0  0.1   4444   756 ?        S    06:19   0:00 /bin/sh /usr/bin/mysqld_safe
mysql     4965 23.4 26.0 1441460 130816 ?      Sl   06:19   0:01 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --log-error=/var/log/mysql/error.log --pid-file=/var/lib/mysql/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306

vagrant@t-ubuntu1404-64:~$ sudo service mysql stop
...
 * Percona Server 5.7.10-3 is stopped

vagrant@t-ubuntu1404-64:~$ ps aux|grep mysql
vagrant   5112  0.0  0.1  11744   916 pts/0    S+   06:19   0:00 grep --color=auto mysql
```

_CASE 2: pid-file without path_

```
vagrant@t-ubuntu1404-64:~$ sudo cat /etc/mysql/my.cnf|grep pid-file                                                                                                                                                                    
pid-file        = mysqld.pid

vagrant@t-ubuntu1404-64:~$ sudo service mysql start
..
 * Percona Server 5.7.10-3 is started

vagrant@t-ubuntu1404-64:~$ ps aux|grep mysql                                                                                                                                                                                           
mysql     5177  0.0  0.1   4444   752 ?        S    06:20   0:00 /bin/sh /usr/bin/mysqld_safe
mysql     5506 29.2 26.0 1441460 130544 ?      Sl   06:20   0:01 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --log-error=/var/log/mysql/error.log --pid-file=/var/lib/mysql/mysqld.pid --socket=/var/run/mysqld/mysqld.sock --port=3306

vagrant@t-ubuntu1404-64:~$ sudo service mysql stop
....
 * Percona Server 5.7.10-3 is stopped

vagrant@t-ubuntu1404-64:~$ ps aux|grep mysql
vagrant   5674  0.0  0.1  11744   916 pts/0    S+   06:20   0:00 grep --color=auto mysql
```

_CASE 3: no pid-file specified_

```
vagrant@t-ubuntu1404-64:~$ sudo cat /etc/mysql/my.cnf|grep pid-file

vagrant@t-ubuntu1404-64:~$ sudo service mysql start
..
 * Percona Server 5.7.10-3 is started

vagrant@t-ubuntu1404-64:~$ ps aux|grep mysql
mysql     5740  0.0  0.1   4444   752 ?        S    06:22   0:00 /bin/sh /usr/bin/mysqld_safe
mysql     6058 19.5 26.0 1441460 130552 ?      Sl   06:22   0:01 /usr/sbin/mysqld --basedir=/usr --datadir=/var/lib/mysql --plugin-dir=/usr/lib/mysql/plugin --log-error=/var/log/mysql/error.log --pid-file=/var/lib/mysql/t-ubuntu1404-64.pid --socket=/var/run/mysqld/mysqld.sock --port=3306

vagrant@t-ubuntu1404-64:~$ sudo service mysql stop
...
 * Percona Server 5.7.10-3 is stopped

vagrant@t-ubuntu1404-64:~$ ps aux|grep mysql
vagrant   6205  0.0  0.1  11744   916 pts/0    S+   06:22   0:00 grep --color=auto mysql
```
