### PR TITLE
Fix bug 1608437 (MTR does not register unit test failures with Subunit)

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -531,6 +531,7 @@ sub main {
       $tinfo->{result}= 'MTR_RES_PASSED';
     }
     mtr_report_test($tinfo);
+    mtr_report_test_subunit($tinfo);
     push @$completed, $tinfo;
   }
 
@@ -6168,6 +6169,7 @@ sub run_ctest() {
   mark_time_used('test');
   mtr_report_test($tinfo);
   chdir($olddir);
+  mtr_report_test_subunit($tinfo);
   return $tinfo;
 }
 


### PR DESCRIPTION
Register test results with Subunit for CTest and Valgrind too.

http://jenkins.percona.com/job/percona-server-5.5-param/1291/
