### PR TITLE
5.7 - Fix for description of the client package in debian (#1201074)

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -129,8 +129,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.5
 Architecture: any

--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -156,8 +156,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.7
 Architecture: any

--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -147,8 +147,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.6
 Architecture: any

--- a/build-ps/debian/control.notokudb
+++ b/build-ps/debian/control.notokudb
@@ -132,8 +132,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.6
 Architecture: any

--- a/build-ps/debian/control.notokudb
+++ b/build-ps/debian/control.notokudb
@@ -140,8 +140,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.7
 Architecture: any

--- a/build-ps/ubuntu/control
+++ b/build-ps/ubuntu/control
@@ -157,8 +157,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.7
 Architecture: any

--- a/build-ps/ubuntu/control.notokudb
+++ b/build-ps/ubuntu/control.notokudb
@@ -141,8 +141,7 @@ Description: Percona Server database client binaries
  query language in the world. The main goals of Percona Server are speed,
  robustness and ease of use.
  .
- This package includes the client binaries and the additional tools
- innotop and mysqlreport.
+ This package includes the client binaries.
 
 Package: percona-server-server-5.7
 Architecture: any


### PR DESCRIPTION
**Bug:**
"apt-cache show" for percona-server-client claims innotop is included
https://bugs.launchpad.net/percona-server/+bug/1201074

This is just to fix the comment of the client package in debian/ubuntu.
