### PR TITLE
Fix bug 1644583 (Test main.percona_expand_fast_index_creation is unst…

### DIFF
--- a/mysql-test/r/percona_expand_fast_index_creation.result
+++ b/mysql-test/r/percona_expand_fast_index_creation.result
@@ -89,26 +89,9 @@ ALTER TABLE t1 ADD KEY (a);
 affected rows: 0
 info: Records: 0  Duplicates: 0  Warnings: 0
 EXPLAIN SELECT COUNT(*) FROM t1, t1 t2 WHERE t1.a = t2.a AND t1.b = t2.b;
-id	1
-select_type	SIMPLE
-table	t1
-type	ALL
-possible_keys	a
-key	NULL
-key_len	NULL
-ref	NULL
-rows	16
-Extra	NULL
-id	1
-select_type	SIMPLE
-table	t2
-type	ALL
-possible_keys	a
-key	NULL
-key_len	NULL
-ref	NULL
-rows	16
-Extra	Using where; Using join buffer (Block Nested Loop)
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	a	NULL	NULL	NULL	#	NULL
+1	SIMPLE	t2	ALL	a	NULL	NULL	NULL	#	Using where; Using join buffer (Block Nested Loop)
 ALTER TABLE t1 DROP KEY a;
 SET expand_fast_index_creation = 1;
 SELECT @@expand_fast_index_creation;
@@ -118,25 +101,8 @@ ALTER TABLE t1 ADD KEY (a);
 affected rows: 0
 info: Records: 0  Duplicates: 0  Warnings: 0
 EXPLAIN SELECT COUNT(*) FROM t1, t1 t2 WHERE t1.a = t2.a AND t1.b = t2.b;
-id	1
-select_type	SIMPLE
-table	t1
-type	ALL
-possible_keys	a
-key	NULL
-key_len	NULL
-ref	NULL
-rows	16
-Extra	NULL
-id	1
-select_type	SIMPLE
-table	t2
-type	ALL
-possible_keys	a
-key	NULL
-key_len	NULL
-ref	NULL
-rows	16
-Extra	Using where; Using join buffer (Block Nested Loop)
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	ALL	a	NULL	NULL	NULL	#	NULL
+1	SIMPLE	t2	ALL	a	NULL	NULL	NULL	#	Using where; Using join buffer (Block Nested Loop)
 SET expand_fast_index_creation = 0;
 DROP TABLE t1;

--- a/mysql-test/t/percona_expand_fast_index_creation.test
+++ b/mysql-test/t/percona_expand_fast_index_creation.test
@@ -99,9 +99,8 @@ ALTER TABLE t1 ADD KEY (a);
 --disable_info
 
 # The default query plan is correct in 5.6
---vertical_results
+--replace_column 9 #
 EXPLAIN SELECT COUNT(*) FROM t1, t1 t2 WHERE t1.a = t2.a AND t1.b = t2.b;
---horizontal_results
 
 ALTER TABLE t1 DROP KEY a;
 
@@ -114,9 +113,8 @@ SELECT @@expand_fast_index_creation;
 ALTER TABLE t1 ADD KEY (a);
 --disable_info
 
---vertical_results
+--replace_column 9 #
 EXPLAIN SELECT COUNT(*) FROM t1, t1 t2 WHERE t1.a = t2.a AND t1.b = t2.b;
---horizontal_results
 
 SET expand_fast_index_creation = 0;
 


### PR DESCRIPTION
…able)

Mask row estimate from EXPLAIN output, as it's unstable with InnoDB
random-dive statistics.

http://jenkins.percona.com/job/percona-server-5.6-param/1494/