### PR TITLE
Fix bug 1644547 (Test rpl.rpl_show_slave_running may crash debug build)

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_show_slave_running.test
+++ b/mysql-test/suite/rpl/t/rpl_show_slave_running.test
@@ -75,9 +75,17 @@ echo Slave_SQL_Running= $status;
 
 # cleanup
 
-connection slave;
+connection master;
+
+# Bug#11765758 - 58754
+# @@global.debug is read by the slave threads through dbug-interface. 
+# Hence, before a client thread set @@global.debug we have to ensure that:
+# (a) the slave threads are stopped, or (b) the slave threads are in
+# sync and waiting.
+sync_slave_with_master;
 
 eval set global debug= '$debug_saved';
+
 SET DEBUG_SYNC= 'RESET';
 --echo End of tests
 --source include/rpl_end.inc


### PR DESCRIPTION
Fix by backporting the rpl.rpl_show_slave_running bits from

commit 570f63336472c1161a2f8311579803382748894e
Author: Andrei Elkin <andrei.elkin@oracle.com>
Date:   Thu Mar 17 20:13:10 2011 +0200

    Bug#11765758 - 58754 rpl_corruption fails.

    There is a crash issue.
    It is caused by concurrent access of @@global.debug reader (IO thread) and a user
    connection that updates the var at that time.
    When @@session.debug == "", it actually points to @@global.debug. So
    if client X has @@session.debug == "", and then @@global.debug is set
    to "foo", then the debug symbol "foo" is active also in client X.
    The slave threads always have @@session.debug == "". Hence, the slave
    threads are affected by the value of @@global.debug. So if we need to
    set @@global.debug but do not want it to affect the slave threads,
    then we have to ensure that the slave threads are either stopped or
    synced.

    Fixed with modifying rpl_corruption and few other potentially vulnerable tests, adding notes
    to the replication failure simulator writer.

    The rule of thumb for using @@global.debug in replication thread failure simulation:
    -----------------------------------------------------------------------------------
    Update the variable when the slave threads or the master dump thread are down or they
    are guaranteed to stay idle e.g
    in waiting for an event. Changing the value while a replication thread is UP can cause
    reading a partial results of the change to end up in a crash.
    For the dump thread one has to consider that a possible small hearbeat period won't break
    waiting for an event in the binlog.

http://jenkins.percona.com/job/percona-server-5.5-param/1455/