### PR TITLE
Problem: RPL.RPL_INIT_SLAVE_ERRORS is randomly failing in Pb2

### DIFF
--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -2849,17 +2849,19 @@ pthread_handler_t handle_slave_io(void *arg)
   pthread_detach_this_thread();
   thd->thread_stack= (char*) &thd; // remember where our stack is
   mi->clear_error();
+  mi->slave_running = 1;
   if (init_slave_thread(thd, SLAVE_THD_IO))
   {
     mysql_cond_broadcast(&mi->start_cond);
     mysql_mutex_unlock(&mi->run_lock);
-    sql_print_error("Failed during slave I/O thread initialization");
+    mi->report(ERROR_LEVEL, ER_SLAVE_FATAL_ERROR,
+               ER_THD(thd, ER_SLAVE_FATAL_ERROR),
+               "Failed during slave I/O thread initialization ");
     goto err;
   }
   mysql_mutex_lock(&LOCK_thread_count);
   threads.append(thd);
   mysql_mutex_unlock(&LOCK_thread_count);
-  mi->slave_running = 1;
   mi->abort_slave = 0;
   mysql_mutex_unlock(&mi->run_lock);
   mysql_cond_broadcast(&mi->start_cond);


### PR DESCRIPTION
Analysis: Two consecutive "start slave IO_THREAD" commands are causing the
above said assert on the server. handle_slave_io() (the entry function for
IO thread) is doing init_slave_thread at the beginning to do some
initialization work for the thread. If init_slave_thread() fails, it release
the lock(mi->run_lock) and will do some remaining work before it exits
the thread. Since the lock is released upon init_slave_thread function fails
and the status of IO thread (slave_running) is still set to '0' which means
not running, the next slave IO thread start can spawn another
thread and can disturb the global object "mi" before the first
IO thread is doing some remaining work. This situation is causing
the above said assert (thd != mi->info_thd).

Fix: Mark the thread status as "MYSQL_SLAVE_RUN_CONNECT" (1) before
it is executing init_slave_thread. This will make sure that next IO thread
start will not spawn a new thread instead it will check the status
as '1' and will exit and it will enter into critical section
(modifying global mi object).

Problem 2:
And also it is observed that when the IO thread is failed while it is
in initialization phase (i.e., a failure from init_slave_thread), it is
not throwing any error to the client. Nothing can be seen 'show slave
status' Last_IO_Error field.

Fix: Now this problem is fixed by calling mi->report(...) in the failure
case. Hence can be seen this error in 'show slave status':Last_IO_Error
field. The test script rpl_init_slave_errors is modified accordingly.

http://jenkins.percona.com/job/percona-server-5.5-param/1430/