### PR TITLE
Fix bug 1577282 (SHOW STATUS in parallel to online buffer pool resizi…

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1543,6 +1543,8 @@ srv_export_innodb_status(void)
 
 	mem_adaptive_hash = 0;
 
+	rw_lock_s_lock(btr_search_latches[0]);
+
 	ut_ad(btr_search_sys->hash_tables);
 
 	for (i = 0; i < btr_ahi_parts; i++) {
@@ -1559,10 +1561,15 @@ srv_export_innodb_status(void)
 		mem_adaptive_hash += ht->n_cells * sizeof(hash_cell_t);
 	}
 
+	rw_lock_s_unlock(btr_search_latches[0]);
+
+	mutex_enter(&dict_sys->mutex);
+
 	mem_dictionary = (dict_sys ? ((dict_sys->table_hash->n_cells
 					+ dict_sys->table_id_hash->n_cells
 				      ) * sizeof(hash_cell_t)
 				+ dict_sys->size) : 0);
+	mutex_exit(&dict_sys->mutex);
 
 	mutex_enter(&srv_innodb_monitor_mutex);
 


### PR DESCRIPTION
…ng may crash)

With online buffer pool resize in 5.7, btr_search_sys->hash_tables and
dict_sys->table_hash no longer are read-only valid pointers throughout
the server lifetime but rather might be changed by the online buffer
pool resize.  Thus their access they have to be protected by their
regular locks (any AHI latch and dict sys mutex).

No testcase as stopping server with DEBUG_SYNC inside of SHOW STATUS holds
LOCK_status, whereas waiting for buffer pool resize to complete needs
to issue SHOW STATUS repeatedly too.

http://jenkins.percona.com/job/mysql-5.7-param/148/
