### PR TITLE
DB-952 : Remove/repair tokudb_pk_insert_mode to be safe and deprecate

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/db739_replace.result
+++ b/mysql-test/suite/tokudb.bugs/r/db739_replace.result
@@ -100010,5 +100010,7 @@ insert into t (id,a) values (999,98);
 insert into t (id,a) values (999,99);
 delete from t where id=404;
 set tokudb_pk_insert_mode=2;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
 replace into t values (404,0,0,0);
 drop table t;

--- a/mysql-test/suite/tokudb.rpl/r/rpl_tokudb_mixed_dml.result
+++ b/mysql-test/suite/tokudb.rpl/r/rpl_tokudb_mixed_dml.result
@@ -1,4 +1,6 @@
 SET SESSION tokudb_pk_insert_mode = 2;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
 include/master-slave.inc
 Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.

--- a/mysql-test/suite/tokudb.sys_vars/r/tokudb_pk_insert_mode_basic.result
+++ b/mysql-test/suite/tokudb.sys_vars/r/tokudb_pk_insert_mode_basic.result
@@ -1,0 +1,85 @@
+SET @orig_global = @@global.tokudb_pk_insert_mode;
+SELECT @orig_global;
+@orig_global
+1
+SET @orig_session = @@session.tokudb_pk_insert_mode;
+SELECT @orig_session;
+@orig_session
+1
+SET GLOBAL tokudb_pk_insert_mode = 10;
+Warnings:
+Warning	1292	Truncated incorrect tokudb_pk_insert_mode value: '10'
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SELECT @@global.tokudb_pk_insert_mode;
+@@global.tokudb_pk_insert_mode
+2
+SET GLOBAL tokudb_pk_insert_mode = 0;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode=0 is deprecated and the parameter may be removed in future releases. Only tokudb_pk_insert_mode=1|2 is allowed.Resettig the value to 1.
+SELECT @@global.tokudb_pk_insert_mode;
+@@global.tokudb_pk_insert_mode
+1
+SET GLOBAL tokudb_pk_insert_mode = DEFAULT;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SELECT @@global.tokudb_pk_insert_mode;
+@@global.tokudb_pk_insert_mode
+1
+SET GLOBAL tokudb_pk_insert_mode = 'foobar';
+ERROR 42000: Incorrect argument type to variable 'tokudb_pk_insert_mode'
+SELECT @@global.tokudb_pk_insert_mode;
+@@global.tokudb_pk_insert_mode
+1
+SET SESSION tokudb_pk_insert_mode = 10;
+Warnings:
+Warning	1292	Truncated incorrect tokudb_pk_insert_mode value: '10'
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SELECT @@session.tokudb_pk_insert_mode;
+@@session.tokudb_pk_insert_mode
+2
+SET SESSION tokudb_pk_insert_mode = 0;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode=0 is deprecated and the parameter may be removed in future releases. Only tokudb_pk_insert_mode=1|2 is allowed.Resettig the value to 1.
+SELECT @@session.tokudb_pk_insert_mode;
+@@session.tokudb_pk_insert_mode
+1
+SET SESSION tokudb_pk_insert_mode = DEFAULT;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SELECT @@session.tokudb_pk_insert_mode;
+@@session.tokudb_pk_insert_mode
+1
+SET SESSION tokudb_pk_insert_mode = 'foobar';
+ERROR 42000: Incorrect argument type to variable 'tokudb_pk_insert_mode'
+SELECT @@session.tokudb_pk_insert_mode;
+@@session.tokudb_pk_insert_mode
+1
+SET GLOBAL tokudb_pk_insert_mode = 12;
+Warnings:
+Warning	1292	Truncated incorrect tokudb_pk_insert_mode value: '12'
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SET SESSION tokudb_pk_insert_mode = 13;
+Warnings:
+Warning	1292	Truncated incorrect tokudb_pk_insert_mode value: '13'
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SELECT @@global.tokudb_pk_insert_mode;
+@@global.tokudb_pk_insert_mode
+2
+SELECT @@session.tokudb_pk_insert_mode;
+@@session.tokudb_pk_insert_mode
+2
+SHOW VARIABLES LIKE 'tokudb_pk_insert_mode';
+Variable_name	Value
+tokudb_pk_insert_mode	2
+SET SESSION tokudb_pk_insert_mode = @orig_session;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SELECT @@session.tokudb_pk_insert_mode;
+@@session.tokudb_pk_insert_mode
+1
+SET GLOBAL tokudb_pk_insert_mode = @orig_global;
+Warnings:
+Warning	131	Using tokudb_pk_insert_mode is deprecated and the parameter may be removed in future releases.
+SELECT @@global.tokudb_pk_insert_mode;
+@@global.tokudb_pk_insert_mode
+1

--- a/mysql-test/suite/tokudb.sys_vars/t/tokudb_pk_insert_mode_basic.test
+++ b/mysql-test/suite/tokudb.sys_vars/t/tokudb_pk_insert_mode_basic.test
@@ -1,0 +1,51 @@
+--source include/have_tokudb.inc
+--enable_warnings
+
+# Check the default value
+SET @orig_global = @@global.tokudb_pk_insert_mode;
+SELECT @orig_global;
+
+SET @orig_session = @@session.tokudb_pk_insert_mode;
+SELECT @orig_session;
+
+# Test global
+SET GLOBAL tokudb_pk_insert_mode = 10;
+SELECT @@global.tokudb_pk_insert_mode;
+
+SET GLOBAL tokudb_pk_insert_mode = 0;
+SELECT @@global.tokudb_pk_insert_mode;
+
+SET GLOBAL tokudb_pk_insert_mode = DEFAULT;
+SELECT @@global.tokudb_pk_insert_mode;
+
+-- error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL tokudb_pk_insert_mode = 'foobar';
+SELECT @@global.tokudb_pk_insert_mode;
+
+# Test session
+SET SESSION tokudb_pk_insert_mode = 10;
+SELECT @@session.tokudb_pk_insert_mode;
+
+SET SESSION tokudb_pk_insert_mode = 0;
+SELECT @@session.tokudb_pk_insert_mode;
+
+SET SESSION tokudb_pk_insert_mode = DEFAULT;
+SELECT @@session.tokudb_pk_insert_mode;
+
+-- error ER_WRONG_TYPE_FOR_VAR
+SET SESSION tokudb_pk_insert_mode = 'foobar';
+SELECT @@session.tokudb_pk_insert_mode;
+
+# both
+SET GLOBAL tokudb_pk_insert_mode = 12;
+SET SESSION tokudb_pk_insert_mode = 13;
+SELECT @@global.tokudb_pk_insert_mode;
+SELECT @@session.tokudb_pk_insert_mode;
+SHOW VARIABLES LIKE 'tokudb_pk_insert_mode';
+
+# Clean up
+SET SESSION tokudb_pk_insert_mode = @orig_session;
+SELECT @@session.tokudb_pk_insert_mode;
+
+SET GLOBAL tokudb_pk_insert_mode = @orig_global;
+SELECT @@global.tokudb_pk_insert_mode;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -462,19 +462,13 @@ static inline bool do_ignore_flag_optimization(
     bool opt_eligible) {
 
     bool do_opt = false;
-    if (opt_eligible) {
-        if (is_replace_into(thd) || is_insert_ignore(thd)) {
-            uint pk_insert_mode = tokudb::sysvars::pk_insert_mode(thd);
-            if ((!table->triggers && pk_insert_mode < 2) ||
-                pk_insert_mode == 0) {
-                if (mysql_bin_log.is_open() &&
-                    thd->variables.binlog_format != BINLOG_FORMAT_STMT) {
-                    do_opt = false;
-                } else {
-                    do_opt = true;
-                }
-            }
-        }
+    if (opt_eligible &&
+        (is_replace_into(thd) || is_insert_ignore(thd)) &&
+        tokudb::sysvars::pk_insert_mode(thd) == 1 &&
+        !table->triggers &&
+        !(mysql_bin_log.is_open() &&
+         thd->variables.binlog_format != BINLOG_FORMAT_STMT)) {
+        do_opt = true;
     }
     return do_opt;
 }

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -406,6 +406,16 @@ static int tokudb_init_func(void *p) {
     db_env->set_errcall(db_env, tokudb_print_error);
     db_env->set_errpfx(db_env, tokudb_hton_name);
 
+    // Handle deprecated options
+    if (tokudb::sysvars::pk_insert_mode(NULL) != 1) {
+        TOKUDB_TRACE("Using tokudb_pk_insert_mode is deprecated and the "
+            "parameter may be removed in future releases. "
+            "tokudb_pk_insert_mode=0 is now forbidden. "
+            "See documentation and release notes for details");
+        if (tokudb::sysvars::pk_insert_mode(NULL) < 1)
+           tokudb::sysvars::set_pk_insert_mode(NULL, 1);
+    }
+
     //
     // set default comparison functions
     //

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -128,6 +128,7 @@ double      optimize_index_fraction(THD* thd);
 const char* optimize_index_name(THD* thd);
 ulonglong   optimize_throttle(THD* thd);
 uint        pk_insert_mode(THD* thd);
+void        set_pk_insert_mode(THD* thd, uint mode);
 my_bool     prelock_empty(THD* thd);
 uint        read_block_size(THD* thd);
 uint        read_buf_size(THD* thd);


### PR DESCRIPTION
- Introduced tokudb.sys_vars.tokudb_pk_insert_mode_basic test.
- Added deprecation warnings to use of tokudb_pk_insert_mode and deprecated mode 0
- Fixed up tests to record new deprecation warnings.
