### PR TITLE
Fix bug 1613986 (Test percona_changed_page_bmp_crash produces warning…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
@@ -25,6 +25,7 @@ SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 1st restart
 ib_modified_log_1
 ib_modified_log_2
+CALL mtr.add_suppression("InnoDB: Warning: database page corruption or a failed");
 2nd restart
 INSERT INTO t1 SELECT x FROM t1;
 ERROR HY000: Lost connection to MySQL server during query

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -60,6 +60,7 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 # Test crash right before writing of new bitmap data
 #
 
+CALL mtr.add_suppression("InnoDB: Warning: database page corruption or a failed");
 --exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --shutdown_server 10
 --source include/wait_until_disconnected.inc


### PR DESCRIPTION
…s if doublewrite was used for recovery)

The intentionally crashed server might need doublewrite buffer to
restore a data page. It produces a warning in the error log in this
case, which should be suppressed.

http://jenkins.percona.com/job/percona-server-5.5-param/1337/
