### PR TITLE
Fix bug 1612084 (MTR include/wait_until_connected_again.inc may timeo…

### DIFF
--- a/mysql-test/include/wait_until_connected_again.inc
+++ b/mysql-test/include/wait_until_connected_again.inc
@@ -3,7 +3,10 @@
 # server has been restored or timeout occurs
 --disable_result_log
 --disable_query_log
-let $counter= 500;
+let $counter= 5000;
+if ($VALGRIND_TEST) {
+  let $counter= 30000;
+}
 let $mysql_errno= 9999;
 while ($mysql_errno)
 {


### PR DESCRIPTION
…ut too soon for Valgrind)

Backport the 5.7 wait_until_connected_again.inc timeout, which is
significantly bumped for the general case (and fix the attempt to bump
it further if running under Valgrind).

http://jenkins.percona.com/job/percona-server-5.5-param/1320/
