### PR TITLE
Fix bug 1614885 (Spurious Valgrind error on main.udf)

### DIFF
--- a/mysql-test/valgrind.supp
+++ b/mysql-test/valgrind.supp
@@ -928,3 +928,10 @@
    fun:my_b_flush_io_cache
    fun:_Z8filesortP3THDP5TABLEP13st_sort_fieldjP10SQL_SELECTybPy
 }
+
+{
+   Spurious dlerror_run errors on main.udf
+   Memcheck:Leak
+   ...
+   fun:dlerror_run
+}


### PR DESCRIPTION
Add a Valgrind suppression for internal libc allocations stemming from
dlerror_run.

http://jenkins.percona.com/job/percona-server-5.5-valgrind-param/10/
