### PR TITLE
Work towards fixing 756387 (Intermittent innodb.innodb_bug60049 test …

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -4805,6 +4805,7 @@ void do_shutdown_server(struct st_command *command)
     die("mysql_shutdown failed");
 
   /* Check that server dies */
+  long orig_timeout= timeout;
   while(timeout--){
     if (my_kill(pid, 0) < 0){
       DBUG_PRINT("info", ("Process %d does not exist anymore", pid));
@@ -4816,6 +4817,11 @@ void do_shutdown_server(struct st_command *command)
 
   /* Kill the server */
   DBUG_PRINT("info", ("Killing server, pid: %d", pid));
+  if (orig_timeout != 0)
+  {
+    log_msg("shutdown_server timeout %ld exceeded, SIGKILL sent to the server",
+            orig_timeout);
+  }
   (void)my_kill(pid, 9);
 
   DBUG_VOID_RETURN;


### PR DESCRIPTION
…failures)

One of the possible ways this testcase can fail is not fully completed
purge before/during the server shutdown. One of the ways the slow
shutdown can fail to complete in MTR is shutdown_server command
exceeding its timeout, in which case the server gets kill -9. As this
and regular shutdown are both possible with shutdown_server, resulting
in two potentially very different outcomes, add mysqltest.cc
diagnostics if kill -9 was issued.

http://jenkins.percona.com/job/percona-server-5.5-param/1287/
