### PR TITLE
Bug#17922198 REMOVE OBSOLETE IFDEF HAVE_PURIFY CODE.

### DIFF
--- a/include/my_global.h
+++ b/include/my_global.h
@@ -1064,19 +1064,9 @@ typedef char		my_bool; /* Small bool */
 				  ((uint32) (uchar) (A)[0])))
 #define sint4korr(A)	(*((long *) (A)))
 #define uint2korr(A)	(*((uint16 *) (A)))
-#if defined(HAVE_purify) && !defined(_WIN32)
 #define uint3korr(A)	(uint32) (((uint32) ((uchar) (A)[0])) +\
 				  (((uint32) ((uchar) (A)[1])) << 8) +\
 				  (((uint32) ((uchar) (A)[2])) << 16))
-#else
-/*
-   ATTENTION !
-   
-    Please, note, uint3korr reads 4 bytes (not 3) !
-    It means, that you have to provide enough allocated space !
-*/
-#define uint3korr(A)	(long) (*((unsigned int *) (A)) & 0xFFFFFF)
-#endif /* HAVE_purify && !_WIN32 */
 #define uint4korr(A)	(*((uint32 *) (A)))
 #define uint5korr(A)	((ulonglong)(((uint32) ((uchar) (A)[0])) +\
 				    (((uint32) ((uchar) (A)[1])) << 8) +\


### PR DESCRIPTION
Patch #5
Remove special purify implementations of the uint3korr macro.

http://jenkins.percona.com/view/PS%205.5/job/percona-server-5.5-asan-param/64/
