### PR TITLE
Work towards diagnosing bug 1607607 (test percona_show_temp_tables_st…

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -7504,7 +7504,17 @@ void handle_error(struct st_command *command,
   }
 
   if (command->abort_on_error)
+  {
+    if (err_errno == ER_NO_SUCH_THREAD)
+    {
+      /* No such thread id, let's dump the available ones */
+      fprintf(stderr, "mysqltest: query '%s returned ER_NO_SUCH_THREAD, "
+              "dumping processlist\n", command->query);
+      show_query(&cur_con->mysql, "SHOW PROCESSLIST");
+    }
+
     die("query '%s' failed: %d: %s", command->query, err_errno, err_error);
+  }
 
   DBUG_PRINT("info", ("expected_errors.count: %d",
                       command->expected_errors.count));
@@ -7550,9 +7560,18 @@ void handle_error(struct st_command *command,
   if (command->expected_errors.count > 0)
   {
     if (command->expected_errors.err[0].type == ERR_ERRNO)
+    {
+      if (err_errno == ER_NO_SUCH_THREAD)
+      {
+        /* No such thread id, let's dump the available ones */
+        fprintf(stderr, "mysqltest: query '%s returned ER_NO_SUCH_THREAD, "
+                "dumping processlist\n", command->query);
+        show_query(&cur_con->mysql, "SHOW PROCESSLIST");
+      }
       die("query '%s' failed with wrong errno %d: '%s', instead of %d...",
           command->query, err_errno, err_error,
           command->expected_errors.err[0].code.errnum);
+    }
     else
       die("query '%s' failed with wrong sqlstate %s: '%s', instead of %s...",
           command->query, err_sqlstate, err_error,

--- a/mysql-test/r/mysqltest.result
+++ b/mysql-test/r/mysqltest.result
@@ -950,4 +950,69 @@ con1
 con2
 con2
 -closed_connection-
+#
+# Test that a query failed with ER_NO_SUCH_THREAD causes mysqltest to dump the processlist before dying
+#
+mysqltest: query 'KILL QUERY 276447231 returned ER_NO_SUCH_THREAD, dumping processlist
+=== SHOW PROCESSLIST ===
+---- 1. ----
+Id MASKED
+User	root
+Host	localhost
+db	test
+Command	Sleep
+Time MASKED
+State	
+Info	
+Rows_sent	0
+Rows_examined	0
+Rows_read	0
+---- 2. ----
+Id MASKED
+User	root
+Host	localhost
+db	test
+Command	Query
+Time MASKED
+State	
+Info	SHOW PROCESSLIST
+Rows_sent	0
+Rows_examined	0
+Rows_read	0
+========================
+
+mysqltest: At line 1: query 'KILL QUERY 276447231' failed: 1094: 
+# PROCESSLIST should not be dumped if error was expected
+KILL QUERY 276447231;
+ERROR HY000: Unknown thread id: 276447231
+# PROCESSLIST should be dumped if a different error was expected
+mysqltest: query 'KILL QUERY 276447231 returned ER_NO_SUCH_THREAD, dumping processlist
+=== SHOW PROCESSLIST ===
+---- 1. ----
+Id MASKED
+User	root
+Host	localhost
+db	test
+Command	Sleep
+Time MASKED
+State	
+Info	
+Rows_sent	0
+Rows_examined	0
+Rows_read	0
+---- 2. ----
+Id MASKED
+User	root
+Host	localhost
+db	test
+Command	Query
+Time MASKED
+State	
+Info	SHOW PROCESSLIST
+Rows_sent	0
+Rows_examined	0
+Rows_read	0
+========================
+
+mysqltest: At line 1: query 'KILL QUERY 276447231' failed with wrong errno 1094: '', instead of 1064...
 End of tests

--- a/mysql-test/t/mysqltest.test
+++ b/mysql-test/t/mysqltest.test
@@ -2931,6 +2931,20 @@ disconnect $x;
 disconnect $y;
 --echo $CURRENT_CONNECTION
 
+--echo #
+--echo # Test that a query failed with ER_NO_SUCH_THREAD causes mysqltest to dump the processlist before dying
+--echo #
+--replace_regex /Id[[:space:]]+[0-9]+/Id MASKED/ /Time[[:space:]]+[0-9]+/Time MASKED/
+--error 1
+--exec echo "KILL QUERY 276447231;" | $MYSQL_TEST 2>&1
+
+--echo # PROCESSLIST should not be dumped if error was expected
+--exec echo "error ER_NO_SUCH_THREAD; KILL QUERY 276447231;" | $MYSQL_TEST 2>&1
+
+--echo # PROCESSLIST should be dumped if a different error was expected
+--replace_regex /Id[[:space:]]+[0-9]+/Id MASKED/ /Time[[:space:]]+[0-9]+/Time MASKED/
+--error 1
+--exec echo "error ER_PARSE_ERROR; KILL QUERY 276447231;" | $MYSQL_TEST 2>&1
 
 --echo End of tests
 


### PR DESCRIPTION
…ress is unstable)

If a mysqltest MySQL query failed with ER_NO_SUCH_THREAD, and the
error is not expected, dump the PROCESSLIST to show the available
thread ids and other info at the time.

```
http://jenkins.percona.com/job/percona-server-5.5-param/1283/
```
