### PR TITLE
Fix bug 1097870 (test rpl_cant_read_event_incident can fail sporadica…

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_cant_read_event_incident.test
+++ b/mysql-test/suite/rpl/t/rpl_cant_read_event_incident.test
@@ -62,7 +62,9 @@ stop slave;
 reset slave;
 # Table was created from binlog, it may not be created if SQL thread is running
 # slowly and IO thread reaches incident before SQL thread applies it.
+--disable_warnings
 drop table if exists t;
+--enable_warnings
 reset master;
 
 --echo End of the tests


### PR DESCRIPTION
…lly)

Disable warnings around "drop table if exists" so that its output is
identical for both existing and non-existing table case.

http://jenkins.percona.com/job/percona-server-5.5-param/1280/
