### PR TITLE
Fix bug 1620583 (Test change_user_notembedded is unstable)

### DIFF
--- a/mysql-test/r/change_user_notembedded.result
+++ b/mysql-test/r/change_user_notembedded.result
@@ -1,5 +1,5 @@
-ERROR 28000: Access denied for user 'foo'@'localhost' (using password: YES)
 Got one of the listed errors
-ERROR 28000: Access denied for user 'foo'@'localhost' (using password: YES)
-ERROR 28000: Access denied for user 'foo'@'localhost' (using password: YES)
-ERROR 28000: Access denied for user 'foo'@'localhost' (using password: YES)
+Got one of the listed errors
+Got one of the listed errors
+Got one of the listed errors
+Got one of the listed errors

--- a/mysql-test/t/change_user_notembedded.test
+++ b/mysql-test/t/change_user_notembedded.test
@@ -3,25 +3,23 @@ source include/not_embedded.inc;
 #
 # MDEV-3915 COM_CHANGE_USER allows fast password brute-forcing
 #
-# only three failed change_user per connection.
-# successful change_user do NOT reset the counter
-#
+--source include/count_sessions.inc
 connect (test,localhost,root,,);
 connection test;
---error ER_ACCESS_DENIED_ERROR
+--enable_reconnect
+# # 2006=CR_SERVER_LOST, 2013=CR_SERVER_GONE_ERROR
+--error ER_ACCESS_DENIED_ERROR,2006,2013
 change_user foo,bar;
-# CR_SERVER_LOST, CR_SERVER_GONE_ERROR
---error 2006,2013
+--error ER_ACCESS_DENIED_ERROR,2006,2013
 change_user foo;
---enable_reconnect
---error ER_ACCESS_DENIED_ERROR
+--error ER_ACCESS_DENIED_ERROR,2006,2013
 change_user foo,bar;
---enable_reconnect
 change_user;
---error ER_ACCESS_DENIED_ERROR
+--error ER_ACCESS_DENIED_ERROR,2006,2013
 change_user foo,bar;
---error ER_ACCESS_DENIED_ERROR
+--error ER_ACCESS_DENIED_ERROR,2006,2013
 change_user foo,bar;
 change_user;
 disconnect test;
 connection default;
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Cleanup the testcase, including that the each authorization failure
can return one of of the three failures, depending on the timing.

http://jenkins.percona.com/job/percona-server-5.6-param/1361/
