### PR TITLE
Fix bug 1617150 (Test rpl.rpl_semi_sync_uninstall_plugin is unstable)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_uninstall_plugin.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_uninstall_plugin.result
@@ -28,7 +28,6 @@ include/stop_slave.inc
 SET GLOBAL rpl_semi_sync_slave_enabled = OFF;
 include/start_slave.inc
 UNINSTALL PLUGIN rpl_semi_sync_slave;
-include/assert.inc [semi sync master clients should be 0.]
 UNINSTALL PLUGIN rpl_semi_sync_master;
 CREATE TABLE t1(i int);
 INSERT INTO t1 values (3);

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_uninstall_plugin.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_uninstall_plugin.test
@@ -125,12 +125,11 @@ SET GLOBAL rpl_semi_sync_slave_enabled = OFF;
 # Step 4.4: Uninstall semi sync plugin, it should be successful now.
 UNINSTALL PLUGIN rpl_semi_sync_slave;
 
-# Step 4.5: On Master, check that semi sync slaves are now '0'.
+# Step 4.5: On Master, wait until semi sync slaves become '0'.
 --connection master
---let $master_clients=[show status like "Rpl_semi_sync_master_clients", Value, 1]
---let assert_cond= $master_clients = 0
---let assert_text= semi sync master clients should be 0.
---source include/assert.inc
+--let $status_var= Rpl_semi_sync_master_clients
+--let $status_var_value= 0
+--source include/wait_for_status_var.inc
 
 # Step 4.6: So uninstalling semi sync plugin should be allowed
 UNINSTALL PLUGIN rpl_semi_sync_master;


### PR DESCRIPTION
The instability is caused by a race condition between master server
disconnecting the async slave asynchronously, and the testcase
checking whether the disconnect has already completed. Replace the
assert with a wait for the disconnect to complete.

http://jenkins.percona.com/job/percona-server-5.5-param/1395/
