### PR TITLE
Bug 1633988: Assertion `thd == _current_thd()' failed

### DIFF
--- a/mysql-test/r/audit_log_many_connections.result
+++ b/mysql-test/r/audit_log_many_connections.result
@@ -1,0 +1,7 @@
+SET @saved_max_connections = @@global.max_connections;
+SET GLOBAL max_connections = 2;
+connect(localhost,root,,test,MYSQL_PORT,MYSQL_SOCK);
+ERROR HY000: Too many connections
+connect(localhost,root,,test,MYSQL_PORT,MYSQL_SOCK);
+ERROR HY000: Too many connections
+SET GLOBAL max_connections= @saved_max_connections;

--- a/mysql-test/t/audit_log_many_connections-master.opt
+++ b/mysql-test/t/audit_log_many_connections-master.opt
@@ -1,0 +1,5 @@
+$AUDIT_LOG_OPT
+$AUDIT_LOG_LOAD
+--audit_log_file=test_audit.log
+--audit-log-format=CSV
+--audit_log_strategy=SEMISYNCHRONOUS

--- a/mysql-test/t/audit_log_many_connections.test
+++ b/mysql-test/t/audit_log_many_connections.test
@@ -1,0 +1,31 @@
+#
+# Bug #1633988: Assertion `thd == _current_thd()' failed
+#
+# Test audit log handling of too many connections error
+#
+
+--disable_query_log
+call mtr.add_suppression("Too many connections");
+--enable_query_log
+
+--source include/count_sessions.inc
+
+SET @saved_max_connections = @@global.max_connections;
+SET GLOBAL max_connections = 2;
+
+--connect (con1, localhost, root)
+--connect (con2, localhost, root)
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_CON_COUNT_ERROR
+--connect (con3, localhost, root)
+--replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
+--error ER_CON_COUNT_ERROR
+--connect (con4, localhost, root)
+
+connection default;
+SET GLOBAL max_connections= @saved_max_connections;
+
+--disconnect con2
+--disconnect con1
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -3092,7 +3092,7 @@ static bool plugin_var_memalloc_session_update(THD *thd,
 
 void plugin_thdvar_safe_update(THD *thd, st_mysql_sys_var *var, char **dest, const char *value)
 {
-  DBUG_ASSERT(thd == current_thd);
+  DBUG_ASSERT(current_thd == NULL || thd == current_thd);
 
   if (var->flags & PLUGIN_VAR_THDLOCAL)
   {


### PR DESCRIPTION
When 'too many connections' error audit log is notified from by main
server thread, but target THD is set to the thread which failed to
connect.

When we are trying to update THD variable of target thread we checking
that current thread is the target thread to make sure operation is
thread-safe. We however are good in case of too many connections error,
i.e. when we are working from main thread and `currnt_thd' is NULL.

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1491/