### PR TITLE
Fix bug 1582741 (mysqlcheck memory leaks)

### DIFF
--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -431,6 +431,7 @@ static int process_all_databases()
     if (process_one_db(row[0]))
       result = 1;
   }
+  mysql_free_result(tableres);
   return result;
 }
 /* process_all_databases */


### PR DESCRIPTION
Free the mysql result set at the end of
mysqlcheck.c:process_all_databases.

http://jenkins.percona.com/job/percona-server-5.5-param/1220/
