### PR TITLE
Fix bug 1613641 (Test rpl.rpl_filter_tables_not_exist produces an uns…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_filter_tables_not_exist.result
+++ b/mysql-test/suite/rpl/r/rpl_filter_tables_not_exist.result
@@ -118,6 +118,7 @@ CREATE TABLE test.t5 (a INT AUTO_INCREMENT PRIMARY KEY, b DECIMAL(20,20), c INT)
 CREATE TABLE test.t1 (a INT);
 INSERT INTO test.t1 VALUES(1);
 call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
 CREATE TABLE test.t_slave (a INT AUTO_INCREMENT PRIMARY KEY, b DECIMAL(20,20), c INT);
 CREATE TRIGGER t1_update AFTER UPDATE ON test.t1 FOR EACH ROW
 INSERT INTO test.t_slave VALUES(NULL, RAND(), @c);

--- a/mysql-test/suite/rpl/t/rpl_filter_tables_not_exist.test
+++ b/mysql-test/suite/rpl/t/rpl_filter_tables_not_exist.test
@@ -219,6 +219,7 @@ connection master;
 CREATE TABLE test.t5 (a INT AUTO_INCREMENT PRIMARY KEY, b DECIMAL(20,20), c INT); # ignored on slave
 CREATE TABLE test.t1 (a INT); # accepted on slave
 INSERT INTO test.t1 VALUES(1);
+call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
 
 --sync_slave_with_master
 call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");


### PR DESCRIPTION
…uppressed warning in the error log)

The unsuppressed warning should be suppressed, as it already is in
5.6+.

http://jenkins.percona.com/job/percona-server-5.5-param/1331/
