### PR TITLE
Fix bug 1607671 (Test rpl.rpl_concurrency_error is unstable)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_concurrency_error.result
+++ b/mysql-test/suite/rpl/r/rpl_concurrency_error.result
@@ -5,10 +5,10 @@ call mtr.add_suppression("Unsafe statement written to the binary log using state
 #                             Environment
 ########################################################################
 CREATE TABLE t (i INT, PRIMARY KEY(i), f CHAR(8)) engine = Innodb;
-CREATE TABLE n (d DATETIME, f CHAR(32)) engine = MyIsam;
+CREATE TABLE n (d INT NOT NULL AUTO_INCREMENT PRIMARY KEY, f CHAR(32)) engine = MyIsam;
 CREATE TRIGGER tr AFTER UPDATE ON t FOR EACH ROW 
 BEGIN 
-INSERT INTO n VALUES ( now(), concat( 'updated t: ', old.f, ' -> ', new.f ) ); 
+INSERT INTO n (f) VALUES ( concat( 'updated t: ', old.f, ' -> ', new.f ) ); 
 END |
 INSERT INTO t VALUES (4,'black'), (2,'red'), (3,'yelow'), (1,'cyan');
 ########################################################################
@@ -18,13 +18,14 @@ SET AUTOCOMMIT = 1;
 BEGIN;
 UPDATE t SET f = 'yellow 2' WHERE i = 3;
 Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it invokes a trigger or a stored function that inserts into an AUTO_INCREMENT column. Inserted values cannot be logged correctly.
 Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement accesses nontransactional table as well as transactional or temporary table, and writes to any of them.
 SET AUTOCOMMIT = 1;
 BEGIN;
 UPDATE t SET f = 'magenta 2' WHERE f = 'red';
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t VALUES (5 + (2 * 10),"brown");
-INSERT INTO n VALUES (now(),"brown");
+INSERT INTO n(f) VALUES ("brown");
 COMMIT;
 ROLLBACK;
 Warnings:
@@ -32,12 +33,15 @@ Warning	1196	Some non-transactional changed tables couldn't be rolled back
 show binlog events from <binlog_start>;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n VALUES (now(),"brown")
+master-bin.000001	#	Intvar	#	#	INSERT_ID=3
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n(f) VALUES ("brown")
 master-bin.000001	#	Query	#	#	COMMIT
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=1
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'yellow 2' WHERE i = 3
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=2
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'magenta 2' WHERE f = 'red'
 master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t VALUES (5 + (2 * 10),"brown")
 master-bin.000001	#	Query	#	#	ROLLBACK
@@ -45,36 +49,41 @@ SET AUTOCOMMIT = 1;
 BEGIN;
 UPDATE t SET f = 'gray 2' WHERE i = 3;
 Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it invokes a trigger or a stored function that inserts into an AUTO_INCREMENT column. Inserted values cannot be logged correctly.
 Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement accesses nontransactional table as well as transactional or temporary table, and writes to any of them.
 SET AUTOCOMMIT = 1;
 BEGIN;
 UPDATE t SET f = 'dark blue 2' WHERE f = 'red';
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t VALUES (6 + (2 * 10),"brown");
-INSERT INTO n VALUES (now(),"brown");
+INSERT INTO n(f) VALUES ("brown");
 COMMIT;
 COMMIT;
 show binlog events from <binlog_start>;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n VALUES (now(),"brown")
+master-bin.000001	#	Intvar	#	#	INSERT_ID=6
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n(f) VALUES ("brown")
 master-bin.000001	#	Query	#	#	COMMIT
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=4
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'gray 2' WHERE i = 3
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=5
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'dark blue 2' WHERE f = 'red'
 master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t VALUES (6 + (2 * 10),"brown")
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */
 SET AUTOCOMMIT = 0;
 UPDATE t SET f = 'yellow 1' WHERE i = 3;
 Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it invokes a trigger or a stored function that inserts into an AUTO_INCREMENT column. Inserted values cannot be logged correctly.
 Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement accesses nontransactional table as well as transactional or temporary table, and writes to any of them.
 SET AUTOCOMMIT = 0;
 UPDATE t SET f = 'magenta 1' WHERE f = 'red';
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t VALUES (5 + (1 * 10),"brown");
-INSERT INTO n VALUES (now(),"brown");
+INSERT INTO n(f) VALUES ("brown");
 COMMIT;
 ROLLBACK;
 Warnings:
@@ -82,35 +91,42 @@ Warning	1196	Some non-transactional changed tables couldn't be rolled back
 show binlog events from <binlog_start>;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n VALUES (now(),"brown")
+master-bin.000001	#	Intvar	#	#	INSERT_ID=9
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n(f) VALUES ("brown")
 master-bin.000001	#	Query	#	#	COMMIT
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=7
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'yellow 1' WHERE i = 3
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=8
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'magenta 1' WHERE f = 'red'
 master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t VALUES (5 + (1 * 10),"brown")
 master-bin.000001	#	Query	#	#	ROLLBACK
 SET AUTOCOMMIT = 0;
 UPDATE t SET f = 'gray 1' WHERE i = 3;
 Warnings:
+Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement is unsafe because it invokes a trigger or a stored function that inserts into an AUTO_INCREMENT column. Inserted values cannot be logged correctly.
 Note	1592	Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT. Statement accesses nontransactional table as well as transactional or temporary table, and writes to any of them.
 SET AUTOCOMMIT = 0;
 UPDATE t SET f = 'dark blue 1' WHERE f = 'red';
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t VALUES (6 + (1 * 10),"brown");
-INSERT INTO n VALUES (now(),"brown");
+INSERT INTO n(f) VALUES ("brown");
 COMMIT;
 COMMIT;
 show binlog events from <binlog_start>;
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
 master-bin.000001	#	Query	#	#	BEGIN
-master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n VALUES (now(),"brown")
+master-bin.000001	#	Intvar	#	#	INSERT_ID=12
+master-bin.000001	#	Query	#	#	use `test`; INSERT INTO n(f) VALUES ("brown")
 master-bin.000001	#	Query	#	#	COMMIT
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=10
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'gray 1' WHERE i = 3
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */
 master-bin.000001	#	Query	#	#	BEGIN
+master-bin.000001	#	Intvar	#	#	INSERT_ID=11
 master-bin.000001	#	Query	#	#	use `test`; UPDATE t SET f = 'dark blue 1' WHERE f = 'red'
 master-bin.000001	#	Query	#	#	use `test`; INSERT INTO t VALUES (6 + (1 * 10),"brown")
 master-bin.000001	#	Xid	#	#	COMMIT /* XID */

--- a/mysql-test/suite/rpl/t/rpl_concurrency_error.test
+++ b/mysql-test/suite/rpl/t/rpl_concurrency_error.test
@@ -29,12 +29,12 @@ call mtr.add_suppression("Unsafe statement written to the binary log using state
 connection master;
 
 CREATE TABLE t (i INT, PRIMARY KEY(i), f CHAR(8)) engine = Innodb;
-CREATE TABLE n (d DATETIME, f CHAR(32)) engine = MyIsam;
+CREATE TABLE n (d INT NOT NULL AUTO_INCREMENT PRIMARY KEY, f CHAR(32)) engine = MyIsam;
 
 DELIMITER |;
 CREATE TRIGGER tr AFTER UPDATE ON t FOR EACH ROW 
 BEGIN 
-  INSERT INTO n VALUES ( now(), concat( 'updated t: ', old.f, ' -> ', new.f ) ); 
+  INSERT INTO n (f) VALUES ( concat( 'updated t: ', old.f, ' -> ', new.f ) ); 
 END |
 DELIMITER ;|
 
@@ -77,7 +77,7 @@ while ($type)
   --error ER_LOCK_WAIT_TIMEOUT
   eval UPDATE t SET f = 'magenta $type' WHERE f = 'red';
   eval INSERT INTO t VALUES (5 + ($type * 10),"brown");
-  INSERT INTO n VALUES (now(),"brown");
+  INSERT INTO n(f) VALUES ("brown");
   
   connection conn1;
   COMMIT;
@@ -112,7 +112,7 @@ while ($type)
   --error ER_LOCK_WAIT_TIMEOUT
   eval UPDATE t SET f = 'dark blue $type' WHERE f = 'red';
   eval INSERT INTO t VALUES (6 + ($type * 10),"brown");
-  INSERT INTO n VALUES (now(),"brown");
+  INSERT INTO n(f) VALUES ("brown");
   
   connection conn1;
   COMMIT;


### PR DESCRIPTION
The triggers in the test run on the master and slave independently,
and so may happen to get different timestamps for the same event,
which then causes differences in table n contents between master and
the slave.

Fix by replacing the timestamp column with an auto_increment one.

http://jenkins.percona.com/job/percona-server-5.5-param/1285/
