### PR TITLE
Fix bug 1644174 (Test rpl.rpl_init_slave_errors is unstable)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_init_slave_errors.result
+++ b/mysql-test/suite/rpl/r/rpl_init_slave_errors.result
@@ -6,6 +6,8 @@ SET GLOBAL debug= "d,simulate_io_slave_error_on_init,simulate_sql_slave_error_on
 start slave;
 include/wait_for_slave_sql_error.inc [errno=1593]
 Last_SQL_Error = 'Failed during slave thread initialization'
+include/wait_for_slave_io_error.inc [errno=1593]
+Last_IO_Error = 'Fatal error: Failed during slave I/O thread initialization '
 call mtr.add_suppression("Failed during slave.* thread initialization");
 SET GLOBAL debug= "";
 reset slave;

--- a/mysql-test/suite/rpl/t/rpl_init_slave_errors.test
+++ b/mysql-test/suite/rpl/t/rpl_init_slave_errors.test
@@ -57,6 +57,9 @@ start slave;
 --let $slave_sql_errno= 1593
 --let $show_slave_sql_error= 1
 --source include/wait_for_slave_sql_error.inc
+--let $slave_io_errno= 1593
+--let $show_slave_io_error= 1
+--source include/wait_for_slave_io_error.inc
 
 call mtr.add_suppression("Failed during slave.* thread initialization");
 


### PR DESCRIPTION
Add missing slave I/O thread stop sync to the testcase.

http://jenkins.percona.com/job/percona-server-5.5-param/1450/

Not a GCA because of https://bugs.launchpad.net/percona-server/+bug/1638897 fix dependency