### PR TITLE
Fix bug 1618718 (percona_show_slave_status_nolock leaves slave server…

### DIFF
--- a/mysql-test/r/percona_show_slave_status_nolock.result
+++ b/mysql-test/r/percona_show_slave_status_nolock.result
@@ -59,10 +59,10 @@ SET DEBUG_SYNC='now SIGNAL signal.continue';
 [slave]
 SET DEBUG_SYNC='now SIGNAL signal.empty';
 
-SET DEBUG_SYNC='RESET';
 [slave_stop]
 include/wait_for_slave_to_stop.inc
 SET GLOBAL DEBUG='';
+SET DEBUG_SYNC='RESET';
 include/start_slave.inc
 SET DEBUG_SYNC='RESET';
 [master]

--- a/mysql-test/t/percona_show_slave_status_nolock.test
+++ b/mysql-test/t/percona_show_slave_status_nolock.test
@@ -64,13 +64,13 @@ connection slave;
 --echo check 'SHOW SLAVE STATUS' and 'SHOW SLAVE STATUS NONBLOCKING' - just NONBLOCKING version should works fine
 --source include/percona_show_slave_status_nolock.inc
 
-SET DEBUG_SYNC='RESET';
-
 connection slave_stop;
 --echo [slave_stop]
 reap;
 --source include/wait_for_slave_to_stop.inc
 SET GLOBAL DEBUG='';
+SET DEBUG_SYNC='RESET';
+
 --source include/start_slave.inc
 SET DEBUG_SYNC='RESET';
 


### PR DESCRIPTION
http://jenkins.percona.com/job/percona-server-5.6-param/1349/

Cherry-pick from 5.5, there will no 5.7 branch (it would be a null cherry-pick)
