### PR TITLE
Bug 1617833: audit_log_default_db failures

### DIFF
--- a/plugin/audit_log/tests/mtr/audit_log_default_db.result
+++ b/plugin/audit_log/tests/mtr/audit_log_default_db.result
@@ -18,9 +18,15 @@ GRANT ALL PRIVILEGES ON ąžąžąžą.* TO 'user2'@'%';
 UNINSTALL PLUGIN audit_log;
 Warnings:
 Warning	1620	Plugin is busy and will be uninstalled on shutdown
+SELECT 'skip this';
+skip this
+skip this
 SELECT * FROM t;
 a
 db2
+SELECT 'skip this';
+skip this
+skip this
 INSTALL PLUGIN audit_log SONAME 'audit_log.so';
 SELECT * FROM t;
 a
@@ -63,10 +69,6 @@ set global audit_log_flush= ON;
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM t","user1[user1] @ localhost []","localhost","","",""
 "Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use 	`db1`","user1[user1] @ localhost []","localhost","","","db1"
 "Change user","<ID>","<DATETIME>","<CONN_ID>",1044,"user2","user2","","","localhost","",""
-"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","","db1"
-"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","","db1"
-"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","","db1"
-"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","","db1"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","","db1"
 "Connect","<ID>","<DATETIME>","<CONN_ID>",1044,"user2","user2","","","localhost","",""
 "Connect","<ID>","<DATETIME>","<CONN_ID>",1045,"user2","user2","","","localhost","",""

--- a/plugin/audit_log/tests/mtr/audit_log_default_db.test
+++ b/plugin/audit_log/tests/mtr/audit_log_default_db.test
@@ -31,11 +31,13 @@ GRANT ALL PRIVILEGES ON ąžąžąžą.* TO 'user2'@'%';
 
 # truncate audit log
 UNINSTALL PLUGIN audit_log;
+SELECT 'skip this';
 --remove_file $log_file
 
 connect (test,localhost,user1,111,db2,);
 connection test;
 SELECT * FROM t;
+SELECT 'skip this';
 
 connect (root,localhost,root,,,);
 connection root;
@@ -47,7 +49,7 @@ connection test;
 SELECT * FROM t;
 use 	`db1`;
 --error ER_DBACCESS_DENIED_ERROR
-change_user user2,111,db1;
+change_user user2,111,db1,do_not_reconnect_on_fail;
 disconnect test;
 --source include/wait_until_disconnected.inc
 --replace_result $MASTER_MYPORT MASTER_MYPORT $MASTER_MYSOCK MASTER_MYSOCK


### PR DESCRIPTION
1. Insert silent statement after UNINSTALL PLUGIN to make sure that SHOW
   WARNINGS is logged before the statement from the next connection.
2. Insert silent statement before establishing the connection which does
   'INSTALL PLUGIN', make sure 'SELECT \* FROM t' gets to the log.
3. Remove problematic 'change_user' because there is no way to
   synchronize it without changing mysqltest.

http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/381/
