### PR TITLE
Fix bug 1578139 (Parallel doublewrite memory not freed with innodb_fa…

### DIFF
--- a/storage/innobase/include/buf0dblwr.h
+++ b/storage/innobase/include/buf0dblwr.h
@@ -161,10 +161,11 @@ computed. It is up to the caller to ensure that this called at safe point */
 void
 buf_parallel_dblwr_delete(void);
 
-/** Close and delete the doublewrite buffer file and free its memory data
-structure. */
+/** Cleanup parallel doublewrite memory structures and optionally close and
+delete the doublewrite buffer file too.
+@param	delete_file	whether to close and delete the buffer file too  */
 void
-buf_parallel_dblwr_destroy(void);
+buf_parallel_dblwr_free(bool delete_file);
 
 /** Release any unused parallel doublewrite pages and free their underlying
 buffer at the end of crash recovery */

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -2405,8 +2405,6 @@ loop:
 		fil_write_flushed_lsn(lsn);
 	}
 
-	buf_parallel_dblwr_destroy();
-
 	fil_close_all_files();
 
 	/* Make some checks that the server really is quiet */

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -1164,6 +1164,7 @@ trx_sys_close(void)
 
 	/* Free the double write data structures. */
 	buf_dblwr_free();
+	buf_parallel_dblwr_free(srv_fast_shutdown != 2);
 
 	/* Only prepared transactions may be left in the system. Free them. */
 	ut_a(UT_LIST_GET_LEN(trx_sys->rw_trx_list) == trx_sys->n_prepared_trx);


### PR DESCRIPTION
…st_shutdown=2)

With a very fast InnoDB shutdown, buf_parallel_dblwr_destroy(), which
closes and deletes the doublewrite file and frees memory, is skipped.
In this configuration the file should not be deleted, thus fix by
renaming buf_parallel_dblwr_destroy() to buf_parallel_dblwr_free()
that unconditionally frees memory and, depending on the arg value,
closes and deletes the file. Call it in the common code path for all
innodb_fast_shutdown values.

http://jenkins.percona.com/job/mysql-5.7-param/158/
