### PR TITLE
Fix bug 1155156 (innodb_log_block_size mismatch between log files and…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_log_block_size.result
+++ b/mysql-test/suite/innodb/r/percona_log_block_size.result
@@ -1,10 +1,17 @@
-DROP TABLE IF EXISTS t1;
+include/assert.inc [innodb_log_block_size must be <> 4KB at the start of this test]
 call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
-1st server restart
+#
+# Bug 1155156: Verify innodb_log_block_size mismatch diagnostics
+#
+# Attempting to start server with different innodb_log_block_size without deleting logs first
+#
+# Bug 1114612: Failing assertion: n % srv_log_block_size == 0 in file os0file.c line 4269
+#
+# restart:--innodb-log-block-size=4096
 CREATE TABLE t1 (a INT) ENGINE=InnoDB ROW_FORMAt=COMPRESSED KEY_BLOCK_SIZE=1;
 INSERT INTO t1 VALUES (1), (2), (3);
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 3
-2nd server restart
+# restart
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_log_block_size.test
+++ b/mysql-test/suite/innodb/t/percona_log_block_size.test
@@ -1,25 +1,37 @@
 #
-# Test that innodb_log_block_size works with the rest of the server (bug 1114612)
+# Tests for innodb_log_block_size feature
 #
 --source include/have_innodb.inc
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
+--let $assert_text= innodb_log_block_size must be <> 4KB at the start of this test
+--let $assert_cond= @@innodb_log_block_size <> 4096
+--source include/assert.inc
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 
 call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
 
---echo 1st server restart
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
-# Do something while server is down
+--echo #
+--echo # Bug 1155156: Verify innodb_log_block_size mismatch diagnostics
+--echo #
+--source include/shutdown_mysqld.inc
+
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/my_restart.err
+
+--echo # Attempting to start server with different innodb_log_block_size without deleting logs first
+--error 1
+--exec $MYSQLD_CMD --innodb-log-block-size=4096 --log-error=$SEARCH_FILE
+
+--let SEARCH_PATTERN=.*InnoDB: Error: The block size of ib_logfile .* is not equal to innodb_log_block_size
+--source include/search_pattern_in_file.inc
+
+--echo #
+--echo # Bug 1114612: Failing assertion: n % srv_log_block_size == 0 in file os0file.c line 4269
+--echo #
+
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
---enable_reconnect
---exec echo "restart:--innodb-log-block-size=4096" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-log-block-size=4096
+--source include/start_mysqld.inc
 
 CREATE TABLE t1 (a INT) ENGINE=InnoDB ROW_FORMAt=COMPRESSED KEY_BLOCK_SIZE=1;
 
@@ -27,14 +39,9 @@ INSERT INTO t1 VALUES (1), (2), (3);
 
 SELECT COUNT(*) FROM t1;
 
---echo 2nd server restart
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
-# Do something while server is down
+--source include/shutdown_mysqld.inc
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
---enable_reconnect
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters=
+--source include/start_mysqld.inc
 
 DROP TABLE t1;

--- a/storage/innobase/log/log0recv.c
+++ b/storage/innobase/log/log0recv.c
@@ -659,6 +659,7 @@ recv_check_cp_is_consistent(
 }
 
 #ifndef UNIV_HOTBACKUP
+
 /********************************************************//**
 Looks for the maximum consistent checkpoint from the log groups.
 @return	error code or DB_SUCCESS */
@@ -685,7 +686,36 @@ recv_find_max_checkpoint(
 	buf = log_sys->checkpoint_buf;
 
 	while (group) {
+
+		ulint	log_hdr_log_block_size;
+
 		group->state = LOG_GROUP_CORRUPTED;
+
+		/* Assert that we can reuse log_sys->checkpoint_buf to read the
+		part of the header that contains the log block size. */
+		ut_ad(LOG_FILE_OS_FILE_LOG_BLOCK_SIZE + 4
+		      < OS_FILE_LOG_BLOCK_SIZE);
+
+		fil_io(OS_FILE_READ | OS_FILE_LOG, TRUE, group->space_id, 0,
+		       0, 0, OS_FILE_LOG_BLOCK_SIZE,
+		       log_sys->checkpoint_buf, NULL);
+		log_hdr_log_block_size
+			= mach_read_from_4(log_sys->checkpoint_buf
+					   + LOG_FILE_OS_FILE_LOG_BLOCK_SIZE);
+		if (log_hdr_log_block_size == 0) {
+			/* 0 means default value */
+			log_hdr_log_block_size = 512;
+		}
+		if (log_hdr_log_block_size != srv_log_block_size) {
+			fprintf(stderr,
+				"InnoDB: Error: The block size of ib_logfile "
+				"%lu is not equal to innodb_log_block_size "
+				"%lu.\n"
+				"InnoDB: Error: Suggestion - Recreate log "
+				"files.\n",
+				log_hdr_log_block_size, srv_log_block_size);
+			return(DB_ERROR);
+		}
 
 		for (field = LOG_CHECKPOINT_1; field <= LOG_CHECKPOINT_2;
 		     field += LOG_CHECKPOINT_2 - LOG_CHECKPOINT_1) {
@@ -2982,7 +3012,6 @@ recv_recovery_from_checkpoint_start_func(
 	log_group_t*	max_cp_group;
 	log_group_t*	up_to_date_group;
 	ulint		max_cp_field;
-	ulint		log_hdr_log_block_size;
 	ib_uint64_t	checkpoint_lsn;
 	ib_uint64_t	checkpoint_no;
 	ib_uint64_t	old_scanned_lsn;
@@ -3083,21 +3112,6 @@ recv_recovery_from_checkpoint_start_func(
 		       max_cp_group->space_id, 0,
 		       0, 0, OS_FILE_LOG_BLOCK_SIZE,
 		       log_hdr_buf, max_cp_group);
-	}
-
-	log_hdr_log_block_size
-		= mach_read_from_4(log_hdr_buf + LOG_FILE_OS_FILE_LOG_BLOCK_SIZE);
-	if (log_hdr_log_block_size == 0) {
-		/* 0 means default value */
-		log_hdr_log_block_size = 512;
-	}
-	if (log_hdr_log_block_size != srv_log_block_size) {
-		fprintf(stderr,
-			"InnoDB: Error: The block size of ib_logfile (%lu) "
-			"is not equal to innodb_log_block_size.\n"
-			"InnoDB: Error: Suggestion - Recreate log files.\n",
-			log_hdr_log_block_size);
-		return(DB_ERROR);
 	}
 
 #ifdef UNIV_LOG_ARCHIVE


### PR DESCRIPTION
… current configuration is diagnosed as "No valid checkpoints found")

The innodb_log_block_size feature attemped to diagnose the situation
where the logs have been created with a log block value that differs
from the current innodb_log_block_size setting. But this diagnostics
came too late, and a different error "No valid checkpoints found" was
produced first, aborting the startup. This error is misleading for
this situation. Fix by moving the log block size diagnostics to
recv_find_max_checkpoint, before the "No valid checkpoints found"
diagnostics. Add a testcase to innodb.percona_log_block_size.

http://jenkins.percona.com/job/percona-server-5.5-param/1245/
