### PR TITLE
Fix bug 1609364 (--innodb_purge_threads=1 may result in incomplete pu…

### DIFF
--- a/storage/innobase/log/log0log.c
+++ b/storage/innobase/log/log0log.c
@@ -3326,6 +3326,8 @@ logs_empty_and_mark_files_at_shutdown(void)
 	algorithm only works if the server is idle at shutdown */
 
 	srv_shutdown_state = SRV_SHUTDOWN_CLEANUP;
+
+	srv_wake_purge_thread();
 loop:
 	os_thread_sleep(100000);
 


### PR DESCRIPTION
…rge with innodb_fast_shutdown=0)

The separate purge thread loop exits immediately on any
srv_shutdown_state > 0 value even though it's supposed to keep on
purging if srv_fast_shutdown == 0.

Fix by
- signalling the purge thread to wake up at the start of
  logs_empty_and_mark_files_at_shutdown;
- adjusting the purge thread suspend condition so that it's never
  suspended during shutdown;
- adjusting the purge thread loop break condition to exit the loop
  immediately if we are at fast shutdown, or if we are at the slow
  shutdown and the last TRX_SYS_N_RSEGS attempts to purge did nothing;
- reverting what looks the previous attempt to fix this, which caused
  master thread to do purging even with separate purge thread enabled,
  but was racy;

This also fixes bug 756387.

http://jenkins.percona.com/job/percona-server-5.5-param/1300/
