### PR TITLE
Fix bug 1583553 (Error log "Too many connections" warning is not prin…

### DIFF
--- a/mysql-test/r/percona_log_connection_error.result
+++ b/mysql-test/r/percona_log_connection_error.result
@@ -1,16 +1,32 @@
 SET @old_max_connections = @@max_connections;
 SET @old_log_warnings = @@log_warnings;
-SET GLOBAL max_connections=2;
+SET GLOBAL max_connections=1;
+CREATE USER nonprivuser@localhost;
 SET GLOBAL LOG_WARNINGS = 0;
 connect(localhost,root,,test,port,socket);
 ERROR HY000: Too many connections
+[log_grep.inc] file: percona_log_connection_error.err pattern: Too many connections
+[log_grep.inc] lines:   0
 SET GLOBAL LOG_WARNINGS = 1;
 connect(localhost,root,,test,port,socket);
 ERROR HY000: Too many connections
+[log_grep.inc] file: percona_log_connection_error.err pattern: Too many connections
+[log_grep.inc] lines:   1
 SET GLOBAL LOG_WARNINGS = 0;
 connect(localhost,root,,test,port,socket);
 ERROR HY000: Too many connections
+[log_grep.inc] file: percona_log_connection_error.err pattern: Too many connections
+[log_grep.inc] lines:   1
+#
+# Bug 1583553: Error log "Too many connections" warning is not printed for the first after the limit non-SUPER login attempt
+#
+SET GLOBAL LOG_WARNINGS = 1;
+connect(localhost,nonprivuser,,test,port,socket);
+ERROR 08004: Too many connections
+[log_grep.inc] file: percona_log_connection_error.err pattern: Too many connections
+[log_grep.inc] lines:   2
 SET GLOBAL max_connections = @old_max_connections;
 SET GLOBAL log_warnings = @old_log_warnings;
-[log_grep.inc] file: percona.log_connection_error.err pattern: Too many connections
-[log_grep.inc] lines:   1
+[log_grep.inc] file: percona_log_connection_error.err pattern: Too many connections
+[log_grep.inc] lines:   2
+DROP USER nonprivuser@localhost;

--- a/mysql-test/suite/perfschema/r/hostcache_ipv4_max_con.result
+++ b/mysql-test/suite/perfschema/r/hostcache_ipv4_max_con.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("Too many connections");
 flush status;
 flush hosts;
 flush user_resources;

--- a/mysql-test/suite/perfschema/r/hostcache_ipv6_max_con.result
+++ b/mysql-test/suite/perfschema/r/hostcache_ipv6_max_con.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("Too many connections");
 flush status;
 flush hosts;
 flush user_resources;

--- a/mysql-test/suite/perfschema/t/hostcache_ipv4_max_con.test
+++ b/mysql-test/suite/perfschema/t/hostcache_ipv4_max_con.test
@@ -12,6 +12,8 @@
 --source include/have_debug.inc
 --source include/have_perfschema.inc
 
+call mtr.add_suppression("Too many connections");
+
 # Enforce a clean state
 --source ../include/wait_for_pfs_thread_count.inc
 --source ../include/hostcache_set_state.inc

--- a/mysql-test/suite/perfschema/t/hostcache_ipv6_max_con.test
+++ b/mysql-test/suite/perfschema/t/hostcache_ipv6_max_con.test
@@ -13,6 +13,8 @@
 --source include/have_ipv6.inc
 --source include/have_perfschema.inc
 
+call mtr.add_suppression("Too many connections");
+
 # Enforce a clean state
 --source ../include/wait_for_pfs_thread_count.inc
 --source ../include/hostcache_set_state.inc

--- a/mysql-test/t/percona_log_connection_error-master.opt
+++ b/mysql-test/t/percona_log_connection_error-master.opt
@@ -1,1 +1,2 @@
---log-error
+--log-error=$MYSQLTEST_VARDIR/percona_log_connection_error.err
+

--- a/mysql-test/t/percona_log_connection_error.test
+++ b/mysql-test/t/percona_log_connection_error.test
@@ -1,54 +1,73 @@
 --source include/not_embedded.inc
+--source include/count_sessions.inc
 
-connect (main,localhost,root,,);
-connection main;
+--let $log_error= `SELECT @@GLOBAL.log_error`
+--let log_file=percona_log_connection_error.err
+--let log_file_full_path=$log_error
+--let grep_pattern= Too many connections
+
 SET @old_max_connections = @@max_connections;
 SET @old_log_warnings = @@log_warnings;
-SET GLOBAL max_connections=2;
+SET GLOBAL max_connections=1;
 let $port=`SELECT Variable_value FROM INFORMATION_SCHEMA.SESSION_VARIABLES WHERE Variable_name LIKE 'port'`;
 let $socket=`SELECT Variable_value FROM INFORMATION_SCHEMA.SESSION_VARIABLES WHERE Variable_name LIKE 'socket'`;
+
+CREATE USER nonprivuser@localhost;
 
 SET GLOBAL LOG_WARNINGS = 0;
 --connect (conn0,localhost,root,,)
 connection conn0;
 replace_result $port port $socket socket;
---error 1040
+--error ER_CON_COUNT_ERROR
 --connect(conn1,localhost,root,,)
 disconnect conn0;
 SLEEP 0.1; # tsarev: hack, but i don't know (and didn't find) how right
 
-connection main;
+connection default;
+
+--source include/log_grep.inc
+
 SET GLOBAL LOG_WARNINGS = 1;
 --connect (conn1,localhost,root,,)
 replace_result $port port $socket socket;
---error 1040
+--error ER_CON_COUNT_ERROR
 --connect (conn0,localhost,root,,)
 disconnect conn1;
 SLEEP 0.1; # tsarev: hack, but i don't know (and didn't find) how right
 
-connection main;
+--source include/log_grep.inc
+
+connection default;
 SET GLOBAL LOG_WARNINGS = 0;
 --connect (conn0,localhost,root,,)
 replace_result $port port $socket socket;
---error 1040
+--error ER_CON_COUNT_ERROR
 --connect(conn1,localhost,root,,)
 disconnect conn0;
 SLEEP 0.1; # tsarev: hack, but i don't know (and didn't find) how right
 
-connection main;
-SET GLOBAL max_connections = @old_max_connections;
-SET GLOBAL log_warnings = @old_log_warnings;
-let $log_error_= `SELECT @@GLOBAL.log_error`;
-if(!`select LENGTH('$log_error_')`)
-{
-  # MySQL Server on windows is started with --console and thus
-  # does not know the location of its .err log, use default location
-  let $log_error_ = $MYSQLTEST_VARDIR/log/mysqld.1.err;
-}
-
---let log_error=$log_error_
---let log_file=percona.log_connection_error.err
---let log_file_full_path=$log_error
---let grep_pattern= Too many connections
 --source include/log_grep.inc
 
+connection default;
+
+--echo #
+--echo # Bug 1583553: Error log "Too many connections" warning is not printed for the first after the limit non-SUPER login attempt
+--echo #
+SET GLOBAL LOG_WARNINGS = 1;
+
+replace_result $port port $socket socket;
+--error ER_CON_COUNT_ERROR
+--connect (conn0,localhost,nonprivuser,,)
+
+--source include/log_grep.inc
+
+# connection main;
+connection default;
+SET GLOBAL max_connections = @old_max_connections;
+SET GLOBAL log_warnings = @old_log_warnings;
+
+--source include/log_grep.inc
+
+DROP USER nonprivuser@localhost;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -11655,6 +11655,10 @@ acl_authenticate(THD *thd, uint com_change_user_pkt_len)
       release_user_connection(thd);
       statistic_increment(connection_errors_max_connection, &LOCK_status);
       my_error(ER_CON_COUNT_ERROR, MYF(0));
+      if (log_warnings)
+      {
+        sql_print_warning("%s", ER_DEFAULT(ER_CON_COUNT_ERROR));
+      }
       DBUG_RETURN(1);
     }
   }


### PR DESCRIPTION
…ted for the first after the limit non-SUPER login attempt)

The error log warning "Too many connections" is only printed for
connection attempts when max_connections + 1 SUPER have connected. If
the extra SUPER is not connected, the warning is not printed for a
non-SUPER connection attempt.

This was caused by the warning being printed only at one of the two
places where the connection can be rejected due to too many
connections.  Fixed thus, and added a testcase to
main.percona_log_connection_error.

http://jenkins.percona.com/job/percona-server-5.6-param/1144/ and http://jenkins.percona.com/job/percona-server-5.6-param/1146/
