### PR TITLE
Fix bug 1622985 (Successful doublewrite recovery should not be a warn…

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_bug14147491.result
+++ b/mysql-test/suite/innodb/r/innodb_bug14147491.result
@@ -1,5 +1,4 @@
 CALL mtr.add_suppression("InnoDB: Error: Unable to read tablespace .* page no .* into the buffer pool after 100 attempts");
-CALL mtr.add_suppression("InnoDB: Warning: database page corruption or a failed");
 # Create and populate the table to be corrupted
 CREATE TABLE t1 (a INT AUTO_INCREMENT PRIMARY KEY, b TEXT) ENGINE=InnoDB;
 INSERT INTO t1 (b) VALUES ('corrupt me');

--- a/mysql-test/suite/innodb/t/innodb-double-write.test
+++ b/mysql-test/suite/innodb/t/innodb-double-write.test
@@ -18,7 +18,6 @@ call mtr.add_suppression("InnoDB: Database page .* contained only zeroes.");
 call mtr.add_suppression("Header page consists of zero bytes");
 call mtr.add_suppression("Checksum mismatch in tablespace");
 call mtr.add_suppression("but the innodb_page_size start-up parameter is");
-call mtr.add_suppression("Database page corruption");
 call mtr.add_suppression("innodb-page-size mismatch in tablespace");
 --enable_query_log
 

--- a/mysql-test/suite/innodb/t/innodb_bug14147491.test
+++ b/mysql-test/suite/innodb/t/innodb_bug14147491.test
@@ -14,7 +14,6 @@ source include/have_innodb.inc;
 source include/have_debug.inc;
 
 CALL mtr.add_suppression("InnoDB: Error: Unable to read tablespace .* page no .* into the buffer pool after 100 attempts");
-CALL mtr.add_suppression("InnoDB: Warning: database page corruption or a failed");
 
 --echo # Create and populate the table to be corrupted
 CREATE TABLE t1 (a INT AUTO_INCREMENT PRIMARY KEY, b TEXT) ENGINE=InnoDB;

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -521,7 +521,7 @@ buf_dblwr_process()
 			if (buf_page_is_corrupted(true, read_buf, zip_size)) {
 
 				fprintf(stderr,
-					"InnoDB: Warning: database page"
+					"InnoDB: Database page"
 					" corruption or a failed\n"
 					"InnoDB: file read of"
 					" space %lu page %lu.\n"


### PR DESCRIPTION
…ing)

Downgrade diagnostics severity from warning to regular note if the
doublewrite user has been used for crash recovery. Remove the
corresponding suppressions from the testcases.

http://jenkins.percona.com/job/percona-server-5.6-param/1374/
