### PR TITLE
Bug 1614439: audit_log/audit_log.c:522: audit_log_general_record: Ass…

### DIFF
--- a/mysql-test/r/audit_log_charset.result
+++ b/mysql-test/r/audit_log_charset.result
@@ -32,6 +32,9 @@ use ฐานข้อมูล;
 DROP DATABASE ฐานข้อมูล;
 DROP DATABASE `???`;
 use test;
+SET @@character_set_client=cp1256;
+CREATE t \217\355ݏ\355ݏ\355\335(\217\260\241\217\260\241\217\260\241 char) DEFAULT CHARSET=ujis engine=TokuDB;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 't \217\355ف?\355ف?\355\335(\217\260\241\217\260\241\217\260\241 char) DEFAULT ' at line 1
 set global audit_log_flush= ON;
 ===================================================================
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
@@ -62,4 +65,6 @@ set global audit_log_flush= ON;
 "Query","<ID>","<DATETIME>","drop_db","<CONN_ID>",0,"DROP DATABASE ฐานข้อมูล","root[root] @ localhost []","localhost","","","ฐานข้อมูล"
 "Query","<ID>","<DATETIME>","drop_db","<CONN_ID>",0,"DROP DATABASE `???`","root[root] @ localhost []","localhost","","","ฐานข้อมูล"
 "Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use test","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET @@character_set_client=cp1256","root[root] @ localhost []","localhost","","","test"
+"Query","<ID>","<DATETIME>","error","<CONN_ID>",1064,"CREATE t \217\355ف?\355ف?\355\335(\217\260\241\217\260\241\217\260\241 char) DEFAULT CHARSET=ujis engine=TokuDB","root[root] @ localhost []","localhost","","","test"
 ===================================================================

--- a/mysql-test/t/audit_log_charset.test
+++ b/mysql-test/t/audit_log_charset.test
@@ -59,4 +59,8 @@ DROP DATABASE `???`;
 
 use test;
 
+SET @@character_set_client=cp1256;
+--error ER_PARSE_ERROR
+CREATE t \217\355ݏ\355ݏ\355\335(\217\260\241\217\260\241\217\260\241 char) DEFAULT CHARSET=ujis engine=TokuDB;
+
 --source audit_log_echo.inc

--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -500,7 +500,6 @@ char *audit_log_general_record(char *buf, size_t buflen,
                              event->general_query,
                              event->general_query_length,
                              event->general_charset, &errors);
-    DBUG_ASSERT(errors == 0);
     query= endptr;
     endptr+= query_length;
 


### PR DESCRIPTION
…ertion `errors == 0' failed

Remove debug assertion, because client plugin can receive byte sequences
which are illegal for client encoding.
