### PR TITLE
Fix bug 1616768 (-Wempty-body warning regression in dispatch_command)

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1474,7 +1474,9 @@ bool dispatch_command(enum enum_server_command command, THD *thd,
 
   thd_proc_info(thd, "cleaning up");
   if (thd->lex->sql_command == SQLCOM_CREATE_TABLE)
+  {
     DEBUG_SYNC(thd, "dispatch_create_table_command_before_thd_root_free");
+  }
   thd->reset_query();
   thd->command=COM_SLEEP;
   dec_thread_running();


### PR DESCRIPTION
Add braces around DEBUG_SYNC.

http://jenkins.percona.com/job/percona-server-5.5-param/1355/
