### PR TITLE
Disable main.events_time_zone test (bug 1616320)

### DIFF
--- a/mysql-test/t/disabled.def
+++ b/mysql-test/t/disabled.def
@@ -17,3 +17,4 @@ log_tables-big           : Bug#11756699 2010-11-15 mattiasj report already exist
 ds_mrr-big @solaris      : Bug#14168107 2012-04-03 Hemant disabled new test added by Olav Sandstå,since this leads to timeout on Solaris on slow sparc servers
 mysql_embedded_client_test	: Bug#13964673 2012-04-16 amitbha since most of the test cases are failing
 mysql_client_test_embedded : Bug#16084066 2013-01-08 Disabled since this test is failing
+events_time_zone         : percona disabled because the test is fundamentally unstable https://bugs.launchpad.net/percona-server/+bug/1616320


### PR DESCRIPTION
The test is fundamentally unstable, a bump of sensitivity parameter
was not enough for our CI, it has a low probability of regressing in
Percona Server compared to MySQL, thus let's just disable it.

http://jenkins.percona.com/job/percona-server-5.6-param/1334/
