### PR TITLE
Fix bug 1614849 (INFORMATION_SCHEMA.TABLES (or other schema info tabl…

### DIFF
--- a/mysql-test/r/percona_show_temp_tables_debug.result
+++ b/mysql-test/r/percona_show_temp_tables_debug.result
@@ -16,3 +16,22 @@ SET DEBUG_SYNC="now SIGNAL finish";
 # connection default
 TABLE_SCHEMA	TABLE_NAME	ENGINE	TABLE_ROWS
 test	t1	MyISAM	0
+#
+# Bug 1614849 (INFORMATION_SCHEMA.TABLES (or other schema info table) and GLOBAL_TEMPORARY_TABLES queries running in parallel may crash or hang)
+#
+# connection con1
+SET DEBUG_SYNC="before_open_in_get_all_tables SIGNAL tables_query_ready WAIT_FOR tables_query_finish";
+SELECT * FROM INFORMATION_SCHEMA.TABLES;
+# connection con2
+SET DEBUG_SYNC="now WAIT_FOR tables_query_ready";
+SET DEBUG_SYNC="fill_global_temporary_tables_thd_item_at_tables_debug_sync SIGNAL temp_tables_query_ready WAIT_FOR temp_tables_query_finish";
+SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+# connection default
+SET DEBUG_SYNC="now WAIT_FOR temp_tables_query_ready";
+SET DEBUG_SYNC="now SIGNAL tables_query_finish";
+# connection con1
+# connection default
+SET DEBUG_SYNC="now SIGNAL temp_tables_query_finish";
+# connection con2
+SESSION_ID	TABLE_SCHEMA	TABLE_NAME	ENGINE	NAME	TABLE_ROWS	AVG_ROW_LENGTH	DATA_LENGTH	INDEX_LENGTH	CREATE_TIME	UPDATE_TIME
+# connection default

--- a/mysql-test/r/percona_show_temp_tables_stress.result
+++ b/mysql-test/r/percona_show_temp_tables_stress.result
@@ -1,12 +1,30 @@
-CREATE PROCEDURE query_temp_tables ()
+CREATE USER event_runner1@localhost;
+GRANT ALL ON *.* TO event_runner1@localhost;
+CREATE USER event_runner2@localhost;
+GRANT ALL ON *.* TO event_runner2@localhost;
+SET @saved_event_scheduler = @@GLOBAL.event_scheduler;
+SET GLOBAL event_scheduler = ON;
+CREATE DEFINER=event_runner1@localhost EVENT query_temp_tables ON SCHEDULE AT CURRENT_TIMESTAMP
+ON COMPLETION PRESERVE
+DO
 WHILE TRUE DO
 SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
 END WHILE|
-CALL query_temp_tables();
+CREATE DEFINER=event_runner2@localhost EVENT query_tables ON SCHEDULE AT CURRENT_TIMESTAMP
+ON COMPLETION PRESERVE
+DO
+WHILE TRUE DO
+SELECT * FROM INFORMATION_SCHEMA.TABLES;
+END WHILE|
 # Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
 COUNT(*)
 1200
 # Dropping the temp tables
-KILL QUERY $con1_id
-DROP PROCEDURE query_temp_tables;
+KILL CONNECTION $ev_thread1_id
+KILL CONNECTION $ev_thread2_id
+SET GLOBAL event_scheduler = @saved_event_scheduler;
+DROP EVENT query_temp_tables;
+DROP EVENT query_tables;
+DROP USER event_runner1@localhost;
+DROP USER event_runner2@localhost;

--- a/mysql-test/t/percona_show_temp_tables_debug.test
+++ b/mysql-test/t/percona_show_temp_tables_debug.test
@@ -47,4 +47,46 @@ reap;
 
 disconnect con2;
 
+--echo #
+--echo # Bug 1614849 (INFORMATION_SCHEMA.TABLES (or other schema info table) and GLOBAL_TEMPORARY_TABLES queries running in parallel may crash or hang)
+--echo #
+connect (con1,localhost,root,,);
+--echo # connection con1
+
+SET DEBUG_SYNC="before_open_in_get_all_tables SIGNAL tables_query_ready WAIT_FOR tables_query_finish";
+send SELECT * FROM INFORMATION_SCHEMA.TABLES;
+
+connect (con2,localhost,root,,);
+--echo # connection con2
+
+SET DEBUG_SYNC="now WAIT_FOR tables_query_ready";
+SET DEBUG_SYNC="fill_global_temporary_tables_thd_item_at_tables_debug_sync SIGNAL temp_tables_query_ready WAIT_FOR temp_tables_query_finish";
+send SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
+
+connection default;
+--echo # connection default
+
+SET DEBUG_SYNC="now WAIT_FOR temp_tables_query_ready";
+SET DEBUG_SYNC="now SIGNAL tables_query_finish";
+
+connection con1;
+--echo # connection con1
+--disable_result_log
+reap;
+--enable_result_log
+
+disconnect con1;
+connection default;
+--echo # connection default
+
+SET DEBUG_SYNC="now SIGNAL temp_tables_query_finish";
+
+connection con2;
+--echo # connection con2
+reap;
+disconnect con2;
+
+connection default;
+--echo # connection default
+
 --source include/wait_until_count_sessions.inc

--- a/mysql-test/t/percona_show_temp_tables_stress.test
+++ b/mysql-test/t/percona_show_temp_tables_stress.test
@@ -1,21 +1,31 @@
 --source include/have_innodb.inc
+--source include/not_embedded.inc
 
---source include/count_sessions.inc
+CREATE USER event_runner1@localhost;
+GRANT ALL ON *.* TO event_runner1@localhost;
+
+CREATE USER event_runner2@localhost;
+GRANT ALL ON *.* TO event_runner2@localhost;
+
+SET @saved_event_scheduler = @@GLOBAL.event_scheduler;
+SET GLOBAL event_scheduler = ON;
 
 delimiter |;
-
-CREATE PROCEDURE query_temp_tables ()
+CREATE DEFINER=event_runner1@localhost EVENT query_temp_tables ON SCHEDULE AT CURRENT_TIMESTAMP
+ON COMPLETION PRESERVE
+DO
   WHILE TRUE DO
     SELECT * FROM INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES;
   END WHILE|
 
+CREATE DEFINER=event_runner2@localhost EVENT query_tables ON SCHEDULE AT CURRENT_TIMESTAMP
+ON COMPLETION PRESERVE
+DO
+  WHILE TRUE DO
+    SELECT * FROM INFORMATION_SCHEMA.TABLES;
+  END WHILE|
+
 delimiter ;|
-
-connect (con1,localhost,root,,);
---let $con1_id= `SELECT connection_id()`
-send CALL query_temp_tables();
-
-connection default;
 
 --let $i=400
 --echo # Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
@@ -43,20 +53,24 @@ while ($i)
 }
 --enable_query_log
 
---echo KILL QUERY \$con1_id
+--let $ev_thread1_id= `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER='event_runner1'`
+--echo KILL CONNECTION \$ev_thread1_id
 --disable_query_log
-eval KILL QUERY $con1_id;
+eval KILL CONNECTION $ev_thread1_id;
 --enable_query_log
 
-connection con1;
---disable_result_log
---error ER_QUERY_INTERRUPTED
-reap;
---enable_result_log
-disconnect con1;
+--let $ev_thread2_id= `SELECT ID FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER='event_runner2'`
+--echo KILL CONNECTION \$ev_thread2_id
+--disable_query_log
+eval KILL CONNECTION $ev_thread2_id;
+--enable_query_log
 
-connection default;
+--source include/no_running_events.inc
 
-DROP PROCEDURE query_temp_tables;
+SET GLOBAL event_scheduler = @saved_event_scheduler;
 
---source include/wait_until_count_sessions.inc
+DROP EVENT query_temp_tables;
+DROP EVENT query_tables;
+
+DROP USER event_runner1@localhost;
+DROP USER event_runner2@localhost;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -1069,10 +1069,6 @@ public:
     XXX Why are internal temporary tables added to this list?
   */
   TABLE *temporary_tables;
-  /**
-     Protects temporary_tables.
-  */
-  mysql_mutex_t LOCK_temporary_tables;
 
   TABLE *derived_tables;
   /*
@@ -1599,6 +1595,11 @@ public:
     Is locked when THD is deleted.
   */
   mysql_mutex_t LOCK_thd_data;
+
+  /**
+     Protects temporary_tables.
+  */
+  mysql_mutex_t LOCK_temporary_tables;
 
   /* all prepared statements and cursors of this connection */
   Statement_map stmt_map;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -3962,6 +3962,17 @@ static int fill_global_temporary_tables(THD *thd, TABLE_LIST *tables, COND *cond
  
   while ((thd_item=it++)) {
     mysql_mutex_lock(&thd_item->LOCK_temporary_tables);
+
+#ifndef DBUG_OFF
+    const char* tmp_proc_info= thd_item->proc_info;
+    if (tmp_proc_info &&
+        !strncmp(tmp_proc_info,
+                 STRING_WITH_LEN("debug sync point: before_open_in_get_all_tables"))) {
+      DEBUG_SYNC(thd,
+                 "fill_global_temporary_tables_thd_item_at_tables_debug_sync");
+    }
+#endif
+
     for (tmp=thd_item->temporary_tables; tmp; tmp=tmp->next) {
 
 #ifndef NO_EMBEDDED_ACCESS_CHECKS


### PR DESCRIPTION
…e) and GLOBAL_TEMPORARY_TABLES queries running in parallel may crash or hang)

LOCK_temporary_tables mutex was declared next to the temporary_tables
field, which happened to be in Open_tables_state class, one of the THD
ancestors. This class is used for taking backups and restoring the
open table state, by default member-wise assignment operator. Thus,
mutex itself was being copied and restored, while potentially also
being locked and unlocked in other threads, resulting in broken mutex
state.

Fix by moving LOCK_temporary_tables to class THD itself. Add a debug
sync testcase to percona_show_temp_tables_debug, and add a
INFORMATION_SCHEMA.TABLES query workload to
percona_show_temp_tables_stress.

At the same time cleanup percona_show_temp_tables_stress:
- grant all global privileges to the event runner accounts so that they
  actually get some data;
- use KILL CONNECTION instead of KILL QUERIES as it's more correct and
  avoids a bug where KILL QUERIES might be ignored by compound statements
  (http://bugs.mysql.com/bug.php?id=82679)
- use include/no_running_events.inc to wait for the event runner threads
  to quit.

http://jenkins.percona.com/job/percona-server-5.5-param/1348/
