### PR TITLE
Fix bug 1617198 (Intermittently stalled or crashing shutdown if it's …

### DIFF
--- a/plugin/HandlerSocket-Plugin-for-MySQL/client/hslongrun.cpp
+++ b/plugin/HandlerSocket-Plugin-for-MySQL/client/hslongrun.cpp
@@ -370,16 +370,6 @@ struct hs_longrun_thread_hs : public hs_longrun_thread_base {
   socket_args sockargs;
 };
 
-struct lock_guard : noncopyable {
-  lock_guard(mutex& mtx) : mtx(mtx) {
-    mtx.lock();
-  }
-  ~lock_guard() {
-    mtx.unlock();
-  }
-  mutex& mtx;
-};
-
 string_ref
 to_string_ref(const std::string& s)
 {

--- a/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/database.hpp
+++ b/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/database.hpp
@@ -114,6 +114,7 @@ struct dbcontext_i {
   virtual ~dbcontext_i() { }
   virtual void init_thread(const void *stack_bottom,
     volatile int& shutdown_flag) = 0;
+  virtual void wait_for_server_to_start() = 0;
   virtual void term_thread() = 0;
   virtual bool check_alive() = 0;
   virtual void lock_tables_if() = 0;

--- a/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/hstcpsvr.cpp
+++ b/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/hstcpsvr.cpp
@@ -125,6 +125,15 @@ hstcpsvr::start_listen()
   for (size_t i = 0; i < threads.size(); ++i) {
     threads[i]->start();
   }
+  {
+    lock_guard crit_sec(const_cast<mutex &>(vshared.v_mutex));
+    while (vshared.threads_started < cshared.num_threads) {
+      pthread_cond_wait(
+        const_cast<pthread_cond_t *>(&vshared.threads_started_cond),
+        (const_cast<mutex &>(vshared.v_mutex)).get());
+    }
+  }
+
   DENA_VERBOSE(20, fprintf(stderr, "threads started\n"));
   return std::string();
 }

--- a/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/hstcpsvr.hpp
+++ b/plugin/HandlerSocket-Plugin-for-MySQL/handlersocket/hstcpsvr.hpp
@@ -38,9 +38,19 @@ struct hstcpsvr_shared_c {
     thread_num_conns(0) { }
 };
 
-struct hstcpsvr_shared_v : public mutex {
+struct hstcpsvr_shared_v : private noncopyable {
   int shutdown;
-  hstcpsvr_shared_v() : shutdown(0) { }
+  long threads_started;
+  pthread_cond_t threads_started_cond;
+  mutex v_mutex;
+  hstcpsvr_shared_v() : shutdown(0), threads_started(0)
+  {
+    pthread_cond_init(&threads_started_cond, NULL);
+  }
+  ~hstcpsvr_shared_v()
+  {
+    pthread_cond_destroy(&threads_started_cond);
+  }
 };
 
 struct hstcpsvr_i;

--- a/plugin/HandlerSocket-Plugin-for-MySQL/libhsclient/mutex.hpp
+++ b/plugin/HandlerSocket-Plugin-for-MySQL/libhsclient/mutex.hpp
@@ -41,8 +41,21 @@ struct mutex : private noncopyable {
       fatal_abort("pthread_mutex_unlock");
     }
   }
+  pthread_mutex_t* get() const {
+    return &mtx;
+  }
  private:
   mutable pthread_mutex_t mtx;
+};
+
+struct lock_guard : noncopyable {
+  lock_guard(mutex& mtx) : mtx(mtx) {
+    mtx.lock();
+  }
+  ~lock_guard() {
+    mtx.unlock();
+  }
+  mutex& mtx;
 };
 
 };

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -888,6 +888,7 @@ void add_global_thread(THD *thd)
 {
   DBUG_PRINT("info", ("add_global_thread %p", thd));
   mysql_mutex_assert_owner(&LOCK_thread_count);
+  DBUG_ASSERT(!shutdown_in_progress);
   const bool have_thread=
     global_thread_list->find(thd) != global_thread_list->end();
   if (!have_thread)


### PR DESCRIPTION
…issued immediately after HandlerSocket startup)

If server is shutdown immediately after HandlerSocket plugin has
initialized, it may hit a race condition between worker thread
initialisation, which happens asynchronously, and at some point adds
threads to the server global thread list, and server shutdown, which
waits for the thread count to go down to zero. This race condition may
result in some worker threads not receiving kill notifications, and
thus hanging the server shutdown.

Fix by making the worker threads bump the worker thread count and
raise a signal after the last one has been started. Wait for that
signal in the spawning thread. Move the server startup check in the
worker threads after the signal.

In the core server, add assert that server is not being shutdown to
add_global_thread function.

http://jenkins.percona.com/job/percona-server-5.6-param/1359/
