### PR TITLE
Work towards diagnosing bug 1615945 (Test percona_slow_query_log_time…

### DIFF
--- a/mysql-test/include/log_grep.inc
+++ b/mysql-test/include/log_grep.inc
@@ -1,4 +1,9 @@
---echo [log_grep.inc] file: $log_file pattern: $grep_pattern
+if ($log_expected_matches) {
+  --echo [log_grep.inc] file: $log_file pattern: $grep_pattern expected_matches: $log_expected_matches
+}
+if (!$log_expected_matches) {
+  --echo [log_grep.inc] file: $log_file pattern: $grep_pattern
+}
 perl;
   $log_file=           $ENV{'log_file'};
   $log_file_full_path= $ENV{'log_file_full_path'};
@@ -35,7 +40,23 @@ perl;
     while(<FILE>) {
       $lines++ if (/$grep_pattern/);
     }
-    print "[log_grep.inc] lines:   $lines\n";
+    $log_expected_matches= $ENV{'log_expected_matches'};
+    if ($log_expected_matches) {
+      if ($log_expected_matches != $lines) {
+        print "[log_grep.inc] ERROR: expected matches: $log_expected_matches, actual matches: $lines\n";
+        print "[log_grep.inc] log file at $log_file_full_path\n";
+        close(FILE);
+        open(FILE, "$log_file_full_path")
+          or die("Cannot open file $log_file_full_path: $!\n");
+        while (<FILE>) {
+          print ;
+        }
+      } else {
+        print "[log_grep.inc] found expected match count: $log_expected_matches\n";
+      }
+    } else {
+      print "[log_grep.inc] lines:   $lines\n";
+    }
   }
   close(FILE);
 EOF

--- a/mysql-test/r/percona_slow_query_log_timestamp_always.result
+++ b/mysql-test/r/percona_slow_query_log_timestamp_always.result
@@ -1,16 +1,16 @@
 SET SESSION min_examined_row_limit=0;
 SET SESSION long_query_time=0;
 SET GLOBAL slow_query_log_timestamp_always=TRUE;
-[log_start.inc] percona_slow_extended_query_log_1
+[log_start.inc] percona_slow_query_log_timestamp_always
 SELECT 1;
 1
 1
 SELECT 2;
 2
 2
-[log_stop.inc] percona_slow_extended_query_log_1
-[log_grep.inc] file: percona_slow_extended_query_log_1 pattern: ^# Time: \d{6} (\d| )\d:\d\d:\d\d$
-[log_grep.inc] lines:   3
+[log_stop.inc] percona_slow_query_log_timestamp_always
+[log_grep.inc] file: percona_slow_query_log_timestamp_always pattern: ^# Time: \d{6} (\d| )\d:\d\d:\d\d$ expected_matches: 3
+[log_grep.inc] found expected match count: 3
 SET GLOBAL slow_query_log_timestamp_always=default;
 SET SESSION long_query_time=default;
 SET SESSION min_examined_row_limit=default;

--- a/mysql-test/t/percona_slow_query_log_timestamp_always.test
+++ b/mysql-test/t/percona_slow_query_log_timestamp_always.test
@@ -7,7 +7,8 @@ SET SESSION min_examined_row_limit=0;
 SET SESSION long_query_time=0;
 SET GLOBAL slow_query_log_timestamp_always=TRUE;
 
---let log_file=percona_slow_extended_query_log_1
+--let log_expected_matches=3
+--let log_file=percona_slow_query_log_timestamp_always
 --source include/log_start.inc
 SELECT 1;
 SELECT 2;


### PR DESCRIPTION
…stamp_always is unstable)

Adjust include/log_grep.inc to optionally accept the expected match
count and dump the grepped file if it does not match. Make
percona_slow_query_log_timestamp_always slow query log filename
unique.

http://jenkins.percona.com/job/percona-server-5.5-param/1349/
