### PR TITLE
Bug 1613647: Sporadic audit_log_filter_users failures

### DIFF
--- a/mysql-test/r/audit_log_filter_users.result
+++ b/mysql-test/r/audit_log_filter_users.result
@@ -56,7 +56,9 @@ NULL	NULL
 SET GLOBAL audit_log_flush=ON;
 SET GLOBAL audit_log_flush=ON;
 SET GLOBAL audit_log_include_accounts= '';
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SELECT 'user1';
 user1
 user1
@@ -75,9 +77,13 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooongusername@veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooonghostname';
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SELECT 'user1';
 user1
 user1
@@ -96,9 +102,13 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SET GLOBAL audit_log_include_accounts= NULL;
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SELECT 'user1';
 user1
 user1
@@ -117,9 +127,13 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%';
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SELECT 'user1';
 user1
 user1
@@ -138,25 +152,22 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
+skip this
+skip this
 SET GLOBAL audit_log_exclude_accounts= NULL;
 set global audit_log_flush= ON;
 ===================================================================
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= ''","root[root] @ localhost []","localhost","","","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooongusername@veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooonghostname'","root[root] @ localhost []","localhost","","","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user1'","user1[user1] @ localhost [127.0.0.1]","localhost","","127.0.0.1","test"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= NULL","root[root] @ localhost []","localhost","","","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user1'","user1[user1] @ localhost [127.0.0.1]","localhost","","127.0.0.1","test"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
@@ -174,10 +185,8 @@ set global audit_log_flush= ON;
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'us,er1'","us,er1[us,er1] @ localhost []","localhost","","","test"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%'","root[root] @ localhost []","localhost","","","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user22'","user22[user22] @ localhost []","localhost","","","test"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
@@ -192,7 +201,6 @@ set global audit_log_flush= ON;
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'us,er1'","us,er1[us,er1] @ localhost []","localhost","","","test"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
-"Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_flush=ON","root[root] @ localhost []","localhost","","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_accounts= NULL","root[root] @ localhost []","localhost","","","test"
 ===================================================================

--- a/mysql-test/t/audit_log_echo.inc
+++ b/mysql-test/t/audit_log_echo.inc
@@ -8,6 +8,10 @@ perl;
   print "===================================================================\n";
   open my $file, $ENV{'log_file'} . '.copy' or die "Can not open log: $!";
   while ($line = <$file>) {
+    if ($line =~ /skip this/) {
+      # skip this
+      next;
+    }
     if ($line =~ /SET NAMES/) {
       # change_user does automatic reconnect and messing up 'SET NAMES' around
       next;

--- a/mysql-test/t/audit_log_filter_events.inc
+++ b/mysql-test/t/audit_log_filter_events.inc
@@ -1,4 +1,4 @@
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';
 
 connect (test,127.0.0.1,user1,password1,,$MASTER_PORT,);
 connection test;
@@ -33,4 +33,4 @@ disconnect test;
 --source include/wait_until_disconnected.inc
 
 connection default;
-SET GLOBAL audit_log_flush=ON;
+SELECT 'skip this';


### PR DESCRIPTION
Insert silent statements (which aren't are grepped away) before
connects to make sure the previous statement we which want to see in
the audit log actually gets there before the connect.

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1338/
