### PR TITLE
Fix lp:1578303 "rpl.rpl_start_stop_slave fail sporadically on 5.5" (5.5).

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_start_stop_slave.test
+++ b/mysql-test/suite/rpl/t/rpl_start_stop_slave.test
@@ -19,6 +19,10 @@
 --source include/master-slave.inc
 
 connection slave;
+
+--let $wait_condition= SELECT COUNT(*) = 1 FROM information_schema.processlist WHERE state LIKE 'Waiting for master to send event'
+--source include/wait_condition.inc
+
 --let $connection_id=`SELECT id FROM information_schema.processlist where state LIKE 'Waiting for master to send event'`
 
 set @time_before_kill := (select CURRENT_TIMESTAMP);


### PR DESCRIPTION
The problem seems to be in
--let $connection_id=`SELECT id FROM information_schema.processlist
  where state LIKE 'Waiting for master to send event'`

At this point slave connection may still be in
'Queueing master event to the relay log' state and therefore
$connection_id can be empty.

To fix, we need to make sure that there is at least 1 connection
with status 'Waiting for master to send event' before reading its id.
"wait_condition.inc" can be used for this purpose.
