### PR TITLE
Bug#14834333 ADDRESSSANITIZER BUGS IN MYSQL_CLIENT_TEST

### DIFF
--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -4057,6 +4057,7 @@ my_bool STDCALL mysql_stmt_bind_result(MYSQL_STMT *stmt, MYSQL_BIND *my_bind)
     stmt->bind was initialized in mysql_stmt_prepare
     stmt->bind overlaps with bind if mysql_stmt_bind_param
     is called from mysql_stmt_store_result.
+    BEWARE of buffer overwrite ...
   */
 
   if (stmt->bind != my_bind)

--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -6167,7 +6167,7 @@ static void test_date_dt()
 static void test_pure_coverage()
 {
   MYSQL_STMT *stmt;
-  MYSQL_BIND my_bind[1];
+  MYSQL_BIND my_bind[2];
   int        rc;
   ulong      length;
 
@@ -6229,6 +6229,7 @@ static void test_pure_coverage()
   rc= mysql_stmt_execute(stmt);
   check_execute(stmt, rc);
 
+  // NOTE: stmt now has two columns, but only my_bind[0] is initialized.
   my_bind[0].buffer_type= MYSQL_TYPE_GEOMETRY;
   rc= mysql_stmt_bind_result(stmt, my_bind);
   check_execute_r(stmt, rc); /* unsupported buffer type */
@@ -6250,7 +6251,8 @@ static void test_pure_coverage()
 static void test_buffers()
 {
   MYSQL_STMT *stmt;
-  MYSQL_BIND my_bind[1];
+  // The test_pure table has two columns.
+  MYSQL_BIND my_bind[2];
   int        rc;
   ulong      length;
   my_bool    is_null;
@@ -8842,7 +8844,7 @@ static void test_parse_error_and_bad_length()
   DIE_UNLESS(rc);
   if (!opt_silent)
     fprintf(stdout, "Got error (as expected): '%s'\n", mysql_error(mysql));
-  rc= mysql_real_query(mysql, "SHOW DATABASES", 100);
+  rc= mysql_real_query(mysql, "SHOW DATABASES", 12); // Incorrect length.
   DIE_UNLESS(rc);
   if (!opt_silent)
     fprintf(stdout, "Got error (as expected): '%s'\n", mysql_error(mysql));
@@ -8853,7 +8855,7 @@ static void test_parse_error_and_bad_length()
     fprintf(stdout, "Got error (as expected): '%s'\n", mysql_error(mysql));
   stmt= mysql_stmt_init(mysql);
   DIE_UNLESS(stmt);
-  rc= mysql_stmt_prepare(stmt, "SHOW DATABASES", 100);
+  rc= mysql_stmt_prepare(stmt, "SHOW DATABASES", 12); // Incorrect length.
   DIE_UNLESS(rc != 0);
   if (!opt_silent)
     fprintf(stdout, "Got error (as expected): '%s'\n", mysql_stmt_error(stmt));
@@ -16846,6 +16848,7 @@ static void test_bug31669()
   DIE_UNLESS(rc);
 
   memset(buff, 'a', sizeof(buff));
+  buff[sizeof(buff) - 1] = '\0';
 
   mysql_close(conn);
   conn= client_connect(0, MYSQL_PROTOCOL_TCP, 0);


### PR DESCRIPTION
Fix errors reported by address sanitizer:
- test_pure_coverage() needs two my_bind structs,
  since the table has two columns
- do not read past the end of the character constant "SHOW DATABASES"
- do not read past the end of 'buff'

http://jenkins.percona.com/job/percona-server-5.5-param/1228/
