### PR TITLE
Fix bug 1608385 (innodb.percona_changed_page_bmp does not cleanup $MY…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
@@ -60,4 +60,4 @@ INSERT INTO t3 VALUES (REPEAT('a', 12582912));
 DROP TABLE t3;
 11th restart
 ib_modified_log_1
-12th restart
+# restart

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
@@ -245,27 +245,24 @@ DROP TABLE t3;
 # Test that bitmap files are created correctly in innodb_data_home_dir without a trailing
 # path separator (bug 1181887)
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
---mkdir $MYSQLTEST_VARDIR/tmpdatadir
+--let $tmpdatadir=$MYSQLTEST_VARDIR/tmpdatadir
+--mkdir $tmpdatadir
 --enable_reconnect
 --echo 11th restart
---exec echo "restart:--innodb-data-home-dir=$MYSQLTEST_VARDIR/tmpdatadir" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--exec echo "restart:--innodb-data-home-dir=$tmpdatadir" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --source include/wait_until_connected_again.inc
 
-file_exists $MYSQLTEST_VARDIR/tmpdatadir/ib_modified_log_1_0.xdb;
+file_exists $tmpdatadir/ib_modified_log_1_0.xdb;
 --replace_regex /_[[:digit:]]+\.xdb$//
-list_files $MYSQLTEST_VARDIR/tmpdatadir ib_modified_log*;
+list_files $tmpdatadir ib_modified_log*;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
 --remove_files_wildcard $MYSQLD_DATADIR ibdata*
 --remove_files_wildcard $MYSQLD_DATADIR ib_modified_log*
---enable_reconnect
---echo 12th restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc
+
+--remove_files_wildcard $tmpdatadir *
+--rmdir $tmpdatadir


### PR DESCRIPTION
…SQLTEST_VARDIR/tmpdatadir)

Remove the created temp directory at the end of testcase. At the same
time replace some of the manual server shutdown/startup sequences with
include files.

http://jenkins.percona.com/job/percona-server-5.5-param/1290/
