### PR TITLE
DB-945 : Assertion `Handlerton: db != NULL ' failed (errno=0) in anal…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
+++ b/mysql-test/suite/tokudb.bugs/r/db757_part_alter_analyze.result
@@ -15,7 +15,7 @@ test.t	analyze	status	OK
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	5	NULL	NULL		BTREE		
-t	1	x	1	x	A	2	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	5	NULL	NULL	YES	BTREE		
 t	1	y	1	y	A	5	NULL	NULL	YES	BTREE		
 alter table t analyze partition p1;
 Table	Op	Msg_type	Msg_text
@@ -23,13 +23,13 @@ test.t	analyze	status	OK
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	5	NULL	NULL		BTREE		
-t	1	x	1	x	A	2	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	5	NULL	NULL	YES	BTREE		
 t	1	y	1	y	A	5	NULL	NULL	YES	BTREE		
 insert into t values (100,1,1),(200,2,1),(300,3,1),(400,4,1),(500,5,1);
 show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	9	NULL	NULL		BTREE		
-t	1	x	1	x	A	4	NULL	NULL	YES	BTREE		
+t	1	x	1	x	A	9	NULL	NULL	YES	BTREE		
 t	1	y	1	y	A	9	NULL	NULL	YES	BTREE		
 alter table t analyze partition p0;
 Table	Op	Msg_type	Msg_text
@@ -46,5 +46,5 @@ show indexes from t;
 Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment
 t	0	PRIMARY	1	id	A	9	NULL	NULL		BTREE		
 t	1	x	1	x	A	9	NULL	NULL	YES	BTREE		
-t	1	y	1	y	A	4	NULL	NULL	YES	BTREE		
+t	1	y	1	y	A	9	NULL	NULL	YES	BTREE		
 drop table t;

--- a/mysql-test/suite/tokudb.bugs/r/db945.result
+++ b/mysql-test/suite/tokudb.bugs/r/db945.result
@@ -1,0 +1,12 @@
+set default_storage_engine='tokudb';
+drop table if exists t1;
+set session tokudb_auto_analyze = 1;
+set session tokudb_analyze_in_background = true;
+set session tokudb_analyze_mode = TOKUDB_ANALYZE_STANDARD;
+set session tokudb_analyze_throttle = 0;
+set session tokudb_analyze_time = 0;
+create table t1(a int, b text(1), c text(1), filler text(1), primary key(a, b(1)), unique key (a, c(1)));
+lock tables t1 write, t1 as a read, t1 as b read;
+insert into t1(a) values(1);
+alter table t1 drop key a;
+unlock tables;

--- a/mysql-test/suite/tokudb.bugs/t/db945.test
+++ b/mysql-test/suite/tokudb.bugs/t/db945.test
@@ -1,0 +1,24 @@
+source include/have_tokudb.inc;
+set default_storage_engine='tokudb';
+disable_warnings;
+drop table if exists t1;
+enable_warnings;
+
+set session tokudb_auto_analyze = 1;
+set session tokudb_analyze_in_background = true;
+set session tokudb_analyze_mode = TOKUDB_ANALYZE_STANDARD;
+set session tokudb_analyze_throttle = 0;
+set session tokudb_analyze_time = 0;
+
+create table t1(a int, b text(1), c text(1), filler text(1), primary key(a, b(1)), unique key (a, c(1)));
+lock tables t1 write, t1 as a read, t1 as b read;
+insert into t1(a) values(1);
+alter table t1 drop key a;
+unlock tables;
+
+# wait for the bjm queue to empty
+-- disable_query_log
+let $wait_condition=select count(*)=0 from information_schema.tokudb_background_job_status;
+-- source include/wait_condition.inc
+
+drop table t1;

--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -772,10 +772,11 @@ int TOKUDB_SHARE::analyze_standard(THD* thd, DB_TXN* txn) {
     int result = HA_ADMIN_OK;
 
     // stub out analyze if optimize is remapped to alter recreate + analyze
-    // when not auto analyze
-    if (txn &&
-        thd_sql_command(thd) != SQLCOM_ANALYZE &&
-        thd_sql_command(thd) != SQLCOM_ALTER_TABLE) {
+    // when not auto analyze or if this is an alter
+    if ((txn &&
+         thd_sql_command(thd) != SQLCOM_ANALYZE &&
+         thd_sql_command(thd) != SQLCOM_ALTER_TABLE) ||
+        thd_sql_command(thd) == SQLCOM_ALTER_TABLE) {
         TOKUDB_HANDLER_DBUG_RETURN(result);
     }
 


### PR DESCRIPTION
…yze_key | tokudb/ha_tokudb_admin.cc:582

It seems that with tokudb_auto_analyze > 0, an ALTER TABLE can trigger an auto analysis.
If tokudb_analyze_in_background = true, this analysis is dispatched to the bjm and executed in parallel.
The problem is that with an ALTER TABLE DROP KEY, the analysis can try to run on the table/key
meta-data (number of and definition of keys) before the table/key meta-data has been updated in the
TOKUDB_SHARE by the process of COMMITing the ALTER (close and re-open) and therefore the analyze will
be operating on old/bad table/key meta-data.

The fix is to not allow an ALTER to trigger an analyze at all.

Added new test case that trigger the assertion without the fix.
Re-recorded tokudb.bugs.db757_part_alter_analyze since it had recorded results that depended on ANALYZE
being run as part of an ALTER TABLE.
