### PR TITLE
Fix bug 1623011 (Test rpl.rpl_percona_crash_resistant_rpl is unstable)

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_percona_crash_resistant_rpl.test
+++ b/mysql-test/suite/rpl/t/rpl_percona_crash_resistant_rpl.test
@@ -96,6 +96,8 @@ START SLAVE;
 --let $rpl_server_number= 2
 --source include/rpl_start_server.inc
 --source include/start_slave.inc
+connection master;
+sync_slave_with_master;
 SELECT COUNT(*) FROM t1;
 
 #


### PR DESCRIPTION
Add missing testcase replication sync.

http://jenkins.percona.com/job/percona-server-5.6-param/1375/
