### PR TITLE
fix Bug #13430919 - GENERATE STABLE DUP KEY SCENARIO FOR

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_corrupt_bit.result
+++ b/mysql-test/suite/innodb/r/innodb_corrupt_bit.result
@@ -1,10 +1,11 @@
+call mtr.add_suppression("Flagged corruption of idx.*in CHECK TABLE");
 set names utf8;
 CREATE TABLE corrupt_bit_test_ā(
 a INT AUTO_INCREMENT PRIMARY KEY,
 b CHAR(100),
 c INT,
 z INT,
-INDEX(b))
+INDEX idx(b))
 ENGINE=InnoDB;
 INSERT INTO corrupt_bit_test_ā VALUES(0,'x',1, 1);
 CREATE UNIQUE INDEX idxā ON corrupt_bit_test_ā(c, b);
@@ -12,33 +13,20 @@ CREATE UNIQUE INDEX idxē ON corrupt_bit_test_ā(z, b);
 SELECT * FROM corrupt_bit_test_ā;
 a	b	c	z
 1	x	1	1
-select @@unique_checks;
-@@unique_checks
-0
-select @@innodb_change_buffering_debug;
-@@innodb_change_buffering_debug
-1
 INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+1,z+1 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+10,z+10 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+20,z+20 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+50,z+50 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+100,z+100 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+200,z+200 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+400,z+400 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+800,z+800 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+1600,z+1600 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+4000,z+4000 FROM corrupt_bit_test_ā;
 select count(*) from corrupt_bit_test_ā;
 count(*)
-1024
-CREATE INDEX idx3 ON corrupt_bit_test_ā(b, c);
-INSERT INTO corrupt_bit_test_ā VALUES(13000,'x',1,1);
-CREATE INDEX idx4 ON corrupt_bit_test_ā(b, z);
+2
+SET SESSION debug="+d,dict_set_index_corrupted";
 check table corrupt_bit_test_ā;
 Table	Op	Msg_type	Msg_text
+test.corrupt_bit_test_ā	check	Warning	InnoDB: The B-tree of index "idx" is corrupted.
 test.corrupt_bit_test_ā	check	Warning	InnoDB: The B-tree of index "idxā" is corrupted.
 test.corrupt_bit_test_ā	check	Warning	InnoDB: The B-tree of index "idxē" is corrupted.
 test.corrupt_bit_test_ā	check	error	Corrupt
+SET SESSION debug="-d,dict_set_index_corrupted";
+CREATE INDEX idx3 ON corrupt_bit_test_ā(b, c);
+CREATE INDEX idx4 ON corrupt_bit_test_ā(b, z);
 select c from corrupt_bit_test_ā;
 ERROR HY000: Index corrupt_bit_test_ā is corrupted
 select z from corrupt_bit_test_ā;
@@ -59,6 +47,7 @@ rollback;
 drop index idxā on corrupt_bit_test_ā;
 check table corrupt_bit_test_ā;
 Table	Op	Msg_type	Msg_text
+test.corrupt_bit_test_ā	check	Warning	InnoDB: Index "idx" is marked as corrupted
 test.corrupt_bit_test_ā	check	Warning	InnoDB: Index "idxē" is marked as corrupted
 test.corrupt_bit_test_ā	check	error	Corrupt
 set names utf8;
@@ -69,14 +58,5 @@ select z from corrupt_bit_test_ā limit 10;
 z
 20001
 1
-1
 2
-11
-12
-21
-22
-31
-32
 drop table corrupt_bit_test_ā;
-DROP DATABASE pad;
-SET GLOBAL innodb_change_buffering_debug = 0;

--- a/mysql-test/suite/innodb/t/innodb_corrupt_bit.test
+++ b/mysql-test/suite/innodb/t/innodb_corrupt_bit.test
@@ -2,35 +2,12 @@
 # Test for persistent corrupt bit for corrupted index and table
 #
 -- source include/have_innodb.inc
-
-# Issues with innodb_change_buffering_debug on Windows, so the test scenario
-# cannot be created on windows
---source include/not_windows.inc
+--source include/not_embedded.inc
 
 # This test needs debug server
 --source include/have_debug.inc
 
--- disable_query_log
-# This test setup is extracted from bug56680.test:
-# The flag innodb_change_buffering_debug is only available in debug builds.
-# It instructs InnoDB to try to evict pages from the buffer pool when
-# change buffering is possible, so that the change buffer will be used
-# whenever possible.
-SET @innodb_change_buffering_debug_orig = @@innodb_change_buffering_debug;
-SET GLOBAL innodb_change_buffering_debug = 1;
-
-# Turn off Unique Check to create corrupted index with dup key
-SET UNIQUE_CHECKS=0;
-
-CREATE DATABASE pad;
-let $i=345;
-while ($i)
-{
-  --eval CREATE TABLE pad.t$i (a INT PRIMARY KEY) ENGINE=InnoDB;
-  dec $i;
-}
-
--- enable_query_log
+call mtr.add_suppression("Flagged corruption of idx.*in CHECK TABLE");
 
 set names utf8;
 
@@ -39,50 +16,31 @@ CREATE TABLE corrupt_bit_test_ā(
        b CHAR(100),
        c INT,
        z INT,
-       INDEX(b))
+       INDEX idx(b))
 ENGINE=InnoDB;
 
 INSERT INTO corrupt_bit_test_ā VALUES(0,'x',1, 1);
 
-# This is the first unique index we intend to corrupt
 CREATE UNIQUE INDEX idxā ON corrupt_bit_test_ā(c, b);
 
-# This is the second unique index we intend to corrupt
 CREATE UNIQUE INDEX idxē ON corrupt_bit_test_ā(z, b);
 
 SELECT * FROM corrupt_bit_test_ā;
 
-select @@unique_checks;
-select @@innodb_change_buffering_debug;
-
-# Create enough rows for the table, so that the insert buffer will be
-# used for modifying the secondary index page. There must be multiple
-# index pages, because changes to the root page are never buffered.
-
 INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+1,z+1 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+10,z+10 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+20,z+20 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+50,z+50 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+100,z+100 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+200,z+200 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+400,z+400 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+800,z+800 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+1600,z+1600 FROM corrupt_bit_test_ā;
-INSERT INTO corrupt_bit_test_ā SELECT 0,b,c+4000,z+4000 FROM corrupt_bit_test_ā;
 
 select count(*) from corrupt_bit_test_ā;
 
-CREATE INDEX idx3 ON corrupt_bit_test_ā(b, c);
+# This will flag all secondary indexes corrupted
+SET SESSION debug="+d,dict_set_index_corrupted";
+check table corrupt_bit_test_ā;
+SET SESSION debug="-d,dict_set_index_corrupted";
 
-# Create a dup key error on index "idxē" and "idxā" by inserting a dup value
-INSERT INTO corrupt_bit_test_ā VALUES(13000,'x',1,1);
+# New index that is not set as corrupted
+CREATE INDEX idx3 ON corrupt_bit_test_ā(b, c);
 
 # creating an index should succeed even if other secondary indexes are corrupted
 CREATE INDEX idx4 ON corrupt_bit_test_ā(b, z);
-
-# Check table will find the unique indexes corrupted
-# with dup key
-check table corrupt_bit_test_ā;
 
 # This selection intend to use the corrupted index. Expect to fail
 -- error ER_INDEX_CORRUPT
@@ -107,7 +65,6 @@ delete from corrupt_bit_test_ā where a = 10001;
 insert into corrupt_bit_test_ā values (10001, "a", 20001, 20001);
 rollback;
 
-# Drop one corrupted index before reboot
 drop index idxā on corrupt_bit_test_ā;
 
 check table corrupt_bit_test_ā;
@@ -125,6 +82,3 @@ select z from corrupt_bit_test_ā limit 10;
 
 # Drop table
 drop table corrupt_bit_test_ā;
-DROP DATABASE pad;
-
-SET GLOBAL innodb_change_buffering_debug = 0;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -9721,7 +9721,14 @@ ha_innobase::check(
 
 		prebuilt->select_lock_type = LOCK_NONE;
 
-		if (!row_check_index_for_mysql(prebuilt, index, &n_rows)) {
+		bool check_result
+			= row_check_index_for_mysql(prebuilt, index, &n_rows);
+		DBUG_EXECUTE_IF(
+			"dict_set_index_corrupted",
+			if (!(index->type & DICT_CLUSTERED)) {
+				check_result = false;
+			});
+		if (!check_result) {
 			innobase_format_name(
 				index_name, sizeof index_name,
 				index->name, TRUE);


### PR DESCRIPTION
INNODB.INNODB_CORRUPT_BIT

rb://1759 approved by Marko

```
http://jenkins.percona.com/job/percona-server-5.5-param/1277/
```
