### PR TITLE
MYR-21 : webscale extends handlerton commit in ways not used by rocksdb

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2686,7 +2686,7 @@ static int rocksdb_recover(handlerton* hton, XID* xid_list, uint len,
   return count;
 }
 
-static int rocksdb_commit(handlerton* hton, THD* thd, bool commit_tx, bool)
+static int rocksdb_commit(handlerton* hton, THD* thd, bool commit_tx)
 {
   DBUG_ENTER("rocksdb_commit");
 


### PR DESCRIPTION
- Remove unused webscale specific implementation/arguments to rocksdb_comit handlerton function.
