### PR TITLE
Work towards diagnosing bug 1616392 (Test parts.partition_debug_innod…

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -4434,6 +4434,13 @@ sub run_testcase ($) {
 	  goto SRVDIED;
 	}
 
+        foreach my $mysqld (mysqlds())
+        {
+          $tinfo->{comment}.=
+            "\nServer " . $mysqld->{proc} . " log: ".
+            get_log_from_proc($mysqld->{proc}, $tinfo->{name});
+        }
+
 	# Test case failure reported by mysqltest
 	report_failure_and_restart($tinfo);
       }


### PR DESCRIPTION
…b is unstable)

The testcase fails to restart the server after a crash, with a very
long timeout. Adjust MTR to dump the error log for all the servers if
mysqltest died.

http://jenkins.percona.com/job/percona-server-5.6-param/1323/
