### PR TITLE
Fix bug 1580993 (LeakSanitizer fails build at gen_lex_hash invocation)

### DIFF
--- a/sql/gen_lex_hash.cc
+++ b/sql/gen_lex_hash.cc
@@ -311,6 +311,7 @@ void print_find_structs()
   set_links(root_by_len,max_len);
   print_hash_map("sql_functions_map");
 
+  free(hash_map);
   hash_map= 0;
   size_hash_map= 0;
 
@@ -319,6 +320,10 @@ void print_find_structs()
   add_structs_to_map(root_by_len2,max_len2);
   set_links(root_by_len2,max_len2);
   print_hash_map("symbols_map");
+
+  free(hash_map);
+  hash_map= 0;
+  size_hash_map= 0;
 }
 
 


### PR DESCRIPTION
Fix by freeing hash_map in sql/gen_lex_hash.cc where it's
needed. Patch by Richard Prohaska.

http://jenkins.percona.com/view/PS%205.5/job/percona-server-5.5-asan-param/2/
