### PR TITLE
Work towards diagnosing bug 1625466 (Test innodb.percona_changed_page…

### DIFF
--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -1209,7 +1209,9 @@ log_online_write_bitmap(void)
 			rbt_next(log_bmp_sys->modified_pages, bmp_tree_node);
 
 		DBUG_EXECUTE_IF("bitmap_page_2_write_error",
-				DBUG_SET("+d,bitmap_page_write_error"););
+				ut_ad(bmp_tree_node); /* 2nd page must exist */
+				DBUG_SET("+d,bitmap_page_write_error");
+				DBUG_SET("-d,bitmap_page_2_write_error"););
 	}
 
 	rbt_reset(log_bmp_sys->modified_pages);
@@ -1575,8 +1577,10 @@ log_online_diagnose_bitmap_eof(
 			/* It's a "Warning" here because it's not a fatal error
 			for the whole server */
 			ib::warn() << "Changed page bitmap file \'"
-				   << bitmap_file->name << "\' does not "
-				"contain a complete run at the end.";
+				   << bitmap_file->name << "\', size "
+				   << bitmap_file->size << " bytes, does not "
+				"contain a complete run at the next read "
+				"offset " << bitmap_file->offset;
 			return false;
 		}
 	}


### PR DESCRIPTION
…_bmp_debug is unstable (failure to find system record))

Add bitmap file size and read offset to the "incomplete run at the
end" diagnostics. Tighten the conditions for the
bitmap_page_2_write_error debug injection.

Cherry-pick, not a merge as the 5.6 change is not GCA
http://jenkins.percona.com/job/mysql-5.7-param/435/
