### PR TITLE
Fix bug 1617949 (HandlerSocket leaks thread objects)

### DIFF
--- a/plugin/HandlerSocket-Plugin-for-MySQL/libhsclient/auto_ptrcontainer.hpp
+++ b/plugin/HandlerSocket-Plugin-for-MySQL/libhsclient/auto_ptrcontainer.hpp
@@ -12,7 +12,7 @@
 namespace dena {
 
 template <typename Tcnt>
-struct auto_ptrcontainer {
+struct auto_ptrcontainer : private noncopyable {
   typedef Tcnt container_type;
   typedef typename container_type::value_type value_type;
   typedef typename container_type::pointer pointer;
@@ -42,9 +42,7 @@ struct auto_ptrcontainer {
   const_reference back() const { cnt.back(); }
   void swap(auto_ptrcontainer& x) { cnt.swap(x.cnt); }
   ~auto_ptrcontainer() {
-    for (iterator i = begin(); i != end(); ++i) {
-      delete *i;
-    }
+    clear();
   }
   template <typename Tap> void push_back_ptr(Tap& ap) {
     cnt.push_back(ap.get());
@@ -56,7 +54,12 @@ struct auto_ptrcontainer {
   }
   reference operator [](size_type n) { return cnt[n]; }
   const_reference operator [](size_type n) const { return cnt[n]; }
-  void clear() { cnt.clear(); }
+  void clear() {
+    for (iterator i = begin(); i != end(); i++) {
+      delete *i;
+    }
+    cnt.clear();
+  }
  private:
   Tcnt cnt;
 };


### PR DESCRIPTION
This is caused by hstcpsvr::threads, which is
auto_ptrcontainer<std::vector<worker_thread_type *> > (effectively
std::vector<foo *>), having clear() method, which clears the container
without deleting the member pointers, which are owned by the
container.

Fix by making clear delete the pointers, and by making destructor to
call clear instead of deleting pointers by itself.

http://jenkins.percona.com/job/percona-server-5.6-param/1341/
http://jenkins.percona.com/job/percona-server-5.6-valgrind/173/
