### PR TITLE
Fix bug 1616333 (Test rpl.rpl_backup_locks_mts is unstable)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_backup_locks_mts.result
+++ b/mysql-test/suite/rpl/r/rpl_backup_locks_mts.result
@@ -12,6 +12,8 @@ include/stop_slave.inc
 SET @save.slave_parallel_workers= @@GLOBAL.slave_parallel_workers;
 SET @@GLOBAL.slave_parallel_workers= 2;
 include/start_slave.inc
+INSERT INTO db_1.test_1 VALUES(2);
+include/sync_slave_sql_with_master.inc
 LOCK BINLOG FOR BACKUP;
 INSERT INTO db_1.test_1 VALUES(1);
 INSERT INTO db_2.test_1 VALUES(1);

--- a/mysql-test/suite/rpl/t/rpl_backup_locks_mts.test
+++ b/mysql-test/suite/rpl/t/rpl_backup_locks_mts.test
@@ -24,6 +24,10 @@ SET @save.slave_parallel_workers= @@GLOBAL.slave_parallel_workers;
 SET @@GLOBAL.slave_parallel_workers= 2;
 
 --source include/start_slave.inc
+# Process the injected relay log Format_description_log_event before binlog is locked
+--connection master
+INSERT INTO db_1.test_1 VALUES(2);
+--source include/sync_slave_sql_with_master.inc
 
 LOCK BINLOG FOR BACKUP;
 


### PR DESCRIPTION
On opening the relay log, slave may inject an
Format_description_log_event event. It might be processed by the slave
SQL thread after LOCK BINLOG FOR BACKUP is issued, and this event
requires async processing for multi-threaded slave, resulting in the
slave SQL thread being blocked instead of slave worker threads, as
expected by the testcase.

Fix by issuing some workload on the master and syncing the slave
before LOCK BINLOG FOR BACKUP, so that the format description event is
processed before binlog is locked.

http://jenkins.percona.com/job/percona-server-5.6-param/1322/
