### PR TITLE
Fix bug 1626500 (Test rpl.rpl_percona_bug1070255 is unstable)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_percona_bug1070255.result
+++ b/mysql-test/suite/rpl/r/rpl_percona_bug1070255.result
@@ -1,15 +1,21 @@
 include/master-slave.inc
 [connection master]
+set @saved_debug= @@global.debug;
 set global DEBUG='+d,dbug_table_map_id_500';
 CREATE TABLE t2 (a INT PRIMARY KEY, b VARCHAR(20));
 INSERT INTO t2 VALUES(1, '1');
+set global DEBUG='-d,dbug_table_map_id_500';
 set global DEBUG='+d,dbug_table_map_id_4B_UINT_MAX+501';
 CREATE TABLE t3 (a INT PRIMARY KEY, b VARCHAR(20));
 INSERT INTO t3 VALUES(1, '1');
+set global DEBUG='-d,dbug_table_map_id_4B_UINT_MAX+501';
 set global DEBUG='+d,dbug_table_map_id_6B_UINT_MAX';
 CREATE TABLE t4 (a INT PRIMARY KEY, b VARCHAR(20));
 INSERT INTO t4 VALUES(1, '1');
 UPDATE t2, t3, t4 SET t2.b='tt2', t3.b='tt3', t4.b='tt4' WHERE t2.a=t3.a and t2.a=t4.a;
+set global DEBUG='-d,dbug_table_map_id_6B_UINT_MAX';
+set global DEBUG=@saved_debug;
+include/start_slave.inc
 SELECT * FROM t2;
 a	b
 1	tt2
@@ -28,10 +34,7 @@ SELECT * FROM t3;
 a	b
 SELECT * FROM t4;
 a	b
-include/stop_slave.inc
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
-set global DEBUG='';
-include/start_slave.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_percona_bug1070255.test
+++ b/mysql-test/suite/rpl/t/rpl_percona_bug1070255.test
@@ -4,24 +4,34 @@
 
 source include/have_debug.inc;
 source include/have_binlog_format_row.inc;
+--let $rpl_skip_start_slave= 1
 source include/master-slave.inc;
 
 connection master;
 
+set @saved_debug= @@global.debug;
 set global DEBUG='+d,dbug_table_map_id_500';
 CREATE TABLE t2 (a INT PRIMARY KEY, b VARCHAR(20));
 INSERT INTO t2 VALUES(1, '1');
 
+set global DEBUG='-d,dbug_table_map_id_500';
 set global DEBUG='+d,dbug_table_map_id_4B_UINT_MAX+501';
 CREATE TABLE t3 (a INT PRIMARY KEY, b VARCHAR(20));
 INSERT INTO t3 VALUES(1, '1');
 
+set global DEBUG='-d,dbug_table_map_id_4B_UINT_MAX+501';
 set global DEBUG='+d,dbug_table_map_id_6B_UINT_MAX';
 CREATE TABLE t4 (a INT PRIMARY KEY, b VARCHAR(20));
 INSERT INTO t4 VALUES(1, '1');
 
 UPDATE t2, t3, t4 SET t2.b='tt2', t3.b='tt3', t4.b='tt4' WHERE t2.a=t3.a and t2.a=t4.a;
 
+set global DEBUG='-d,dbug_table_map_id_6B_UINT_MAX';
+set global DEBUG=@saved_debug;
+
+--connection slave
+--source include/start_slave.inc
+--connection master
 sync_slave_with_master;
 
 SELECT * FROM t2;
@@ -40,19 +50,10 @@ SELECT * FROM t2;
 SELECT * FROM t3;
 SELECT * FROM t4;
 
---source include/stop_slave.inc
-
 connection master;
 
 DROP TABLE t2;
 DROP TABLE t3;
 DROP TABLE t4;
-
-# Needs to happen with slave stopped, see Oracle bug 58754
-set global DEBUG='';
-
-connection slave;
-
---source include/start_slave.inc
 
 --source include/rpl_end.inc


### PR DESCRIPTION
Rewrite the testcase to
- avoid updating global DEBUG variable while a slave is connected to
  master;
- save and restore DEBUG around modifications;
- pop DEBUG states before pushined new ones.

http://jenkins.percona.com/job/percona-server-5.5-param/1390/
