### PR TITLE
DB-917 : Assertion `Handlerton: kc_info->cp_info[keynr] == NULL ' fai…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/t/disabled.def
+++ b/mysql-test/suite/tokudb.bugs/t/disabled.def
@@ -14,3 +14,4 @@ checkpoint_lock_2: test can not work when the checkpoint_safe_lock is a fair rwl
 db768 : https://tokutek.atlassian.net/browse/DB-768
 dict_leak_3518 : https://tokutek.atlassian.net/browse/DB-635
 1872 : https://tokutek.atlassian.net/browse/DB-750
+db917 : https://tokutek.atlassian.net/browse/DB-917


### PR DESCRIPTION
…led in tokudb/ha_tokudb.cc:1441 init
- Disabled mtr test case until bug is fixed in PerconaFT
