### PR TITLE
Bug#19583563: RPL.RPL_SEMI_SYNC_SHUTDOWN_HANG FAILS

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_hang.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_shutdown_hang.test
@@ -49,6 +49,7 @@ SET GLOBAL rpl_semi_sync_master_timeout = 10000000;
 --enable_result_log
 
 --source include/rpl_connection_master.inc
+--error 0,2013
 --reap
 --let $rpl_server_number=1
 --source include/rpl_start_server.inc


### PR DESCRIPTION
SPORADICALLY ON PB2

Problem:
========
CURRENT_TEST: rpl.rpl_semi_sync_shutdown_hang
mysqltest: At line 52: query 'reap' failed: 2013: Lost
connection to MySQL server during query

Analysis:
========
As part of test script with semisync enabled we stop the
slave's IO thread and execute a CREATE TABLE on master. This
statement will hang waiting for acknowledgement from slave
and IO thread has gone away. This CREATE TABLE statement is
kept in hang mode using --send command. Then master server
goes down because of shutdown causing the CREATE TABLE
statement to end successfully. When ever --send is used in
MTR it expects a --reap command to be used to capture the
return status of the statement that used --send. Because of
timing issue some times --reap command is able to get the
successful return status of --send command and some times
the --reap command is executed post the server has actually
shutdown. Because of this the reap command complains that it
has lost connection to mysql server during query. --reap
commands return code is not important for the actual bugfix
verification. The main aim of test script is shutdown should
not hang.

Fix:
===
As part of fix --error 0,2013 is added above the --reap
command.

http://jenkins.percona.com/job/percona-server-5.6-param/1493/