### PR TITLE
Fix bug 1552682 / upstream 80606 (Audit log worker thread may crash o…

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1,5 +1,6 @@
 /*
    Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2016, Percona Inc. All Rights Reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -4040,7 +4041,12 @@ void THD::end_attachable_transaction()
 extern "C" int thd_killed(const MYSQL_THD thd)
 {
   if (thd == NULL)
-    return current_thd->killed;
+  {
+    MYSQL_THD curr_thd= current_thd;
+    if (curr_thd)
+      return curr_thd->killed;
+    return FALSE;
+  }
   return thd->killed;
 }
 


### PR DESCRIPTION
…n write call writing fewer bytes than requested)

Audit log plugin has an utility thread that calls my_write. If
my_write system write calls writes fewer bytes than requested, the
code will check whether the current connection has received a
KILL. Since the thread has NULL for current_thd, it will crash in
thd_killed by trying to dereference current_thd for
current_thd->killed. It does not matter that the thread has called
my_thread_init.

Fix by making thd_killed return FALSE for current_thd == NULL.

http://jenkins.percona.com/job/mysql-5.7-param/109/
