### PR TITLE
Fix bug 1580227 (Killed connection threads might get their sockets cl…

### DIFF
--- a/vio/viosocket.c
+++ b/vio/viosocket.c
@@ -487,8 +487,9 @@ int vio_shutdown(Vio * vio, int how)
 
   r= vio_cancel(vio, how);
 
-  if (mysql_socket_close(vio->mysql_socket))
-    r= -1;
+  if (vio->inactive == FALSE)
+    if (mysql_socket_close(vio->mysql_socket))
+      r= -1;
 
   if (r)
   {


### PR DESCRIPTION
…osed twice on shutdown)

In some scenarios, THD::disconnect might get called twice for a single
connection, e.g. the first time by kill_server_threads -> kill_server
-> close_connections -> close_connection, and the second time by
handle_one_connection -> do_handle_one_connection ->
close_connection. This will result in the 1st call closing the network
socket and setting it to -1 and the 2nd call calling close on -1.

Fix by checking VIO state before calling close on the socket.

http://jenkins.percona.com/job/percona-server-5.6-param/1129
