### PR TITLE
Fix bug 1636500 (Threadpool "thread limit reached" / "failed to creat…

### DIFF
--- a/mysql-test/r/pool_of_threads.result
+++ b/mysql-test/r/pool_of_threads.result
@@ -2151,6 +2151,7 @@ Privat (Private Nutzung)	Mobilfunk
 Warnings:
 Warning	1052	Column 'kundentyp' in group statement is ambiguous
 drop table t1;
+call mtr.add_suppression("Threadpool could not create additional thread to handle queries");
 SELECT sleep(50000);
 SELECT sleep(50000);
 # -- Success: more than --thread_pool_max_threads normal connections not possible

--- a/mysql-test/t/pool_of_threads.test
+++ b/mysql-test/t/pool_of_threads.test
@@ -7,6 +7,7 @@
 # Test that we cannot have more simultaneous connections than
 # --thread-pool-size on the standard port, but _can_ have additional
 # connections on the extra port.
+call mtr.add_suppression("Threadpool could not create additional thread to handle queries");
 
 # First set two connections running, and check that extra connection
 # on normal port fails due to --thread-pool-max_threads=2

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1751,26 +1751,29 @@ A likely cause of pool blocks are clients that lock resources for long time. \
 
 static void print_pool_blocked_message(bool max_threads_reached)
 {
-  ulonglong now;
+  ulonglong now= my_microsecond_getsystime();
   static bool msg_written;
-  
-  now= my_microsecond_getsystime();
+
   if (pool_block_start == 0)
   {
     pool_block_start= now;
-    msg_written = false;
-    return;
+    msg_written= false;
   }
-  
-  if (now > pool_block_start + BLOCK_MSG_DELAY && !msg_written)
+
+  if (!msg_written
+      && ((now > pool_block_start + BLOCK_MSG_DELAY)
+          || (now == pool_block_start)))
   {
     if (max_threads_reached)
       sql_print_error(MAX_THREADS_REACHED_MSG);
     else
       sql_print_error(CREATE_THREAD_ERROR_MSG, my_errno);
-    
-    sql_print_information("Threadpool has been blocked for %u seconds\n",
-      (uint)((now- pool_block_start)/1000000));
+
+    if (now > pool_block_start)
+    {
+      sql_print_information("Threadpool has been blocked for %u seconds\n",
+                            (uint)((now - pool_block_start)/1000000));
+    }
     /* avoid reperated messages for the same blocking situation */
     msg_written= true;
   }


### PR DESCRIPTION
…e thread" should be printed on the 1st occurrence too)

Currently, threadpool prints "max thread limit reached" and "failed to
create a thread" messages only if 1) the above situation has already
occurred, 2) more than 30 seconds have passed, and 3) the above
situation has occured again.

Adjust this so that diagnostics is printed on the first time the
situation occurrs, and then reprinted as needed, but not more often
than every 30 seconds.

This also fixes bug 1635184 (Spurious warnings on main.pool_of_threads)

http://jenkins.percona.com/job/percona-server-5.5-param/1423/
