### PR TITLE
Fix bug 1536469 (Assertion `length == 0 || json_binary::parse_binary(…

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -32,6 +32,7 @@ extern "C" {
 
 #include "my_compare.h"
 #include "my_tree.h"
+#include "binary_log_types.h" // enum_field_types
 
 /* Define index limits to be identical to MyISAM ones for compatibility. */
 
@@ -142,7 +143,7 @@ typedef struct st_hp_keydef		/* Key definition with open */
 
 typedef struct st_heap_columndef		/* column information */
 {
-  int16  type;	  			/* en_fieldtype */
+  enum_field_types  type;	  	/* en_fieldtype */
   uint32 length;		  	/* length of field */
   uint32 offset;		  	/* Offset to position in row */
   uint8  null_bit;			/* If column may be 0 */

--- a/mysql-test/r/percona_heap_json.result
+++ b/mysql-test/r/percona_heap_json.result
@@ -1,0 +1,12 @@
+#
+# Bug 1536469 (Assertion `length == 0 || json_binary::parse_binary(ptr, length).is_valid()'
+# failed in sql/field.cc:8975: type_conversion_status Field_json::store_binary(const char*, size_t))
+#
+CREATE TABLE t0(utf0k json) ENGINE=MEMORY;
+INSERT INTO t0 values('0');
+INSERT INTO t0 VALUES('DBMS stands for DataBase ...');
+ERROR 22032: Invalid JSON text: "Invalid value." at position 0 in value (or column) 'DBMS stands for DataBase ...'.
+SELECT * FROM t0;
+utf0k
+0
+DROP TABLE t0;

--- a/mysql-test/t/percona_heap_json.test
+++ b/mysql-test/t/percona_heap_json.test
@@ -1,0 +1,15 @@
+#
+# Tests for JSON data type in MEMORY tables
+#
+
+--echo #
+--echo # Bug 1536469 (Assertion `length == 0 || json_binary::parse_binary(ptr, length).is_valid()'
+--echo # failed in sql/field.cc:8975: type_conversion_status Field_json::store_binary(const char*, size_t))
+--echo #
+
+CREATE TABLE t0(utf0k json) ENGINE=MEMORY;
+INSERT INTO t0 values('0');
+--error ER_INVALID_JSON_TEXT
+INSERT INTO t0 VALUES('DBMS stands for DataBase ...');
+SELECT * FROM t0;
+DROP TABLE t0;

--- a/storage/heap/ha_heap.cc
+++ b/storage/heap/ha_heap.cc
@@ -684,7 +684,7 @@ heap_prepare_hp_create_info(TABLE *table_arg, bool internal_table,
   {
     Field* field= *(table_arg->field + column_idx);
     HP_COLUMNDEF* column= columndef + column_idx;
-    column->type= (uint16) field->type();
+    column->type= field->type();
     column->length= field->pack_length();
     column->offset= field->offset(table_arg->record[0]);
 
@@ -703,7 +703,7 @@ heap_prepare_hp_create_info(TABLE *table_arg, bool internal_table,
     {
       column->length_bytes= (uint8) (((Field_varstring *) field)->length_bytes);
     }
-    else if (field->type() == MYSQL_TYPE_BLOB)
+    else if (field->flags & BLOB_FLAG)
     {
       blobs++;
       column->length_bytes= (uint8)

--- a/storage/heap/heapdef.h
+++ b/storage/heap/heapdef.h
@@ -61,6 +61,9 @@ if (!(info->update & HA_STATE_AKTIV))\
   ((rec_length + (info)->chunk_dataspace_length - 1) / \
    (info)->chunk_dataspace_length)
 
+#define is_blob_column(c) \
+  ((c)->type == MYSQL_TYPE_BLOB || (c)->type == MYSQL_TYPE_JSON)
+
 typedef struct st_hp_hash_info
 {
   struct st_hp_hash_info *next_key;

--- a/storage/heap/hp_create.c
+++ b/storage/heap/hp_create.c
@@ -138,7 +138,7 @@ int heap_create(const char *name, HP_CREATE_INFO *create_info,
         HP_COLUMNDEF *column= create_info->columndef + i;
 	if ((column->type == MYSQL_TYPE_VARCHAR &&
 	     (column->length - column->length_bytes) >= 32) ||
-	    column->type == MYSQL_TYPE_BLOB)
+            is_blob_column(column))
         {
             /*
               The field has to be either blob or >= 5.0.3 true VARCHAR

--- a/storage/heap/hp_record.c
+++ b/storage/heap/hp_record.c
@@ -76,7 +76,7 @@ uint hp_get_encoded_data_length(HP_SHARE *info, const uchar *record,
                              (uint) *(uchar *) (record + src_offset) :
                              uint2korr(record + src_offset));
     }
-    else if (column->type == MYSQL_TYPE_BLOB)
+    else if (is_blob_column(column))
     {
       uint pack_length= column->length_bytes;
 
@@ -257,7 +257,7 @@ uint hp_process_record_data_to_chunkset(HP_SHARE *info, const uchar *record,
       pack_length= column->length_bytes;
       length= pack_length + (pack_length == 1 ? (uint) *data : uint2korr(data));
     }
-    else if (column->type == MYSQL_TYPE_BLOB)
+    else if (is_blob_column(column))
     {
       uint pack_length;
 
@@ -396,7 +396,7 @@ int hp_extract_record(HP_INFO *info, uchar *record, const uchar *pos)
     }
 
     to= record + column->offset;
-    if (column->type == MYSQL_TYPE_VARCHAR || column->type == MYSQL_TYPE_BLOB)
+    if (column->type == MYSQL_TYPE_VARCHAR || is_blob_column(column))
     {
       uint pack_length, i;
       uchar *tmp= to;
@@ -417,7 +417,7 @@ int hp_extract_record(HP_INFO *info, uchar *record, const uchar *pos)
       */
       length= hp_calc_blob_length(pack_length, tmp);
 
-      if (column->type == MYSQL_TYPE_BLOB && length == 0)
+      if (is_blob_column(column) && length == 0)
       {
         /*
           Store a zero pointer for zero-length BLOBs because the server
@@ -425,7 +425,7 @@ int hp_extract_record(HP_INFO *info, uchar *record, const uchar *pos)
         */
         *(uchar **) to= 0;
       }
-      else if (column->type == MYSQL_TYPE_BLOB && length > 0)
+      else if (is_blob_column(column) && length > 0)
       {
         uint newsize= info->blob_offset + length;
 


### PR DESCRIPTION
…ptr, length).is_valid()'...)

The issue was MEMORY storage engine not considering JSON fields as
BLOB ones, which they fundamentally are.

Fixed by
- fixing the type of HP_COLUMNDEF::type to be enum_field_types;
- replacing "field->type() == MYSQL_TYPE_BLOB" checks with
  "field->flags & BLOB_FLAG", which covers any BLOB-like data type;
- introducing is_blob_column macro that checks for either
  MYSQL_TYPE_BLOB or MYSQL_TYPE_JSON column, and replacing any direct
  comparisons with MYSQL_TYPE_BLOB with it.

Added a new testcase percona_heap_json.

http://jenkins.percona.com/job/mysql-5.7-param/121/
