### PR TITLE
Work towards diagnosing bug 1607606 (test percona_extended_innodb_sta…

### DIFF
--- a/mysql-test/suite/innodb/include/percona_extended_innodb_status.inc
+++ b/mysql-test/suite/innodb/include/percona_extended_innodb_status.inc
@@ -48,16 +48,27 @@ perl;
   use strict;
   use warnings;
 
+  my $expected_locks = $ENV{'expected_locks'};
   my $output = $ENV{'STATUS'};
   if ($output =~ /^Record lock, heap no \d+ PHYSICAL RECORD: n_fields \d+; compact format; info bits \d+$/m)
   {
     print "\"Record lock\" found\n";
     my $records = () = $output =~ /^\s*\d+: len \d+; hex [[:xdigit:]]+; asc .*;;$/gm;
     print "n = $records\n";
+    if ($expected_locks != $records)
+    {
+       print "Expected $expected_locks, found $records. Dumping status\n";
+       print $output;
+    }
   }
   else
   {
     print "\"Record lock\" not found\n";
+    if ($expected_locks != 0)
+    {
+       print "Expected $expected_locks, found 0. Dumping status\n";
+       print $output;
+    }
   }
   if($output =~ /^TOO MANY LOCKS PRINTED FOR THIS TRX: SUPPRESSING FURTHER PRINTS$/m)
   {

--- a/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
+++ b/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
@@ -15,25 +15,30 @@ INSERT INTO t(id) VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
 
 # first, check regular output with monitor turned off
 SET GLOBAL innodb_show_verbose_locks = 0;
+--let expected_locks= 0
 --source suite/innodb/include/percona_extended_innodb_status.inc
 
 # then, verbose output with monitor turned off
 SET GLOBAL innodb_show_verbose_locks = 1;
+--let expected_locks= 4
 --source suite/innodb/include/percona_extended_innodb_status.inc
 
 # create monitor table
 CREATE TABLE innodb_lock_monitor (a INT) ENGINE=InnoDB;
 
 # after that, verbose output with monitor turned on
+--let expected_locks= 12
 --source suite/innodb/include/percona_extended_innodb_status.inc
 
 # and finally, verbose output with monitor turned on and record limit set to 1
 SET GLOBAL innodb_show_locks_held = 1;
+--let expected_locks= 4
 --source suite/innodb/include/percona_extended_innodb_status.inc
 
 # in addition, setting record limit to 0 should act as verbose output with
 # monitor turned off
 SET GLOBAL innodb_show_locks_held = 0;
+--let expected_locks= 4
 --source suite/innodb/include/percona_extended_innodb_status.inc
 
 # wait until all additional connections close


### PR DESCRIPTION
…tus test is unstable)

This test sometimes fails with apparently different record lock count
than expected. Make the test dump the whole SHOW ENGINE INNODB STATUS
output if that happens.

```
http://jenkins.percona.com/job/percona-server-5.5-param/1284/
```
