### PR TITLE
DB-962 : broken memory management in TokuDB 5.6.28-76.1

### DIFF
--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -612,8 +612,8 @@ int standard_t::analyze_key(uint64_t* rec_per_key_part) {
                 analyze_standard_cursor_callback,
                 this);
 
-            memset(&key, 0, sizeof(DBT)); key.flags = DB_DBT_REALLOC;
-            memset(&prev_key, 0, sizeof(DBT)); prev_key.flags = DB_DBT_REALLOC;
+            memset(&key, 0, sizeof(DBT));
+            memset(&prev_key, 0, sizeof(DBT));
             copy_key = true;
         }
 
@@ -681,7 +681,6 @@ int standard_t::analyze_key(uint64_t* rec_per_key_part) {
             _key_elapsed_time >= _half_time &&
             _rows < _half_rows)) {
 
-            tokudb::memory::free(key.data); key.data = NULL;
             tokudb::memory::free(prev_key.data); prev_key.data = NULL;
             close_error = cursor->c_close(cursor);
             assert_always(close_error == 0);
@@ -690,7 +689,6 @@ int standard_t::analyze_key(uint64_t* rec_per_key_part) {
         }
     }
     // cleanup
-    if (key.data) tokudb::memory::free(key.data);
     if (prev_key.data) tokudb::memory::free(prev_key.data);
     if (cursor) close_error = cursor->c_close(cursor);
     assert_always(close_error == 0);


### PR DESCRIPTION
Issue is in flags that analysis uses when setting up DBT structs to extract keys from PerconaFT.
Code previously used DB_DBT_REALLOC for some unknown reason rather than '0'.
DB_DBT_REALLOC places the burden of managing the memory of the returned keys on the user of PerconaFT,
'0' leaves that burden with PurconaFT and the key/value data is managed and freed by the cursor->close call.
There is no apparant performance difference between the two or any benefit of using one over the other.
- Removed DB_DBT_REALLOC from initial DBT key flags.
- Verified that memory is properly managed on cursor->c_next and cursor->close calls.
