### PR TITLE
Fix bug 1591202 (client and libmysqlclient VIO drops connection if si…

### DIFF
--- a/sql/net_serv.cc
+++ b/sql/net_serv.cc
@@ -678,13 +678,13 @@ net_real_write(NET *net,const uchar *packet, size_t len)
 		  my_progname);
 #endif /* EXTRA_DEBUG */
       }
-#if defined(THREAD_SAFE_CLIENT) && !defined(MYSQL_SERVER)
+#if !defined(MYSQL_SERVER)
       if (vio_errno(net->vio) == SOCKET_EINTR)
       {
 	DBUG_PRINT("warning",("Interrupted write. Retrying..."));
 	continue;
       }
-#endif /* defined(THREAD_SAFE_CLIENT) && !defined(MYSQL_SERVER) */
+#endif /* !defined(MYSQL_SERVER) */
       net->error= 2;				/* Close socket */
       net->last_errno= (interrupted ? ER_NET_WRITE_INTERRUPTED :
                                ER_NET_ERROR_ON_WRITE);
@@ -892,7 +892,7 @@ my_real_read(NET *net, size_t *complen)
 		    my_progname,vio_errno(net->vio));
 #endif /* EXTRA_DEBUG */
 	  }
-#if defined(THREAD_SAFE_CLIENT) && !defined(MYSQL_SERVER)
+#if !defined(MYSQL_SERVER)
 	  if (vio_errno(net->vio) == SOCKET_EINTR)
 	  {
 	    DBUG_PRINT("warning",("Interrupted read. Retrying..."));


### PR DESCRIPTION
…gnal received during read())

On read()/write() syscall returning EINTR, 5.5 clients will retry only
a couple of times before returning failure. This is different from
both lower and higher versions where client EINTR is retried
indefinitely. It appears that this is a regression caused by
THREAD_SAFE_CLIENT symbol removal cleanup, which effectively disabled
code protected by this symbol whereas it should have been
enabled. Fixed accordingly.

http://jenkins.percona.com/job/percona-server-5.5-param/1247/
