### PR TITLE
Bug#22173419 VALGRIND FAILURE IN MAIN.GROUP_MIN_MAX

### DIFF
--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -10902,7 +10902,12 @@ bool QUICK_GROUP_MIN_MAX_SELECT::add_range(SEL_ARG *sel_range)
     if (sel_range->maybe_null &&
         sel_range->min_value[0] && sel_range->max_value[0])
       range_flag|= NULL_RANGE; /* IS NULL condition */
-    else if (memcmp(sel_range->min_value, sel_range->max_value,
+    /*
+      Do not perform comparison if one of the argiment is NULL value.
+    */
+    else if (!sel_range->min_value[0] &&
+             !sel_range->max_value[0] &&
+             memcmp(sel_range->min_value, sel_range->max_value,
                     min_max_arg_len) == 0)
       range_flag|= EQ_RANGE;  /* equality condition */
   }


### PR DESCRIPTION
Query below produces valgrind warning:

select a1,a2,b,min(c) from t2 where
((a1 > 'a') or (a1 < '9')) and (a2 >= 'b') and (b = 'a') and (c < 'h112')
group by a1,a2,b;

Problematic expession is (c < 'h112').
SEL_ARG::min_range is is_null_string which has length=2, memcmp
is executed with the length which is bigger than is_null_string.

The fix: Do not perform comparison if one of the argument is NULL value.

http://jenkins.percona.com/job/percona-server-5.5-param/1307/
