### PR TITLE
Add assert to catch bug 1622952 (Test innodb.innodb-log-file-size-1 i…

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -489,6 +489,8 @@ fil_space_get_by_id(
 		    ut_ad(space->magic_n == FIL_SPACE_MAGIC_N),
 		    space->id == id);
 
+	/* The system tablespace must always be found */
+	ut_ad(space || id != 0 || srv_is_being_started);
 	return(space);
 }
 


### PR DESCRIPTION
…s unstable)

InnoDB shutdown hangs with error messages indicating I/O attempts to
non-existing tablespace, where the tablespace is the system one, that
must exist. Add an assert to catch this condition.

http://jenkins.percona.com/job/percona-server-5.6-param/1372/
