### PR TITLE
Bug#14258884 RPL.RPL_HEARTBEAT_BASIC FAILS SPORADICALLY ON PB2

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_heartbeat_basic.result
+++ b/mysql-test/suite/rpl/r/rpl_heartbeat_basic.result
@@ -172,12 +172,15 @@ ERROR 42000: You have an error in your SQL syntax; check the manual that corresp
 RESET SLAVE;
 
 *** Running slave ***
-CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=MASTER_PORT, MASTER_USER='root', MASTER_CONNECT_RETRY=20, MASTER_HEARTBEAT_PERIOD=0.1;
+CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=MASTER_PORT, MASTER_USER='root', MASTER_CONNECT_RETRY=20, MASTER_HEARTBEAT_PERIOD= 3.0;
+SELECT unix_timestamp() into @time_0;
 include/start_slave.inc
+SELECT unix_timestamp() into @time_1;
 Heartbeat event received
 
 *** Stopped slave ***
 include/stop_slave.inc
+CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=MASTER_PORT, MASTER_USER='root', MASTER_CONNECT_RETRY=20, MASTER_HEARTBEAT_PERIOD= 0.1;
 Number of received heartbeat events while slave stopped: 0
 
 *** Started slave ***
@@ -210,22 +213,8 @@ call mtr.add_suppression("Slave SQL.*Duplicate entry .1. for key .PRIMARY.. on q
 call mtr.add_suppression("Slave SQL.*Request to stop slave SQL Thread received while applying a group that has non-transactional changes; waiting for completion of the group");
 Heartbeat events are received while sql thread stopped (1 means 'yes'): 1
 include/stop_slave.inc
-DROP TABLE t1;
-
-*** Master send to slave ***
-CREATE EVENT e1 
-ON SCHEDULE EVERY 1 SECOND
-DO
-BEGIN
-UPDATE test.t1 SET a = a + 1 WHERE a < 10;
-END|
-RESET SLAVE;
-CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=MASTER_PORT, MASTER_USER='root', MASTER_CONNECT_RETRY=20, MASTER_HEARTBEAT_PERIOD=5;
-include/start_slave.inc
-SET @@global.event_scheduler=1;
-Number of received heartbeat events: 0
 DELETE FROM t1;
-DROP EVENT e1;
+include/start_slave.inc
 
 *** Flush logs on slave ***
 STOP SLAVE;

--- a/mysql-test/suite/rpl/t/rpl_heartbeat_basic.test
+++ b/mysql-test/suite/rpl/t/rpl_heartbeat_basic.test
@@ -239,24 +239,38 @@ RESET SLAVE;
 #
 # Testing heartbeat 
 #
-
-# Check received heartbeat events for running slave
+# Check received heartbeat events for running slave.
+# It must arrived not ealier than as specified by HEARTBEAT_PERIOD.
+#
+--let $hb_period= 3.0
 --echo *** Running slave ***
 --replace_result $MASTER_MYPORT MASTER_PORT
-eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$MASTER_MYPORT, MASTER_USER='root', MASTER_CONNECT_RETRY=$connect_retry, MASTER_HEARTBEAT_PERIOD=0.1;
+--replace_column 2 ####
+eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$MASTER_MYPORT, MASTER_USER='root', MASTER_CONNECT_RETRY=$connect_retry, MASTER_HEARTBEAT_PERIOD= $hb_period;
+SELECT unix_timestamp() into @time_0;
 --source include/start_slave.inc
+
 --connection master
 --sync_slave_with_master
 let $status_var_value= query_get_value(SHOW STATUS LIKE 'slave_received_heartbeats', Value, 1);
 let $status_var= slave_received_heartbeats;
 let $status_var_comparsion= >;
 --source include/wait_for_status_var.inc
+SELECT unix_timestamp() into @time_1;
+if (`SELECT @time_1 - @time_0 < $hb_period`)
+{
+    --echo "Heartbeat is received ealier than specified."
+    --die
+}
 --echo Heartbeat event received
 --echo
 
 # Check received heartbeat events for stopped slave
 --echo *** Stopped slave ***
 --source include/stop_slave.inc
+--replace_result $MASTER_MYPORT MASTER_PORT
+eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$MASTER_MYPORT, MASTER_USER='root', MASTER_CONNECT_RETRY=$connect_retry, MASTER_HEARTBEAT_PERIOD= 0.1;
+
 let $rcvd_heartbeats_before= query_get_value(SHOW STATUS LIKE 'slave_received_heartbeats', Value, 1);
 sleep 2;
 let $rcvd_heartbeats_after= query_get_value(SHOW STATUS LIKE 'slave_received_heartbeats', Value, 1);
@@ -329,40 +343,11 @@ let $rcvd_heartbeats_after= query_get_value(SHOW STATUS LIKE 'slave_received_hea
 let $result= query_get_value(SELECT ($rcvd_heartbeats_after - $rcvd_heartbeats_before) > 0 AS Result, Result, 1);
 --echo Heartbeat events are received while sql thread stopped (1 means 'yes'): $result
 --source include/stop_slave.inc
-DROP TABLE t1;
---echo
-
-# Check received heartbeat events while master send events to slave
---echo *** Master send to slave ***
---connection master
-# Create the event that will update table t1 every second
-DELIMITER |;
-CREATE EVENT e1 
-  ON SCHEDULE EVERY 1 SECOND
-  DO
-    BEGIN
-      UPDATE test.t1 SET a = a + 1 WHERE a < 10;
-    END|
-DELIMITER ;|
---connection slave
-RESET SLAVE;
---replace_result $MASTER_MYPORT MASTER_PORT
-eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$MASTER_MYPORT, MASTER_USER='root', MASTER_CONNECT_RETRY=$connect_retry, MASTER_HEARTBEAT_PERIOD=5;
+DELETE FROM t1;
 --source include/start_slave.inc
 --connection master
-# Enable scheduler
-SET @@global.event_scheduler=1;
 --sync_slave_with_master
-let $rcvd_heartbeats_before= query_get_value(SHOW STATUS LIKE 'slave_received_heartbeats', Value, 1);
-# Wait some updates for table t1 from master
-let $wait_condition= SELECT COUNT(*)=1 FROM t1 WHERE a > 5;
---source include/wait_condition.inc
-let $rcvd_heartbeats_after= query_get_value(SHOW STATUS LIKE 'slave_received_heartbeats', Value, 1);
-let $result= query_get_value(SELECT ($rcvd_heartbeats_after - $rcvd_heartbeats_before) > 0 AS Result, Result, 1);
---echo Number of received heartbeat events: $result
 --connection master
-DELETE FROM t1;
-DROP EVENT e1;
 --sync_slave_with_master
 --echo
 


### PR DESCRIPTION
Bug#13627066 RPL.RPL_DEADLOCK_INNODB FAILS ON PB2 SPRADICALLY

Sporadic and long time standing mismatch at the test run

  include/start_slave.inc
  SET @@global.event_scheduler=1;
  -Number of received heartbeat events: 0
  +Number of received heartbeat events: 1

was caused by a incorrect assumption the no hearbeat event should
be sent in the context of that test's snippet.
In fact, there is no guarantee that empty binlog status won't last
over the hearbeat period. Even though period of scheduled by the server scheduler
UPDATE queries is 1/5 th of the heartbeat period, the actual time in between of two
successive bin-logging actions can last as long as the HB period. That's what PB run
proves in practice.

Fixed with removing ineffecient piece of the test.

Bug#13627066 RPL.RPL_DEADLOCK_INNODB FAILS ON PB2 SPRADICALLY

A possible reason of SQL thread to fail to increment slave_transaction_retries
status is a failure to start the slave threads that went unnoticible thanks to unblocking
style of the slave start.
combined with also small of innodb_lock_wait_timeout. That could allow a race of
the SQL thread retrying after timeout and the mtr user thread counting through polling in a interval.

Attempted to fix with correcting the start slave.
A separate failure in this test that radomly happens on PB near

 source include/wait_for_slave_sql_error.inc;

is addressed with adding a debug print-outs via rpl_debug=1.
Extra info will be necessary to actually tackle this issue (to be repoted once the extra info will
be available in PB saved test logs).

http://jenkins.percona.com/job/percona-server-5.5-param/1382/
