### PR TITLE
Backport fixes for bug 1621046 / 45679 (KILL QUERY not behaving consi…

### DIFF
--- a/mysql-test/r/ps.result
+++ b/mysql-test/r/ps.result
@@ -3917,6 +3917,6 @@ CREATE TABLE t1 (col1 INT);
 KILL QUERY <con1_id>;
 # Connection con1
 SELECT * FROM t1;
-ERROR 70100: Query execution was interrupted
+col1
 # Connection default
 DROP TABLE t1;

--- a/mysql-test/r/show_check.result
+++ b/mysql-test/r/show_check.result
@@ -1458,7 +1458,7 @@ DROP USER test_u@localhost;
 #    was killed
 #
 SHOW CREATE TABLE non_existent;
-ERROR 70100: Query execution was interrupted
+ERROR 42S02: Table 'test.non_existent' doesn't exist
 End of 5.1 tests
 #
 # Bug#52593 SHOW CREATE TABLE is blocked if table is locked

--- a/mysql-test/t/ps.test
+++ b/mysql-test/t/ps.test
@@ -3512,7 +3512,6 @@ eval KILL QUERY $con1_id;
 --echo # Connection con1
 connection con1;
 # Here the server asserts when running with "--ps-protocol"
---error ER_QUERY_INTERRUPTED
 SELECT * FROM t1;
 disconnect con1;
 --source include/wait_until_disconnected.inc

--- a/mysql-test/t/show_check.test
+++ b/mysql-test/t/show_check.test
@@ -1219,7 +1219,12 @@ eval KILL QUERY $ID;
 --enable_query_log
 
 CONNECTION con1;
---error ER_QUERY_INTERRUPTED
+let $wait_timeout= 5;
+let $wait_condition=
+  SELECT COUNT(*)=0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE
+  INFO= "KILL QUERY $ID";
+--source include/wait_condition.inc
+--error ER_NO_SUCH_TABLE
 SHOW CREATE TABLE non_existent;
 
 DISCONNECT con1;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1948,8 +1948,13 @@ void THD::awake(THD::killed_state state_to_set)
   THD_CHECK_SENTRY(this);
   mysql_mutex_assert_owner(&LOCK_thd_data);
 
-  /* Set the 'killed' flag of 'this', which is the target THD object. */
-  killed= state_to_set;
+  /*
+    If there is no command executing on the server, we should not set the
+    killed flag so that it does not affect the next command incorrectly.
+  */
+  if (!this->m_server_idle)
+    /* Set the 'killed' flag of 'this', which is the target THD object. */
+    killed= state_to_set;
 
   if (state_to_set != THD::KILL_QUERY &&
       state_to_set != THD::KILL_TIMEOUT)

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5572,13 +5572,6 @@ finish:
     /* report error issued during command execution */
     if (thd->killed_errno())
       thd->send_kill_message();
-    if (thd->killed == THD::KILL_QUERY ||
-        thd->killed == THD::KILL_TIMEOUT ||
-        thd->killed == THD::KILL_BAD_DATA)
-    {
-      thd->killed= THD::NOT_KILLED;
-      thd->mysys_var->abort= 0;
-    }
     if (thd->is_error() || (thd->variables.option_bits & OPTION_MASTER_SQL_ERROR))
       trans_rollback_stmt(thd);
     else
@@ -5587,6 +5580,13 @@ finish:
       thd->get_stmt_da()->set_overwrite_status(true);
       trans_commit_stmt(thd);
       thd->get_stmt_da()->set_overwrite_status(false);
+    }
+    if (thd->killed == THD::KILL_QUERY ||
+        thd->killed == THD::KILL_TIMEOUT ||
+        thd->killed == THD::KILL_BAD_DATA)
+    {
+      thd->killed= THD::NOT_KILLED;
+      thd->mysys_var->abort= 0;
     }
   }
 


### PR DESCRIPTION
…stently and will hang in some cases)

Backported commits:

commit 1ff551ee095c6abbb89e8185063c033d6f49c349
Author: Raghav Kapoor raghav.kapoor@oracle.com
Date:   Mon Feb 25 14:07:35 2013 +0530

```
BUG#11790057 KILL QUERY WILL AFFECT THE NEXT COMMAND INCORRECTLY
Bug#11754124:KILL QUERY NOT BEHAVING CONSISTENTLY AND WILL HANG IN SOME CASES

BACKGROUND OF BUG#11790057
SCENARIO 1:
When a very long SELECT is running in one connection and it
is just flushing its output on the console and, In another
connection a KILL QUERY command is issued, the next query
executed in the first connection would throw
ER_QUERY_INTERRUPTED which is wrong.

SCENARIO 2:
When an INSERT query is running in one connection and it is
in final stage to commit itself by acquiring MDL locks and
waiting for the lock (i.e it is blocked because Flush Tables
With Read Lock (FTWRL) is issued in another connection) and,
In another connection, a KILL QUERY command is issued to kill
that blocked INSERT query, it would not result a Query
Interrupted Error.
Rather the next query issued after INSERT in the connection
would throw error ER_QUERY_INTERRUPTED.
This behaviour is wrong.

ANALYSIS OF BUG#11790057:
SCENARIO 1:
In this scenario, SELECT has cleared all the stages and it is
just flushing its output on the console through send() system
call which is non blocking.
Here if a user issues kill query in another connection,
in the kill reception code there was no check to determine if
the command is finished executing and it should not set the kill
flag for that thread.

SCENARIO 2:
The state of blocked INSERT query is set to MDL_wait::KILLED due
to KILL QUERY being issued in another session. No error was thrown.
The state of INSERT executing thread would be set to THD::KILL_QUERY
by kill reception code and it would affect the next command incorrectly.

FIX FOR BUG#11790057:
SCENARIO 1:
A check has been added in the kill reception code that if any
kill request comes in after the command is processed but
before the next command is received, it should not set the kill
flag for that thread because there is no active command being
processed.
SCENARIO 2:
When the query waiting on MDL Lock is killed, its state is set to
MDL_WAIT::KILLED. As a fix, an error ER_QUERY_INTERRUPTED is thrown
from there.
After the error is thrown from inside trans_commit_stmt() function,
the thread state is reset to NOT_KILLED, by rearranging the code
inside if (!thd->sub_stmt) so that next command does not get affected.

BACKGROUND OF BUG#11754124:
This bug is pretty similar or we can say duplicate of Bug#11790057,
Only difference is more number of scenarios of unexpected behaviour
of KILL QUERY are presented in this bug than Bug#11790057, and they
are pretty much clear from the bug description.

ANALYSIS OF BUG#11754124:
All the scenarios mentioned in this bug are already been taken care
by the patch submitted for Bug#11790057. Only Additional test cases
are written to test the scenarios mentioned in this bug.
DETAILED ANALYSIS OF SCENARIOS:
1. Scenario 1, 2, 4 and 8 mentioned in the bug report are reproducible
   and are fixed with the current patch.
2. Scenario 3 is Reproducible in 5.1. It is not reproducible in 5.5,
   5.6 and trunk.
   The above scenarios 1, 2, 4 and 8 were fixed by the check
   added in sql_kill() function submitted as a patch for
   Scenario 1 of Bug#11790057.
3. Scenario 5, 6, 7 are not reproducible as they are
   described in the bug report in any of the versions.
   When we CALL a successfully created stored procedure, and a
   KILL QUERY is issued before in another session, the CALL to
   stored procedure terminates with ER_QUERY_INTERRUPTED error.
   After that if we again CALL it, it works fine.
   The above is applicable to Scenarios 5, 6 and 7 mentioned
   in the bug report.
   Scenario 9 is special because here KILL is issued concurrently
   when we are calling the stored procedure.
   For Scenario 9 there are two cases:
   CASE 1:
   A SELECT SLEEP(10) query is present inside a stored procedure
   and a handler is declared for it. In this case, When we do KILL
   when the sleep is executing, it goes to  pthread_cond_timedwait()
   system call. This system call does not return an error code of EINTR,
   when it is killed. The system call passes and only the state of
   thread is set to KILL_QUERY.
   Since there is no error generated by the SLEEP(10), handler does not
   get activated in any of the versions. This behaviour is present in all
   the versions starting from 5.1 and is correct.
   CASE 2:
   A very long running SELECT query is present inside a Stored Procedure
   and a handler is declared for it. In 5.1, CONTINUE handler for this is
   executed when a FATAL error happens which should not be the behaviour.
   See Bug #15192 for more details.
   In 5.5, 5.6 and trunk, handler for this is not executed since it is a
   FATAL error. Therefore, this behaviour is correct.

FIX FOR BUG#11754124:
The fix for this bug is same as the patch submitted for Bug#11790057.
Additional test coverage is submitted as patch for this bug.
```

commit 33eba69e9f7732e0f16e6b6a1f40b39287f0721c
Author: Raghav Kapoor raghav.kapoor@oracle.com
Date:   Sun Mar 10 15:42:52 2013 +0530

```
BUG#16457803 - MAIN.SHOW_CHECK UNSTABLE ON PB2

BACKGROUND:
After fix for Bug#11754124, main.show_check starts failing
occasionally on pb2.

FIX:
Submitted the patch to make the test case more robust.
```

commit 3f5ccb3f28443334ef2ab957490e4750de6954c5
Author: Raghav Kapoor raghav.kapoor@oracle.com
Date:   Tue Apr 9 17:12:15 2013 +0530

```
BUG#16457803 - MAIN.SHOW_CHECK UNSTABLE ON PB2

BACKGROUND:
After fix for Bug#11754124, main.show_check starts failing
occasionally on pb2 under high load.

FIX:
Submitted the patch by to make the test case more robust.
```

http://jenkins.percona.com/job/percona-server-5.6-param/1365/
