### PR TITLE
Replication does not work when @@GLOBAL.SERVER_UUID is missing on the master (breaks 5.5 to 5.7 replication)

### DIFF
--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2416,6 +2416,15 @@ static int get_master_uuid(MYSQL *mysql, Master_info *mi)
                  mysql_error(mysql));
       ret= 2;
     }
+    else if (mysql_errno(mysql) == 1193)
+    {
+      mi->master_uuid[0]= 0;
+      mi->report(WARNING_LEVEL, ER_UNKNOWN_SYSTEM_VARIABLE,
+                 "Unknown system variable 'SERVER_UUID' on master. "
+                 "A probable cause is that the variable is not supported on the "
+                 "master (version: %s), even though it is on the slave (version: %s)",
+                 mysql->server_version, server_version);
+    }
     else
     {
       /* Fatal error */

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2435,15 +2435,6 @@ static int get_master_uuid(MYSQL *mysql, Master_info *mi)
       ret= 1;
     }
   }
-  else if (!master_row && master_res)
-  {
-    mi->master_uuid[0]= 0;
-    mi->report(WARNING_LEVEL, ER_UNKNOWN_SYSTEM_VARIABLE,
-               "Unknown system variable 'SERVER_UUID' on master. "
-               "A probable cause is that the variable is not supported on the "
-               "master (version: %s), even though it is on the slave (version: %s)",
-               mysql->server_version, server_version);
-  }
 
   if (master_res)
     mysql_free_result(master_res);


### PR DESCRIPTION
In commit  https://github.com/mysql/mysql-server/commit/14d664f0ddca7c69d44599693ffcd3455557e7e6#diff-43cb87a950ecc24df928a17c509677c8L2278, the code that fetches the `SERVER_UUID` changed from `SHOW GLOBAL VARIABLES` to `SELECT @@GLOBAL`, which now returns an error if the variable is not there instead of an empty row.

However, as you can see in https://github.com/grypyrg/percona-server/blob/5.7/sql/rpl_slave.cc#L2429-L2437 the code actually catches the non presence of a row which is using the `SHOW GLOBAL VARIABLES` way.

This patch just made it handle `SELECT @@GLOBAL` properly.

This caused any replication from MySQL < 5.6 to MySQL 5.7 to break.
