### PR TITLE
Fix bug 1583147 (Regular user extra port connection fails if max_conn…

### DIFF
--- a/mysql-test/include/connect2.inc
+++ b/mysql-test/include/connect2.inc
@@ -28,7 +28,7 @@ while ($wait_counter)
 {
     --disable_abort_on_error
     --disable_result_log
-    --connect ($con_name,localhost,$con_user_name)
+    --connect ($con_name,127.0.0.1,$con_user_name,,,$con_port,)
     --enable_result_log
     --enable_abort_on_error
 

--- a/mysql-test/r/extra_port.result
+++ b/mysql-test/r/extra_port.result
@@ -1,0 +1,54 @@
+call mtr.add_suppression("Too many connections");
+CREATE USER nonprivuser@localhost;
+SELECT VARIABLE_VALUE INTO @cemc_1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='Connection_errors_max_connections';
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	1
+SELECT sleep(500000);
+# -- Success: non-SUPER user failed to connect with max_connections already being connected
+# Wait until Connection_errors_max_connections is bumped
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	2
+# -- Establishing connection 'con3' (user: root)...
+# -- Connection 'con3' has been established.
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	3
+SELECT sleep(500000);
+SELECT VARIABLE_VALUE INTO @cemc_2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='Connection_errors_max_connections';
+# -- Success: only max_connections + 1 SUPER connections allowed on the main port
+# Wait until Connection_errors_max_connections is bumped
+SELECT VARIABLE_VALUE INTO @cemc_3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME='Connection_errors_max_connections';
+Regular user connected on extra_port
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	3
+SELECT sleep(500000);
+# -- Success: non-SUPER user failed to connect on extra_port with extra_max_connections already being connected
+# Wait until Connection_errors_max_connections is bumped
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	3
+# -- Establishing connection 'extracon2' (user: root)...
+# -- Connection 'extracon2' has been established.
+SUPER user connected on extra_port
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	3
+KILL QUERY $con2_id
+KILL QUERY $con3_id
+KILL QUERY $extracon_id
+DROP USER nonprivuser@localhost;
+sleep(500000)
+1
+sleep(500000)
+1
+sleep(500000)
+1
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	1

--- a/mysql-test/t/extra_port.cnf
+++ b/mysql-test/t/extra_port.cnf
@@ -1,0 +1,12 @@
+!include include/default_my.cnf
+
+[mysqld.1]
+max-connections= 2
+extra-port= @OPT.port
+extra-max-connections= 1
+
+[client]
+connect-timeout= 2
+
+[ENV]
+MASTER_EXTRA_PORT= @OPT.port

--- a/mysql-test/t/extra_port.test
+++ b/mysql-test/t/extra_port.test
@@ -1,0 +1,173 @@
+# Test the interaction between max_connections, extra_port, and extra_max_connections
+--source include/count_sessions.inc
+
+call mtr.add_suppression("Too many connections");
+
+CREATE USER nonprivuser@localhost;
+
+SELECT VARIABLE_VALUE INTO @cemc_1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+       WHERE VARIABLE_NAME='Connection_errors_max_connections';
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+
+connect(con2,localhost,root,,);
+connection con2;
+
+let $con2_id= `SELECT connection_id()`;
+
+send SELECT sleep(500000);
+--sleep 2.5
+
+--disable_abort_on_error
+--disable_result_log
+--disable_query_log
+connect(con3,localhost,nonprivuser,,);
+--enable_query_log
+--enable_result_log
+--enable_abort_on_error
+let $error = $mysql_errno;
+if (!$error)
+{
+  --echo # -- Error: non-SUPER user connected with max_connections already being connected
+}
+if ($error)
+{
+  --echo # -- Success: non-SUPER user failed to connect with max_connections already being connected
+}
+
+connection default;
+
+--echo # Wait until Connection_errors_max_connections is bumped
+--let $wait_condition= SELECT VARIABLE_VALUE-@cemc_1 = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='Connection_errors_max_connections'
+--source include/wait_condition.inc
+
+# Threads_connected might be at 3 if server is still finishing cleaning up the failed con3
+# attempt above. Wait for it to settle.
+--let $status_var= Threads_connected
+--let $status_var_value= 2
+--source include/wait_for_status_var.inc
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+
+# The cleanup of the refused connection above in the server is async with the testsuite
+# client. Thus, the connection below might fail to connect on the first attempt.
+# Use connect2.inc which retries connecting.
+--let $con_name=con3
+--let $con_user_name=root
+--source include/connect2.inc
+connection con3;
+
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+
+let $con3_id= `SELECT connection_id()`;
+send SELECT sleep(500000);
+--sleep 2.5
+
+connection default;
+SELECT VARIABLE_VALUE INTO @cemc_2 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+       WHERE VARIABLE_NAME='Connection_errors_max_connections';
+
+--disable_abort_on_error
+--disable_result_log
+--disable_query_log
+connect(con4,localhost,root,,);
+--enable_query_log
+--enable_result_log
+--enable_abort_on_error
+let $error = $mysql_errno;
+if (!$error)
+{
+  --echo # -- Error: managed to establish more than max_connections + 1 SUPER connection on the main port
+}
+if ($error)
+{
+  --echo # -- Success: only max_connections + 1 SUPER connections allowed on the main port
+}
+
+connection default;
+--echo # Wait until Connection_errors_max_connections is bumped
+--let $wait_condition= SELECT VARIABLE_VALUE-@cemc_2 = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='Connection_errors_max_connections'
+--source include/wait_condition.inc
+
+SELECT VARIABLE_VALUE INTO @cemc_3 FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+       WHERE VARIABLE_NAME='Connection_errors_max_connections';
+
+connect(extracon,127.0.0.1,nonprivuser,,test,$MASTER_EXTRA_PORT,);
+connection extracon;
+--echo Regular user connected on extra_port
+--let $status_var= Threads_connected
+--let $status_var_value= 3
+--source include/wait_for_status_var.inc
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+
+let $extracon_id= `SELECT connection_id()`;
+send SELECT sleep(500000);
+--sleep 2.5
+
+--disable_abort_on_error
+--disable_result_log
+--disable_query_log
+connect(extracon2,127.0.0.1,nonprivuser,,test,$MASTER_EXTRA_PORT,);
+--enable_query_log
+--enable_result_log
+--enable_abort_on_error
+let $error = $mysql_errno;
+if (!$error)
+{
+  --echo # -- Error: non-SUPER user connected on extra_port with extra_max_connections already being connected
+}
+if ($error)
+{
+  --echo # -- Success: non-SUPER user failed to connect on extra_port with extra_max_connections already being connected
+}
+
+connection default;
+--echo # Wait until Connection_errors_max_connections is bumped
+--let $wait_condition= SELECT VARIABLE_VALUE-@cemc_3 = 1 FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='Connection_errors_max_connections'
+--source include/wait_condition.inc
+
+--let $status_var= Threads_connected
+--let $status_var_value= 3
+--source include/wait_for_status_var.inc
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+
+--let $con_name=extracon2
+--let $con_user_name=root
+--let $con_port=$MASTER_EXTRA_PORT
+--source include/connect2.inc
+connection extracon2;
+--echo SUPER user connected on extra_port
+
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+
+--echo KILL QUERY \$con2_id
+--disable_query_log
+eval KILL QUERY $con2_id;
+--enable_query_log
+
+--echo KILL QUERY \$con3_id
+--disable_query_log
+eval KILL QUERY $con3_id;
+--enable_query_log
+
+--echo KILL QUERY \$extracon_id
+--disable_query_log
+eval KILL QUERY $extracon_id;
+--enable_query_log
+
+DROP USER nonprivuser@localhost;
+--disconnect extracon2
+
+--connection extracon
+--reap
+--disconnect extracon
+
+--connection con3
+--reap
+--disconnect con3
+
+--connection con2
+--reap
+--disconnect con2
+
+--connection default
+--source include/wait_until_count_sessions.inc
+SHOW GLOBAL STATUS LIKE 'Threads_connected';

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -115,6 +115,7 @@ extern MYSQL_PLUGIN_IMPORT bool volatile abort_loop;
 extern bool in_bootstrap;
 extern my_bool opt_bootstrap;
 extern uint connection_count;
+extern uint extra_connection_count;
 extern my_bool opt_safe_user_create;
 extern my_bool opt_safe_show_db, opt_local_infile, opt_myisam_use_mmap;
 extern my_bool opt_slave_compressed_protocol, use_temp_pool;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11648,7 +11648,9 @@ acl_authenticate(THD *thd, uint com_change_user_pkt_len)
       !(thd->main_security_ctx.master_access & SUPER_ACL))
   {
     mysql_mutex_lock(&LOCK_connection_count);
-    bool count_ok= (connection_count <= max_connections);
+    bool count_ok= (thd->scheduler != extra_thread_scheduler)
+        ? (connection_count <= max_connections)
+        : (extra_connection_count <= extra_max_connections);
     mysql_mutex_unlock(&LOCK_connection_count);
     if (!count_ok)
     {                                         // too many connections


### PR DESCRIPTION
…ections + 1 already connected on the main port)

The maximum connection check at acl_authenticate only checked main
port connction count against max_connections. Change it to check extra
port connection count against extra_max_connections if the connection
was made on the extra port.

Backport and stabilise main.extra_port testcase from 5.7.

http://jenkins.percona.com/job/percona-server-5.6-param/1143/
