### PR TITLE
vio: Handling of cerficate chains

### DIFF
--- a/vio/viosslfactories.c
+++ b/vio/viosslfactories.c
@@ -191,7 +191,7 @@ vio_set_cert_stuff(SSL_CTX *ctx, const char *cert_file, const char *key_file,
     key_file= cert_file;
 
   if (cert_file &&
-      SSL_CTX_use_certificate_file(ctx, cert_file, SSL_FILETYPE_PEM) <= 0)
+      SSL_CTX_use_certificate_chain_file(ctx, cert_file) <= 0)
   {
     *error= SSL_INITERR_CERT;
     DBUG_PRINT("error",("%s from file '%s'", sslGetErrString(*error), cert_file));


### PR DESCRIPTION
While using pki and client certificates, clients fails to validate the
server's certificate and server fails to validate client certifiate.

PKI may look like this:
             +---------+
             | Root CA |
             +---------+
                  |
          /-------+---------\
          |                 |
     +----------+     +-----------+
     | MySQL CA |     | Client CA |
     +----------+     +-----------+
           |                |
    +-------------+  +-------------+
    |   Server    |  |   Client    |
    | certificate |  | certificate |
    +-------------+  +-------------+

my.cnf:

```
[mysqld]
ssl
ssl_ca=(clientca.crt rootca.crt)
ssl_cert=(server.crt mysqlca.crt)
ssl_key=(server.key)
[mysql]
ssl
ssl_ca=(rootca.crt)
ssl_cert=(clientcertificate.crt clientca.crt)
ssl_key=(client.key)
ssl-verify-server-cert=1
```

mysqld will now send the full chain allowing a client to validate the
servers certificate.
mysql will now send the full chain allowing a server to validate the
client certificate.

Reported upsteam at [#80698](http://bugs.mysql.com/bug.php?id=80698) and [#54158](https://bugs.mysql.com/bug.php?id=54158), merged in mariadb [MDEV-2870](https://jira.mariadb.org/browse/MDEV-2870)
