### PR TITLE
Fix bug 1612076 (Test rpl.rpl_cant_read_event_incident is unstable)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_cant_read_event_incident.result
+++ b/mysql-test/suite/rpl/r/rpl_cant_read_event_incident.result
@@ -6,7 +6,6 @@ include/rpl_start_server.inc [server_number=1]
 show binlog events;
 ERROR HY000: Error when executing command SHOW BINLOG EVENTS: Wrong offset or I/O error
 call mtr.add_suppression("Slave I/O: Got fatal error 1236 from master when reading data from binary log");
-stop slave;
 reset slave;
 start slave;
 include/wait_for_slave_param.inc [Last_IO_Errno]

--- a/mysql-test/suite/rpl/t/rpl_cant_read_event_incident.test
+++ b/mysql-test/suite/rpl/t/rpl_cant_read_event_incident.test
@@ -12,8 +12,9 @@
 # and replication is started from it.
 #
 
---source include/master-slave.inc
 --source include/have_binlog_format_mixed.inc
+--let $rpl_skip_start_slave= 1
+--source include/master-slave.inc
 
 call mtr.add_suppression("Error in Log_event::read_log_event()");
 
@@ -37,7 +38,6 @@ show binlog events;
 
 --connection slave
 call mtr.add_suppression("Slave I/O: Got fatal error 1236 from master when reading data from binary log");
-stop slave;
 reset slave;
 start slave;
 


### PR DESCRIPTION
The testcase shuts down the master, replaces its binlog file contents,
restarts the master, and resets/the connects the slave. This has a
race condition, that the slave may reconnect to the master after its
restart, and replay the CREATE TABLE statement before the slave
reset/restart. This will then cause SQL thread error as the same
statement will be replayed the 2nd time.

Fix by postponing slave connect to the master until the master has the
test binlog.

http://jenkins.percona.com/job/percona-server-5.5-param/1402/

Committed on the tip as the GCA does not have the latest version of the testcase.
