### PR TITLE
Fix bug 1617246 (recv_recovery_from_checkpoint_start_func -Wmaybe-uni…

### DIFF
--- a/storage/innobase/log/log0recv.c
+++ b/storage/innobase/log/log0recv.c
@@ -2986,7 +2986,7 @@ recv_recovery_from_checkpoint_start_func(
 	ib_uint64_t	checkpoint_lsn;
 	ib_uint64_t	checkpoint_no;
 	ib_uint64_t	old_scanned_lsn;
-	ib_uint64_t	group_scanned_lsn;
+	ib_uint64_t	group_scanned_lsn = 0;
 	ib_uint64_t	contiguous_lsn;
 #ifdef UNIV_LOG_ARCHIVE
 	ib_uint64_t	archived_lsn;


### PR DESCRIPTION
…nitialized warning for group_scanned_lsn)

Initialise group_scanned_lsn, even though it does get initialised
later, but the control flow is apparently too complex for compiler.

http://jenkins.percona.com/job/percona-server-5.5-param/1359/
