### PR TITLE
BUG#1618634 [sql] [binlog] fix undefined behavior

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -7065,6 +7065,7 @@ MYSQL_BIN_LOG::flush_and_set_pending_rows_event(THD *thd,
           stmt_cannot_safely_rollback(thd))
         cache_data->set_incident();
       delete pending;
+      pending= NULL;
       cache_data->set_pending(NULL);
       DBUG_RETURN(1);
     }


### PR DESCRIPTION
Greetings, on line number 7072 of ‘[sql/binlog.cc](https://github.com/percona/percona-server/blob/5.7/sql/binlog.cc#L7072)’ there is a double-delete causing undefined behavior.

So, after calling ‘`delete pending`’ the first time (on line number 7067), we should do `pending= NULL`, so if (by any chance), ‘`delete pending`’ is called again, nothing will happen.

REF: https://bugs.launchpad.net/percona-server/+bug/1618634
