### PR TITLE
Fix bug 1633061 (Test main.mysqltest is unstable)

### DIFF
--- a/mysql-test/r/mysqltest.result
+++ b/mysql-test/r/mysqltest.result
@@ -964,7 +964,7 @@ Command	Sleep
 Time MASKED
 State	
 Info	
-Rows_sent	0
+Rows_sent	1
 Rows_examined	0
 Rows_read	0
 ---- 2. ----
@@ -997,7 +997,7 @@ Command	Sleep
 Time MASKED
 State	
 Info	
-Rows_sent	0
+Rows_sent	1
 Rows_examined	0
 Rows_read	0
 ---- 2. ----

--- a/mysql-test/t/mysqltest.test
+++ b/mysql-test/t/mysqltest.test
@@ -2931,6 +2931,10 @@ disconnect $x;
 disconnect $y;
 --echo $CURRENT_CONNECTION
 
+connection default;
+# Wait till we reached the initial number of concurrent sessions
+--source include/wait_until_count_sessions.inc
+
 --echo #
 --echo # Test that a query failed with ER_NO_SUCH_THREAD causes mysqltest to dump the processlist before dying
 --echo #
@@ -2947,7 +2951,3 @@ disconnect $y;
 --exec echo "error ER_PARSE_ERROR; KILL QUERY 276447231;" | $MYSQL_TEST 2>&1
 
 --echo End of tests
-
-connection default;
-# Wait till we reached the initial number of concurrent sessions
---source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Wait for disconnects to complete before doing SHOW PROCESSLIST tests
for KILL.

http://jenkins.percona.com/job/percona-server-5.5-param/1400/
