### PR TITLE
Add testcase for bug 1592290 (SHOW GLOBAL STATUS blocks too much)

### DIFF
--- a/mysql-test/suite/innodb/r/percona_xtradb_status_variables.result
+++ b/mysql-test/suite/innodb/r/percona_xtradb_status_variables.result
@@ -1,0 +1,30 @@
+#
+# Test extra XtraDB status variables
+#
+SET @saved_innodb_adaptive_hash_index = @@GLOBAL.innodb_adaptive_hash_index;
+CREATE FUNCTION test_memory_accounting(status_var VARCHAR(100)) RETURNS BOOL
+BEGIN
+DECLARE pfs_status_var INT;
+SELECT VARIABLE_VALUE INTO @pfs_status_var FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME LIKE status_var;
+RETURN (@pfs_status_var > 0);
+END|
+CREATE FUNCTION test_ahi_memory() RETURNS BOOL
+BEGIN
+RETURN test_memory_accounting("innodb_mem_adaptive_hash");
+END|
+CREATE FUNCTION test_dd_memory() RETURNS BOOL
+BEGIN
+RETURN test_memory_accounting("innodb_mem_dictionary");
+END|
+SET GLOBAL innodb_adaptive_hash_index = ON;
+include/assert.inc [innodb_mem_adaptive_hash must be greater than zero]
+include/assert.inc [innodb_mem_dictionary must be greater than zero]
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+include/assert.inc [innodb_mem_adaptive_hash must be greater than zero]
+SET GLOBAL innodb_adaptive_hash_index = ON;
+include/assert.inc [innodb_mem_adaptive_hash must be greater than zero]
+SET GLOBAL innodb_adaptive_hash_index = @saved_innodb_adaptive_hash_index;
+DROP FUNCTION test_ahi_memory;
+DROP FUNCTION test_dd_memory;
+DROP FUNCTION test_memory_accounting;

--- a/mysql-test/suite/innodb/t/percona_xtradb_status_variables.test
+++ b/mysql-test/suite/innodb/t/percona_xtradb_status_variables.test
@@ -1,0 +1,57 @@
+--source include/have_innodb.inc
+
+--echo #
+--echo # Test extra XtraDB status variables
+--echo #
+
+SET @saved_innodb_adaptive_hash_index = @@GLOBAL.innodb_adaptive_hash_index;
+
+# 5.5 version only tests that the variable is greater than zero. Still keep the functions
+# for easier upmerges.
+DELIMITER |;
+CREATE FUNCTION test_memory_accounting(status_var VARCHAR(100)) RETURNS BOOL
+BEGIN
+  DECLARE pfs_status_var INT;
+  SELECT VARIABLE_VALUE INTO @pfs_status_var FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+         WHERE VARIABLE_NAME LIKE status_var;
+  RETURN (@pfs_status_var > 0);
+END|
+
+CREATE FUNCTION test_ahi_memory() RETURNS BOOL
+BEGIN
+  RETURN test_memory_accounting("innodb_mem_adaptive_hash");
+END|
+
+CREATE FUNCTION test_dd_memory() RETURNS BOOL
+BEGIN
+  RETURN test_memory_accounting("innodb_mem_dictionary");
+END|
+DELIMITER ;|
+
+SET GLOBAL innodb_adaptive_hash_index = ON;
+
+--let $assert_text= innodb_mem_adaptive_hash must be greater than zero
+--let $assert_cond= test_ahi_memory() = TRUE
+--source include/assert.inc
+
+--let $assert_text= innodb_mem_dictionary must be greater than zero
+--let $assert_cond= test_dd_memory() = TRUE
+--source include/assert.inc
+
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+
+--let $assert_text= innodb_mem_adaptive_hash must be greater than zero
+--let $assert_cond= test_ahi_memory() = TRUE
+--source include/assert.inc
+
+SET GLOBAL innodb_adaptive_hash_index = ON;
+
+--let $assert_text= innodb_mem_adaptive_hash must be greater than zero
+--let $assert_cond= test_ahi_memory() = TRUE
+--source include/assert.inc
+
+SET GLOBAL innodb_adaptive_hash_index = @saved_innodb_adaptive_hash_index;
+
+DROP FUNCTION test_ahi_memory;
+DROP FUNCTION test_dd_memory;
+DROP FUNCTION test_memory_accounting;


### PR DESCRIPTION
Add a basic testcase for innodb_mem_adaptive_hash and
innodb_mem_dictionary status variables.

http://jenkins.percona.com/job/percona-server-5.5-param/1251/
