### PR TITLE
Fix bug 1642230 (handle_fatal_signal (sig=11) in THD::set_new_thread_id)

### DIFF
--- a/mysql-test/r/threadpool_debug.result
+++ b/mysql-test/r/threadpool_debug.result
@@ -1,0 +1,17 @@
+#
+# Debug build tests for pool of threads
+#
+#
+# Bug 1642230 (handle_fatal_signal (sig=11) in THD::set_new_thread_id)
+#
+call mtr.add_suppression("Out of memory");
+SET @saved_debug= @@GLOBAL.debug;
+SET GLOBAL debug= '+d,simulate_resource_failure';
+connect(localhost,root,,test,MYSQL_PORT,MYSQL_SOCK);
+ERROR HY000: Lost connection to MySQL server at 'reading initial communication packet', system error: NUM
+SET GLOBAL debug= '-d,simulate_resource_failure';
+SET GLOBAL debug= '+d,simulate_tp_alloc_connection_oom';
+connect(localhost,root,,test,MYSQL_PORT,MYSQL_SOCK);
+ERROR HY000: Lost connection to MySQL server at 'reading initial communication packet', system error: NUM
+SET GLOBAL debug= '-d,simulate_tp_alloc_connection_oom';
+SET GLOBAL debug= @saved_debug;

--- a/mysql-test/t/threadpool_debug-master.opt
+++ b/mysql-test/t/threadpool_debug-master.opt
@@ -1,0 +1,1 @@
+--thread-handling=pool-of-threads

--- a/mysql-test/t/threadpool_debug.test
+++ b/mysql-test/t/threadpool_debug.test
@@ -1,0 +1,34 @@
+--source include/have_debug.inc
+--source include/have_pool_of_threads.inc
+
+--echo #
+--echo # Debug build tests for pool of threads
+--echo #
+
+--echo #
+--echo # Bug 1642230 (handle_fatal_signal (sig=11) in THD::set_new_thread_id)
+--echo #
+
+call mtr.add_suppression("Out of memory");
+
+SET @saved_debug= @@GLOBAL.debug;
+SET GLOBAL debug= '+d,simulate_resource_failure';
+
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--replace_regex /system error: [0-9]+/system error: NUM/
+--error 2013
+connect (con1,localhost,root,,);
+
+connection default;
+SET GLOBAL debug= '-d,simulate_resource_failure';
+
+SET GLOBAL debug= '+d,simulate_tp_alloc_connection_oom';
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--replace_regex /system error: [0-9]+/system error: NUM/
+--error 2013
+connect (con1,localhost,root,,);
+
+connection default;
+SET GLOBAL debug= '-d,simulate_tp_alloc_connection_oom';
+
+SET GLOBAL debug= @saved_debug;

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1301,6 +1301,7 @@ static void wait_end(thread_group_t *thread_group)
 static connection_t *alloc_connection(THD *thd)
 {
   DBUG_ENTER("alloc_connection");
+  DBUG_EXECUTE_IF("simulate_tp_alloc_connection_oom", DBUG_RETURN(NULL););
 
   connection_t* connection = (connection_t *)
       my_malloc(key_memory_thread_pool_connection,
@@ -1328,6 +1329,23 @@ bool Thread_pool_connection_handler::add_connection(Channel_info *channel_info)
   DBUG_ENTER("Thread_pool_connection_handler::add_connection");
 
   THD* thd= channel_info->create_thd();
+
+  if (unlikely(!thd))
+  {
+    channel_info->send_error_and_close_channel(ER_OUT_OF_RESOURCES, 0, false);
+    DBUG_RETURN(true);
+  }
+
+  connection_t *connection= alloc_connection(thd);
+
+  if (unlikely(!connection))
+  {
+    thd->get_protocol_classic()->end_net();
+    delete thd;
+    channel_info->send_error_and_close_channel(ER_OUT_OF_RESOURCES, 0, false);
+    DBUG_RETURN(true);
+  }
+
   delete channel_info;
 
   thd->set_new_thread_id();
@@ -1336,15 +1354,6 @@ bool Thread_pool_connection_handler::add_connection(Channel_info *channel_info)
   thd->scheduler= &tp_event_functions;
 
   Global_THD_manager::get_instance()->add_thd(thd);
-
-  connection_t *connection= alloc_connection(thd);
-
-  if (!connection)
-  {
-    /* Allocation failed */
-    threadpool_remove_connection(thd);
-    DBUG_RETURN(true);
-  }
 
   thd->event_scheduler.data= connection;
 


### PR DESCRIPTION
With threadpool enabled, if an out-of-memory error happens while
creating a new THD object for an incoming object, the object will be
NULL, and threadpool code will dereference it.

Fix by checking for this condition and properly closing the
communication channel instead.

Start a new debug build MTR testcase for threadpool,
main.threadpool_debug.

http://jenkins.percona.com/job/mysql-5.7-param/500/ and http://jenkins.percona.com/job/mysql-5.7-param/502/