### PR TITLE
Allow to log only queries for specific DBs in audit log plugin

### DIFF
--- a/plugin/audit_log/audit_log.h
+++ b/plugin/audit_log/audit_log.h
@@ -24,6 +24,7 @@ extern PSI_memory_key key_memory_audit_log_logger_handle;
 extern PSI_memory_key key_memory_audit_log_handler;
 extern PSI_memory_key key_memory_audit_log_buffer;
 extern PSI_memory_key key_memory_audit_log_accounts;
+extern PSI_memory_key key_memory_audit_log_databases;
 
 #ifdef __cplusplus
 extern "C" {

--- a/plugin/audit_log/filter.h
+++ b/plugin/audit_log/filter.h
@@ -29,6 +29,12 @@ my_bool audit_log_check_account_included(const char *user, size_t user_length,
                                          const char *host, size_t host_length);
 my_bool audit_log_check_account_excluded(const char *user, size_t user_length,
                                          const char *host, size_t host_length);
+
+void audit_log_set_include_databases(const char *val);
+void audit_log_set_exclude_databases(const char *val);
+my_bool audit_log_check_database_included(const char *name, size_t length);
+my_bool audit_log_check_database_excluded(const char *name, size_t length);
+
 void audit_log_filter_init();
 void audit_log_filter_destroy();
 

--- a/plugin/audit_log/tests/mtr/audit_log_csv.result
+++ b/plugin/audit_log/tests/mtr/audit_log_csv.result
@@ -25,11 +25,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -57,11 +59,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/plugin/audit_log/tests/mtr/audit_log_echo.inc
+++ b/plugin/audit_log/tests/mtr/audit_log_echo.inc
@@ -20,6 +20,10 @@ perl;
       # skip opening log record
       next;
     }
+    if ($line =~ /SELECT count\(\*\)=1 FROM t WHERE a=7/) {
+      # skip checking for event shot
+      next;
+    }
     $line =~ s/"([a-zA-Z_ ]*)","([0-9]+)_[0-9_ :T-]*","[0-9_ :A-Z-]*"/"$1","<ID>","<DATETIME>"/;
     $line =~ s/"(Connect|Quit|Change user)","<ID>","<DATETIME>","[0-9]+"/"$1","<ID>","<DATETIME>","<CONN_ID>"/;
     $line =~ s/"([A-Za-z ]+)","<ID>","<DATETIME>","([a-z_]+)","[0-9]+"/"$1","<ID>","<DATETIME>","$2","<CONN_ID>"/;

--- a/plugin/audit_log/tests/mtr/audit_log_filter_db-master.opt
+++ b/plugin/audit_log/tests/mtr/audit_log_filter_db-master.opt
@@ -1,0 +1,5 @@
+--audit_log_file=test_audit.log
+--audit_log_policy=ALL
+--audit-log-format=CSV
+--audit_log_strategy=SYNCHRONOUS
+--thread_stack=16777216

--- a/plugin/audit_log/tests/mtr/audit_log_filter_db.result
+++ b/plugin/audit_log/tests/mtr/audit_log_filter_db.result
@@ -1,0 +1,1555 @@
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+CREATE DATABASE ```db3"`;
+CREATE DATABASE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+SHOW DATABASES;
+Database
+information_schema
+`db3"
+db1
+db2
+mtr
+mysql
+performance_schema
+some_very_long,database_na'me`some_very_long_database_n"ame____q
+sys
+test
+SET GLOBAL audit_log_include_databases= '`some_very_long,database_na\'me``some_very_long_database_n"ame____q`,```db1"`,db3';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+`some_very_long,database_na'me``some_very_long_database_n"ame____q`,```db1"`,db3	NULL
+SET GLOBAL audit_log_exclude_databases= 'db2';
+ERROR 42000: Variable 'audit_log_exclude_databases' can't be set to the value of 'db2'
+SET GLOBAL audit_log_exclude_databases= NULL;
+ERROR 42000: Variable 'audit_log_exclude_databases' can't be set to the value of 'NULL'
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+`some_very_long,database_na'me``some_very_long_database_n"ame____q`,```db1"`,db3	NULL
+SET GLOBAL audit_log_include_databases= 'db1, db2, db3';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+db1, db2, db3	NULL
+SET GLOBAL audit_log_include_databases= '';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+	NULL
+SET GLOBAL audit_log_exclude_databases= 'db1';
+ERROR 42000: Variable 'audit_log_exclude_databases' can't be set to the value of 'db1'
+SET GLOBAL audit_log_include_databases= NULL;
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+NULL	NULL
+SET GLOBAL audit_log_exclude_databases= 'db2,`db3 `';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+NULL	db2,`db3 `
+SET GLOBAL audit_log_include_databases= 'db1, db2, db3';
+ERROR 42000: Variable 'audit_log_include_databases' can't be set to the value of 'db1, db2, db3'
+SET GLOBAL audit_log_include_databases= NULL;
+ERROR 42000: Variable 'audit_log_include_databases' can't be set to the value of 'NULL'
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+NULL	db2,`db3 `
+SET GLOBAL audit_log_exclude_databases= 'db1, db2, db3';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+NULL	db1, db2, db3
+SET GLOBAL audit_log_exclude_databases= '';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+NULL	
+SET GLOBAL audit_log_include_databases= 'db2';
+ERROR 42000: Variable 'audit_log_include_databases' can't be set to the value of 'db2'
+SET GLOBAL audit_log_exclude_databases= NULL;
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+@@audit_log_include_databases	@@audit_log_exclude_databases
+NULL	NULL
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_include_databases= 'db1,```db3"`';
+SET GLOBAL event_scheduler = ON;
+CREATE TABLE db1.t (a INT);
+CREATE TABLE db1.trig (a INT);
+CREATE TABLE db2.t (a INT);
+CREATE TABLE ```db3"`.t (a INT);
+CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t (a INT);
+CREATE TABLE db1.words (id INT, word TEXT);
+USE db1;
+CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t;
+CREATE VIEW vup AS SELECT * FROM db2.t;
+CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7);
+CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100);
+INSERT INTO t VALUES (1), (2), (3);
+CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END//
+CALL p1();
+CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END//
+SET max_sp_recursion_depth = 20;
+CALL p2(10);
+INSERT INTO trig VALUES (1), (2), (3);
+INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three');
+CREATE TABLE a0 (a INT);
+CREATE TABLE a1 (a INT);
+CREATE TABLE a2 (a INT);
+CREATE TABLE a3 (a INT);
+CREATE TABLE a4 (a INT);
+CREATE TABLE a5 (a INT);
+CREATE TABLE a6 (a INT);
+CREATE TABLE a7 (a INT);
+CREATE TABLE a8 (a INT);
+CREATE TABLE a9 (a INT);
+CREATE TABLE a10 (a INT);
+CREATE TABLE a11 (a INT);
+CREATE TABLE a12 (a INT);
+CREATE TABLE a13 (a INT);
+CREATE TABLE a14 (a INT);
+CREATE TABLE a15 (a INT);
+CREATE TABLE a16 (a INT);
+CREATE TABLE a17 (a INT);
+CREATE TABLE a18 (a INT);
+CREATE TABLE a19 (a INT);
+CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a);
+CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a);
+CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a);
+CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a);
+CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a);
+CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a);
+CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a);
+CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a);
+CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a);
+CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a);
+CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a);
+CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a);
+CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a);
+CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a);
+CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a);
+CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a);
+CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a);
+CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a);
+CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a);
+INSERT INTO a19 VALUES (1);
+SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2;
+a	id	word	a
+2	2	two	NULL
+3	3	three	NULL
+1	NULL	NULL	2
+7	NULL	NULL	NULL
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2;
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2;
+USE db2;
+INSERT INTO t VALUES (1), (2), (3), (6);
+INSERT INTO t SELECT * FROM db1.t;
+USE ```db3"`;
+INSERT INTO t VALUES (1), (2), (3);
+USE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+INSERT INTO t VALUES (1), (2), (3);
+use db1;
+INSERT INTO vup VALUES (1);
+SELECT * FROM vjoin;
+s	a
+3	3
+SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+s	a
+3	3
+SELECT * FROM vmat;
+s
+3
+SELECT a FROM vjoin;
+a
+3
+SELECT s FROM vjoin;
+s
+3
+SELECT a,s FROM vjoin;
+a	s
+3	3
+SELECT s FROM vmat;
+s
+3
+SELECT a FROM vup;
+a
+207
+210
+101
+102
+103
+1
+2
+3
+6
+1
+2
+1
+UPDATE vup SET a=a+1;
+UPDATE vjoin SET a=a+1;
+USE test;
+SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t);
+a
+1
+2
+SELECT 1;
+1
+1
+DROP TABLE db1.t;
+DROP TABLE db1.words;
+DROP TABLE db1.trig;
+DROP TABLE db2.t;
+DROP TABLE ```db3"`.t;
+DROP TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t;
+DROP PROCEDURE db1.p1;
+DROP PROCEDURE db1.p2;
+DROP VIEW db1.vmat;
+DROP VIEW db1.vup;
+DROP VIEW db1.vjoin;
+DROP TABLE db1.a0;
+DROP TABLE db1.a1;
+DROP TABLE db1.a2;
+DROP TABLE db1.a3;
+DROP TABLE db1.a4;
+DROP TABLE db1.a5;
+DROP TABLE db1.a6;
+DROP TABLE db1.a7;
+DROP TABLE db1.a8;
+DROP TABLE db1.a9;
+DROP TABLE db1.a10;
+DROP TABLE db1.a11;
+DROP TABLE db1.a12;
+DROP TABLE db1.a13;
+DROP TABLE db1.a14;
+DROP TABLE db1.a15;
+DROP TABLE db1.a16;
+DROP TABLE db1.a17;
+DROP TABLE db1.a18;
+DROP TABLE db1.a19;
+SET GLOBAL event_scheduler = OFF;
+SET GLOBAL audit_log_include_databases= 'db2,```db3"`';
+SET GLOBAL event_scheduler = ON;
+CREATE TABLE db1.t (a INT);
+CREATE TABLE db1.trig (a INT);
+CREATE TABLE db2.t (a INT);
+CREATE TABLE ```db3"`.t (a INT);
+CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t (a INT);
+CREATE TABLE db1.words (id INT, word TEXT);
+USE db1;
+CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t;
+CREATE VIEW vup AS SELECT * FROM db2.t;
+CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7);
+CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100);
+INSERT INTO t VALUES (1), (2), (3);
+CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END//
+CALL p1();
+CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END//
+SET max_sp_recursion_depth = 20;
+CALL p2(10);
+INSERT INTO trig VALUES (1), (2), (3);
+INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three');
+CREATE TABLE a0 (a INT);
+CREATE TABLE a1 (a INT);
+CREATE TABLE a2 (a INT);
+CREATE TABLE a3 (a INT);
+CREATE TABLE a4 (a INT);
+CREATE TABLE a5 (a INT);
+CREATE TABLE a6 (a INT);
+CREATE TABLE a7 (a INT);
+CREATE TABLE a8 (a INT);
+CREATE TABLE a9 (a INT);
+CREATE TABLE a10 (a INT);
+CREATE TABLE a11 (a INT);
+CREATE TABLE a12 (a INT);
+CREATE TABLE a13 (a INT);
+CREATE TABLE a14 (a INT);
+CREATE TABLE a15 (a INT);
+CREATE TABLE a16 (a INT);
+CREATE TABLE a17 (a INT);
+CREATE TABLE a18 (a INT);
+CREATE TABLE a19 (a INT);
+CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a);
+CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a);
+CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a);
+CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a);
+CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a);
+CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a);
+CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a);
+CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a);
+CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a);
+CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a);
+CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a);
+CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a);
+CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a);
+CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a);
+CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a);
+CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a);
+CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a);
+CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a);
+CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a);
+INSERT INTO a19 VALUES (1);
+SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2;
+a	id	word	a
+2	2	two	NULL
+3	3	three	NULL
+1	NULL	NULL	2
+7	NULL	NULL	NULL
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2;
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2;
+USE db2;
+INSERT INTO t VALUES (1), (2), (3), (6);
+INSERT INTO t SELECT * FROM db1.t;
+USE ```db3"`;
+INSERT INTO t VALUES (1), (2), (3);
+USE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+INSERT INTO t VALUES (1), (2), (3);
+use db1;
+INSERT INTO vup VALUES (1);
+SELECT * FROM vjoin;
+s	a
+3	3
+SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+s	a
+3	3
+SELECT * FROM vmat;
+s
+3
+SELECT a FROM vjoin;
+a
+3
+SELECT s FROM vjoin;
+s
+3
+SELECT a,s FROM vjoin;
+a	s
+3	3
+SELECT s FROM vmat;
+s
+3
+SELECT a FROM vup;
+a
+207
+210
+101
+102
+103
+1
+2
+3
+6
+1
+2
+1
+UPDATE vup SET a=a+1;
+UPDATE vjoin SET a=a+1;
+USE test;
+SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t);
+a
+1
+2
+SELECT 1;
+1
+1
+DROP TABLE db1.t;
+DROP TABLE db1.words;
+DROP TABLE db1.trig;
+DROP TABLE db2.t;
+DROP TABLE ```db3"`.t;
+DROP TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t;
+DROP PROCEDURE db1.p1;
+DROP PROCEDURE db1.p2;
+DROP VIEW db1.vmat;
+DROP VIEW db1.vup;
+DROP VIEW db1.vjoin;
+DROP TABLE db1.a0;
+DROP TABLE db1.a1;
+DROP TABLE db1.a2;
+DROP TABLE db1.a3;
+DROP TABLE db1.a4;
+DROP TABLE db1.a5;
+DROP TABLE db1.a6;
+DROP TABLE db1.a7;
+DROP TABLE db1.a8;
+DROP TABLE db1.a9;
+DROP TABLE db1.a10;
+DROP TABLE db1.a11;
+DROP TABLE db1.a12;
+DROP TABLE db1.a13;
+DROP TABLE db1.a14;
+DROP TABLE db1.a15;
+DROP TABLE db1.a16;
+DROP TABLE db1.a17;
+DROP TABLE db1.a18;
+DROP TABLE db1.a19;
+SET GLOBAL event_scheduler = OFF;
+SET GLOBAL audit_log_include_databases= NULL;
+SET GLOBAL event_scheduler = ON;
+CREATE TABLE db1.t (a INT);
+CREATE TABLE db1.trig (a INT);
+CREATE TABLE db2.t (a INT);
+CREATE TABLE ```db3"`.t (a INT);
+CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t (a INT);
+CREATE TABLE db1.words (id INT, word TEXT);
+USE db1;
+CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t;
+CREATE VIEW vup AS SELECT * FROM db2.t;
+CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7);
+CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100);
+INSERT INTO t VALUES (1), (2), (3);
+CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END//
+CALL p1();
+CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END//
+SET max_sp_recursion_depth = 20;
+CALL p2(10);
+INSERT INTO trig VALUES (1), (2), (3);
+INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three');
+CREATE TABLE a0 (a INT);
+CREATE TABLE a1 (a INT);
+CREATE TABLE a2 (a INT);
+CREATE TABLE a3 (a INT);
+CREATE TABLE a4 (a INT);
+CREATE TABLE a5 (a INT);
+CREATE TABLE a6 (a INT);
+CREATE TABLE a7 (a INT);
+CREATE TABLE a8 (a INT);
+CREATE TABLE a9 (a INT);
+CREATE TABLE a10 (a INT);
+CREATE TABLE a11 (a INT);
+CREATE TABLE a12 (a INT);
+CREATE TABLE a13 (a INT);
+CREATE TABLE a14 (a INT);
+CREATE TABLE a15 (a INT);
+CREATE TABLE a16 (a INT);
+CREATE TABLE a17 (a INT);
+CREATE TABLE a18 (a INT);
+CREATE TABLE a19 (a INT);
+CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a);
+CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a);
+CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a);
+CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a);
+CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a);
+CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a);
+CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a);
+CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a);
+CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a);
+CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a);
+CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a);
+CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a);
+CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a);
+CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a);
+CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a);
+CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a);
+CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a);
+CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a);
+CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a);
+INSERT INTO a19 VALUES (1);
+SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2;
+a	id	word	a
+2	2	two	NULL
+3	3	three	NULL
+1	NULL	NULL	2
+7	NULL	NULL	NULL
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2;
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2;
+USE db2;
+INSERT INTO t VALUES (1), (2), (3), (6);
+INSERT INTO t SELECT * FROM db1.t;
+USE ```db3"`;
+INSERT INTO t VALUES (1), (2), (3);
+USE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+INSERT INTO t VALUES (1), (2), (3);
+use db1;
+INSERT INTO vup VALUES (1);
+SELECT * FROM vjoin;
+s	a
+3	3
+SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+s	a
+3	3
+SELECT * FROM vmat;
+s
+3
+SELECT a FROM vjoin;
+a
+3
+SELECT s FROM vjoin;
+s
+3
+SELECT a,s FROM vjoin;
+a	s
+3	3
+SELECT s FROM vmat;
+s
+3
+SELECT a FROM vup;
+a
+207
+210
+101
+102
+103
+1
+2
+3
+6
+1
+2
+1
+UPDATE vup SET a=a+1;
+UPDATE vjoin SET a=a+1;
+USE test;
+SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t);
+a
+1
+2
+SELECT 1;
+1
+1
+DROP TABLE db1.t;
+DROP TABLE db1.words;
+DROP TABLE db1.trig;
+DROP TABLE db2.t;
+DROP TABLE ```db3"`.t;
+DROP TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t;
+DROP PROCEDURE db1.p1;
+DROP PROCEDURE db1.p2;
+DROP VIEW db1.vmat;
+DROP VIEW db1.vup;
+DROP VIEW db1.vjoin;
+DROP TABLE db1.a0;
+DROP TABLE db1.a1;
+DROP TABLE db1.a2;
+DROP TABLE db1.a3;
+DROP TABLE db1.a4;
+DROP TABLE db1.a5;
+DROP TABLE db1.a6;
+DROP TABLE db1.a7;
+DROP TABLE db1.a8;
+DROP TABLE db1.a9;
+DROP TABLE db1.a10;
+DROP TABLE db1.a11;
+DROP TABLE db1.a12;
+DROP TABLE db1.a13;
+DROP TABLE db1.a14;
+DROP TABLE db1.a15;
+DROP TABLE db1.a16;
+DROP TABLE db1.a17;
+DROP TABLE db1.a18;
+DROP TABLE db1.a19;
+SET GLOBAL event_scheduler = OFF;
+SET GLOBAL audit_log_exclude_databases= 'db1,`some_very_long,database_na\'me``some_very_long_database_n"ame____q`';
+SET GLOBAL event_scheduler = ON;
+CREATE TABLE db1.t (a INT);
+CREATE TABLE db1.trig (a INT);
+CREATE TABLE db2.t (a INT);
+CREATE TABLE ```db3"`.t (a INT);
+CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t (a INT);
+CREATE TABLE db1.words (id INT, word TEXT);
+USE db1;
+CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t;
+CREATE VIEW vup AS SELECT * FROM db2.t;
+CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7);
+CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100);
+INSERT INTO t VALUES (1), (2), (3);
+CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END//
+CALL p1();
+CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END//
+SET max_sp_recursion_depth = 20;
+CALL p2(10);
+INSERT INTO trig VALUES (1), (2), (3);
+INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three');
+CREATE TABLE a0 (a INT);
+CREATE TABLE a1 (a INT);
+CREATE TABLE a2 (a INT);
+CREATE TABLE a3 (a INT);
+CREATE TABLE a4 (a INT);
+CREATE TABLE a5 (a INT);
+CREATE TABLE a6 (a INT);
+CREATE TABLE a7 (a INT);
+CREATE TABLE a8 (a INT);
+CREATE TABLE a9 (a INT);
+CREATE TABLE a10 (a INT);
+CREATE TABLE a11 (a INT);
+CREATE TABLE a12 (a INT);
+CREATE TABLE a13 (a INT);
+CREATE TABLE a14 (a INT);
+CREATE TABLE a15 (a INT);
+CREATE TABLE a16 (a INT);
+CREATE TABLE a17 (a INT);
+CREATE TABLE a18 (a INT);
+CREATE TABLE a19 (a INT);
+CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a);
+CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a);
+CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a);
+CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a);
+CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a);
+CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a);
+CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a);
+CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a);
+CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a);
+CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a);
+CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a);
+CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a);
+CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a);
+CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a);
+CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a);
+CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a);
+CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a);
+CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a);
+CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a);
+INSERT INTO a19 VALUES (1);
+SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2;
+a	id	word	a
+2	2	two	NULL
+3	3	three	NULL
+1	NULL	NULL	2
+7	NULL	NULL	NULL
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2;
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2;
+USE db2;
+INSERT INTO t VALUES (1), (2), (3), (6);
+INSERT INTO t SELECT * FROM db1.t;
+USE ```db3"`;
+INSERT INTO t VALUES (1), (2), (3);
+USE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+INSERT INTO t VALUES (1), (2), (3);
+use db1;
+INSERT INTO vup VALUES (1);
+SELECT * FROM vjoin;
+s	a
+3	3
+SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+s	a
+3	3
+SELECT * FROM vmat;
+s
+3
+SELECT a FROM vjoin;
+a
+3
+SELECT s FROM vjoin;
+s
+3
+SELECT a,s FROM vjoin;
+a	s
+3	3
+SELECT s FROM vmat;
+s
+3
+SELECT a FROM vup;
+a
+207
+210
+101
+102
+103
+1
+2
+3
+6
+1
+2
+1
+UPDATE vup SET a=a+1;
+UPDATE vjoin SET a=a+1;
+USE test;
+SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t);
+a
+1
+2
+SELECT 1;
+1
+1
+DROP TABLE db1.t;
+DROP TABLE db1.words;
+DROP TABLE db1.trig;
+DROP TABLE db2.t;
+DROP TABLE ```db3"`.t;
+DROP TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t;
+DROP PROCEDURE db1.p1;
+DROP PROCEDURE db1.p2;
+DROP VIEW db1.vmat;
+DROP VIEW db1.vup;
+DROP VIEW db1.vjoin;
+DROP TABLE db1.a0;
+DROP TABLE db1.a1;
+DROP TABLE db1.a2;
+DROP TABLE db1.a3;
+DROP TABLE db1.a4;
+DROP TABLE db1.a5;
+DROP TABLE db1.a6;
+DROP TABLE db1.a7;
+DROP TABLE db1.a8;
+DROP TABLE db1.a9;
+DROP TABLE db1.a10;
+DROP TABLE db1.a11;
+DROP TABLE db1.a12;
+DROP TABLE db1.a13;
+DROP TABLE db1.a14;
+DROP TABLE db1.a15;
+DROP TABLE db1.a16;
+DROP TABLE db1.a17;
+DROP TABLE db1.a18;
+DROP TABLE db1.a19;
+SET GLOBAL event_scheduler = OFF;
+SET GLOBAL audit_log_exclude_databases= 'db1,db2';
+SET GLOBAL event_scheduler = ON;
+CREATE TABLE db1.t (a INT);
+CREATE TABLE db1.trig (a INT);
+CREATE TABLE db2.t (a INT);
+CREATE TABLE ```db3"`.t (a INT);
+CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t (a INT);
+CREATE TABLE db1.words (id INT, word TEXT);
+USE db1;
+CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t;
+CREATE VIEW vup AS SELECT * FROM db2.t;
+CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7);
+CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100);
+INSERT INTO t VALUES (1), (2), (3);
+CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END//
+CALL p1();
+CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END//
+SET max_sp_recursion_depth = 20;
+CALL p2(10);
+INSERT INTO trig VALUES (1), (2), (3);
+INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three');
+CREATE TABLE a0 (a INT);
+CREATE TABLE a1 (a INT);
+CREATE TABLE a2 (a INT);
+CREATE TABLE a3 (a INT);
+CREATE TABLE a4 (a INT);
+CREATE TABLE a5 (a INT);
+CREATE TABLE a6 (a INT);
+CREATE TABLE a7 (a INT);
+CREATE TABLE a8 (a INT);
+CREATE TABLE a9 (a INT);
+CREATE TABLE a10 (a INT);
+CREATE TABLE a11 (a INT);
+CREATE TABLE a12 (a INT);
+CREATE TABLE a13 (a INT);
+CREATE TABLE a14 (a INT);
+CREATE TABLE a15 (a INT);
+CREATE TABLE a16 (a INT);
+CREATE TABLE a17 (a INT);
+CREATE TABLE a18 (a INT);
+CREATE TABLE a19 (a INT);
+CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a);
+CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a);
+CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a);
+CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a);
+CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a);
+CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a);
+CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a);
+CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a);
+CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a);
+CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a);
+CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a);
+CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a);
+CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a);
+CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a);
+CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a);
+CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a);
+CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a);
+CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a);
+CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a);
+INSERT INTO a19 VALUES (1);
+SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2;
+a	id	word	a
+2	2	two	NULL
+3	3	three	NULL
+1	NULL	NULL	2
+7	NULL	NULL	NULL
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2;
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2;
+USE db2;
+INSERT INTO t VALUES (1), (2), (3), (6);
+INSERT INTO t SELECT * FROM db1.t;
+USE ```db3"`;
+INSERT INTO t VALUES (1), (2), (3);
+USE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+INSERT INTO t VALUES (1), (2), (3);
+use db1;
+INSERT INTO vup VALUES (1);
+SELECT * FROM vjoin;
+s	a
+3	3
+SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+s	a
+3	3
+SELECT * FROM vmat;
+s
+3
+SELECT a FROM vjoin;
+a
+3
+SELECT s FROM vjoin;
+s
+3
+SELECT a,s FROM vjoin;
+a	s
+3	3
+SELECT s FROM vmat;
+s
+3
+SELECT a FROM vup;
+a
+207
+210
+101
+102
+103
+1
+2
+3
+6
+1
+2
+1
+UPDATE vup SET a=a+1;
+UPDATE vjoin SET a=a+1;
+USE test;
+SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t);
+a
+1
+2
+SELECT 1;
+1
+1
+DROP TABLE db1.t;
+DROP TABLE db1.words;
+DROP TABLE db1.trig;
+DROP TABLE db2.t;
+DROP TABLE ```db3"`.t;
+DROP TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t;
+DROP PROCEDURE db1.p1;
+DROP PROCEDURE db1.p2;
+DROP VIEW db1.vmat;
+DROP VIEW db1.vup;
+DROP VIEW db1.vjoin;
+DROP TABLE db1.a0;
+DROP TABLE db1.a1;
+DROP TABLE db1.a2;
+DROP TABLE db1.a3;
+DROP TABLE db1.a4;
+DROP TABLE db1.a5;
+DROP TABLE db1.a6;
+DROP TABLE db1.a7;
+DROP TABLE db1.a8;
+DROP TABLE db1.a9;
+DROP TABLE db1.a10;
+DROP TABLE db1.a11;
+DROP TABLE db1.a12;
+DROP TABLE db1.a13;
+DROP TABLE db1.a14;
+DROP TABLE db1.a15;
+DROP TABLE db1.a16;
+DROP TABLE db1.a17;
+DROP TABLE db1.a18;
+DROP TABLE db1.a19;
+SET GLOBAL event_scheduler = OFF;
+SET GLOBAL audit_log_exclude_databases= NULL;
+set global audit_log_flush= ON;
+===================================================================
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_databases= 'db1,```db3""`'","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = ON","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.trig (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db2.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE ```db3""`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.words (id INT, word TEXT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vup AS SELECT * FROM db2.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_event","<CONN_ID>",0,"CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"INSERT INTO t VALUES (7)","root[root] @ localhost [localhost]","localhost","","localhost",""
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p1()","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET max_sp_recursion_depth = 20","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p2(10)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO trig VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three')","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a0 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a1 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a2 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a3 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a4 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a5 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a6 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a7 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a8 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a9 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a10 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a11 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a12 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a13 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a14 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a15 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a16 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a17 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a18 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a19 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a0 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a1 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a2 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a3 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a4 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a5 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a6 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a7 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a8 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a9 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a10 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a11 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a12 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a13 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a14 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a15 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a16 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a17 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a18 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a19 VALUES (1)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","delete_multi","<CONN_ID>",0,"DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","delete_multi","<CONN_ID>",0,"DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db2","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","insert_select","<CONN_ID>",0,"INSERT INTO t SELECT * FROM db1.t","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE ```db3""`","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE `some_very_long,database_na'me``some_very_long_database_n""ame____q`","root[root] @ localhost []","localhost","","","some_very_long,database_na'me``some_very_long_database_n""ame____q"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vmat","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a,s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT s FROM vmat","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","update_multi","<CONN_ID>",0,"UPDATE vjoin SET a=a+1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE test","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.words","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.trig","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db2.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE ```db3""`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vmat","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vup","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vjoin","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a0","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a3","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a4","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a5","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a6","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a7","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a8","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a9","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a10","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a11","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a12","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a13","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a14","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a15","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a16","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a17","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a18","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a19","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = OFF","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_databases= 'db2,```db3""`'","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = ON","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.trig (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db2.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE ```db3""`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.words (id INT, word TEXT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vup AS SELECT * FROM db2.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_event","<CONN_ID>",0,"CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"INSERT INTO db2.t VALUES (207)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p1()","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET max_sp_recursion_depth = 20","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"INSERT INTO db2.t VALUES (200 + a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p2(10)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO trig VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a0 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a1 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a2 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a3 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a4 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a5 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a6 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a7 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a8 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a9 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a10 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a11 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a12 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a13 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a14 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a15 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a16 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a17 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a18 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a19 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","delete_multi","<CONN_ID>",0,"DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db2","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3), (6)","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","insert_select","<CONN_ID>",0,"INSERT INTO t SELECT * FROM db1.t","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE ```db3""`","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE `some_very_long,database_na'me``some_very_long_database_n""ame____q`","root[root] @ localhost []","localhost","","","some_very_long,database_na'me``some_very_long_database_n""ame____q"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO vup VALUES (1)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a,s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a FROM vup","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","update","<CONN_ID>",0,"UPDATE vup SET a=a+1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","update_multi","<CONN_ID>",0,"UPDATE vjoin SET a=a+1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE test","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.words","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.trig","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db2.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE ```db3""`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vmat","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vup","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vjoin","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a0","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a3","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a4","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a5","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a6","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a7","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a8","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a9","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a10","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a11","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a12","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a13","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a14","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a15","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a16","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a17","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a18","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a19","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = OFF","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_databases= NULL","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = ON","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.trig (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db2.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE ```db3""`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.words (id INT, word TEXT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vup AS SELECT * FROM db2.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_event","<CONN_ID>",0,"CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"INSERT INTO t VALUES (7)","root[root] @ localhost [localhost]","localhost","","localhost",""
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"INSERT INTO db2.t VALUES (207)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p1()","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET max_sp_recursion_depth = 20","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"INSERT INTO db2.t VALUES (200 + a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p2(10)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO trig VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three')","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a0 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a1 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a2 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a3 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a4 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a5 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a6 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a7 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a8 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a9 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a10 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a11 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a12 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a13 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a14 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a15 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a16 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a17 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a18 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a19 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a0 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a1 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a2 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a3 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a4 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a5 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a6 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a7 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a8 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a9 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a10 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a11 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a12 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a13 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a14 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a15 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a16 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a17 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a18 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO a19 VALUES (1)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","delete_multi","<CONN_ID>",0,"DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","delete_multi","<CONN_ID>",0,"DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db2","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3), (6)","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","insert_select","<CONN_ID>",0,"INSERT INTO t SELECT * FROM db1.t","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE ```db3""`","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE `some_very_long,database_na'me``some_very_long_database_n""ame____q`","root[root] @ localhost []","localhost","","","some_very_long,database_na'me``some_very_long_database_n""ame____q"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","some_very_long,database_na'me``some_very_long_database_n""ame____q"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO vup VALUES (1)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vmat","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a,s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT s FROM vmat","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a FROM vup","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","update","<CONN_ID>",0,"UPDATE vup SET a=a+1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","update_multi","<CONN_ID>",0,"UPDATE vjoin SET a=a+1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE test","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.words","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.trig","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db2.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE ```db3""`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vmat","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vup","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vjoin","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a0","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a3","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a4","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a5","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a6","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a7","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a8","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a9","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a10","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a11","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a12","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a13","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a14","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a15","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a16","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a17","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a18","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a19","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = OFF","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_databases= 'db1,`some_very_long,database_na\'me``some_very_long_database_n""ame____q`'","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = ON","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.trig (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db2.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE ```db3""`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.words (id INT, word TEXT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vup AS SELECT * FROM db2.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_event","<CONN_ID>",0,"CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"INSERT INTO db2.t VALUES (207)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p1()","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET max_sp_recursion_depth = 20","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"INSERT INTO db2.t VALUES (200 + a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p2(10)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO trig VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a0 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a1 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a2 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a3 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a4 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a5 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a6 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a7 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a8 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a9 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a10 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a11 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a12 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a13 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a14 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a15 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a16 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a17 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a18 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a19 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","delete_multi","<CONN_ID>",0,"DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db2","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3), (6)","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","insert_select","<CONN_ID>",0,"INSERT INTO t SELECT * FROM db1.t","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE ```db3""`","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE `some_very_long,database_na'me``some_very_long_database_n""ame____q`","root[root] @ localhost []","localhost","","","some_very_long,database_na'me``some_very_long_database_n""ame____q"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO vup VALUES (1)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a,s FROM vjoin","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT a FROM vup","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","update","<CONN_ID>",0,"UPDATE vup SET a=a+1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","update_multi","<CONN_ID>",0,"UPDATE vjoin SET a=a+1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE test","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.words","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.trig","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db2.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE ```db3""`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vmat","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vup","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vjoin","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a0","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a3","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a4","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a5","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a6","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a7","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a8","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a9","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a10","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a11","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a12","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a13","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a14","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a15","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a16","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a17","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a18","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a19","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = OFF","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_databases= 'db1,db2'","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = ON","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.trig (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db2.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE ```db3""`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t (a INT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE db1.words (id INT, word TEXT)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vup AS SELECT * FROM db2.t","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_view","<CONN_ID>",0,"CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_event","<CONN_ID>",0,"CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p1()
+BEGIN
+INSERT INTO db2.t VALUES (207);
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p1()","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_procedure","<CONN_ID>",0,"CREATE PROCEDURE p2(a INT)
+BEGIN
+INSERT INTO db2.t VALUES (200 + a);
+IF a = 0 THEN
+CALL p2(a - 1);
+END IF;
+END","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET max_sp_recursion_depth = 20","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","call_procedure","<CONN_ID>",0,"CALL p2(10)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a0 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a1 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a2 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a3 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a4 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a5 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a6 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a7 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a8 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a9 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a10 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a11 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a12 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a13 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a14 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a15 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a16 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a17 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a18 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_table","<CONN_ID>",0,"CREATE TABLE a19 (a INT)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr1 BEFORE INSERT ON a1 FOR EACH ROW INSERT INTO a0 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr2 BEFORE INSERT ON a2 FOR EACH ROW INSERT INTO a1 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr3 BEFORE INSERT ON a3 FOR EACH ROW INSERT INTO a2 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr4 BEFORE INSERT ON a4 FOR EACH ROW INSERT INTO a3 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr5 BEFORE INSERT ON a5 FOR EACH ROW INSERT INTO a4 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr6 BEFORE INSERT ON a6 FOR EACH ROW INSERT INTO a5 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr7 BEFORE INSERT ON a7 FOR EACH ROW INSERT INTO a6 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr8 BEFORE INSERT ON a8 FOR EACH ROW INSERT INTO a7 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr9 BEFORE INSERT ON a9 FOR EACH ROW INSERT INTO a8 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr10 BEFORE INSERT ON a10 FOR EACH ROW INSERT INTO a9 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr11 BEFORE INSERT ON a11 FOR EACH ROW INSERT INTO a10 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr12 BEFORE INSERT ON a12 FOR EACH ROW INSERT INTO a11 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr13 BEFORE INSERT ON a13 FOR EACH ROW INSERT INTO a12 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr14 BEFORE INSERT ON a14 FOR EACH ROW INSERT INTO a13 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr15 BEFORE INSERT ON a15 FOR EACH ROW INSERT INTO a14 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr16 BEFORE INSERT ON a16 FOR EACH ROW INSERT INTO a15 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr17 BEFORE INSERT ON a17 FOR EACH ROW INSERT INTO a16 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr18 BEFORE INSERT ON a18 FOR EACH ROW INSERT INTO a17 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","create_trigger","<CONN_ID>",0,"CREATE TRIGGER tr19 BEFORE INSERT ON a19 FOR EACH ROW INSERT INTO a18 VALUES (new.a)","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE db2","root[root] @ localhost []","localhost","","","db2"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE ```db3""`","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","``db3"""
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE `some_very_long,database_na'me``some_very_long_database_n""ame____q`","root[root] @ localhost []","localhost","","","some_very_long,database_na'me``some_very_long_database_n""ame____q"
+"Query","<ID>","<DATETIME>","insert","<CONN_ID>",0,"INSERT INTO t VALUES (1), (2), (3)","root[root] @ localhost []","localhost","","","some_very_long,database_na'me``some_very_long_database_n""ame____q"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use db1","root[root] @ localhost []","localhost","","","db1"
+"Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"USE test","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t)","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.words","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.trig","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db2.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE ```db3""`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE `some_very_long,database_na'me``some_very_long_database_n""ame____q`.t","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_procedure","<CONN_ID>",0,"DROP PROCEDURE db1.p2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vmat","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vup","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_view","<CONN_ID>",0,"DROP VIEW db1.vjoin","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a0","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a1","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a2","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a3","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a4","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a5","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a6","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a7","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a8","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a9","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a10","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a11","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a12","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a13","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a14","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a15","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a16","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a17","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a18","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","drop_table","<CONN_ID>",0,"DROP TABLE db1.a19","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL event_scheduler = OFF","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_databases= NULL","root[root] @ localhost []","localhost","","","test"
+===================================================================
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP DATABASE ```db3"`;
+DROP DATABASE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;

--- a/plugin/audit_log/tests/mtr/audit_log_filter_db.test
+++ b/plugin/audit_log/tests/mtr/audit_log_filter_db.test
@@ -1,0 +1,87 @@
+--source include/not_embedded.inc
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+let $log_file=$MYSQLD_DATADIR/test_audit.log;
+
+# setup some databases
+
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+CREATE DATABASE ```db3"`;
+CREATE DATABASE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+
+SHOW DATABASES;
+
+# test set/unset filters
+
+SET GLOBAL audit_log_include_databases= '`some_very_long,database_na\'me``some_very_long_database_n"ame____q`,```db1"`,db3';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_exclude_databases= 'db2';
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_exclude_databases= NULL;
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+SET GLOBAL audit_log_include_databases= 'db1, db2, db3';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+SET GLOBAL audit_log_include_databases= '';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_exclude_databases= 'db1';
+SET GLOBAL audit_log_include_databases= NULL;
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+
+SET GLOBAL audit_log_exclude_databases= 'db2,`db3 `';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_include_databases= 'db1, db2, db3';
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_include_databases= NULL;
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+SET GLOBAL audit_log_exclude_databases= 'db1, db2, db3';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+SET GLOBAL audit_log_exclude_databases= '';
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL audit_log_include_databases= 'db2';
+SET GLOBAL audit_log_exclude_databases= NULL;
+SELECT @@audit_log_include_databases, @@audit_log_exclude_databases;
+
+let $MYSQLD_DATADIR= `select @@datadir`;
+let MYSQLD_DATADIR= $MYSQLD_DATADIR;
+
+SET GLOBAL audit_log_flush=ON;
+--remove_file $MYSQLD_DATADIR/test_audit.log
+SET GLOBAL audit_log_flush=ON;
+
+# testing include
+SET GLOBAL audit_log_include_databases= 'db1,```db3"`';
+
+--source audit_log_filter_db_events.inc
+
+SET GLOBAL audit_log_include_databases= 'db2,```db3"`';
+
+--source audit_log_filter_db_events.inc
+
+# log everything
+SET GLOBAL audit_log_include_databases= NULL;
+
+--source audit_log_filter_db_events.inc
+
+# testing exclude
+SET GLOBAL audit_log_exclude_databases= 'db1,`some_very_long,database_na\'me``some_very_long_database_n"ame____q`';
+
+--source audit_log_filter_db_events.inc
+
+SET GLOBAL audit_log_exclude_databases= 'db1,db2';
+
+--source audit_log_filter_db_events.inc
+
+SET GLOBAL audit_log_exclude_databases= NULL;
+
+--source audit_log_echo.inc
+
+# cleanup databases
+DROP DATABASE db1;
+DROP DATABASE db2;
+DROP DATABASE ```db3"`;
+DROP DATABASE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;

--- a/plugin/audit_log/tests/mtr/audit_log_filter_db_events.inc
+++ b/plugin/audit_log/tests/mtr/audit_log_filter_db_events.inc
@@ -1,0 +1,113 @@
+
+SET GLOBAL event_scheduler = ON;
+
+CREATE TABLE db1.t (a INT);
+CREATE TABLE db1.trig (a INT);
+CREATE TABLE db2.t (a INT);
+CREATE TABLE ```db3"`.t (a INT);
+CREATE TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t (a INT);
+
+CREATE TABLE db1.words (id INT, word TEXT);
+
+USE db1;
+
+CREATE VIEW vmat AS SELECT SUM(a) AS s FROM db1.t;
+CREATE VIEW vup AS SELECT * FROM db2.t;
+CREATE VIEW vjoin AS SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+
+CREATE EVENT ev1 ON SCHEDULE AT CURRENT_TIMESTAMP DO INSERT INTO t VALUES (7);
+let $wait_condition=SELECT count(*)=1 FROM t WHERE a=7;
+--source include/wait_condition.inc
+CREATE TRIGGER ins_tring BEFORE INSERT ON db1.trig FOR EACH ROW INSERT INTO db2.t VALUES (new.a + 100);
+INSERT INTO t VALUES (1), (2), (3);
+DELIMITER //;
+CREATE PROCEDURE p1()
+BEGIN
+  INSERT INTO db2.t VALUES (207);
+END//
+DELIMITER ;//
+CALL p1();
+DELIMITER //;
+CREATE PROCEDURE p2(a INT)
+BEGIN
+  INSERT INTO db2.t VALUES (200 + a);
+  IF a = 0 THEN
+    CALL p2(a - 1);
+  END IF;
+END//
+DELIMITER ;//
+SET max_sp_recursion_depth = 20;
+CALL p2(10);
+INSERT INTO trig VALUES (1), (2), (3);
+INSERT INTO words VALUES (0, 'one'), (2, 'two'), (3, 'three');
+
+let $i=0;
+while ($i < 20)
+{
+eval CREATE TABLE a$i (a INT);
+inc $i;
+}
+
+let $i=1;
+let $j=0;
+while ($i < 20)
+{
+eval CREATE TRIGGER tr$i BEFORE INSERT ON a$i FOR EACH ROW INSERT INTO a$j VALUES (new.a);
+inc $i;
+inc $j;
+}
+
+INSERT INTO a19 VALUES (1);
+
+SELECT * FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2;
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN t q ON t.a = q.a / 2 WHERE t.a > 2;
+DELETE t, q, words FROM t LEFT JOIN words ON t.a = words.id LEFT JOIN db2.t q ON t.a = q.a / 2 WHERE t.a > 2;
+
+USE db2;
+INSERT INTO t VALUES (1), (2), (3), (6);
+INSERT INTO t SELECT * FROM db1.t;
+
+USE ```db3"`;
+INSERT INTO t VALUES (1), (2), (3);
+
+USE `some_very_long,database_na'me``some_very_long_database_n"ame____q`;
+INSERT INTO t VALUES (1), (2), (3);
+
+use db1;
+INSERT INTO vup VALUES (1);
+SELECT * FROM vjoin;
+SELECT * FROM vmat JOIN vup ON vmat.s=vup.a;
+SELECT * FROM vmat;
+SELECT a FROM vjoin;
+SELECT s FROM vjoin;
+SELECT a,s FROM vjoin;
+SELECT s FROM vmat;
+SELECT a FROM vup;
+UPDATE vup SET a=a+1;
+UPDATE vjoin SET a=a+1;
+
+USE test;
+
+SELECT * FROM db1.t WHERE a IN (SELECT a FROM `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t);
+
+SELECT 1;
+
+DROP TABLE db1.t;
+DROP TABLE db1.words;
+DROP TABLE db1.trig;
+DROP TABLE db2.t;
+DROP TABLE ```db3"`.t;
+DROP TABLE `some_very_long,database_na'me``some_very_long_database_n"ame____q`.t;
+DROP PROCEDURE db1.p1;
+DROP PROCEDURE db1.p2;
+DROP VIEW db1.vmat;
+DROP VIEW db1.vup;
+DROP VIEW db1.vjoin;
+let $i=0;
+while ($i < 20)
+{
+eval DROP TABLE db1.a$i;
+inc $i;
+}
+
+SET GLOBAL event_scheduler = OFF;

--- a/plugin/audit_log/tests/mtr/audit_log_filter_users.result
+++ b/plugin/audit_log/tests/mtr/audit_log_filter_users.result
@@ -1,6 +1,6 @@
 CREATE USER 'user1'@'127.0.0.1' IDENTIFIED BY 'password1';
 CREATE USER 'user22'@'%' IDENTIFIED BY 'password1';
-CREATE USER '22user'@'localhost' IDENTIFIED BY 'password1';
+CREATE USER '22user'@'LOCALHOST' IDENTIFIED BY 'password1';
 CREATE USER 'admin'@'%' IDENTIFIED BY 'password1';
 CREATE USER 'us,er1'@'localhost' IDENTIFIED BY 'password1';
 SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%';
@@ -140,6 +140,28 @@ us,er1
 us,er1
 SET GLOBAL audit_log_flush=ON;
 SET GLOBAL audit_log_exclude_accounts= NULL;
+SET GLOBAL audit_log_include_accounts= '22user@LocalHost,User22@%';
+SET GLOBAL audit_log_flush=ON;
+SELECT 'user1';
+user1
+user1
+SELECT 'user22';
+user22
+user22
+SELECT '22user';
+22user
+22user
+SELECT 'user22';
+user22
+user22
+SELECT 'admin';
+admin
+admin
+SELECT 'us,er1';
+us,er1
+us,er1
+SET GLOBAL audit_log_flush=ON;
+SET GLOBAL audit_log_include_accounts= NULL;
 set global audit_log_flush= ON;
 ===================================================================
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
@@ -195,6 +217,14 @@ set global audit_log_flush= ON;
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_accounts= NULL","root[root] @ localhost []","localhost","","","test"
+*************************************************************
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= '22user@LocalHost,User22@%'","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"22user","22user","","","localhost","","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT '22user'","22user[22user] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
+*************************************************************
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= NULL","root[root] @ localhost []","localhost","","","test"
 ===================================================================
 DROP USER 'user1'@'127.0.0.1';
 DROP USER 'user22'@'%';

--- a/plugin/audit_log/tests/mtr/audit_log_filter_users.test
+++ b/plugin/audit_log/tests/mtr/audit_log_filter_users.test
@@ -4,7 +4,7 @@
 
 CREATE USER 'user1'@'127.0.0.1' IDENTIFIED BY 'password1';
 CREATE USER 'user22'@'%' IDENTIFIED BY 'password1';
-CREATE USER '22user'@'localhost' IDENTIFIED BY 'password1';
+CREATE USER '22user'@'LOCALHOST' IDENTIFIED BY 'password1';
 CREATE USER 'admin'@'%' IDENTIFIED BY 'password1';
 CREATE USER 'us,er1'@'localhost' IDENTIFIED BY 'password1';
 
@@ -70,6 +70,13 @@ SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin
 --source audit_log_filter_events.inc
 
 SET GLOBAL audit_log_exclude_accounts= NULL;
+
+# testing case sensitivity
+SET GLOBAL audit_log_include_accounts= '22user@LocalHost,User22@%';
+
+--source audit_log_filter_events.inc
+
+SET GLOBAL audit_log_include_accounts= NULL;
 
 --source audit_log_echo.inc
 

--- a/plugin/audit_log/tests/mtr/audit_log_json.result
+++ b/plugin/audit_log/tests/mtr/audit_log_json.result
@@ -25,11 +25,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	JSON
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -57,11 +59,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	JSON
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/plugin/audit_log/tests/mtr/audit_log_new.result
+++ b/plugin/audit_log/tests/mtr/audit_log_new.result
@@ -25,11 +25,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	NEW
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	LOGINS
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -57,11 +59,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	NEW
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	LOGINS
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/plugin/audit_log/tests/mtr/audit_log_old.result
+++ b/plugin/audit_log/tests/mtr/audit_log_old.result
@@ -25,11 +25,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	4096
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	OLD
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -57,11 +59,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	4096
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	test_audit.log
 audit_log_flush	OFF
 audit_log_format	OLD
 audit_log_handler	FILE
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0

--- a/plugin/audit_log/tests/mtr/audit_log_syslog.result
+++ b/plugin/audit_log/tests/mtr/audit_log_syslog.result
@@ -23,11 +23,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	SYSLOG
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0
@@ -55,11 +57,13 @@ show variables like 'audit_log%';
 Variable_name	Value
 audit_log_buffer_size	1048576
 audit_log_exclude_accounts	
+audit_log_exclude_databases	
 audit_log_file	audit.log
 audit_log_flush	OFF
 audit_log_format	CSV
 audit_log_handler	SYSLOG
 audit_log_include_accounts	
+audit_log_include_databases	
 audit_log_policy	ALL
 audit_log_rotate_on_size	0
 audit_log_rotations	0


### PR DESCRIPTION
Blueprint:

https://blueprints.launchpad.net/percona-server/+spec/audit-filer-db

Add two global variables:
-   `audit_log_include_databases` comma separated list of databases to
  include in audit logging
-   `audit_log_exclude_databases` comma separated list of databases to
  exclude from audit logging

Allow escaped backticks in the `next_word` function. This change
needs to be backported to the 5.6.
