### PR TITLE
MYR-10 : myrocks and facebook/webscale extend error messaging

### DIFF
--- a/mysql-test/suite/rocksdb/r/lock.result
+++ b/mysql-test/suite/rocksdb/r/lock.result
@@ -15,9 +15,9 @@ id2	COUNT(DISTINCT id)
 UPDATE t1 SET id=-1 WHERE id=1;
 connection con1;
 SELECT id,id2 FROM t1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table metadata: test.t1
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 LOCK TABLE t1 READ;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table metadata: test.t1
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection default;
 LOCK TABLE t1 READ;
 UPDATE t1 SET id=1 WHERE id=1;
@@ -27,9 +27,9 @@ SELECT COUNT(DISTINCT id) FROM t1;
 COUNT(DISTINCT id)
 1
 UPDATE t1 SET id=2 WHERE id=2;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table: test.t1
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 LOCK TABLE t1 WRITE;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table metadata: test.t1
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 LOCK TABLE t1 READ;
 UNLOCK TABLES;
 connection default;
@@ -83,13 +83,13 @@ UNLOCK TABLES;
 FLUSH TABLES t1, t2 WITH READ LOCK;
 connection con1;
 INSERT INTO t1 (a,b) VALUES (1,'a'),(2,'b');
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on table metadata: test.t1
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection default;
 UNLOCK TABLES;
 FLUSH TABLES WITH READ LOCK;
 connection con1;
 INSERT INTO t1 (a,b) VALUES (1,'a'),(2,'b');
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on global read: 
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection default;
 UNLOCK TABLES;
 INSERT INTO t1 (a,b) VALUES (1,'a'),(2,'b');

--- a/mysql-test/suite/rocksdb/r/lock_rows_not_exist.result
+++ b/mysql-test/suite/rocksdb/r/lock_rows_not_exist.result
@@ -11,7 +11,7 @@ connection con2;
 SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 BEGIN;
 SELECT * FROM t WHERE id1=1 AND id2=1 AND id3=1 FOR UPDATE;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT * FROM t WHERE id1=1 AND id2=1 AND id3=2 FOR UPDATE;
 id1	id2	id3	value
 connection con1;
@@ -22,7 +22,7 @@ connection con2;
 ROLLBACK;
 BEGIN;
 UPDATE t SET value=value+100 WHERE id1=1 AND id2=1 AND id3=1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t SET value=value+100 WHERE id1=1 AND id2=0 AND id3=1;
 connection con1;
 ROLLBACK;
@@ -32,7 +32,7 @@ connection con2;
 ROLLBACK;
 BEGIN;
 DELETE FROM t WHERE id1=1 AND id2=1 AND id3=1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 DELETE FROM t WHERE id1=1 AND id2=1 AND id3=0;
 connection default;
 disconnect con1;

--- a/mysql-test/suite/rocksdb/r/locking_issues.result
+++ b/mysql-test/suite/rocksdb/r/locking_issues.result
@@ -15,9 +15,9 @@ id1	id2	value
 SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 BEGIN;
 INSERT INTO t0 VALUES (1,5,0);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT * FROM t0 WHERE id1=1 AND id2=5 FOR UPDATE;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 COMMIT;
 DROP TABLE t0;
 
@@ -37,9 +37,9 @@ id1	id2	value
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 BEGIN;
 INSERT INTO t0 VALUES (1,5,0);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT * FROM t0 WHERE id1=1 AND id2=5 FOR UPDATE;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 COMMIT;
 DROP TABLE t0;
 
@@ -109,7 +109,7 @@ id	value
 5	1
 UPDATE t0 SET VALUE=10 WHERE id=1;
 UPDATE t0 SET VALUE=10 WHERE id=5;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t0 SET value=100 WHERE id in (4,5) and value>0;
 SELECT * FROM t0 WHERE id=4 FOR UPDATE;
 id	value
@@ -147,7 +147,7 @@ id	value
 5	1
 UPDATE t0 SET VALUE=10 WHERE id=1;
 UPDATE t0 SET VALUE=10 WHERE id=5;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t0 SET value=100 WHERE id in (4,5) and value>0;
 SELECT * FROM t0 WHERE id=4 FOR UPDATE;
 id	value
@@ -185,7 +185,7 @@ id	value
 2	1
 5	1
 UPDATE t0 SET VALUE=10 WHERE id=1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 COMMIT;
 DROP TABLE t0;
 SET GLOBAL rocksdb_lock_scanned_rows=0;
@@ -212,7 +212,7 @@ id	value
 2	1
 5	1
 UPDATE t0 SET VALUE=10 WHERE id=1;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t0.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 COMMIT;
 DROP TABLE t0;
 SET GLOBAL rocksdb_lock_scanned_rows=0;
@@ -440,7 +440,7 @@ BEGIN;
 lock_scanned_rows is 1
 UPDATE t1 JOIN t2 ON t1.id = t2.id SET t1.value=t1.value+100 WHERE t2.id=3;
 UPDATE t2 SET value=value+100 WHERE id=3;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t2.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t2 SET value=value+100 WHERE id IN (1,2,4,5);
 SELECT * FROM t2;
 id	value
@@ -475,7 +475,7 @@ BEGIN;
 lock_scanned_rows is 1
 UPDATE t1 JOIN t2 ON t1.id = t2.id SET t1.value=t1.value+100 WHERE t2.id=3;
 UPDATE t2 SET value=value+100 WHERE id=3;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t2.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t2 SET value=value+100 WHERE id IN (1,2,4,5);
 SELECT * FROM t2;
 id	value

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -390,7 +390,7 @@ rocksdb_lock_wait_timeout	2
 begin;
 update t17 set col1='UPD2-AA' where pk='row2';
 update t17 set col1='UPD2-BB' where pk='row2';
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t17.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 set rocksdb_lock_wait_timeout=1000;
 update t17 set col1='UPD2-CC' where pk='row2';
 rollback;
@@ -488,7 +488,7 @@ row3	row3data
 connection default;
 set rocksdb_lock_wait_timeout=1;
 update t27 set col1='row2-modified' where pk='row3';
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t27.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection con1;
 rollback;
 connection default;
@@ -1146,7 +1146,7 @@ BEGIN;
 UPDATE t1 SET i = 100;
 connect  con1,localhost,root,,test;
 DELETE IGNORE FROM t1 ORDER BY i;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 disconnect con1;
 connection default;
 COMMIT;
@@ -2131,7 +2131,7 @@ id
 6
 begin;
 select * from t1 where id=4 for update;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 select * from t1 where id=7 for update;
 id
 select * from t1 where id=9 for update;

--- a/mysql-test/suite/rocksdb/r/rocksdb_locks.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_locks.result
@@ -30,7 +30,7 @@ set @@rocksdb_lock_wait_timeout=2;
 set autocommit=0;
 begin;
 select * from t1 where pk=1 for update;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection default;
 rollback;
 set autocommit=1;

--- a/mysql-test/suite/rocksdb/r/select_for_update.result
+++ b/mysql-test/suite/rocksdb/r/select_for_update.result
@@ -14,9 +14,9 @@ a	b
 1	a
 3	a
 SELECT a,b FROM t1 WHERE b='a' LOCK IN SHARE MODE;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t1 SET b='c' WHERE b='a';
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection con1;
 COMMIT;
 SELECT a,b FROM t1;

--- a/mysql-test/suite/rocksdb/r/select_lock_in_share_mode.result
+++ b/mysql-test/suite/rocksdb/r/select_lock_in_share_mode.result
@@ -17,9 +17,9 @@ a	b
 # Currently, SELECT ... LOCK IN SHARE MODE works like 
 #   SELECT FOR UPDATE
 SELECT a,b FROM t1 WHERE b='a' LOCK IN SHARE MODE;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t1 SET b='c' WHERE b='a';
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 connection con1;
 COMMIT;
 SELECT a,b FROM t1;

--- a/mysql-test/suite/rocksdb/r/unique_check.result
+++ b/mysql-test/suite/rocksdb/r/unique_check.result
@@ -53,9 +53,9 @@ set debug_sync='now WAIT_FOR parked1';
 set debug_sync='now WAIT_FOR parked2';
 set session rocksdb_lock_wait_timeout=1;
 insert into t1 values (1,2);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 insert into t2 values (2,1,2);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t2.id2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 set debug_sync='now SIGNAL go1';
 set debug_sync='now SIGNAL go2';
 insert into t1 values (1,2);

--- a/mysql-test/suite/rocksdb/r/unique_sec.result
+++ b/mysql-test/suite/rocksdb/r/unique_sec.result
@@ -75,32 +75,32 @@ COUNT(*)
 13
 # Primary key should prevent duplicate on insert
 INSERT INTO t1 VALUES (30, 31, 30, 30, 30, 30, 30, 30);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Primary key should prevent duplicate on update
 UPDATE t1 SET id1=30, id2=31 WHERE id2=10;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Unique secondary key should prevent duplicate on insert
 INSERT INTO t1 VALUES (31, 31, 32, 33, 30, 30, 30, 30);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t1 VALUES (32, 32, 32, 32, 34, 32, 32, 32);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Unique secondary key should prevent duplicate on update
 UPDATE t1 SET id2=31, id3=32, id4=33 WHERE id2=8;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t1 SET id5=34 WHERE id2=8;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Adding multiple rows where one of the rows fail the duplicate
 # check should fail the whole statement
 INSERT INTO t1 VALUES (35, 35, 35, 35, 35, 35, 35, 35),
 (36, 36, 36, 36, 36, 36, 36, 36),
 (37, 31, 32, 33, 37, 37, 37, 37),
 (38, 38, 38, 38, 38, 38, 38, 38);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t1 VALUES (35, 35, 35, 35, 35, 35, 35, 35),
 (36, 36, 36, 36, 36, 36, 36, 36),
 (37, 37, 37, 37, 34, 37, 37, 37),
 (38, 38, 38, 38, 38, 38, 38, 38);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # NULL values are unique and duplicates in value fields are ignored
 INSERT INTO t1 VALUES (37, 31, 32, NULL, 37, 37, 37, 37),
 (38, 31, 32, NULL, 38, 37, 37, 37),
@@ -113,7 +113,7 @@ UPDATE t1 SET id5=37 WHERE id1=38;
 ERROR 23000: Duplicate entry '37' for key 'id5'
 # Fail on lock timeout for row modified in another transaction
 UPDATE t1 SET id5=34 WHERE id1=38;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # NULL values are unique
 UPDATE t1 SET id5=NULL WHERE value1 > 37;
 COMMIT;
@@ -126,9 +126,9 @@ BEGIN;
 INSERT INTO t1 VALUES (40, 40, 40, 40, 40, 40, 40, 40);
 # When transaction is pending, fail on lock acquisition
 INSERT INTO t1 VALUES (40, 40, 40, 40, 40, 40, 40, 40);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t1 VALUES (41, 40, 40, 40, 40, 40, 40, 40);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 17

--- a/mysql-test/suite/rocksdb/r/unique_sec_rev_cf.result
+++ b/mysql-test/suite/rocksdb/r/unique_sec_rev_cf.result
@@ -75,32 +75,32 @@ COUNT(*)
 13
 # Primary key should prevent duplicate on insert
 INSERT INTO t1 VALUES (30, 31, 30, 30, 30, 30, 30, 30);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Primary key should prevent duplicate on update
 UPDATE t1 SET id1=30, id2=31 WHERE id2=10;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Unique secondary key should prevent duplicate on insert
 INSERT INTO t1 VALUES (31, 31, 32, 33, 30, 30, 30, 30);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t1 VALUES (32, 32, 32, 32, 34, 32, 32, 32);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Unique secondary key should prevent duplicate on update
 UPDATE t1 SET id2=31, id3=32, id4=33 WHERE id2=8;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 UPDATE t1 SET id5=34 WHERE id2=8;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # Adding multiple rows where one of the rows fail the duplicate
 # check should fail the whole statement
 INSERT INTO t1 VALUES (35, 35, 35, 35, 35, 35, 35, 35),
 (36, 36, 36, 36, 36, 36, 36, 36),
 (37, 31, 32, 33, 37, 37, 37, 37),
 (38, 38, 38, 38, 38, 38, 38, 38);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t1 VALUES (35, 35, 35, 35, 35, 35, 35, 35),
 (36, 36, 36, 36, 36, 36, 36, 36),
 (37, 37, 37, 37, 34, 37, 37, 37),
 (38, 38, 38, 38, 38, 38, 38, 38);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # NULL values are unique and duplicates in value fields are ignored
 INSERT INTO t1 VALUES (37, 31, 32, NULL, 37, 37, 37, 37),
 (38, 31, 32, NULL, 38, 37, 37, 37),
@@ -113,7 +113,7 @@ UPDATE t1 SET id5=37 WHERE id1=38;
 ERROR 23000: Duplicate entry '37' for key 'id5'
 # Fail on lock timeout for row modified in another transaction
 UPDATE t1 SET id5=34 WHERE id1=38;
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id5
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # NULL values are unique
 UPDATE t1 SET id5=NULL WHERE value1 > 37;
 COMMIT;
@@ -126,9 +126,9 @@ BEGIN;
 INSERT INTO t1 VALUES (40, 40, 40, 40, 40, 40, 40, 40);
 # When transaction is pending, fail on lock acquisition
 INSERT INTO t1 VALUES (40, 40, 40, 40, 40, 40, 40, 40);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.PRIMARY
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO t1 VALUES (41, 40, 40, 40, 40, 40, 40, 40);
-ERROR HY000: Lock wait timeout exceeded; try restarting transaction: Timeout on index: test.t1.id2_2
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 17


### PR DESCRIPTION
- Removed extended error info implementation from MyRocks, no server support.
- fixed testcases for error messages:
  mysql-test/suite/rocksdb/r/lock.result
  mysql-test/suite/rocksdb/r/lock_rows_not_exist.result
  mysql-test/suite/rocksdb/r/locking_issues.result
  mysql-test/suite/rocksdb/r/rocksdb.result
  mysql-test/suite/rocksdb/r/rocksdb_locks.result
  mysql-test/suite/rocksdb/r/select_for_update.result
  mysql-test/suite/rocksdb/r/select_lock_in_share_mode.result
  mysql-test/suite/rocksdb/r/unique_check.result
  mysql-test/suite/rocksdb/r/unique_sec.result
  mysql-test/suite/rocksdb/r/unique_sec_rev_cf.result
