### PR TITLE
MYR-8 : myrocks implements empty handler::delete_all_rows

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8159,17 +8159,6 @@ int ha_rocksdb::index_end()
   return 0;
 }
 
-
-int ha_rocksdb::delete_all_rows(ha_rows* nrows)
-{
-  DBUG_ENTER("ha_rocksdb::delete_all_rows");
-  /*
-    We will have to delete records one-by-one anyway. Let the SQL layer do
-    it.
-  */
-  DBUG_RETURN(HA_ERR_WRONG_COMMAND);
-}
-
 int ha_rocksdb::truncate()
 {
   m_tbl_def->m_auto_incr_val= 1;

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -909,7 +909,6 @@ public:
     __attribute__((__warn_unused_result__));
   int external_lock(THD *thd, int lock_type)
     __attribute__((__warn_unused_result__));
-  int delete_all_rows(ha_rows* nrows) __attribute__((__warn_unused_result__));
   int truncate() __attribute__((__warn_unused_result__));
 
   int reset() override


### PR DESCRIPTION
- myrocks implements delete_all_rows that does exactly what the default implementation does.
  In FacebookSQL though, there is a slightly different function signature which causes a compiler warning: virtual int handler::delete_all_rows() was hidden
- Removed unnecessary and empty implementation of delete_all_rows
