### PR TITLE
DB-1012: Add read-free-replication support for TokuDB partition table

### DIFF
--- a/mysql-test/suite/tokudb.rpl/r/rpl_tokudb_rfr_partition_table.result
+++ b/mysql-test/suite/tokudb.rpl/r/rpl_tokudb_rfr_partition_table.result
@@ -1,0 +1,36 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+call mtr.add_suppression(".*read free replication is disabled for TokuDB table.*continue with rows lookup");
+CREATE TABLE t1 (id int(11) NOT NULL, pid int(11), PRIMARY KEY (id)) ENGINE=TokuDB
+PARTITION BY RANGE (id)
+(PARTITION p_1 VALUES LESS THAN (10) ENGINE = TokuDB,
+PARTITION p_2 VALUES LESS THAN (20) ENGINE = TokuDB,
+PARTITION p_all VALUES LESS THAN MAXVALUE ENGINE = TokuDB);
+insert into t1 values (1, 1), (2, 2), (3, 3), (11, 11), (12, 12), (13, 13);
+CREATE TABLE t2 (id int(11) NOT NULL, pid int(11), key idx_1(id)) ENGINE=TokuDB
+PARTITION BY RANGE (id)
+(PARTITION p_1 VALUES LESS THAN (10) ENGINE = TokuDB,
+PARTITION p_2 VALUES LESS THAN (20) ENGINE = TokuDB,
+PARTITION p_all VALUES LESS THAN MAXVALUE ENGINE = TokuDB);
+insert into t2 values (1, 1), (2, 2), (3, 3), (11, 11), (12, 12), (13, 13);
+include/stop_slave.inc
+set global debug= "+d,tokudb_crash_if_rpl_looks_up_row,tokudb_crash_if_rpl_does_uniqueness_check";
+include/start_slave.inc
+insert into t1 values(21, 21);
+delete from t1 where id = 11;
+update t1 set pid = 2 where id = 1;
+include/diff_tables.inc [master:test.t1, slave:test.t1]
+insert into t2 values(21, 21);
+delete from t2 where id = 11;
+update t2 set pid = 2 where id = 1;
+include/diff_tables.inc [master:test.t2, slave:test.t2]
+drop table t1;
+drop table t2;
+include/stop_slave.inc
+set global debug= "-d,tokudb_crash_if_rpl_looks_up_row,tokudb_crash_if_rpl_does_uniqueness_check";
+set global debug= @saved_debug;
+include/start_slave.inc
+include/rpl_end.inc

--- a/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_rfr_partition_table-slave.opt
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_rfr_partition_table-slave.opt
@@ -1,0 +1,1 @@
+--read-only=ON --loose-tokudb-rpl-unique-checks=OFF  --loose-tokudb-rpl-lookup-rows=OFF

--- a/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_rfr_partition_table.test
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_rfr_partition_table.test
@@ -1,0 +1,74 @@
+# test tokudb read free replication feature with partition table
+
+--source include/have_debug.inc
+--source include/have_tokudb.inc
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+call mtr.add_suppression(".*read free replication is disabled for TokuDB table.*continue with rows lookup");
+
+connection master;
+
+# partition table with explicit PK
+CREATE TABLE t1 (id int(11) NOT NULL, pid int(11), PRIMARY KEY (id)) ENGINE=TokuDB
+PARTITION BY RANGE (id)
+(PARTITION p_1 VALUES LESS THAN (10) ENGINE = TokuDB,
+ PARTITION p_2 VALUES LESS THAN (20) ENGINE = TokuDB,
+ PARTITION p_all VALUES LESS THAN MAXVALUE ENGINE = TokuDB);
+
+insert into t1 values (1, 1), (2, 2), (3, 3), (11, 11), (12, 12), (13, 13);
+
+# partition table without explicit PK
+CREATE TABLE t2 (id int(11) NOT NULL, pid int(11), key idx_1(id)) ENGINE=TokuDB
+PARTITION BY RANGE (id)
+(PARTITION p_1 VALUES LESS THAN (10) ENGINE = TokuDB,
+ PARTITION p_2 VALUES LESS THAN (20) ENGINE = TokuDB,
+ PARTITION p_all VALUES LESS THAN MAXVALUE ENGINE = TokuDB);
+
+insert into t2 values (1, 1), (2, 2), (3, 3), (11, 11), (12, 12), (13, 13);
+
+--sync_slave_with_master
+
+# set tokudb rfr crash/assert conditions if we enter lookup code
+# to make sure no unique checks or row lookups is invoked
+connection slave;
+--source include/stop_slave.inc
+let $saved_debug = `select @@debug`;
+set global debug= "+d,tokudb_crash_if_rpl_looks_up_row,tokudb_crash_if_rpl_does_uniqueness_check";
+--source include/start_slave.inc
+
+connection master;
+insert into t1 values(21, 21);
+delete from t1 where id = 11;
+update t1 set pid = 2 where id = 1;
+
+sync_slave_with_master;
+
+connection master;
+
+--let $diff_tables= master:test.t1, slave:test.t1
+--source include/diff_tables.inc
+
+# print rfr disabled warning in errlog
+connection master;
+insert into t2 values(21, 21);
+delete from t2 where id = 11;
+update t2 set pid = 2 where id = 1;
+
+sync_slave_with_master;
+
+--let $diff_tables= master:test.t2, slave:test.t2
+--source include/diff_tables.inc
+
+connection master;
+drop table t1;
+drop table t2;
+sync_slave_with_master;
+
+connection slave;
+--source include/stop_slave.inc
+set global debug= "-d,tokudb_crash_if_rpl_looks_up_row,tokudb_crash_if_rpl_does_uniqueness_check";
+set global debug= @saved_debug;
+--source include/start_slave.inc
+
+--source include/rpl_end.inc

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -4089,10 +4089,14 @@ int ha_partition::update_row(const uchar *old_data, uchar *new_data)
     error instead of correcting m_last_part, to make the user aware of the
     problem!
 
+    For TokuDB Read-Free-Replication optimization, there is no need to do
+    a read before update(row lookup is omitted), so m_last_part is not
+    necessarily same with old_part_id.
+
     Notice that HA_READ_BEFORE_WRITE_REMOVAL does not require this protocol,
     so this is not supported for this engine.
   */
-  if (old_part_id != m_last_part)
+  if (old_part_id != m_last_part && rpl_lookup_rows())
   {
     m_err_rec= old_data;
     DBUG_RETURN(HA_ERR_ROW_IN_WRONG_PARTITION);
@@ -4229,13 +4233,17 @@ int ha_partition::delete_row(const uchar *buf)
     error instead of forwarding the delete to the correct (m_last_part)
     partition!
 
+    For TokuDB Read-Free-Replication optimization, there is no need to do
+    a read before delete(row lookup is omitted), so m_last_part is not
+    necessarily same with part_id.
+
     Notice that HA_READ_BEFORE_WRITE_REMOVAL does not require this protocol,
     so this is not supported for this engine.
 
     TODO: change the assert in InnoDB into an error instead and make this one
     an assert instead and remove the get_part_for_delete()!
   */
-  if (part_id != m_last_part)
+  if (part_id != m_last_part && rpl_lookup_rows())
   {
     m_err_rec= buf;
     DBUG_RETURN(HA_ERR_ROW_IN_WRONG_PARTITION);
@@ -9035,6 +9043,92 @@ int ha_partition::check_for_upgrade(HA_CHECK_OPT *check_opt)
   DBUG_RETURN(error);
 }
 
+
+/*
+  We don't know which partition table will be updated before executing
+  Write_rows_log_event, so update all partitions.
+*/
+void ha_partition::rpl_before_write_rows()
+{
+  uint i;
+  for (i= 0; i < m_tot_parts; i++)
+  {
+    m_file[i]->rpl_before_write_rows();
+  }
+}
+
+/*
+  Clear flag of all partitions after executing Write_rows_log_event.
+*/
+void ha_partition::rpl_after_write_rows()
+{
+  uint i;
+  for (i= 0; i < m_tot_parts; i++)
+  {
+    m_file[i]->rpl_after_write_rows();
+  }
+}
+
+/*
+  We don't know which partition table will be updated before executing
+  Delete_rows_log_event, so update all partitions.
+*/
+void ha_partition::rpl_before_delete_rows()
+{
+
+  uint i;
+  for (i= 0; i < m_tot_parts; i++)
+  {
+    m_file[i]->rpl_before_delete_rows();
+  }
+}
+
+/*
+  Clear flag of all partitions after executing Delete_rows_log_event.
+*/
+void ha_partition::rpl_after_delete_rows()
+{
+  uint i;
+  for (i= 0; i < m_tot_parts; i++)
+  {
+    m_file[i]->rpl_after_delete_rows();
+  }
+}
+
+/*
+  We don't know which partition table will be updated before executing
+  Update_rows_log_event, so update all partitions.
+*/
+void ha_partition::rpl_before_update_rows()
+{
+  uint i;
+  for (i= 0; i < m_tot_parts; i++)
+  {
+    m_file[i]->rpl_before_update_rows();
+  }
+}
+
+/*
+  Clear flag of all partitions after executing Update_rows_log_event.
+*/
+void ha_partition::rpl_after_update_rows()
+{
+  uint i;
+  for (i= 0; i < m_tot_parts; i++)
+  {
+    m_file[i]->rpl_after_update_rows();
+  }
+}
+
+/*
+  Check whether we need to perform row lookup when executing
+  Update_rows_log_event or Delete_rows_log_event. Use the 1st
+  partition is enough, see @c ha_tokudb::rpl_lookup_rows().
+*/
+bool ha_partition::rpl_lookup_rows()
+{
+  return m_file[0]->rpl_lookup_rows();
+}
 
 struct st_mysql_storage_engine partition_storage_engine=
 { MYSQL_HANDLERTON_INTERFACE_VERSION };

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -1244,6 +1244,15 @@ public:
     -------------------------------------------------------------------------
     virtual void append_create_info(String *packet)
   */
+
+    /* For TokuDB Read Free Replication */
+    void rpl_before_write_rows();
+    void rpl_after_write_rows();
+    void rpl_before_delete_rows();
+    void rpl_after_delete_rows();
+    void rpl_before_update_rows();
+    void rpl_after_update_rows();
+    bool rpl_lookup_rows();
 };
 
 #endif /* HA_PARTITION_INCLUDED */

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -10020,8 +10020,11 @@ Rows_log_event::decide_row_lookup_algorithm_and_key()
                                       get_flags(COMPLETE_ROWS_F) &&
                                       !m_table->file->rpl_lookup_rows())))
   {
+    /**
+       Only TokuDB engine can satisfy delete/update row lookup optimization,
+       so we don't need to check engine type here.
+    */
     if (delete_update_lookup_condition &&
-        table->file->ht->db_type == DB_TYPE_TOKUDB &&
         table->s->primary_key == MAX_KEY)
     {
         if (!table->s->rfr_lookup_warning)

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -3695,6 +3695,8 @@ int ha_tokudb::do_uniqueness_checks(uchar* record, DB_TXN* txn, THD* thd) {
     // first do uniqueness checks
     //
     if (share->has_unique_keys && do_unique_checks(thd, in_rpl_write_rows)) {
+        DBUG_EXECUTE_IF("tokudb_crash_if_rpl_does_uniqueness_check",
+                        DBUG_ASSERT(0););
         for (uint keynr = 0; keynr < table_share->keys; keynr++) {
             bool is_unique_key = (table->key_info[keynr].flags & HA_NOSAME) || (keynr == primary_key);
             bool is_unique = false;
@@ -5915,6 +5917,7 @@ int ha_tokudb::rnd_pos(uchar * buf, uchar * pos) {
     // test rpl slave by inducing a delay before the point query
     THD *thd = ha_thd();
     if (thd->slave_thread && (in_rpl_delete_rows || in_rpl_update_rows)) {
+        DBUG_EXECUTE_IF("tokudb_crash_if_rpl_looks_up_row", DBUG_ASSERT(0););
         uint64_t delay_ms = tokudb::sysvars::rpl_lookup_rows_delay(thd);
         if (delay_ms)
             usleep(delay_ms * 1000);


### PR DESCRIPTION
Copyright (c) <2016>, <Fungo Wang> All rights reserved.

Redistribution and use in source and binary forms, with or without
modification, are permitted provided that the following conditions
are met:
1. Redistributions of source code must retain the above copyright
   notice, this list of conditions and the following disclaimer.
2. Redistributions in binary form must reproduce the above copyright
   notice, this list of conditions and the following disclaimer in the
   documentation and/or other materials provided with the distribution.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
OF THE POSSIBILITY OF SUCH DAMAGE.
