### PR TITLE
Fix bug 1587426 / 81657 (DBUG_PRINT in THD::decide_logging_format pri…

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4599,9 +4599,10 @@ int THD::decide_logging_format(TABLE_LIST *tables)
 #ifndef DBUG_OFF
     {
       static const char *prelocked_mode_name[] = {
-        "NON_PRELOCKED",
-        "PRELOCKED",
-        "PRELOCKED_UNDER_LOCK_TABLES",
+        "LTM_NONE",
+        "LTM_LOCK_TABLES",
+        "LTM_PRELOCKED",
+        "LTM_PRELOCKED_UNDER_LOCK_TABLES"
       };
       DBUG_PRINT("debug", ("prelocked_mode: %s",
                            prelocked_mode_name[locked_tables_mode]));


### PR DESCRIPTION
…nts incorrectly, access out-of-bound)

Debug-only print code for printing THD::locked_tables_mode handles
only three values, with their names printed incorrectly. But the enum
can have four values, and an attempt to print the last one would
result in out-of-bounds read. Fix by syncing the printing code with
the enum.

http://jenkins.percona.com/job/percona-server-5.5-param/1227/
