### PR TITLE
BUG#16906827-CAN'T SET QUERY_CACHE_TYPE TO 0 WHEN IT IS ALREADY 0

### DIFF
--- a/mysql-test/r/query_cache_disabled.result
+++ b/mysql-test/r/query_cache_disabled.result
@@ -6,9 +6,28 @@ ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1
 SET GLOBAL query_cache_type=DEMAND;
 ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
 SET GLOBAL query_cache_type=OFF;
-ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
 SET GLOBAL query_cache_size=1024*1024;
 SHOW GLOBAL VARIABLES LIKE 'query_cache_size';
 Variable_name	Value
 query_cache_size	1048576
 SET GLOBAL query_cache_size=DEFAULT;
+#
+# BUG#16906827 - CAN'T SET QUERY_CACHE_TYPE TO 0 WHEN IT IS ALREADY 0
+#
+SHOW GLOBAL VARIABLES LIKE 'query_cache_type';
+Variable_name	Value
+query_cache_type	OFF
+# This statement will pass if run with the fix and fail with 
+# ER_QUERY_CACHE_DISABLED if run without the fix.
+SET GLOBAL query_cache_type=OFF;
+SET GLOBAL query_cache_type=ON;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
+SET GLOBAL query_cache_type=DEMAND;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
+# This statement will pass if run with the fix and fail with 
+# ER_QUERY_CACHE_DISABLED if run without the fix.
+SET SESSION query_cache_type=OFF;
+SET SESSION query_cache_type=ON;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it
+SET SESSION query_cache_type=DEMAND;
+ERROR HY000: Query cache is disabled; restart the server with query_cache_type=1 to enable it

--- a/mysql-test/t/query_cache_disabled.test
+++ b/mysql-test/t/query_cache_disabled.test
@@ -7,8 +7,26 @@ SHOW GLOBAL VARIABLES LIKE 'query_cache_type';
 SET GLOBAL query_cache_type=ON;
 --error ER_QUERY_CACHE_DISABLED
 SET GLOBAL query_cache_type=DEMAND;
---error ER_QUERY_CACHE_DISABLED
 SET GLOBAL query_cache_type=OFF;
 SET GLOBAL query_cache_size=1024*1024;
 SHOW GLOBAL VARIABLES LIKE 'query_cache_size';
 SET GLOBAL query_cache_size=DEFAULT;
+
+--echo #
+--echo # BUG#16906827 - CAN'T SET QUERY_CACHE_TYPE TO 0 WHEN IT IS ALREADY 0
+--echo #
+SHOW GLOBAL VARIABLES LIKE 'query_cache_type';
+--echo # This statement will pass if run with the fix and fail with 
+--echo # ER_QUERY_CACHE_DISABLED if run without the fix.
+SET GLOBAL query_cache_type=OFF;
+--error ER_QUERY_CACHE_DISABLED
+SET GLOBAL query_cache_type=ON;
+--error ER_QUERY_CACHE_DISABLED
+SET GLOBAL query_cache_type=DEMAND;
+--echo # This statement will pass if run with the fix and fail with 
+--echo # ER_QUERY_CACHE_DISABLED if run without the fix.
+SET SESSION query_cache_type=OFF;
+--error ER_QUERY_CACHE_DISABLED
+SET SESSION query_cache_type=ON;
+--error ER_QUERY_CACHE_DISABLED
+SET SESSION query_cache_type=DEMAND;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2746,7 +2746,13 @@ static Sys_var_ulong Sys_query_cache_min_res_unit(
 static const char *query_cache_type_names[]= { "OFF", "ON", "DEMAND", 0 };
 static bool check_query_cache_type(sys_var *self, THD *thd, set_var *var)
 {
-  if (query_cache.is_disabled())
+  /*
+   Setting it to 0 (or OFF) is always OK, even if the query cache
+   is disabled.
+  */
+  if (var->save_result.ulonglong_value == 0)
+    return false;
+  else if (query_cache.is_disabled())
   {
     my_error(ER_QUERY_CACHE_DISABLED, MYF(0));
     return true;


### PR DESCRIPTION
BACKGROUND:
The crux of the problem reported in the bug report is User 
does not want to see the error message when the server is 
started with query cache disabled and User is disabling the
query cache by setting query_cache_type to 0 during runtime 
(in client session).

ANALYSIS:
The check in check_query_cache_type() function was throwing
error for all three values 0, 1 or 2 when query cache is disabled.
According to the bug or user requirement, User wants to bypass 
this error check when we are setting query_cache_type to 0 (or OFF)
during runtime when it is already disabled 0 (or OFF) during startup.

FIX:
As a fix for this bug, the check in check_query_cache_type() 
function is modified to take into account to _NOT_ throw the 
error when we are setting it 0 (or OFF) when query cache is 
already disabled.

http://jenkins.percona.com/job/percona-server-5.6-param/1402/
