### PR TITLE
Work towards fixing bug 756387 (Intermittent innodb.innodb_bug60049 f…

### DIFF
--- a/mysql-test/include/restart_mysqld.inc
+++ b/mysql-test/include/restart_mysqld.inc
@@ -19,8 +19,9 @@ if (!$restart_parameters)
 --exec echo "wait" > $_expect_file_name
 
 # Send shutdown to the connected server and give
-# it 10 seconds to die before zapping it
-shutdown_server 10;
+shutdown_server;
+
+--source include/wait_until_disconnected.inc
 
 # Write file to make mysql-test-run.pl start up the server again
 --exec echo "$restart_parameters" > $_expect_file_name

--- a/mysql-test/include/rpl_stop_server.inc
+++ b/mysql-test/include/rpl_stop_server.inc
@@ -46,10 +46,13 @@ if ($rpl_debug)
 # it until it's told to
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.$rpl_server_number.expect
 
-# Send shutdown to the connected server and give
-# it 10 seconds to die before zapping it
-shutdown_server 10;
-
+# Send shutdown to the connected server
+--let $shutdown_server_timeout= 60
+if ($VALGRIND_TEST)
+{
+  let $shutdown_server_timeout= `SELECT $shutdown_server_timeout * 6`;
+}
+shutdown_server $shutdown_server_timeout;
 --source include/wait_until_disconnected.inc
 
 

--- a/mysql-test/suite/sys_vars/t/innodb_read_ahead_startup.test
+++ b/mysql-test/suite/sys_vars/t/innodb_read_ahead_startup.test
@@ -2,74 +2,42 @@
 
 --source include/have_innodb.inc
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=none" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=none
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=random" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=random
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=linear" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=linear
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=both" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=both
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=0" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=0
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=1" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=1
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=2" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=2
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_read_ahead=3" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_read_ahead=3
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_read_ahead;


### PR DESCRIPTION
…ailures)

Previous work added diagnostics if MTR server shutdown times out and
kill -9 is issued. Here the testcases are cleaned up to ensure clean
shutdowns according to those diagnostics, mostly by backporting 5.7
changes:
- mysql-test/include/restart_mysqld.inc: use the default shutdown
  timeout value (60 seconds) instead of 10;
- mysql-test/include/rpl_stop_server.inc: use 60 second timeout
  instead of 10, further multiply it by 6 if running under Valgrind;
- mysql-test/suite/sys_vars/t/innodb_read_ahead_tartup.test: rewrite
  to use restart_mysqld.inc.

http://jenkins.percona.com/job/percona-server-5.5-param/1296/
