### PR TITLE
Work towards fixing bug 1612076 (Test rpl.rpl_cant_read_event_inciden…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_cant_read_event_incident.result
+++ b/mysql-test/suite/rpl/r/rpl_cant_read_event_incident.result
@@ -12,6 +12,11 @@ start slave;
 include/wait_for_slave_param.inc [Last_IO_Errno]
 Last_IO_Errno = '1236'
 Last_IO_Error = 'Got fatal error 1236 from master when reading data from binary log: 'binlog truncated in the middle of event; consider out of disk space on master; the first event '' at XXX, the last event read from './master-bin.000001' at XXX, the last byte read from './master-bin.000001' at XXX.''
+include/wait_for_slave_io_to_stop.inc
+Slave_IO_Running = 'No'
+Slave_SQL_Running = 'Yes'
+Last_SQL_Errno = '0'
+Last_SQL_Error = ''
 reset master;
 stop slave;
 reset slave;

--- a/mysql-test/suite/rpl/t/rpl_cant_read_event_incident.test
+++ b/mysql-test/suite/rpl/t/rpl_cant_read_event_incident.test
@@ -50,6 +50,11 @@ start slave;
 --let $status_items= Last_IO_Errno, Last_IO_Error
 --source include/show_slave_status.inc
 
+--source include/wait_for_slave_io_to_stop.inc
+
+--let $status_items= Slave_IO_Running, Slave_SQL_Running, Last_SQL_Errno, Last_SQL_Error
+--source include/show_slave_status.inc
+
 #
 # Cleanup
 #


### PR DESCRIPTION
…t is unstable)

The testcase fails with STOP SLAVE indicating that both slave threads
have already been stopped, when the SQL thread should have been
running. Record the running SQL thread SHOW SLAVE STATUS, so that the
next testcase failure would show the SQL thread stopping reason.

http://jenkins.percona.com/job/percona-server-5.5-param/1323/
