### PR TITLE
Fix bug 1466414 / 77399 (Deadlocks missed by INFORMATION_SCHEMA.INNOD…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_innodb_deadlock_count.result
+++ b/mysql-test/suite/innodb/r/percona_innodb_deadlock_count.result
@@ -1,13 +1,11 @@
 # Establish connection con1 (user=root)
 # Establish connection con2 (user=root)
-# Establish connection con3 (user=root)
-# Drop test table
-drop table if exists t;
 # Create test table
 create table t(a INT PRIMARY KEY, b INT) engine=InnoDB;
 # Insert two rows to test table
 insert into t values(2,1);
 insert into t values(1,2);
+SET GLOBAL innodb_monitor_reset = lock_deadlocks;
 # Switch to connection con1
 BEGIN;
 SELECT b FROM t WHERE a=1 FOR UPDATE;
@@ -22,7 +20,13 @@ SELECT b FROM t WHERE a=1 FOR UPDATE;
 ROLLBACK;
 # Switch to connection con2
 ROLLBACK;
-# Switch to connection con3
+# Switch to connection default
+SELECT COUNT INTO @lock_deadlocks_var FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME='lock_deadlocks';
+include/assert.inc [Exactly one deadlock should have been found]
+SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME='lock_deadlocks';
+NAME	COUNT
+lock_deadlocks	1
 Deadlocks: 1
 # Drop test table
 drop table t;
+SET GLOBAL innodb_monitor_reset = default;

--- a/mysql-test/suite/innodb/t/percona_innodb_deadlock_count.test
+++ b/mysql-test/suite/innodb/t/percona_innodb_deadlock_count.test
@@ -1,14 +1,10 @@
 --source include/have_innodb.inc
+--source include/count_sessions.inc
+
 --echo # Establish connection con1 (user=root)
 connect (con1,localhost,root,,);
 --echo # Establish connection con2 (user=root)
 connect (con2,localhost,root,,);
---echo # Establish connection con3 (user=root)
-connect (con3,localhost,root,,);
---echo # Drop test table
---disable_warnings
-drop table if exists t;
---enable_warnings
 
 --echo # Create test table
 create table t(a INT PRIMARY KEY, b INT) engine=InnoDB;
@@ -16,6 +12,7 @@ create table t(a INT PRIMARY KEY, b INT) engine=InnoDB;
 insert into t values(2,1);
 insert into t values(1,2);
 
+SET GLOBAL innodb_monitor_reset = lock_deadlocks;
 #--echo # Save current deadlock count
 let $current = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'Innodb_deadlocks'`;
 
@@ -49,13 +46,28 @@ connection con2;
 reap;
 ROLLBACK;
 
---echo # Switch to connection con3
-connection con3;
+--echo # Switch to connection default
+connection default;
 let $result = `SELECT VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME = 'Innodb_deadlocks'`;
 
 --enable_result_log
+
+--disconnect con1
+--disconnect con2
+
+SELECT COUNT INTO @lock_deadlocks_var FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME='lock_deadlocks';
+--let $assert_text= Exactly one deadlock should have been found
+--let $assert_cond= @lock_deadlocks_var = 1
+--source include/assert.inc
+SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME='lock_deadlocks';
 
 let $diff = `SELECT $result - $current`;
 echo Deadlocks: $diff;
 --echo # Drop test table
 drop table t;
+
+--disable_warnings
+SET GLOBAL innodb_monitor_reset = default;
+--enable_warnings
+
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -4037,8 +4037,6 @@ lock_deadlock_check_and_resolve(
 				lock_deadlock_joining_trx_print(trx, lock);
 			}
 
-			MONITOR_INC(MONITOR_DEADLOCK);
-
 		} else if (victim_trx_id != 0 && victim_trx_id != trx->id) {
 
 			ut_ad(victim_trx_id == ctx.wait_lock->trx->id);
@@ -4047,14 +4045,15 @@ lock_deadlock_check_and_resolve(
 			lock_deadlock_found = TRUE;
 
 			MONITOR_INC(MONITOR_DEADLOCK);
+			srv_stats.lock_deadlock_count.inc();
 		}
-
 	} while (victim_trx_id != 0 && victim_trx_id != trx->id);
 
 	/* If the joining transaction was selected as the victim. */
 	if (victim_trx_id != 0) {
 		ut_a(victim_trx_id == trx->id);
 
+		MONITOR_INC(MONITOR_DEADLOCK);
 		srv_stats.lock_deadlock_count.inc();
 
 		lock_deadlock_fputs("*** WE ROLL BACK TRANSACTION (2)\n");


### PR DESCRIPTION
…B_METRICS lock_deadlocks counter)

Fix by moving the lock_deadlocks metrics bump where it's not
missed. At the same time sync INNODB_METRICS and Innodb_deadlocks
status variable counter bump.

Extend the existing Innodb_deadlocks testcase for INNODB_METRICS, move
it to innodb suite.

http://jenkins.percona.com/job/percona-server-5.6-param/1147/#showFailuresLink
