### PR TITLE
Fix bug 1626069 (LRU manager thread might run too long on server shut…

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2568,6 +2568,11 @@ page_cleaner_sleep_if_needed(
 	ulint	next_loop_time)	/*!< in: time when next loop iteration
 				should start */
 {
+	/* No sleep if we are cleaning the buffer pool during the shutdown
+	with everything else finished */
+	if (srv_shutdown_state == SRV_SHUTDOWN_FLUSH_PHASE)
+		return;
+
 	ulint	cur_time = ut_time_ms();
 
 	if (next_loop_time > cur_time) {

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -3490,7 +3490,7 @@ loop:
 	before proceeding further. */
 	srv_shutdown_state = SRV_SHUTDOWN_FLUSH_PHASE;
 	count = 0;
-	while (buf_page_cleaner_is_active) {
+	while (buf_page_cleaner_is_active || buf_lru_manager_is_active) {
 		++count;
 		os_thread_sleep(100000);
 		if (srv_print_verbose_log && count > 600) {


### PR DESCRIPTION
…down)

Synchronize server shutdown thread with LRU manager thread quitting:
- during SRV_SHUTDOWN_FLUSH_PHASE, wait for it to quit, in addition to
  checking whether the page cleaner thread has quit;
- adjust sleep heuristics for both cleaner and LRU manager threads to
  skip any sleeps during SRV_SHUTDOWN_FLUSH_PHASE.

http://jenkins.percona.com/job/percona-server-5.6-param/1409/
