### PR TITLE
Fix bug 1607359 (rpl_4threads_deadlock may crash due to concurrent db…

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_4threads_deadlock.test
+++ b/mysql-test/suite/rpl/t/rpl_4threads_deadlock.test
@@ -32,6 +32,7 @@
 --source include/have_binlog_format_statement.inc
 --source include/master-slave.inc
 
+--source include/count_sessions.inc
 connect(master2,127.0.0.1,root,,test,$MASTER_MYPORT,);
 connect(master3,127.0.0.1,root,,test,$MASTER_MYPORT,);
 --connection master
@@ -112,6 +113,7 @@ while ($iter)
 --disconnect master3
 
 --connection master
+--source include/wait_until_count_sessions.inc
 SET DEBUG_SYNC='RESET';
 SET GLOBAL DEBUG=@save_debug;
 source include/rpl_end.inc;


### PR DESCRIPTION
…ug access)

A client disconnect and SET DEBUG=... running in parallel race in dbug
data structure access. Add synchronisation so that disconnects are
completed before SET DEBUG stats.

```
http://jenkins.percona.com/job/percona-server-5.5-param/1279/
```
