### PR TITLE
Fix bug 1619572 (Test rpl.rpl_init_slave leaves max_connections = 500…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_init_slave.result
+++ b/mysql-test/suite/rpl/r/rpl_init_slave.result
@@ -1,6 +1,7 @@
 include/master-slave.inc
 [connection master]
 set global max_connections=151;
+create table t1(a int);
 include/stop_slave.inc
 include/start_slave.inc
 show variables like 'init_slave';
@@ -21,6 +22,7 @@ set global init_connect="set @c=1";
 show variables like 'init_connect';
 Variable_name	Value
 init_connect	set @c=1
+drop table t1;
 set global init_connect= @my_global_init_connect;
 set global max_connections= default;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_init_slave.test
+++ b/mysql-test/suite/rpl/t/rpl_init_slave.test
@@ -5,6 +5,9 @@ source include/master-slave.inc;
 #
 
 set global max_connections=151;
+# Add some workload to replicate, so that it is guaranteed for the SQL thread
+# to execute init-slave at the next sync
+create table t1(a int);
 
 connection slave;
 source include/stop_slave.inc;
@@ -24,6 +27,7 @@ set @my_global_init_connect= @@global.init_connect;
 set global init_connect="set @c=1";
 show variables like 'init_connect';
 connection master;
+drop table t1;
 sync_slave_with_master;
 
 # Restore changed global variable


### PR DESCRIPTION
… at the end intermittently)

This is caused by the slave SQL thread racing to execute init-slave
with the testcase, and no synchronisation between the two. Add some
workload on the master server that will be replicated by the SQL
thread at the next sync, forcing init-slave execution too.

http://jenkins.percona.com/job/percona-server-5.5-param/1378/
