### PR TITLE
Fix bug 1582761 / 78223 (memory leak in mysqlbinlog)

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -39,6 +39,21 @@
 #include "my_dir.h"
 #include <welcome_copyright_notice.h> // ORACLE_WELCOME_COPYRIGHT_NOTICE
 
+/**
+   The function represents Log_event delete wrapper
+   to reset possibly active temp_buf member.
+   It's to be invoked in context where the member is
+   not bound with dynamically allocated memory and therefore can
+   be reset as simple as with plain assignment to NULL.
+
+   @param ev  a pointer to Log_event instance
+*/
+inline void reset_temp_buf_and_delete(Log_event *ev)
+{
+  ev->temp_buf= NULL;
+  delete ev;
+}
+
 /* Needed for Rpl_filter */
 CHARSET_INFO* system_charset_info= &my_charset_utf8_general_ci;
 
@@ -1884,6 +1899,7 @@ static Exit_status dump_remote_log_entries(PRINT_EVENT_INFO *print_event_info,
             if ((rev->ident_len != logname_len) ||
                 memcmp(rev->new_log_ident, logname, logname_len))
             {
+              reset_temp_buf_and_delete(rev);
               DBUG_RETURN(OK_CONTINUE);
             }
             /*
@@ -1892,6 +1908,7 @@ static Exit_status dump_remote_log_entries(PRINT_EVENT_INFO *print_event_info,
               log. If we are running with to_last_remote_log, we print it,
               because it serves as a useful marker between binlogs then.
             */
+            reset_temp_buf_and_delete(rev);
             continue;
           }
           len= 1; // fake Rotate, so don't increment old_off


### PR DESCRIPTION
Backport the fix from 5.7:

commit 6772eb52d666bfc11b52b1c99e27bd7d96874f01
Author: Andrei Elkin andrei.elkin@oracle.com
Date:   Fri Dec 11 17:14:06 2015 +0200

```
Bug#21697461 MEMORY LEAK IN MYSQLBINLOG

**Problem description**

At running mtr with a recently introduced --valgrind-clients
instances of not deallocated memory were revealed along the following
execution path:

Rotate_log_event::Rotate_log_event() -> ...
    inary_log::Rotate_event::Rotate_event() ->
       bapi_strndup() -> ... my_raw_malloc

The reason is turned down to be missed 'delete' for fake
(as defined by ev->when == 0) Rotate event
in case binlog is read from a running server (remote dumping).

**Fixed**

with calling the delete operator in proper places where
the fake Rotate event becomes out of interest at once after its reading,
that is its handling skips process_event().

That's done with care to clear the event's temp_buf.
```

http://jenkins.percona.com/job/percona-server-5.5-param/1221/#showFailuresLink
