### PR TITLE
Fix patch to suit build logic

### DIFF
--- a/build-ps/debian/percona-server-server-5.7.install
+++ b/build-ps/debian/percona-server-server-5.7.install
@@ -58,6 +58,7 @@ usr/lib/mysql/plugin/validate_password.so
 usr/lib/mysql/plugin/version_token.so
 usr/lib/mysql/plugin/keyring_file.so
 usr/lib/mysql/plugin/mysqlx.so
+usr/lib/mysql/plugin/keyring_udf.so
 usr/lib/mysql/plugin/debug/adt_null.so
 usr/lib/mysql/plugin/debug/auth_socket.so
 usr/lib/mysql/plugin/debug/innodb_engine.so
@@ -74,6 +75,7 @@ usr/lib/mysql/plugin/debug/validate_password.so
 usr/lib/mysql/plugin/debug/version_token.so
 usr/lib/mysql/plugin/debug/keyring_file.so
 usr/lib/mysql/plugin/debug/mysqlx.so
+usr/lib/mysql/plugin/debug/keyring_udf.so
 # Percona plugins
 usr/lib/mysql/plugin/audit_log.so
 usr/lib/mysql/plugin/debug/audit_log.so

--- a/build-ps/debian/percona-server-test-5.7.install
+++ b/build-ps/debian/percona-server-test-5.7.install
@@ -38,6 +38,7 @@ usr/lib/mysql/plugin/qa_auth_server.so
 usr/lib/mysql/plugin/replication_observers_example_plugin.so
 usr/lib/mysql/plugin/rewrite_example.so
 usr/lib/mysql/plugin/test_security_context.so
+usr/lib/mysql/plugin/test_udf_services.so
 usr/lib/mysql/plugin/debug/auth_test_plugin.so
 usr/lib/mysql/plugin/debug/ha_example.so
 usr/lib/mysql/plugin/debug/libdaemon_example.so
@@ -68,5 +69,6 @@ usr/lib/mysql/plugin/debug/qa_auth_server.so
 usr/lib/mysql/plugin/debug/replication_observers_example_plugin.so
 usr/lib/mysql/plugin/debug/rewrite_example.so
 usr/lib/mysql/plugin/debug/test_security_context.so
+usr/lib/mysql/plugin/debug/test_udf_services.so
 # test suite
 usr/lib/mysql-test/*

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -650,6 +650,7 @@ fi
 %attr(755, root, root) %{_libdir}/mysql/plugin/validate_password.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/version_token.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/mysqlx.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/keyring_udf.so
 %dir %{_libdir}/mysql/plugin/debug
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/adt_null.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/auth_socket.so
@@ -667,6 +668,7 @@ fi
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/validate_password.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/version_token.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/mysqlx.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/debug/keyring_udf.so
 %if 0%{?mecab}
 %{_libdir}/mysql/mecab
 %attr(755, root, root) %{_libdir}/mysql/plugin/libpluginmecab.so
@@ -708,6 +710,7 @@ fi
 %attr(644, root, root) %{_datadir}/percona-server/uninstall_rewriter.sql
 %attr(644, root, root) %{_datadir}/percona-server/magic
 %if 0%{?systemd}
+%attr(644, root, root) %{_unitdir}/mysqld@.service
 %attr(644, root, root) %{_unitdir}/mysqld.service
 %attr(644, root, root) %{_prefix}/lib/tmpfiles.d/mysql.conf
 %else
@@ -842,6 +845,7 @@ fi
 %attr(755, root, root) %{_libdir}/mysql/plugin/qa_auth_interface.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/qa_auth_server.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/test_security_context.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/test_udf_services.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/auth.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/auth_test_plugin.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/libdaemon_example.so
@@ -871,6 +875,7 @@ fi
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/qa_auth_interface.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/qa_auth_server.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/test_security_context.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/debug/test_udf_services.so
 
 %attr(644, root, root) %{_mandir}/man1/mysql_client_test.1*
 %attr(644, root, root) %{_mandir}/man1/mysql-stress-test.pl.1*

--- a/build-ps/rpm/mysql-5.7-sharedlib-rename.patch
+++ b/build-ps/rpm/mysql-5.7-sharedlib-rename.patch
@@ -246,13 +246,19 @@ diff -rup old/libmysql/libmysql.map new/libmysql/libmysql.map
 diff -rup old/libmysql/libmysql.ver.in new/libmysql/libmysql.ver.in
 --- old/libmysql/libmysql.ver.in	2016-03-09 09:25:21.000000000 +0100
 +++ new/libmysql/libmysql.ver.in	2016-03-09 11:41:15.159325622 +0100
-@@ -14,5 +14,5 @@
+@@ -13,9 +13,8 @@
+    along with this program; if not, write to the Free Software
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA */
  
- 
+-
 -libperconaserverclient_@SHARED_LIB_MAJOR_VERSION@.0
++libmysqlclient_@SHARED_LIB_MAJOR_VERSION@.0
+ { global: ${CLIENT_API_FUNCTIONS};${CLIENT_API_FUNCTIONS_UNDOCUMENTED_20_0}; local: *; };
+
+-libperconaserverclient_@SHARED_LIB_MAJOR_VERSION@.3
+-{ ${CLIENT_API_FUNCTIONS_UNDOCUMENTED_20_3}; } libperconaserverclient_@SHARED_LIB_MAJOR_VERSION@.0;
 +libmysqlclient_@SHARED_LIB_MAJOR_VERSION@.@SHARED_LIB_MINOR_VERSION@
- { global: ${CLIENT_API_FUNCTIONS};${CLIENT_API_FUNCTIONS_UNDOCUMENTED}; local: *; };
++{ ${CLIENT_API_FUNCTIONS_UNDOCUMENTED_20_3}; } libmysqlclient_@SHARED_LIB_MAJOR_VERSION@.0;
 diff -rup old/plugin/percona-pam-for-mysql/CMakeLists.txt new/plugin/percona-pam-for-mysql/CMakeLists.txt
 --- old/plugin/percona-pam-for-mysql/CMakeLists.txt	2016-03-09 09:25:25.000000000 +0100
 +++ new/plugin/percona-pam-for-mysql/CMakeLists.txt	2016-03-09 11:41:15.163325622 +0100

--- a/build-ps/ubuntu/percona-server-server-5.7.install
+++ b/build-ps/ubuntu/percona-server-server-5.7.install
@@ -58,6 +58,7 @@ usr/lib/mysql/plugin/validate_password.so
 usr/lib/mysql/plugin/version_token.so
 usr/lib/mysql/plugin/keyring_file.so
 usr/lib/mysql/plugin/mysqlx.so
+usr/lib/mysql/plugin/keyring_udf.so
 usr/lib/mysql/plugin/debug/adt_null.so
 usr/lib/mysql/plugin/debug/auth_socket.so
 usr/lib/mysql/plugin/debug/innodb_engine.so
@@ -74,6 +75,7 @@ usr/lib/mysql/plugin/debug/validate_password.so
 usr/lib/mysql/plugin/debug/version_token.so
 usr/lib/mysql/plugin/debug/keyring_file.so
 usr/lib/mysql/plugin/debug/mysqlx.so
+usr/lib/mysql/plugin/debug/keyring_udf.so
 # Percona plugins
 usr/lib/mysql/plugin/audit_log.so
 usr/lib/mysql/plugin/debug/audit_log.so

--- a/build-ps/ubuntu/percona-server-test-5.7.install
+++ b/build-ps/ubuntu/percona-server-test-5.7.install
@@ -38,6 +38,7 @@ usr/lib/mysql/plugin/qa_auth_server.so
 usr/lib/mysql/plugin/replication_observers_example_plugin.so
 usr/lib/mysql/plugin/rewrite_example.so
 usr/lib/mysql/plugin/test_security_context.so
+usr/lib/mysql/plugin/test_udf_services.so
 usr/lib/mysql/plugin/debug/auth_test_plugin.so
 usr/lib/mysql/plugin/debug/ha_example.so
 usr/lib/mysql/plugin/debug/libdaemon_example.so
@@ -68,5 +69,6 @@ usr/lib/mysql/plugin/debug/qa_auth_server.so
 usr/lib/mysql/plugin/debug/replication_observers_example_plugin.so
 usr/lib/mysql/plugin/debug/rewrite_example.so
 usr/lib/mysql/plugin/debug/test_security_context.so
+usr/lib/mysql/plugin/debug/test_udf_services.so
 # test suite
 usr/lib/mysql-test/*


### PR DESCRIPTION
http://jenkins.percona.com/job/percona-server-5.7-RELEASE/36/

Installed:
  Percona-Server-57-debuginfo.x86_64 0:5.7.13-6.1.el7  Percona-Server-client-57.x86_64 0:5.7.13-6.1.el7  
  Percona-Server-devel-57.x86_64 0:5.7.13-6.1.el7      Percona-Server-server-57.x86_64 0:5.7.13-6.1.el7  
  Percona-Server-shared-57.x86_64 0:5.7.13-6.1.el7     Percona-Server-shared-compat-57.x86_64 0:5.7.13-6.1.el7 
  Percona-Server-test-57.x86_64 0:5.7.13-6.1.el7      

Dependency Installed:
  net-tools.x86_64 0:2.0-0.17.20131004git.el7                                                                  

Complete!
[korvin@localhost percona-server]$ sudo service mysql start
Redirecting to /bin/systemctl start  mysql.service
[korvin@localhost percona-server]$ sudo service mysql status
Redirecting to /bin/systemctl status  mysql.service
● mysqld.service - MySQL Server
   Loaded: loaded (/usr/lib/systemd/system/mysqld.service; enabled; vendor preset: disabled)
   Active: active (running) since Mon 2016-06-27 04:20:40 EDT; 7s ago
  Process: 2325 ExecStart=/usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid $MYSQLD_OPTS (code=exited, status=0/SUCCESS)
  Process: 2275 ExecStartPre=/usr/bin/mysqld_pre_systemd (code=exited, status=0/SUCCESS)
 Main PID: 2329 (mysqld)
   CGroup: /system.slice/mysqld.service
           └─2329 /usr/sbin/mysqld --daemonize --pid-file=/var/run/mysqld/mysqld.pid
