### PR TITLE
DB-1007 : Extend percona_show_temp_tables_stress to handle TokuDB

### DIFF
--- a/mysql-test/include/has_tokudb.inc
+++ b/mysql-test/include/has_tokudb.inc
@@ -1,0 +1,18 @@
+#
+# Script tests if TokuDB _should_ be present.
+# Sets $HAS_TOKUDB to either 0 or 1
+#
+--let $HAS_TOKUDB=0
+#
+# Check if server has support for loading plugins
+#
+if (`SELECT @@have_dynamic_loading = 'YES'`) {
+  if ($TOKUDB) {
+    #
+    # Check if --plugin-dir was setup for TokuDB
+    #
+    if (`SELECT CONCAT('--plugin-dir=', REPLACE(@@plugin_dir, '\\\\', '/')) = '$TOKUDB_OPT/'`) {
+      --let $HAS_TOKUDB=1
+    }
+  }
+}

--- a/mysql-test/r/percona_show_temp_tables_stress.result
+++ b/mysql-test/r/percona_show_temp_tables_stress.result
@@ -3,10 +3,7 @@ WHILE TRUE DO
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
 END WHILE|
 CALL query_temp_tables();
-# Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
-SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
-COUNT(*)
-1200
+# Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY, and possibly TokuDB
 # Dropping the temp tables
 KILL QUERY $con1_id
 DROP PROCEDURE query_temp_tables;

--- a/mysql-test/t/percona_show_temp_tables_stress-master.opt
+++ b/mysql-test/t/percona_show_temp_tables_stress-master.opt
@@ -1,0 +1,1 @@
+$TOKUDB_OPT $TOKUDB_LOAD_ADD --loose-tokudb-check-jemalloc=0 --loose-tokudb-cache-size=512M --loose-tokudb-block-size=1M

--- a/mysql-test/t/percona_show_temp_tables_stress.test
+++ b/mysql-test/t/percona_show_temp_tables_stress.test
@@ -1,5 +1,7 @@
 --source include/have_innodb.inc
 
+--source include/has_tokudb.inc
+
 --source include/count_sessions.inc
 
 delimiter |;
@@ -18,18 +20,35 @@ send CALL query_temp_tables();
 connection default;
 
 --let $i=400
---echo # Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
+--echo # Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY, and possibly TokuDB
 --disable_query_log
 while ($i)
 {
   --eval CREATE TEMPORARY TABLE tmp_myisam_$i (a VARCHAR(256)) ENGINE=MyISAM
   --eval CREATE TEMPORARY TABLE tmp_innodb_$i (a VARCHAR(256)) ENGINE=InnoDB
   --eval CREATE TEMPORARY TABLE tmp_memory_$i (a VARCHAR(256)) ENGINE=MEMORY
+  if ($HAS_TOKUDB)
+  {
+    --eval CREATE TEMPORARY TABLE tmp_tokudb_$i (a VARCHAR(256)) ENGINE=TokuDB
+  }
   --dec $i
 }
 --enable_query_log
-
-SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+--let $table_count=`SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES`
+if ($HAS_TOKUDB == 0)
+{
+  if ($table_count != 1200)
+  {
+    --die ERROR IN TEST: Expected count of I_S.GLOBAL_TEMPORARY_TABLES to be 1200.
+  }
+}
+if ($HAS_TOKUDB == 1)
+{
+  if ($table_count != 1600)
+  {
+    --die ERROR IN TEST: Expected count of I_S.GLOBAL_TEMPORARY_TABLES to be 1600.
+  }
+}
 
 --let $i=400
 --echo # Dropping the temp tables
@@ -39,6 +58,10 @@ while ($i)
   --eval DROP TEMPORARY TABLE tmp_myisam_$i
   --eval DROP TEMPORARY TABLE tmp_innodb_$i
   --eval DROP TEMPORARY TABLE tmp_memory_$i
+  if ($HAS_TOKUDB)
+  {
+    --eval DROP TEMPORARY TABLE tmp_tokudb_$i
+  }
   --dec $i
 }
 --enable_query_log


### PR DESCRIPTION
- Created new include file that will indicate if TokuDB _should_ be present.
- Altered test to use TokuDB along with other engines if TokuDB should be presentwith consideration to run successfully if there is no TokuDB.
