### PR TITLE
Bug#21254060: ASAN: MEMORY LEAK IN MYSQLTEST

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -2611,6 +2611,7 @@ void var_set_query_get_value(struct st_command *command, VAR *var)
                   mysql_sqlstate(mysql), &ds_res);
     /* If error was acceptable, return empty string */
     dynstr_free(&ds_query);
+    dynstr_free(&ds_col);
     eval_expr(var, "", 0);
     DBUG_VOID_RETURN;
   }
@@ -4916,7 +4917,7 @@ void do_get_errcodes(struct st_command *command)
     /* code to handle variables passed to mysqltest */
      if( *p == '$')
      {
-        const char* fin;
+        const char* fin= NULL;
         VAR *var = var_get(p,&fin,0,0);
         p=var->str_val;
         end=p+var->str_val_len;
@@ -5196,6 +5197,7 @@ void do_close_connection(struct st_command *command)
     {
       vio_delete(con->mysql.net.vio);
       con->mysql.net.vio = 0;
+      end_server(&con->mysql);
     }
   }
 #else
@@ -5668,6 +5670,7 @@ void do_connect(struct st_command *command)
   {
     DBUG_PRINT("info", ("Inserting connection %s in connection pool",
                         ds_connection_name.str));
+    my_free(con_slot->name);
     if (!(con_slot->name= my_strdup(ds_connection_name.str, MYF(MY_WME))))
       die("Out of memory");
     con_slot->name_len= strlen(con_slot->name);


### PR DESCRIPTION
Fix 3 different memory leaks in mysqltest:
1) Call dynstr_free() also in case of error.
2) Call end_server() also when doing dirty close.
3) Free st_connection::name before assigning new name.

Also fixes a valgrind warning about
Conditional jump or move depends on uninitialised value(s)

http://jenkins.percona.com/job/percona-server-5.5-param/1219/#showFailuresLink
