### PR TITLE
Work towards diagnosing bug 1628079 (Intemittent hangs on shutdown, A…

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -4819,10 +4819,10 @@ void do_shutdown_server(struct st_command *command)
   DBUG_PRINT("info", ("Killing server, pid: %d", pid));
   if (orig_timeout != 0)
   {
-    log_msg("shutdown_server timeout %ld exceeded, SIGKILL sent to the server",
+    log_msg("shutdown_server timeout %ld exceeded, SIGABRT sent to the server",
             orig_timeout);
   }
-  (void)my_kill(pid, 9);
+  (void)my_kill(pid, (orig_timeout != 0) ? SIGABRT : SIGKILL);
 
   DBUG_VOID_RETURN;
 


### PR DESCRIPTION
…San build)

If MTR shutdown_server times out, and the original timeout was not
zero, kill the server by SIGABRT rather than SIGSEGV, so that we get a
stacktrace.

http://jenkins.percona.com/job/percona-server-5.5-param/1391/
