### PR TITLE
Fix bug 1618718 (percona_show_slave_status_nolock leaves slave server…

### DIFF
--- a/mysql-test/r/percona_show_slave_status_nolock.result
+++ b/mysql-test/r/percona_show_slave_status_nolock.result
@@ -56,10 +56,10 @@ SET DEBUG_SYNC='now SIGNAL signal.continue';
 [slave]
 SET DEBUG_SYNC='now SIGNAL signal.empty';
 
-SET DEBUG_SYNC='RESET';
 [slave_stop]
 include/wait_for_slave_to_stop.inc
 SET GLOBAL DEBUG='';
+SET DEBUG_SYNC='RESET';
 include/start_slave.inc
 [master]
 SET DEBUG_SYNC='RESET';

--- a/mysql-test/t/percona_show_slave_status_nolock.test
+++ b/mysql-test/t/percona_show_slave_status_nolock.test
@@ -64,13 +64,13 @@ connection slave;
 --echo check 'SHOW SLAVE STATUS' and 'SHOW SLAVE STATUS NOLOCK' - just NOLOCK version should works fine
 --source include/percona_show_slave_status_nolock.inc
 
-SET DEBUG_SYNC='RESET';
-
 connection slave_stop;
 --echo [slave_stop]
 reap;
 --source include/wait_for_slave_to_stop.inc
 SET GLOBAL DEBUG='';
+SET DEBUG_SYNC='RESET';
+
 --source include/start_slave.inc
 
 connection master;


### PR DESCRIPTION
… DEBUG_SYNC set)

Move slave DEBUG_SYNC reset after the DEBUG reset.

http://jenkins.percona.com/job/percona-server-5.5-param/1368/

Commit on the 5.5 tip, will be cherry-picked to 5.6.
