### PR TITLE
Fix bug 1617323 (main.percona_show_temp_tables_debug spuriously skipped)

### DIFF
--- a/mysql-test/include/mtr_check.sql
+++ b/mysql-test/include/mtr_check.sql
@@ -30,6 +30,9 @@ BEGIN
     WHERE variable_name NOT IN ('timestamp', 'innodb_file_format_max')
       ORDER BY VARIABLE_NAME;
 
+  SELECT * FROM INFORMATION_SCHEMA.SESSION_VARIABLES
+    WHERE variable_name = 'debug_sync';
+
   -- Dump all databases, there should be none
   -- except those that was created during bootstrap
   SELECT * FROM INFORMATION_SCHEMA.SCHEMATA;

--- a/mysql-test/r/percona_bug1017192.result
+++ b/mysql-test/r/percona_bug1017192.result
@@ -8,3 +8,4 @@ SET DEBUG_SYNC='now WAIT_FOR run_show_innodb_status';
 SHOW ENGINE INNODB STATUS;
 SET DEBUG_SYNC='now SIGNAL show_innodb_status_done';
 DROP TABLE t1;
+SET DEBUG_SYNC='reset';

--- a/mysql-test/r/percona_bug1113388.result
+++ b/mysql-test/r/percona_bug1113388.result
@@ -11,3 +11,4 @@ test.t1	optimize	status	OK
 COUNT(*)
 1
 DROP TABLE t1;
+SET DEBUG_SYNC= 'RESET';

--- a/mysql-test/r/percona_processlist_row_stats.result
+++ b/mysql-test/r/percona_processlist_row_stats.result
@@ -67,4 +67,5 @@ id	info	rows_sent	rows_examined	rows_read
 ###	UPDATE t2 SET a = 15 WHERE a = 20	0	5	6
 ###	UPDATE t2 SET a = 15 WHERE a = 10	0	5	6
 SET DEBUG_SYNC= 'now SIGNAL threads_dumped';
+SET DEBUG_SYNC= 'reset';
 DROP TABLES t1, t2;

--- a/mysql-test/r/percona_show_temp_tables_debug.result
+++ b/mysql-test/r/percona_show_temp_tables_debug.result
@@ -16,3 +16,4 @@ SET DEBUG_SYNC="now SIGNAL finish";
 # connection default
 TABLE_SCHEMA	TABLE_NAME	ENGINE	TABLE_ROWS
 test	t1	MyISAM	0
+SET DEBUG_SYNC="reset";

--- a/mysql-test/r/percona_status_wait_query_cache_mutex.result
+++ b/mysql-test/r/percona_status_wait_query_cache_mutex.result
@@ -17,4 +17,5 @@ action
 mutex_locked_query
 action
 try_lock_mutex_query
+SET DEBUG_SYNC= "RESET";
 SET GLOBAL query_cache_size=0;

--- a/mysql-test/t/percona_bug1017192.test
+++ b/mysql-test/t/percona_bug1017192.test
@@ -15,6 +15,7 @@ SET DEBUG_SYNC='reset';
 CREATE TABLE IF NOT EXISTS t1 (`a` INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4);
 
+--source include/count_sessions.inc
 --connect (con1,localhost,root,,)
 
 --connection default
@@ -37,4 +38,9 @@ SET DEBUG_SYNC='now SIGNAL show_innodb_status_done';
 --connection default
 --reap
 
+disconnect con1;
+
 DROP TABLE t1;
+SET DEBUG_SYNC='reset';
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/t/percona_bug1113388.test
+++ b/mysql-test/t/percona_bug1113388.test
@@ -4,6 +4,8 @@
 --source include/have_innodb.inc
 --source include/have_debug_sync.inc
 
+--source include/count_sessions.inc
+
 CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 
@@ -27,3 +29,6 @@ disconnect conn2;
 connection default;
 
 DROP TABLE t1;
+SET DEBUG_SYNC= 'RESET';
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/t/percona_processlist_row_stats.test
+++ b/mysql-test/t/percona_processlist_row_stats.test
@@ -74,6 +74,8 @@ reap;
 reap;
 
 --connection default
+SET DEBUG_SYNC= 'reset';
+
 disconnect conn1;
 disconnect conn2;
 DROP TABLES t1, t2;

--- a/mysql-test/t/percona_show_temp_tables_debug.test
+++ b/mysql-test/t/percona_show_temp_tables_debug.test
@@ -45,6 +45,8 @@ connection default;
 
 reap;
 
+SET DEBUG_SYNC="reset";
+
 disconnect con2;
 
 --source include/wait_until_count_sessions.inc

--- a/mysql-test/t/percona_status_wait_query_cache_mutex.test
+++ b/mysql-test/t/percona_status_wait_query_cache_mutex.test
@@ -5,6 +5,8 @@ SET GLOBAL query_cache_size=1355776;
 --source include/percona_query_cache_with_comments_clear.inc
 --let try_lock_mutex_query=SELECT "try_lock_mutex_query" as action
 
+--source include/count_sessions.inc
+
 --connect (mutex_locked_conn, localhost, root,,)
 --connect (try_mutex_lock_conn, localhost, root,,)
 
@@ -29,7 +31,11 @@ reap;
 --connection try_mutex_lock_conn
 reap;
 
---connection default
 --disconnect mutex_locked_conn
 --disconnect try_mutex_lock_conn
+
+--connection default
+SET DEBUG_SYNC= "RESET";
 SET GLOBAL query_cache_size=0;
+
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
mysql-test/include/have_debug_sync.inc expects session DEBUG_SYNC
variable to have certain values, which is violated by some previous
testcase not cleaning it up. Add a check to
mysql-test/include/mtr_check.sql that the testcase does not change
DEBUG_SYNC value, cleanup several testcases that fail that check.

http://jenkins.percona.com/job/percona-server-5.5-param/1364/
