### PR TITLE
Fix bug 1644183 (New GCC 6 -Wnonnull-compare warnings on 5.5 release …

### DIFF
--- a/storage/innobase/include/page0page.h
+++ b/storage/innobase/include/page0page.h
@@ -792,8 +792,7 @@ page_copy_rec_list_end(
 	buf_block_t*	block,		/*!< in: index page containing rec */
 	rec_t*		rec,		/*!< in: record on page */
 	dict_index_t*	index,		/*!< in: record descriptor */
-	mtr_t*		mtr)		/*!< in: mtr */
-	__attribute__((nonnull));
+	mtr_t*		mtr);		/*!< in: mtr */
 /*************************************************************//**
 Copies records from page to new_page, up to the given record, NOT
 including that record. Infimum and supremum records are not copied.
@@ -808,8 +807,7 @@ page_copy_rec_list_start(
 	buf_block_t*	block,		/*!< in: index page containing rec */
 	rec_t*		rec,		/*!< in: record on page */
 	dict_index_t*	index,		/*!< in: record descriptor */
-	mtr_t*		mtr)		/*!< in: mtr */
-	__attribute__((nonnull));
+	mtr_t*		mtr);		/*!< in: mtr */
 /*************************************************************//**
 Deletes records from a page from a given record onward, including that record.
 The infimum and supremum records are not deleted. */
@@ -852,8 +850,7 @@ page_move_rec_list_end(
 	buf_block_t*	block,		/*!< in: index page from where to move */
 	rec_t*		split_rec,	/*!< in: first record to move */
 	dict_index_t*	index,		/*!< in: record descriptor */
-	mtr_t*		mtr)		/*!< in: mtr */
-	__attribute__((nonnull(1, 2, 4, 5)));
+	mtr_t*		mtr);		/*!< in: mtr */
 /*************************************************************//**
 Moves record list start to another page. Moved records do not include
 split_rec.

--- a/storage/innobase/include/page0zip.h
+++ b/storage/innobase/include/page0zip.h
@@ -402,8 +402,7 @@ page_zip_reorganize(
 				out: data, n_blobs,
 				m_start, m_end, m_nonempty */
 	dict_index_t*	index,	/*!< in: index of the B-tree node */
-	mtr_t*		mtr)	/*!< in: mini-transaction */
-	__attribute__((nonnull));
+	mtr_t*		mtr);	/*!< in: mini-transaction */
 #ifndef UNIV_HOTBACKUP
 /**********************************************************************//**
 Copy the records of a page byte for byte.  Do not copy the page header


### PR DESCRIPTION
…build)

Remove nonnull annotations from affected functions.

http://jenkins.percona.com/job/percona-server-5.5-param/1451/