### PR TITLE
Work towards diagnosing bug 1644198 (Test rpl.rpl_binlog_errors is un…

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -4819,8 +4819,9 @@ void do_shutdown_server(struct st_command *command)
   DBUG_PRINT("info", ("Killing server, pid: %d", pid));
   if (orig_timeout != 0)
   {
-    log_msg("shutdown_server timeout %ld exceeded, SIGKILL sent to the server",
-            orig_timeout);
+    log_msg("shutdown_server timeout %ld exceeded, "
+            "SIGKILL sent to the server PID %d",
+            orig_timeout, pid);
   }
   (void)my_kill(pid, 9);
 


### PR DESCRIPTION
…stable)

Make mysqltest print the PID of a process it is sending
SIGABRT/SIGKILL to.

http://jenkins.percona.com/job/percona-server-5.5-param/1452/