### PR TITLE
Fix bug 1588650 (Memory leak in base64-t test)

### DIFF
--- a/unittest/mysys/base64-t.c
+++ b/unittest/mysys/base64-t.c
@@ -90,6 +90,9 @@ main(void)
       diag("src length: %.8x, dst length: %.8x\n",
            (uint) src_len, (uint) dst_len);
     }
+    free(str);
+    free(src);
+    free(dst);
   }
   return exit_status();
 }


### PR DESCRIPTION
Free str, src, dst at the end of each loop iteration.

http://jenkins.percona.com/job/percona-server-5.5-param/1238/
