### PR TITLE
Fix bug 1547525 (Change buffer merge throttled to 5% of I/O capacity …

### DIFF
--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -2892,7 +2892,7 @@ ibuf_contract_in_background(
 		sum_bytes += n_bytes;
 		sum_pages += n_pag2;
 
-		srv_inc_activity_count();
+		srv_inc_activity_count(true);
 	}
 
 	return(sum_bytes);

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -832,19 +832,29 @@ ulint
 srv_get_activity_count(void);
 /*========================*/
 /*******************************************************************//**
-Check if there has been any activity.
+Check if there has been any activity. Considers background change buffer
+merge as regular server activity unless a non-default
+old_ibuf_merge_activity_count value is passed, in which case the merge will be
+treated as keeping server idle.
 @return FALSE if no change in activity counter. */
 UNIV_INTERN
 ibool
 srv_check_activity(
 /*===============*/
-	ulint		old_activity_count);	/*!< old activity count */
+	ulint		old_activity_count,	/*!< old activity count */
+						/*!< old change buffer merge
+						activity count, or
+						ULINT_UNDEFINED */
+	ulint		old_ibuf_merge_activity_count = ULINT_UNDEFINED);
 /******************************************************************//**
 Increment the server activity counter. */
 UNIV_INTERN
 void
-srv_inc_activity_count(void);
-/*=========================*/
+srv_inc_activity_count(
+/*===================*/
+	bool ibuf_merge_activity = false);	/*!< whether this activity bump
+						is caused by the background
+						change buffer merge */
 
 /**********************************************************************//**
 Enqueues a task to server task queue and releases a worker thread, if there


### PR DESCRIPTION
…on an idle server)

XtraDB 5.6 has added server activity bump to the background change
buffer merge, so that buffer pool flushing is performed as for the
active server, which is required for this workload. This worked,
however change buffer merge itself was broken: since a merge bumps
server activity, the InnoDB master thread considers the server to be
active and requests merge at 5% not 100% of I/O capacity, resulting in
a very slow merge on an idle server.

Fix by introducing a change buffer background merge activity counter,
which is bumped in addition to the main activity counter in
srv_inc_activity_counter if needed, and by making srv_check_activity
optionally consider the server to be idle, if all the activity change
can be attributed to the change buffer merge alone.

```
http://jenkins.percona.com/job/percona-server-5.6-param/1091/
```
