### PR TITLE
Tokudb dir per db 5.7 gca

### DIFF
--- a/mysql-test/include/table_files_replace_pattern.inc
+++ b/mysql-test/include/table_files_replace_pattern.inc
@@ -1,0 +1,1 @@
+--replace_regex  /[a-z0-9]+_[a-z0-9]+_[a-z0-9]+(_[BP]_[a-z0-9]+){0,1}\./id./ /sqlx_[a-z0-9]+_[a-z0-9]+_/sqlx_nnnn_nnnn_/ /sqlx-[a-z0-9]+_[a-z0-9]+/sqlx-nnnn_nnnn/ /#p#/#P#/ /#sp#/#SP#/ /#tmp#/#TMP#/ $ADDITIONAL_REGEX

--- a/mysql-test/include/table_files_replace_pattern_in_file.inc
+++ b/mysql-test/include/table_files_replace_pattern_in_file.inc
@@ -1,0 +1,36 @@
+--perl
+
+my $filename = $ENV{'TABLE_FILES_REPLACE_FILE'};
+my $data = read_file($filename);
+
+$data =~ s/[a-z0-9]+_[a-z0-9]+_[a-z0-9]+(_[BP]_[a-z0-9]+){0,1}\./id./g;
+$data =~ s/sqlx_[a-z0-9]+_[a-z0-9]+_/sqlx_nnnn_nnnn_/g;
+$data =~ s/sqlx-[a-z0-9]+_[a-z0-9]+/sqlx-nnnn_nnnn/g;
+$data =~ s/#p#/#P#/g;
+$data =~ s/#sp#/#SP#/g;
+$data =~ s/#tmp#/#TMP#/g;
+
+write_file($filename, $data);
+
+sub read_file {
+    my ($filename) = @_;
+
+    open my $in, '<', $filename or die "Could not open '$filename' for reading $!";
+    undef $/;
+    my $all = <$in>;
+    close $in;
+
+    return $all;
+}
+
+sub write_file {
+    my ($filename, $content) = @_;
+
+    open my $out, '>', $filename or die "Could not open '$filename' for writing $!";;
+    print $out $content;
+    close $out;
+
+    return;
+}
+
+EOF

--- a/mysql-test/suite/parts/inc/partition_crash.inc
+++ b/mysql-test/suite/parts/inc/partition_crash.inc
@@ -3,7 +3,7 @@
 --eval $create_statement
 --eval $insert_statement
 --echo # State before crash
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -14,14 +14,14 @@ SELECT * FROM t1;
 --error 2013
 --eval $crash_statement
 --echo # State after crash (before recovery)
---replace_regex /sqlx.*\./sqlx-nnnn_nnnn./ /#p#/#P#/ /#sp#/#SP#/ /#tmp#/#TMP#/
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --enable_reconnect
 let $WAIT_COUNT=6000;
 --source include/wait_time_until_connected_again.inc
 --echo # State after crash recovery
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result

--- a/mysql-test/suite/parts/inc/partition_fail.inc
+++ b/mysql-test/suite/parts/inc/partition_fail.inc
@@ -3,7 +3,7 @@
 --eval $create_statement
 --eval $insert_statement
 --echo # State before failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -12,7 +12,7 @@ SELECT * FROM t1;
 --eval $fail_statement
 --enable_abort_on_error
 --echo # State after failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -23,7 +23,7 @@ DROP TABLE t1;
 --eval $create_statement
 --eval $insert_statement
 --echo # State before failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -33,7 +33,7 @@ LOCK TABLE t1 WRITE;
 --eval $fail_statement
 --enable_abort_on_error
 --echo # State after failure
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result

--- a/mysql-test/suite/parts/inc/partition_fail_t2.inc
+++ b/mysql-test/suite/parts/inc/partition_fail_t2.inc
@@ -8,7 +8,7 @@ SELECT * FROM t2;
 --eval $create_statement
 --eval $insert_statement
 --echo # State before failure
---replace_result #p# #P#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -19,7 +19,7 @@ SELECT * FROM t1;
 --eval $fail_statement
 --enable_abort_on_error
 --echo # State after failure
---replace_result #p# #P#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result

--- a/mysql-test/suite/parts/inc/partition_layout.inc
+++ b/mysql-test/suite/parts/inc/partition_layout.inc
@@ -10,6 +10,7 @@ eval SHOW CREATE TABLE t1;
 if ($ls)
 {
    let $MYSQLD_DATADIR= `select @@datadir`;
-   --replace_result $MYSQLD_DATADIR MYSQLD_DATADIR #p# #P# #sp# #SP#
+   --let $ADDITIONAL_REGEX="/$MYSQLD_DATADIR/MYSQLD_DATADIR/"
+   --source include/table_files_replace_pattern.inc
    --list_files $MYSQLD_DATADIR/test t1*
 }

--- a/mysql-test/suite/parts/inc/partition_layout_check1.inc
+++ b/mysql-test/suite/parts/inc/partition_layout_check1.inc
@@ -44,6 +44,10 @@ if ($do_file_tests)
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-data-dir t1*
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-idx-dir t1*
   }
+
+  --let TABLE_FILES_REPLACE_FILE=$ls_file
+  --source include/table_files_replace_pattern_in_file.inc
+
   eval SET @aux = load_file('$ls_file');
 
   # clean up
@@ -69,7 +73,6 @@ if ($do_file_tests)
    if ($ls)
    {
       # Print the list of files into the protocol
-      replace_result $MYSQLD_DATADIR MYSQLD_DATADIR $MYSQLTEST_VARDIR MYSQLTEST_VARDIR #p# #P# #sp# #SP# part_n part_N;
       SELECT file_list AS "unified filelist"
        FROM t0_definition WHERE state = 'old';
    }

--- a/mysql-test/suite/parts/inc/partition_layout_check2.inc
+++ b/mysql-test/suite/parts/inc/partition_layout_check2.inc
@@ -42,6 +42,10 @@ if ($do_file_tests)
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-data-dir t1*
     --list_files_append_file $ls_file $MYSQLTEST_VARDIR/mysql-test-idx-dir t1*
   }
+
+  --let TABLE_FILES_REPLACE_FILE=$ls_file
+  --source include/table_files_replace_pattern_in_file.inc
+
   eval SET @aux = load_file('$ls_file');
 
   # clean up
@@ -67,7 +71,6 @@ let $run= `SELECT @aux`;
 if ($run)
 {
    --vertical_results
-   --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR #p# #P# #sp# #SP#
    SELECT state,
    REPLACE(create_command,'\n',' ') AS "Table definition",
    REPLACE(file_list     ,'\n',' ') AS "File list"

--- a/mysql-test/suite/parts/inc/partition_mgm_crash.inc
+++ b/mysql-test/suite/parts/inc/partition_mgm_crash.inc
@@ -26,14 +26,14 @@ let $crash_statement= ALTER TABLE t1 ADD PARTITION
 --eval $create_statement
 --eval $insert_statement
 --echo # State before statement
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
 SELECT * FROM t1;
 --eval $crash_statement
 --echo # State after statement
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
@@ -57,14 +57,14 @@ let $crash_statement= ALTER TABLE t1 REORGANIZE PARTITION p10 INTO
 --eval $create_statement
 --eval $insert_statement
 --echo # State before statement
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result
 SELECT * FROM t1;
 --eval $crash_statement
 --echo # State after statement
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $DATADIR/test
 SHOW CREATE TABLE t1;
 --sorted_result

--- a/mysql-test/suite/tokudb.parts/r/partition_alter3_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_alter3_tokudb.result
@@ -59,6 +59,8 @@ t1	CREATE TABLE `t1` (
   `f_varchar` varchar(30) DEFAULT NULL
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
+t1_main_id.tokudb
+t1_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -85,6 +87,8 @@ t1	CREATE TABLE `t1` (
 /*!50100 PARTITION BY HASH (YEAR(f_date)) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -106,6 +110,8 @@ t1	CREATE TABLE `t1` (
 /*!50100 PARTITION BY HASH (DAYOFYEAR(f_date)) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -125,6 +131,8 @@ t1	CREATE TABLE `t1` (
 /*!50100 PARTITION BY HASH (YEAR(f_date)) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -153,6 +161,12 @@ t1	CREATE TABLE `t1` (
  PARTITION part7 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	part1	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
@@ -180,6 +194,14 @@ t1	CREATE TABLE `t1` (
  PARTITION part2 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
@@ -208,6 +230,22 @@ t1	CREATE TABLE `t1` (
  PARTITION p7 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_p5_main_id.tokudb
+t1_P_p5_status_id.tokudb
+t1_P_p6_main_id.tokudb
+t1_P_p6_status_id.tokudb
+t1_P_p7_main_id.tokudb
+t1_P_p7_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
@@ -247,6 +285,20 @@ t1	CREATE TABLE `t1` (
  PARTITION p6 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_p5_main_id.tokudb
+t1_P_p5_status_id.tokudb
+t1_P_p6_main_id.tokudb
+t1_P_p6_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p6	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
@@ -272,6 +324,18 @@ t1	CREATE TABLE `t1` (
  PARTITION p5 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_p5_main_id.tokudb
+t1_P_p5_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p4	ALL	NULL	NULL	NULL	NULL	4	25.00	Using where
@@ -296,6 +360,16 @@ t1	CREATE TABLE `t1` (
  PARTITION p4 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	4	25.00	Using where
@@ -319,6 +393,14 @@ t1	CREATE TABLE `t1` (
  PARTITION part2 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
@@ -341,6 +423,12 @@ t1	CREATE TABLE `t1` (
  PARTITION part7 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	part1	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
@@ -362,6 +450,10 @@ t1	CREATE TABLE `t1` (
  PARTITION part1 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	10	10.00	Using where
@@ -382,6 +474,8 @@ t1	CREATE TABLE `t1` (
 (PARTITION p0 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -403,6 +497,8 @@ t1	CREATE TABLE `t1` (
   `f_varchar` varchar(30) DEFAULT NULL
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
+t1_main_id.tokudb
+t1_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) FROM t1 WHERE f_date = '1000-02-10';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -446,6 +542,8 @@ t1	CREATE TABLE `t1` (
   `f_charbig` varchar(1000) DEFAULT NULL
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
+t1_main_id.tokudb
+t1_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -473,6 +571,8 @@ t1	CREATE TABLE `t1` (
 /*!50100 PARTITION BY KEY (f_int1) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -504,6 +604,12 @@ t1	CREATE TABLE `t1` (
  PARTITION part7 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
@@ -531,6 +637,14 @@ t1	CREATE TABLE `t1` (
  PARTITION part2 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
@@ -562,6 +676,22 @@ t1	CREATE TABLE `t1` (
  PARTITION p7 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_p5_main_id.tokudb
+t1_P_p5_status_id.tokudb
+t1_P_p6_main_id.tokudb
+t1_P_p6_status_id.tokudb
+t1_P_p7_main_id.tokudb
+t1_P_p7_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p6	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
@@ -599,6 +729,20 @@ t1	CREATE TABLE `t1` (
  PARTITION p6 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_p5_main_id.tokudb
+t1_P_p5_status_id.tokudb
+t1_P_p6_main_id.tokudb
+t1_P_p6_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	4	25.00	Using where
@@ -627,6 +771,18 @@ t1	CREATE TABLE `t1` (
  PARTITION p5 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_p5_main_id.tokudb
+t1_P_p5_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	3	33.33	Using where
@@ -654,6 +810,16 @@ t1	CREATE TABLE `t1` (
  PARTITION p4 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p4	ALL	NULL	NULL	NULL	NULL	10	10.00	Using where
@@ -680,6 +846,14 @@ t1	CREATE TABLE `t1` (
  PARTITION part2 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	5	20.00	Using where
@@ -705,6 +879,12 @@ t1	CREATE TABLE `t1` (
  PARTITION part7 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part7_main_id.tokudb
+t1_P_part7_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	part7	ALL	NULL	NULL	NULL	NULL	7	14.29	Using where
@@ -729,6 +909,10 @@ t1	CREATE TABLE `t1` (
  PARTITION part1 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	10	10.00	Using where
@@ -752,6 +936,8 @@ t1	CREATE TABLE `t1` (
 (PARTITION p0 ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	p0	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where
@@ -776,6 +962,8 @@ t1	CREATE TABLE `t1` (
   `f_charbig` varchar(1000) DEFAULT NULL
 ) ENGINE=TokuDB DEFAULT CHARSET=latin1
 t1.frm
+t1_main_id.tokudb
+t1_status_id.tokudb
 EXPLAIN PARTITIONS SELECT COUNT(*) <> 1 FROM t1 WHERE f_int1 = 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	20	10.00	Using where

--- a/mysql-test/suite/tokudb.parts/r/partition_basic_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_basic_tokudb.result
@@ -81,6 +81,10 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -540,6 +544,16 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -1014,6 +1028,22 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -1484,6 +1514,18 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -1950,6 +1992,22 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -2429,6 +2487,22 @@ SUBPARTITION BY KEY (f_int1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -2910,6 +2984,22 @@ SUBPARTITION BY HASH (f_int1 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -3377,6 +3467,24 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -3838,6 +3946,10 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -4297,6 +4409,16 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -4771,6 +4893,22 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -5241,6 +5379,18 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -5707,6 +5857,22 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -6184,6 +6350,22 @@ SUBPARTITION BY KEY (f_int2)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -6661,6 +6843,22 @@ SUBPARTITION BY HASH (f_int2 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -7128,6 +7326,24 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -7595,6 +7811,12 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -8091,6 +8313,21 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_key_uidx1_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_key_uidx1_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_key_uidx1_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -8602,6 +8839,30 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_key_uidx1_id.tokudb
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_key_uidx1_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_key_uidx1_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_key_uidx1_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_key_uidx1_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_key_uidx1_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_key_uidx1_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_key_uidx1_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -9109,6 +9370,24 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_key_uidx1_id.tokudb
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_key_uidx1_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_key_uidx1_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_key_uidx1_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_key_uidx1_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_key_uidx1_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -9612,6 +9891,30 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -10128,6 +10431,30 @@ SUBPARTITION BY KEY (f_int1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -10646,6 +10973,30 @@ SUBPARTITION BY HASH (f_int1 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_key_uidx1_id.tokudb
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_key_uidx1_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_key_uidx1_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_key_uidx1_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_key_uidx1_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_key_uidx1_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_key_uidx1_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_key_uidx1_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -11150,6 +11501,33 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -11647,6 +12025,12 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -12143,6 +12527,21 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_key_uidx1_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_key_uidx1_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_key_uidx1_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -12654,6 +13053,30 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_key_uidx1_id.tokudb
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_key_uidx1_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_key_uidx1_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_key_uidx1_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_key_uidx1_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_key_uidx1_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_key_uidx1_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_key_uidx1_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -13161,6 +13584,24 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_key_uidx1_id.tokudb
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_key_uidx1_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_key_uidx1_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_key_uidx1_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_key_uidx1_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_key_uidx1_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -13664,6 +14105,30 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -14180,6 +14645,30 @@ SUBPARTITION BY KEY (f_int1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -14698,6 +15187,30 @@ SUBPARTITION BY HASH (f_int1 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_key_uidx1_id.tokudb
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_key_uidx1_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_key_uidx1_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_key_uidx1_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_key_uidx1_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_key_uidx1_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_key_uidx1_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_key_uidx1_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -15202,6 +15715,33 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -15699,6 +16239,14 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_key_uidx2_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_key_uidx2_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -16211,6 +16759,26 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_key_uidx2_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_key_uidx2_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_key_uidx1_id.tokudb
+t1_P_p2_key_uidx2_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_key_uidx1_id.tokudb
+t1_P_p3_key_uidx2_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_key_uidx1_id.tokudb
+t1_P_p4_key_uidx2_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -16738,6 +17306,38 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_key_uidx1_id.tokudb
+t1_P_part0_key_uidx2_id.tokudb
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_key_uidx1_id.tokudb
+t1_P_part1_key_uidx2_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_key_uidx1_id.tokudb
+t1_P_part2_key_uidx2_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_key_uidx1_id.tokudb
+t1_P_part3_key_uidx2_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_key_uidx1_id.tokudb
+t1_P_part_1_key_uidx2_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_key_uidx1_id.tokudb
+t1_P_part_2_key_uidx2_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_key_uidx1_id.tokudb
+t1_P_part_3_key_uidx2_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_key_uidx1_id.tokudb
+t1_P_part_N_key_uidx2_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -17261,6 +17861,30 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_key_uidx1_id.tokudb
+t1_P_parta_key_uidx2_id.tokudb
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_key_uidx1_id.tokudb
+t1_P_partb_key_uidx2_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_key_uidx1_id.tokudb
+t1_P_partc_key_uidx2_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_key_uidx1_id.tokudb
+t1_P_partd_key_uidx2_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_key_uidx1_id.tokudb
+t1_P_parte_key_uidx2_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_key_uidx1_id.tokudb
+t1_P_partf_key_uidx2_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -17780,6 +18404,38 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp0_key_uidx2_id.tokudb
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx2_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx2_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx2_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx2_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx2_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx2_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx2_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -18312,6 +18968,38 @@ SUBPARTITION BY KEY (f_int1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart11_key_uidx2_id.tokudb
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx2_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx2_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx2_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx2_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx2_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx2_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx2_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -18846,6 +19534,38 @@ SUBPARTITION BY HASH (f_int1 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_key_uidx1_id.tokudb
+t1_P_part1_SP_sp11_key_uidx2_id.tokudb
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_key_uidx1_id.tokudb
+t1_P_part1_SP_sp12_key_uidx2_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_key_uidx1_id.tokudb
+t1_P_part2_SP_sp21_key_uidx2_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_key_uidx1_id.tokudb
+t1_P_part2_SP_sp22_key_uidx2_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_key_uidx1_id.tokudb
+t1_P_part3_SP_sp31_key_uidx2_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_key_uidx1_id.tokudb
+t1_P_part3_SP_sp32_key_uidx2_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_key_uidx1_id.tokudb
+t1_P_part4_SP_sp41_key_uidx2_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_key_uidx1_id.tokudb
+t1_P_part4_SP_sp42_key_uidx2_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -19366,6 +20086,42 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp0_key_uidx2_id.tokudb
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx2_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx2_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx2_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx2_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx2_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx2_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx2_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx2_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -19884,6 +20640,12 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -20380,6 +21142,21 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_key_uidx1_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_key_uidx1_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_key_uidx1_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -20891,6 +21668,30 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_key_uidx1_id.tokudb
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_key_uidx1_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_key_uidx1_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_key_uidx1_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_key_uidx1_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_key_uidx1_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_key_uidx1_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_key_uidx1_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -21398,6 +22199,24 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_key_uidx1_id.tokudb
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_key_uidx1_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_key_uidx1_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_key_uidx1_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_key_uidx1_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_key_uidx1_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -21901,6 +22720,30 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -22415,6 +23258,30 @@ SUBPARTITION BY KEY (f_int2)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -22929,6 +23796,30 @@ SUBPARTITION BY HASH (f_int2 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_key_uidx1_id.tokudb
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_key_uidx1_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_key_uidx1_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_key_uidx1_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_key_uidx1_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_key_uidx1_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_key_uidx1_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_key_uidx1_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -23433,6 +24324,33 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -23930,6 +24848,12 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -24426,6 +25350,21 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_key_uidx1_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_key_uidx1_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_key_uidx1_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -24937,6 +25876,30 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_key_uidx1_id.tokudb
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_key_uidx1_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_key_uidx1_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_key_uidx1_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_key_uidx1_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_key_uidx1_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_key_uidx1_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_key_uidx1_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -25444,6 +26407,24 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_key_uidx1_id.tokudb
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_key_uidx1_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_key_uidx1_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_key_uidx1_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_key_uidx1_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_key_uidx1_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -25947,6 +26928,30 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -26461,6 +27466,30 @@ SUBPARTITION BY KEY (f_int2)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -26975,6 +28004,30 @@ SUBPARTITION BY HASH (f_int2 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_key_uidx1_id.tokudb
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_key_uidx1_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_key_uidx1_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_key_uidx1_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_key_uidx1_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_key_uidx1_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_key_uidx1_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_key_uidx1_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -27479,6 +28532,33 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -27976,6 +29056,14 @@ PARTITIONS 2 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_key_uidx2_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_key_uidx2_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -28488,6 +29576,26 @@ PARTITIONS 5 */
 unified filelist
 t1.frm
 t1.par
+t1_P_p0_key_uidx1_id.tokudb
+t1_P_p0_key_uidx2_id.tokudb
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_key_uidx1_id.tokudb
+t1_P_p1_key_uidx2_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
+t1_P_p2_key_uidx1_id.tokudb
+t1_P_p2_key_uidx2_id.tokudb
+t1_P_p2_main_id.tokudb
+t1_P_p2_status_id.tokudb
+t1_P_p3_key_uidx1_id.tokudb
+t1_P_p3_key_uidx2_id.tokudb
+t1_P_p3_main_id.tokudb
+t1_P_p3_status_id.tokudb
+t1_P_p4_key_uidx1_id.tokudb
+t1_P_p4_key_uidx2_id.tokudb
+t1_P_p4_main_id.tokudb
+t1_P_p4_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -29015,6 +30123,38 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_part0_key_uidx1_id.tokudb
+t1_P_part0_key_uidx2_id.tokudb
+t1_P_part0_main_id.tokudb
+t1_P_part0_status_id.tokudb
+t1_P_part1_key_uidx1_id.tokudb
+t1_P_part1_key_uidx2_id.tokudb
+t1_P_part1_main_id.tokudb
+t1_P_part1_status_id.tokudb
+t1_P_part2_key_uidx1_id.tokudb
+t1_P_part2_key_uidx2_id.tokudb
+t1_P_part2_main_id.tokudb
+t1_P_part2_status_id.tokudb
+t1_P_part3_key_uidx1_id.tokudb
+t1_P_part3_key_uidx2_id.tokudb
+t1_P_part3_main_id.tokudb
+t1_P_part3_status_id.tokudb
+t1_P_part_1_key_uidx1_id.tokudb
+t1_P_part_1_key_uidx2_id.tokudb
+t1_P_part_1_main_id.tokudb
+t1_P_part_1_status_id.tokudb
+t1_P_part_2_key_uidx1_id.tokudb
+t1_P_part_2_key_uidx2_id.tokudb
+t1_P_part_2_main_id.tokudb
+t1_P_part_2_status_id.tokudb
+t1_P_part_3_key_uidx1_id.tokudb
+t1_P_part_3_key_uidx2_id.tokudb
+t1_P_part_3_main_id.tokudb
+t1_P_part_3_status_id.tokudb
+t1_P_part_N_key_uidx1_id.tokudb
+t1_P_part_N_key_uidx2_id.tokudb
+t1_P_part_N_main_id.tokudb
+t1_P_part_N_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -29538,6 +30678,30 @@ t1	CREATE TABLE `t1` (
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_key_uidx1_id.tokudb
+t1_P_parta_key_uidx2_id.tokudb
+t1_P_parta_main_id.tokudb
+t1_P_parta_status_id.tokudb
+t1_P_partb_key_uidx1_id.tokudb
+t1_P_partb_key_uidx2_id.tokudb
+t1_P_partb_main_id.tokudb
+t1_P_partb_status_id.tokudb
+t1_P_partc_key_uidx1_id.tokudb
+t1_P_partc_key_uidx2_id.tokudb
+t1_P_partc_main_id.tokudb
+t1_P_partc_status_id.tokudb
+t1_P_partd_key_uidx1_id.tokudb
+t1_P_partd_key_uidx2_id.tokudb
+t1_P_partd_main_id.tokudb
+t1_P_partd_status_id.tokudb
+t1_P_parte_key_uidx1_id.tokudb
+t1_P_parte_key_uidx2_id.tokudb
+t1_P_parte_main_id.tokudb
+t1_P_parte_status_id.tokudb
+t1_P_partf_key_uidx1_id.tokudb
+t1_P_partf_key_uidx2_id.tokudb
+t1_P_partf_main_id.tokudb
+t1_P_partf_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -30057,6 +31221,38 @@ SUBPARTITIONS 2
 unified filelist
 t1.frm
 t1.par
+t1_P_parta_SP_partasp0_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp0_key_uidx2_id.tokudb
+t1_P_parta_SP_partasp0_main_id.tokudb
+t1_P_parta_SP_partasp0_status_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx1_id.tokudb
+t1_P_parta_SP_partasp1_key_uidx2_id.tokudb
+t1_P_parta_SP_partasp1_main_id.tokudb
+t1_P_parta_SP_partasp1_status_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp0_key_uidx2_id.tokudb
+t1_P_partb_SP_partbsp0_main_id.tokudb
+t1_P_partb_SP_partbsp0_status_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx1_id.tokudb
+t1_P_partb_SP_partbsp1_key_uidx2_id.tokudb
+t1_P_partb_SP_partbsp1_main_id.tokudb
+t1_P_partb_SP_partbsp1_status_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp0_key_uidx2_id.tokudb
+t1_P_partc_SP_partcsp0_main_id.tokudb
+t1_P_partc_SP_partcsp0_status_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx1_id.tokudb
+t1_P_partc_SP_partcsp1_key_uidx2_id.tokudb
+t1_P_partc_SP_partcsp1_main_id.tokudb
+t1_P_partc_SP_partcsp1_status_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp0_key_uidx2_id.tokudb
+t1_P_partd_SP_partdsp0_main_id.tokudb
+t1_P_partd_SP_partdsp0_status_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx1_id.tokudb
+t1_P_partd_SP_partdsp1_key_uidx2_id.tokudb
+t1_P_partd_SP_partdsp1_main_id.tokudb
+t1_P_partd_SP_partdsp1_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -30587,6 +31783,38 @@ SUBPARTITION BY KEY (f_int2)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_subpart11_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart11_key_uidx2_id.tokudb
+t1_P_part1_SP_subpart11_main_id.tokudb
+t1_P_part1_SP_subpart11_status_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx1_id.tokudb
+t1_P_part1_SP_subpart12_key_uidx2_id.tokudb
+t1_P_part1_SP_subpart12_main_id.tokudb
+t1_P_part1_SP_subpart12_status_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart21_key_uidx2_id.tokudb
+t1_P_part2_SP_subpart21_main_id.tokudb
+t1_P_part2_SP_subpart21_status_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx1_id.tokudb
+t1_P_part2_SP_subpart22_key_uidx2_id.tokudb
+t1_P_part2_SP_subpart22_main_id.tokudb
+t1_P_part2_SP_subpart22_status_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart31_key_uidx2_id.tokudb
+t1_P_part3_SP_subpart31_main_id.tokudb
+t1_P_part3_SP_subpart31_status_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx1_id.tokudb
+t1_P_part3_SP_subpart32_key_uidx2_id.tokudb
+t1_P_part3_SP_subpart32_main_id.tokudb
+t1_P_part3_SP_subpart32_status_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart41_key_uidx2_id.tokudb
+t1_P_part4_SP_subpart41_main_id.tokudb
+t1_P_part4_SP_subpart41_status_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx1_id.tokudb
+t1_P_part4_SP_subpart42_key_uidx2_id.tokudb
+t1_P_part4_SP_subpart42_main_id.tokudb
+t1_P_part4_SP_subpart42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -31117,6 +32345,38 @@ SUBPARTITION BY HASH (f_int2 + 1)
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_sp11_key_uidx1_id.tokudb
+t1_P_part1_SP_sp11_key_uidx2_id.tokudb
+t1_P_part1_SP_sp11_main_id.tokudb
+t1_P_part1_SP_sp11_status_id.tokudb
+t1_P_part1_SP_sp12_key_uidx1_id.tokudb
+t1_P_part1_SP_sp12_key_uidx2_id.tokudb
+t1_P_part1_SP_sp12_main_id.tokudb
+t1_P_part1_SP_sp12_status_id.tokudb
+t1_P_part2_SP_sp21_key_uidx1_id.tokudb
+t1_P_part2_SP_sp21_key_uidx2_id.tokudb
+t1_P_part2_SP_sp21_main_id.tokudb
+t1_P_part2_SP_sp21_status_id.tokudb
+t1_P_part2_SP_sp22_key_uidx1_id.tokudb
+t1_P_part2_SP_sp22_key_uidx2_id.tokudb
+t1_P_part2_SP_sp22_main_id.tokudb
+t1_P_part2_SP_sp22_status_id.tokudb
+t1_P_part3_SP_sp31_key_uidx1_id.tokudb
+t1_P_part3_SP_sp31_key_uidx2_id.tokudb
+t1_P_part3_SP_sp31_main_id.tokudb
+t1_P_part3_SP_sp31_status_id.tokudb
+t1_P_part3_SP_sp32_key_uidx1_id.tokudb
+t1_P_part3_SP_sp32_key_uidx2_id.tokudb
+t1_P_part3_SP_sp32_main_id.tokudb
+t1_P_part3_SP_sp32_status_id.tokudb
+t1_P_part4_SP_sp41_key_uidx1_id.tokudb
+t1_P_part4_SP_sp41_key_uidx2_id.tokudb
+t1_P_part4_SP_sp41_main_id.tokudb
+t1_P_part4_SP_sp41_status_id.tokudb
+t1_P_part4_SP_sp42_key_uidx1_id.tokudb
+t1_P_part4_SP_sp42_key_uidx2_id.tokudb
+t1_P_part4_SP_sp42_main_id.tokudb
+t1_P_part4_SP_sp42_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1
@@ -31637,6 +32897,42 @@ SUBPARTITIONS 3
 unified filelist
 t1.frm
 t1.par
+t1_P_part1_SP_part1sp0_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp0_key_uidx2_id.tokudb
+t1_P_part1_SP_part1sp0_main_id.tokudb
+t1_P_part1_SP_part1sp0_status_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp1_key_uidx2_id.tokudb
+t1_P_part1_SP_part1sp1_main_id.tokudb
+t1_P_part1_SP_part1sp1_status_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx1_id.tokudb
+t1_P_part1_SP_part1sp2_key_uidx2_id.tokudb
+t1_P_part1_SP_part1sp2_main_id.tokudb
+t1_P_part1_SP_part1sp2_status_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp0_key_uidx2_id.tokudb
+t1_P_part2_SP_part2sp0_main_id.tokudb
+t1_P_part2_SP_part2sp0_status_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp1_key_uidx2_id.tokudb
+t1_P_part2_SP_part2sp1_main_id.tokudb
+t1_P_part2_SP_part2sp1_status_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx1_id.tokudb
+t1_P_part2_SP_part2sp2_key_uidx2_id.tokudb
+t1_P_part2_SP_part2sp2_main_id.tokudb
+t1_P_part2_SP_part2sp2_status_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp0_key_uidx2_id.tokudb
+t1_P_part3_SP_part3sp0_main_id.tokudb
+t1_P_part3_SP_part3sp0_status_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp1_key_uidx2_id.tokudb
+t1_P_part3_SP_part3sp1_main_id.tokudb
+t1_P_part3_SP_part3sp1_status_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx1_id.tokudb
+t1_P_part3_SP_part3sp2_key_uidx2_id.tokudb
+t1_P_part3_SP_part3sp2_main_id.tokudb
+t1_P_part3_SP_part3sp2_status_id.tokudb
 
 # check prerequisites-1 success:    1
 # check COUNT(*) success:    1

--- a/mysql-test/suite/tokudb.parts/r/partition_debug_sync_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_debug_sync_tokudb.result
@@ -55,6 +55,8 @@ t1	CREATE TABLE `t1` (
 (PARTITION p0 VALUES LESS THAN MAXVALUE ENGINE = TokuDB) */
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 SET DEBUG_SYNC='before_open_in_get_all_tables SIGNAL parked WAIT_FOR open';
 SET DEBUG_SYNC='partition_open_error SIGNAL alter WAIT_FOR finish';
 SELECT TABLE_SCHEMA, TABLE_NAME, PARTITION_NAME, PARTITION_ORDINAL_POSITION,
@@ -77,6 +79,10 @@ test	t1	p0	1	10	1
 test	t1	p10	2	MAXVALUE	3
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/tokudb.parts/r/partition_debug_tokudb.result
+++ b/mysql-test/suite/tokudb.parts/r/partition_debug_tokudb.result
@@ -22,6 +22,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before statement
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -46,6 +50,12 @@ ALTER TABLE t1 ADD PARTITION
 # State after statement
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -78,6 +88,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -103,9 +117,17 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -137,6 +159,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -164,9 +190,17 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -198,6 +232,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -225,9 +263,17 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -259,6 +305,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -286,9 +336,17 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -320,6 +378,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -347,9 +409,19 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -381,6 +453,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -408,9 +484,19 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -442,6 +528,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -469,9 +559,21 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -505,6 +607,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -530,6 +636,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -560,6 +670,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -586,6 +700,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -618,6 +736,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -643,6 +765,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -673,6 +799,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -699,6 +829,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -731,6 +865,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -756,6 +894,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -786,6 +928,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -812,6 +958,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -844,6 +994,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -869,6 +1023,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -899,6 +1057,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -925,6 +1087,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -957,6 +1123,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -982,6 +1152,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1012,6 +1186,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1038,6 +1216,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1070,6 +1252,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1095,6 +1281,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1125,6 +1315,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1151,6 +1345,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1183,6 +1381,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1208,6 +1410,12 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1239,6 +1447,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1265,6 +1477,12 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1299,6 +1517,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1323,9 +1545,17 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1357,6 +1587,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1383,9 +1617,17 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1417,6 +1659,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1443,9 +1689,17 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1477,6 +1731,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1503,9 +1761,15 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1532,6 +1796,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1558,9 +1826,15 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1588,6 +1862,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1612,6 +1890,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1642,6 +1924,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1667,6 +1953,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1699,6 +1989,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1723,6 +2017,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1753,6 +2051,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1778,6 +2080,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1810,6 +2116,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1834,6 +2144,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1864,6 +2178,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1889,6 +2207,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1921,6 +2243,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1945,6 +2271,8 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1970,6 +2298,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -1995,6 +2327,8 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2022,6 +2356,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2046,6 +2384,8 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2071,6 +2411,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2096,6 +2440,8 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2125,6 +2471,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before statement
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2150,6 +2500,12 @@ PARTITION p20 VALUES IN (20,21,22,23,24,25,26,27,28,29));
 # State after statement
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2183,6 +2539,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2209,9 +2569,17 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2243,6 +2611,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2271,9 +2643,17 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2305,6 +2685,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2333,9 +2717,17 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2367,6 +2759,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2395,9 +2791,21 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_TMP_main_id.tokudb
+t1_P_p10_TMP_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_TMP_main_id.tokudb
+t1_P_p20_TMP_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2429,6 +2837,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2457,9 +2869,21 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_TMP_main_id.tokudb
+t1_P_p10_TMP_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_TMP_main_id.tokudb
+t1_P_p20_TMP_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2491,6 +2915,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2519,9 +2947,23 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_TMP_main_id.tokudb
+t1_P_p10_TMP_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_TMP_main_id.tokudb
+t1_P_p20_TMP_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2554,6 +2996,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2582,9 +3028,23 @@ ERROR HY000: Lost connection to MySQL server during query
 #sql-t1.par
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_TMP_main_id.tokudb
+t1_P_p10_TMP_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_TMP_main_id.tokudb
+t1_P_p20_TMP_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2619,6 +3079,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2645,6 +3109,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2675,6 +3143,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2702,6 +3174,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2734,6 +3210,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2760,6 +3240,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2790,6 +3274,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2817,6 +3305,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2849,6 +3341,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2875,6 +3371,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2905,6 +3405,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2932,6 +3436,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2964,6 +3472,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -2990,6 +3502,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3020,6 +3536,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3047,6 +3567,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3079,6 +3603,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3105,6 +3633,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3135,6 +3667,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3162,6 +3698,10 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3194,6 +3734,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3220,6 +3764,12 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3251,6 +3801,10 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3278,6 +3832,12 @@ ERROR HY000: Unknown error
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p10_main_id.tokudb
+t1_P_p10_status_id.tokudb
+t1_P_p20_main_id.tokudb
+t1_P_p20_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3331,7 +3891,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3360,11 +3926,23 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3427,7 +4005,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3456,11 +4040,23 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3523,7 +4119,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3552,11 +4154,23 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3619,7 +4233,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3646,13 +4266,25 @@ a	b
 ALTER TABLE t1 EXCHANGE PARTITION p0 WITH TABLE t2;
 ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
+_sqlx_nnnn_nnnn_main_id.tokudb
+_sqlx_nnnn_nnnn_status_id.tokudb
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3715,7 +4347,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3742,13 +4380,25 @@ a	b
 ALTER TABLE t1 EXCHANGE PARTITION p0 WITH TABLE t2;
 ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
+_sqlx_nnnn_nnnn_main_id.tokudb
+_sqlx_nnnn_nnnn_status_id.tokudb
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3811,7 +4461,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3838,13 +4494,25 @@ a	b
 ALTER TABLE t1 EXCHANGE PARTITION p0 WITH TABLE t2;
 ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
+_sqlx_nnnn_nnnn_main_id.tokudb
+_sqlx_nnnn_nnnn_status_id.tokudb
 t1.frm
 t1.par
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3907,7 +4575,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -3934,13 +4608,25 @@ a	b
 ALTER TABLE t1 EXCHANGE PARTITION p0 WITH TABLE t2;
 ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
+_sqlx_nnnn_nnnn_main_id.tokudb
+_sqlx_nnnn_nnnn_status_id.tokudb
 t1.frm
 t1.par
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4003,7 +4689,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4032,11 +4724,23 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4099,7 +4803,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before crash
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4128,11 +4838,23 @@ ERROR HY000: Lost connection to MySQL server during query
 # State after crash (before recovery)
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 # State after crash recovery
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4195,7 +4917,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4224,7 +4952,13 @@ ERROR HY000: Error in DDL log
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4287,7 +5021,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4316,7 +5056,13 @@ ERROR HY000: Error in DDL log
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4379,7 +5125,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4408,7 +5160,13 @@ ERROR HY000: Error on rename of './test/t2' to './test/#sqlx-nnnn_nnnn' (errno: 
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4471,7 +5229,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4500,7 +5264,13 @@ ERROR HY000: Error in DDL log
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4563,7 +5333,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4592,7 +5368,13 @@ ERROR HY000: Error on rename of './test/t1#P#p0' to './test/t2' (errno: 0 - n/a)
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4655,7 +5437,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4684,7 +5472,13 @@ ERROR HY000: Error in DDL log
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4747,7 +5541,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4776,7 +5576,13 @@ ERROR HY000: Error on rename of './test/#sqlx-nnnn_nnnn' to './test/t1#P#p0' (er
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4839,7 +5645,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4868,7 +5680,13 @@ ERROR HY000: Error in DDL log
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4931,7 +5749,13 @@ INSERT INTO t1 VALUES (1, "Original from partition p0"), (2, "Original from part
 # State before failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -4960,7 +5784,13 @@ ERROR HY000: Error in DDL log
 # State after failure
 t1.frm
 t1.par
+t1_P_p0_main_id.tokudb
+t1_P_p0_status_id.tokudb
+t1_P_p1_main_id.tokudb
+t1_P_p1_status_id.tokudb
 t2.frm
+t2_main_id.tokudb
+t2_status_id.tokudb
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb.test
+++ b/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb.test
@@ -56,7 +56,7 @@ partition by range (a)
 insert into t1 values (1), (11), (21), (33);
 SELECT * FROM t1;
 SHOW CREATE TABLE t1;
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $MYSQLD_DATADIR/test
 
 SET DEBUG_SYNC='before_open_in_get_all_tables SIGNAL parked WAIT_FOR open';
@@ -82,7 +82,7 @@ ALTER TABLE t1 REORGANIZE PARTITION p0 INTO
 disconnect con1;
 connection default;
 --reap
---replace_result #p# #P# #sp# #SP#
+--source include/table_files_replace_pattern.inc
 --list_files $MYSQLD_DATADIR/test
 SHOW CREATE TABLE t1;
 SELECT * FROM t1;

--- a/mysql-test/suite/tokudb/r/dir-per-db-with-custom-data-dir.result
+++ b/mysql-test/suite/tokudb/r/dir-per-db-with-custom-data-dir.result
@@ -1,0 +1,10 @@
+SELECT @@tokudb_dir_per_db;
+@@tokudb_dir_per_db
+1
+TOKUDB_DATA_DIR_CHANGED
+1
+CREATE DATABASE tokudb_test;
+USE tokudb_test;
+CREATE TABLE t (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=tokudb;
+DROP TABLE t;
+DROP DATABASE tokudb_test;

--- a/mysql-test/suite/tokudb/r/dir_per_db.result
+++ b/mysql-test/suite/tokudb/r/dir_per_db.result
@@ -1,0 +1,180 @@
+########
+#  tokudb_dir_per_db = 1
+########
+SET GLOBAL tokudb_dir_per_db= 1;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_key_ab_id.tokudb
+t1_key_b_id.tokudb
+t1_main_id.tokudb
+t1_status_id.tokudb
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t2_key_ab_id.tokudb
+t2_key_b_id.tokudb
+t2_main_id.tokudb
+t2_status_id.tokudb
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+########
+#  tokudb_dir_per_db = 0
+########
+SET GLOBAL tokudb_dir_per_db= 0;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+_test_t1_key_ab_id.tokudb
+_test_t1_key_b_id.tokudb
+_test_t1_main_id.tokudb
+_test_t1_status_id.tokudb
+## Looking for *.tokudb files in data_dir/test
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+_test_t1_key_ab_id.tokudb
+_test_t1_key_b_id.tokudb
+_test_t1_main_id.tokudb
+_test_t1_status_id.tokudb
+## Looking for *.tokudb files in data_dir/test
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+########
+#  CREATE on tokudb_dir_per_db = 0 and RENAME on tokudb_dir_per_db = 1 and vice versa
+########
+########
+#  tokudb_dir_per_db = (1 - 1);
+########
+SET GLOBAL tokudb_dir_per_db= (1 - 1);;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+_test_t1_key_ab_id.tokudb
+_test_t1_key_b_id.tokudb
+_test_t1_main_id.tokudb
+_test_t1_status_id.tokudb
+## Looking for *.tokudb files in data_dir/test
+########
+#  tokudb_dir_per_db = 1
+########
+SET GLOBAL tokudb_dir_per_db= 1;
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t2_key_ab_id.tokudb
+t2_key_b_id.tokudb
+t2_main_id.tokudb
+t2_status_id.tokudb
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+########
+#  tokudb_dir_per_db = (1 - 0);
+########
+SET GLOBAL tokudb_dir_per_db= (1 - 0);;
+########
+#  CREATE
+########
+CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+INSERT INTO t1 SET b = 10;
+INSERT INTO t1 SET b = 20;
+SELECT b FROM t1 ORDER BY a;
+b
+10
+20
+CREATE INDEX b ON t1 (b);
+CREATE INDEX ab ON t1 (a,b);
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_key_ab_id.tokudb
+t1_key_b_id.tokudb
+t1_main_id.tokudb
+t1_status_id.tokudb
+########
+#  tokudb_dir_per_db = 0
+########
+SET GLOBAL tokudb_dir_per_db= 0;
+########
+#  RENAME
+########
+RENAME TABLE t1 TO t2;
+SELECT b FROM t2 ORDER BY a;
+b
+10
+20
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_key_ab_id.tokudb
+t1_key_b_id.tokudb
+t1_main_id.tokudb
+t1_status_id.tokudb
+########
+#  DROP
+########
+DROP TABLE t2;
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+SET GLOBAL tokudb_dir_per_db=default;

--- a/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir-master.opt
+++ b/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir-master.opt
@@ -1,0 +1,1 @@
+--tokudb_data_dir="$MYSQL_TMP_DIR" --tokudb-dir-per-db=1

--- a/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir.test
+++ b/mysql-test/suite/tokudb/t/dir-per-db-with-custom-data-dir.test
@@ -1,0 +1,16 @@
+--source include/have_tokudb.inc
+
+SELECT @@tokudb_dir_per_db;
+
+--disable_query_log
+--eval SELECT STRCMP(@@tokudb_data_dir, '$MYSQL_TMP_DIR') = 0 AS TOKUDB_DATA_DIR_CHANGED
+--enable_query_log
+
+CREATE DATABASE tokudb_test;
+USE tokudb_test;
+CREATE TABLE t (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=tokudb;
+
+--file_exists $MYSQL_TMP_DIR/tokudb_test
+
+DROP TABLE t;
+DROP DATABASE tokudb_test;

--- a/mysql-test/suite/tokudb/t/dir_per_db.test
+++ b/mysql-test/suite/tokudb/t/dir_per_db.test
@@ -1,0 +1,76 @@
+source include/have_tokudb.inc;
+
+--let $DB= test
+--let $DATADIR= `select @@datadir`
+--let $i= 2
+
+while ($i) {
+  --dec $i
+  --echo ########
+  --echo #  tokudb_dir_per_db = $i
+  --echo ########
+  --eval SET GLOBAL tokudb_dir_per_db= $i
+  --echo ########
+  --echo #  CREATE
+  --echo ########
+  CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+  INSERT INTO t1 SET b = 10;
+  INSERT INTO t1 SET b = 20;
+  SELECT b FROM t1 ORDER BY a;
+  CREATE INDEX b ON t1 (b);
+  CREATE INDEX ab ON t1 (a,b);
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  RENAME
+  --echo ########
+  RENAME TABLE t1 TO t2;
+  SELECT b FROM t2 ORDER BY a;
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  DROP
+  --echo ########
+  DROP TABLE t2;
+  --source dir_per_db_show_table_files.inc
+}
+
+--echo ########
+--echo #  CREATE on tokudb_dir_per_db = 0 and RENAME on tokudb_dir_per_db = 1 and vice versa
+--echo ########
+
+--let $i= 2
+
+while ($i) {
+  --dec $i
+  --let $inv_i= (1 - $i);
+  --echo ########
+  --echo #  tokudb_dir_per_db = $inv_i
+  --echo ########
+  --eval SET GLOBAL tokudb_dir_per_db= $inv_i
+  --echo ########
+  --echo #  CREATE
+  --echo ########
+  CREATE TABLE t1 (a INT UNSIGNED AUTO_INCREMENT PRIMARY KEY, b INT(10) UNSIGNED NOT NULL) ENGINE=tokudb;
+  INSERT INTO t1 SET b = 10;
+  INSERT INTO t1 SET b = 20;
+  SELECT b FROM t1 ORDER BY a;
+  CREATE INDEX b ON t1 (b);
+  CREATE INDEX ab ON t1 (a,b);
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  tokudb_dir_per_db = $i
+  --echo ########
+  --eval SET GLOBAL tokudb_dir_per_db= $i
+  --echo ########
+  --echo #  RENAME
+  --echo ########
+  RENAME TABLE t1 TO t2;
+  SELECT b FROM t2 ORDER BY a;
+  --source dir_per_db_show_table_files.inc
+  --echo ########
+  --echo #  DROP
+  --echo ########
+  DROP TABLE t2;
+  --source dir_per_db_show_table_files.inc
+}
+
+SET GLOBAL tokudb_dir_per_db=default;

--- a/mysql-test/suite/tokudb/t/dir_per_db_show_table_files.inc
+++ b/mysql-test/suite/tokudb/t/dir_per_db_show_table_files.inc
@@ -1,0 +1,9 @@
+--sorted_result
+
+--echo ## Looking for *.tokudb files in data_dir
+--source include/table_files_replace_pattern.inc
+--list_files $DATADIR *.tokudb
+
+--echo ## Looking for *.tokudb files in data_dir/$DB
+--source include/table_files_replace_pattern.inc
+--list_files $DATADIR/$DB/ *.tokudb

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -535,6 +535,7 @@ static int tokudb_init_func(void *p) {
     db_env->change_fsync_log_period(db_env, tokudb::sysvars::fsync_log_period);
 
     db_env->set_lock_timeout_callback(db_env, tokudb_lock_timeout_callback);
+    db_env->set_dir_per_db(db_env, tokudb::sysvars::dir_per_db);
 
     db_env->set_loader_memory_size(
         db_env,

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -544,6 +544,7 @@ static int tokudb_init_func(void *p) {
     db_env->change_fsync_log_period(db_env, tokudb::sysvars::fsync_log_period);
 
     db_env->set_lock_timeout_callback(db_env, tokudb_lock_timeout_callback);
+    db_env->set_dir_per_db(db_env, tokudb::sysvars::dir_per_db);
 
     db_env->set_loader_memory_size(
         db_env,

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -66,6 +66,7 @@ uint        read_status_frequency = 0;
 my_bool     strip_frm_data = FALSE;
 char*       tmp_dir = NULL;
 uint        write_status_frequency = 0;
+my_bool     dir_per_db = FALSE;
 char*       version = (char*) TOKUDB_VERSION_STR;
 
 // file system reserve as a percentage of total disk space
@@ -395,6 +396,18 @@ static MYSQL_SYSVAR_UINT(
     0,
     ~0U,
     0);
+
+static void tokudb_dir_per_db_update(THD* thd,
+                                     struct st_mysql_sys_var* sys_var,
+                                     void* var, const void* save) {
+    my_bool *value = (my_bool *) var;
+    *value = *(const my_bool *) save;
+    db_env->set_dir_per_db(db_env, *value);
+}
+
+static MYSQL_SYSVAR_BOOL(dir_per_db, dir_per_db,
+    0, "TokuDB store ft files in db directories",
+    NULL, tokudb_dir_per_db_update, FALSE);
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL
 static MYSQL_SYSVAR_STR(
@@ -909,6 +922,7 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(tmp_dir),
     MYSQL_SYSVAR(version),
     MYSQL_SYSVAR(write_status_frequency),
+    MYSQL_SYSVAR(dir_per_db),
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL
     MYSQL_SYSVAR(gdb_path),

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -66,6 +66,7 @@ uint        read_status_frequency = 0;
 my_bool     strip_frm_data = FALSE;
 char*       tmp_dir = NULL;
 uint        write_status_frequency = 0;
+my_bool     dir_per_db = TRUE;
 char*       version = (char*) TOKUDB_VERSION_STR;
 
 // file system reserve as a percentage of total disk space
@@ -395,6 +396,18 @@ static MYSQL_SYSVAR_UINT(
     0,
     ~0U,
     0);
+
+static void tokudb_dir_per_db_update(THD* thd,
+                                     struct st_mysql_sys_var* sys_var,
+                                     void* var, const void* save) {
+    my_bool *value = (my_bool *) var;
+    *value = *(const my_bool *) save;
+    db_env->set_dir_per_db(db_env, *value);
+}
+
+static MYSQL_SYSVAR_BOOL(dir_per_db, dir_per_db,
+    0, "TokuDB store ft files in db directories",
+    NULL, tokudb_dir_per_db_update, TRUE);
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL
 static MYSQL_SYSVAR_STR(
@@ -917,6 +930,7 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(tmp_dir),
     MYSQL_SYSVAR(version),
     MYSQL_SYSVAR(write_status_frequency),
+    MYSQL_SYSVAR(dir_per_db),
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL
     MYSQL_SYSVAR(gdb_path),

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -81,6 +81,7 @@ extern uint         read_status_frequency;
 extern my_bool      strip_frm_data;
 extern char*        tmp_dir;
 extern uint         write_status_frequency;
+extern my_bool      dir_per_db;
 extern char*        version;
 
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL


### PR DESCRIPTION
The option is on by default. If this option is on then newly created or
renamed tokudb table files will be placed into directories which correspond
to database names in data directory otherwise the files will be in root
data directory.

Some table can be converted from one directory layout to another with "rename"
operation. When some table is renamed the table files will be renamed into
directory layout which corresponds to tokudb_dir_per_db option.

http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/185
