### PR TITLE
Fix bug 1554043 / 80607 (main.log_tables-big unstable on loaded hosts)

### DIFF
--- a/mysql-test/r/log_tables-big.result
+++ b/mysql-test/r/log_tables-big.result
@@ -4,25 +4,25 @@ select get_lock('bug27638', 1);
 get_lock('bug27638', 1)
 1
 set session long_query_time=1;
-truncate table mysql.slow_log;
 select get_lock('bug27638', 2);
 get_lock('bug27638', 2)
 0
-select if (query_time between '00:00:01' and '00:00:10', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log;
+select if (query_time >= '00:00:01', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log
+where sql_text = 'select get_lock(\'bug27638\', 2)';
 qt	sql_text
 OK	select get_lock('bug27638', 2)
-truncate table mysql.slow_log;
 select get_lock('bug27638', 60);
 get_lock('bug27638', 60)
 0
-select if (query_time between '00:00:59' and '00:01:10', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log;
+select if (query_time >= '00:00:59', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log
+where sql_text = 'select get_lock(\'bug27638\', 60)';
 qt	sql_text
 OK	select get_lock('bug27638', 60)
-truncate table mysql.slow_log;
 select get_lock('bug27638', 101);
 get_lock('bug27638', 101)
 0
-select if (query_time between '00:01:40' and '00:01:50', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log;
+select if (query_time >= '00:01:40', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log
+where sql_text = 'select get_lock(\'bug27638\', 101)';
 qt	sql_text
 OK	select get_lock('bug27638', 101)
 select release_lock('bug27638');

--- a/mysql-test/t/log_tables-big.test
+++ b/mysql-test/t/log_tables-big.test
@@ -22,15 +22,15 @@ set session long_query_time=10;
 select get_lock('bug27638', 1);
 connection con2;
 set session long_query_time=1;
-truncate table mysql.slow_log;
 select get_lock('bug27638', 2);
-select if (query_time between '00:00:01' and '00:00:10', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log;
-truncate table mysql.slow_log;
+select if (query_time >= '00:00:01', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log
+       where sql_text = 'select get_lock(\'bug27638\', 2)';
 select get_lock('bug27638', 60);
-select if (query_time between '00:00:59' and '00:01:10', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log;
-truncate table mysql.slow_log;
+select if (query_time >= '00:00:59', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log
+       where sql_text = 'select get_lock(\'bug27638\', 60)';
 select get_lock('bug27638', 101);
-select if (query_time between '00:01:40' and '00:01:50', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log;
+select if (query_time >= '00:01:40', 'OK', 'WRONG') as qt, sql_text from mysql.slow_log
+       where sql_text = 'select get_lock(\'bug27638\', 101)';
 connection con1;
 select release_lock('bug27638');
 connection default;


### PR DESCRIPTION
Fix by making following changes:
1) remove upper time bound for expected timing-out "select get_lock"
completion time, and test only that they don't finish sooner than the
specified timeout value;
2) to avoid slow TRUNCATE TABLE getting to the slow query log and
being selected instead of "select get_lock", add WHERE sql_text=... to
select only the desired query.

http://jenkins.percona.com/job/mysql-5.7-param/113/
