### PR TITLE
Add diagnostics and code cleanups for bug 1620532 (Test percona_chang…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS t1;
+call mtr.add_suppression("simulating bitmap write error in log_online_write_bitmap_page");
 call mtr.add_suppression("log tracking bitmap write failed, stopping log tracking thread!");
 call mtr.add_suppression("last tracked LSN in");
 1st restart

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -11,6 +11,7 @@ DROP TABLE IF EXISTS t1;
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 
+call mtr.add_suppression("simulating bitmap write error in log_online_write_bitmap_page");
 call mtr.add_suppression("log tracking bitmap write failed, stopping log tracking thread!");
 call mtr.add_suppression("last tracked LSN in");
 


### PR DESCRIPTION
…ed_page_bmp_debug is unstable)

Add srv_track_changed_pages invariant assert to some functions, and
remove runtime check for it from log_online_follow_redo_log. Add
diagnostics to log_online_write_bitmap_page for the injected failure.

http://jenkins.percona.com/job/percona-server-5.6-param/1360/
