### PR TITLE
Fix bug 1608845 (Test percona_show_slave_status_nolock is unstable)

### DIFF
--- a/mysql-test/r/percona_show_slave_status_nolock.result
+++ b/mysql-test/r/percona_show_slave_status_nolock.result
@@ -4,11 +4,12 @@ call mtr.add_suppression("Slave SQL: Request to stop slave SQL Thread received w
 include/rpl_connect.inc [creating slave_lock]
 include/rpl_connect.inc [creating slave_nolock]
 [master]
-DROP TABLE IF EXISTS t;
 CREATE TABLE t(id INT);
 [slave]
+include/stop_slave.inc
 SET DEBUG_SYNC='RESET';
 SET GLOBAL DEBUG="+d,after_mysql_insert,after_show_slave_status";
+include/start_slave.inc
 [master]
 INSERT INTO t VALUES(0);
 [slave]
@@ -55,15 +56,12 @@ SET DEBUG_SYNC='now SIGNAL signal.continue';
 [slave]
 SET DEBUG_SYNC='now SIGNAL signal.empty';
 
+SET DEBUG_SYNC='RESET';
 [slave_stop]
 include/wait_for_slave_to_stop.inc
-START SLAVE;
-include/wait_for_slave_to_start.inc
-[master]
-SET DEBUG_SYNC='RESET';
-[slave]
 SET GLOBAL DEBUG='';
-SET DEBUG_SYNC='RESET';
+include/start_slave.inc
 [master]
+SET DEBUG_SYNC='RESET';
 DROP TABLE t;
 include/rpl_end.inc

--- a/mysql-test/t/percona_show_slave_status_nolock.test
+++ b/mysql-test/t/percona_show_slave_status_nolock.test
@@ -1,6 +1,7 @@
---source include/master-slave.inc
+--source include/have_debug.inc
 --source include/have_debug_sync.inc
 --source include/have_binlog_format_statement.inc
+--source include/master-slave.inc
 
 call mtr.add_suppression("Slave SQL: Request to stop slave SQL Thread received while applying a group that has non-transactional changes");
 
@@ -17,16 +18,14 @@ call mtr.add_suppression("Slave SQL: Request to stop slave SQL Thread received w
 
 connection master;
 --echo [master]
---disable_warnings
-DROP TABLE IF EXISTS t;
---enable_warnings
 CREATE TABLE t(id INT);
 sync_slave_with_master;
 
-connection slave;
 --echo [slave]
+--source include/stop_slave.inc
 SET DEBUG_SYNC='RESET';
 SET GLOBAL DEBUG="+d,after_mysql_insert,after_show_slave_status";
+--source include/start_slave.inc
 
 connection master;
 --echo [master]
@@ -65,26 +64,18 @@ connection slave;
 --echo check 'SHOW SLAVE STATUS' and 'SHOW SLAVE STATUS NOLOCK' - just NOLOCK version should works fine
 --source include/percona_show_slave_status_nolock.inc
 
+SET DEBUG_SYNC='RESET';
 
 connection slave_stop;
 --echo [slave_stop]
 reap;
 --source include/wait_for_slave_to_stop.inc
-START SLAVE;
---source include/wait_for_slave_to_start.inc
-
-connection master;
---echo [master]
-SET DEBUG_SYNC='RESET';
-
-connection slave;
---echo [slave]
 SET GLOBAL DEBUG='';
-SET DEBUG_SYNC='RESET';
+--source include/start_slave.inc
 
 connection master;
 --echo [master]
+SET DEBUG_SYNC='RESET';
 DROP TABLE t;
-sync_slave_with_master;
 
 --source include/rpl_end.inc


### PR DESCRIPTION
Rewrite the testcase to avoid SET GLOBAL DEBUG=... in any context
where anything asynchronuous (such as slave threads) might be running,
and to simplify the testcase.

http://jenkins.percona.com/job/percona-server-5.5-param/1297/
