### PR TITLE
Fix bug 1553166 (InnoDB: Failing assertion: block->n_pointers == 0 in…

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_buffer_pool_debug.result
+++ b/mysql-test/suite/innodb/r/innodb_buffer_pool_debug.result
@@ -1,0 +1,25 @@
+SET @old_innodb_buffer_pool_evict = @@innodb_buffer_pool_evict;
+SET @old_innodb_file_format = @@innodb_file_format;
+SET @old_innodb_file_per_table = @@innodb_file_per_table;
+SET GLOBAL innodb_file_format='Barracuda';
+SET GLOBAL innodb_file_per_table=ON;
+CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE = InnoDB ROW_FORMAT = COMPRESSED;
+SET GLOBAL innodb_buffer_pool_evict = 'uncompressed';
+DROP TABLE t1;
+#
+# Bug 1553166: InnoDB: Failing assertion: block->n_pointers == 0 in buf0lru.cc line 2259
+#
+CREATE TABLE t1(i INT)ROW_FORMAT=COMPRESSED;
+CREATE TABLE t2(cdate date,note char(1));
+XA START '1553166';
+INSERT INTO t2 VALUES('2001-01-01',1),('2001-01-01',2);
+INSERT INTO t1 VALUES(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1);
+DELETE FROM t1 .*,test.t2.*,a.* USING t1,t2,t1 AS a;
+SET GLOBAL innodb_buffer_pool_evict='uncompressed';
+XA END '1553166';
+XA PREPARE '1553166';
+XA COMMIT '1553166';
+DROP TABLE t1, t2;
+SET GLOBAL innodb_buffer_pool_evict = @old_innodb_buffer_pool_evict;
+SET GLOBAL innodb_file_per_table = @old_innodb_file_per_table;
+SET GLOBAL innodb_file_format = @old_innodb_file_format;

--- a/mysql-test/suite/innodb/t/innodb_buffer_pool_debug.test
+++ b/mysql-test/suite/innodb/t/innodb_buffer_pool_debug.test
@@ -1,0 +1,36 @@
+--source include/have_innodb.inc
+--source include/have_debug.inc
+
+SET @old_innodb_buffer_pool_evict = @@innodb_buffer_pool_evict;
+SET @old_innodb_file_format = @@innodb_file_format;
+SET @old_innodb_file_per_table = @@innodb_file_per_table;
+
+SET GLOBAL innodb_file_format='Barracuda';
+SET GLOBAL innodb_file_per_table=ON;
+
+CREATE TABLE t1 (id INT PRIMARY KEY) ENGINE = InnoDB ROW_FORMAT = COMPRESSED;
+SET GLOBAL innodb_buffer_pool_evict = 'uncompressed';
+
+DROP TABLE t1;
+
+--echo #
+--echo # Bug 1553166: InnoDB: Failing assertion: block->n_pointers == 0 in buf0lru.cc line 2259
+--echo #
+
+CREATE TABLE t1(i INT)ROW_FORMAT=COMPRESSED;
+CREATE TABLE t2(cdate date,note char(1));
+XA START '1553166';
+INSERT INTO t2 VALUES('2001-01-01',1),('2001-01-01',2);
+INSERT INTO t1 VALUES(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1);
+DELETE FROM t1 .*,test.t2.*,a.* USING t1,t2,t1 AS a;
+SET GLOBAL innodb_buffer_pool_evict='uncompressed';
+
+XA END '1553166';
+XA PREPARE '1553166';
+XA COMMIT '1553166';
+
+DROP TABLE t1, t2;
+
+SET GLOBAL innodb_buffer_pool_evict = @old_innodb_buffer_pool_evict;
+SET GLOBAL innodb_file_per_table = @old_innodb_file_per_table;
+SET GLOBAL innodb_file_format = @old_innodb_file_format;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12595,7 +12595,7 @@ innodb_buffer_pool_evict_update(
 
 					mutex_enter(&block->mutex);
 					buf_LRU_free_block(&block->page,
-							   FALSE, FALSE);
+							   FALSE, TRUE);
 					mutex_exit(&block->mutex);
 					block = prev_block;
 				}


### PR DESCRIPTION
… buf0lru.cc line 2259)

innodb_buffer_pool_evict_update calling buf_LRU_free_block was an
untested code path, that made incorrect assumption which mutex was
already locked. Fix trivially.

Backport the innodb.innodb_buffer_pool_debug testcase and add the test there.

```
http://jenkins.percona.com/job/percona-server-5.5-param/1209/
```
