### PR TITLE
Fix bug 1603978 / 81674 (LeakSanitizer-enabled build fails to bootstr…

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -309,6 +309,8 @@ buf_flush_init_flush_rbt(void)
 
 		buf_flush_list_mutex_enter(buf_pool);
 
+		ut_ad(buf_pool->flush_rbt == NULL);
+
 		/* Create red black tree for speedy insertions in flush list. */
 		buf_pool->flush_rbt = rbt_create(
 			sizeof(buf_page_t*), buf_flush_block_cmp);


### PR DESCRIPTION
…ap server for MTR)

by cherry-picking the following from 5.7:

Fix Bug#18253089 BUF_POOL->FLUSH_RBT IS CREATED WHEN RECOVERY IS NOT NEEDED,
THEN NEVER FREED
- recv_recovery_from_checkpoint_start() is only called from
  innobase_start_or_create_for_mysql() and
  recv_recovery_from_checkpoint_start() calls recv_sys_create()&recv_sys_init()
  but those two functions have already been called earlier in
  innobase_start_or_create_for_mysql(). Those two functions return immediately
  if recv_sys is created/initialized. From this follows that their invokations
  from recv_recovery_from_checkpoint_start() are noops and thus I am removing
  them.
- The code used to initialize buf_pool->flush_rbt (buf_flush_init_flush_rbt())
  from recv_sys_init(). Change this so that it is initialized directly from
  recv_recovery_from_checkpoint_start(). This is the only functional change
  in this patch - buf_pool->flush_rbt will now be initialized later in the
  startup code path.
- The code used to free buf_pool->flush_rbt (buf_flush_free_flush_rbt()) from
  recv_sys_debug_free(). Change this so that the free is done from
  recv_recovery_from_checkpoint_finish(), which is the only caller of
  recv_sys_debug_free(). This is a noop, but made for consistency wrt where
  alloc/free is done - call
  buf_flush_init_flush_rbt() from recv_recovery_from_checkpoint_start() and
  buf_flush_free_flush_rbt() from recv_recovery_from_checkpoint_finish().

This way the code will be restored as of before
annamalai.gurusami@oracle.com-20140210082850-vqlzadis1asdws0e (the fix of
Bug#18144349 INNODB CANNOT USE THE DOUBLEWRITE BUFFER FOR THE FIRST PAGE OF
SYSTEM TABLESPACE) wrt buf_pool->flush_rbt initialization.

Approved by:    Yasufumi (rb:5409)

http://jenkins.percona.com/job/percona-server-5.6-param/1241/#showFailuresLink
