### PR TITLE
Do not check THP if jemalloc is not checked.

### DIFF
--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -539,7 +539,9 @@ static int tokudb_init_func(void *p) {
     db_env->set_loader_memory_size(
         db_env,
         tokudb_get_loader_memory_size_callback);
-
+#if TOKUDB_CHECK_JEMALLOC
+    db_env->set_check_thp(db_env, tokudb::sysvars::check_jemalloc);
+#endif
     r = db_env->open(
         db_env,
         tokudb_home,

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -75,7 +75,7 @@ my_bool     gdb_on_fatal = FALSE;
 #endif
 
 #if TOKUDB_CHECK_JEMALLOC
-uint        check_jemalloc = 0;
+my_bool        check_jemalloc = TRUE;
 #endif
 
 static MYSQL_SYSVAR_ULONGLONG(
@@ -417,17 +417,14 @@ static MYSQL_SYSVAR_BOOL(
 #endif
 
 #if TOKUDB_CHECK_JEMALLOC
-static MYSQL_SYSVAR_UINT(
+static MYSQL_SYSVAR_BOOL(
     check_jemalloc,
     check_jemalloc,
-    0,
-    "check if jemalloc is linked",
+    PLUGIN_VAR_READONLY|PLUGIN_VAR_RQCMDARG,
+    "check if jemalloc is linked and transparent huge pages are disabled",
     NULL,
     NULL,
-    1,
-    0,
-    1,
-    0);
+    TRUE);
 #endif
 
 

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -89,7 +89,7 @@ extern my_bool      gdb_on_fatal;
 #endif
 
 #if TOKUDB_CHECK_JEMALLOC
-extern uint         check_jemalloc;
+extern my_bool         check_jemalloc;
 #endif
 
 #if TOKUDB_DEBUG


### PR DESCRIPTION
If --tokudb-check-jemalloc option is not set then THP is not checked.

This fix also contains some work around tokudb_check_jemalloc system
variable. Now this variable is 'bool' instead of 'uint', it is readonly
and can not be changed dynamically.

http://jenkins.percona.com/job/percona-server-5.6-param/1135/
https://github.com/percona/PerconaFT/pull/350
