### PR TITLE
Fix bug 1615959 (Unsuppressed Valgrind warning on plugin_auth_qa_2)

### DIFF
--- a/mysql-test/valgrind.supp
+++ b/mysql-test/valgrind.supp
@@ -153,8 +153,6 @@
    Memcheck:Leak
    fun:calloc
    fun:_dlerror_run
-   fun:dlsym
-   fun:__errno_location
 }
 
 


### PR DESCRIPTION
Make libc _dlerror_run Valgrind suppression general enough to catch
the new unsupressed case.

http://jenkins.percona.com/job/percona-server-5.5-valgrind-param/11/
