### PR TITLE
Fix bug 1616785 (Shutdown waiting for purge to complete is undiagnose…

### DIFF
--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -3491,12 +3491,14 @@ loop:
 	srv_shutdown_state = SRV_SHUTDOWN_FLUSH_PHASE;
 	count = 0;
 	while (buf_page_cleaner_is_active) {
-		++count;
-		os_thread_sleep(100000);
-		if (srv_print_verbose_log && count > 600) {
+		if (srv_print_verbose_log && count == 0) {
 			ib_logf(IB_LOG_LEVEL_INFO,
 				"Waiting for page_cleaner to "
 				"finish flushing of buffer pool");
+		}
+		++count;
+		os_thread_sleep(100000);
+		if (count > 600) {
 			count = 0;
 		}
 	}


### PR DESCRIPTION
…d for the 1st minute)

Tweak shutdown loop that waits for the buffer pool to be fully flushed
so that the diagnostic message is printed at the start, not end, of
a 60-second interval.

http://jenkins.percona.com/job/percona-server-5.6-param/1331/
