### PR TITLE
Fix bug 1581949 (Querying GLOBAL_TEMPORARY_TABLES crashes if temp-tab…

### DIFF
--- a/mysql-test/r/percona_show_temp_tables_debug.result
+++ b/mysql-test/r/percona_show_temp_tables_debug.result
@@ -1,0 +1,18 @@
+#
+# Bug 1581949 (Querying GLOBAL_TEMPORARY_TABLES crashes if temp-table owning threads execute new queries)
+#
+# connection con2
+SET DEBUG_SYNC="dispatch_create_table_command_before_thd_root_free SIGNAL con2_ready WAIT_FOR thd_root_free";
+CREATE TEMPORARY TABLE t1 (a VARCHAR(256)) ENGINE=MyISAM;
+# connection default
+SET DEBUG_SYNC="now WAIT_FOR con2_ready";
+SET DEBUG_SYNC="start_handler_ha_open_cloned SIGNAL con_default_ready WAIT_FOR finish";
+SELECT TABLE_SCHEMA, TABLE_NAME, ENGINE, TABLE_ROWS FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+# connection con1
+SET DEBUG_SYNC="now WAIT_FOR con_default_ready";
+SET DEBUG_SYNC="now SIGNAL thd_root_free";
+# connection con2
+SET DEBUG_SYNC="now SIGNAL finish";
+# connection default
+TABLE_SCHEMA	TABLE_NAME	ENGINE	TABLE_ROWS
+test	t1	MyISAM	0

--- a/mysql-test/r/percona_show_temp_tables_stress.result
+++ b/mysql-test/r/percona_show_temp_tables_stress.result
@@ -1,0 +1,12 @@
+CREATE PROCEDURE query_temp_tables ()
+WHILE TRUE DO
+SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+END WHILE|
+CALL query_temp_tables();
+# Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+COUNT(*)
+1200
+# Dropping the temp tables
+KILL QUERY $con1_id
+DROP PROCEDURE query_temp_tables;

--- a/mysql-test/t/percona_show_temp_tables_debug.test
+++ b/mysql-test/t/percona_show_temp_tables_debug.test
@@ -1,0 +1,50 @@
+#
+# Debug build tests for INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES
+#
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+--source include/count_sessions.inc
+
+--echo #
+--echo # Bug 1581949 (Querying GLOBAL_TEMPORARY_TABLES crashes if temp-table owning threads execute new queries)
+--echo #
+
+connect (con1,localhost,root,,);
+connect (con2,localhost,root,,);
+--echo # connection con2
+
+SET DEBUG_SYNC="dispatch_create_table_command_before_thd_root_free SIGNAL con2_ready WAIT_FOR thd_root_free";
+
+send CREATE TEMPORARY TABLE t1 (a VARCHAR(256)) ENGINE=MyISAM;
+
+connection default;
+--echo # connection default
+
+SET DEBUG_SYNC="now WAIT_FOR con2_ready";
+SET DEBUG_SYNC="start_handler_ha_open_cloned SIGNAL con_default_ready WAIT_FOR finish";
+
+send SELECT TABLE_SCHEMA, TABLE_NAME, ENGINE, TABLE_ROWS FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+
+connection con1;
+--echo # connection con1
+
+SET DEBUG_SYNC="now WAIT_FOR con_default_ready";
+SET DEBUG_SYNC="now SIGNAL thd_root_free";
+disconnect con1;
+
+connection con2;
+--echo # connection con2
+
+reap;
+
+SET DEBUG_SYNC="now SIGNAL finish";
+
+connection default;
+--echo # connection default
+
+reap;
+
+disconnect con2;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/t/percona_show_temp_tables_stress.test
+++ b/mysql-test/t/percona_show_temp_tables_stress.test
@@ -1,0 +1,62 @@
+--source include/have_innodb.inc
+
+--source include/count_sessions.inc
+
+delimiter |;
+
+CREATE PROCEDURE query_temp_tables ()
+  WHILE TRUE DO
+    SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+  END WHILE|
+
+delimiter ;|
+
+connect (con1,localhost,root,,);
+--let $con1_id= `SELECT connection_id()`
+send CALL query_temp_tables();
+
+connection default;
+
+--let $i=400
+--echo # Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
+--disable_query_log
+while ($i)
+{
+  --eval CREATE TEMPORARY TABLE tmp_myisam_$i (a VARCHAR(256)) ENGINE=MyISAM
+  --eval CREATE TEMPORARY TABLE tmp_innodb_$i (a VARCHAR(256)) ENGINE=InnoDB
+  --eval CREATE TEMPORARY TABLE tmp_memory_$i (a VARCHAR(256)) ENGINE=MEMORY
+  --dec $i
+}
+--enable_query_log
+
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+
+--let $i=400
+--echo # Dropping the temp tables
+--disable_query_log
+while ($i)
+{
+  --eval DROP TEMPORARY TABLE tmp_myisam_$i
+  --eval DROP TEMPORARY TABLE tmp_innodb_$i
+  --eval DROP TEMPORARY TABLE tmp_memory_$i
+  --dec $i
+}
+--enable_query_log
+
+--echo KILL QUERY \$con1_id
+--disable_query_log
+eval KILL QUERY $con1_id;
+--enable_query_log
+
+connection con1;
+--disable_result_log
+--error ER_QUERY_INTERRUPTED
+reap;
+--enable_result_log
+disconnect con1;
+
+connection default;
+
+DROP PROCEDURE query_temp_tables;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2349,6 +2349,11 @@ int handler::ha_open(TABLE *table_arg, const char *name, int mode,
   DBUG_ASSERT(table->s == table_share);
   DBUG_ASSERT(alloc_root_inited(&table->mem_root));
 
+
+  if (cloned) {
+    DEBUG_SYNC(ha_thd(), "start_handler_ha_open_cloned");
+  }
+
   if ((error=open(name,mode,test_if_locked)))
   {
     if ((error == EACCES || error == EROFS) && mode == O_RDWR &&

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1473,6 +1473,8 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
   log_slow_statement(thd);
 
   thd_proc_info(thd, "cleaning up");
+  if (thd->lex->sql_command == SQLCOM_CREATE_TABLE)
+    DEBUG_SYNC(thd, "dispatch_create_table_command_before_thd_root_free");
   thd->reset_query();
   thd->command=COM_SLEEP;
   dec_thread_running();


### PR DESCRIPTION
…le owning threads execute new queries)

INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES query cloning temp table
handler passed the memory root of the temp table connection thread
object. This memory root is being freed at the end of query of that
thread, which may result, depending on scheduling, in the
GLOBAL_TEMPORARY_TABLES-querying thread accessing cloned object after it
has been freed.

Fixed by using a memory root of the GLOBAL_TEMPORARY_TABLES-querying
thread.

Add percona_show_temp_tables_debug testcase to test this exact scenario
and percona_show_temp_tables_stress to test querying
GLOBAL_TEMPORARY_TABLES in parallel to creating and destroying them.

http://jenkins.percona.com/job/percona-server-5.5-param/1225/
