### PR TITLE
Fix bug 1622977 (Test connect_debug is unstable)

### DIFF
--- a/mysql-test/t/connect_debug.test
+++ b/mysql-test/t/connect_debug.test
@@ -55,10 +55,8 @@ SET DEBUG_SYNC='RESET';
 
 --echo
 --echo # -- Waiting for connection to close...
-let $wait_condition =
-  SELECT COUNT(*) = 2
-  FROM information_schema.processlist;
---source include/wait_condition.inc
+let $count_sessions= 2;
+--source include/wait_until_count_sessions.inc
 
 --connect (con_3, localhost, root)
 
@@ -81,4 +79,5 @@ SET GLOBAL max_connections= @saved_max_connections;
 --echo
 
 # Wait till all disconnects are completed
+let $count_sessions= 1;
 --source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Avoid race condition between the server and the testcase by replacing
the processlist-based disconnect check with a Threads_connected-based
one.

http://jenkins.percona.com/job/percona-server-5.6-param/1373/
