### PR TITLE
Fix bug 1613728 (Test rpl.rpl_bug58546 may crash server due to concur…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_bug58546.result
+++ b/mysql-test/suite/rpl/r/rpl_bug58546.result
@@ -37,8 +37,9 @@ SET DEBUG_SYNC= 'RESET';
 [connection slave]
 include/wait_for_slave_to_stop.inc
 [connection slave1]
-include/start_slave.inc
 [connection master]
-DROP TABLE t1, t2;
 SET GLOBAL debug= $debug_save;
+DROP TABLE t1, t2;
+[connection slave1]
+include/start_slave.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_bug58546.test
+++ b/mysql-test/suite/rpl/t/rpl_bug58546.test
@@ -61,9 +61,12 @@ source include/wait_for_slave_to_stop.inc;
 
 --source include/rpl_connection_slave1.inc
 reap;
-source include/start_slave.inc;
 
 --source include/rpl_connection_master.inc
-DROP TABLE t1, t2;
 SET GLOBAL debug= $debug_save;
+DROP TABLE t1, t2;
+
+--source include/rpl_connection_slave1.inc
+source include/start_slave.inc;
+
 --source include/rpl_end.inc


### PR DESCRIPTION
…rent DBUG access), 2nd attempt

The previous attempt to ensure that DEBUG variable is not set while
binlog dump threads are active failed to ensure that by DROP TABLE
being issued before SET DEBUG. Since dump threads do not necessarily
quit when slave disconnects, they are running and see the extra binlog
written. Fix by setting DEBUG when master binlog dump threads are in
the state of having sent all binlogs to the slave.

http://jenkins.percona.com/job/percona-server-5.5-param/1344/
