### PR TITLE
Bug 1608902: Constant buffer size set on max_nss_name_len is not enou…

### DIFF
--- a/plugin/percona-pam-for-mysql/src/groups.c
+++ b/plugin/percona-pam-for-mysql/src/groups.c
@@ -1,5 +1,5 @@
 /*
-(C) 2013 Percona LLC and/or its affiliates
+(C) 2013, 2016 Percona LLC and/or its affiliates
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -17,19 +17,21 @@ Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <pwd.h>
 #include <grp.h>
+#include <errno.h>
+#include <my_sys.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>
 
-enum { max_nss_name_len = 10240 };
-enum { max_number_of_groups = 1024 };
+static int gr_buf_size= 0;
 
 /** Groups iterator. It's not exposed outsude */
 struct groups_iter {
-  char buf[max_nss_name_len];
-  gid_t groups[max_number_of_groups];
+  char *buf;
+  gid_t *groups;
   int current_group;
   int ngroups;
+  int buf_size;
 };
 
 /** Create iterator through user groups.
@@ -41,23 +43,58 @@ struct groups_iter *groups_iter_new(const char *user_name)
   int error;
   struct groups_iter *it;
 
-  it= calloc(1, sizeof(struct groups_iter));
-  if (it == NULL)
-    return NULL;
+  if (gr_buf_size <= 0)
+  {
+    long gr_size_max, pw_size_max;
+    gr_size_max= sysconf(_SC_GETGR_R_SIZE_MAX);
+    pw_size_max= sysconf(_SC_GETPW_R_SIZE_MAX);
+    gr_buf_size= gr_size_max > pw_size_max ? gr_size_max : pw_size_max;
+  }
 
-  error= getpwnam_r(user_name, &pwd, it->buf, max_nss_name_len, &pwd_result);
+  it= (struct groups_iter *) my_malloc(sizeof(struct groups_iter),
+                                       MYF(MY_FAE | MY_ZEROFILL));
+
+  it->buf_size= gr_buf_size;
+  if (it->buf_size <= 0)
+    it->buf_size= 1024;
+
+  it->buf= (char *) my_malloc(it->buf_size, MYF(MY_FAE));
+
+  while ((error= getpwnam_r(user_name, &pwd, it->buf, it->buf_size,
+                            &pwd_result)) == ERANGE)
+  {
+    it->buf_size= it->buf_size * 2;
+    it->buf= (char *) my_realloc(it->buf, it->buf_size, MYF(MY_FAE));
+  }
   if (error != 0 || pwd_result == NULL)
   {
-    free(it);
+    fprintf(stderr, "auth_pam: Unable to obtain the passwd entry for the user "
+                    "'%s'.", user_name);
+    my_free(it->buf);
+    my_free(it);
     return NULL;
   }
 
-  it->ngroups= max_number_of_groups;
+  gr_buf_size= it->buf_size;
+
+  it->ngroups= 1024;
+  it->groups= (gid_t *) my_malloc(it->ngroups * sizeof(gid_t), MYF(MY_FAE));
   error= getgrouplist(user_name, pwd_result->pw_gid, it->groups, &it->ngroups);
   if (error == -1)
   {
-    free(it);
-    return NULL;
+    it->groups= (gid_t *) my_realloc(it->groups, it->ngroups * sizeof(gid_t),
+                                     MYF(MY_FAE));
+    error= getgrouplist(user_name, pwd_result->pw_gid, it->groups,
+                        &it->ngroups);
+    if (error == -1)
+    {
+      fprintf(stderr, "auth_pam: Unable to obtain the group access list for "
+                      "the user '%s'.", user_name);
+      my_free(it->buf);
+      my_free(it->groups);
+      my_free(it);
+      return NULL;
+    }
   }
 
   return it;
@@ -74,17 +111,24 @@ const char *groups_iter_next(struct groups_iter *it)
   if (it->current_group >= it->ngroups)
     return NULL;
 
-  error= getgrgid_r(it->groups[it->current_group++],
-                    &grp, it->buf, max_nss_name_len, &grp_result);
+  while ((error= getgrgid_r(it->groups[it->current_group], &grp, it->buf,
+                            it->buf_size, &grp_result)) == ERANGE)
+  {
+    it->buf_size= it->buf_size * 2;
+    it->buf= (char *) my_realloc(it->buf, it->buf_size, MYF(MY_FAE));
+  }
   if (error != 0 || grp_result == NULL)
   {
+    fprintf(stderr, "auth_pam: Unable to obtain the group record for the group "
+                    "id %d.", (int) it->groups[it->current_group]);
     return NULL;
   }
+  ++it->current_group;
 
   return grp_result->gr_name;
 }
 
-/** Make iterator to point to beginning again */
+/** Make iterator to point to the beginning again */
 void groups_iter_reset(struct groups_iter *it)
 {
   it->current_group= 0;
@@ -93,6 +137,8 @@ void groups_iter_reset(struct groups_iter *it)
 /** Finish iteration and release iterator */
 void groups_iter_free(struct groups_iter *it)
 {
-  free(it);
+  my_free(it->buf);
+  my_free(it->groups);
+  my_free(it);
 }
 


### PR DESCRIPTION
…gh to get results from getgrgid_r if there are thousands of members in a group

PAM plugin makes a list of the names of the groups which the user belongs
to as following:
- receive the list of group ids with `getgrouplist`
- for each group id call `getgrgid_r` to get its name

There are two issues:
- Fixed length array passed to `getgrouplist`. If its size isn't enough,
  plugin aborts authentication. Fixed by reallocating the array using
  the number of groups reported by the unsuccessful call and retrying
  the call.
- `getpwnam_r` and `getgrgid_r` return `ERANGE` in case of insufficient
  buffer.
  
  Fix:
  1. Use values of `sysconf(_SC_GETGR_R_SIZE_MAX)` and
     `sysconf(_SC_GETPW_R_SIZE_MAX)` as initial buffer size.
  2. In case of `ERANGE` allocate the buffer with the double size and
     try again until the result is different from `ERANGE`.
