### PR TITLE
Bug 1610242: Reading past the end of heap buffer on saving the defaul…

### DIFF
--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -880,7 +880,8 @@ void audit_log_update_thd_local(audit_log_thd_local *local,
       name in STATUS event, so remember it now. */
 
       DBUG_ASSERT(event_general->general_query_length <= sizeof(local->db));
-      memcpy(local->db, event_general->general_query, sizeof(local->db));
+      memcpy(local->db, event_general->general_query,
+             event_general->general_query_length);
       local->db[event_general->general_query_length]= 0;
     }
     if (event_general->event_subclass == MYSQL_AUDIT_GENERAL_STATUS &&


### PR DESCRIPTION
…t DB in audit plugin

memcpy in the call

memcpy(local->db, event_general->general_query, sizeof(local->db));

always copies `NAME_LEN` bytes, but the real length of the
`general_query` can be less than `NAME_LEN`

Fix is to copy `general_query_length` bytes.
