### PR TITLE
Bug 1455432: Audit log plugin should allow to include or exclude

### DIFF
--- a/mysql-test/r/audit_log_csv.result
+++ b/mysql-test/r/audit_log_csv.result
@@ -24,10 +24,12 @@ DEALLOCATE PREPARE stmt1;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -54,10 +56,12 @@ drop table renamed_t1, t2;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/mysql-test/r/audit_log_filter_users.result
+++ b/mysql-test/r/audit_log_filter_users.result
@@ -1,0 +1,187 @@
+CREATE USER 'user1'@'127.0.0.1' IDENTIFIED BY 'password1';
+CREATE USER 'user22'@'%' IDENTIFIED BY 'password1';
+CREATE USER '22user'@'localhost' IDENTIFIED BY 'password1';
+CREATE USER 'admin'@'%' IDENTIFIED BY 'password1';
+CREATE USER 'us,er1'@'localhost' IDENTIFIED BY 'password1';
+SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+user1@localhost,, user22@127.0.0.1,admin@%	NULL
+SET GLOBAL audit_log_exclude_accounts= '22useer@localhost';
+ERROR 42000: Variable 'audit_log_exclude_accounts' can't be set to the value of '22useer@localhost'
+SET GLOBAL audit_log_exclude_accounts= NULL;
+ERROR 42000: Variable 'audit_log_exclude_accounts' can't be set to the value of 'NULL'
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+user1@localhost,, user22@127.0.0.1,admin@%	NULL
+SET GLOBAL audit_log_include_accounts= 'user1@localhost, user2@localhost, user3@localhost';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+user1@localhost, user2@localhost, user3@localhost	NULL
+SET GLOBAL audit_log_include_accounts= '';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+	NULL
+SET GLOBAL audit_log_exclude_accounts= '22useer@localhost';
+ERROR 42000: Variable 'audit_log_exclude_accounts' can't be set to the value of '22useer@localhost'
+SET GLOBAL audit_log_include_accounts= NULL;
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+NULL	NULL
+SET GLOBAL audit_log_exclude_accounts= "'us,er1'@'localhost',, user22@127.0.0.1,admin@%";
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+NULL	'us,er1'@'localhost',, user22@127.0.0.1,admin@%
+SET GLOBAL audit_log_include_accounts= '22useer@localhost';
+ERROR 42000: Variable 'audit_log_include_accounts' can't be set to the value of '22useer@localhost'
+SET GLOBAL audit_log_include_accounts= NULL;
+ERROR 42000: Variable 'audit_log_include_accounts' can't be set to the value of 'NULL'
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+NULL	'us,er1'@'localhost',, user22@127.0.0.1,admin@%
+SET GLOBAL audit_log_exclude_accounts= 'user1@localhost, user2@localhost, user3@localhost';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+NULL	user1@localhost, user2@localhost, user3@localhost
+SET GLOBAL audit_log_exclude_accounts= '';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+NULL	
+SET GLOBAL audit_log_include_accounts= '22useer@localhost';
+ERROR 42000: Variable 'audit_log_include_accounts' can't be set to the value of '22useer@localhost'
+SET GLOBAL audit_log_exclude_accounts= NULL;
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+@@audit_log_include_accounts	@@audit_log_exclude_accounts
+NULL	NULL
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_include_accounts= '';
+SELECT 'user1';
+user1
+user1
+SELECT 'user22';
+user22
+user22
+SELECT '22user';
+22user
+22user
+SELECT 'user22';
+user22
+user22
+SELECT 'admin';
+admin
+admin
+SELECT 'us,er1';
+us,er1
+us,er1
+SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooongusername@veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooonghostname';
+SELECT 'user1';
+user1
+user1
+SELECT 'user22';
+user22
+user22
+SELECT '22user';
+22user
+22user
+SELECT 'user22';
+user22
+user22
+SELECT 'admin';
+admin
+admin
+SELECT 'us,er1';
+us,er1
+us,er1
+SET GLOBAL audit_log_include_accounts= NULL;
+SELECT 'user1';
+user1
+user1
+SELECT 'user22';
+user22
+user22
+SELECT '22user';
+22user
+22user
+SELECT 'user22';
+user22
+user22
+SELECT 'admin';
+admin
+admin
+SELECT 'us,er1';
+us,er1
+us,er1
+SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%';
+SELECT 'user1';
+user1
+user1
+SELECT 'user22';
+user22
+user22
+SELECT '22user';
+22user
+22user
+SELECT 'user22';
+user22
+user22
+SELECT 'admin';
+admin
+admin
+SELECT 'us,er1';
+us,er1
+us,er1
+SET GLOBAL audit_log_exclude_accounts= NULL;
+set global audit_log_flush= ON;
+===================================================================
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","",""
+*************************************************************
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= ''","root[root] @ localhost []","localhost","",""
+*************************************************************
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooongusername@veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooonghostname'","root[root] @ localhost []","localhost","",""
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user1'","user1[user1] @ localhost [127.0.0.1]","localhost","","127.0.0.1"
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
+*************************************************************
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= NULL","root[root] @ localhost []","localhost","",""
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user1'","user1[user1] @ localhost [127.0.0.1]","localhost","","127.0.0.1"
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user22'","user22[user22] @ localhost []","localhost","",""
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"22user","22user","","","localhost","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT '22user'","22user[22user] @ localhost []","localhost","",""
+"Change user","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","",""
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user22'","user22[user22] @ localhost []","localhost","",""
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","",""
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'admin'","admin[admin] @ localhost [127.0.0.1]","localhost","","127.0.0.1"
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'us,er1'","us,er1[us,er1] @ localhost []","localhost","",""
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
+*************************************************************
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%'","root[root] @ localhost []","localhost","",""
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user22'","user22[user22] @ localhost []","localhost","",""
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"22user","22user","","","localhost","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT '22user'","22user[22user] @ localhost []","localhost","",""
+"Change user","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","",""
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user22'","user22[user22] @ localhost []","localhost","",""
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","",""
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'admin'","admin[admin] @ localhost [127.0.0.1]","localhost","","127.0.0.1"
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'us,er1'","us,er1[us,er1] @ localhost []","localhost","",""
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
+*************************************************************
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_accounts= NULL","root[root] @ localhost []","localhost","",""
+===================================================================
+DROP USER 'user1'@'127.0.0.1';
+DROP USER 'user22'@'%';
+DROP USER '22user'@'localhost';
+DROP USER 'admin'@'%';
+DROP USER 'us,er1'@'localhost';

--- a/mysql-test/r/audit_log_json.result
+++ b/mysql-test/r/audit_log_json.result
@@ -24,10 +24,12 @@ DEALLOCATE PREPARE stmt1;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	JSON
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -54,10 +56,12 @@ drop table renamed_t1, t2;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	JSON
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/mysql-test/r/audit_log_new.result
+++ b/mysql-test/r/audit_log_new.result
@@ -24,10 +24,12 @@ DEALLOCATE PREPARE stmt1;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	NEW
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	LOGINS
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -54,10 +56,12 @@ drop table renamed_t1, t2;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	NEW
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	LOGINS
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/mysql-test/r/audit_log_old.result
+++ b/mysql-test/r/audit_log_old.result
@@ -24,10 +24,12 @@ DEALLOCATE PREPARE stmt1;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	4096
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	OLD
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -54,10 +56,12 @@ drop table renamed_t1, t2;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	4096
+audit_log_exclude_accounts	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	OLD
 audit_log_handler	FILE
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/mysql-test/r/audit_log_syslog.result
+++ b/mysql-test/r/audit_log_syslog.result
@@ -22,10 +22,12 @@ DEALLOCATE PREPARE stmt1;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	SYSLOG
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -52,10 +54,12 @@ drop table renamed_t1, t2;
 show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
+audit_log_exclude_accounts	
 audit_log_file	audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	SYSLOG
+audit_log_include_accounts	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/mysql-test/t/audit_log_filter_events.inc
+++ b/mysql-test/t/audit_log_filter_events.inc
@@ -1,0 +1,33 @@
+connect (test,127.0.0.1,user1,password1,,$MASTER_PORT,);
+connection test;
+SELECT 'user1';
+disconnect test;
+--source include/wait_until_disconnected.inc
+
+connect (test,localhost,user22,password1,,);
+connection test;
+SELECT 'user22';
+disconnect test;
+--source include/wait_until_disconnected.inc
+
+connect (test,localhost,22user,password1,,);
+connection test;
+SELECT '22user';
+change_user user22,password1;
+SELECT 'user22';
+disconnect test;
+--source include/wait_until_disconnected.inc
+
+connect (test,127.0.0.1,admin,password1,,$MASTER_PORT,);
+connection test;
+SELECT 'admin';
+disconnect test;
+--source include/wait_until_disconnected.inc
+
+connect (test,localhost,"us,er1",password1,,);
+connection test;
+SELECT 'us,er1';
+disconnect test;
+--source include/wait_until_disconnected.inc
+
+connection default;

--- a/mysql-test/t/audit_log_filter_users-master.opt
+++ b/mysql-test/t/audit_log_filter_users-master.opt
@@ -1,0 +1,6 @@
+$AUDIT_LOG_OPT
+$AUDIT_LOG_LOAD
+--audit_log_file=test_audit.log
+--audit_log_policy=ALL
+--audit-log-format=CSV
+--audit_log_strategy=SYNCHRONOUS

--- a/mysql-test/t/audit_log_filter_users.test
+++ b/mysql-test/t/audit_log_filter_users.test
@@ -1,0 +1,99 @@
+--source include/not_embedded.inc
+
+# setup some user accounts
+
+CREATE USER 'user1'@'127.0.0.1' IDENTIFIED BY 'password1';
+CREATE USER 'user22'@'%' IDENTIFIED BY 'password1';
+CREATE USER '22user'@'localhost' IDENTIFIED BY 'password1';
+CREATE USER 'admin'@'%' IDENTIFIED BY 'password1';
+CREATE USER 'us,er1'@'localhost' IDENTIFIED BY 'password1';
+
+# test set/unset filters
+
+SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_exclude_accounts= '22useer@localhost';
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_exclude_accounts= NULL;
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+SET GLOBAL audit_log_include_accounts= 'user1@localhost, user2@localhost, user3@localhost';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+SET GLOBAL audit_log_include_accounts= '';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_exclude_accounts= '22useer@localhost';
+SET GLOBAL audit_log_include_accounts= NULL;
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+
+SET GLOBAL audit_log_exclude_accounts= "'us,er1'@'localhost',, user22@127.0.0.1,admin@%";
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_include_accounts= '22useer@localhost';
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_include_accounts= NULL;
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+SET GLOBAL audit_log_exclude_accounts= 'user1@localhost, user2@localhost, user3@localhost';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+SET GLOBAL audit_log_exclude_accounts= '';
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_include_accounts= '22useer@localhost';
+SET GLOBAL audit_log_exclude_accounts= NULL;
+SELECT @@audit_log_include_accounts, @@audit_log_exclude_accounts;
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+let MYSQLD_DATADIR= $MYSQLD_DATADIR;
+
+SET GLOBAL audit_log_flush=ON;
+--remove_file $MYSQLD_DATADIR/test_audit.log
+SET GLOBAL audit_log_flush=ON;
+
+# log nothing
+SET GLOBAL audit_log_include_accounts= '';
+
+--source audit_log_filter_events.inc
+
+# testing include
+SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooongusername@veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooonghostname';
+
+--source audit_log_filter_events.inc
+
+# log everything
+SET GLOBAL audit_log_include_accounts= NULL;
+
+--source audit_log_filter_events.inc
+
+# testing exclude
+SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%';
+
+--source audit_log_filter_events.inc
+
+SET GLOBAL audit_log_exclude_accounts= NULL;
+
+--move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_csv.log
+set global audit_log_flush= ON;
+perl;
+  print "===================================================================\n";
+  open my $file, $ENV{'MYSQLD_DATADIR'} . '/test_audit_csv.log' or die "Can not open log: $!";
+  while ($line = <$file>) {
+    $line =~ s/"([a-zA-Z_ ]*)","([0-9]+)_[0-9_ :T-]*","[0-9_ :A-Z-]*"/"$1","<ID>","<DATETIME>"/;
+    $line =~ s/"(Connect|Quit|Change user)","<ID>","<DATETIME>","[0-9]+"/"$1","<ID>","<DATETIME>","<CONN_ID>"/;
+    $line =~ s/"([A-Za-z ]+)","<ID>","<DATETIME>","([a-z_]+)","[0-9]+"/"$1","<ID>","<DATETIME>","$2","<CONN_ID>"/;
+    if ($line =~ /SET GLOBAL .*_accounts/) {
+    	print "*************************************************************\n";
+    }
+    print "$line";
+  };
+  close $file;
+  print "===================================================================\n";
+EOF
+--remove_file $MYSQLD_DATADIR/test_audit.log
+--remove_file $MYSQLD_DATADIR/test_audit_csv.log
+
+# cleanup users
+DROP USER 'user1'@'127.0.0.1';
+DROP USER 'user22'@'%';
+DROP USER '22user'@'localhost';
+DROP USER 'admin'@'%';
+DROP USER 'us,er1'@'localhost';

--- a/plugin/audit_log/CMakeLists.txt
+++ b/plugin/audit_log/CMakeLists.txt
@@ -14,5 +14,5 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
 MYSQL_ADD_PLUGIN(audit_log audit_log.c file_logger.c buffer.c audit_file.c
- audit_syslog.c
+ audit_syslog.c filter.c
  MODULE_ONLY MODULE_OUTPUT_NAME "audit_log")

--- a/plugin/audit_log/audit_log.h
+++ b/plugin/audit_log/audit_log.h
@@ -1,0 +1,22 @@
+/* Copyright (c) 2015-2016 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef AUDIT_LOG_H_INCLUDED
+#define AUDIT_LOG_H_INCLUDED
+
+#define AUDIT_LOG_PSI_CATEGORY "audit_log"
+
+#endif /* AUDIT_LOG_H_INCLUDED */

--- a/plugin/audit_log/buffer.c
+++ b/plugin/audit_log/buffer.c
@@ -18,6 +18,7 @@
 
 #include <my_pthread.h>
 #include <my_sys.h>
+#include "audit_log.h"
 
 struct audit_log_buffer {
   char *buf;
@@ -121,13 +122,10 @@ audit_log_buffer_t *audit_log_buffer_init(size_t size, int drop_if_full,
                                  calloc(sizeof(audit_log_buffer_t) + size, 1);
 
 #ifdef HAVE_PSI_INTERFACE
-  if(PSI_server)
-  {
-    PSI_server->register_mutex("server_audit",
-                               mutex_key_list, array_elements(mutex_key_list));
-    PSI_server->register_cond("server_audit",
-                              cond_key_list, array_elements(cond_key_list));
-  }
+  mysql_mutex_register(AUDIT_LOG_PSI_CATEGORY,
+                       mutex_key_list, array_elements(mutex_key_list));
+  mysql_cond_register(AUDIT_LOG_PSI_CATEGORY,
+                      cond_key_list, array_elements(cond_key_list));
 #endif /* HAVE_PSI_INTERFACE */
 
   if (log != NULL)

--- a/plugin/audit_log/file_logger.c
+++ b/plugin/audit_log/file_logger.c
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "logger.h"
+#include "audit_log.h"
 
 extern char *mysql_data_home;
 
@@ -330,8 +331,8 @@ int logger_printf(LOGGER_HANDLE *log, const char *fmt, ...)
 void logger_init_mutexes()
 {
 #if defined(HAVE_PSI_INTERFACE) && !defined(FLOGGER_NO_PSI) && !defined(FLOGGER_NO_THREADSAFE)
-  if (PSI_server)
-    PSI_server->register_mutex("audit_logger", mutex_list, 1);
+  mysql_mutex_register(AUDIT_LOG_PSI_CATEGORY,
+                       mutex_list, array_elements(mutex_list));
 #endif /*HAVE_PSI_INTERFACE && !FLOGGER_NO_PSI*/
 }
 

--- a/plugin/audit_log/filter.c
+++ b/plugin/audit_log/filter.c
@@ -1,0 +1,235 @@
+/* Copyright (c) 2016 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include <my_global.h>
+#include <my_sys.h>
+#include <my_user.h>
+#include <mysql_com.h>
+#include <hash.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "filter.h"
+#include "audit_log.h"
+
+typedef struct
+{
+  /* user + '@' + host + '\0' */
+  char name[USERNAME_LENGTH + HOSTNAME_LENGTH + 2];
+  size_t length;
+} account;
+
+static HASH include_accounts;
+static HASH exclude_accounts;
+
+#if defined(HAVE_PSI_INTERFACE)
+
+static PSI_rwlock_key key_LOCK_account_list;
+static PSI_rwlock_info all_rwlock_list[]=
+{{ &key_LOCK_account_list, "audit_log_filter::account_list", PSI_FLAG_GLOBAL}};
+
+#endif
+
+mysql_rwlock_t LOCK_account_list;
+
+/*
+  Initialize account
+*/
+static
+void account_init(account *acc, const char *user, size_t user_length,
+                                const char *host, size_t host_length)
+{
+  DBUG_ASSERT(user_length + host_length + 2 <= sizeof(acc->name));
+
+  memcpy(acc->name, user, user_length);
+  memcpy(acc->name + user_length + 1, host, host_length);
+  acc->name[user_length]= '@';
+  acc->name[user_length + host_length + 1]= 0;
+  acc->length= user_length + host_length + 1;
+}
+
+/*
+  Allocate memory and initialize new account
+*/
+
+static
+account *account_create(const char *user, size_t user_length,
+                        const char *host, size_t host_length)
+{
+  account *acc= (account *) my_malloc(sizeof(account), MYF(MY_FAE));
+
+  account_init(acc, user, user_length, host, host_length);
+
+  return acc;
+}
+
+/*
+  Get account key
+*/
+uchar *account_get_key(const account *acc, size_t *length,
+                       my_bool not_used __attribute__((unused)))
+{
+  *length= acc->length;
+  return (uchar*) acc->name;
+}
+
+/*
+  Remove enclosing quotes from string if any.
+*/
+static
+void unquote_string(char *string, size_t *string_length)
+{
+  if (string[0] == '\'' && string[*string_length - 1] == '\'')
+  {
+    *string_length-= 2;
+    memmove(string, string + 1, *string_length);
+    string[*string_length]= 0;
+  }
+}
+
+/*
+  Parse comma-separated list of accounts and add it into account list.
+  Empty user name is allowed.
+*/
+static
+void account_list_from_string(HASH *hash, const char *string)
+{
+  char *string_copy= my_strdup(string, MYF(MY_FAE));
+  char *entry= string_copy;
+  int string_length= strlen(string_copy);
+  char user[USERNAME_LENGTH + 1], host[HOSTNAME_LENGTH + 1];
+  size_t user_length, host_length;
+
+  my_hash_reset(hash);
+
+  while (entry - string_copy < string_length)
+  {
+    size_t entry_length= 0;
+    my_bool quote= FALSE;
+
+    while (*entry == ' ')
+      entry++;
+
+    entry_length= 0;
+    while (((entry[entry_length] != ' ' && entry[entry_length] != ',') || quote)
+           && entry[entry_length] != 0)
+    {
+      if (entry[entry_length] == '\'')
+        quote= !quote;
+      entry_length++;
+    }
+
+    entry[entry_length]= 0;
+
+    parse_user(entry, entry_length, user, &user_length, host, &host_length);
+    unquote_string(user, &user_length);
+    unquote_string(host, &host_length);
+
+    my_hash_insert(hash,
+        (uchar*) account_create(user, user_length, host, host_length));
+
+    entry+= entry_length + 1;
+  }
+
+  my_free(string_copy);
+}
+
+/* public interface */
+
+void audit_log_filter_init()
+{
+#ifdef HAVE_PSI_INTERFACE
+  mysql_rwlock_register(AUDIT_LOG_PSI_CATEGORY, all_rwlock_list,
+                        array_elements(all_rwlock_list));
+#endif /* HAVE_PSI_INTERFACE */
+  mysql_rwlock_init(key_LOCK_account_list, &LOCK_account_list);
+
+  my_hash_init(&include_accounts, &my_charset_utf8_general_ci,
+               20, 0, 0,
+               (my_hash_get_key) account_get_key,
+               my_free, HASH_UNIQUE);
+
+  my_hash_init(&exclude_accounts, &my_charset_utf8_general_ci,
+               20, 0, 0,
+               (my_hash_get_key) account_get_key,
+               my_free, HASH_UNIQUE);
+}
+
+void audit_log_filter_destroy()
+{
+  my_hash_free(&include_accounts);
+  my_hash_free(&exclude_accounts);
+  mysql_rwlock_destroy(&LOCK_account_list);
+}
+
+/*
+  Parse and store the list of included accounts.
+*/
+void audit_log_set_include_accounts(const char *val)
+{
+  mysql_rwlock_wrlock(&LOCK_account_list);
+  account_list_from_string(&include_accounts, val);
+  mysql_rwlock_unlock(&LOCK_account_list);
+}
+
+/*
+  Parse and store the list of excluded accounts.
+*/
+void audit_log_set_exclude_accounts(const char *val)
+{
+  mysql_rwlock_wrlock(&LOCK_account_list);
+  account_list_from_string(&exclude_accounts, val);
+  mysql_rwlock_unlock(&LOCK_account_list);
+}
+
+/*
+  Check if account has to be included.
+*/
+my_bool audit_log_check_account_included(const char *user, size_t user_length,
+                                         const char *host, size_t host_length)
+{
+  account acc;
+  my_bool res;
+
+  account_init(&acc, user, user_length, host, host_length);
+
+  mysql_rwlock_rdlock(&LOCK_account_list);
+
+  res= my_hash_search(&include_accounts,
+                      (const uchar*) acc.name, acc.length) != NULL;
+
+  mysql_rwlock_unlock(&LOCK_account_list);
+  return res;
+}
+
+/*
+  Check if account has to be excluded.
+*/
+my_bool audit_log_check_account_excluded(const char *user, size_t user_length,
+                                         const char *host, size_t host_length)
+{
+  account acc;
+  my_bool res;
+
+  account_init(&acc, user, user_length, host, host_length);
+
+  mysql_rwlock_rdlock(&LOCK_account_list);
+
+  res= my_hash_search(&exclude_accounts,
+                      (const uchar*) acc.name, acc.length) != NULL;
+  mysql_rwlock_unlock(&LOCK_account_list);
+  return res;
+}

--- a/plugin/audit_log/filter.h
+++ b/plugin/audit_log/filter.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2016 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef AUDIT_LOG_FILTER_INCLUDED
+#define AUDIT_LOG_FILTER_INCLUDED
+
+#include <my_global.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void audit_log_set_include_accounts(const char *val);
+void audit_log_set_exclude_accounts(const char *val);
+my_bool audit_log_check_account_included(const char *user, size_t user_length,
+                                         const char *host, size_t host_length);
+my_bool audit_log_check_account_excluded(const char *user, size_t user_length,
+                                         const char *host, size_t host_length);
+void audit_log_filter_init();
+void audit_log_filter_destroy();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
logging for specific users

Added two global variables:
- audit_log_include_accounts: accounts to include in audit logging.
- audit_log_exclude_accounts: accounts to exclude from audit logging.

The value can be NULL, empty string or comma separated list of
accounts in form user@host or 'user'@'host' (if user or host contains
comma).

Only one variable can be not empty at a time. If one is set to be not
empty, another one becomes empty.
