### PR TITLE
Work towards diagnosing bug 1628431 (Test main.percona_log_slow_admin…

### DIFF
--- a/mysql-test/r/percona_log_slow_admin_statements.result
+++ b/mysql-test/r/percona_log_slow_admin_statements.result
@@ -6,8 +6,8 @@ SET GLOBAL log_slow_admin_statements=ON;
 [log_start.inc] percona_log_slow_admin_stmt_1
 ALTER TABLE t1 ADD INDEX a(a);
 [log_stop.inc] percona_log_slow_admin_stmt_1
-[log_grep.inc] file: percona_log_slow_admin_stmt_1 pattern: ALTER TABLE t1 ADD INDEX a\(a\);
-[log_grep.inc] lines:   1
+[log_grep.inc] file: percona_log_slow_admin_stmt_1 pattern: ALTER TABLE t1 ADD INDEX a\(a\); expected_matches: 1
+[log_grep.inc] found expected match count: 1
 SET GLOBAL log_slow_admin_statements=OFF;
 [log_start.inc] percona_log_slow_admin_stmt_2
 ALTER TABLE t1 DROP INDEX a;

--- a/mysql-test/t/percona_log_slow_admin_statements.test
+++ b/mysql-test/t/percona_log_slow_admin_statements.test
@@ -20,6 +20,7 @@ SET GLOBAL log_slow_admin_statements=ON;
 ALTER TABLE t1 ADD INDEX a(a);
 --source include/log_stop.inc
 --let grep_pattern=ALTER TABLE t1 ADD INDEX a\(a\);
+--let log_expected_matches= 1
 --source include/log_grep.inc
 
 #
@@ -31,6 +32,7 @@ SET GLOBAL log_slow_admin_statements=OFF;
 ALTER TABLE t1 DROP INDEX a;
 --source include/log_stop.inc
 --let grep_pattern=ALTER TABLE t1 DROP INDEX a;
+--let log_expected_matches= 0
 --source include/log_grep.inc
 
 SET GLOBAL log_slow_admin_statements=default;


### PR DESCRIPTION
…_statements is unstable)

Add expected match counts to the testcase, so that more info is dumped
on a failure.

http://jenkins.percona.com/job/percona-server-5.6-param/1426/
