### PR TITLE
Fix bug 904714 (Intermittent rpl.percona_bug860910 failures)

### DIFF
--- a/mysql-test/include/rpl_generate_sync_chain.inc
+++ b/mysql-test/include/rpl_generate_sync_chain.inc
@@ -45,12 +45,13 @@
 #         a tail, such as 1->2->3->1->4->5. We should first sync the
 #         loop, and then the tail. To ensure all servers in the loop
 #         are synced, we must sync the loop two turns minus two
-#         servers. For example, the loop 1->2->3->4->5->1 is fully
+#         servers for data and minus one server for log positions. For
+#         example, the loop 1->2->3->4->5->1 is fully
 #         synced by this sequence of 1-step synchronizations:
-#         1->2->3->4->5->1->2->3->4. Hence we do this: in the list of
+#         1->2->3->4->5->1->2->3->4->5. Hence we do this: in the list of
 #         traversed servers (in order from grand-master to
 #         grand-slave), find the first occurrence of S. Take the
-#         sub-list starting at the 3rd server and ending at the first
+#         sub-list starting at the 2nd server and ending at the first
 #         occurrence of S. Append this sub-list it to the end of
 #         $rpl_sync_chain. Then append the entire list of traversed
 #         servers (in order from grand-master to grand-slave) to
@@ -86,11 +87,11 @@ while ($_rpl_start_server)
       {
         # Get sub-list of servers to prepend to server list.
         # E.g., if topology is 1->2->3->4->1->5, then at this point
-        # $_rpl_seen_list='1,2,3,4,1,5,' and we have to prepend '4,3,'
+        # $_rpl_seen_list='1,2,3,4,1,5,' and we have to prepend '2,3,4'
         # to it. Hence, the sub-list starts at position
-        # 1+2*($rpl_server_count_length+1) and ends at the first
+        # $rpl_server_count_length + 2 and ends at the first
         # occurrence of ',1,' in the list.
-        --let $_rpl_extra_list= `SELECT SUBSTRING('$_rpl_seen_list', 1 + 2 * ($rpl_server_count_length + 1), LOCATE(',$_rpl_server,', '$_rpl_seen_list') - 2 * ($rpl_server_count_length + 1))`
+        --let $_rpl_extra_list= `SELECT SUBSTRING('$_rpl_seen_list', $rpl_server_count_length + 2, LOCATE(',$_rpl_server,', '$_rpl_seen_list') - ($rpl_server_count_length + 1))`
         --let $_rpl_seen_list= $_rpl_extra_list$_rpl_seen_list
       }
       # Append the seen servers. Only need to append if the list

--- a/mysql-test/suite/rpl/r/rpl_test_framework.result
+++ b/mysql-test/suite/rpl/r/rpl_test_framework.result
@@ -44,7 +44,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1]
 include/rpl_end.inc
 include/rpl_init.inc [topology=1->2, 2->1]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 212'
+rpl_sync_chain= ' 1212'
 [connection server_1]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (4);
@@ -56,7 +56,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1]
 include/rpl_end.inc
 include/rpl_init.inc [topology=1->2->1]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 212'
+rpl_sync_chain= ' 1212'
 [connection server_2]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (5);
@@ -68,7 +68,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1]
 include/rpl_end.inc
 include/rpl_init.inc [topology=2->1->2]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 212'
+rpl_sync_chain= ' 1212'
 [connection server_1]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (6);
@@ -89,7 +89,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1]
 include/rpl_end.inc
 include/rpl_init.inc [topology=2->3->2->1]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 323 21'
+rpl_sync_chain= ' 2323 21'
 [connection server_3]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (8);
@@ -98,7 +98,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1]
 include/rpl_end.inc
 include/rpl_init.inc [topology=1->2,2->3,3->1]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 23123'
+rpl_sync_chain= ' 123123'
 [connection server_3]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (9);
@@ -107,7 +107,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1]
 include/rpl_end.inc
 include/rpl_init.inc [topology=1->3->2->1]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 13213'
+rpl_sync_chain= ' 213213'
 [connection server_3]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (10);
@@ -117,7 +117,7 @@ include/rpl_end.inc
 ==== Test 6-server topologies ====
 include/rpl_init.inc [topology=1->2->3->4->1->5->6]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 341234156'
+rpl_sync_chain= ' 2341234156'
 [connection server_1]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (11);
@@ -126,7 +126,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1,server_4:t1,server_
 include/rpl_end.inc
 include/rpl_init.inc [topology=3->4->5->6->3->1->2]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 4563456 312'
+rpl_sync_chain= ' 34563456 312'
 [connection server_4]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (12);
@@ -144,7 +144,7 @@ include/diff_tables.inc [server_1:t1,server_2:t1,server_3:t1,server_4:t1,server_
 include/rpl_end.inc
 include/rpl_init.inc [topology=1->2->3->1,4->5->6]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 456 23123'
+rpl_sync_chain= ' 456 123123'
 [connection server_3]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (14);
@@ -157,7 +157,7 @@ include/rpl_end.inc
 ==== Test 9-server topology ====
 include/rpl_init.inc [topology=1->2, 2->3, 3->4, 4->5, 5->1, 1->6, 6->7, 6->8, 8->9]
 include/rpl_generate_sync_chain.inc
-rpl_sync_chain= ' 345123451689 67'
+rpl_sync_chain= ' 2345123451689 67'
 [connection server_2]
 DELETE FROM t1;
 INSERT INTO t1 VALUES (15);


### PR DESCRIPTION
The failing testcase sets up circular replication between two servers,
issues a workload, syncs the servers, and checks that master binlog
position on one server is equal to Exec_Master_Log_Pos. The testcase
intermittently fails that positions are not equal, and when it does,
the 1st server points to the position of 2nd server that comes before
the 1st->2nd replicated events, i.e. while the data is in sync, the
positions aren't, for that the 1st server should receive back its own
events from the 2nd server, and advance log positions without
executing them.

This is caused by rpl_sync.inc include file rpl_generate_sync_chain.inc
generating sync chains that propagate all the data but not necessarily
the log positions as described above in case of loops. Fix by
performing one more synchronisation step in the loop.

http://jenkins.percona.com/job/percona-server-5.5-param/1374/
