### PR TITLE
Bugfix lp:719368 log_slow_sp_statements interferes with log_slow_admin_statements

### DIFF
--- a/mysql-test/r/percona_log_slow_admin_statements_sp.result
+++ b/mysql-test/r/percona_log_slow_admin_statements_sp.result
@@ -1,0 +1,50 @@
+CREATE TABLE t1 (a INT);
+SET @old_log_slow_admin_statements=@@global.log_slow_admin_statements;
+SET @old_log_slow_sp_statements=@@global.log_slow_sp_statements;
+SET SESSION min_examined_row_limit=0;
+SET SESSION long_query_time=0;
+CREATE PROCEDURE test()
+BEGIN
+INSERT INTO t1 VALUES(0);
+CREATE INDEX i ON t1(a);
+INSERT INTO t1 VALUES(1);
+END^
+SET GLOBAL log_slow_admin_statements=OFF;
+SET GLOBAL log_slow_sp_statements=ON;
+[log_start.inc] percona_log_slow_admin_stmt_sp_1
+call test();
+[log_stop.inc] percona_log_slow_admin_stmt_sp_1
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(0\);
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: CREATE INDEX i ON t1\(a\);
+[log_grep.inc] lines:   0
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(1\);
+[log_grep.inc] lines:   1
+DROP INDEX i ON t1;
+SET GLOBAL log_slow_admin_statements=ON;
+SET GLOBAL log_slow_sp_statements=OFF;
+[log_start.inc] percona_log_slow_admin_stmt_sp_1
+call test();
+[log_stop.inc] percona_log_slow_admin_stmt_sp_1
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(0\);
+[log_grep.inc] lines:   0
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: CREATE INDEX i ON t1\(a\);
+[log_grep.inc] lines:   0
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(1\);
+[log_grep.inc] lines:   0
+DROP INDEX i ON t1;
+SET GLOBAL log_slow_admin_statements=ON;
+SET GLOBAL log_slow_sp_statements=ON;
+[log_start.inc] percona_log_slow_admin_stmt_sp_1
+call test();
+[log_stop.inc] percona_log_slow_admin_stmt_sp_1
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(0\);
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: CREATE INDEX i ON t1\(a\);
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(1\);
+[log_grep.inc] lines:   1
+DROP TABLE t1;
+DROP PROCEDURE test;
+SET GLOBAL log_slow_admin_statements=@old_log_slow_admin_statements;
+SET GLOBAL log_slow_sp_statements=@old_log_slow_sp_statements;

--- a/mysql-test/t/percona_log_slow_admin_statements_sp.test
+++ b/mysql-test/t/percona_log_slow_admin_statements_sp.test
@@ -1,0 +1,84 @@
+#
+# Test log_slow_slave_admin_statements in stored procedures
+#
+
+CREATE TABLE t1 (a INT);
+
+SET @old_log_slow_admin_statements=@@global.log_slow_admin_statements;
+SET @old_log_slow_sp_statements=@@global.log_slow_sp_statements;
+SET SESSION min_examined_row_limit=0;
+SET SESSION long_query_time=0;
+
+delimiter ^;
+CREATE PROCEDURE test()
+BEGIN
+   INSERT INTO t1 VALUES(0);
+   CREATE INDEX i ON t1(a);
+   INSERT INTO t1 VALUES(1);
+END^
+delimiter ;^
+
+#
+# Test disabled admin statement slow-logging in stored procedures
+#
+SET GLOBAL log_slow_admin_statements=OFF;
+SET GLOBAL log_slow_sp_statements=ON;
+
+--let log_file=percona_log_slow_admin_stmt_sp_1
+--source include/log_start.inc
+call test();
+--source include/log_stop.inc
+--let grep_pattern=INSERT INTO t1 VALUES\(0\);
+--source include/log_grep.inc
+--let grep_pattern=CREATE INDEX i ON t1\(a\);
+--source include/log_grep.inc
+--let grep_pattern=INSERT INTO t1 VALUES\(1\);
+--source include/log_grep.inc
+
+DROP INDEX i ON t1;
+--source include/log_cleanup.inc
+
+#
+# Test admin statement slow-logging disabled by stored procedures
+#
+SET GLOBAL log_slow_admin_statements=ON;
+SET GLOBAL log_slow_sp_statements=OFF;
+
+--let log_file=percona_log_slow_admin_stmt_sp_1
+--source include/log_start.inc
+call test();
+--source include/log_stop.inc
+--let grep_pattern=INSERT INTO t1 VALUES\(0\);
+--source include/log_grep.inc
+--let grep_pattern=CREATE INDEX i ON t1\(a\);
+--source include/log_grep.inc
+--let grep_pattern=INSERT INTO t1 VALUES\(1\);
+--source include/log_grep.inc
+
+DROP INDEX i ON t1;
+--source include/log_cleanup.inc
+
+#
+# Test enabled admin statement slow-logging in stored procedures
+#
+SET GLOBAL log_slow_admin_statements=ON;
+SET GLOBAL log_slow_sp_statements=ON;
+
+--let log_file=percona_log_slow_admin_stmt_sp_1
+--source include/log_start.inc
+call test();
+--source include/log_stop.inc
+--let grep_pattern=INSERT INTO t1 VALUES\(0\);
+--source include/log_grep.inc
+--let grep_pattern=CREATE INDEX i ON t1\(a\);
+--source include/log_grep.inc
+--let grep_pattern=INSERT INTO t1 VALUES\(1\);
+--source include/log_grep.inc
+
+DROP TABLE t1;
+DROP PROCEDURE test;
+
+SET GLOBAL log_slow_admin_statements=@old_log_slow_admin_statements;
+SET GLOBAL log_slow_sp_statements=@old_log_slow_sp_statements;
+
+--source include/log_cleanup.inc

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -3114,6 +3114,7 @@ sp_instr_stmt::execute(THD *thd, uint *nextp)
   DBUG_ENTER("sp_instr_stmt::execute");
   DBUG_PRINT("info", ("command: %d", m_lex_keeper.sql_command()));
 
+  const bool sp_level_enable_slow_log = thd->enable_slow_log;
   const CSET_STRING query_backup= thd->query_string;
 #if defined(ENABLED_PROFILING)
   /* This s-p instr is profilable and will be captured. */
@@ -3157,7 +3158,7 @@ sp_instr_stmt::execute(THD *thd, uint *nextp)
 
       query_cache_end_of_result(thd);
 
-      if (!res && unlikely(thd->enable_slow_log))
+      if (!res && unlikely(thd->enable_slow_log && sp_level_enable_slow_log))
         log_slow_statement(thd);
     }
     else
@@ -3172,6 +3173,8 @@ sp_instr_stmt::execute(THD *thd, uint *nextp)
   /* Restore the original query start time */
   if (thd->enable_slow_log)
     thd->set_time(&time_info);
+
+  thd->enable_slow_log = sp_level_enable_slow_log;
 
   DBUG_RETURN(res || thd->is_error());
 }


### PR DESCRIPTION
Bug fix for https://bugs.launchpad.net/percona-server/+bug/719368

Backup thd->enable_slow_log value before executing statements inside stored procedures.

http://jenkins.percona.com/job/percona-server-5.5-param/1241/
