### PR TITLE
DB-914 : ./sql/sql_class.h:2309:8: warning: 'template<class> class st…

### DIFF
--- a/storage/tokudb/CMakeLists.txt
+++ b/storage/tokudb/CMakeLists.txt
@@ -20,7 +20,7 @@ include(CheckCXXCompilerFlag)
 # pick language dialect
 check_cxx_compiler_flag(-std=c++11 HAVE_STDCXX11)
 if (HAVE_STDCXX11)
-  set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-std=c++11 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
 else ()
   message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -std=c++11, you need one that does.")
 endif ()


### PR DESCRIPTION
…d::auto_ptr' is deprecated [-Wdeprecated-declarations] std::auto_ptr<Transaction_ctx> m_transaction;
- Added -Wno-deprecated-declarations to TokuDB CMakeLists.txt where it is also specifying C++11 be used.
