### PR TITLE
Bug fix for lp:1536663.

### DIFF
--- a/mysql-test/suite/tokudb.rpl/r/rpl_rfr_disable_on_expl_pk_absence.result
+++ b/mysql-test/suite/tokudb.rpl/r/rpl_rfr_disable_on_expl_pk_absence.result
@@ -1,0 +1,47 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+call mtr.add_suppression("read free replication is disabled for tokudb table");
+CREATE TABLE t (a int(11), b char(20)) ENGINE = TokuDB;
+INSERT INTO t (a, b) VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+SELECT * FROM t;
+a	b
+1	a
+2	b
+3	c
+4	d
+5	e
+UPDATE t SET a = a + 10 WHERE b = 'b';
+SELECT * FROM t;
+a	b
+1	a
+12	b
+3	c
+4	d
+5	e
+SELECT * FROM t;
+a	b
+1	a
+12	b
+3	c
+4	d
+5	e
+UPDATE t SET a = a + 10 WHERE b = 'b';
+SELECT * FROM t;
+a	b
+1	a
+22	b
+3	c
+4	d
+5	e
+SELECT * FROM t;
+a	b
+1	a
+22	b
+3	c
+4	d
+5	e
+DROP TABLE t;
+include/rpl_end.inc

--- a/mysql-test/suite/tokudb.rpl/t/rpl_rfr_disable_on_expl_pk_absence-slave.opt
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_rfr_disable_on_expl_pk_absence-slave.opt
@@ -1,0 +1,1 @@
+--read-only=true --tokudb-rpl-unique-checks=false --tokudb-rpl-lookup-rows=false

--- a/mysql-test/suite/tokudb.rpl/t/rpl_rfr_disable_on_expl_pk_absence.test
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_rfr_disable_on_expl_pk_absence.test
@@ -1,0 +1,48 @@
+# Test case for bug#1536663
+#
+# When read-free-replication is enabled for tokudb and there is no explicit
+# pk for replicated table there can be dublicated records in the table on
+# update operation.
+#
+# Consider this update operation:
+# UPDATE t SET a = a + 10 WHERE b = 'b';
+# The master does rows lookup and updates the rows which values correspond to
+# the condition. The update events are written to binary log with
+# rows values from the master. As rows lookup is forbidden for slave
+# the new rows are added instead of updating corresponding rows.
+#
+# Without the fix there will be several rows with b = 'b' in the table on slave
+# instead of one updated row.
+#
+
+--source include/have_tokudb.inc
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+call mtr.add_suppression("read free replication is disabled for tokudb table");
+
+--connection master
+CREATE TABLE t (a int(11), b char(20)) ENGINE = TokuDB;
+INSERT INTO t (a, b) VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+
+--sync_slave_with_master
+--sorted_result
+SELECT * FROM t;
+
+--let $i = 2
+--while($i) {
+  --dec $i
+  --connection master
+  UPDATE t SET a = a + 10 WHERE b = 'b';
+  --sorted_result
+  SELECT * FROM t;
+  --sync_slave_with_master
+  --sorted_result
+  SELECT * FROM t;
+}
+
+--connection master
+DROP TABLE t;
+--sync_slave_with_master
+
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -10041,15 +10041,36 @@ Rows_log_event::decide_row_lookup_algorithm_and_key()
   TABLE *table= this->m_table;
   uint event_type= this->get_general_type_code();
   MY_BITMAP *cols= &this->m_cols;
+  bool delete_update_lookup_condition= false;
   this->m_rows_lookup_algorithm= ROW_LOOKUP_NOT_NEEDED;
   this->m_key_index= MAX_KEY;
   this->m_key_info= NULL;
 
   // row lookup not needed
   if (event_type == WRITE_ROWS_EVENT ||
-     ((event_type == DELETE_ROWS_EVENT || event_type == UPDATE_ROWS_EVENT) &&
-      get_flags(COMPLETE_ROWS_F) && !m_table->file->rpl_lookup_rows()))
-    DBUG_VOID_RETURN;
+     (delete_update_lookup_condition= ((event_type == DELETE_ROWS_EVENT ||
+                                        event_type == UPDATE_ROWS_EVENT) &&
+                                      get_flags(COMPLETE_ROWS_F) &&
+                                      !m_table->file->rpl_lookup_rows())))
+  {
+    if (delete_update_lookup_condition &&
+        table->file->ht->db_type == DB_TYPE_TOKUDB &&
+        table->s->primary_key == MAX_KEY)
+    {
+        if (!table->s->rfr_lookup_warning)
+        {
+          sql_print_warning("Slave: read free replication is disabled "
+                            "for tokudb table `%s.%s` "
+                            "as it does not have implicit primary key, "
+                            "continue with rows lookup",
+                            print_slave_db_safe(table->s->db.str),
+                            m_table->s->table_name.str);
+          table->s->rfr_lookup_warning= true;
+        }
+    }
+    else
+      DBUG_VOID_RETURN;
+  }
 
   if (!(slave_rows_search_algorithms_options & SLAVE_ROWS_INDEX_SCAN))
     goto TABLE_OR_INDEX_HASH_SCAN;

--- a/sql/table.h
+++ b/sql/table.h
@@ -752,6 +752,12 @@ struct TABLE_SHARE
   */ 
   const File_parser *view_def;
 
+  /**
+    True in the case if tokudb read-free-replication is used for the table
+    without explicit pk and corresponding warning was issued to disable
+    repeated warning.
+  */
+  bool rfr_lookup_warning;
 
   /*
     Set share's table cache key and update its db and table name appropriately.


### PR DESCRIPTION
When read-free-replication is enabled for tokudb and there is no
explicit pk for replicated table there can be dublicated records in the table
on update operation.

Consider this update operation:
  UPDATE t SET a = a + 10 WHERE b = 'b';
The master does rows lookup and updates the rows which values
correspond to the condition. The update events are written to binary log with
rows values from the master. As rows lookup is forbidden for slave
the new rows are added instead of updating corresponding rows.

Without the fix there will be several rows with b = 'b' in the table
on slave instead of one updated row.

The fix disables RFR for tables without explicit pk and do rows lookup
for update and delete binlog events and issues warning.

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1122/
