### PR TITLE
Bug 1620152: The audit log plugin uses too much memory

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -421,6 +421,10 @@ DECLARE_MYSQL_THDVAR_SIMPLE(name, double) = { \
 #define THDVAR(thd, name) \
   (*(MYSQL_SYSVAR_NAME(name).resolve(thd, MYSQL_SYSVAR_NAME(name).offset)))
 
+#define THDVAR_SET(thd, name, value) \
+  plugin_thdvar_safe_update(thd, MYSQL_SYSVAR(name), \
+                            (char **) &THDVAR(thd, name), \
+                            (const char *) value);
 
 /*
   Plugin description structure.

--- a/mysql-test/r/plugin.result
+++ b/mysql-test/r/plugin.result
@@ -38,9 +38,11 @@ Variable_name	Value
 example_func_example	enum_var is 0, ulong_var is 500, double_var is 8.500000, really
 show variables like 'example%';
 Variable_name	Value
+example_create_count_thdvar	1
 example_double_thdvar	8.500000
 example_double_var	8.500000
 example_enum_var	e1
+example_last_create_thdvar	Last creation './test/t1'
 example_ulong_var	500
 UNINSTALL PLUGIN example;
 UNINSTALL PLUGIN EXAMPLE;
@@ -232,3 +234,26 @@ DROP PROCEDURE p_install;
 SET DEBUG_SYNC='RESET';
 disconnect con1;
 disconnect con2;
+#
+# Bug #19917521: MEMORY LEAK WITH STRING THREAD VARIABLE 
+#                THAT SET MEMALLOC FLAG
+#
+INSTALL PLUGIN example SONAME 'ha_example.so';
+SET SESSION example_create_count_thdvar = 0;
+SET SESSION example_last_create_thdvar = '';
+CREATE TABLE t10(a INT) ENGINE=EXAMPLE;
+SELECT @@SESSION.example_create_count_thdvar;
+@@SESSION.example_create_count_thdvar
+1
+SELECT @@SESSION.example_last_create_thdvar;
+@@SESSION.example_last_create_thdvar
+Last creation './test/t10'
+CREATE TABLE t20(a INT) ENGINE=EXAMPLE;
+SELECT @@SESSION.example_create_count_thdvar;
+@@SESSION.example_create_count_thdvar
+2
+SELECT @@SESSION.example_last_create_thdvar;
+@@SESSION.example_last_create_thdvar
+Last creation './test/t20'
+DROP TABLE t10, t20;
+UNINSTALL PLUGIN example;

--- a/mysql-test/t/plugin.test
+++ b/mysql-test/t/plugin.test
@@ -277,3 +277,25 @@ disconnect con1;
 disconnect con2;
 
 --disable_connect_log
+
+--echo #
+--echo # Bug #19917521: MEMORY LEAK WITH STRING THREAD VARIABLE 
+--echo #                THAT SET MEMALLOC FLAG
+--echo #
+--replace_regex /\.dll/.so/
+eval INSTALL PLUGIN example SONAME '$EXAMPLE_PLUGIN';
+
+SET SESSION example_create_count_thdvar = 0;
+SET SESSION example_last_create_thdvar = '';
+
+CREATE TABLE t10(a INT) ENGINE=EXAMPLE;
+SELECT @@SESSION.example_create_count_thdvar;
+SELECT @@SESSION.example_last_create_thdvar;
+
+CREATE TABLE t20(a INT) ENGINE=EXAMPLE;
+SELECT @@SESSION.example_create_count_thdvar;
+SELECT @@SESSION.example_last_create_thdvar;
+
+DROP TABLE t10, t20;
+
+UNINSTALL PLUGIN example;

--- a/plugin/audit_log/filter.c
+++ b/plugin/audit_log/filter.c
@@ -170,6 +170,7 @@ void account_list_from_string(HASH *hash, const char *string)
   {
     size_t entry_length= 0;
     my_bool quote= FALSE;
+    account *acc;
 
     while (*entry == ' ')
       entry++;
@@ -190,8 +191,9 @@ void account_list_from_string(HASH *hash, const char *string)
     unquote_string(host, &host_length);
     my_casedn_str(&my_charset_utf8_general_ci, host);
 
-    my_hash_insert(hash,
-        (uchar*) account_create(user, user_length, host, host_length));
+    acc= account_create(user, user_length, host, host_length);
+    if (my_hash_insert(hash, (uchar*) acc))
+      my_free(acc);
 
     entry+= entry_length + 1;
   }
@@ -223,7 +225,8 @@ void command_list_from_string(HASH *hash, const char *string)
     {
       command *cmd= command_create(entry, len);
       my_casedn_str(&my_charset_utf8_general_ci, cmd->name);
-      my_hash_insert(hash, (uchar*) cmd);
+      if (my_hash_insert(hash, (uchar*) cmd))
+        my_free(cmd);
     }
 
     entry+= len;

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -3078,6 +3078,34 @@ static bool plugin_var_memalloc_session_update(THD *thd,
 
 
 /**
+  Set value for a thread local variable.
+
+  @param[in]     thd   Thread context.
+  @param[in]     var   Plugin variable.
+  @param[in,out] dest  Destination memory pointer.
+  @param[in]     value New value.
+
+  Note: new value should be '\0'-terminated for string variables.
+
+  Used in plugin.h:THDVAR_SET(thd, name, value) macro.
+*/
+
+void plugin_thdvar_safe_update(THD *thd, st_mysql_sys_var *var, char **dest, const char *value)
+{
+  DBUG_ASSERT(thd == current_thd);
+
+  if (var->flags & PLUGIN_VAR_THDLOCAL)
+  {
+    if ((var->flags & PLUGIN_VAR_TYPEMASK) == PLUGIN_VAR_STR &&
+        var->flags & PLUGIN_VAR_MEMALLOC)
+      plugin_var_memalloc_session_update(thd, var, dest, value);
+    else
+      var->update(thd, var, dest, value);
+  }
+}
+
+
+/**
   Free all elements allocated by plugin_var_memalloc_session_update().
 
   @param[in]     vars  system variables structure

--- a/sql/sql_plugin.h
+++ b/sql/sql_plugin.h
@@ -160,6 +160,8 @@ extern bool mysql_uninstall_plugin(THD *thd, const LEX_STRING *name);
 extern bool plugin_register_builtin(struct st_mysql_plugin *plugin);
 extern void plugin_thdvar_init(THD *thd, bool enable_plugins);
 extern void plugin_thdvar_cleanup(THD *thd);
+extern "C" void plugin_thdvar_safe_update(THD *thd, st_mysql_sys_var *var,
+                                          char **dest, const char *value);
 extern SHOW_COMP_OPTION plugin_status(const char *name, size_t len, int type);
 extern bool check_valid_path(const char *path, size_t length);
 

--- a/storage/example/ha_example.cc
+++ b/storage/example/ha_example.cc
@@ -879,6 +879,26 @@ ha_rows ha_example::records_in_range(uint inx, key_range *min_key,
 }
 
 
+static MYSQL_THDVAR_STR(
+  last_create_thdvar,
+  PLUGIN_VAR_MEMALLOC,
+  NULL,
+  NULL,
+  NULL,
+  NULL);
+
+static MYSQL_THDVAR_UINT(
+  create_count_thdvar,
+  0,
+  NULL,
+  NULL,
+  NULL,
+  0,
+  0,
+  1000,
+  0);
+
+
 /**
   @brief
   create() is called to create a database. The variable name will have the name
@@ -906,6 +926,19 @@ int ha_example::create(const char *name, TABLE *table_arg,
     This is not implemented but we want someone to be able to see that it
     works.
   */
+
+  /*
+    It's just an example of THDVAR_SET() usage below.
+  */
+  THD *thd = ha_thd();
+  char *buf = (char *) my_malloc(SHOW_VAR_FUNC_BUFF_SIZE, MYF(MY_FAE));
+  my_snprintf(buf, SHOW_VAR_FUNC_BUFF_SIZE, "Last creation '%s'", name);
+  THDVAR_SET(thd, last_create_thdvar, buf);
+  my_free(buf);
+
+  uint count= THDVAR(thd, create_count_thdvar) + 1;
+  THDVAR_SET(thd, create_count_thdvar, &count);
+
   DBUG_RETURN(0);
 }
 
@@ -978,6 +1011,8 @@ static struct st_mysql_sys_var* example_system_variables[]= {
   MYSQL_SYSVAR(ulong_var),
   MYSQL_SYSVAR(double_var),
   MYSQL_SYSVAR(double_thdvar),
+  MYSQL_SYSVAR(last_create_thdvar),
+  MYSQL_SYSVAR(create_count_thdvar),
   NULL
 };
 


### PR DESCRIPTION
1. Backport fix for bug #19917521 from MySQL 8.
2. Fix memory leaks in audit plugin using THDVAR_SET.
3. Fix memory leaks when non-unique keys inserted into the hash table.
