### PR TITLE
Bug#20458574 FIX ALL THE ARRAY BOUNDS WARNINGS

### DIFF
--- a/sql/filesort.cc
+++ b/sql/filesort.cc
@@ -869,7 +869,7 @@ static void make_sortkey(register SORTPARAM *param,
         if (sort_field->need_strxnfrm)
         {
           char *from=(char*) res->ptr();
-          uint tmp_length;
+          uint tmp_length __attribute__((unused));
           if ((uchar*) from == to)
           {
             DBUG_ASSERT(sort_field->length >= length);

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -662,7 +662,7 @@ terminate_slave_thread(THD *thd,
 
   while (*slave_running)                        // Should always be true
   {
-    int error;
+    int error __attribute__((unused));
     DBUG_PRINT("loop", ("killing slave thread"));
 
     mysql_mutex_lock(&thd->LOCK_thd_data);

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -448,7 +448,7 @@ void mysql_binlog_send(THD* thd, char* log_ident, my_off_t pos,
   IO_CACHE log;
   File file = -1;
   String* packet = &thd->packet;
-  int error;
+  int error= 0;
   const char *errmsg = "Unknown error";
   char error_text[MAX_SLAVE_ERRMSG]; // to be send to slave via my_message()
   NET* net = &thd->net;

--- a/strings/ctype-ucs2.c
+++ b/strings/ctype-ucs2.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2003, 2013, Oracle and/or its affiliates. All rights reserved.
+/* Copyright (c) 2003, 2015, Oracle and/or its affiliates. All rights reserved.
    
    This library is free software; you can redistribute it and/or
    modify it under the terms of the GNU Library General Public
@@ -2318,14 +2318,17 @@ void my_fill_utf32(CHARSET_INFO *cs,
                    char *s, size_t slen, int fill)
 {
   char buf[10];
-  uint buflen;
   char *e= s + slen;
   
   DBUG_ASSERT((slen % 4) == 0);
-
-  buflen= cs->cset->wc_mb(cs, (my_wc_t) fill, (uchar*) buf,
-                          (uchar*) buf + sizeof(buf));
-  DBUG_ASSERT(buflen == 4);
+  {
+#ifndef DBUG_OFF
+    uint buflen=
+#endif
+      cs->cset->wc_mb(cs, (my_wc_t) fill, (uchar*) buf,
+                      (uchar*) buf + sizeof(buf));
+    DBUG_ASSERT(buflen == 4);
+  }
   while (s < e)
   {
     memcpy(s, buf, 4);

--- a/strings/decimal.c
+++ b/strings/decimal.c
@@ -1,4 +1,4 @@
-/* Copyright (c) 2004, 2014, Oracle and/or its affiliates. All rights reserved.
+/* Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -211,6 +211,74 @@ static const dec1 frac_max[DIG_PER_DEC1-1]={
           (to)=a;                                                       \
         } while(0)
 
+
+/*
+  This is a direct loop unrolling of code that used to look like this:
+  for (; *buf_beg < powers10[i--]; start++) ;
+
+  @param   i    start index
+  @param   val  value to compare against list of powers of 10
+
+  @retval  Number of leading zeroes that can be removed from fraction.
+
+  @note Why unroll? To get rid of lots of compiler warnings [-Warray-bounds]
+        Nice bonus: unrolled code is significantly faster.
+ */
+static inline int count_leading_zeroes(int i, dec1 val)
+{
+  int ret= 0;
+  switch (i)
+  {
+  /* @note Intentional fallthrough in all case labels */
+  case 9: if (val >= 1000000000) break; ++ret;
+  case 8: if (val >= 100000000) break; ++ret;
+  case 7: if (val >= 10000000) break; ++ret;
+  case 6: if (val >= 1000000) break; ++ret;
+  case 5: if (val >= 100000) break; ++ret;
+  case 4: if (val >= 10000) break; ++ret;
+  case 3: if (val >= 1000) break; ++ret;
+  case 2: if (val >= 100) break; ++ret;
+  case 1: if (val >= 10) break; ++ret;
+  case 0: if (val >= 1) break; ++ret;
+  default: { DBUG_ASSERT(FALSE); }
+  }
+  return ret;
+}
+
+/*
+  This is a direct loop unrolling of code that used to look like this:
+  for (; *buf_end % powers10[i++] == 0; stop--) ;
+
+  @param   i    start index
+  @param   val  value to compare against list of powers of 10
+
+  @retval  Number of trailing zeroes that can be removed from fraction.
+
+  @note Why unroll? To get rid of lots of compiler warnings [-Warray-bounds]
+        Nice bonus: unrolled code is significantly faster.
+ */
+static inline int count_trailing_zeroes(int i, dec1 val)
+{
+  int ret= 0;
+  switch(i)
+  {
+  /* @note Intentional fallthrough in all case labels */
+  case 0: if ((val % 1) != 0) break; ++ret;
+  case 1: if ((val % 10) != 0) break; ++ret;
+  case 2: if ((val % 100) != 0) break; ++ret;
+  case 3: if ((val % 1000) != 0) break; ++ret;
+  case 4: if ((val % 10000) != 0) break; ++ret;
+  case 5: if ((val % 100000) != 0) break; ++ret;
+  case 6: if ((val % 1000000) != 0) break; ++ret;
+  case 7: if ((val % 10000000) != 0) break; ++ret;
+  case 8: if ((val % 100000000) != 0) break; ++ret;
+  case 9: if ((val % 1000000000) != 0) break; ++ret;
+  default: { DBUG_ASSERT(FALSE); }
+  }
+  return ret;
+}
+
+
 /*
   Get maximum value for given precision and scale
 
@@ -261,7 +329,7 @@ static dec1 *remove_leading_zeroes(const decimal_t *from, int *intg_result)
   }
   if (intg > 0)
   {
-    for (i= (intg - 1) % DIG_PER_DEC1; *buf0 < powers10[i--]; intg--) ;
+    intg-= count_leading_zeroes((intg - 1) % DIG_PER_DEC1, *buf0);
     DBUG_ASSERT(intg > 0);
   }
   else
@@ -296,9 +364,8 @@ int decimal_actual_fraction(decimal_t *from)
   }
   if (frac > 0)
   {
-    for (i= DIG_PER_DEC1 - ((frac - 1) % DIG_PER_DEC1);
-         *buf0 % powers10[i++] == 0;
-         frac--) ;
+    frac-=
+      count_trailing_zeroes(DIG_PER_DEC1 - ((frac - 1) % DIG_PER_DEC1), *buf0);
   }
   return frac;
 }
@@ -475,7 +542,8 @@ static void digits_bounds(decimal_t *from, int *start_result, int *end_result)
     start= (int) ((buf_beg - from->buf) * DIG_PER_DEC1);
   }
   if (buf_beg < end)
-    for (; *buf_beg < powers10[i--]; start++) ;
+    start+= count_leading_zeroes(i, *buf_beg);
+
   *start_result= start; /* index of first decimal digit (from 0) */
 
   /* find non-zero digit at the end */
@@ -493,7 +561,7 @@ static void digits_bounds(decimal_t *from, int *start_result, int *end_result)
     stop= (int) ((buf_end - from->buf + 1) * DIG_PER_DEC1);
     i= 1;
   }
-  for (; *buf_end % powers10[i++] == 0; stop--) ;
+  stop-= count_trailing_zeroes(i, *buf_end);
   *end_result= stop; /* index of position after last decimal digit (from 0) */
 }
 
@@ -2142,7 +2210,7 @@ static int do_div_mod(const decimal_t *from1, const decimal_t *from2,
   }
   if (prec2 <= 0) /* short-circuit everything: from2 == 0 */
     return E_DEC_DIV_ZERO;
-  for (i= (prec2 - 1) % DIG_PER_DEC1; *buf2 < powers10[i--]; prec2--) ;
+  prec2-= count_leading_zeroes((prec2 - 1) % DIG_PER_DEC1, *buf2);
   DBUG_ASSERT(prec2 > 0);
 
   i=((prec1-1) % DIG_PER_DEC1)+1;
@@ -2157,7 +2225,7 @@ static int do_div_mod(const decimal_t *from1, const decimal_t *from2,
     decimal_make_zero(to);
     return E_DEC_OK;
   }
-  for (i=(prec1-1) % DIG_PER_DEC1; *buf1 < powers10[i--]; prec1--) ;
+  prec1-= count_leading_zeroes((prec1-1) % DIG_PER_DEC1, *buf1);
   DBUG_ASSERT(prec1 > 0);
 
   /* let's fix scale_incr, taking into account frac1,frac2 increase */


### PR DESCRIPTION
Remove compiler warnings when building in optimized mode:

In strings/decimal.c fix numerous warnings of the type:
array subscript is below array bounds [-Werror=array-bounds]
This part of the patch is based on a patch
from https://github.com/webscalesql/webscalesql-5.6
That patch added some bounds-checks for loops, and worked for
gcc4.8.3 but not for gcc 4.9.1 so it was re-written to unroll the loops instead.

In other source files, fix numerous warnings of the type:
variable XX set but not used [-Werror=unused-but-set-variable]
variable XX may be used uninitialized in this function [-Werror=maybe-uninitialized]
These were variables used only for debugging purposes,
or variables not proven to be set by all execution paths.

Compiled with gcc 4.7.2 4.8.3 4.9.1 in optimized mode, with -Wall -Werror
