### PR TITLE
Bug 1544443: Percona PAM doesn't support spaces for groups

### DIFF
--- a/plugin/percona-pam-for-mysql/src/auth_mapping.c
+++ b/plugin/percona-pam-for-mysql/src/auth_mapping.c
@@ -1,5 +1,5 @@
 /*
-(C) 2012, 2013 Percona LLC and/or its affiliates
+(C) 2012, 2016 Percona LLC and/or its affiliates
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -68,6 +68,19 @@ static const char *get_token(struct token *token,
     token->token_len= 1;
     token->token_type = tok_eq;
     ++ptr;
+    break;
+  case '"':
+    token->token_len= 0;
+    ++ptr;
+    token->token= ptr;
+    while (*ptr && *ptr != '"')
+    {
+      ++token->token_len;
+      ++ptr;
+    }
+    token->token_type= tok_id;
+    if (*ptr)
+      ++ptr;
     break;
   default:
     token->token_len= 0;


### PR DESCRIPTION
Add an option to quote identifier inside the authentication sting with
double quotes.

Example:

CREATE USER ''@'' IDENTIFIED WITH auth_pam AS 'mysqld, "data entry members" = data_entry, _developer="developer"';
