### PR TITLE
Fix bug 1615970 ("InnoDB: Failed to set NUMA memory policy" on 32-bit…

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_populate_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_populate_basic.result
@@ -1,4 +1,6 @@
 CALL mtr.add_suppression(".* Forcing preallocation by faulting in pages.");
+CALL mtr.add_suppression("Failed to set NUMA memory policy to .+ \\(error: Function not implemented\\)");
+CALL mtr.add_suppression("Failed to set NUMA memory policy of buffer pool page frames to MPOL_INTERLEAVE \\(error: Function not implemented\\)");
 SELECT @@GLOBAL.innodb_buffer_pool_populate;
 @@GLOBAL.innodb_buffer_pool_populate
 1

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_populate_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_populate_basic.test
@@ -1,8 +1,10 @@
 --source include/have_innodb.inc
 
 CALL mtr.add_suppression(".* Forcing preallocation by faulting in pages.");
+CALL mtr.add_suppression("Failed to set NUMA memory policy to .+ \\(error: Function not implemented\\)");
+CALL mtr.add_suppression("Failed to set NUMA memory policy of buffer pool page frames to MPOL_INTERLEAVE \\(error: Function not implemented\\)");
 
-# Display current value of innodb_use_sys_malloc
+# Display current value of innodb_buffer_pool_populate
 SELECT @@GLOBAL.innodb_buffer_pool_populate;
 --echo 1 Expected
 


### PR DESCRIPTION
… hosts)

Suppress the warnings stemming from the NUMA calls returning ENOSYS.

http://jenkins.percona.com/job/percona-server-5.6-param/1329/
