### PR TITLE
Bug#17933308 - VALGRIND: MEMORY LEAK IN MYSQL_OPTIONS() AND MYSQL_LOA…

### DIFF
--- a/include/sql_common.h
+++ b/include/sql_common.h
@@ -29,6 +29,20 @@ extern const char	*unknown_sqlstate;
 extern const char	*cant_connect_sqlstate;
 extern const char	*not_error_sqlstate;
 
+
+/*
+  Free all memory allocated in MYSQL handle except the
+  current options.
+*/
+void mysql_close_free(MYSQL *mysql);
+
+/*
+  Clear connection options stored in MYSQL handle and
+  free memory used by them.
+*/
+void mysql_close_free_options(MYSQL *mysql);
+
+
 struct st_mysql_options_extention {
   char *plugin_dir;
   char *default_auth;

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -115,8 +115,8 @@ char		 *shared_memory_base_name= 0;
 const char 	*def_shared_memory_base_name= default_shared_memory_base_name;
 #endif
 
-static void mysql_close_free_options(MYSQL *mysql);
-static void mysql_close_free(MYSQL *mysql);
+void mysql_close_free_options(MYSQL *mysql);
+void mysql_close_free(MYSQL *mysql);
 static void mysql_prune_stmt_list(MYSQL *mysql);
 
 CHARSET_INFO *default_client_charset_info = &my_charset_latin1;
@@ -3952,7 +3952,7 @@ mysql_select_db(MYSQL *mysql, const char *db)
   If handle is alloced by mysql connect free it.
 *************************************************************************/
 
-static void mysql_close_free_options(MYSQL *mysql)
+void mysql_close_free_options(MYSQL *mysql)
 {
   DBUG_ENTER("mysql_close_free_options");
 
@@ -3988,6 +3988,7 @@ static void mysql_close_free_options(MYSQL *mysql)
   {
     my_free(mysql->options.extension->plugin_dir);
     my_free(mysql->options.extension->default_auth);
+    my_free(mysql->options.extension->server_public_key_path);
     my_hash_free(&mysql->options.extension->connection_attributes);
     my_free(mysql->options.extension);
   }
@@ -3996,18 +3997,24 @@ static void mysql_close_free_options(MYSQL *mysql)
 }
 
 
-static void mysql_close_free(MYSQL *mysql)
+/*
+  Free all memory allocated in a MYSQL handle but preserve
+  current options if any.
+*/
+
+void mysql_close_free(MYSQL *mysql)
 {
   my_free(mysql->host_info);
   my_free(mysql->user);
   my_free(mysql->passwd);
   my_free(mysql->db);
+
 #if defined(EMBEDDED_LIBRARY) || MYSQL_VERSION_ID >= 50100
   my_free(mysql->info_buffer);
   mysql->info_buffer= 0;
 #endif
   /* Clear pointers for better safety */
-  mysql->host_info= mysql->user= mysql->passwd= mysql->db= 0;
+  mysql->host_info= mysql->user= mysql->passwd= mysql->db= mysql->extension= 0;
 }
 
 

--- a/sql-common/client_plugin.c
+++ b/sql-common/client_plugin.c
@@ -281,6 +281,8 @@ int mysql_client_plugin_init()
 
   load_env_plugins(&mysql);
 
+  mysql_close_free(&mysql);
+
   return 0;
 }
 


### PR DESCRIPTION
…D_PLUGIN_V()

Two leaks fixed:
1. Freeing memory allocated for
   mysql->options.extension->server_public_key_path inside
   mysql_close_free_options() function.
2. Freeing memory allocated inside a dummy MYSQL connection handle used
   by mysql_client_plugin_init() by calling mysql_close_free() at the
   end of the function.

Functions mysql_close_free() and mysql_close_free_options() are made available outside the sql-common/client.c file. Also, mysql_close_free() is updated to free memory used by mysql->extension.

http://jenkins.percona.com/job/percona-server-5.6-param/1244/
