### PR TITLE
Fix bug 1604774 (Memory leaks in unit tests)

### DIFF
--- a/mysys/queues.c
+++ b/mysys/queues.c
@@ -582,7 +582,7 @@ my_bool do_test(uint no_parts, uint l_max_ind, my_bool l_fix_used)
   tot_no_parts= no_parts;
   tot_no_loops= 1024;
   perform_insert(&queue);
-  if ((result= perform_ins_del(&queue, max_ind)))
+  result= perform_ins_del(&queue, max_ind);
   delete_queue(&queue);
   if (result)
   {
@@ -664,6 +664,7 @@ static void benchmark_test()
     queue_remove(queue, (uint) 0);
   queue_remove_all(queue);
   stop_measurement();
+  delete_queue(queue);
 }
 
 int main()

--- a/storage/perfschema/unittest/pfs-t.cc
+++ b/storage/perfschema/unittest/pfs-t.cc
@@ -183,6 +183,22 @@ PSI * load_perfschema()
   return (PSI*) psi;
 }
 
+static
+void close_perfschema()
+{
+  // A lot of PFS cleanup is disabled due to bug 56666 in
+  // shutdown_performance_schema. This bug does not apply
+  // for a single-threaded unit test, thus cleanup manually here.
+  cleanup_table_share();
+  cleanup_instruments();
+  cleanup_socket_class();
+  cleanup_file_class();
+  cleanup_sync_class();
+  cleanup_thread_class();
+  cleanup_events_waits_history_long();
+  shutdown_performance_schema();
+}
+
 void test_bad_registration()
 {
   PSI *psi;
@@ -582,7 +598,7 @@ void test_bad_registration()
   ok(dummy_socket_key == 2, "assigned key");
 
 
-  shutdown_performance_schema();
+  close_perfschema();
 }
 
 void test_init_disabled()
@@ -1016,7 +1032,7 @@ void test_init_disabled()
   socket_A1= psi->init_socket(99, NULL, NULL, 0);
   ok(socket_A1 == NULL, "broken socket key not instrumented");
   
-  shutdown_performance_schema();
+  close_perfschema();
 }
 
 void test_locker_disabled()
@@ -1350,7 +1366,7 @@ void test_locker_disabled()
   socket_locker= psi->start_socket_wait(&socket_state, socket_A1, PSI_SOCKET_SEND, 12, "foo.cc", 12);
   ok(socket_locker == NULL, "no locker");
 
-  shutdown_performance_schema();
+  close_perfschema();
 }
 
 void test_file_instrumentation_leak()
@@ -1437,7 +1453,7 @@ void test_file_instrumentation_leak()
   file_locker= psi->get_thread_file_descriptor_locker(&file_state, (File) 12, PSI_FILE_WRITE);
   ok(file_locker == NULL, "no locker, no leak");
 
-  shutdown_performance_schema();
+  close_perfschema();
 }
 
 void test_enabled()
@@ -1473,7 +1489,7 @@ void test_enabled()
     { & cond_key_B, "C-B", 0}
   };
 
-  shutdown_performance_schema();
+  close_perfschema();
 #endif
 }
 

--- a/storage/perfschema/unittest/pfs_instr-oom-t.cc
+++ b/storage/perfschema/unittest/pfs_instr-oom-t.cc
@@ -354,6 +354,7 @@ void test_oom()
   init_event_name_sizing(& param);
   rc= init_instruments(& param);
   ok(rc == 1, "oom (per thread wait)");
+  cleanup_instruments();
 
   param.m_enabled= true;
   param.m_mutex_class_sizing= 0;


### PR DESCRIPTION
Trivailly fix memory leaks in the unit tests that have been exposed by
LeakSanitiser testing.

```
http://jenkins.percona.com/job/percona-server-5.6-param/1246/
```
