### PR TITLE
Fix bug 1606782 (Shutdown hangs if redo log tracker thread stopped)

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12539,7 +12539,6 @@ innodb_track_changed_pages_validate(
 						for update function */
 	struct st_mysql_value*		value)	/*!< in: incoming bool */
 {
-	static bool     enabled_on_startup = false;
 	long long	intbuf = 0;
 
 	if (value->val_int(value, &intbuf)) {
@@ -12547,8 +12546,7 @@ innodb_track_changed_pages_validate(
 		return 1;
 	}
 
-	if (srv_track_changed_pages || enabled_on_startup) {
-		enabled_on_startup = true;
+	if (srv_redo_log_thread_started) {
 		*reinterpret_cast<ulong*>(save)
 			= static_cast<ulong>(intbuf);
 		return 0;

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -74,6 +74,11 @@ extern os_event_t	srv_checkpoint_completed_event;
 that the (slow) shutdown may proceed */
 extern os_event_t	srv_redo_log_thread_finished_event;
 
+/** Whether the redo log tracker thread has been started. Does not take into
+account whether the tracking is currently enabled (see srv_track_changed_pages
+for that) */
+extern my_bool		srv_redo_log_thread_started;
+
 /* If the last data file is auto-extended, we add this many pages to it
 at a time */
 #define SRV_AUTO_EXTEND_INCREMENT	\
@@ -141,6 +146,9 @@ extern char*	srv_doublewrite_file;
 
 extern ibool	srv_recovery_stats;
 
+/** Whether the redo log tracking is currently enabled. Note that it is
+possible for the log tracker thread to be running and the tracking to be
+disabled */
 extern my_bool		srv_track_changed_pages;
 extern ib_uint64_t	srv_max_bitmap_file_size;
 

--- a/storage/innobase/log/log0log.c
+++ b/storage/innobase/log/log0log.c
@@ -3499,7 +3499,7 @@ loop:
 		srv_shutdown_state = SRV_SHUTDOWN_LAST_PHASE;
 		/* Wake the log tracking thread which will then immediatelly
 		quit because of srv_shutdown_state value */
-		if (srv_track_changed_pages) {
+		if (srv_redo_log_thread_started) {
 			os_event_set(srv_checkpoint_completed_event);
 			os_event_wait(srv_redo_log_thread_finished_event);
 		}
@@ -3576,7 +3576,7 @@ loop:
 	srv_shutdown_state = SRV_SHUTDOWN_LAST_PHASE;
 
 	/* Signal the log following thread to quit */
-	if (srv_track_changed_pages) {
+	if (srv_redo_log_thread_started) {
 		os_event_set(srv_checkpoint_completed_event);
 	}
 
@@ -3600,7 +3600,7 @@ loop:
 
 	fil_flush_file_spaces(FIL_TABLESPACE);
 
-	if (srv_track_changed_pages) {
+	if (srv_redo_log_thread_started) {
 		os_event_wait(srv_redo_log_thread_finished_event);
 	}
 


### PR DESCRIPTION
If the log tracking stops due to margin violation or any other reason
(user request in debug build; I/O error), then shutdown will wait for
a long time for the log tracker thread to quit, which it never does.

This is caused by the tracking margin code setting
srv_track_changed_pages = FALSE as tracking cannot continue, and then
never raising the tracking event so that the tracker thread can wake
up and quit.

The root cause is srv_track_changed_pages attempting to handle two
different purposes: 1) whether the tracking is currently active; 2)
whether the tracker thread has been started.

Fix by splitting off srv_redo_log_thread_started flag out of
srv_track_changed_pages, and using it where appropriate.

```
http://jenkins.percona.com/job/percona-server-5.5-param/1275/
```
