### PR TITLE
Fix bug 1616392 (Small buffer pools might be too small for rseg init …

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -4492,7 +4492,9 @@ corrupt:
 			recv_recover_page(TRUE, (buf_block_t*) bpage);
 		}
 
-		if (uncompressed && !recv_no_ibuf_operations) {
+		if (uncompressed && !recv_no_ibuf_operations
+		    && fil_page_get_type(frame) == FIL_PAGE_INDEX
+		    && page_is_leaf(frame)) {
 
 			buf_block_t*	block;
 			ibool		update_ibuf_bitmap;


### PR DESCRIPTION
…during crash recovery)

With 8MB buffer pool, crash recovery initialising rseg might end up in
a situation where all of the buffer pool is pinned by one of the two
MTRs (opened at either trx_undo_list_init, either
trx_sys_init_at_db_start.). Then it tries to merge ibuf for yet
another rseg page and fails to flush anything from the buffer pool to
make room for a page to be read.

Since rseg does not need ibuf merge at all, fix by backporting
bug 1618393 / http://bugs.mysql.com/bug.php?id=75235 (Optimize ibuf
merge when reading a page from disk) fix, which skips ibuf merge on
data page read for all non-index non-leaf pages.

http://jenkins.percona.com/job/percona-server-5.6-param/1344/
