### PR TITLE
Fix bug 1607607 (test percona_show_temp_tables_stress is unstable)

### DIFF
--- a/mysql-test/r/percona_show_temp_tables_stress.result
+++ b/mysql-test/r/percona_show_temp_tables_stress.result
@@ -1,0 +1,16 @@
+CREATE USER event_runner@localhost;
+SET @saved_event_scheduler = @@GLOBAL.event_scheduler;
+SET GLOBAL event_scheduler = ON;
+CREATE DEFINER=event_runner@localhost EVENT query_temp_tables ON SCHEDULE AT CURRENT_TIMESTAMP
+DO
+WHILE TRUE DO
+SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+END WHILE|
+# Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+COUNT(*)
+1200
+# Dropping the temp tables
+KILL QUERY $ev_thread_id
+SET GLOBAL event_scheduler = @saved_event_scheduler;
+DROP USER event_runner@localhost;

--- a/mysql-test/t/percona_show_temp_tables_stress.test
+++ b/mysql-test/t/percona_show_temp_tables_stress.test
@@ -1,0 +1,50 @@
+--source include/have_innodb.inc
+
+CREATE USER event_runner@localhost;
+
+SET @saved_event_scheduler = @@GLOBAL.event_scheduler;
+SET GLOBAL event_scheduler = ON;
+
+delimiter |;
+CREATE DEFINER=event_runner@localhost EVENT query_temp_tables ON SCHEDULE AT CURRENT_TIMESTAMP
+DO
+  WHILE TRUE DO
+    SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+  END WHILE|
+delimiter ;|
+
+--let $i=400
+--echo # Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
+--disable_query_log
+while ($i)
+{
+  --eval CREATE TEMPORARY TABLE tmp_myisam_$i (a VARCHAR(256)) ENGINE=MyISAM
+  --eval CREATE TEMPORARY TABLE tmp_innodb_$i (a VARCHAR(256)) ENGINE=InnoDB
+  --eval CREATE TEMPORARY TABLE tmp_memory_$i (a VARCHAR(256)) ENGINE=MEMORY
+  --dec $i
+}
+--enable_query_log
+
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+
+--let $i=400
+--echo # Dropping the temp tables
+--disable_query_log
+while ($i)
+{
+  --eval DROP TEMPORARY TABLE tmp_myisam_$i
+  --eval DROP TEMPORARY TABLE tmp_innodb_$i
+  --eval DROP TEMPORARY TABLE tmp_memory_$i
+  --dec $i
+}
+--enable_query_log
+
+--let $ev_thread_id= `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER='event_runner'`
+--echo KILL QUERY \$ev_thread_id
+--disable_query_log
+eval KILL QUERY $ev_thread_id;
+--enable_query_log
+
+SET GLOBAL event_scheduler = @saved_event_scheduler;
+
+DROP USER event_runner@localhost;


### PR DESCRIPTION
In the testcase, one thread queries
INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES in an infinite loop, called
from a stored procedure. The results of this query are never
collected, causing a network write failure from the server if the
testcase is running long enough.

Rewrite this testcase to use the event scheduler so that network I/O
is avoided.

http://jenkins.percona.com/job/percona-server-5.5-param/1304/
The test results expose a crash that was fixed in a later 5.5, tested locally with 5.5 trunk too.
