### PR TITLE
Fix bug 1617586 (SELECT DISTINCT x...ORDER BY y LIMIT N,N crashes ser…

### DIFF
--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -2170,7 +2170,7 @@ test_if_skip_sort_order(JOIN_TAB *tab, ORDER *order, ha_rows select_limit,
       */
       DBUG_ASSERT(tab->quick() == save_quick || tab->quick() == NULL);
       tab->set_quick(qck);
-      if (qck)
+      if (qck && !no_changes)
         tab->set_type(calc_join_type(qck->get_type()));
     }
     order_direction= best_key_direction;


### PR DESCRIPTION
…ver)

Make the Percona Server / TokuDB-spefific test_if_skip_sort_order patch
honor the no_changes flag value if it desires to change the QEP.

http://jenkins.percona.com/job/mysql-5.7-param/456/

The testcase is 15K rows of customer data. If we succeed in reproducing the testcase with synthetic data, it will be added in a separate commit
