### PR TITLE
Work towards diagnosing bug 1621060 (Test innodb.innodb_stats_auto_re…

### DIFF
--- a/mysql-test/include/wait_condition.inc
+++ b/mysql-test/include/wait_condition.inc
@@ -57,5 +57,5 @@ if (!$success)
   {
     --source include/show_rpl_debug_info.inc
   }
-  die Timeout in wait_condition.inc for $wait_condition;
+  echo Timeout in wait_condition.inc for $wait_condition;
 }


### PR DESCRIPTION
…cals fails intermittently)

Replace "die" with "echo" in mysql-test/include/wait_condition.inc in
case of failure to allow the testcase to proceed and show the result
diff. This also makes this include file consistent with both 5.5 and
5.7.

http://jenkins.percona.com/job/percona-server-5.6-param/1367/
