### PR TITLE
Fix bug 1617216 (Test percona_processlist_row_stats is unstable)

### DIFF
--- a/mysql-test/r/percona_processlist_row_stats.result
+++ b/mysql-test/r/percona_processlist_row_stats.result
@@ -1,5 +1,3 @@
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
 CREATE TABLE t2 (a INT);
 INSERT INTO t2 VALUES(10);
 INSERT INTO t2 VALUES(10);
@@ -23,10 +21,10 @@ id	info	rows_sent	rows_examined
 ###	CREATE TABLE t1 (a INT)	0	0
 ###	SELECT a FROM t2 WHERE a > 15	2	5
 SET DEBUG_SYNC= 'now SIGNAL threads_dumped';
-SET DEBUG_SYNC= 'RESET';
 a
 20
 20
+SET DEBUG_SYNC= 'RESET';
 SET DEBUG_SYNC= 'RESET';
 SET DEBUG_SYNC= 'sent_row SIGNAL thread1_ready WAIT_FOR threads_dumped NO_CLEAR_EVENT';
 SELECT a FROM t2 WHERE a < 15;
@@ -49,10 +47,10 @@ a
 10
 10
 10
-SET DEBUG_SYNC= 'RESET';
 a
 20
 20
+SET DEBUG_SYNC= 'RESET';
 SET DEBUG_SYNC= 'RESET';
 SET DEBUG_SYNC= 'execute_command_after_close_tables SIGNAL thread1_ready WAIT_FOR threads_dumped NO_CLEAR_EVENT';
 UPDATE t2 SET a = 15 WHERE a = 20;
@@ -72,3 +70,4 @@ id	info	rows_sent	rows_examined
 ###	UPDATE t2 SET a = 15 WHERE a = 10	0	5
 SET DEBUG_SYNC= 'now SIGNAL threads_dumped';
 DROP TABLES t1, t2;
+SET DEBUG_SYNC= 'RESET';

--- a/mysql-test/t/percona_processlist_row_stats.test
+++ b/mysql-test/t/percona_processlist_row_stats.test
@@ -1,11 +1,6 @@
 # Testing of INFORMATION_SCHEMA.PROCESSLIST fields ROWS_SENT and ROWS_EXAMINED
 --source include/have_debug_sync.inc
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
---enable_warnings
-
 CREATE TABLE t2 (a INT);
 INSERT INTO t2 VALUES(10);
 INSERT INTO t2 VALUES(10);
@@ -13,6 +8,7 @@ INSERT INTO t2 VALUES(20);
 INSERT INTO t2 VALUES(10);
 INSERT INTO t2 VALUES(20);
 
+--source include/count_sessions.inc
 --connect (conn1, localhost, root, ,)
 --connect (conn2, localhost, root, ,)
 
@@ -32,12 +28,12 @@ SET DEBUG_SYNC= 'now WAIT_FOR thread2_ready';
 
 --connection conn1
 reap;
-SET DEBUG_SYNC= 'RESET';
 --connection conn2
 reap;
 SET DEBUG_SYNC= 'RESET';
 
 --connection conn1
+SET DEBUG_SYNC= 'RESET';
 SET DEBUG_SYNC= 'sent_row SIGNAL thread1_ready WAIT_FOR threads_dumped NO_CLEAR_EVENT';
 send SELECT a FROM t2 WHERE a < 15;
 --connection default
@@ -53,12 +49,12 @@ SET DEBUG_SYNC= 'now WAIT_FOR thread2_ready';
 
 --connection conn1
 reap;
-SET DEBUG_SYNC= 'RESET';
 --connection conn2
 reap;
 SET DEBUG_SYNC= 'RESET';
 
 --connection conn1
+SET DEBUG_SYNC= 'RESET';
 SET DEBUG_SYNC= 'execute_command_after_close_tables SIGNAL thread1_ready WAIT_FOR threads_dumped NO_CLEAR_EVENT';
 send UPDATE t2 SET a = 15 WHERE a = 20;
 --connection default
@@ -80,4 +76,8 @@ reap;
 --connection default
 disconnect conn1;
 disconnect conn2;
+
 DROP TABLES t1, t2;
+SET DEBUG_SYNC= 'RESET';
+
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Only clear "threads_dumped" signal after both threads have processed
it. Reset DEBUG_SYNC at the end of testcase. Clean up the testcase in
general.

http://jenkins.percona.com/job/percona-server-5.6-param/1335/
