### PR TITLE
Fix bug 1616937 (semisync_master.cc "variable may be uninitialized" w…

### DIFF
--- a/plugin/semisync/semisync_master.cc
+++ b/plugin/semisync/semisync_master.cc
@@ -1054,7 +1054,7 @@ int ReplSemiSyncMaster::readSlaveReply(NET *net, uint32 server_id,
   ulong    packet_len;
   int      result = -1;
 
-  struct timespec start_ts;
+  struct timespec start_ts= { 0, 0 };
   ulong trc_level = trace_level_;
 
   function_enter(kWho);


### PR DESCRIPTION
…arnings)

Initialise start_ts in ReplSemiSyncMaster::readSlaveReply, same as the
commit below does in 5.6:

commit 977438625606e34c80715cf42caf920fe849a17b
Author: Tor Didriksen tor.didriksen@oracle.com
Date:   Thu Aug 30 13:44:55 2012 +0200

```
Fix broken -Werror -O3 in pushbuild.
Platforms used:
Oracle Linux Server release 6.3
gcc (GCC) 4.4.6 20120305 (Red Hat 4.4.6-4)

Fedora release 14 (Laughlin)
gcc (GCC) 4.5.1 20100924 (Red Hat 4.5.1-4)
```

http://jenkins.percona.com/job/percona-server-5.5-param/1356/
