### PR TITLE
Fix bug 1611229 (Test mysql_plugin intermittently fails to shutdown t…

### DIFF
--- a/mysql-test/include/search_pattern_in_file.inc
+++ b/mysql-test/include/search_pattern_in_file.inc
@@ -41,7 +41,7 @@
 #    # Stop the server
 #    let $restart_file= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect;
 #    --exec echo "wait" > $restart_file
-#    --shutdown_server 10
+#    --shutdown_server 
 #    --source include/wait_until_disconnected.inc
 #
 #    --error 1

--- a/mysql-test/suite/binlog/t/binlog_max_extension.test
+++ b/mysql-test/suite/binlog/t/binlog_max_extension.test
@@ -39,7 +39,7 @@ RESET MASTER;
 
 # 1. Stop master server
 -- exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
--- shutdown_server 10
+-- shutdown_server 
 -- source include/wait_until_disconnected.inc
 
 # 2. Prepare log and index file
@@ -68,7 +68,7 @@ FLUSH LOGS;
 
 # 1. Stop the server
 -- exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
--- shutdown_server 10
+-- shutdown_server 
 -- source include/wait_until_disconnected.inc
 
 # 2. Undo changes to index and log files

--- a/mysql-test/suite/innodb/r/innodb_bug14147491.result
+++ b/mysql-test/suite/innodb/r/innodb_bug14147491.result
@@ -6,9 +6,6 @@ INSERT INTO t1 (b) VALUES ('corrupt me');
 INSERT INTO t1 (b) VALUES ('corrupt me');
 # Write file to make mysql-test-run.pl expect the "crash", but don't
 # start it until it's told to
-# We give 30 seconds to do a clean shutdown because we do not want
-# to redo apply the pages of t1.ibd at the time of recovery.
-# We want SQL to initiate the first access to t1.ibd.
 # Wait until disconnected.
 # Backup the t1.ibd before corrupting
 # Corrupt the table

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_1364315.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_1364315.result
@@ -3,3 +3,4 @@ select count(*) > 1 from information_schema.innodb_changed_pages;
 count(*) > 1
 1
 2nd restart
+# restart

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush.result
@@ -3,18 +3,22 @@ RESET CHANGED_PAGE_BITMAPS;
 CREATE TABLE t1 (a INT, b BLOB) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1, REPEAT("a", 20000));
 ib_modified_log_1
+# restart:--innodb-track-changed-pages=1 --innodb-flush-method=O_DSYNC
 INSERT INTO t1 VALUES (2, REPEAT("b", 20000));
 ib_modified_log_1
 ib_modified_log_2
+# restart:--innodb-track-changed-pages=1 --innodb-flush-method=O_DIRECT
 INSERT INTO t1 VALUES (3, REPEAT("c", 20000));
 call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
 ib_modified_log_1
 ib_modified_log_2
 ib_modified_log_3
+# restart:--innodb-track-changed-pages=1 --innodb-log-block-size=4096 --innodb-flush-method=ALL_O_DIRECT
 INSERT INTO t1 VALUES (4, REPEAT("d", 20000));
 ib_modified_log_1
 ib_modified_log_2
 ib_modified_log_3
 ib_modified_log_4
+# restart
 RESET CHANGED_PAGE_BITMAPS;
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_log_block_size.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_log_block_size.result
@@ -1,6 +1,8 @@
 DROP TABLE IF EXISTS t1;
 call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
+# restart:--innodb-log-block-size=4096 --innodb-track-changed-pages=1
 CREATE TABLE t1 (a INT, b BLOB) ENGINE=InnoDB;
 INSERT INTO t1 VALUES(1, REPEAT("a", 20000));
 INSERT INTO t1 VALUES(2, REPEAT("b", 20000));
 DROP TABLE t1;
+# restart

--- a/mysql-test/suite/innodb/t/innodb_bug14147491.test
+++ b/mysql-test/suite/innodb/t/innodb_bug14147491.test
@@ -36,10 +36,7 @@ let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd;
 --echo # start it until it's told to
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 
---echo # We give 30 seconds to do a clean shutdown because we do not want
---echo # to redo apply the pages of t1.ibd at the time of recovery.
---echo # We want SQL to initiate the first access to t1.ibd.
-shutdown_server 30;
+shutdown_server;
 
 --echo # Wait until disconnected.
 --source include/wait_until_disconnected.inc

--- a/mysql-test/suite/innodb/t/innodb_bug60196.test
+++ b/mysql-test/suite/innodb/t/innodb_bug60196.test
@@ -49,7 +49,7 @@ SELECT * FROM bug_60196;
 -- exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 
 # Send a shutdown request to the server
--- shutdown_server 10
+-- shutdown_server
 
 # Call script that will poll the server waiting for it to disapear
 -- source include/wait_until_disconnected.inc
@@ -122,7 +122,7 @@ SELECT * FROM Bug_60309;
 -- exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 
 # Send a shutdown request to the server
--- shutdown_server 10
+-- shutdown_server
 
 # Call script that will poll the server waiting for it to disapear
 -- source include/wait_until_disconnected.inc

--- a/mysql-test/suite/innodb/t/percona_all_o_direct_debug.test
+++ b/mysql-test/suite/innodb/t/percona_all_o_direct_debug.test
@@ -9,7 +9,7 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 
 --echo # Shutting down...
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
+--shutdown_server
 --source include/wait_until_disconnected.inc
 
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_1364315.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_1364315.test
@@ -6,9 +6,7 @@
 
 --let $TMPDATADIR= $MYSQLTEST_VARDIR/tmpdatadir_1364315
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 --mkdir $TMPDATADIR
 --enable_reconnect
 --echo 1st restart
@@ -17,14 +15,8 @@
 
 select count(*) > 1 from information_schema.innodb_changed_pages;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
-
+--source include/shutdown_mysqld.inc
 --remove_files_wildcard $TMPDATADIR *
 --rmdir $TMPDATADIR
-
---enable_reconnect
 --echo 2nd restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/start_mysqld.inc

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_1368530.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_1368530.test
@@ -9,14 +9,9 @@ SET @@GLOBAL.innodb_track_changed_pages=TRUE;
 # purge causes crash described in lp:1368530
 PURGE CHANGED_PAGE_BITMAPS BEFORE 0;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
-
---enable_reconnect
+--let $restart_parameters= restart: --innodb_track_changed_pages=1
 --echo 1st restart
---exec echo "restart: --innodb_track_changed_pages=1" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/restart_mysqld.inc
 
 SET @@GLOBAL.innodb_track_changed_pages=FALSE;
 SELECT @@GLOBAL.innodb_track_changed_pages;
@@ -24,14 +19,9 @@ SELECT @@GLOBAL.innodb_track_changed_pages;
 SET @@GLOBAL.innodb_track_changed_pages=TRUE;
 SELECT @@GLOBAL.innodb_track_changed_pages;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
-
---enable_reconnect
+--let $restart_parameters=
 --echo 2nd restart
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--source include/restart_mysqld.inc
 
 # remove ib_modified_log_1_0.xdb file created by test
 RESET CHANGED_PAGE_BITMAPS;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -60,13 +60,10 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 # Test crash right before writing of new bitmap data
 #
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:-#d,crash_before_bitmap_write" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:-#d,crash_before_bitmap_write
 --echo 2nd restart
+--source include/restart_mysqld.inc
+
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --error 2013
 INSERT INTO t1 SELECT x FROM t1;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush.test
@@ -18,12 +18,8 @@ CREATE TABLE t1 (a INT, b BLOB) ENGINE=InnoDB;
 #
 # Test innodb_flush_method=fdatasync (the default)
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb-track-changed-pages=1" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-track-changed-pages=1
+--source include/restart_mysqld.inc
 
 INSERT INTO t1 VALUES (1, REPEAT("a", 20000));
 
@@ -31,16 +27,13 @@ INSERT INTO t1 VALUES (1, REPEAT("a", 20000));
 # Test innodb_flush_method=O_DSYNC
 # Check that the previous test produced bitmap data while the server is down.
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 file_exists $BITMAP_FILE;
 # Here and below remove the LSNs from the file names on listing them
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
---enable_reconnect
---exec echo "restart:--innodb-track-changed-pages=1 --innodb-flush-method=O_DSYNC" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-track-changed-pages=1 --innodb-flush-method=O_DSYNC
+--source include/start_mysqld.inc
 
 INSERT INTO t1 VALUES (2, REPEAT("b", 20000));
 
@@ -48,15 +41,12 @@ INSERT INTO t1 VALUES (2, REPEAT("b", 20000));
 # Test innodb_flush_method=O_DIRECT
 # Check that the previous test produced bitmap data while the server is down.
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
---enable_reconnect
---exec echo "restart:--innodb-track-changed-pages=1 --innodb-flush-method=O_DIRECT" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-track-changed-pages=1 --innodb-flush-method=O_DIRECT
+--source include/start_mysqld.inc
 
 INSERT INTO t1 VALUES (3, REPEAT("c", 20000));
 
@@ -65,33 +55,26 @@ INSERT INTO t1 VALUES (3, REPEAT("c", 20000));
 # Check that the previous test produced bitmap data while the server is down.
 #
 call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
-
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
---enable_reconnect
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
---exec echo "restart:--innodb-track-changed-pages=1 --innodb-log-block-size=4096 --innodb-flush-method=ALL_O_DIRECT" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-track-changed-pages=1 --innodb-log-block-size=4096 --innodb-flush-method=ALL_O_DIRECT
+--source include/start_mysqld.inc
 
 INSERT INTO t1 VALUES (4, REPEAT("d", 20000));
 
 #
 # Restart the server with default options
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
---enable_reconnect
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters=
+--source include/start_mysqld.inc
 
 RESET CHANGED_PAGE_BITMAPS;
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_log_block_size.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_log_block_size.test
@@ -11,13 +11,10 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 
 call mtr.add_suppression("InnoDB: Warning: innodb_log_block_size has been changed from default value");
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
---enable_reconnect
---exec echo "restart:--innodb-log-block-size=4096 --innodb-track-changed-pages=1" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-log-block-size=4096 --innodb-track-changed-pages=1
+--source include/start_mysqld.inc
 
 CREATE TABLE t1 (a INT, b BLOB) ENGINE=InnoDB;
 
@@ -26,11 +23,8 @@ INSERT INTO t1 VALUES(2, REPEAT("b", 20000));
 
 DROP TABLE t1;
 
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
+--source include/shutdown_mysqld.inc
 --file_exists $MYSQLD_DATADIR/ib_modified_log_1_0.xdb
 --remove_files_wildcard $MYSQLD_DATADIR ib_logfile*
---enable_reconnect
---exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters=
+--source include/start_mysqld.inc

--- a/mysql-test/suite/innodb/t/percona_changed_pages.test
+++ b/mysql-test/suite/innodb/t/percona_changed_pages.test
@@ -345,13 +345,9 @@ CREATE TABLE ICP_COPY (
 INSERT INTO ICP_COPY SELECT * FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
        WHERE END_LSN <= @max_end_lsn;
 
-# Restart with log tracking disabled       
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb-track-changed-pages=FALSE" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+# Restart with log tracking disabled
+--let $restart_parameters= restart:--innodb-track-changed-pages=FALSE
+--source include/restart_mysqld.inc
 
 SELECT @@global.innodb_track_changed_pages;
 
@@ -372,6 +368,7 @@ let $icp_2_checksum= `CHECKSUM TABLE ICP_COPY`;
 eval SELECT "$icp_1_checksum" LIKE "$icp_2_checksum" AS should_be_1;
 --enable_query_log
 
+--let $restart_parameters=
 --source include/restart_mysqld.inc
 
 SELECT @@global.innodb_track_changed_pages;

--- a/mysql-test/suite/innodb/t/percona_corrupted_sys_stats.test
+++ b/mysql-test/suite/innodb/t/percona_corrupted_sys_stats.test
@@ -16,18 +16,15 @@ INSERT INTO t1 VALUES (10);
 SELECT a FROM t1;
 
 # Restart server with an option that will cause SYS_STATS to be detected as corrupted
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--innodb-persistent-stats-root-page=7" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--innodb-persistent-stats-root-page=7
+--source include/restart_mysqld.inc
 
 INSERT INTO t1 VALUES (20);
 
 SELECT a FROM t1;
 
 # Test that dictionary header is rewritten correctly by restarting the server again
+--let $restart_parameters=
 --source include/restart_mysqld.inc
 
 INSERT INTO t1 VALUES (30);

--- a/mysql-test/suite/rpl/r/rpl_mdev382.result
+++ b/mysql-test/suite/rpl/r/rpl_mdev382.result
@@ -310,6 +310,7 @@ a`
 1
 2
 5
+include/rpl_restart_server.inc [server_number=1]
 set timestamp=1000000000;
 # The table should be empty on the master.
 SELECT * FROM `db1``; select 'oops!'`.`t``1`;

--- a/mysql-test/suite/rpl/t/rpl_mdev382.test
+++ b/mysql-test/suite/rpl/t/rpl_mdev382.test
@@ -204,16 +204,8 @@ SELECT * FROM `db1``; select 'oops!'`.`t``1` ORDER BY 1;
 # Restart the master mysqld.
 # This will cause an implicit truncation of the memory-based table, which will
 # cause logging of an explicit DELETE FROM to binlog.
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-wait-rpl_mdev382.test
-EOF
-
---shutdown_server 30
-
---remove_file $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---write_file $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-restart-rpl_mdev382.test
-EOF
+--let $rpl_server_number= 1
+--source include/rpl_restart_server.inc
 
 connection default;
 --enable_reconnect

--- a/mysql-test/t/log_errchk.test
+++ b/mysql-test/t/log_errchk.test
@@ -32,7 +32,7 @@ call mtr.add_suppression("Could not use");
 --echo #         and slow query log file.
 # Restart server with fifo file as general log file.
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 60
+--shutdown_server 
 --source include/wait_until_disconnected.inc
 --enable_reconnect
 # Write file to make mysql-test-run.pl start up the server again

--- a/mysql-test/t/mysql_plugin.test
+++ b/mysql-test/t/mysql_plugin.test
@@ -112,7 +112,7 @@ SELECT * FROM mysql.plugin WHERE dl like 'libdaemon%' ORDER BY name;
 --echo #
 
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
+--shutdown_server 
 --source include/wait_until_disconnected.inc
 
 #
@@ -150,7 +150,7 @@ eval INSERT INTO mysql.plugin VALUES ('wonky', '$DAEMONEXAMPLE');
 SELECT * FROM mysql.plugin WHERE dl like 'libdaemon%' ORDER BY name;
 
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
+--shutdown_server 
 --source include/wait_until_disconnected.inc
 
 #
@@ -177,7 +177,7 @@ SELECT * FROM mysql.plugin WHERE dl like 'libdaemon%' ORDER BY name;
 SELECT * FROM mysql.plugin WHERE dl like '%libdaemon%' ORDER BY name;
 
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
+--shutdown_server 
 --source include/wait_until_disconnected.inc
 
 # To test the case where the same plugin is reloaded with a different soname,
@@ -208,7 +208,7 @@ SELECT * FROM mysql.plugin WHERE dl like '%libdaemon%' ORDER BY name;
 --echo #
 
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
+--shutdown_server 
 --source include/wait_until_disconnected.inc
 
 #
@@ -238,7 +238,7 @@ SELECT * FROM mysql.plugin WHERE dl like '%libdaemon%' ORDER BY name;
 #
 
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
+--shutdown_server 
 --source include/wait_until_disconnected.inc
 
 --echo #

--- a/mysql-test/t/percona_enhanced_options_modifiers.test
+++ b/mysql-test/t/percona_enhanced_options_modifiers.test
@@ -59,12 +59,8 @@ SET @@GLOBAL.INNODB_READ_AHEAD_THRESHOLD=32;
 #
 # restart the server with some options modifiers and limits
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--auto-increment-increment=7 --minimum-auto-increment-increment=5 --maximum-auto-increment-increment=10 --readonly-auto-increment-offset=TRUE --hidden-autocommit=TRUE --innodb-io-capacity=150 --minimum-innodb-io-capacity=150 --maximum-innodb-io-capacity=200 --readonly-innodb-spin-wait-delay=TRUE --hidden-innodb-read-ahead-threshold=TRUE" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--auto-increment-increment=7 --minimum-auto-increment-increment=5 --maximum-auto-increment-increment=10 --readonly-auto-increment-offset=TRUE --hidden-autocommit=TRUE --innodb-io-capacity=150 --minimum-innodb-io-capacity=150 --maximum-innodb-io-capacity=200 --readonly-innodb-spin-wait-delay=TRUE --hidden-innodb-read-ahead-threshold=TRUE
+--source include/restart_mysqld.inc
 
 #
 # test the limits set by the above options modifiers
@@ -135,12 +131,8 @@ SET @@GLOBAL.INNODB_READ_AHEAD_THRESHOLD=32;
 #
 # Now test allowed modifier combinations
 #
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---shutdown_server 10
---source include/wait_until_disconnected.inc
---enable_reconnect
---exec echo "restart:--readonly-loose-auto-increment-offset=TRUE --hidden-loose-autocommit=TRUE --readonly-loose-innodb-spin-wait-delay=TRUE --hidden-loose-innodb-read-ahead-threshold=TRUE" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---source include/wait_until_connected_again.inc
+--let $restart_parameters= restart:--readonly-loose-auto-increment-offset=TRUE --hidden-loose-autocommit=TRUE --readonly-loose-innodb-spin-wait-delay=TRUE --hidden-loose-innodb-read-ahead-threshold=TRUE
+--source include/restart_mysqld.inc
 
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SET @@GLOBAL.AUTO_INCREMENT_OFFSET=5;


### PR DESCRIPTION
…he server in 10 seconds)

Clean up MTR testcases not to specify non-default shutdown_server
timeout, if greater than zero. For upstream testcases, this is mostly
[1], with some follow-up cleanup not handled by that commit. For our
testcases, use include files as appropriate.

[1]:

commit 5505f669979a0504988c36fa1e13b42daeda1b6e
Author: Anitha anitha.gopi@oracle.com
Date:   Thu Dec 18 09:30:01 2014 +0100

```
Bug#20225524 TESTS SHOULD USE AT LEAST 60 SEC TIMEOUT FOR SHUTDOWN_SERVER
COMMAND

Removed timeouts less than the default from all shutdown_server commands in the
.tets and .inc files
```

http://jenkins.percona.com/job/percona-server-5.5-param/1311/
