### PR TITLE
Fix bug 1618819 (audit_log testcases do not wait for connections to f…

### DIFF
--- a/mysql-test/include/audit_log_events.inc
+++ b/mysql-test/include/audit_log_events.inc
@@ -18,6 +18,7 @@ SHOW STATUS LIKE 'audit_log%';
 DEALLOCATE PREPARE stmt1;
 
 show variables like 'audit_log%';
+--source include/count_sessions.inc
 connect (con1,localhost,root,,mysql);
 connection default;
 disconnect con1;
@@ -54,3 +55,4 @@ create user 'jeffrey'@'localhost' IDENTIFIED BY 'mypass';
 drop user 'jeffrey'@'localhost';
 select '&;&&&""""<><<>>>>';
 disconnect con1;
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
…inish disconnecting)

Include count_sessions.inc and wait_until_count_sessions.inc.

http://jenkins.percona.com/job/percona-server-5.5-param/1373/
