### PR TITLE
Fix bug 1540338 (CREATE TABLE ... LIKE ... may create a system table …

### DIFF
--- a/mysql-test/r/percona_enforce_se_create_table_like.result
+++ b/mysql-test/r/percona_enforce_se_create_table_like.result
@@ -1,0 +1,24 @@
+#
+# Bug 1540338 (CREATE TABLE ... LIKE ... may create a system table with an unsupported enforced engine)
+#
+SELECT ENGINE INTO @mysql_proc_engine FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA="mysql" AND TABLE_NAME="proc";
+include/assert.inc [Enforced SE and existing mysql.proc SE must differ]
+RENAME TABLE mysql.proc TO proc_backup;
+SELECT ENGINE INTO @proc_backup_engine FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA="test" AND TABLE_NAME="proc_backup";
+include/assert.inc [RENAME TABLE must not change SE]
+SET SESSION sql_mode='';
+CREATE TABLE mysql.proc LIKE proc_backup;
+ERROR HY000: Storage engine 'InnoDB' does not support system tables. [mysql.proc]
+SET SESSION sql_mode=NO_ENGINE_SUBSTITUTION;
+CREATE TABLE mysql.proc LIKE proc_backup;
+ERROR 42000: Unknown storage engine 'MyISAM'
+SET SESSION sql_mode=default;
+RENAME TABLE proc_backup TO mysql.proc;
+SELECT ENGINE INTO @new_mysql_proc_engine FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA="mysql" AND TABLE_NAME="proc";
+include/assert.inc [RENAME TABLE must not change SE]
+# Verify that mysql.proc is working
+select routine_name,routine_schema from information_schema.routines where routine_schema like 'bug0%';
+routine_name	routine_schema

--- a/mysql-test/t/percona_enforce_se_create_table_like-master.opt
+++ b/mysql-test/t/percona_enforce_se_create_table_like-master.opt
@@ -1,0 +1,1 @@
+--enforce-storage-engine=INNODB

--- a/mysql-test/t/percona_enforce_se_create_table_like.test
+++ b/mysql-test/t/percona_enforce_se_create_table_like.test
@@ -1,0 +1,42 @@
+--source include/have_innodb.inc
+
+--echo #
+--echo # Bug 1540338 (CREATE TABLE ... LIKE ... may create a system table with an unsupported enforced engine)
+--echo #
+
+SELECT ENGINE INTO @mysql_proc_engine FROM INFORMATION_SCHEMA.TABLES
+       WHERE TABLE_SCHEMA="mysql" AND TABLE_NAME="proc";
+
+--let $assert_text= Enforced SE and existing mysql.proc SE must differ
+--let $assert_cond= @@enforce_storage_engine != @mysql_proc_engine
+--source include/assert.inc
+
+RENAME TABLE mysql.proc TO proc_backup;
+
+SELECT ENGINE INTO @proc_backup_engine FROM INFORMATION_SCHEMA.TABLES
+       WHERE TABLE_SCHEMA="test" AND TABLE_NAME="proc_backup";
+
+--let $assert_text= RENAME TABLE must not change SE
+--let $assert_cond= @mysql_proc_engine = @proc_backup_engine
+--source include/assert.inc
+
+SET SESSION sql_mode='';
+--error ER_UNSUPPORTED_ENGINE
+CREATE TABLE mysql.proc LIKE proc_backup;
+
+SET SESSION sql_mode=NO_ENGINE_SUBSTITUTION;
+--error ER_UNKNOWN_STORAGE_ENGINE
+CREATE TABLE mysql.proc LIKE proc_backup;
+SET SESSION sql_mode=default;
+
+RENAME TABLE proc_backup TO mysql.proc;
+
+SELECT ENGINE INTO @new_mysql_proc_engine FROM INFORMATION_SCHEMA.TABLES
+       WHERE TABLE_SCHEMA="mysql" AND TABLE_NAME="proc";
+
+--let $assert_text= RENAME TABLE must not change SE
+--let $assert_cond= @mysql_proc_engine = @new_mysql_proc_engine
+--source include/assert.inc
+
+--echo # Verify that mysql.proc is working
+select routine_name,routine_schema from information_schema.routines where routine_schema like 'bug0%';

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7797,8 +7797,7 @@ static bool check_engine(THD *thd, const char *db_name,
     Check, if the given table name is system table, and if the storage engine 
     does supports it.
   */
-  if ((create_info->used_fields & HA_CREATE_USED_ENGINE) &&
-      !ha_check_if_supported_system_table(*new_engine, db_name, table_name))
+  if (!ha_check_if_supported_system_table(*new_engine, db_name, table_name))
   {
     my_error(ER_UNSUPPORTED_ENGINE, MYF(0),
              ha_resolve_storage_engine_name(*new_engine), db_name, table_name);


### PR DESCRIPTION
…with an unsupported enforced engine)

CREATE TABLE ... LIKE ... currently bypasses the system table SE
compatibility check. This results in system tables being created with
an enforced storage engine, which might be incompatible with a given
system table.

Fix by making check_engine in sql_table.cc call
ha_check_if_supported_system_table when (create_info->used_fields &
HA_CREATE_USED_TABLE) does not hold (which covers CREATE TABLE
... LIKE ... statement).

Add a new testcase main.percona_enforce_se_create_table_like.

```
http://jenkins.percona.com/job/percona-server-5.5-param/1207/
```
