### PR TITLE
Fix bug 1608515 (test group_commit is unstable)

### DIFF
--- a/mysql-test/r/group_commit.result
+++ b/mysql-test/r/group_commit.result
@@ -7,6 +7,7 @@ SET DEBUG_SYNC= "commit_before_get_LOCK_commit_ordered SIGNAL group1_running WAI
 INSERT INTO t1 VALUES ("con1");
 set DEBUG_SYNC= "now WAIT_FOR group1_running";
 SET DEBUG_SYNC= "commit_group_commit_queue SIGNAL group2_con2";
+SET DEBUG_SYNC= "commit_before_get_LOCK_commit_ordered SIGNAL group2_running";
 SET DEBUG_SYNC= "commit_after_release_LOCK_log WAIT_FOR group3_committed";
 SET DEBUG_SYNC= "commit_after_group_run_commit_ordered SIGNAL group2_visible WAIT_FOR group2_checked";
 INSERT INTO t1 VALUES ("con2");
@@ -26,6 +27,7 @@ a
 con1
 SET DEBUG_SYNC= "commit_before_get_LOCK_commit_ordered SIGNAL group3_con5";
 SET DEBUG_SYNC= "commit_after_get_LOCK_log SIGNAL con5_leader WAIT_FOR con6_queued";
+set DEBUG_SYNC= "now WAIT_FOR group2_running";
 INSERT INTO t1 VALUES ("con5");
 SET DEBUG_SYNC= "now WAIT_FOR con5_leader";
 SET DEBUG_SYNC= "commit_group_commit_queue SIGNAL con6_queued";

--- a/mysql-test/t/group_commit.test
+++ b/mysql-test/t/group_commit.test
@@ -37,6 +37,7 @@ send INSERT INTO t1 VALUES ("con1");
 connection con2;
 set DEBUG_SYNC= "now WAIT_FOR group1_running";
 SET DEBUG_SYNC= "commit_group_commit_queue SIGNAL group2_con2";
+SET DEBUG_SYNC= "commit_before_get_LOCK_commit_ordered SIGNAL group2_running";
 SET DEBUG_SYNC= "commit_after_release_LOCK_log WAIT_FOR group3_committed";
 SET DEBUG_SYNC= "commit_after_group_run_commit_ordered SIGNAL group2_visible WAIT_FOR group2_checked";
 send INSERT INTO t1 VALUES ("con2");
@@ -70,6 +71,7 @@ SELECT * FROM t1 ORDER BY a;
 connection con5;
 SET DEBUG_SYNC= "commit_before_get_LOCK_commit_ordered SIGNAL group3_con5";
 SET DEBUG_SYNC= "commit_after_get_LOCK_log SIGNAL con5_leader WAIT_FOR con6_queued";
+set DEBUG_SYNC= "now WAIT_FOR group2_running";
 send INSERT INTO t1 VALUES ("con5");
 
 connection con6;


### PR DESCRIPTION
The test has a race condition where con5 catches the previous commit
group and attaches to it instead of becoming a leader of a new group.

Fix by applying a patch from MariaDB:

```
revno: 2732.26.19
committer: knielsen@knielsen-hq.org
branch nick: work-5.2-rpl
timestamp: Thu 2011-04-14 13:23:02 +0200
message:
  Fix race in testcase innodb_plugin.group_commit

  The problem was that connection con5, which is supposed to be the leader for
  the third group, could if timing was bad end up as participant in the second
  group, causing the test to fail.

  Fixed by ensuring that group 2 is running before starting the transaction
  for group 3.
```

http://jenkins.percona.com/job/percona-server-5.5-param/1293/
