### PR TITLE
General spelling fixes in comments in Innobase/Xtradb and TokuDB

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -6580,7 +6580,7 @@ int ha_tokudb::external_lock(THD * thd, int lock_type) {
                       This happens if the thread didn't update any rows
                       We must in this case commit the work to keep the row locks
                     */
-                    DBUG_PRINT("trans", ("commiting non-updating transaction"));
+                    DBUG_PRINT("trans", ("committing non-updating transaction"));
                     reset_stmt_progress(&trx->stmt_progress);
                     commit_txn(trx->stmt, 0);
                     trx->stmt = NULL;

--- a/storage/tokudb/tokudb_update_fun.cc
+++ b/storage/tokudb/tokudb_update_fun.cc
@@ -147,7 +147,7 @@ enum {
 //     field null num     4 bit 31 is 1 if the field is nullible and the
 //                          remaining bits contain the null bit number
 //     field offset       4 for fixed fields, this is the offset from
-//                          begining of the row of the field
+//                          beginning of the row of the field
 //     value:
 //         value length   4 == N, length of the value
 //         value          N value to add or subtract


### PR DESCRIPTION
Contribution released with the BSD 2-clause license and thus available for
any MySQL variant to use freely.

Copyright (c) 2016 Otto Kekäläinen / The MariaDB Foundation
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

Signed-off-by: Otto Kekäläinen otto@mariadb.org
