### PR TITLE
Fix bug 82980 / 1619622 (Multi-threaded slave leaks worker threads in…

### DIFF
--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -6057,10 +6057,6 @@ void slave_stop_workers(Relay_log_info *rli, bool *mts_inited)
 {
   int i;
   THD *thd= rli->info_thd;
-  if (!*mts_inited)
-    return;
-  else if (rli->slave_parallel_workers == 0)
-    goto end;
 
   /*
     If request for stop slave is received notify worker
@@ -6119,6 +6115,11 @@ void slave_stop_workers(Relay_log_info *rli, bool *mts_inited)
     }
     mysql_mutex_unlock(&w->jobs_lock);
   }
+
+  if (!*mts_inited)
+    return;
+  else if (rli->slave_parallel_workers == 0)
+    goto end;
 
   if (thd->killed == THD::NOT_KILLED)
     (void) mts_checkpoint_routine(rli, 0, false, true/*need_data_lock=true*/); // TODO:consider to propagate an error out of the function


### PR DESCRIPTION
… case of thread create failure)

Move early exits in the slave_stop_workers to the middle of the function
so that the running slave worker threads are terminated.

http://jenkins.percona.com/job/percona-server-5.6-param/1379/
