### PR TITLE
Fix bug 1616404 (Test perfschema.setup_instruments_defaults is unstable)

### DIFF
--- a/mysql-test/suite/perfschema/r/setup_instruments_defaults.result
+++ b/mysql-test/suite/perfschema/r/setup_instruments_defaults.result
@@ -50,12 +50,6 @@ WHERE name like "%wait/io/table/sql/handler%";
 NAME	ENABLED	TIMED
 wait/io/table/sql/handler	YES	YES
 #
-# Stop server
-# Restart server with wait/io/table/sql/handler disabled
-# Enable reconnect
-# Wait until connected again
-# Disable reconnect
-#
 # Verify that wait/io/table is disabled
 #
 SELECT * FROM performance_schema.setup_instruments

--- a/mysql-test/suite/perfschema/t/setup_instruments_defaults.test
+++ b/mysql-test/suite/perfschema/t/setup_instruments_defaults.test
@@ -53,28 +53,8 @@ SHOW VARIABLES LIKE "%/wait/synch/mutex%";
 SELECT * FROM performance_schema.setup_instruments
 WHERE name like "%wait/io/table/sql/handler%";
 
-# Write file to make mysql-test-run.pl wait for the server to stop
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-
-# Restart the server
---echo #
---echo # Stop server
---send_shutdown
---echo # Restart server with wait/io/table/sql/handler disabled
-
---exec echo "restart:--loose-performance-schema-instrument='%wait/io/table/sql/%=off'" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-
-# Turn on reconnect
---echo # Enable reconnect
---enable_reconnect
-
-# Wait for server to be back online again
---echo # Wait until connected again
---source include/wait_until_connected_again.inc
-
-# Turn off reconnect again
---echo # Disable reconnect
---disable_reconnect
+--let $restart_parameters= restart:--loose-performance-schema-instrument='%wait/io/table/sql/%=off'
+--source include/restart_mysqld.inc
 
 --echo #
 --echo # Verify that wait/io/table is disabled


### PR DESCRIPTION
Replace the custom shutdown sequence (that uses send_shutdown,
creating a race condition) with an include file use.

http://jenkins.percona.com/job/percona-server-5.6-param/1324/
