### PR TITLE
Work towards diagnosing bug 1625466 (Test innodb.percona_changed_page…

### DIFF
--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -1198,7 +1198,9 @@ log_online_write_bitmap(void)
 			rbt_next(log_bmp_sys->modified_pages, bmp_tree_node);
 
 		DBUG_EXECUTE_IF("bitmap_page_2_write_error",
-				DBUG_SET("+d,bitmap_page_write_error"););
+				ut_ad(bmp_tree_node); /* 2nd page must exist */
+				DBUG_SET("+d,bitmap_page_write_error");
+				DBUG_SET("-d,bitmap_page_2_write_error"););
 	}
 
 	rbt_reset(log_bmp_sys->modified_pages);
@@ -1566,9 +1568,12 @@ log_online_diagnose_bitmap_eof(
 			/* It's a "Warning" here because it's not a fatal error
 			for the whole server */
 			ib_logf(IB_LOG_LEVEL_WARN,
-				"changed page bitmap file \'%s\' does not "
-				"contain a complete run at the end.",
-				bitmap_file->name);
+				"changed page bitmap file \'%s\', size "
+				UINT64PF " bytes, does not "
+				"contain a complete run at the next read "
+				"offset " UINT64PF,
+				bitmap_file->name, bitmap_file->size,
+				bitmap_file->offset);
 			return FALSE;
 		}
 	}


### PR DESCRIPTION
…_bmp_debug is unstable (failure to find system record))

Add bitmap file size and read offset to the "incomplete run at the
end" diagnostics. Tighten the conditions for the
bitmap_page_2_write_error debug injection.

Commit on trunk instead of GCA to include other recent percona_changed_page_bmp_debug fixes.
http://jenkins.percona.com/job/percona-server-5.6-param/1406/
