### PR TITLE
DB-955 : tokudb.rpl.rpl_tokudb_mixed_dml fails mtr due to auto analysis

### DIFF
--- a/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_mixed_dml-master.opt
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_mixed_dml-master.opt
@@ -1,0 +1,1 @@
+--tokudb_auto_analyze=0 --tokudb_analyze_in_background=false

--- a/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_mixed_dml-slave.opt
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_mixed_dml-slave.opt
@@ -1,0 +1,1 @@
+--tokudb_auto_analyze=0 --tokudb_analyze_in_background=false


### PR DESCRIPTION
- Added master and slave opt files to disable auto analysis and background analysis during test.
