### PR TITLE
Fix bug 79610 / 1525407 (Failed DROP DATABASE due FK constraint on ma…

### DIFF
--- a/mysql-test/extra/binlog_tests/database.test
+++ b/mysql-test/extra/binlog_tests/database.test
@@ -86,8 +86,8 @@ RESET MASTER;
 
 --error ER_ROW_IS_REFERENCED
 DROP DATABASE db1;                      # Fails because of the fk
-SHOW TABLES FROM db1;                   # t1 was dropped, t2 remains
---source include/show_binlog_events.inc # Check that the binlog drops t1
+SHOW TABLES FROM db1;                   # t1 and t2 remain
+--source include/show_binlog_events.inc # Check that the binlog drops nothing
 
 # Cleanup
 DROP TABLE t3;

--- a/mysql-test/extra/rpl_tests/rpl_foreign_key.test
+++ b/mysql-test/extra/rpl_tests/rpl_foreign_key.test
@@ -59,4 +59,54 @@ select count(*) from t1 /* must be zero */;
 connection master;
 drop table t2,t1;
 
+--echo #
+--echo # Bug 79610: Failed DROP DATABASE due FK constraint on master breaks slave
+--echo #
+
+SET foreign_key_checks=1;
+CREATE DATABASE `db2`;
+
+USE `db2`;
+
+create table a1(f1 int);
+
+eval CREATE TABLE `table0` (`ID` bigint(20) primary key) ENGINE=$engine_type;
+eval CREATE TABLE `table1` (`ID` bigint(20) primary key) ENGINE=$engine_type;
+
+create database db1;
+use db1;
+
+eval CREATE TABLE `table2` ( `ID` bigint(20) NOT NULL AUTO_INCREMENT,
+                             `DIVISION_ID` bigint(20) DEFAULT NULL,
+                             PRIMARY KEY (`ID`), KEY `FK_TABLE1_DIVISION_1` (`DIVISION_ID`),
+                             CONSTRAINT `FK_TABLE1_DIVISION_1` FOREIGN KEY (`DIVISION_ID`)
+                             REFERENCES `db2`.`table1` (`ID`) ON DELETE NO ACTION ) ENGINE=$engine_type;
+
+--sync_slave_with_master
+use db2;
+eval CREATE TABLE `table2` ( `ID` bigint(20) NOT NULL AUTO_INCREMENT,
+                             `DIVISION_ID` bigint(20) DEFAULT NULL,
+                             PRIMARY KEY (`ID`), KEY `FK_TABLE1_DIVISION_1` (`DIVISION_ID`),
+                             CONSTRAINT `FK_TABLE1_DIVISION_1` FOREIGN KEY (`DIVISION_ID`)
+                             REFERENCES `db2`.`table0` (`ID`) ON DELETE NO ACTION ) ENGINE=$engine_type;
+
+--connection master
+--error ER_ROW_IS_REFERENCED
+DROP DATABASE db2;
+
+--echo # DROP DATABASE should not have deleted any tables
+--echo # master:
+SHOW TABLES IN db2;
+
+--connection slave
+--echo # slave:
+SHOW TABLES IN db2;
+
+--connection master
+SET foreign_key_checks=0;
+DROP DATABASE db2;
+DROP DATABASE db1;
+
+--sync_slave_with_master
+
 --source include/rpl_end.inc

--- a/mysql-test/suite/binlog/r/binlog_database.result
+++ b/mysql-test/suite/binlog/r/binlog_database.result
@@ -76,10 +76,10 @@ DROP DATABASE db1;
 ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
 SHOW TABLES FROM db1;
 Tables_in_db1
+t1
 t2
 show binlog events from <binlog_start>;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-master-bin.000001	#	Query	#	#	use `db1`; DROP TABLE IF EXISTS `t1`
 DROP TABLE t3;
 DROP DATABASE db1;
 set binlog_format=mixed;
@@ -159,10 +159,10 @@ DROP DATABASE db1;
 ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
 SHOW TABLES FROM db1;
 Tables_in_db1
+t1
 t2
 show binlog events from <binlog_start>;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-master-bin.000001	#	Query	#	#	use `db1`; DROP TABLE IF EXISTS `t1`
 DROP TABLE t3;
 DROP DATABASE db1;
 set binlog_format=row;
@@ -244,10 +244,10 @@ DROP DATABASE db1;
 ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
 SHOW TABLES FROM db1;
 Tables_in_db1
+t1
 t2
 show binlog events from <binlog_start>;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
-master-bin.000001	#	Query	#	#	use `db1`; DROP TABLE IF EXISTS `t1`
 DROP TABLE t3;
 DROP DATABASE db1;
 show databases;

--- a/mysql-test/suite/rpl/r/rpl_foreign_key_innodb.result
+++ b/mysql-test/suite/rpl/r/rpl_foreign_key_innodb.result
@@ -48,4 +48,45 @@ select count(*) from t1 /* must be zero */;
 count(*)
 0
 drop table t2,t1;
+#
+# Bug 79610: Failed DROP DATABASE due FK constraint on master breaks slave
+#
+SET foreign_key_checks=1;
+CREATE DATABASE `db2`;
+USE `db2`;
+create table a1(f1 int);
+CREATE TABLE `table0` (`ID` bigint(20) primary key) ENGINE=INNODB;
+CREATE TABLE `table1` (`ID` bigint(20) primary key) ENGINE=INNODB;
+create database db1;
+use db1;
+CREATE TABLE `table2` ( `ID` bigint(20) NOT NULL AUTO_INCREMENT,
+`DIVISION_ID` bigint(20) DEFAULT NULL,
+PRIMARY KEY (`ID`), KEY `FK_TABLE1_DIVISION_1` (`DIVISION_ID`),
+CONSTRAINT `FK_TABLE1_DIVISION_1` FOREIGN KEY (`DIVISION_ID`)
+REFERENCES `db2`.`table1` (`ID`) ON DELETE NO ACTION ) ENGINE=INNODB;
+use db2;
+CREATE TABLE `table2` ( `ID` bigint(20) NOT NULL AUTO_INCREMENT,
+`DIVISION_ID` bigint(20) DEFAULT NULL,
+PRIMARY KEY (`ID`), KEY `FK_TABLE1_DIVISION_1` (`DIVISION_ID`),
+CONSTRAINT `FK_TABLE1_DIVISION_1` FOREIGN KEY (`DIVISION_ID`)
+REFERENCES `db2`.`table0` (`ID`) ON DELETE NO ACTION ) ENGINE=INNODB;
+DROP DATABASE db2;
+ERROR 23000: Cannot delete or update a parent row: a foreign key constraint fails
+# DROP DATABASE should not have deleted any tables
+# master:
+SHOW TABLES IN db2;
+Tables_in_db2
+a1
+table0
+table1
+# slave:
+SHOW TABLES IN db2;
+Tables_in_db2
+a1
+table0
+table1
+table2
+SET foreign_key_checks=0;
+DROP DATABASE db2;
+DROP DATABASE db1;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_foreign_key_innodb-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_foreign_key_innodb-master.opt
@@ -1,0 +1,1 @@
+--replicate-ignore-db=db1 --replicate-wild-ignore-table=db1.%

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -842,6 +842,17 @@ struct handlerton
    my_bool (*flush_changed_page_bitmaps)(void);
    my_bool (*purge_changed_page_bitmaps)(ulonglong lsn);
    my_bool (*is_fake_change)(handlerton *hton, THD *thd);
+   /**
+      Get the list of foreign keys referencing a specified table
+
+      @param thd        The thread handle
+      @param path       Path to the table
+      @param f_key_list[out]    The list of foreign keys
+
+      @return error code or zero for success
+    */
+   int (*get_parent_fk_list)(THD *thd, const char *path,
+                             List<FOREIGN_KEY_INFO>* f_key_list);
    uint32 flags;                                /* global handler flags */
    /*
       Those handlerton functions below are properly initialized at handler

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -1975,6 +1975,84 @@ bool mysql_rm_table(THD *thd,TABLE_LIST *tables, my_bool if_exists,
   DBUG_RETURN(FALSE);
 }
 
+/**
+   Check if DROP DATABASE would not fail due to foreign key constraints
+
+   @param thd           thread handle
+   @param tables        list of the tables in the database to be dropped
+   @param drop_view     whether VIEW .frm files are to be delete too
+
+   @retval true         a FK constraint would prevent DROP DATABASE from fully
+   completing
+   @retval false        no FK constraints would prevent DROP DATABASE from
+   fully completing or some error has happened
+ */
+static
+bool check_drop_database_foreign_keys(THD *thd, TABLE_LIST *tables,
+                                      bool drop_view)
+{
+  DBUG_ASSERT(thd_sql_command(thd) == SQLCOM_DROP_DB);
+
+  for (TABLE_LIST *table= tables; table; table= table->next_local)
+  {
+    const char *db=table->db;
+    const char *alias= (lower_case_table_names == 2)
+      ? table->alias : table->table_name;
+
+    char path[FN_REFLEN + 1];
+    const uint path_length= build_table_filename(path, sizeof(path) - 1, db,
+                                                 alias, reg_ext,
+                                                 table->internal_tmp_table ?
+                                                 FN_IS_TMP : 0);
+
+    // Here and below in case of any failure skip FK check for this table and
+    // let the caller fail later
+    if ((access(path, F_OK) &&
+         ha_create_table_from_engine(thd, db, alias)))
+      continue;
+
+    enum legacy_db_type frm_db_type= DB_TYPE_UNKNOWN;
+    enum frm_type_enum frm_type= dd_frm_type(thd, path, &frm_db_type);
+    if (!drop_view && frm_type != FRMTYPE_TABLE)
+      continue;
+
+    handlerton *table_hton= ha_resolve_by_legacy_type(thd, frm_db_type);
+    if (table_hton == NULL || table_hton->get_parent_fk_list == NULL)
+      continue;
+
+    char *end;
+    *(end= path + path_length - reg_ext_length)= '\0';
+
+    List<FOREIGN_KEY_INFO> fk_list;
+    if (table_hton->get_parent_fk_list(thd, path, &fk_list))
+      continue;
+
+    List_iterator_fast<FOREIGN_KEY_INFO> it;
+    it.init(fk_list);
+
+    FOREIGN_KEY_INFO *fk_info;
+    while ((fk_info= it++))
+    {
+      DBUG_ASSERT(!my_strcasecmp(system_charset_info,
+                                 fk_info->referenced_db->str,
+                                 table->db));
+
+      DBUG_ASSERT(!my_strcasecmp(system_charset_info,
+                                 fk_info->referenced_table->str,
+                                 table->table_name));
+
+      /* Allow FK constraints to any table in the database being dropped */
+      if (my_strcasecmp(system_charset_info, fk_info->foreign_db->str,
+                        table->db))
+      {
+        my_message(ER_ROW_IS_REFERENCED, ER(ER_ROW_IS_REFERENCED), MYF(0));
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
 
 /**
   Execute the drop of a normal or temporary table.
@@ -2022,6 +2100,15 @@ int mysql_rm_table_no_locks(THD *thd, TABLE_LIST *tables, bool if_exists,
   String built_query;
   String built_trans_tmp_query, built_non_trans_tmp_query;
   DBUG_ENTER("mysql_rm_table_no_locks");
+
+  if (thd_sql_command(thd) == SQLCOM_DROP_DB
+      && !drop_temporary
+      && !(thd->variables.option_bits & OPTION_NO_FOREIGN_KEY_CHECKS))
+  {
+    error= check_drop_database_foreign_keys(thd, tables, drop_view);
+    if (error)
+      DBUG_RETURN(error);
+  }
 
   /*
     Prepares the drop statements that will be written into the binary

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -475,6 +475,19 @@ innobase_is_fake_change(
 	THD*		thd);	/*!< in: MySQL thread handle of the user for
 				  whom the transaction is being committed */
 
+/** Get the list of foreign keys referencing a specified table
+table.
+@param thd		The thread handle
+@param path		Path to the table
+@param f_key_list[out]	The list of foreign keys
+
+@return error code or zero for success */
+static
+int
+innobase_get_parent_fk_list(
+	THD*			thd,
+	const char*		path,
+	List<FOREIGN_KEY_INFO>*	f_key_list);
 
 /******************************************************************//**
 Maps a MySQL trx isolation level code to the InnoDB isolation level code
@@ -2710,6 +2723,7 @@ innobase_init(
 	innobase_hton->purge_changed_page_bitmaps
 		= innobase_purge_changed_page_bitmaps;
 	innobase_hton->is_fake_change = innobase_is_fake_change;
+	innobase_hton->get_parent_fk_list = innobase_get_parent_fk_list;
 
 	ut_a(DATA_MYSQL_TRUE_VARCHAR == (ulint)MYSQL_TYPE_VARCHAR);
 
@@ -10057,6 +10071,73 @@ get_foreign_key_info(
 	return(pf_key_info);
 }
 
+/** Get the list of foreign keys referencing a specified table
+table.
+@param thd		The thread handle
+@param path		Path to the table
+@param f_key_list[out]	The list of foreign keys */
+static
+void
+fill_foreign_key_list(THD* thd,
+		      const dict_table_t* table,
+		      List<FOREIGN_KEY_INFO>* f_key_list)
+{
+	ut_ad(mutex_own(&dict_sys->mutex));
+
+	for (dict_foreign_t* foreign
+		     = UT_LIST_GET_FIRST(table->referenced_list);
+	     foreign != NULL;
+	     foreign = UT_LIST_GET_NEXT(referenced_list, foreign)) {
+
+		FOREIGN_KEY_INFO* pf_key_info
+			= get_foreign_key_info(thd, foreign);
+		if (pf_key_info) {
+			f_key_list->push_back(pf_key_info);
+		}
+	}
+}
+
+/** Get the list of foreign keys referencing a specified table
+table.
+@param thd		The thread handle
+@param path		Path to the table
+@param f_key_list[out]	The list of foreign keys
+
+@return error code or zero for success */
+static
+int
+innobase_get_parent_fk_list(
+	THD*			thd,
+	const char*		path,
+	List<FOREIGN_KEY_INFO>*	f_key_list)
+{
+	ut_a(strlen(path) <= FN_REFLEN);
+	char	norm_name[FN_REFLEN + 1];
+	normalize_table_name(norm_name, path);
+
+	trx_t*	parent_trx = check_trx_exists(thd);
+	parent_trx->op_info = "getting list of referencing foreign keys";
+	trx_search_latch_release_if_reserved(parent_trx);
+
+	mutex_enter(&dict_sys->mutex);
+
+	dict_table_t*	table
+		= dict_table_get_low(norm_name,
+				     static_cast<dict_err_ignore_t>(
+					     DICT_ERR_IGNORE_INDEX_ROOT
+					     | DICT_ERR_IGNORE_CORRUPT));
+	if (!table) {
+		mutex_exit(&dict_sys->mutex);
+		return(HA_ERR_NO_SUCH_TABLE);
+	}
+
+	fill_foreign_key_list(thd, table, f_key_list);
+
+	mutex_exit(&dict_sys->mutex);
+	parent_trx->op_info = "";
+	return(0);
+}
+
 /*******************************************************************//**
 Gets the list of foreign keys in this table.
 @return always 0, that is, always succeeds */
@@ -10105,9 +10186,6 @@ ha_innobase::get_parent_foreign_key_list(
 	THD*			thd,		/*!< in: user thread handle */
 	List<FOREIGN_KEY_INFO>*	f_key_list)	/*!< out: foreign key list */
 {
-	FOREIGN_KEY_INFO*	pf_key_info;
-	dict_foreign_t*		foreign;
-
 	ut_a(prebuilt != NULL);
 	update_thd(ha_thd());
 
@@ -10116,16 +10194,7 @@ ha_innobase::get_parent_foreign_key_list(
 	trx_search_latch_release_if_reserved(prebuilt->trx);
 
 	mutex_enter(&(dict_sys->mutex));
-
-	for (foreign = UT_LIST_GET_FIRST(prebuilt->table->referenced_list);
-	     foreign != NULL;
-	     foreign = UT_LIST_GET_NEXT(referenced_list, foreign)) {
-		pf_key_info = get_foreign_key_info(thd, foreign);
-		if (pf_key_info) {
-			f_key_list->push_back(pf_key_info);
-		}
-	}
-
+	fill_foreign_key_list(thd, prebuilt->table, f_key_list);
 	mutex_exit(&(dict_sys->mutex));
 
 	prebuilt->trx->op_info = "";


### PR DESCRIPTION
…ster breaks slave)

If DROP DATABASE fails to delete any of the tables, it is binlogged as
DROP TABLE t1, t2, ... for the tables for which drop succeeded. If slave
has different schema so that it references any of the dropped tables,
replication will break.

Fix by running foreign key checks on all the DROP DATABASE tables before
any table is actually dropped. If any FK constraint would fail, do not
convert DROP DATABASE to DROP TABLE in the binary log and abort
immediately.

To implement the fix,
- add a new handlerton method get_parent_fk_list, that returns the list
  of foreign keys referencing the given table;
- implement this method for InnoDB, make it share code with
  ha_innobase::get_parent_foreign_key_list handler method;
- call it from a new function check_drop_database_foreign_keys, which is
  called from mysql_rm_table_no_locks.

Add a testcase to rpl.rpl_foreign_key_innodb, and adjust
binlog.binlog_database as needed.

http://jenkins.percona.com/job/percona-server-5.5-param/1253/ + http://jenkins.percona.com/job/percona-server-5.5-param/1254/
