### PR TITLE
Fix bug 1586265 (Requesting flush burst to LSN_MAX is broken)

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3683,7 +3683,8 @@ buf_flush_request_force(
 	lsn_t	lsn_limit)
 {
 	/* adjust based on lsn_avg_rate not to get old */
-	lsn_t	lsn_target = lsn_limit + lsn_avg_rate * 3;
+	lsn_t	lsn_target = (lsn_limit != LSN_MAX)
+		? (lsn_limit + lsn_avg_rate * 3) : LSN_MAX;
 
 	mutex_enter(&page_cleaner->mutex);
 	if (lsn_target > buf_flush_sync_lsn) {


### PR DESCRIPTION
With parallel doublewrite, it is possible to call
buf_flush_request_force(LSN_MAX) to request flushing the whole of the
buffer pool, instead of performing query thread flushing as
previously. However, buf_flush_request_force does not process this
argument correctly as it adds lsn_avg_rate \* 3 to its argument,
overflowing in the case of LSN_MAX. Fixed trivially.

http://jenkins.percona.com/job/mysql-5.7-param/189/
