### PR TITLE
Fix bug 1609422 (Unit test lf-t unstable)

### DIFF
--- a/unittest/mysys/lf-t.c
+++ b/unittest/mysys/lf-t.c
@@ -48,12 +48,14 @@ pthread_handler_t test_lf_pinbox(void *arg)
     pins= lf_pinbox_get_pins(&lf_allocator.pinbox);
   }
   lf_pinbox_put_pins(pins);
+
+  if (with_my_thread_init)
+    my_thread_end();
+
   pthread_mutex_lock(&mutex);
   if (!--running_threads) pthread_cond_signal(&cond);
   pthread_mutex_unlock(&mutex);
 
-  if (with_my_thread_init)
-    my_thread_end();
 
   return 0;
 }
@@ -105,11 +107,15 @@ pthread_handler_t test_lf_alloc(void *arg)
     bad|= lf_allocator.mallocs - lf_alloc_pool_count(&lf_allocator);
 #endif
   }
-  if (!--running_threads) pthread_cond_signal(&cond);
   pthread_mutex_unlock(&mutex);
 
   if (with_my_thread_init)
     my_thread_end();
+
+  pthread_mutex_lock(&mutex);
+  if (!--running_threads) pthread_cond_signal(&cond);
+  pthread_mutex_unlock(&mutex);
+
   return 0;
 }
 
@@ -159,10 +165,14 @@ pthread_handler_t test_lf_hash(void *arg)
          lf_hash.size, inserts);
     bad|= lf_hash.count;
   }
-  if (!--running_threads) pthread_cond_signal(&cond);
   pthread_mutex_unlock(&mutex);
+
   if (with_my_thread_init)
     my_thread_end();
+
+  pthread_mutex_lock(&mutex);
+  if (!--running_threads) pthread_cond_signal(&cond);
+  pthread_mutex_unlock(&mutex);
   return 0;
 }
 

--- a/unittest/mysys/thr_template.c
+++ b/unittest/mysys/thr_template.c
@@ -79,11 +79,6 @@ int main(int argc __attribute__((unused)), char **argv)
 
   do_tests();
 
-  /*
-    workaround until we know why it crashes randomly on some machine
-    (BUG#22320).
-  */
-  sleep(2);
   pthread_mutex_destroy(&mutex);
   pthread_cond_destroy(&cond);
   pthread_attr_destroy(&thr_attr);


### PR DESCRIPTION
Adjust lf-t test threads so that they call my_thread_end before
signalling the main thread that test is done, in order to avoid race
on with_my_thread_init flag, which would cause
my_thread_init/my_thread_end mismatch. Remove obsolete "sleep(2)" from
the test framework.

http://jenkins.percona.com/job/percona-server-5.5-param/1303/
