### PR TITLE
Fix bug 1603073 (ssl_ca and ssl_crl test failures)

### DIFF
--- a/mysql-test/r/ssl_ca.result
+++ b/mysql-test/r/ssl_ca.result
@@ -5,7 +5,7 @@
 ERROR 2026 (HY000): SSL connection error: SSL_CTX_set_default_verify_paths failed
 # try to connect with correct '--ssl-ca' path : should connect
 Variable_name	Value
-Ssl_cipher	DHE-RSA-AES256-SHA
+Ssl_cipher	SSL_CIPHER
 #
 # Bug#21920678: SSL-CA DOES NOT ACCEPT ~USER TILDE HOME DIRECTORY
 #               PATH SUBSTITUTION
@@ -13,12 +13,12 @@ Ssl_cipher	DHE-RSA-AES256-SHA
 # try to connect with '--ssl-ca' option using tilde home directoy
 # path substitution : should connect
 Variable_name	Value
-Ssl_cipher	DHE-RSA-AES256-SHA
+Ssl_cipher	SSL_CIPHER
 # try to connect with '--ssl-key' option using tilde home directoy
 # path substitution : should connect
 Variable_name	Value
-Ssl_cipher	DHE-RSA-AES256-SHA
+Ssl_cipher	SSL_CIPHER
 # try to connect with '--ssl-cert' option using tilde home directoy
 # path substitution : should connect
 Variable_name	Value
-Ssl_cipher	DHE-RSA-AES256-SHA
+Ssl_cipher	SSL_CIPHER

--- a/mysql-test/t/ssl_ca.test
+++ b/mysql-test/t/ssl_ca.test
@@ -10,6 +10,7 @@
 --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/wrong-cacert.pem --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem test -e "SHOW STATUS LIKE 'Ssl_cipher'" 2>&1
 
 --echo # try to connect with correct '--ssl-ca' path : should connect
+--replace_result DHE-RSA-AES128-GCM-SHA256 SSL_CIPHER DHE-RSA-AES256-SHA SSL_CIPHER DHE-RSA-AES128-SHA SSL_CIPHER
 --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem test -e "SHOW STATUS LIKE 'Ssl_cipher'"
 
 --echo #
@@ -21,15 +22,15 @@
 
 --echo # try to connect with '--ssl-ca' option using tilde home directoy
 --echo # path substitution : should connect
---replace_result $MYSQL_TEST_DIR MYSQL_TEST_DIR
+--replace_result $MYSQL_TEST_DIR MYSQL_TEST_DIR DHE-RSA-AES128-GCM-SHA256 SSL_CIPHER DHE-RSA-AES256-SHA SSL_CIPHER DHE-RSA-AES128-SHA SSL_CIPHER
 --exec $MYSQL --ssl-ca=$mysql_test_dir_path/std_data/cacert.pem --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem test -e "SHOW STATUS LIKE 'Ssl_cipher'"
 
 --echo # try to connect with '--ssl-key' option using tilde home directoy
 --echo # path substitution : should connect
---replace_result $MYSQL_TEST_DIR MYSQL_TEST_DIR
+--replace_result $MYSQL_TEST_DIR MYSQL_TEST_DIR DHE-RSA-AES128-GCM-SHA256 SSL_CIPHER DHE-RSA-AES256-SHA SSL_CIPHER DHE-RSA-AES128-SHA SSL_CIPHER
 --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-key=$mysql_test_dir_path/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem test -e "SHOW STATUS LIKE 'Ssl_cipher'"
 
 --echo # try to connect with '--ssl-cert' option using tilde home directoy
 --echo # path substitution : should connect
---replace_result $MYSQL_TEST_DIR MYSQL_TEST_DIR
+--replace_result $MYSQL_TEST_DIR MYSQL_TEST_DIR DHE-RSA-AES128-GCM-SHA256 SSL_CIPHER DHE-RSA-AES256-SHA SSL_CIPHER DHE-RSA-AES128-SHA SSL_CIPHER
 --exec $MYSQL --ssl-ca=$MYSQL_TEST_DIR/std_data/cacert.pem --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$mysql_test_dir_path/std_data/client-cert.pem test -e "SHOW STATUS LIKE 'Ssl_cipher'"


### PR DESCRIPTION
5.5.50 upstream merge has introduced a new testcase, ssl_ca, which has
to be adjusted for the recent TLSv1.2 changes.  Make the testcase
accept both YaSSL and OpenSSL whitelisted default ciphers.

http://jenkins.percona.com/job/percona-server-5.5-param/1257/
