### PR TITLE
Work towards fixing bug 1612063 (Test show_processlist is unstable)

### DIFF
--- a/mysql-test/include/check-testcase.test
+++ b/mysql-test/include/check-testcase.test
@@ -8,6 +8,12 @@
 
 --disable_query_log
 
+# Check that the testcase has closed (and the server has finished cleaning up)
+# all the connection it opened. Exclude binlog dump threads as these may
+# linger around indefinitely.
+--replace_column 1 <Id> 6 <Time> 7 <State> 9 X 10 X 11 X
+SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST WHERE COMMAND != 'Binlog Dump';
+
 # We want to ensure all slave configuration is restored.  But SHOW
 # SLAVE STATUS returns nothing for servers not configured as slaves,
 # and (after BUG#28796 was fixed) there is no way to de-configure a


### PR DESCRIPTION
The failure of main.show_processlist shows an extra connection at the
start of the testcase that is gone by the next processlist
query. Thus, it could be a connection by a previous testcase that
hadn't cleaned up fully yet. To catch this, add processlist query to
the MTR testcase checker, so that any open connections at the end of
testcases are caught.

http://jenkins.percona.com/job/percona-server-5.5-param/1318/
