### PR TITLE
Fix bug 1606478 (rpl.rpl_extra_col_master_myisam test unstable on 5.5)

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_extra_col_master.test
+++ b/mysql-test/extra/rpl_tests/rpl_extra_col_master.test
@@ -450,7 +450,6 @@ connection master;
 --echo ** Stop and Reset Slave **
 --echo
 STOP SLAVE;
-RESET SLAVE;
 --echo
 --echo ** create table slave side **
 eval CREATE TABLE t10 (a INT PRIMARY KEY, b BLOB, c CHAR(5)
@@ -462,12 +461,14 @@ eval CREATE TABLE t10 (a INT PRIMARY KEY, b BLOB, c CHAR(5)
 --connection master
 eval CREATE TABLE t10 (a INT KEY, b BLOB, f DOUBLE DEFAULT '233',
                       c CHAR(5), e INT DEFAULT '1')ENGINE=$engine_type;
-RESET MASTER;
 
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***
@@ -507,7 +508,6 @@ sync_slave_with_master;
 --echo
 --echo  *** Create t11 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 
 eval CREATE TABLE t11 (a INT PRIMARY KEY, b BLOB, c VARCHAR(254)
                        ) ENGINE=$engine_type;
@@ -518,12 +518,13 @@ connection master;
 eval CREATE TABLE t11 (a INT KEY, b BLOB, f TEXT,
                       c CHAR(5) DEFAULT 'test', e INT DEFAULT '1')ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***
@@ -563,7 +564,6 @@ sync_slave_with_master;
 --echo
 --echo  *** Create t12 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 eval CREATE TABLE t12 (a INT PRIMARY KEY, b BLOB, c BLOB
                        ) ENGINE=$engine_type;
 
@@ -573,12 +573,13 @@ connection master;
 eval CREATE TABLE t12 (a INT KEY, b BLOB, f TEXT,
                       c CHAR(5) DEFAULT 'test', e INT DEFAULT '1')ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***
@@ -614,7 +615,6 @@ sync_slave_with_master;
 --echo
 --echo *** Create t14 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 eval CREATE TABLE t14 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
                        ) ENGINE=$engine_type;
 
@@ -626,12 +626,13 @@ eval CREATE TABLE t14 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
                       c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
                       )ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***
@@ -689,7 +690,6 @@ connection slave;
 #***************************
 
 STOP SLAVE;
-RESET SLAVE;
 
 --echo
 --echo *** Drop t14  ***
@@ -697,10 +697,12 @@ DROP TABLE t14;
 
 connection master;
 DROP TABLE t14;
-RESET MASTER;
 
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 #################################################
 --echo
@@ -711,7 +713,6 @@ START SLAVE;
 --echo
 --echo *** Create t15 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 eval CREATE TABLE t15 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
                        ) ENGINE=$engine_type;
 
@@ -723,12 +724,13 @@ eval CREATE TABLE t15 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
                       c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
                       )ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***
@@ -753,7 +755,6 @@ connection slave;
 --let $show_slave_sql_error= 1
 --source include/wait_for_slave_sql_error.inc
 STOP SLAVE;
-RESET SLAVE;
 
 --echo
 --echo *** Drop t15  ***
@@ -761,10 +762,12 @@ DROP TABLE t15;
 
 connection master;
 DROP TABLE t15;
-RESET MASTER;
 
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 ####################################################
 --echo
@@ -775,7 +778,6 @@ START SLAVE;
 --echo
 --echo *** Create t16 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 eval CREATE TABLE t16 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
                        ) ENGINE=$engine_type;
 
@@ -787,12 +789,13 @@ eval CREATE TABLE t16 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
                       c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
                       )ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Create Index and Data Insert ***
@@ -830,7 +833,6 @@ connection slave;
 --let $show_slave_sql_error= 1
 --source include/wait_for_slave_sql_error.inc
 STOP SLAVE;
-RESET SLAVE;
 
 --echo
 --echo *** Drop t16  ***
@@ -838,11 +840,12 @@ DROP TABLE t16;
 
 connection master;
 DROP TABLE t16;
-RESET MASTER;
 
 connection slave;
-START SLAVE;
-#*******************************************
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 ####################################################
 --echo
@@ -853,7 +856,6 @@ START SLAVE;
 --echo
 --echo *** Create t17 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 eval CREATE TABLE t17 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
                        ) ENGINE=$engine_type;
 
@@ -865,12 +867,13 @@ eval CREATE TABLE t17 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
                       c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
                       )ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***
@@ -919,7 +922,6 @@ sync_slave_with_master;
 --echo 
 
 STOP SLAVE;
-RESET SLAVE;
 eval CREATE TABLE t18 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
                        ) ENGINE=$engine_type;
 
@@ -931,12 +933,13 @@ eval CREATE TABLE t18 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
                       c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
                       )ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***
@@ -982,7 +985,6 @@ sync_slave_with_master;
 --echo
 --echo *** Create t5 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 eval CREATE TABLE t5 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
                        ) ENGINE=$engine_type;
 
@@ -994,12 +996,13 @@ eval CREATE TABLE t5 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
                       c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
                       )ENGINE=$engine_type;
 
-RESET MASTER;
-
 --echo
 --echo *** Start Slave ***
 connection slave;
-START SLAVE;
+
+# reset master and slave and start slave
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
 
 --echo
 --echo *** Master Data Insert ***

--- a/mysql-test/suite/rpl/r/rpl_extra_col_master_innodb.result
+++ b/mysql-test/suite/rpl/r/rpl_extra_col_master_innodb.result
@@ -433,7 +433,6 @@ include/check_slave_is_running.inc
 ** Stop and Reset Slave **
 
 STOP SLAVE;
-RESET SLAVE;
 
 ** create table slave side **
 CREATE TABLE t10 (a INT PRIMARY KEY, b BLOB, c CHAR(5)
@@ -443,10 +442,9 @@ CREATE TABLE t10 (a INT PRIMARY KEY, b BLOB, c CHAR(5)
 
 CREATE TABLE t10 (a INT KEY, b BLOB, f DOUBLE DEFAULT '233',
 c CHAR(5), e INT DEFAULT '1')ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -472,17 +470,15 @@ DROP TABLE t10;
 
 *** Create t11 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t11 (a INT PRIMARY KEY, b BLOB, c VARCHAR(254)
 ) ENGINE='InnoDB';
 
 *** Create t11 on Master ***
 CREATE TABLE t11 (a INT KEY, b BLOB, f TEXT,
 c CHAR(5) DEFAULT 'test', e INT DEFAULT '1')ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -508,17 +504,15 @@ DROP TABLE t11;
 
 *** Create t12 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t12 (a INT PRIMARY KEY, b BLOB, c BLOB
 ) ENGINE='InnoDB';
 
 *** Create t12 on Master ***
 CREATE TABLE t12 (a INT KEY, b BLOB, f TEXT,
 c CHAR(5) DEFAULT 'test', e INT DEFAULT '1')ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -551,7 +545,6 @@ DROP TABLE t12;
 
 *** Create t14 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t14 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='InnoDB';
 
@@ -560,10 +553,9 @@ CREATE TABLE t14 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 ALTER TABLE t14 ADD COLUMN c2 DECIMAL(8,2) AFTER c1;
@@ -610,13 +602,11 @@ c1	c3	hex(c4)	c5	c6
 include/wait_for_slave_sql_error.inc [errno=1091]
 Last_SQL_Error = 'Error 'Can't DROP 'c7'; check that column/key exists' on query. Default database: 'test'. Query: 'ALTER TABLE t14 DROP COLUMN c7''
 STOP SLAVE;
-RESET SLAVE;
 
 *** Drop t14  ***
 DROP TABLE t14;
 DROP TABLE t14;
-RESET MASTER;
-START SLAVE;
+include/rpl_reset.inc
 
 *************************************************
 * - Alter Master adding columns at end of table *
@@ -625,7 +615,6 @@ START SLAVE;
 
 *** Create t15 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t15 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='InnoDB';
 
@@ -634,10 +623,9 @@ CREATE TABLE t15 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 ALTER TABLE t15 ADD COLUMN c2 DECIMAL(8,2) AFTER c7;
@@ -659,13 +647,11 @@ c1	hex(c4)	c5	c6	c7	c2
 include/wait_for_slave_sql_error.inc [errno=1054]
 Last_SQL_Error = 'Error 'Unknown column 'c7' in 't15'' on query. Default database: 'test'. Query: 'ALTER TABLE t15 ADD COLUMN c2 DECIMAL(8,2) AFTER c7''
 STOP SLAVE;
-RESET SLAVE;
 
 *** Drop t15  ***
 DROP TABLE t15;
 DROP TABLE t15;
-RESET MASTER;
-START SLAVE;
+include/rpl_reset.inc
 
 ************************************************
 * - Create index on Master column not on slave *
@@ -674,7 +660,6 @@ START SLAVE;
 
 *** Create t16 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t16 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='InnoDB';
 
@@ -683,10 +668,9 @@ CREATE TABLE t16 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Create Index and Data Insert ***
 CREATE INDEX part_of_c6 ON t16 (c6);
@@ -708,13 +692,11 @@ c1	hex(c4)	c5	c6	c7
 include/wait_for_slave_sql_error.inc [errno=1072]
 Last_SQL_Error = 'Error 'Key column 'c6' doesn't exist in table' on query. Default database: 'test'. Query: 'CREATE INDEX part_of_c6 ON t16 (c6)''
 STOP SLAVE;
-RESET SLAVE;
 
 *** Drop t16  ***
 DROP TABLE t16;
 DROP TABLE t16;
-RESET MASTER;
-START SLAVE;
+include/rpl_reset.inc
 
 *****************************************************
 * - Delete rows using column on Master not on slave *
@@ -723,7 +705,6 @@ START SLAVE;
 
 *** Create t17 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t17 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='InnoDB';
 
@@ -732,10 +713,9 @@ CREATE TABLE t17 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -781,7 +761,6 @@ DROP TABLE t17;
 *** Create t18 on slave  ***
 
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t18 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='InnoDB';
 
@@ -790,10 +769,9 @@ CREATE TABLE t18 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -838,7 +816,6 @@ DROP TABLE t18;
 
 *** Create t5 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t5 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='InnoDB';
 
@@ -847,10 +824,9 @@ CREATE TABLE t5 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 LONG, 
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='InnoDB';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';

--- a/mysql-test/suite/rpl/r/rpl_extra_col_master_myisam.result
+++ b/mysql-test/suite/rpl/r/rpl_extra_col_master_myisam.result
@@ -433,7 +433,6 @@ include/check_slave_is_running.inc
 ** Stop and Reset Slave **
 
 STOP SLAVE;
-RESET SLAVE;
 
 ** create table slave side **
 CREATE TABLE t10 (a INT PRIMARY KEY, b BLOB, c CHAR(5)
@@ -443,10 +442,9 @@ CREATE TABLE t10 (a INT PRIMARY KEY, b BLOB, c CHAR(5)
 
 CREATE TABLE t10 (a INT KEY, b BLOB, f DOUBLE DEFAULT '233',
 c CHAR(5), e INT DEFAULT '1')ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -472,17 +470,15 @@ DROP TABLE t10;
 
 *** Create t11 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t11 (a INT PRIMARY KEY, b BLOB, c VARCHAR(254)
 ) ENGINE='MyISAM';
 
 *** Create t11 on Master ***
 CREATE TABLE t11 (a INT KEY, b BLOB, f TEXT,
 c CHAR(5) DEFAULT 'test', e INT DEFAULT '1')ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -508,17 +504,15 @@ DROP TABLE t11;
 
 *** Create t12 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t12 (a INT PRIMARY KEY, b BLOB, c BLOB
 ) ENGINE='MyISAM';
 
 *** Create t12 on Master ***
 CREATE TABLE t12 (a INT KEY, b BLOB, f TEXT,
 c CHAR(5) DEFAULT 'test', e INT DEFAULT '1')ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -551,7 +545,6 @@ DROP TABLE t12;
 
 *** Create t14 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t14 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='MyISAM';
 
@@ -560,10 +553,9 @@ CREATE TABLE t14 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 ALTER TABLE t14 ADD COLUMN c2 DECIMAL(8,2) AFTER c1;
@@ -610,13 +602,11 @@ c1	c3	hex(c4)	c5	c6
 include/wait_for_slave_sql_error.inc [errno=1091]
 Last_SQL_Error = 'Error 'Can't DROP 'c7'; check that column/key exists' on query. Default database: 'test'. Query: 'ALTER TABLE t14 DROP COLUMN c7''
 STOP SLAVE;
-RESET SLAVE;
 
 *** Drop t14  ***
 DROP TABLE t14;
 DROP TABLE t14;
-RESET MASTER;
-START SLAVE;
+include/rpl_reset.inc
 
 *************************************************
 * - Alter Master adding columns at end of table *
@@ -625,7 +615,6 @@ START SLAVE;
 
 *** Create t15 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t15 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='MyISAM';
 
@@ -634,10 +623,9 @@ CREATE TABLE t15 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 ALTER TABLE t15 ADD COLUMN c2 DECIMAL(8,2) AFTER c7;
@@ -659,13 +647,11 @@ c1	hex(c4)	c5	c6	c7	c2
 include/wait_for_slave_sql_error.inc [errno=1054]
 Last_SQL_Error = 'Error 'Unknown column 'c7' in 't15'' on query. Default database: 'test'. Query: 'ALTER TABLE t15 ADD COLUMN c2 DECIMAL(8,2) AFTER c7''
 STOP SLAVE;
-RESET SLAVE;
 
 *** Drop t15  ***
 DROP TABLE t15;
 DROP TABLE t15;
-RESET MASTER;
-START SLAVE;
+include/rpl_reset.inc
 
 ************************************************
 * - Create index on Master column not on slave *
@@ -674,7 +660,6 @@ START SLAVE;
 
 *** Create t16 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t16 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='MyISAM';
 
@@ -683,10 +668,9 @@ CREATE TABLE t16 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Create Index and Data Insert ***
 CREATE INDEX part_of_c6 ON t16 (c6);
@@ -708,13 +692,11 @@ c1	hex(c4)	c5	c6	c7
 include/wait_for_slave_sql_error.inc [errno=1072]
 Last_SQL_Error = 'Error 'Key column 'c6' doesn't exist in table' on query. Default database: 'test'. Query: 'CREATE INDEX part_of_c6 ON t16 (c6)''
 STOP SLAVE;
-RESET SLAVE;
 
 *** Drop t16  ***
 DROP TABLE t16;
 DROP TABLE t16;
-RESET MASTER;
-START SLAVE;
+include/rpl_reset.inc
 
 *****************************************************
 * - Delete rows using column on Master not on slave *
@@ -723,7 +705,6 @@ START SLAVE;
 
 *** Create t17 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t17 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='MyISAM';
 
@@ -732,10 +713,9 @@ CREATE TABLE t17 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -781,7 +761,6 @@ DROP TABLE t17;
 *** Create t18 on slave  ***
 
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t18 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='MyISAM';
 
@@ -790,10 +769,9 @@ CREATE TABLE t18 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 INT DEFAULT '1',
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';
@@ -838,7 +816,6 @@ DROP TABLE t18;
 
 *** Create t5 on slave  ***
 STOP SLAVE;
-RESET SLAVE;
 CREATE TABLE t5 (c1 INT PRIMARY KEY, c4 BLOB, c5 CHAR(5)
 ) ENGINE='MyISAM';
 
@@ -847,10 +824,9 @@ CREATE TABLE t5 (c1 INT KEY, c4 BLOB, c5 CHAR(5),
 c6 LONG, 
 c7 TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP
 )ENGINE='MyISAM';
-RESET MASTER;
 
 *** Start Slave ***
-START SLAVE;
+include/rpl_reset.inc
 
 *** Master Data Insert ***
 set @b1 = 'b1b1b1b1';


### PR DESCRIPTION
rpl_extra_col_master_myisam test fails on 5.5 with

rpl.rpl_extra_col_master_myisam 'row' w4 [ fail ] Found warnings/errors in server log file!
...
160719 21:13:07 [Warning] Slave I/O: SET @master_heartbeat_period to master failed with error: Lost connection to MySQL server during query, Error_code: 2013
...
^ Found warnings in /mnt/workspace/percona-server-5.5-trunk/BUILD_TYPE/debug/Host/ubuntu-precise-64bit/mysql-test/var/4/log/mysqld.2.err
...

The likely cause is the test doing

START SLAVE;

followed almost immediately by

STOP SLAVE;

as START SLAVE is async command, it might not be fully completed by
the time STOP SLAVE comes, getting killed by it, and resulting in the
above warning.

Fix by partially backporting [1], which uses rpl_reset.inc, which
waits synchronously for START SLAVE to complete.

[1]:

commit 82320f93675824a165b2bbf2cb2cdb667a9cfa1e
Author: Sven Sandberg sven.sandberg@oracle.com
Date: Mon Dec 19 11:41:54 2011 +0100

```
WL#3584 bugfixes
 - bugfix: reset slave should not reset Gtid_state
 - bugfix: always register binlog handler when acquiring ownership of
   GTIDs, so that ownership can be released
 - bugfix: write empty GTID to binary log when releasing ownership of
   GTIDs, if GTID is not already in binary log
 - bugfix: don't acquire ownership for empty statements
 - feature: added @@global.gtid_owned and @@session.gtid_owned
 - cleanup: don't pass gtid_state, global_sid_lock, or global_sid_map as arguments
   in functions in Group_cache, and zgroup_execution.cc
 - cleanup: pass Gtid instead of (rpl_sidno, rpl_gno) to some
   functions
 - cleanup: moved Group_cache::update_gtid_state to Gtid_state::update
 - extra assertions
 - clean up some comments
 - disable use of gtid_next_list until we need it
 - clean up some tests
```

http://jenkins.percona.com/job/percona-server-5.5-param/1263/
