### PR TITLE
Work towards fixing bug 904714 (Intermittent rpl.percona_bug860910 fa…

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4268,7 +4268,7 @@ sub run_testcase ($) {
       {
         $tinfo->{comment}.=
 	   "== $log_file_name == \n".
-	     mtr_lastlinesfromfile($log_file_name, 20)."\n";
+	     mtr_lastlinesfromfile($log_file_name, 500)."\n";
       }
       $tinfo->{'timeout'}= testcase_timeout($tinfo); # Mark as timeout
       run_on_all($tinfo, 'analyze-timeout');
@@ -4817,7 +4817,7 @@ sub report_failure_and_restart ($) {
 	    $tinfo->{comment}.=
 	      "The result from queries just before the failure was:".
 	      "\n< snip >\n".
-	      mtr_lastlinesfromfile($log_file_name, 20)."\n";
+	      mtr_lastlinesfromfile($log_file_name, 500)."\n";
 	  }
 	}
       }
@@ -5674,7 +5674,7 @@ sub start_mysqltest ($) {
   mtr_add_arg($args, "--test-file=%s", $tinfo->{'path'});
 
   # Number of lines of resut to include in failure report
-  mtr_add_arg($args, "--tail-lines=20");
+  mtr_add_arg($args, "--tail-lines=500");
 
   if ( defined $tinfo->{'result_file'} ) {
     mtr_add_arg($args, "--result-file=%s", $tinfo->{'result_file'});


### PR DESCRIPTION
…ilures)

The testcase dumps RPL debug info on failure, which is then truncated
by MTR, since it only dumps the last 20 lines of queries before the
failure. Bump that limit to 500.

http://jenkins.percona.com/job/percona-server-5.5-param/1338/
