### PR TITLE
BUG#14221043: MYSQL_UPGRADE FAILS WHEN SERVER IS RUNNING WITH GTID-MO…

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -149,10 +149,10 @@ static struct my_option my_long_options[]=
    &opt_verbose, &opt_verbose, 0,
    GET_BOOL, NO_ARG, 1, 0, 0, 0, 0, 0},
   {"write-binlog", OPT_WRITE_BINLOG,
-   "All commands including mysqlcheck are binlogged. Enabled by default;"
-   "use --skip-write-binlog when commands should not be sent to replication slaves.",
+   "All commands including mysqlcheck are binlogged. Disabled by default; "
+   "use when commands should be sent to replication slaves.",
    &opt_write_binlog, &opt_write_binlog, 0, GET_BOOL, NO_ARG,
-   1, 0, 0, 0, 0, 0},
+   0, 0, 0, 0, 0, 0},
   {0, 0, 0, 0, 0, 0, GET_NO_ARG, NO_ARG, 0, 0, 0, 0, 0, 0}
 };
 

--- a/mysql-test/r/mysql_upgrade.result
+++ b/mysql-test/r/mysql_upgrade.result
@@ -226,6 +226,33 @@ mysql.time_zone_name                               OK
 mysql.time_zone_transition                         OK
 mysql.time_zone_transition_type                    OK
 mysql.user                                         OK
+# Running mysql_upgrade with --write-binlog..
+mtr.global_suppressions                            OK
+mtr.test_suppressions                              OK
+mysql.columns_priv                                 OK
+mysql.db                                           OK
+mysql.event                                        OK
+mysql.func                                         OK
+mysql.general_log                                  OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.host                                         OK
+mysql.ndb_binlog_index                             OK
+mysql.plugin                                       OK
+mysql.proc                                         OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.servers                                      OK
+mysql.slow_log                                     OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.user                                         OK
 #
 # Bug #21489398: MYSQL_UPGRADE: FATAL ERROR: UPGRADE FAILED - IMPROVE ERROR
 #

--- a/mysql-test/suite/rpl/t/rpl_mysql_upgrade.test
+++ b/mysql-test/suite/rpl/t/rpl_mysql_upgrade.test
@@ -23,8 +23,8 @@ connection master;
 let $before_position= query_get_value(SHOW MASTER STATUS, Position, 1);
 
 #With '--force' option, mysql_upgrade always executes all sql statements for upgrading.
-#--skip-write-binlog option disables binlog.
---exec $MYSQL_UPGRADE --skip-write-binlog --skip-verbose --force --user=root > $MYSQLTEST_VARDIR/log/mysql_upgrade.log 2>&1
+#binlog is disabled by default.
+--exec $MYSQL_UPGRADE --skip-verbose --force --user=root > $MYSQLTEST_VARDIR/log/mysql_upgrade.log 2>&1
 sync_slave_with_master;
 
 connection master;
@@ -42,7 +42,8 @@ source include/wait_for_slave_sql_to_stop.inc;
 
 connection master;
 #With '--force' option, mysql_upgrade always executes all sql statements for upgrading.
---exec $MYSQL_UPGRADE --skip-verbose --force --user=root > $MYSQLTEST_VARDIR/log/mysql_upgrade.log 2>&1
+#--write-binlog option enables binlog.
+--exec $MYSQL_UPGRADE --write-binlog --skip-verbose --force --user=root > $MYSQLTEST_VARDIR/log/mysql_upgrade.log 2>&1
 
 connection master;
 let $after_file= query_get_value(SHOW MASTER STATUS, File, 1);

--- a/mysql-test/t/mysql_upgrade.test
+++ b/mysql-test/t/mysql_upgrade.test
@@ -124,6 +124,13 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 # so the following command should never fail.
 --remove_file $MYSQLD_DATADIR/mysql_upgrade_info
 
+--echo # Running mysql_upgrade with --write-binlog..
+--replace_result $MYSQLTEST_VARDIR var
+--exec $MYSQL_UPGRADE --skip-verbose --write-binlog
+
+# mysql_upgrade must have created mysql_upgrade_info file,
+# so the following command should never fail.
+--remove_file $MYSQLD_DATADIR/mysql_upgrade_info
 
 --echo #
 --echo # Bug #21489398: MYSQL_UPGRADE: FATAL ERROR: UPGRADE FAILED - IMPROVE ERROR


### PR DESCRIPTION
…DE=ON

mysql_upgrade fails when server is running with gtid_mode=ON and
--disable-gtid-unsafe-statements because system tables are stored
using MyISAM.

Changed default logging behaviour of mysql_upgrade, disabling it
by default. Logging can still be enable using the option
--write-binlog.
Actions taken by mysql_upgrade depend on the server version, them
should not be replicated to slaves.

http://jenkins.percona.com/job/percona-server-5.5-param/1385/
