### PR TITLE
Fix bug 1612551 (Test innodb.percona_changed_page_bmp_crash is unstable)

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
@@ -1,5 +1,4 @@
 RESET CHANGED_PAGE_BITMAPS;
-DROP TABLE IF EXISTS t1, t2;
 CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -25,6 +24,7 @@ SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 1st restart
 ib_modified_log_1
 ib_modified_log_2
+INSERT INTO t2 VALUES (1);
 2nd restart
 INSERT INTO t1 SELECT x FROM t1;
 ERROR HY000: Lost connection to MySQL server during query

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -7,13 +7,7 @@
 --source include/have_debug.inc
 --source include/not_valgrind.inc
 
-# Delete any existing bitmaps
---source include/restart_mysqld.inc
 RESET CHANGED_PAGE_BITMAPS;
-
---disable_warnings
-DROP TABLE IF EXISTS t1, t2;
---enable_warnings
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 let $BITMAP_FILE= $MYSQLD_DATADIR/ib_modified_log_1_0.xdb;
@@ -56,6 +50,9 @@ file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
 
+# Make sure the current bitmap file does not end up zero-sized and reused
+INSERT INTO t2 VALUES (1);
+
 #
 # Test crash right before writing of new bitmap data
 #
@@ -72,6 +69,7 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 INSERT INTO t1 SELECT x FROM t1;
 --enable_reconnect
 --source include/wait_until_connected_again.inc
+--disable_reconnect
 
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 


### PR DESCRIPTION
Ensure that the second bitmap file is never zero-sized by issuing some
write workload while it's the current bitmap output file. Then a clean
shutdown happens, ensuring that the bitmap is written. Cleanup the
testcase.

http://jenkins.percona.com/job/percona-server-5.5-param/1330/
