### PR TITLE
Fix bug 1609523 (Needless sleep between purge thread iterations durin…

### DIFF
--- a/storage/innobase/srv/srv0srv.c
+++ b/storage/innobase/srv/srv0srv.c
@@ -4183,6 +4183,9 @@ srv_purge_thread(
 
 		srv_sync_log_buffer_in_background();
 
+		if (srv_shutdown_state != SRV_SHUTDOWN_NONE)
+			continue;
+
 		cur_time = ut_time_ms();
 		if (next_itr_time > cur_time) {
 			os_thread_sleep(ut_min(1000000,


### PR DESCRIPTION
…g shutdown)

After bug 1609364 fix, the 5.5 separate purge thread tries to purge up
to TRX_SYS_N_RSEGS times when there is nothing to purge before
quitting, but it sleeps needlessly for up to 1 second between these
iterations, delaying the shutdown. Fix by skipping the sleep if we are
in shutdown.

http://jenkins.percona.com/job/percona-server-5.5-param/1301/
