### PR TITLE
DB-937 : 5.7 mtr engines/funcs and engines/iuds tests failing

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/2219.result
+++ b/mysql-test/suite/tokudb.bugs/r/2219.result
@@ -57,6 +57,8 @@ a
 insert into foo values (2);
 ERROR 23000: Duplicate entry '2' for key 'PRIMARY'
 insert ignore into foo values (5),(2),(6);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 select * From foo;
 a
 1
@@ -70,6 +72,8 @@ alter table foo add unique index (a);
 insert into foo values (3);
 ERROR 23000: Duplicate entry '3' for key 'a'
 insert ignore into foo values (7),(2),(8);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'a'
 select * from foo;
 a
 1

--- a/mysql-test/suite/tokudb.bugs/r/2262.result
+++ b/mysql-test/suite/tokudb.bugs/r/2262.result
@@ -7,6 +7,8 @@ foo CHAR(10)
 set session transaction isolation level read uncommitted;
 replace into test_bug (id, foo) VALUES (1, "bar");
 insert ignore into test_bug (id, foo) VALUES (1, "bar");
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 insert into test_bug (id, foo) VALUES (1, "bar") ON DUPLICATE KEY UPDATE foo='baz';
 set session transaction isolation level serializable;
 DROP TABLE test_bug;

--- a/mysql-test/suite/tokudb/r/locks-blocking-row-locks.result
+++ b/mysql-test/suite/tokudb/r/locks-blocking-row-locks.result
@@ -93,8 +93,14 @@ a	b
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -110,6 +116,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -316,8 +324,14 @@ update t set b=b where a=1;
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -333,6 +347,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -458,6 +474,8 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t where a=1 for update;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 select * from t where a=2 for update;
@@ -498,6 +516,8 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 update t set b=b where a=1;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 update t set b=b where a=2;
@@ -530,11 +550,19 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -550,6 +578,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -562,6 +592,8 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 replace t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 replace t values(2, 100);
@@ -594,6 +626,8 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t where a<=2 for update;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 select * from t where a>=0 for update;
@@ -642,6 +676,8 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 update t set b=b where a<=2;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 update t set b=b where a>=0;
@@ -750,8 +786,14 @@ replace t values(1, 100);
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -767,6 +809,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -1167,8 +1211,14 @@ a	b
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -1184,6 +1234,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -1200,6 +1252,8 @@ a	b
 1	100
 insert ignore t values(1, 175);
 commit;
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t where a=1 for update;
 a	b
@@ -1427,8 +1481,14 @@ update t set b=b where a=1;
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -1444,6 +1504,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -1458,6 +1520,8 @@ begin;
 update t set b=b where a=1;
 insert ignore t values(1, 175);
 commit;
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 update t set b=b where a=1;
 replace t values(1, 100);
@@ -1588,6 +1652,8 @@ update t set b=b where a<=2;
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t where a=1 for update;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 select * from t where a=2 for update;
@@ -1628,12 +1694,16 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 150);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t where a=1 for update;
 commit;
 a	b
 1	175
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 update t set b=b where a=1;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 update t set b=b where a=2;
@@ -1666,15 +1736,25 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 150);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 update t set b=b where a=1;
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -1690,6 +1770,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -1702,10 +1784,16 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 150);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 insert ignore t values(1, 175);
 commit;
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 replace t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 replace t values(2, 100);
@@ -1738,10 +1826,14 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 150);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 replace t values(1, 175);
 commit;
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t where a<=2 for update;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 select * from t where a>=0 for update;
@@ -1790,6 +1882,8 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 150);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t where a<=2 for update;
 commit;
 a	b
@@ -1797,6 +1891,8 @@ a	b
 2	100
 begin;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 update t set b=b where a<=2;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 update t set b=b where a>=0;
@@ -1830,6 +1926,8 @@ a	b
 commit;
 begin;
 insert ignore t values(1, 150);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 update t set b=b where a<=2;
 commit;
 begin;
@@ -1919,8 +2017,14 @@ replace t values(1, 100);
 insert ignore t values(1, 100);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert ignore t values(2, 100);
+Warnings:
+Warning	1062	Duplicate entry '2' for key 'PRIMARY'
 insert ignore t values(3, 100);
+Warnings:
+Warning	1062	Duplicate entry '3' for key 'PRIMARY'
 insert ignore t values(4, 100);
+Warnings:
+Warning	1062	Duplicate entry '4' for key 'PRIMARY'
 begin;
 select * from t;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
@@ -1936,6 +2040,8 @@ a	b
 commit;
 commit;
 insert ignore t values(1, 100);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 select * from t;
 a	b
@@ -1950,6 +2056,8 @@ begin;
 replace t values(1, 150);
 insert ignore t values(1, 175);
 commit;
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 begin;
 replace t values(1, 100);
 replace t values(1, 100);

--- a/mysql-test/suite/tokudb/r/replace-ignore.result
+++ b/mysql-test/suite/tokudb/r/replace-ignore.result
@@ -57,6 +57,8 @@ insert into t values
 (49, 49, 490),
 (50, 50, 500);
 insert ignore t values (8, 8, -1);
+Warnings:
+Warning	1062	Duplicate entry '8-8' for key 'PRIMARY'
 explain select * from t where a = 8;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t	NULL	ref	PRIMARY	PRIMARY	4	const	1	100.00	NULL
@@ -75,7 +77,7 @@ a	b	c
 8	8	80
 explain select * from t where c = 80;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	52	10.00	Using where
+1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	51	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t`.`a` AS `a`,`test`.`t`.`b` AS `b`,`test`.`t`.`c` AS `c` from `test`.`t` where (`test`.`t`.`c` = 80)
 select * from t where c = 80;
@@ -83,12 +85,14 @@ a	b	c
 8	8	80
 explain select * from t where c = -1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	52	10.00	Using where
+1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	51	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t`.`a` AS `a`,`test`.`t`.`b` AS `b`,`test`.`t`.`c` AS `c` from `test`.`t` where (`test`.`t`.`c` = <cache>(-(1)))
 select * from t where c = -1;
 a	b	c
 insert ignore t values (15, 15, -1);
+Warnings:
+Warning	1062	Duplicate entry '15-15' for key 'PRIMARY'
 explain select * from t where a = 15;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t	NULL	ref	PRIMARY	PRIMARY	4	const	1	100.00	NULL
@@ -107,7 +111,7 @@ a	b	c
 15	15	150
 explain select * from t where c = 150;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	53	10.00	Using where
+1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	51	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t`.`a` AS `a`,`test`.`t`.`b` AS `b`,`test`.`t`.`c` AS `c` from `test`.`t` where (`test`.`t`.`c` = 150)
 select * from t where c = 150;
@@ -115,7 +119,7 @@ a	b	c
 15	15	150
 explain select * from t where c = -1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	53	10.00	Using where
+1	SIMPLE	t	NULL	ALL	NULL	NULL	NULL	NULL	51	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t`.`a` AS `a`,`test`.`t`.`b` AS `b`,`test`.`t`.`c` AS `c` from `test`.`t` where (`test`.`t`.`c` = <cache>(-(1)))
 select * from t where c = -1;

--- a/mysql-test/suite/tokudb/r/savepoint-1078-2.result
+++ b/mysql-test/suite/tokudb/r/savepoint-1078-2.result
@@ -240,6 +240,8 @@ a	b
 4	40
 savepoint b;
 insert ignore into t1 values (8,80),(1,100),(9,90);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t1;
 a	b
 1	10

--- a/mysql-test/suite/tokudb/r/savepoint-1078-3.result
+++ b/mysql-test/suite/tokudb/r/savepoint-1078-3.result
@@ -240,6 +240,8 @@ a	b
 4	40
 savepoint b;
 insert ignore into t1 values (8,80),(1,100),(9,90);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t1;
 a	b
 1	10

--- a/mysql-test/suite/tokudb/r/savepoint-1078-4.result
+++ b/mysql-test/suite/tokudb/r/savepoint-1078-4.result
@@ -240,6 +240,8 @@ a	b
 4	40
 savepoint b;
 insert ignore into t1 values (8,80),(1,100),(9,90);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t1;
 a	b
 1	10

--- a/mysql-test/suite/tokudb/r/savepoint-1078.result
+++ b/mysql-test/suite/tokudb/r/savepoint-1078.result
@@ -240,6 +240,8 @@ a	b
 4	40
 savepoint b;
 insert ignore into t1 values (8,80),(1,100),(9,90);
+Warnings:
+Warning	1062	Duplicate entry '1' for key 'PRIMARY'
 select * from t1;
 a	b
 1	10

--- a/mysql-test/suite/tokudb/t/rows-32m-rand-insert.test
+++ b/mysql-test/suite/tokudb/t/rows-32m-rand-insert.test
@@ -16,6 +16,10 @@ set global max_allowed_packet=100000000;
 
 connect(conn1,localhost,root,,);
 
+# disable warnings here as we will get a lot of unpredictable
+# 1062 Dulicate entry warnings in 5.7 with fix for DB-937
+--disable_warnings
+
 let $nrows=1000;
 let $maxid=$nrows;
 let $maxblob=32*1024*1024;
@@ -23,6 +27,8 @@ while ($nrows) {
       eval insert ignore into t (id,v) values (floor(rand()*$maxid),repeat('a',($maxblob-4)*rand()));
       dec $nrows;
 }
+
+--enable_warnings
 
 connection default;
 disconnect conn1;


### PR DESCRIPTION
Tests were failing due to incorrect behavior of TokuDB ha_tokudb::write_rows during INSERT IGNORE.
Server expects SE to return ER_DUP_ENTRY from ha_tokudb::write_rows if there is a duplicate key
match even if INSERT IGNORE is in use, TokuDB was detecting INSERT IGNORE and returning no error
when it should have. Server then translates this error into a warning during INSERT IGNORE.
- Changed TokuDB logic to return ER_DUP_ENTRY on duplicate key ignore.
- Re-recorded tests that intentionally used INSERT IGNORE to capture mtr results of SHOW WARNINGS.
- Changed tokudb.rows-32m-rand-insert that was using INSERT IGNORE with many random values to
  disable warnings during insertion sequences.
