### PR TITLE
Fix bug 1566642 / 80962 (Replication does not work when @@GLOBAL.SERV…

### DIFF
--- a/mysql-test/suite/rpl/r/bug80962.result
+++ b/mysql-test/suite/rpl/r/bug80962.result
@@ -1,0 +1,21 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+[connection slave]
+include/stop_slave.inc
+SET @saved_debug= @@GLOBAL.debug;
+SET GLOBAL debug= "+d,dbug.simulate_no_server_uuid";
+call mtr.add_suppression("Unknown system variable 'SERVER_UUID' on master.");
+include/start_slave.inc
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
+Master_UUID = ''
+Warnings:
+Warning	3090	Changing sql mode 'NO_AUTO_CREATE_USER' is deprecated. It will be removed in a future release.
+SET GLOBAL debug= "-d,dbug.simulate_no_server_uuid";
+SET GLOBAL debug= @old_debug;
+include/stop_slave.inc
+include/start_slave.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/bug80962.test
+++ b/mysql-test/suite/rpl/t/bug80962.test
@@ -1,0 +1,27 @@
+--source include/have_debug.inc
+# No need to test all binlog formats
+--source include/have_binlog_format_row.inc
+
+--source include/master-slave.inc
+
+--source include/rpl_connection_slave.inc
+--source include/stop_slave.inc
+
+SET @saved_debug= @@GLOBAL.debug;
+SET GLOBAL debug= "+d,dbug.simulate_no_server_uuid";
+
+call mtr.add_suppression("Unknown system variable 'SERVER_UUID' on master.");
+
+# With the bug present START SLAVE fails
+--source include/start_slave.inc
+
+--let $status_items= Master_UUID
+--source include/show_slave_status.inc
+
+SET GLOBAL debug= "-d,dbug.simulate_no_server_uuid";
+SET GLOBAL debug= @old_debug;
+
+--source include/stop_slave.inc
+--source include/start_slave.inc
+
+--source include/rpl_end.inc

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -5201,6 +5201,12 @@ mysql_real_query(MYSQL *mysql, const char *query, ulong length)
                     DBUG_SET("-d,inject_ER_NET_READ_INTERRUPTED");
                     DBUG_RETURN(1);
                   });
+  DBUG_EXECUTE_IF("inject_ER_UNKNOWN_SYSTEM_VARIABLE",
+                  {
+                    mysql->net.last_errno= ER_UNKNOWN_SYSTEM_VARIABLE;
+                    DBUG_SET("-d,inject_ER_UNKNOWN_SYSTEM_VARIABLE");
+                    DBUG_RETURN(1);
+                  });
 
   if (mysql_send_query(mysql,query,length))
     DBUG_RETURN(1);


### PR DESCRIPTION
…ER_UUID is missing on the master)

Based on analysis and patch by Ceri Williams and Kenny Gryp:

The query to get master server UUID has been changed from SHOW GLOBAL
VARIABLES to SELECT @@GLOBAL. If the variable is not present, this
returns an error instead of an empty row as previously. However, the
code still attempts to check for an empty row, does not handle the
error returned, and as a result, a 5.7 slave connecting to a 5.5
master fails to start.

Fix by handling the error instead of checking for an empty row, add a
testcase.

http://jenkins.percona.com/job/mysql-5.7-param/132/
