### PR TITLE
Fix bug 1604676 (Do not free SSL_COMP_get_compression_methods() direc…

### DIFF
--- a/mysql-test/valgrind.supp
+++ b/mysql-test/valgrind.supp
@@ -84,17 +84,7 @@
    Memcheck:Leak
    fun:calloc
    fun:allocate_dtv
-   fun:_dl_allocate_tls_storage
-   fun:__GI__dl_allocate_tls
-   fun:pthread_create
-}
-
-{
-   pthread allocate_dtv memory loss second
-   Memcheck:Leak
-   fun:calloc
-   fun:allocate_dtv
-   fun:_dl_allocate_tls
+   ...
    fun:pthread_create*
 }
 
@@ -876,6 +866,39 @@
    fun:buf_buddy_free_low
    fun:buf_buddy_free
 }
+
+{
+   OpenSSL still reachable.
+   Memcheck:Leak
+   fun:malloc
+   fun:CRYPTO_malloc
+   fun:sk_new
+   fun:*
+   fun:SSL_COMP_get_compression_methods
+   fun:SSL_library_init
+}
+
+{
+   OpenSSL still reachable 2
+   Memcheck:Leak
+   fun:malloc
+   fun:CRYPTO_malloc
+   ...
+   fun:FIPS_mode_set
+   fun:OPENSSL_init_library
+}
+
+{
+   OpenSSL libstdc++ version 5 / three
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:malloc
+   ...
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+}
+
 {
    zlib longest_match false positive
    Memcheck:Cond

--- a/vio/vio.c
+++ b/vio/vio.c
@@ -311,9 +311,9 @@ void vio_end(void)
 #ifdef HAVE_YASSL
   yaSSL_CleanUp();
 #elif defined(HAVE_OPENSSL)
+  ERR_remove_state(0);
   ERR_free_strings();
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
-  sk_SSL_COMP_free(SSL_COMP_get_compression_methods());
 #endif
 }


### PR DESCRIPTION
…tly)

The fix for bug 1341067 added
sk_SSL_COMP_free(SSL_COMP_get_compression_methods()) call to free some
of the heap memory allocated by OpenSSL. This is not safe for repeated
calls if OpenSSL is linked twice through different libraries and each
is trying to free the same. The proper fix would be to call
SSL_COMP_free_compression_methods(), but this API has been introduced
in newer OpenSSL versions than what we are supporting. Thus, fix by
not attempting to free compression methods at all, and add a
corresponding Valgrind suppression.

At the same time call ERR_remove_state(0) to free what's legal to
free, and fix-up/backport/add the rest of Valgrind suppressions in
order to get clean runs on SSL-related testcases.

http://jenkins.percona.com/job/percona-server-5.5-param/1262/
