### PR TITLE
Fix bug 1606782 (rpl_percona_bug1070255 may crash due to concurrent d…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_percona_bug1070255.result
+++ b/mysql-test/suite/rpl/r/rpl_percona_bug1070255.result
@@ -28,8 +28,10 @@ SELECT * FROM t3;
 a	b
 SELECT * FROM t4;
 a	b
+include/stop_slave.inc
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
 set global DEBUG='';
+include/start_slave.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_percona_bug1070255.test
+++ b/mysql-test/suite/rpl/t/rpl_percona_bug1070255.test
@@ -40,12 +40,19 @@ SELECT * FROM t2;
 SELECT * FROM t3;
 SELECT * FROM t4;
 
+--source include/stop_slave.inc
+
 connection master;
 
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
 
+# Needs to happen with slave stopped, see Oracle bug 58754
 set global DEBUG='';
+
+connection slave;
+
+--source include/start_slave.inc
 
 --source include/rpl_end.inc


### PR DESCRIPTION
…bug access)

The --source include/rpl_stop.inc is preceded by set global DEBUG='';
executed with the slaves running. Thus, this has the same underlying
issue as upstream bug 58754 / 11765758 and is fixed the same way, by
executing SET GLOBAL DEBUG=... with a stopped slave.
