### PR TITLE
Fix bug 1588318 (mysqltest memory leak on invalid replace_regex)

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -9443,6 +9443,7 @@ struct st_replace_regex* init_replace_regex(char* expr)
   return res;
 
 err:
+  delete_dynamic(&res->regex_arr);
   my_free(res);
   die("Error parsing replace_regex \"%s\"", expr);
   return 0;


### PR DESCRIPTION
Function init_replace_regex() did not free res->regex_arr on
error. Fixed trivally.

http://jenkins.percona.com/job/percona-server-5.5-param/1233/
