### PR TITLE
Fix bug 1597143 (InnoDB: Failing assertion: log_sys->buf == ut_align(…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug1597143.result
+++ b/mysql-test/suite/innodb/r/percona_bug1597143.result
@@ -1,0 +1,12 @@
+SET @saved_innodb_log_write_ahead_size=@@GLOBAL.innodb_log_write_ahead_size;
+SET GLOBAL innodb_log_write_ahead_size=8192;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+SET GLOBAL innodb_log_write_ahead_size=16384;
+INSERT INTO t1 VALUES (2);
+SET GLOBAL innodb_log_write_ahead_size=512;
+INSERT INTO t1 VALUES (3);
+SET GLOBAL innodb_log_write_ahead_size=2048;
+INSERT INTO t1 VALUES (4);
+DROP TABLE t1;
+SET GLOBAL innodb_log_write_ahead_size=@saved_innodb_log_write_ahead_size;

--- a/mysql-test/suite/innodb/t/percona_bug1597143.test
+++ b/mysql-test/suite/innodb/t/percona_bug1597143.test
@@ -1,0 +1,23 @@
+--source include/have_innodb.inc
+
+SET @saved_innodb_log_write_ahead_size=@@GLOBAL.innodb_log_write_ahead_size;
+SET GLOBAL innodb_log_write_ahead_size=8192;
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+SET GLOBAL innodb_log_write_ahead_size=16384;
+
+INSERT INTO t1 VALUES (2);
+
+SET GLOBAL innodb_log_write_ahead_size=512;
+
+INSERT INTO t1 VALUES (3);
+
+SET GLOBAL innodb_log_write_ahead_size=2048;
+
+INSERT INTO t1 VALUES (4);
+
+DROP TABLE t1;
+
+SET GLOBAL innodb_log_write_ahead_size=@saved_innodb_log_write_ahead_size;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -20472,8 +20472,8 @@ static MYSQL_SYSVAR_ULONG(log_write_ahead_size, srv_log_write_ahead_size,
   "Redo log write ahead unit size to avoid read-on-write,"
   " it should match the OS cache block IO size",
   NULL, innodb_log_write_ahead_size_update,
-  DEFAULT_SRV_LOG_WRITE_AHEAD_SIZE, OS_FILE_LOG_BLOCK_SIZE, UNIV_PAGE_SIZE_DEF,
-  OS_FILE_LOG_BLOCK_SIZE);
+  DEFAULT_SRV_LOG_WRITE_AHEAD_SIZE, OS_FILE_LOG_BLOCK_SIZE,
+  MAX_SRV_LOG_WRITE_AHEAD_SIZE, OS_FILE_LOG_BLOCK_SIZE);
 
 static MYSQL_SYSVAR_UINT(old_blocks_pct, innobase_old_blocks_pct,
   PLUGIN_VAR_RQCMDARG,

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -310,6 +310,7 @@ extern ulint	srv_log_buffer_size;
 extern uint	srv_flush_log_at_timeout;
 
 enum { DEFAULT_SRV_LOG_WRITE_AHEAD_SIZE = 8 * 1024L };
+enum { MAX_SRV_LOG_WRITE_AHEAD_SIZE = UNIV_PAGE_SIZE_DEF };
 
 extern ulong	srv_log_write_ahead_size;
 extern char	srv_use_global_flush_log_at_trx_commit;

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -262,9 +262,10 @@ log_buffer_extend(
 	log_sys->buf_size = LOG_BUFFER_SIZE;
 
 	log_sys->buf_ptr = static_cast<byte*>(
-		ut_zalloc_nokey(log_sys->buf_size * 2 + srv_log_write_ahead_size));
+		ut_zalloc_nokey(log_sys->buf_size * 2
+				+ MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 	log_sys->buf = static_cast<byte*>(
-		ut_align(log_sys->buf_ptr, srv_log_write_ahead_size));
+		ut_align(log_sys->buf_ptr, MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	log_sys->first_in_use = true;
 
@@ -875,9 +876,10 @@ log_init(void)
 	log_sys->buf_size = LOG_BUFFER_SIZE;
 
 	log_sys->buf_ptr = static_cast<byte*>(
-		ut_zalloc_nokey(log_sys->buf_size * 2 + srv_log_write_ahead_size));
+		ut_zalloc_nokey(log_sys->buf_size * 2
+				+ MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 	log_sys->buf = static_cast<byte*>(
-		ut_align(log_sys->buf_ptr, srv_log_write_ahead_size));
+		ut_align(log_sys->buf_ptr, MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	log_sys->first_in_use = true;
 
@@ -905,10 +907,12 @@ log_init(void)
 		SYNC_NO_ORDER_CHECK);
 
 	log_sys->checkpoint_buf_ptr = static_cast<byte*>(
-		ut_zalloc_nokey(OS_FILE_LOG_BLOCK_SIZE + srv_log_write_ahead_size));
+		ut_zalloc_nokey(OS_FILE_LOG_BLOCK_SIZE
+				+ MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	log_sys->checkpoint_buf = static_cast<byte*>(
-		ut_align(log_sys->checkpoint_buf_ptr, srv_log_write_ahead_size));
+		ut_align(log_sys->checkpoint_buf_ptr,
+			 MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	/*----------------------------*/
 
@@ -959,18 +963,20 @@ log_group_init(
 	for (i = 0; i < n_files; i++) {
 		group->file_header_bufs_ptr[i] = static_cast<byte*>(
 			ut_zalloc_nokey(LOG_FILE_HDR_SIZE
-					+ srv_log_write_ahead_size));
+					+ MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 		group->file_header_bufs[i] = static_cast<byte*>(
 			ut_align(group->file_header_bufs_ptr[i],
-				 srv_log_write_ahead_size));
+				 MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 	}
 
 	group->checkpoint_buf_ptr = static_cast<byte*>(
-		ut_zalloc_nokey(OS_FILE_LOG_BLOCK_SIZE + srv_log_write_ahead_size));
+		ut_zalloc_nokey(OS_FILE_LOG_BLOCK_SIZE +
+				MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	group->checkpoint_buf = static_cast<byte*>(
-		ut_align(group->checkpoint_buf_ptr,srv_log_write_ahead_size));
+		ut_align(group->checkpoint_buf_ptr,
+			 MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	UT_LIST_ADD_LAST(log_sys->log_groups, group);
 
@@ -1247,13 +1253,13 @@ log_buffer_switch()
 						 OS_FILE_LOG_BLOCK_SIZE);
 
 	if (log_sys->first_in_use) {
-		ut_ad(log_sys->buf == ut_align(log_sys->buf_ptr,
-					       srv_log_write_ahead_size));
+		ut_ad((reinterpret_cast<uintptr_t>(log_sys->buf)
+		       % srv_log_write_ahead_size) == 0);
 		log_sys->buf += log_sys->buf_size;
 	} else {
 		log_sys->buf -= log_sys->buf_size;
-		ut_ad(log_sys->buf == ut_align(log_sys->buf_ptr,
-					       srv_log_write_ahead_size));
+		ut_ad((reinterpret_cast<uintptr_t>(log_sys->buf)
+		       % srv_log_write_ahead_size) == 0);
 	}
 
 	log_sys->first_in_use = !log_sys->first_in_use;

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -623,10 +623,11 @@ log_online_read_init(void)
 	log_bmp_sys = static_cast<log_bitmap_struct *>
 		(ut_malloc(sizeof(*log_bmp_sys), mem_key_log_online_sys));
 	log_bmp_sys->read_buf_ptr = static_cast<byte *>
-		(ut_malloc(FOLLOW_SCAN_SIZE + srv_log_write_ahead_size,
+		(ut_malloc(FOLLOW_SCAN_SIZE + MAX_SRV_LOG_WRITE_AHEAD_SIZE,
 			   mem_key_log_online_read_buf));
 	log_bmp_sys->read_buf = static_cast<byte *>
-		(ut_align(log_bmp_sys->read_buf_ptr, srv_log_write_ahead_size));
+		(ut_align(log_bmp_sys->read_buf_ptr,
+			  MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	mutex_create(LATCH_ID_LOG_ONLINE, &log_bmp_sys->mutex);
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -934,10 +934,11 @@ recv_sys_init(
 	recv_sys->apply_batch_on = FALSE;
 
 	recv_sys->last_block_buf_start = static_cast<byte*>(
-		ut_malloc_nokey(OS_FILE_LOG_BLOCK_SIZE + srv_log_write_ahead_size));
+		ut_malloc_nokey(OS_FILE_LOG_BLOCK_SIZE
+				+ MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	recv_sys->last_block = static_cast<byte*>(ut_align(
-		recv_sys->last_block_buf_start, srv_log_write_ahead_size));
+		recv_sys->last_block_buf_start, MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	recv_sys->found_corrupt_log = false;
 	recv_sys->found_corrupt_fs = false;
@@ -3989,9 +3990,11 @@ recv_recovery_from_checkpoint_start(
 	const page_id_t	page_id(max_cp_group->space_id, 0);
 
 	byte* log_hdr_buf_unalign = static_cast<byte*>(ut_malloc_nokey(
-				LOG_FILE_HDR_SIZE + srv_log_write_ahead_size));
+				LOG_FILE_HDR_SIZE
+				+ MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 	log_hdr_buf = static_cast<byte*>(ut_align(
-				log_hdr_buf_unalign, srv_log_write_ahead_size));
+				log_hdr_buf_unalign,
+				MAX_SRV_LOG_WRITE_AHEAD_SIZE));
 
 	fil_io(IORequestLogRead, true, page_id, univ_page_size, 0,
 	       LOG_FILE_HDR_SIZE, log_hdr_buf, max_cp_group);


### PR DESCRIPTION
…log_sys->buf_ptr, srv_log_write_ahead_size))

In order to support innodb_flush_method=ALL_O_DIRECT, the log I/O
buffers were aligned to innodb_log_write_ahead_size. This missed that
the variable is dynamic. Fix by aligning to the maximum possible
innodb_log_write_ahead_size instead, and replace ut_align in the
failing asserts-which checks not only alignment but a particular
address-with a modulo-based alignment check.

http://jenkins.percona.com/job/mysql-5.7-param/228/
