### PR TITLE
Fix bug 1587840 / 81675 (mysqlbinlog does not free the existing conne…

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -1611,6 +1611,9 @@ static int parse_args(int *argc, char*** argv)
 */
 static Exit_status safe_connect()
 {
+  /* If we are opening a new connection, close the old one first */
+  if (mysql)
+    mysql_close(mysql);
   mysql= mysql_init(NULL);
 
   if (!mysql)


### PR DESCRIPTION
…ction before opening new remote one)

If mysqlbinlog is invoked with --read-from-remote-server and several
binlog file names, each file will be read with the server connection
re-opened. But the existing connection is only closed on mysqlbinlog
termination, not before a new connection is opened for the next
file. This causes a memory leak.

Fix by closing the old connection, if any, at the start of
safe_connect().

http://jenkins.percona.com/job/percona-server-5.5-param/1230/
