### PR TITLE
Fix bug 1618478 (innodb.percona_changed_page_bmp might not shutdown s…

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -4750,7 +4750,7 @@ static int my_kill(int pid, int sig)
 
 void do_shutdown_server(struct st_command *command)
 {
-  long timeout=60;
+  long timeout=90;
   int pid;
   DYNAMIC_STRING ds_pidfile_name;
   MYSQL* mysql = &cur_con->mysql;


### PR DESCRIPTION
…erver under 60 seconds under ASan)

Bump the default shutdown_server timeout to 90. This is in line with
e.g. rpl_shutdown_server.inc multiplying shutdown timeout by 6 if
running under Valgrind. Since we cannot determine whether we are
running under ASan or not, just bump the timeout unconditionally.

http://jenkins.percona.com/job/percona-server-5.5-param/1366/
