### PR TITLE
Fix bug 1583589 (Some issues with THD sub statement save/restore for …

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4738,8 +4738,6 @@ void THD::clear_slow_extended()
 void THD::reset_sub_statement_state_slow_extended(Sub_statement_state *backup)
 {
   DBUG_ENTER("THD::reset_sub_statement_state_slow_extended");
-  backup->sent_row_count=               m_sent_row_count;
-  backup->examined_row_count=           m_examined_row_count;
   backup->tmp_tables_used=              tmp_tables_used;
   backup->tmp_tables_disk_used=         tmp_tables_disk_used;
   backup->tmp_tables_size=              tmp_tables_size;
@@ -4759,8 +4757,6 @@ void THD::reset_sub_statement_state_slow_extended(Sub_statement_state *backup)
 void THD::restore_sub_statement_state_slow_extended(const Sub_statement_state *backup)
 {
   DBUG_ENTER("THD::restore_sub_statement_state_slow_extended");
-  m_sent_row_count=              backup->sent_row_count;
-  m_examined_row_count+=         backup->examined_row_count;
   tmp_tables_used+=              backup->tmp_tables_used;
   tmp_tables_disk_used+=         backup->tmp_tables_disk_used;
   tmp_tables_size+=              backup->tmp_tables_size;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2458,9 +2458,11 @@ public:
 
   /*** Following methods used in slow_extended.patch ***/
   void clear_slow_extended();
+private:
   void reset_sub_statement_state_slow_extended(Sub_statement_state *backup);
   void restore_sub_statement_state_slow_extended(const Sub_statement_state *backup);
   /*** The methods above used in slow_extended.patch ***/
+public:
 
   /* <> 0 if we are inside of trigger or stored function. */
   uint in_sub_stmt;


### PR DESCRIPTION
…slow query log extensions)

1) THD::reset_sub_statement_state_slow_extended copies
m_sent_row_count and m_examined_row_count to backup. This is already
done by its sole caller THD::reset_sub_statement_state.
2) THD::restore_sub_statement_state_slow_extended adds to
m_sent_row_count and m_examined_row_count from backup. This already
done by its sole caller THD::restore_sub_statement_state, resulting in
those variables being added to twice.
3) These two methods can be made private.

Fixed trivially.

http://jenkins.percona.com/job/percona-server-5.6-param/1145/
