### PR TITLE
5.5 - Fix for description of the client package in debian (#1201074)

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -129,8 +129,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.5
 Architecture: any


### PR DESCRIPTION
**Bug:**
"apt-cache show" for percona-server-client claims innotop is included
https://bugs.launchpad.net/percona-server/+bug/1201074

This is just to fix the comment of the client package in debian/ubuntu.
