### PR TITLE
tokudb_dir_per_db option is introduced.

### DIFF
--- a/mysql-test/include/table_files_replace_pattern.inc
+++ b/mysql-test/include/table_files_replace_pattern.inc
@@ -1,0 +1,1 @@
+--replace_regex  /[a-z0-9]+_[a-z0-9]+_[a-z0-9]+(_[BP]_[a-z0-9]+){0,1}\./id./ /sqlx_[a-z0-9]+_[a-z0-9]+_/sqlx_nnnn_nnnn_/ /sqlx-[a-z0-9]+_[a-z0-9]+/sqlx-nnnn_nnnn/ /#p#/#P#/ /#sp#/#SP#/ /#tmp#/#TMP#/ $ADDITIONAL_REGEX

--- a/mysql-test/include/table_files_replace_pattern_in_file.inc
+++ b/mysql-test/include/table_files_replace_pattern_in_file.inc
@@ -1,0 +1,36 @@
+--perl
+
+my $filename = $ENV{'TABLE_FILES_REPLACE_FILE'};
+my $data = read_file($filename);
+
+$data =~ s/[a-z0-9]+_[a-z0-9]+_[a-z0-9]+(_[BP]_[a-z0-9]+){0,1}\./id./g;
+$data =~ s/sqlx_[a-z0-9]+_[a-z0-9]+_/sqlx_nnnn_nnnn_/g;
+$data =~ s/sqlx-[a-z0-9]+_[a-z0-9]+/sqlx-nnnn_nnnn/g;
+$data =~ s/#p#/#P#/g;
+$data =~ s/#sp#/#SP#/g;
+$data =~ s/#tmp#/#TMP#/g;
+
+write_file($filename, $data);
+
+sub read_file {
+    my ($filename) = @_;
+
+    open my $in, '<', $filename or die "Could not open '$filename' for reading $!";
+    undef $/;
+    my $all = <$in>;
+    close $in;
+
+    return $all;
+}
+
+sub write_file {
+    my ($filename, $content) = @_;
+
+    open my $out, '>', $filename or die "Could not open '$filename' for writing $!";;
+    print $out $content;
+    close $out;
+
+    return;
+}
+
+EOF

--- a/mysql-test/suite/parts/inc/partition_crash.inc
+++ b/mysql-test/suite/parts/inc/partition_crash.inc
@@ -3,7 +3,7 @@
 --eval $create_statement
 --eval $insert_statement
 --echo # State before crash
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -14,14 +14,14 @@ SELECT * FROM t1;
 --error 2013
 --eval $crash_statement
 --echo # State after crash (before recovery)
---replace_regex /sqlx.*\./sqlx-nnnn_nnnn./ /#p#/#P#/ /#sp#/#SP#/ /#tmp#/#TMP#/
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --enable_reconnect
 let $WAIT_COUNT=6000;
 --source include/wait_time_until_connected_again.inc
 --echo # State after crash recovery
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result

--- a/mysql-test/suite/parts/inc/partition_fail.inc
+++ b/mysql-test/suite/parts/inc/partition_fail.inc
@@ -3,7 +3,7 @@
 --eval $create_statement
 --eval $insert_statement
 --echo # State before failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -12,7 +12,7 @@ SELECT * FROM t1;
 --eval $fail_statement
 --enable_abort_on_error
 --echo # State after failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -23,7 +23,7 @@ DROP TABLE t1;
 --eval $create_statement
 --eval $insert_statement
 --echo # State before failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -33,7 +33,7 @@ LOCK TABLE t1 WRITE;
 --eval $fail_statement
 --enable_abort_on_error
 --echo # State after failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result

--- a/mysql-test/suite/parts/inc/partition_fail_t2.inc
+++ b/mysql-test/suite/parts/inc/partition_fail_t2.inc
@@ -8,7 +8,7 @@ SELECT * FROM t2;
 --eval $create_statement
 --eval $insert_statement
 --echo # State before failure
---replace_result #p# #P#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -19,7 +19,7 @@ SELECT * FROM t1;
 --eval $fail_statement
 --enable_abort_on_error
 --echo # State after failure
---replace_result #p# #P#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result

--- a/mysql-test/suite/parts/inc/partition_layout.inc
+++ b/mysql-test/suite/parts/inc/partition_layout.inc
@@ -10,6 +10,7 @@ eval SHOW CREATE TABLE t1;
 if ($ls)
 {
    let $MYSQLD_DATADIR= `select @@datadir`;
-   --replace_result $MYSQLD_DATADIR MYSQLD_DATADIR #p# #P# #sp# #SP#
+   --let $ADDITIONAL_REGEX="/$MYSQLD_DATADIR/MYSQLD_DATADIR/"
+   --source include/table_files_replace_pattern.inc
    --list_files $MYSQLD_DATADIR/test t1*
 }

--- a/mysql-test/suite/parts/inc/partition_layout_check1.inc
+++ b/mysql-test/suite/parts/inc/partition_layout_check1.inc
@@ -44,6 +44,10 @@ if ($do_file_tests)
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-data-dir t1*
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-idx-dir t1*
   }
+
+  --let TABLE_FILES_REPLACE_FILE=$ls_file
+  --source include/table_files_replace_pattern_in_file.inc
+
   eval SET @aux = load_file('$ls_file');
 
   # clean up
@@ -69,7 +73,6 @@ if ($do_file_tests)
    if ($ls)
    {
       # Print the list of files into the protocol
-      replace_result $MYSQLD_DATADIR MYSQLD_DATADIR $MYSQLTEST_VARDIR MYSQLTEST_VARDIR #p# #P# #sp# #SP# part_n part_N;
       SELECT file_list AS "unified filelist"
        FROM t0_definition WHERE state = 'old';
    }

--- a/mysql-test/suite/parts/inc/partition_layout_check2.inc
+++ b/mysql-test/suite/parts/inc/partition_layout_check2.inc
@@ -42,6 +42,10 @@ if ($do_file_tests)
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-data-dir t1*
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-idx-dir t1*
   }
+
+  --let TABLE_FILES_REPLACE_FILE=$ls_file
+  --source include/table_files_replace_pattern_in_file.inc
+
   eval SET @aux = load_file('$ls_file');
 
   # clean up
@@ -67,7 +71,6 @@ let $run= `SELECT @aux`;
 if ($run)
 {
    --vertical_results
-   --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR #p# #P# #sp# #SP#
    SELECT state,
    REPLACE(create_command,'\n',' ') AS "Table definition",
    REPLACE(file_list     ,'\n',' ') AS "File list"

--- a/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb.test
@@ -56,7 +56,7 @@ partition by range (a)
 insert into t1 values (1), (11), (21), (33);
 SELECT * FROM t1;
 SHOW CREATE TABLE t1;
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $MYSQLD_DATADIR/test
 
 SET DEBUG_SYNC='before_open_in_get_all_tables SIGNAL parked WAIT_FOR open';
@@ -82,7 +82,7 @@ ALTER TABLE t1 REORGANIZE PARTITION p0 INTO
 disconnect con1;
 connection default;
 --reap
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $MYSQLD_DATADIR/test
 SHOW CREATE TABLE t1;
 SELECT * FROM t1;

--- a/mysql-test/suite/tokudb/r/dir-per-db-with-custom-data-dir.result
+++ b/mysql-test/suite/tokudb/r/dir-per-db-with-custom-data-dir.result
@@ -1,0 +1,10 @@
+SELECT @@tokudb_dir_per_db;
+@@tokudb_dir_per_db
+1
+TOKUDB_DATA_DIR_CHANGED
+1
+CREATE DATABASE tokudb_test;
+USE tokudb_test;
+CREATE TABLE t (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=tokudb;
+DROP TABLE t;
+DROP DATABASE tokudb_test;

--- a/mysql-test/suite/tokudb/r/dir_per_db.result
+++ b/mysql-test/suite/tokudb/r/dir_per_db.result
@@ -1,0 +1,180 @@
+########
+#  tokudb_dir_per_db = 1
+########
+SET GLOBAL tokudb_dir_per_db= 1;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_key_ab_id.tokudb
+t1_key_b_id.tokudb
+t1_main_id.tokudb
+t1_status_id.tokudb
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t2_key_ab_id.tokudb
+t2_key_b_id.tokudb
+t2_main_id.tokudb
+t2_status_id.tokudb
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+########
+#  tokudb_dir_per_db = 0
+########
+SET GLOBAL tokudb_dir_per_db= 0;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+_test_t1_key_ab_id.tokudb
+_test_t1_key_b_id.tokudb
+_test_t1_main_id.tokudb
+_test_t1_status_id.tokudb
+## Looking for *.tokudb files in data_dir/test
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+_test_t1_key_ab_id.tokudb
+_test_t1_key_b_id.tokudb
+_test_t1_main_id.tokudb
+_test_t1_status_id.tokudb
+## Looking for *.tokudb files in data_dir/test
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+########
+#  CREATE on tokudb_dir_per_db = 0 and RENAME on tokudb_dir_per_db = 1 and vice versa
+########
+########
+#  tokudb_dir_per_db = (1 - 1);
+########
+SET GLOBAL tokudb_dir_per_db= (1 - 1);;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+_test_t1_key_ab_id.tokudb
+_test_t1_key_b_id.tokudb
+_test_t1_main_id.tokudb
+_test_t1_status_id.tokudb
+## Looking for *.tokudb files in data_dir/test
+########
+#  tokudb_dir_per_db = 1
+########
+SET GLOBAL tokudb_dir_per_db= 1;
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t2_key_ab_id.tokudb
+t2_key_b_id.tokudb
+t2_main_id.tokudb
+t2_status_id.tokudb
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+########
+#  tokudb_dir_per_db = (1 - 0);
+########
+SET GLOBAL tokudb_dir_per_db= (1 - 0);;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_key_ab_id.tokudb
+t1_key_b_id.tokudb
+t1_main_id.tokudb
+t1_status_id.tokudb
+########
+#  tokudb_dir_per_db = 0
+########
+SET GLOBAL tokudb_dir_per_db= 0;
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_key_ab_id.tokudb
+t1_key_b_id.tokudb
+t1_main_id.tokudb
+t1_status_id.tokudb
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+SET GLOBAL tokudb_dir_per_db=default;

--- a/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir-master.opt
+++ b/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir-master.opt
@@ -1,0 +1,1 @@
+--tokudb_data_dir="$MYSQL_TMP_DIR" --tokudb-dir-per-db=1

--- a/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir.test
+++ b/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir.test
@@ -1,0 +1,16 @@
+--source include/have_tokudb.inc
+
+SELECT @@tokudb_dir_per_db;
+
+--disable_query_log
+--eval SELECT STRCMP(@@tokudb_data_dir, '$MYSQL_TMP_DIR') = 0 AS TOKUDB_DATA_DIR_CHANGED
+--enable_query_log
+
+CREATE DATABASE tokudb_test;
+USE tokudb_test;
+CREATE TABLE t (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=tokudb;
+
+--file_exists $MYSQL_TMP_DIR/tokudb_test
+
+DROP TABLE t;
+DROP DATABASE tokudb_test;

--- a/mysql-test/suite/tokudb/t/dir_per_db.test
+++ b/mysql-test/suite/tokudb/t/dir_per_db.test
@@ -1,0 +1,76 @@
+source include/have_tokudb.inc;
+
+--let $DB= test
+--let $DATADIR= `select @@datadir`
+--let $i= 2
+
+while ($i) {
+  --dec $i
+  --echo ########
+  --echo #  tokudb_dir_per_db = $i
+  --echo ########
+  --eval SET GLOBAL tokudb_dir_per_db= $i
+  --echo ########
+  --echo #  CREATE
+  --echo ########
+  CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+  INSERT INTO t1 SET b = 10;
+  INSERT INTO t1 SET b = 20;
+  SELECT b FROM t1 ORDER BY a;
+  CREATE INDEX b ON t1 (b);
+  CREATE INDEX ab ON t1 (a,b);
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  RENAME
+  --echo ########
+  RENAME TABLE t1 TO t2;
+  SELECT b FROM t2 ORDER BY a;
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  DROP
+  --echo ########
+  DROP TABLE t2;
+  --source dir_per_db_show_table_files.inc
+}
+
+--echo ########
+--echo #  CREATE on tokudb_dir_per_db = 0 and RENAME on tokudb_dir_per_db = 1 and vice versa
+--echo ########
+
+--let $i= 2
+
+while ($i) {
+  --dec $i
+  --let $inv_i= (1 - $i);
+  --echo ########
+  --echo #  tokudb_dir_per_db = $inv_i
+  --echo ########
+  --eval SET GLOBAL tokudb_dir_per_db= $inv_i
+  --echo ########
+  --echo #  CREATE
+  --echo ########
+  CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+  INSERT INTO t1 SET b = 10;
+  INSERT INTO t1 SET b = 20;
+  SELECT b FROM t1 ORDER BY a;
+  CREATE INDEX b ON t1 (b);
+  CREATE INDEX ab ON t1 (a,b);
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  tokudb_dir_per_db = $i
+  --echo ########
+  --eval SET GLOBAL tokudb_dir_per_db= $i
+  --echo ########
+  --echo #  RENAME
+  --echo ########
+  RENAME TABLE t1 TO t2;
+  SELECT b FROM t2 ORDER BY a;
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  DROP
+  --echo ########
+  DROP TABLE t2;
+  --source dir_per_db_show_table_files.inc
+}
+
+SET GLOBAL tokudb_dir_per_db=default;

--- a/mysql-test/suite/tokudb/t/dir_per_db_show_table_files.inc
+++ b/mysql-test/suite/tokudb/t/dir_per_db_show_table_files.inc
@@ -1,0 +1,9 @@
+--sorted_result
+
+--echo ## Looking for *.tokudb files in data_dir
+--source include/table_files_replace_pattern.inc
+--list_files $DATADIR *.tokudb
+
+--echo ## Looking for *.tokudb files in data_dir/$DB
+--source include/table_files_replace_pattern.inc
+--list_files $DATADIR/$DB/ *.tokudb

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -535,6 +535,7 @@ static int tokudb_init_func(void *p) {
     db_env->change_fsync_log_period(db_env, tokudb::sysvars::fsync_log_period);
 
     db_env->set_lock_timeout_callback(db_env, tokudb_lock_timeout_callback);
+    db_env->set_dir_per_db(db_env, tokudb::sysvars::dir_per_db);
 
     db_env->set_loader_memory_size(
         db_env,

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -66,6 +66,7 @@ uint        read_status_frequency = 0;
 my_bool     strip_frm_data = FALSE;
 char*       tmp_dir = NULL;
 uint        write_status_frequency = 0;
+my_bool     dir_per_db = FALSE;
 char*       version = (char*) TOKUDB_VERSION_STR;
 
 // file system reserve as a percentage of total disk space
@@ -395,6 +396,18 @@ static MYSQL_SYSVAR_UINT(
     0,
     ~0U,
     0);
+
+static void tokudb_dir_per_db_update(THD* thd,
+                                     struct st_mysql_sys_var* sys_var,
+                                     void* var, const void* save) {
+    my_bool *value = (my_bool *) var;
+    *value = *(const my_bool *) save;
+    db_env->set_dir_per_db(db_env, *value);
+}
+
+static MYSQL_SYSVAR_BOOL(dir_per_db, dir_per_db,
+    0, "TokuDB store ft files in db directories",
+    NULL, tokudb_dir_per_db_update, FALSE);
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL
 static MYSQL_SYSVAR_STR(
@@ -909,6 +922,7 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(tmp_dir),
     MYSQL_SYSVAR(version),
     MYSQL_SYSVAR(write_status_frequency),
+    MYSQL_SYSVAR(dir_per_db),
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL
     MYSQL_SYSVAR(gdb_path),

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -81,6 +81,7 @@ extern uint         read_status_frequency;
 extern my_bool      strip_frm_data;
 extern char*        tmp_dir;
 extern uint         write_status_frequency;
+extern my_bool      dir_per_db;
 extern char*        version;
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL


### PR DESCRIPTION
The option is off by default. If this option is on then newly created or
renamed tokudb table files will be placed into directories which correspond
to database names in data directory otherwise the files will be in root
data directory.

Some table can be converted from one directory layout to another with "rename"
operation. When some table is renamed the table files will be renamed into
directory layout which corresponds to tokudb_dir_per_db option.

http://jenkins.percona.com/job/percona-server-5.6-param/1142
