### PR TITLE
Deprecate scalability metrics plugin

### DIFF
--- a/mysql-test/include/have_scalability_metrics_plugin.inc
+++ b/mysql-test/include/have_scalability_metrics_plugin.inc
@@ -2,20 +2,20 @@
 # Check if server has support for loading plugins
 #
 if (`SELECT @@have_dynamic_loading != 'YES'`) {
-  --skip Example plugin requires dynamic loading
+  --skip Scalability metrics plugin requires dynamic loading
 }
 
 #
 # Check if the variable SCALABILITY_METRICS is set
 #
 if (!$SCALABILITY_METRICS) {
-  --skip Example plugin requires the environment variable \$SCALABILITY_METRICS to be set (normally done by mtr)
+  --skip Scalability metrics plugin requires the environment variable \$SCALABILITY_METRICS to be set (normally done by mtr)
 }
 
 #
 # Check if --plugin-dir was setup for exampledb
 #
 if (`SELECT CONCAT('--plugin-dir=', REPLACE(@@plugin_dir, '\\\\', '/')) != '$SCALABILITY_METRICS_OPT/'`) {
-  --skip Example plugin requires that --plugin-dir is set to the example plugin dir (either the .opt file does not contain \$SCALABILITY_METRICS_OPT or another plugin is in use)
+  --skip Scalability metrics plugin requires that --plugin-dir is set to the example plugin dir (either the .opt file does not contain \$SCALABILITY_METRICS_OPT or another plugin is in use)
 }
 enable_query_log;

--- a/plugin/scalability_metrics/CMakeLists.txt
+++ b/plugin/scalability_metrics/CMakeLists.txt
@@ -13,5 +13,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
+IF (NOT WITH_SCALABILITY_METRICS)
+  SET(SCALABILITY_METRICS_DISABLED 1)
+ENDIF()
 MYSQL_ADD_PLUGIN(scalability_metrics scalability_metrics.c
  MODULE_ONLY MODULE_OUTPUT_NAME "scalability_metrics")


### PR DESCRIPTION
This implements
https://blueprints.launchpad.net/percona-server/+spec/deprecate-scalability-metrics
blueprint.

Disable scalability metrics plugin at CMake level unless
-DWITH_SCALABILITY_METRICS=ON is given.

Fix diagnostics at
mysql-test/include/have_scalability_metrics_plugin.inc so that the
skipped test is not mistakenly diagnosed as belonging to Example
plugin.

http://jenkins.percona.com/job/percona-server-5.5-param/1410/
