### PR TITLE
Fix bug 728082 (USER_STATISTICS shows incorrect value for number of concurrent connections)

### DIFF
--- a/mysql-test/include/percona_userstat_conn_handling.inc
+++ b/mysql-test/include/percona_userstat_conn_handling.inc
@@ -1,0 +1,78 @@
+SET @userstat_old= @@userstat;
+SET GLOBAL userstat=ON;
+
+CREATE USER mysqltest_1@localhost;
+CREATE USER mysqltest_2@localhost;
+
+# Make a single connection for mysqltest_1 user
+connect (conn1,localhost,mysqltest_1,,);
+SELECT 1;
+connection default;
+
+--let $assert_text= I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: single connection
+--let $query_result= query_get_value(SELECT CONCURRENT_CONNECTIONS FROM INFORMATION_SCHEMA.USER_STATISTICS WHERE USER LIKE 'mysqltest_1', CONCURRENT_CONNECTIONS, 1)
+--let $assert_cond= "$query_result" = 1
+--source include/assert.inc
+
+# Make two connections for mysqltest_1 user
+connect (conn2,localhost,mysqltest_1,,);
+SELECT 1;
+connection default;
+
+--let $assert_text= I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: two connections
+--let $query_result= query_get_value(SELECT CONCURRENT_CONNECTIONS FROM INFORMATION_SCHEMA.USER_STATISTICS WHERE USER LIKE 'mysqltest_1', CONCURRENT_CONNECTIONS, 1)
+--let $assert_cond= "$query_result" = 2
+--source include/assert.inc
+
+# Check if number of concurrent connections decreased
+disconnect conn2;
+let $count_sessions= 2;
+--source include/wait_until_count_sessions.inc
+
+--let $assert_text= I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: handle disconnects
+--let $query_result= query_get_value(SELECT CONCURRENT_CONNECTIONS FROM INFORMATION_SCHEMA.USER_STATISTICS WHERE USER LIKE 'mysqltest_1', CONCURRENT_CONNECTIONS, 1)
+--let $assert_cond= "$query_result" = 1
+--source include/assert.inc
+
+# Number of concurrent connections shouldn't be affected by different users
+connect (conn3,localhost,mysqltest_2,,);
+SELECT 1;
+connection default;
+
+--let $assert_text= I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: connections from other users
+--let $query_result= query_get_value(SELECT CONCURRENT_CONNECTIONS FROM INFORMATION_SCHEMA.USER_STATISTICS WHERE USER LIKE 'mysqltest_1', CONCURRENT_CONNECTIONS, 1)
+--let $assert_cond= "$query_result" = 1
+--source include/assert.inc
+
+
+# if there is no connections, concurrent connections counter should be zero
+disconnect conn1;
+let $count_sessions= 2;
+--source include/wait_until_count_sessions.inc
+
+--let $assert_text= I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: no connections - zero concurrency
+--let $query_result= query_get_value(SELECT CONCURRENT_CONNECTIONS FROM INFORMATION_SCHEMA.USER_STATISTICS WHERE USER LIKE 'mysqltest_1', CONCURRENT_CONNECTIONS, 1)
+--let $assert_cond= "$query_result" = 0
+--source include/assert.inc
+
+disconnect conn3;
+let $count_sessions= 1;
+--source include/wait_until_count_sessions.inc
+
+# Unknown users are counted in USER_STATISTICS, concurrent connections should be positive
+--disable_query_log
+--error ER_ACCESS_DENIED_ERROR
+connect (conn4,localhost,mysqltest_unknownuser,,);
+--enable_query_log
+connection default;
+
+--let $assert_text= I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: unknown user connection
+--let $query_result= query_get_value(SELECT CONCURRENT_CONNECTIONS FROM INFORMATION_SCHEMA.USER_STATISTICS WHERE USER LIKE 'mysqltest_unknownuser', CONCURRENT_CONNECTIONS, 1)
+--let $assert_cond= "$query_result" = 0
+--source include/assert.inc
+
+
+DROP USER mysqltest_1@localhost;
+DROP USER mysqltest_2@localhost;
+
+SET GLOBAL userstat= @userstat_old;

--- a/mysql-test/r/percona_userstat_conn_handling.result
+++ b/mysql-test/r/percona_userstat_conn_handling.result
@@ -1,0 +1,23 @@
+SET @userstat_old= @@userstat;
+SET GLOBAL userstat=ON;
+CREATE USER mysqltest_1@localhost;
+CREATE USER mysqltest_2@localhost;
+SELECT 1;
+1
+1
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: single connection]
+SELECT 1;
+1
+1
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: two connections]
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: handle disconnects]
+SELECT 1;
+1
+1
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: connections from other users]
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: no connections - zero concurrency]
+ERROR 28000: Access denied for user 'mysqltest_unknownuser'@'localhost' (using password: NO)
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: unknown user connection]
+DROP USER mysqltest_1@localhost;
+DROP USER mysqltest_2@localhost;
+SET GLOBAL userstat= @userstat_old;

--- a/mysql-test/r/percona_userstat_conn_handling_threadpool.result
+++ b/mysql-test/r/percona_userstat_conn_handling_threadpool.result
@@ -1,0 +1,23 @@
+SET @userstat_old= @@userstat;
+SET GLOBAL userstat=ON;
+CREATE USER mysqltest_1@localhost;
+CREATE USER mysqltest_2@localhost;
+SELECT 1;
+1
+1
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: single connection]
+SELECT 1;
+1
+1
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: two connections]
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: handle disconnects]
+SELECT 1;
+1
+1
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: connections from other users]
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: no connections - zero concurrency]
+ERROR 28000: Access denied for user 'mysqltest_unknownuser'@'localhost' (using password: NO)
+include/assert.inc [I_S.USER_STATISTICS CONCURRENT_CONNECTIONS: unknown user connection]
+DROP USER mysqltest_1@localhost;
+DROP USER mysqltest_2@localhost;
+SET GLOBAL userstat= @userstat_old;

--- a/mysql-test/t/percona_userstat_conn_handling.test
+++ b/mysql-test/t/percona_userstat_conn_handling.test
@@ -1,0 +1,1 @@
+--source include/percona_userstat_conn_handling.inc

--- a/mysql-test/t/percona_userstat_conn_handling_threadpool-master.opt
+++ b/mysql-test/t/percona_userstat_conn_handling_threadpool-master.opt
@@ -1,0 +1,1 @@
+--thread-handling=pool-of-threads

--- a/mysql-test/t/percona_userstat_conn_handling_threadpool.test
+++ b/mysql-test/t/percona_userstat_conn_handling_threadpool.test
@@ -1,0 +1,2 @@
+--source include/have_pool_of_threads.inc
+--source include/percona_userstat_conn_handling.inc

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1384,6 +1384,7 @@ void THD::reset_diff_stats(void)
   diff_lost_connections=           0;
   diff_access_denied_errors=       0;
   diff_empty_queries=              0;
+  diff_disconnects=                0;
 }
 
 // Updates 'diff' stats of a THD.

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2351,6 +2351,7 @@ public:
   ulonglong diff_access_denied_errors;
   // Number of queries that return 0 rows
   ulonglong diff_empty_queries;
+  ulonglong diff_disconnects;
 
   // Per account query delay in miliseconds. When not 0, sleep this number of
   // milliseconds before every SQL command.

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -421,6 +421,7 @@ static int increment_count_by_name(const char *name, const char *role_name,
       return 1; // Out of memory
     }
   }
+  user_stats->concurrent_connections++;
   user_stats->total_connections++;
   if (thd->net.vio &&  thd->net.vio->type == VIO_TYPE_SSL)
     user_stats->total_ssl_connections++;
@@ -542,6 +543,11 @@ static void update_global_user_stats_with_user(THD* thd,
   user_stats->lost_connections+=     thd->diff_lost_connections;
   user_stats->access_denied_errors+= thd->diff_access_denied_errors;
   user_stats->empty_queries+=        thd->diff_empty_queries;
+
+  if (thd->diff_disconnects && thd->diff_denied_connections == 0) {
+    DBUG_ASSERT(user_stats->concurrent_connections > 0);
+    user_stats->concurrent_connections-=  thd->diff_disconnects;
+  }
 }
 
 static void update_global_thread_stats_with_thread(THD* thd,
@@ -1210,6 +1216,12 @@ void end_connection(THD *thd)
     of someone else.
   */
   release_user_connection(thd);
+
+  if (unlikely(opt_userstat)) {
+    thd->update_stats(false);
+    thd->diff_disconnects= 1;
+    update_global_user_stats(thd, false, time(NULL));
+  }
 
   if (thd->killed || (net->error && net->vio != 0))
   {


### PR DESCRIPTION
https://bugs.launchpad.net/percona-server/+bug/728082

I have implemented counting for current connections "CONCURRENT_CONNECTIONS – The number of concurrent connections for this user." and only for userstats table.

I'm not sure if this parameter will be useful in production in opposite to max(CONCURRENT_CONNECTIONS) since last flush, because current concurrent connections parameter could be obtained from I_S.processlist.
Also not sure about diff_disconnect variable. Originally I have considered to have total number of disconnects, but bug could be resolved just with simple bool flag (maybe it should be diff_concurrent_connections).
