### PR TITLE
Fix bug 1616091 (Test rpl.rpl_semi_sync is unstable)

### DIFF
--- a/mysql-test/include/wait_condition.inc
+++ b/mysql-test/include/wait_condition.inc
@@ -23,8 +23,6 @@
 #    events_bugs.test, events_time_zone.test
 #
 
---disable_query_log
-
 let $wait_counter= 300;
 if ($wait_timeout)
 {
@@ -55,5 +53,3 @@ if (!$success)
 {
   echo Timeout in wait_condition.inc for $wait_condition;
 }
-
---enable_query_log


### PR DESCRIPTION
mysql-test/include/stop_dump_threads.inc tries to disable result and
query log, but wait_condition.inc re-enables the query log, making the
testcase produce output if the loop does more than one iteration. Fix
by making wait_condition.inc not change the query log status.

http://jenkins.percona.com/job/percona-server-5.5-param/1353/
