### PR TITLE
Fix bug 1613663 (Test main.mysqltest is unstable)

### DIFF
--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -1942,7 +1942,10 @@ void mysqld_list_processes(THD *thd,const char *user, bool verbose)
     else
       protocol->store(command_name[thd_info->command].str, system_charset_info);
     if (thd_info->start_time)
-      protocol->store_long ((longlong) (now - thd_info->start_time));
+    {
+      protocol->store_long ((thd_info->start_time > now) ? 0
+        : (longlong) (now - thd_info->start_time));
+    }
     else
       protocol->store_null();
     protocol->store(thd_info->state_info, system_charset_info);


### PR DESCRIPTION
Prevent negative time in SHOW PROCESSLIST by replacing it with 0. A
proper fix would be to use only monotonic clocks for time duration
measurements, but that's too invasive for us to fix.

http://jenkins.percona.com/job/percona-server-5.5-param/1333/
