### PR TITLE
Fix bug 1536693 (More memory overhead per page in the InnoDB buffer p…

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1454,6 +1454,7 @@ buf_pool_free_instance(
 	buf_chunk_t*	chunk;
 	buf_chunk_t*	chunks;
 	buf_page_t*	bpage;
+	ulint		i;
 
 	bpage = UT_LIST_GET_LAST(buf_pool->LRU);
 	while (bpage != NULL) {
@@ -1477,10 +1478,29 @@ buf_pool_free_instance(
 	mem_free(buf_pool->watch);
 	buf_pool->watch = NULL;
 
+	for (i = BUF_FLUSH_LRU; i < BUF_FLUSH_N_TYPES; i++) {
+		os_event_free(buf_pool->no_flush[i]);
+	}
+	mutex_free(&buf_pool->LRU_list_mutex);
+	mutex_free(&buf_pool->free_list_mutex);
+	mutex_free(&buf_pool->zip_free_mutex);
+	mutex_free(&buf_pool->zip_hash_mutex);
+	mutex_free(&buf_pool->zip_mutex);
+	mutex_free(&buf_pool->flush_state_mutex);
+	mutex_free(&buf_pool->flush_list_mutex);
+
 	chunks = buf_pool->chunks;
 	chunk = chunks + buf_pool->n_chunks;
 
 	while (--chunk >= chunks) {
+		buf_block_t* block = chunk->blocks;
+		for (i = 0; i < chunk->size; i++, block++) {
+			mutex_free(&block->mutex);
+			rw_lock_free(&block->lock);
+#ifdef UNIV_SYNC_DEBUG
+			rw_lock_free(&block->debug_latch);
+#endif
+		}
 		os_mem_free_large(chunk->mem, chunk->mem_size);
 	}
 

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -6254,10 +6254,7 @@ void
 fil_close(void)
 /*===========*/
 {
-#ifndef UNIV_HOTBACKUP
-	/* The mutex should already have been freed. */
-	ut_ad(fil_system->mutex.magic_n == 0);
-#endif /* !UNIV_HOTBACKUP */
+	mutex_free(&fil_system->mutex);
 
 	hash_table_free(fil_system->spaces);
 

--- a/storage/innobase/ha/ha0ha.cc
+++ b/storage/innobase/ha/ha0ha.cc
@@ -155,11 +155,15 @@ ha_clear(
 
 	switch (table->type) {
 	case HASH_TABLE_SYNC_MUTEX:
+		for (ulint i = 0; i < table->n_sync_obj; i++)
+			mutex_free(table->sync_obj.mutexes + i);
 		mem_free(table->sync_obj.mutexes);
 		table->sync_obj.mutexes = NULL;
 		break;
 
 	case HASH_TABLE_SYNC_RW_LOCK:
+		for (ulint i = 0; i < table->n_sync_obj; i++)
+			rw_lock_free(table->sync_obj.rw_locks + i);
 		mem_free(table->sync_obj.rw_locks);
 		table->sync_obj.rw_locks = NULL;
 		break;

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -449,12 +449,6 @@ os_get_os_version(void);
 /*===================*/
 #endif /* __WIN__ */
 #ifndef UNIV_HOTBACKUP
-/****************************************************************//**
-Creates the seek mutexes used in positioned reads and writes. */
-UNIV_INTERN
-void
-os_io_init_simple(void);
-/*===================*/
 /***********************************************************************//**
 Creates a temporary file.  This function is like tmpfile(3), but
 the temporary file is created in the MySQL temporary directory.

--- a/storage/innobase/include/sync0rw.h
+++ b/storage/innobase/include/sync0rw.h
@@ -737,8 +737,8 @@ struct rw_lock_t {
 				/*!< Thread id of writer thread. Is only
 				guaranteed to have sane and non-stale
 				value iff recursive flag is set. */
-	os_event_t	event;	/*!< Used by sync0arr.cc for thread queueing */
-	os_event_t	wait_ex_event;
+	struct os_event	event;	/*!< Used by sync0arr.cc for thread queueing */
+	struct os_event	wait_ex_event;
 				/*!< Event for next-writer to wait on. A thread
 				must decrement lock_word before waiting. */
 #ifndef INNODB_RW_LOCKS_USE_ATOMICS
@@ -788,12 +788,12 @@ struct prio_rw_lock_t {
 	volatile ulint		high_priority_s_waiters;
 						/* Number of high priority S
 						waiters */
-	os_event_t		high_priority_s_event; /* High priority wait
+	struct os_event		high_priority_s_event; /* High priority wait
 						array event for S waiters */
 	volatile ulint		high_priority_x_waiters;
 						/* Number of high priority X
 						waiters */
-	os_event_t		high_priority_x_event;
+	struct os_event		high_priority_x_event;
 						/* High priority wait arraay
 						event for X waiters */
 	volatile ulint		high_priority_wait_ex_waiter;

--- a/storage/innobase/include/sync0rw.ic
+++ b/storage/innobase/include/sync0rw.ic
@@ -585,7 +585,7 @@ rw_lock_s_unlock_func(
 		/* wait_ex waiter exists. It may not be asleep, but we signal
 		anyway. We do not wake other waiters, because they can't
 		exist without wait_ex waiter and wait_ex waiter goes first.*/
-		os_event_set(lock->wait_ex_event);
+		os_event_set(&lock->wait_ex_event);
 		sync_array_object_signalled();
 
 	}
@@ -625,7 +625,7 @@ rw_lock_s_unlock_func(
 
 		/* A waiting next-writer exists, either high priority or
 		regular, sharing the same wait event.  */
-		os_event_set(lock->base_lock.wait_ex_event);
+		os_event_set(&lock->base_lock.wait_ex_event);
 		sync_array_object_signalled();
 
 	} else if (lock_word == X_LOCK_DECR) {
@@ -636,7 +636,7 @@ rw_lock_s_unlock_func(
 		if (lock->base_lock.waiters) {
 
 			rw_lock_reset_waiter_flag(&lock->base_lock);
-			os_event_set(lock->base_lock.event);
+			os_event_set(&lock->base_lock.event);
 			sync_array_object_signalled();
 		}
 	}
@@ -718,7 +718,7 @@ rw_lock_x_unlock_func(
 
 		if (lock->waiters) {
 			rw_lock_reset_waiter_flag(lock);
-			os_event_set(lock->event);
+			os_event_set(&lock->event);
 			sync_array_object_signalled();
 		}
 	}
@@ -761,16 +761,16 @@ rw_lock_x_unlock_func(
 
 		if (lock->high_priority_x_waiters) {
 
-			os_event_set(lock->high_priority_x_event);
+			os_event_set(&lock->high_priority_x_event);
 			sync_array_object_signalled();
 		} else if (lock->high_priority_s_waiters) {
 
-			os_event_set(lock->high_priority_s_event);
+			os_event_set(&lock->high_priority_s_event);
 			sync_array_object_signalled();
 		} else if (lock->base_lock.waiters) {
 
 			rw_lock_reset_waiter_flag(&lock->base_lock);
-			os_event_set(lock->base_lock.event);
+			os_event_set(&lock->base_lock.event);
 			sync_array_object_signalled();
 		}
 	}

--- a/storage/innobase/include/sync0sync.h
+++ b/storage/innobase/include/sync0sync.h
@@ -922,7 +922,7 @@ implementation of a mutual exclusion semaphore. */
 
 /** InnoDB mutex */
 struct ib_mutex_t {
-	os_event_t	event;	/*!< Used by sync0arr.cc for the wait queue */
+	struct os_event	event;	/*!< Used by sync0arr.cc for the wait queue */
 	volatile lock_word_t	lock_word;	/*!< lock_word is the target
 				of the atomic test-and-set instruction when
 				atomic operations are enabled. */
@@ -969,14 +969,13 @@ struct ib_mutex_t {
 struct ib_prio_mutex_t {
 	ib_mutex_t	base_mutex;	/* The regular mutex provides the lock
 					word etc. for the priority mutex  */
-	os_event_t	high_priority_event; /* High priority wait array
+	struct os_event	high_priority_event; /* High priority wait array
 					event */
 	volatile ulint	high_priority_waiters; /* Number of threads that asked
 					for this mutex to be acquired with high
 					priority in the global wait array
 					waiting for this mutex to be
 					released. */
-	UT_LIST_NODE_T(ib_prio_mutex_t)	list;
 };
 
 /** Constant determining how long spin wait is continued before suspending

--- a/storage/innobase/include/sync0sync.ic
+++ b/storage/innobase/include/sync0sync.ic
@@ -225,7 +225,7 @@ mutex_exit_func(
 	/* Wake up any high priority waiters first.  */
 	if (mutex->high_priority_waiters != 0) {
 
-		os_event_set(mutex->high_priority_event);
+		os_event_set(&mutex->high_priority_event);
 		sync_array_object_signalled();
 
 	} else if (mutex_get_waiters(&mutex->base_mutex) != 0) {

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -641,6 +641,17 @@ lock_sys_close(void)
 	mutex_free(&lock_sys->mutex);
 	mutex_free(&lock_sys->wait_mutex);
 
+	os_event_free(lock_sys->timeout_event);
+
+	for (srv_slot_t* slot = lock_sys->waiting_threads;
+	     slot < lock_sys->waiting_threads + OS_THREAD_MAX_N; slot++) {
+
+		ut_ad(!slot->in_use);
+		ut_ad(!slot->thr);
+		if (slot->event != NULL)
+			os_event_free(slot->event);
+	}
+
 	mem_free(lock_stack);
 	mem_free(lock_sys);
 

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -3930,6 +3930,7 @@ log_shutdown(void)
 	rw_lock_free(&log_sys->checkpoint_lock);
 
 	mutex_free(&log_sys->mutex);
+	mutex_free(&log_sys->log_flush_order_mutex);
 
 #ifdef UNIV_LOG_ARCHIVE
 	rw_lock_free(&log_sys->archive_lock);

--- a/storage/innobase/mem/mem0pool.cc
+++ b/storage/innobase/mem/mem0pool.cc
@@ -280,6 +280,7 @@ mem_pool_free(
 /*==========*/
 	mem_pool_t*	pool)	/*!< in, own: memory pool */
 {
+	mutex_free(&pool->mutex);
 	ut_free(pool->buf);
 	ut_free(pool);
 }

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -750,7 +750,7 @@ os_file_lock(
 #ifndef UNIV_HOTBACKUP
 /****************************************************************//**
 Creates the seek mutexes used in positioned reads and writes. */
-UNIV_INTERN
+static
 void
 os_io_init_simple(void)
 /*===================*/
@@ -4194,6 +4194,14 @@ os_aio_free(void)
 		os_event_free(os_aio_segment_wait_events[i]);
 	}
 
+#if !defined(HAVE_ATOMIC_BUILTINS) || UNIV_WORD_SIZE < 8
+	os_mutex_free(os_file_count_mutex);
+#endif /* !HAVE_ATOMIC_BUILTINS || UNIV_WORD_SIZE < 8 */
+
+	for (ulint i = 0; i < OS_FILE_N_SEEK_MUTEXES; i++) {
+		os_mutex_free(os_file_seek_mutexes[i]);
+	}
+
 	ut_free(os_aio_segment_wait_events);
 	os_aio_segment_wait_events = 0;
 	os_aio_n_segments = 0;
@@ -5898,7 +5906,7 @@ os_aio_print(
 			srv_io_thread_function[i]);
 
 #ifndef __WIN__
-		if (os_aio_segment_wait_events[i]->is_set) {
+		if (os_aio_segment_wait_events[i]->is_set()) {
 			fprintf(file, " ev set");
 		}
 #endif /* __WIN__ */

--- a/storage/innobase/os/os0sync.cc
+++ b/storage/innobase/os/os0sync.cc
@@ -47,26 +47,13 @@ struct os_mutex_t{
 				do not assume that the OS mutex
 				supports recursive locking, though
 				NT seems to do that */
-	UT_LIST_NODE_T(os_mutex_t) os_mutex_list;
-				/* list of all 'slow' OS mutexes created */
 };
 
-/** Mutex protecting counts and the lists of OS mutexes and events */
-UNIV_INTERN os_ib_mutex_t	os_sync_mutex;
-/** TRUE if os_sync_mutex has been initialized */
-static ibool		os_sync_mutex_inited	= FALSE;
-/** TRUE when os_sync_free() is being executed */
-static ibool		os_sync_free_called	= FALSE;
+// All the os_*_count variables are accessed atomically
 
 /** This is incremented by 1 in os_thread_create and decremented by 1 in
-os_thread_exit */
+os_thread_exit. */
 UNIV_INTERN ulint	os_thread_count		= 0;
-
-/** The list of all events created */
-static UT_LIST_BASE_NODE_T(os_event)		os_event_list;
-
-/** The list of all OS 'slow' mutexes */
-static UT_LIST_BASE_NODE_T(os_mutex_t)		os_mutex_list;
 
 UNIV_INTERN ulint	os_event_count		= 0;
 UNIV_INTERN ulint	os_mutex_count		= 0;
@@ -79,11 +66,6 @@ static const ulint MICROSECS_IN_A_SECOND = 1000000;
 UNIV_INTERN mysql_pfs_key_t	event_os_mutex_key;
 UNIV_INTERN mysql_pfs_key_t	os_mutex_key;
 #endif
-
-/* Because a mutex is embedded inside an event and there is an
-event embedded inside a mutex, on free, this generates a recursive call.
-This version of the free event function doesn't acquire the global lock */
-static void os_event_free_internal(os_event_t	event);
 
 /* On Windows (Vista and later), load function pointers for condition
 variable handling. Those functions are not available in prior versions,
@@ -289,55 +271,43 @@ void
 os_sync_init(void)
 /*==============*/
 {
-	UT_LIST_INIT(os_event_list);
-	UT_LIST_INIT(os_mutex_list);
-
-	os_sync_mutex = NULL;
-	os_sync_mutex_inited = FALSE;
-
 	/* Now for Windows only */
 	os_cond_module_init();
-
-	os_sync_mutex = os_mutex_create();
-
-	os_sync_mutex_inited = TRUE;
 }
 
-/*********************************************************//**
-Frees created events and OS 'slow' mutexes. */
+/** Create an event semaphore, i.e., a semaphore which may just have two
+states: signaled and nonsignaled. The created event is manual reset: it must be
+reset explicitly by calling sync_os_reset_event.
+@param[in,out]	event	memory block where to create the event */
 UNIV_INTERN
 void
-os_sync_free(void)
-/*==============*/
+os_event_create(os_event_t event)
 {
-	os_event_t	event;
-	os_ib_mutex_t	mutex;
+#ifdef __WIN__
+	if(!srv_use_native_conditions) {
 
-	os_sync_free_called = TRUE;
-	event = UT_LIST_GET_FIRST(os_event_list);
-
-	while (event) {
-
-		os_event_free(event);
-
-		event = UT_LIST_GET_FIRST(os_event_list);
-	}
-
-	mutex = UT_LIST_GET_FIRST(os_mutex_list);
-
-	while (mutex) {
-		if (mutex == os_sync_mutex) {
-			/* Set the flag to FALSE so that we do not try to
-			reserve os_sync_mutex any more in remaining freeing
-			operations in shutdown */
-			os_sync_mutex_inited = FALSE;
+		event->handle = CreateEvent(NULL, TRUE, FALSE, NULL);
+		if (!event->handle) {
+			fprintf(stderr,
+				"InnoDB: Could not create a Windows event"
+				" semaphore; Windows error %lu\n",
+				(ulong) GetLastError());
 		}
+	} else /* Windows with condition variables */
+#endif
+	{
+#ifndef PFS_SKIP_EVENT_MUTEX
+		os_fast_mutex_init(event_os_mutex_key, &event->os_mutex);
+#else
+		os_fast_mutex_init(PFS_NOT_INSTRUMENTED, &event->os_mutex);
+#endif
 
-		os_mutex_free(mutex);
+		os_cond_init(&(event->cond_var));
 
-		mutex = UT_LIST_GET_FIRST(os_mutex_list);
+		event->init_count_and_set();
 	}
-	os_sync_free_called = FALSE;
+
+	os_atomic_increment_ulint(&os_event_count, 1);
 }
 
 /*********************************************************//**
@@ -350,59 +320,9 @@ os_event_t
 os_event_create(void)
 /*==================*/
 {
-	os_event_t	event;
+	os_event_t event = static_cast<os_event_t>(ut_malloc(sizeof(*event)));;
 
-#ifdef __WIN__
-	if(!srv_use_native_conditions) {
-
-		event = static_cast<os_event_t>(ut_malloc(sizeof(*event)));
-
-		event->handle = CreateEvent(NULL, TRUE, FALSE, NULL);
-		if (!event->handle) {
-			fprintf(stderr,
-				"InnoDB: Could not create a Windows event"
-				" semaphore; Windows error %lu\n",
-				(ulong) GetLastError());
-		}
-	} else /* Windows with condition variables */
-#endif
-	{
-		event = static_cast<os_event_t>(ut_malloc(sizeof *event));
-
-#ifndef PFS_SKIP_EVENT_MUTEX
-		os_fast_mutex_init(event_os_mutex_key, &event->os_mutex);
-#else
-		os_fast_mutex_init(PFS_NOT_INSTRUMENTED, &event->os_mutex);
-#endif
-
-		os_cond_init(&(event->cond_var));
-
-		event->is_set = FALSE;
-
-		/* We return this value in os_event_reset(), which can then be
-		be used to pass to the os_event_wait_low(). The value of zero
-		is reserved in os_event_wait_low() for the case when the
-		caller does not want to pass any signal_count value. To
-		distinguish between the two cases we initialize signal_count
-		to 1 here. */
-		event->signal_count = 1;
-	}
-
-	/* The os_sync_mutex can be NULL because during startup an event
-	can be created [ because it's embedded in the mutex/rwlock ] before
-	this module has been initialized */
-	if (os_sync_mutex != NULL) {
-		os_mutex_enter(os_sync_mutex);
-	}
-
-	/* Put to the list of events */
-	UT_LIST_ADD_FIRST(os_event_list, os_event_list, event);
-
-	os_event_count++;
-
-	if (os_sync_mutex != NULL) {
-		os_mutex_exit(os_sync_mutex);
-	}
+	os_event_create(event);
 
 	return(event);
 }
@@ -427,11 +347,11 @@ os_event_set(
 
 	os_fast_mutex_lock(&(event->os_mutex));
 
-	if (event->is_set) {
+	if (UNIV_UNLIKELY(event->is_set())) {
 		/* Do nothing */
 	} else {
-		event->is_set = TRUE;
-		event->signal_count += 1;
+		event->set();
+		event->inc_signal_count();
 		os_cond_broadcast(&(event->cond_var));
 	}
 
@@ -465,46 +385,15 @@ os_event_reset(
 
 	os_fast_mutex_lock(&(event->os_mutex));
 
-	if (!event->is_set) {
+	if (UNIV_UNLIKELY(!event->is_set())) {
 		/* Do nothing */
 	} else {
-		event->is_set = FALSE;
+		event->reset();
 	}
-	ret = event->signal_count;
+	ret = event->signal_count();
 
 	os_fast_mutex_unlock(&(event->os_mutex));
 	return(ret);
-}
-
-/**********************************************************//**
-Frees an event object, without acquiring the global lock. */
-static
-void
-os_event_free_internal(
-/*===================*/
-	os_event_t	event)	/*!< in: event to free */
-{
-#ifdef __WIN__
-	if(!srv_use_native_conditions) {
-		ut_a(event);
-		ut_a(CloseHandle(event->handle));
-	} else
-#endif
-	{
-		ut_a(event);
-
-		/* This is to avoid freeing the mutex twice */
-		os_fast_mutex_free(&(event->os_mutex));
-
-		os_cond_destroy(&(event->cond_var));
-	}
-
-	/* Remove from the list of events */
-	UT_LIST_REMOVE(os_event_list, os_event_list, event);
-
-	os_event_count--;
-
-	ut_free(event);
 }
 
 /**********************************************************//**
@@ -513,7 +402,9 @@ UNIV_INTERN
 void
 os_event_free(
 /*==========*/
-	os_event_t	event)	/*!< in: event to free */
+	os_event_t	event,	/*!< in: event to free */
+	bool		free_memory)/*!< in: if true, deallocate the event
+				    memory block too */
 
 {
 	ut_a(event);
@@ -528,16 +419,10 @@ os_event_free(
 		os_cond_destroy(&(event->cond_var));
 	}
 
-	/* Remove from the list of events */
-	os_mutex_enter(os_sync_mutex);
+	os_atomic_decrement_ulint(&os_event_count, 1);
 
-	UT_LIST_REMOVE(os_event_list, os_event_list, event);
-
-	os_event_count--;
-
-	os_mutex_exit(os_sync_mutex);
-
-	ut_free(event);
+	if (free_memory)
+		ut_free(event);
 }
 
 /**********************************************************//**
@@ -585,10 +470,10 @@ os_event_wait_low(
 	os_fast_mutex_lock(&event->os_mutex);
 
 	if (!reset_sig_count) {
-		reset_sig_count = event->signal_count;
+		reset_sig_count = event->signal_count();
 	}
 
-	while (!event->is_set && event->signal_count == reset_sig_count) {
+	while (!event->is_set() && event->signal_count() == reset_sig_count) {
 		os_cond_wait(&(event->cond_var), &(event->os_mutex));
 
 		/* Solaris manual said that spurious wakeups may occur: we
@@ -686,11 +571,12 @@ os_event_wait_time_low(
 	os_fast_mutex_lock(&event->os_mutex);
 
 	if (!reset_sig_count) {
-		reset_sig_count = event->signal_count;
+		reset_sig_count = event->signal_count();
 	}
 
 	do {
-		if (event->is_set || event->signal_count != reset_sig_count) {
+		if (event->is_set()
+		    || event->signal_count() != reset_sig_count) {
 
 			break;
 		}
@@ -734,18 +620,7 @@ os_mutex_create(void)
 	mutex_str->count = 0;
 	mutex_str->event = os_event_create();
 
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		/* When creating os_sync_mutex itself we cannot reserve it */
-		os_mutex_enter(os_sync_mutex);
-	}
-
-	UT_LIST_ADD_FIRST(os_mutex_list, os_mutex_list, mutex_str);
-
-	os_mutex_count++;
-
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		os_mutex_exit(os_sync_mutex);
-	}
+	os_atomic_increment_ulint(&os_mutex_count, 1);
 
 	return(mutex_str);
 }
@@ -791,21 +666,9 @@ os_mutex_free(
 {
 	ut_a(mutex);
 
-	if (UNIV_LIKELY(!os_sync_free_called)) {
-		os_event_free_internal(mutex->event);
-	}
+	os_event_free(mutex->event);
 
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		os_mutex_enter(os_sync_mutex);
-	}
-
-	UT_LIST_REMOVE(os_mutex_list, os_mutex_list, mutex);
-
-	os_mutex_count--;
-
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		os_mutex_exit(os_sync_mutex);
-	}
+	os_atomic_decrement_ulint(&os_mutex_count, 1);
 
 	os_fast_mutex_free(static_cast<os_fast_mutex_t*>(mutex->handle));
 	ut_free(mutex->handle);
@@ -827,18 +690,7 @@ os_fast_mutex_init_func(
 #else
 	ut_a(0 == pthread_mutex_init(fast_mutex, MY_MUTEX_INIT_FAST));
 #endif
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		/* When creating os_sync_mutex itself (in Unix) we cannot
-		reserve it */
-
-		os_mutex_enter(os_sync_mutex);
-	}
-
-	os_fast_mutex_count++;
-
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		os_mutex_exit(os_sync_mutex);
-	}
+	os_atomic_increment_ulint(&os_fast_mutex_count, 1);
 }
 
 /**********************************************************//**
@@ -900,17 +752,6 @@ os_fast_mutex_free_func(
 		putc('\n', stderr);
 	}
 #endif
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		/* When freeing the last mutexes, we have
-		already freed os_sync_mutex */
 
-		os_mutex_enter(os_sync_mutex);
-	}
-
-	ut_ad(os_fast_mutex_count > 0);
-	os_fast_mutex_count--;
-
-	if (UNIV_LIKELY(os_sync_mutex_inited)) {
-		os_mutex_exit(os_sync_mutex);
-	}
+	os_atomic_decrement_ulint(&os_fast_mutex_count, 1);
 }

--- a/storage/innobase/srv/srv0conc.cc
+++ b/storage/innobase/srv/srv0conc.cc
@@ -158,6 +158,10 @@ srv_conc_free(void)
 {
 #ifndef HAVE_ATOMIC_BUILTINS
 	os_fast_mutex_free(&srv_conc_mutex);
+
+	for (ulint i = 0; i < OS_THREAD_MAX_N; i++)
+		os_event_free(srv_conc_slots[i].event);
+
 	mem_free(srv_conc_slots);
 	srv_conc_slots = NULL;
 #endif /* !HAVE_ATOMIC_BUILTINS */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1101,8 +1101,9 @@ srv_init(void)
 
 		srv_checkpoint_completed_event = os_event_create();
 
+		srv_redo_log_tracked_event = os_event_create();
+
 		if (srv_track_changed_pages) {
-			srv_redo_log_tracked_event = os_event_create();
 			os_event_set(srv_redo_log_tracked_event);
 		}
 
@@ -1144,17 +1145,30 @@ srv_free(void)
 {
 	srv_conc_free();
 
-	/* The mutexes srv_sys->mutex and srv_sys->tasks_mutex should have
-	been freed by sync_close() already. */
+	if (!srv_read_only_mode) {
+
+		for (ulint i = 0; i < srv_sys->n_sys_threads; i++)
+			os_event_free(srv_sys->sys_threads[i].event);
+
+		os_event_free(srv_error_event);
+		os_event_free(srv_monitor_event);
+		os_event_free(srv_buf_dump_event);
+		os_event_free(srv_checkpoint_completed_event);
+		os_event_free(srv_redo_log_tracked_event);
+		mutex_free(&srv_sys->mutex);
+		mutex_free(&srv_sys->tasks_mutex);
+	}
+
+#ifndef HAVE_ATOMIC_BUILTINS
+	mutex_free(&server_mutex);
+#endif
+	mutex_free(&srv_innodb_monitor_mutex);
+	mutex_free(&page_zip_stat_per_index_mutex);
+
 	mem_free(srv_sys);
 	srv_sys = NULL;
 
 	trx_i_s_cache_free(trx_i_s_cache);
-
-	if (!srv_read_only_mode) {
-		os_event_free(srv_buf_dump_event);
-		srv_buf_dump_event = NULL;
-	}
 }
 
 /*********************************************************************//**

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -3058,8 +3058,7 @@ innobase_shutdown_for_mysql(void)
 		logs_empty_and_mark_files_at_shutdown() and should have
 		already quit or is quitting right now. */
 
-		os_mutex_enter(os_sync_mutex);
-
+		os_rmb;
 		if (os_thread_count == 0) {
 			/* All the threads have exited or are just exiting;
 			NOTE that the threads may not have completed their
@@ -3069,14 +3068,10 @@ innobase_shutdown_for_mysql(void)
 			os_thread_exit().  Now we just sleep 0.1
 			seconds and hope that is enough! */
 
-			os_mutex_exit(os_sync_mutex);
-
 			os_thread_sleep(100000);
 
 			break;
 		}
-
-		os_mutex_exit(os_sync_mutex);
 
 		os_thread_sleep(100000);
 	}
@@ -3138,26 +3133,23 @@ innobase_shutdown_for_mysql(void)
 	que_close();
 	row_mysql_close();
 	srv_mon_free();
-	sync_close();
 	srv_free();
 	fil_close();
 
-	/* 4. Free the os_conc_mutex and all os_events and os_mutexes */
-
-	os_sync_free();
-
-	/* 5. Free all allocated memory */
+	/* 4. Free all allocated memory */
 
 	pars_lexer_close();
 	log_mem_free();
 	buf_pool_free(srv_buf_pool_instances);
 	mem_close();
+	sync_close();
 
 	/* ut_free_all_mem() frees all allocated memory not freed yet
 	in shutdown, and it will also free the ut_list_mutex, so it
 	should be the last one for all operation */
 	ut_free_all_mem();
 
+	os_rmb;
 	if (os_thread_count != 0
 	    || os_event_count != 0
 	    || os_mutex_count != 0

--- a/storage/innobase/sync/sync0arr.cc
+++ b/storage/innobase/sync/sync0arr.cc
@@ -295,21 +295,21 @@ sync_cell_get_event(
 	ulint type = cell->request_type;
 
 	if (type == SYNC_MUTEX) {
-		return(((ib_mutex_t*) cell->wait_object)->event);
+		return(&((ib_mutex_t*) cell->wait_object)->event);
 	} else if (type == SYNC_PRIO_MUTEX) {
-		return(((ib_prio_mutex_t*) cell->wait_object)
+		return(&((ib_prio_mutex_t*) cell->wait_object)
 		       ->high_priority_event);
 	} else if (type == RW_LOCK_WAIT_EX) {
-		return(((rw_lock_t*) cell->wait_object)->wait_ex_event);
+		return(&((rw_lock_t*) cell->wait_object)->wait_ex_event);
 	} else if (type == PRIO_RW_LOCK_SHARED) {
-		return(((prio_rw_lock_t *) cell->wait_object)
+		return(&((prio_rw_lock_t *) cell->wait_object)
 		       ->high_priority_s_event);
 	} else if (type == PRIO_RW_LOCK_EX) {
-		return(((prio_rw_lock_t *) cell->wait_object)
+		return(&((prio_rw_lock_t *) cell->wait_object)
 		       ->high_priority_x_event);
 	} else { /* RW_LOCK_SHARED and RW_LOCK_EX wait on the same event */
 		ut_ad(type == RW_LOCK_SHARED || type == RW_LOCK_EX);
-		return(((rw_lock_t*) cell->wait_object)->event);
+		return(&((rw_lock_t*) cell->wait_object)->event);
 	}
 }
 

--- a/storage/innobase/sync/sync0rw.cc
+++ b/storage/innobase/sync/sync0rw.cc
@@ -264,8 +264,8 @@ rw_lock_create_func(
 	lock->last_x_file_name = "not yet reserved";
 	lock->last_s_line = 0;
 	lock->last_x_line = 0;
-	lock->event = os_event_create();
-	lock->wait_ex_event = os_event_create();
+	os_event_create(&lock->event);
+	os_event_create(&lock->wait_ex_event);
 
 	mutex_enter(&rw_lock_list_mutex);
 
@@ -306,9 +306,9 @@ rw_lock_create_func(
 #endif
 			    cmutex_name);
 	lock->high_priority_s_waiters = 0;
-	lock->high_priority_s_event = os_event_create();
+	os_event_create(&lock->high_priority_s_event);
 	lock->high_priority_x_waiters = 0;
-	lock->high_priority_x_event = os_event_create();
+	os_event_create(&lock->high_priority_x_event);
 	lock->high_priority_wait_ex_waiter = 0;
 }
 
@@ -336,9 +336,9 @@ rw_lock_free_func(
 	mutex = rw_lock_get_mutex(lock);
 #endif /* !INNODB_RW_LOCKS_USE_ATOMICS */
 
-	os_event_free(lock->event);
+	os_event_free(&lock->event, false);
 
-	os_event_free(lock->wait_ex_event);
+	os_event_free(&lock->wait_ex_event, false);
 
 	ut_ad(UT_LIST_GET_PREV(list, lock) == NULL
 	      || UT_LIST_GET_PREV(list, lock)->magic_n == RW_LOCK_MAGIC_N);
@@ -368,8 +368,8 @@ rw_lock_free_func(
 /*==============*/
 	prio_rw_lock_t*	lock)	/*!< in: rw-lock */
 {
-	os_event_free(lock->high_priority_s_event);
-	os_event_free(lock->high_priority_x_event);
+	os_event_free(&lock->high_priority_s_event, false);
+	os_event_free(&lock->high_priority_x_event, false);
 	rw_lock_free_func(&lock->base_lock);
 }
 

--- a/storage/innobase/sync/sync0sync.cc
+++ b/storage/innobase/sync/sync0sync.cc
@@ -209,10 +209,7 @@ UNIV_INTERN mysql_pfs_key_t	sync_thread_mutex_key;
 /** Global list of database mutexes (not OS mutexes) created. */
 UNIV_INTERN ut_list_base_node_t  mutex_list;
 
-/** Global list of priority mutexes. A subset of mutex_list */
-UNIV_INTERN UT_LIST_BASE_NODE_T(ib_prio_mutex_t)  prio_mutex_list;
-
-/** Mutex protecting the mutex_list and prio_mutex_list variables */
+/** Mutex protecting the mutex_list variable */
 UNIV_INTERN ib_mutex_t mutex_list_mutex;
 
 #ifdef UNIV_PFS_MUTEX
@@ -283,7 +280,7 @@ mutex_create_func(
 	os_fast_mutex_init(PFS_NOT_INSTRUMENTED, &mutex->os_fast_mutex);
 	mutex->lock_word = 0;
 #endif
-	mutex->event = os_event_create();
+	os_event_create(&mutex->event);
 	mutex_set_waiters(mutex, 0);
 #ifdef UNIV_DEBUG
 	mutex->magic_n = MUTEX_MAGIC_N;
@@ -355,11 +352,7 @@ mutex_create_func(
 #endif /* UNIV_DEBUG */
 			  cmutex_name);
 	mutex->high_priority_waiters = 0;
-	mutex->high_priority_event = os_event_create();
-
-	mutex_enter(&mutex_list_mutex);
-	UT_LIST_ADD_FIRST(list, prio_mutex_list, mutex);
-	mutex_exit(&mutex_list_mutex);
+	os_event_create(&mutex->high_priority_event);
 }
 
 /******************************************************************//**
@@ -406,7 +399,7 @@ mutex_free_func(
 		mutex_exit(&mutex_list_mutex);
 	}
 
-	os_event_free(mutex->event);
+	os_event_free(&mutex->event, false);
 #ifdef UNIV_MEM_DEBUG
 func_exit:
 #endif /* UNIV_MEM_DEBUG */
@@ -433,12 +426,8 @@ mutex_free_func(
 /*============*/
 	ib_prio_mutex_t*	mutex)	/*!< in: mutex */
 {
-	mutex_enter(&mutex_list_mutex);
-	UT_LIST_REMOVE(list, prio_mutex_list, mutex);
-	mutex_exit(&mutex_list_mutex);
-
 	ut_a(mutex->high_priority_waiters == 0);
-	os_event_free(mutex->high_priority_event);
+	os_event_free(&mutex->high_priority_event, false);
 	mutex_free_func(&mutex->base_mutex);
 }
 
@@ -703,7 +692,7 @@ mutex_signal_object(
 
 	/* The memory order of resetting the waiters field and
 	signaling the object is important. See LEMMA 1 above. */
-	os_event_set(mutex->event);
+	os_event_set(&mutex->event);
 	sync_array_object_signalled();
 }
 
@@ -1584,7 +1573,6 @@ sync_init(void)
 	/* Init the mutex list and create the mutex to protect it. */
 
 	UT_LIST_INIT(mutex_list);
-	UT_LIST_INIT(prio_mutex_list);
 	mutex_create(mutex_list_mutex_key, &mutex_list_mutex,
 		     SYNC_NO_ORDER_CHECK);
 #ifdef UNIV_SYNC_DEBUG
@@ -1636,22 +1624,21 @@ sync_thread_level_arrays_free(void)
 #endif /* UNIV_SYNC_DEBUG */
 
 /******************************************************************//**
-Frees the resources in InnoDB's own synchronization data structures. Use
-os_sync_free() after calling this. */
+Frees the resources in InnoDB's own synchronization data structures. */
 UNIV_INTERN
 void
 sync_close(void)
 /*===========*/
 {
 	ib_mutex_t*		mutex;
-	ib_prio_mutex_t*	prio_mutex;
 
 	sync_array_close();
 
-	for (prio_mutex = UT_LIST_GET_FIRST(prio_mutex_list); prio_mutex;) {
-		mutex_free(prio_mutex);
-		prio_mutex = UT_LIST_GET_FIRST(prio_mutex_list);
-	}
+#ifdef UNIV_SYNC_DEBUG
+	os_event_free(rw_lock_debug_event);
+	mutex_free(&rw_lock_debug_mutex);
+#endif
+	mutex_free(&rw_lock_list_mutex);
 
 	for (mutex = UT_LIST_GET_FIRST(mutex_list);
 	     mutex != NULL;
@@ -1669,7 +1656,6 @@ sync_close(void)
 		mutex = UT_LIST_GET_FIRST(mutex_list);
 	}
 
-	mutex_free(&mutex_list_mutex);
 #ifdef UNIV_SYNC_DEBUG
 	mutex_free(&sync_thread_mutex);
 
@@ -1678,6 +1664,8 @@ sync_close(void)
 
 	sync_thread_level_arrays_free();
 #endif /* UNIV_SYNC_DEBUG */
+
+	mutex_free(&mutex_list_mutex);
 
 	sync_initialized = FALSE;
 }

--- a/storage/innobase/trx/trx0i_s.cc
+++ b/storage/innobase/trx/trx0i_s.cc
@@ -1466,6 +1466,8 @@ trx_i_s_cache_free(
 /*===============*/
 	trx_i_s_cache_t*	cache)	/*!< in, own: cache to free */
 {
+	rw_lock_free(&cache->rw_lock);
+	mutex_free(&cache->last_read_mutex);
 	hash_table_free(cache->locks_hash);
 	ha_storage_free(cache->storage);
 	table_cache_free(&cache->innodb_trx);


### PR DESCRIPTION
…ool) / 72466 / 62535

Reduce memory waste by the following:
- Pack struct os_event fields ibool is_set and ib_int64_t signal_count
  into a single ib_uint64_t field. Convert the struct into a C++
  class, make the combined field private, provide inline methods to
  access it.
- Do not link OS events and mutexes into lists, remove os_event_list
  and os_mutex_list corresponding struct fields.
- Do not protect the counters of currently existing threads, events
  and mutexes by os_sync_mutex but access them atomically instead. The
  counters are os_thread_count, os_event_count, os_mutex_count,
  os_fast_mutex_count.
- Allow OS events struct variables to be accessed directly not, not
  only through pointers. To support this, add free_memory argument to
  os_event_free function, with default true value to avoid updating
  all the callers. Create a second os_event_create overload that
  creates event in the passed arg instead of allocating memory and
  returning a pointer to newly created event. Inline OS events used in
  RW locks, priority RW locks, mutexes, and priority mutexes.
- Remove the separate priority mutex list as it does not provide much
  over the general mutex list.
- Explicitly free all events, mutexes, and rwlocks instead of
  iterating over their lists at shutdown
- Remove os_io_init_simple prototype and make this function static to
  os0file.cc, remove os_sync_mutex, os_sync_mutex_initialized,
  os_sync_free_called, os_event_list, and os_mutex_list variables, and
  os_sync_free, os_event_free_internal functions.
  
    http://jenkins.percona.com/job/percona-server-5.6-param/1121/
