### PR TITLE
Fix bug 1622449 (Test innodb.innodb_replace is unstable)

### DIFF
--- a/mysql-test/suite/innodb/t/innodb_replace.test
+++ b/mysql-test/suite/innodb/t/innodb_replace.test
@@ -74,12 +74,15 @@ SET DEBUG_SYNC='now SIGNAL select2';
 connection con1;
 reap;
 
+connection default;
+reap;
+
+connection con1;
 SET DEBUG_SYNC='write_row_replace SIGNAL insert3 WAIT_FOR select3';
 --send
 INSERT INTO t1 VALUES(3,5) ON DUPLICATE KEY UPDATE b=b+20;
 
 connection default;
-reap;
 SET DEBUG_SYNC='now WAIT_FOR insert3';
 --send
 SELECT b FROM t1 LOCK IN SHARE MODE;


### PR DESCRIPTION
Prevent INSERT on con1 overtaking SELECT LOCK IN SHARE MODE on the
default connection by reaping its query first.

http://jenkins.percona.com/job/percona-server-5.6-param/1369/
