### PR TITLE
Fix bug 1607606 (percona_extended_innodb_status test is unstable)

### DIFF
--- a/mysql-test/suite/innodb/include/percona_extended_innodb_status.inc
+++ b/mysql-test/suite/innodb/include/percona_extended_innodb_status.inc
@@ -49,6 +49,13 @@ perl;
   use warnings;
 
   my $output = $ENV{'STATUS'};
+  # Only consider the part after "TRANSACTIONS", or we could end up counting
+  # "LAST FOREIGN KEY ERROR" record locks too
+  my @output = split "\n", $output;
+  my $index = 0;
+  $index++ until @output[$index] eq 'TRANSACTIONS';
+  splice @output, 0, $index;
+  $output = join("\n", @output);
   if ($output =~ /^Record lock, heap no \d+ PHYSICAL RECORD: n_fields \d+; compact format; info bits \d+$/m)
   {
     print "\"Record lock\" found\n";


### PR DESCRIPTION
If the MTR worker happened to run a test that resulted in a foreign
key errors, SHOW ENGINE INNODB STATUS will show this error and its
associated record locks, which will be counted too in this testcase,
failing it.

Fix by counting record locks only starting with "TRANSCATION" section
in the InnoDB status.

http://jenkins.percona.com/job/percona-server-5.5-param/1298/
