### PR TITLE
Fix bug 1587757 (Allocator/deallocator mismatch in User_var_log_event…

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -6187,7 +6187,7 @@ void User_var_log_event::print(FILE* file, PRINT_EVENT_INFO* print_event_info)
                     cs->csname, hex_str, quoted_charset_name.c_ptr(),
                     print_event_info->delimiter);
       }
-      my_afree(hex_str);
+      my_free(hex_str);
     }
       break;
     case ROW_RESULT:


### PR DESCRIPTION
…::print)

hex_str in User_var_log_event::print is allocated using my_malloc, but
freed with my_afree (which pairs with my_alloca) instead of
my_free. Fixed trivially.

http://jenkins.percona.com/job/percona-server-5.5-param/1229/
