### PR TITLE
Fix bug 1617998 (HandlerSocket may access freed memory on startup)

### DIFF
--- a/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/database.cpp
+++ b/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/database.cpp
@@ -277,7 +277,7 @@ dbcontext::init_thread(const void *stack_bottom, volatile int& shutdown_flag)
   DBG_THR(fprintf(stderr, "HNDSOCK init thread\n"));
   {
     my_thread_init();
-    thd = new THD;
+    thd = new THD(false);
     thd->thread_stack = (char *)stack_bottom;
     DBG_THR(fprintf(stderr,
       "thread_stack = %p sizeof(THD)=%zu sizeof(mtx)=%zu "


### PR DESCRIPTION
There is a race condition between HS worker threads initializing
default SE and default temp SE fields and the server main thread
initializing the same globally w/o locking.

As HS workers do not care about the default (temp) SE, initialise
their THD handles without plugin support.

http://jenkins.percona.com/job/percona-server-5.6-param/1343/
