### PR TITLE
Fix bug 1619665 (Test innodb.innodb_bug30423 is unstable)

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_bug30423.result
+++ b/mysql-test/suite/innodb/r/innodb_bug30423.result
@@ -48,9 +48,9 @@ ON orgs.org_id=sa_opportunities.org_id
 LEFT JOIN bug30243_2 contacts
 ON orgs.org_id=contacts.org_id ;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	orgs	index	NULL	org_id	4	NULL	128	Using index
-1	SIMPLE	sa_opportunities	ref	org_id	org_id	5	test.orgs.org_id	1	Using index
-1	SIMPLE	contacts	ref	contacts$org_id	contacts$org_id	5	test.orgs.org_id	1	Using index
+1	SIMPLE	orgs	index	NULL	org_id	4	NULL	ROWS	Using index
+1	SIMPLE	sa_opportunities	ref	org_id	org_id	5	test.orgs.org_id	ROWS	Using index
+1	SIMPLE	contacts	ref	contacts$org_id	contacts$org_id	5	test.orgs.org_id	ROWS	Using index
 select @@innodb_stats_method;
 @@innodb_stats_method
 nulls_ignored
@@ -74,9 +74,9 @@ ON orgs.org_id=sa_opportunities.org_id
 LEFT JOIN bug30243_2 contacts
 ON orgs.org_id=contacts.org_id;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	orgs	index	NULL	org_id	4	NULL	128	Using index
-1	SIMPLE	sa_opportunities	ref	org_id	org_id	5	test.orgs.org_id	1	Using index
-1	SIMPLE	contacts	ref	contacts$org_id	contacts$org_id	5	test.orgs.org_id	1	Using index
+1	SIMPLE	orgs	index	NULL	org_id	4	NULL	ROWS	Using index
+1	SIMPLE	sa_opportunities	ref	org_id	org_id	5	test.orgs.org_id	ROWS	Using index
+1	SIMPLE	contacts	ref	contacts$org_id	contacts$org_id	5	test.orgs.org_id	ROWS	Using index
 SELECT COUNT(*) FROM table_bug30423 WHERE org_id IS NULL;
 COUNT(*)
 1024

--- a/mysql-test/suite/innodb/t/innodb_bug30423.test
+++ b/mysql-test/suite/innodb/t/innodb_bug30423.test
@@ -140,6 +140,7 @@ analyze table bug30243_3;
 
 # Following query plan shows that we get the correct rows per
 # unique value (should be approximately 1 row per value)
+-- replace_column 9 ROWS
 explain SELECT COUNT(*), 0
 	FROM bug30243_1 orgs
 	LEFT JOIN bug30243_3 sa_opportunities
@@ -160,6 +161,7 @@ analyze table bug30243_3;
 
 # Following query plan shows that we get the correct rows per
 # unique value (~1)
+-- replace_column 9 ROWS
 explain SELECT COUNT(*), 0
 	FROM bug30243_1 orgs
 	LEFT JOIN bug30243_3 sa_opportunities


### PR DESCRIPTION
Backport the 5.6 that masks rows value in EXPLAIN SELECT output for
this testcase, as it's not fully deterministic.

http://jenkins.percona.com/job/percona-server-5.5-param/1380/
