### PR TITLE
Bug#14840488 VALGRIND ERRORS IN MYSQL_CLIENT_TEST

### DIFF
--- a/tests/mysql_client_test.c
+++ b/tests/mysql_client_test.c
@@ -985,6 +985,7 @@ static void test_wl4435_2()
     rc= mysql_query(mysql, "DROP PROCEDURE p1");
     myquery(rc);
   }
+  mct_close_log();
 }
 
 
@@ -1049,6 +1050,7 @@ static void test_wl4435_2()
   rc= mysql_stmt_next_result(ps); \
   DIE_UNLESS(rc == 0); \
   \
+  mysql_free_result(rs_metadata); \
   mysql_stmt_free_result(ps); \
   mysql_stmt_close(ps); \
   \
@@ -17712,6 +17714,8 @@ static void test_bug43560(void)
   rc= mysql_stmt_execute(stmt);
   DIE_UNLESS(rc && mysql_stmt_errno(stmt) == CR_SERVER_LOST);
 
+  mysql_stmt_close(stmt);
+
   opt_drop_db= 0;
   client_disconnect(conn);
   rc= mysql_query(mysql, "DROP TABLE t1");
@@ -18011,6 +18015,7 @@ static void test_bug42373()
   DIE_UNLESS(rc == 1);
 
   mysql_stmt_close(stmt);
+  mysql_close(&con);
 
   /* Now try with a multi-statement. */
   DIE_UNLESS(mysql_client_init(&con));


### PR DESCRIPTION
Add missing DBUG_RETURNs, otherwise the debug-stack gets messed up,
and _db_enter_ and _db_exit_ will access data outside the current stack frame.

Add some missing mysql_free_xx() mysql_close_xx() to fix memory leaks.

http://jenkins.percona.com/job/percona-server-5.5-param/1242/
