### PR TITLE
Fix bug 1629879 (Server won't start with innodb_force_recovery=6 beca…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_doublewrite.result
+++ b/mysql-test/suite/innodb/r/percona_doublewrite.result
@@ -29,3 +29,13 @@ xb_doublewrite
 # Test that zero-sized doublewrite file is diagnosed and accepted
 # restart:<hidden args>
 # restart
+#
+# Bug 1629879: Server won't start with innodb_force_recovery=6 because parallel doublewrite file exists
+#
+# Test that --innodb_force_recovery=6 fails to start with the doublewrite file present
+call mtr.add_suppression("InnoDB: Failed to find tablespace for table");
+SET GLOBAL innodb_fast_shutdown=2;
+# Test that --innodb_force_recovery=6 succeeds to start without the doublewrite file
+# restart:--innodb-force-recovery=6
+# Cleanup
+# restart

--- a/mysql-test/suite/innodb/t/percona_doublewrite.test
+++ b/mysql-test/suite/innodb/t/percona_doublewrite.test
@@ -115,6 +115,33 @@ EOF
 --source include/start_mysqld.inc
 --let SEARCH_PATTERN= Parallel doublewrite buffer is zero-sized
 --source include/search_pattern_in_file.inc
+--remove_file $SEARCH_FILE
 
 --let $restart_parameters=
 --source include/restart_mysqld.inc
+
+--echo #
+--echo # Bug 1629879: Server won't start with innodb_force_recovery=6 because parallel doublewrite file exists
+--echo #
+
+--echo # Test that --innodb_force_recovery=6 fails to start with the doublewrite file present
+call mtr.add_suppression("InnoDB: Failed to find tablespace for table");
+SET GLOBAL innodb_fast_shutdown=2;
+--source include/shutdown_mysqld.inc
+
+--error 1
+--exec $MYSQLD_CMD --innodb_force_recovery=6 $args
+--let SEARCH_PATTERN= please move away the file above
+--source include/search_pattern_in_file.inc
+--remove_file $SEARCH_FILE
+
+--echo # Test that --innodb_force_recovery=6 succeeds to start without the doublewrite file
+--move_file $DOUBLEWRITE_FILE $DOUBLEWRITE_FILE2
+--let $restart_parameters=restart:--innodb-force-recovery=6
+--source include/start_mysqld.inc
+
+--echo # Cleanup
+--source include/shutdown_mysqld.inc
+--move_file $DOUBLEWRITE_FILE2 $DOUBLEWRITE_FILE
+--let $restart_parameters=
+--source include/start_mysqld.inc

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -1514,6 +1514,14 @@ buf_parallel_dblwr_file_create(void)
 			ib::error() << "A parallel doublewrite file "
 				    << parallel_dblwr_buf.path
 				    << " found on startup.";
+			if (srv_force_recovery == SRV_FORCE_NO_LOG_REDO) {
+				ib::error() << "Since --innodb-force-recovery "
+					"is set to 6, which skips doublewrite "
+					"buffer recovery, please move away "
+					"the file above and restore it before "
+					"attempting a lower forced recovery "
+					"setting";
+			}
 		}
 		return(DB_ERROR);
 	}


### PR DESCRIPTION
…use parallel doublewrite file exists)

With --innodb_force_recovery=6, the doublewrite buffer recovery is
skipped. But the instance may still write to the doublewrite buffer,
potentially overwriting the uncovered pages. With the parallel
doublewrite, the server already refuses to startup with
--innodb_force_recovery=6 if the doublewrite buffer file is present,
preventing the overwite of the uncovered pages. However the error
message is not intuitive, thus improve it.
