### PR TITLE
Fix bug 1618811 (MTR Subunit support should report testcase check fai…

### DIFF
--- a/mysql-test/lib/mtr_report.pm
+++ b/mysql-test/lib/mtr_report.pm
@@ -277,17 +277,21 @@ sub mtr_report_test_subunit ($) {
   }
   elsif ($result eq 'MTR_RES_PASSED')
   {
-    # Show any problems check-testcase found
-    if ( defined $tinfo->{'check'} )
-    {
-      mtr_report($tinfo->{'check'});
-    }
     # report info to subunit for Jenkins reporting
-    # TODO:  catch 'check-testcase' output??
     Subunit::report_time(time() - $tinfo->{timer}/1000);
     Subunit::subunit_start_test($subunit_testname);
     Subunit::report_time(time());
     Subunit::subunit_pass_test($subunit_testname);
+    if (defined $tinfo->{'check'})
+    {
+      my $check_testname= "testcase-check-" . $subunit_testname;
+      Subunit::subunit_start_test($check_testname);
+      Subunit::subunit_fail_test($check_testname, $tinfo->{'check'});
+    }
+  }
+  else
+  {
+    die "mtr_report_test_subunit: unhandled testcase result " . $result . "\n";
   }
 }
 


### PR DESCRIPTION
…lures)

Adjust mtr_report_test_subunit to report an additional testcase
"testcase-check-<original-name>" as failing if the testcase check has
failed.

http://jenkins.percona.com/job/percona-server-5.5-param/1372/
