### PR TITLE
Fix bug 1553938 (Valgrind error on hp_test2)

### DIFF
--- a/storage/heap/hp_test2.c
+++ b/storage/heap/hp_test2.c
@@ -113,6 +113,7 @@ int main(int argc, char *argv[])
   keyinfo[2].seg[0].length=8;
   keyinfo[2].seg[0].null_bit=0;
   keyinfo[2].seg[0].charset=cs;
+  keyinfo[2].seg[0].flag=0;
   keyinfo[3].seg=keyseg+4;
   keyinfo[3].keysegs=1;
   keyinfo[3].flag=HA_NOSAME;
@@ -617,8 +618,10 @@ end:
   printf("\nFollowing test have been made:\n");
   printf("Write records: %d\nUpdate records: %d\nDelete records: %d\n", write_count,update,opt_delete);
   heap_clear(file);
+  heap_clear(file2);
   if (heap_close(file) || (file2 && heap_close(file2)))
     goto err;
+  hp_free(tmp_share);
   heap_delete_table(filename2);
   hp_panic(HA_PANIC_CLOSE);
   my_end(MY_GIVE_INFO);


### PR DESCRIPTION
Trivailly fix Valgrind errors on the hp_test2 testcase.

http://jenkins.percona.com/job/percona-server-5.5-param/1350/
