### PR TITLE
Bug 1614949: audit plugin: Invalid read of size 1

### DIFF
--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -304,7 +304,7 @@ char *escape_string(const char *in, size_t inlen,
     if (endptr)
       *endptr= out;
     if (full_outlen)
-      *full_outlen+= calculate_escape_string_buf_len(in + inlen, inlen);
+      *full_outlen+= calculate_escape_string_buf_len(in, inlen);
   }
   else if (in != NULL)
   {
@@ -317,7 +317,7 @@ char *escape_string(const char *in, size_t inlen,
     if (full_outlen)
     {
       *full_outlen+= outlen;
-      *full_outlen+= calculate_escape_string_buf_len(in + inlen,
+      *full_outlen+= calculate_escape_string_buf_len(in + inlen_res,
                                                      inlen - inlen_res);
     }
   }


### PR DESCRIPTION
`escape_buf` passed incorrect input buffer to the
`calculate_escape_string_buf_len`.
