### PR TITLE
5.5 - Fix for startup fail when using PAM auth and proxies (#1558312)

### DIFF
--- a/build-ps/rpm/mysql-systemd
+++ b/build-ps/rpm/mysql-systemd
@@ -88,7 +88,7 @@ pinger () {
 
     while /bin/true ; do
         sleep 1
-        mysqladmin --no-defaults --socket="$adminsocket" --user=UNKNOWN_MYSQL_USER ping >/dev/null 2>&1 && break
+        mysqladmin --socket="$adminsocket" ping >/dev/null 2>&1 && break
     done
     exit 0
 }


### PR DESCRIPTION
Ticket:
https://bugs.launchpad.net/percona-server/+bug/1558312

Info:
This is basically just to revert a part of other change made here:
https://github.com/percona/percona-server/commit/136b0a03f4c814800b2dbc4e534b94b4ec2fd0c3
since there were added "--no-defaults" and "--user=UNKNOWN_MYSQL_USER" options which seems to not work when using pam auth plugin and proxy user. Those options were not needed initially for the custom socket location change so I'll revert that part.
The change was made for PS 5.5 and 5.6 for centos7 only.

Test:

```
mysql> CREATE USER ''@'' IDENTIFIED WITH auth_pam_compat;
Query OK, 0 rows affected (0.01 sec)

mysql> select user,host,password_expired,plugin from mysql.user;
+------+--------------+------------------+-----------------------+
| user | host         | password_expired | plugin                |
+------+--------------+------------------+-----------------------+
| root | localhost    | N                | mysql_native_password |
| root | t-centos7-64 | N                | mysql_native_password |
| root | 127.0.0.1    | N                | mysql_native_password |
| root | ::1          | N                | mysql_native_password |
|      |              | N                | auth_pam_compat       |
+------+--------------+------------------+-----------------------+
```

CURRENTLY:

```
[vagrant@t-centos7-64 ~]$ sudo systemctl start mysql

[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Percona Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: activating (start-post) since Uto 2016-05-03 16:43:36 CEST; 2min 35s ago
```

script just hangs and it's stuck in start-post loop.

WITH FIXED LINE:

```
[vagrant@t-centos7-64 ~]$ sudo systemctl start mysql
[vagrant@t-centos7-64 ~]$ sudo systemctl status mysql
mysqld.service - MySQL Percona Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled)
   Active: active (running) since Uto 2016-05-03 16:49:56 CEST; 8s ago
```

...works ok
