### PR TITLE
Fix bug 1610858 (Some MTR tests cause server kill on shutdown with Va…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
@@ -13,6 +13,7 @@ ib_modified_log_1
 ib_modified_log_2
 ib_modified_log_3
 3rd restart
+# restart
 INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
@@ -33,17 +34,21 @@ INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
 ib_modified_log_1
 ib_modified_log_2
 4th restart
+# restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 ib_modified_log_1
 ib_modified_log_2
 5th restart
+# restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 ib_modified_log_1
 6th restart
+# restart
 call mtr.add_suppression("InnoDB: Warning: truncated block detected.*");
 ib_modified_log_1
 ib_modified_log_2
 7th restart
+# restart
 ib_modified_log_1
 ib_modified_log_2
 ib_modified_log_3
@@ -61,3 +66,4 @@ DROP TABLE t3;
 11th restart
 ib_modified_log_1
 12th restart
+# restart

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
@@ -65,16 +65,12 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 # possible to re-read the entire missing range.
 #
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 remove_files_wildcard $MYSQLD_DATADIR ib_modified_log*;
 write_file $BITMAP_FILE;
 EOF
---enable_reconnect
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --echo 3rd restart
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc
 
 #
 # Test tracking more log data than the log capacity and the second tablespace id
@@ -109,16 +105,12 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 # Test that an empty existing bitmap file is handled properly when it's impossible to re-read the full missing range.
 #
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 remove_files_wildcard $MYSQLD_DATADIR ib_modified_log*;
 write_file $BITMAP_FILE;
 EOF
---enable_reconnect
 --echo 4th restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc
 
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 
@@ -130,32 +122,24 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 # Test that the bitmap file is read in block size multiples with junk at the end discarded
 #
 
-# 1st restart: remove all the bitmap files
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+# 5th restart: remove all the bitmap files
+--source include/shutdown_mysqld.inc
 remove_files_wildcard $MYSQLD_DATADIR ib_modified_log*;
---enable_reconnect
 --echo 5th restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc
 
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
 
-# 2nd restart: there should be only one bitmap file, append junk to it
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+# 6th restart: there should be only one bitmap file, append junk to it
+--source include/shutdown_mysqld.inc
 append_file $BITMAP_FILE;
 junk junk junk junk
 EOF
---enable_reconnect
 --echo 6th restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc
 call mtr.add_suppression("InnoDB: Warning: truncated block detected.*");
 
 # TODO: check the tracked LSN range continuity once this info is exposed through
@@ -169,9 +153,7 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 # Test that last tracked LSN is determined correctly when the last bitmap file is fully
 # corrupted
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 
 # Create and source a file with the following contents:
 # --remove_file 2nd_bmp_file
@@ -193,10 +175,8 @@ EOF
 END_OF_FILE
 source $MYSQLD_DATADIR/corrupt_bmp_2.inc;
 remove_file $MYSQLD_DATADIR/corrupt_bmp_2.inc;
---enable_reconnect
 --echo 7th restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc
 
 # TODO: check the tracked LSN range continuity once this info is exposed through
 # INFORMATION_SCHEMA.
@@ -211,19 +191,16 @@ DROP TABLE t1, t2;
 # Test for log tracking compatibility with innodb_force_recovery (bug 1083596).
 #
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
 --echo 8th restart
---exec echo "restart:--innodb-force-recovery=6" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-force-recovery=6
+--source include/restart_mysqld.inc
 
 # innodb_force_recovery desyncs bitmap data and logs
 RESET CHANGED_PAGE_BITMAPS;
 
 call mtr.add_suppression("InnoDB: Error: page [0-9]* log sequence number [0-9]*");
 --echo 9th restart
+--let $restart_parameters=
 --source include/restart_mysqld.inc
 
 #
@@ -245,27 +222,22 @@ DROP TABLE t3;
 # Test that bitmap files are created correctly in innodb_data_home_dir without a trailing
 # path separator (bug 1181887)
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
 --mkdir $MYSQLTEST_VARDIR/tmpdatadir
 --enable_reconnect
 --echo 11th restart
 --exec echo "restart:--innodb-data-home-dir=$MYSQLTEST_VARDIR/tmpdatadir" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --source include/wait_until_connected_again.inc
+--disable_reconnect
 
 file_exists $MYSQLTEST_VARDIR/tmpdatadir/ib_modified_log_1_0.xdb;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLTEST_VARDIR/tmpdatadir ib_modified_log*;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
 --remove_files_wildcard $MYSQLD_DATADIR ibdata*
 --remove_files_wildcard $MYSQLD_DATADIR ib_modified_log*
---enable_reconnect
 --echo 12th restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -24,12 +24,8 @@ CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 
 # Setup an error on bitmap write
 --echo 2nd restart
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:-#d,bitmap_page_write_error" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:-#d,bitmap_page_write_error
+--source include/restart_mysqld.inc
 
 # Generate log data that is larger than the log capacity
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -53,6 +49,7 @@ INSERT INTO t1 SELECT x FROM t1;
 # TODO: test its status through I_S query once the table is implemented
 
 --echo 3rd restart
+--let $restart_parameters=
 --source include/restart_mysqld.inc
 
 DROP TABLE t1;
@@ -141,12 +138,8 @@ RESET CHANGED_PAGE_BITMAPS;
 
 # Setup an error on the 2nd bitmap page write, so that bitmap contains an incomplete run
 --echo 4th restart
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:-#d,bitmap_page_2_write_error" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:-#d,bitmap_page_2_write_error
+--source include/restart_mysqld.inc
 
 --source include/count_sessions.inc
 

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests.test
@@ -130,12 +130,8 @@ DROP USER mysqltest_1@localhost;
 #
 # Test FLUSH and PURGE requests with log tracking disabled
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_track_changed_pages=FALSE" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_track_changed_pages=FALSE
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_track_changed_pages;
 
@@ -169,16 +165,13 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 #
 
 # Generate some bitmap data again
+--let $restart_parameters=
 --source include/restart_mysqld.inc
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 --source include/restart_mysqld.inc
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_track_changed_pages=FALSE" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_track_changed_pages=FALSE
+--source include/restart_mysqld.inc
 
 --echo Before the RESET while tracking disabled:
 --replace_regex /_[[:digit:]]+\.xdb$//

--- a/mysql-test/suite/sys_vars/t/innodb_adaptive_flushing_method_startup.test
+++ b/mysql-test/suite/sys_vars/t/innodb_adaptive_flushing_method_startup.test
@@ -2,56 +2,32 @@
 
 --source include/have_innodb.inc
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_adaptive_flushing_method=native" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_adaptive_flushing_method=native
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_adaptive_flushing_method;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_adaptive_flushing_method=estimate" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_adaptive_flushing_method=estimate
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_adaptive_flushing_method;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_adaptive_flushing_method=keep_average" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_adaptive_flushing_method=keep_average
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_adaptive_flushing_method;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_adaptive_flushing_method=0" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_adaptive_flushing_method=0
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_adaptive_flushing_method;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_adaptive_flushing_method=1" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_adaptive_flushing_method=1
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_adaptive_flushing_method;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_adaptive_flushing_method=2" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_adaptive_flushing_method=2
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_adaptive_flushing_method;

--- a/mysql-test/suite/sys_vars/t/innodb_flush_neighbor_pages_startup.test
+++ b/mysql-test/suite/sys_vars/t/innodb_flush_neighbor_pages_startup.test
@@ -2,56 +2,32 @@
 
 --source include/have_innodb.inc
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_flush_neighbor_pages=none" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_flush_neighbor_pages=none
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_flush_neighbor_pages;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_flush_neighbor_pages=area" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_flush_neighbor_pages=area
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_flush_neighbor_pages;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_flush_neighbor_pages=cont" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_flush_neighbor_pages=cont
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_flush_neighbor_pages;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_flush_neighbor_pages=0" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_flush_neighbor_pages=0
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_flush_neighbor_pages;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_flush_neighbor_pages=1" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_flush_neighbor_pages=1
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_flush_neighbor_pages;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb_flush_neighbor_pages=2" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb_flush_neighbor_pages=2
+--source include/restart_mysqld.inc
 
 SELECT @@GLOBAL.innodb_flush_neighbor_pages;


### PR DESCRIPTION
…lgrind)

Replace custom shutdown/startup MTR sequences with include file
use. This also removes hardcoded 10 second shutdown timeout in those
places, and using the default 60 second one, which is more appropriate
for running under Valgrind.

http://jenkins.percona.com/job/percona-server-5.5-param/1308/
