### PR TITLE
Backported compressed columns 5.7 fixes discovered during the merge.

### DIFF
--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_antelope_compact.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_antelope_compact.test
@@ -1,3 +1,4 @@
+--source include/big_test.inc
 --source include/have_innodb.inc
 
 --let $file_format= Antelope

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_antelope_redundant.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_antelope_redundant.test
@@ -1,3 +1,4 @@
+--source include/big_test.inc
 --source include/have_innodb.inc
 
 --let $file_format= Antelope

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_compact.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_compact.test
@@ -1,3 +1,4 @@
+--source include/big_test.inc
 --source include/have_innodb.inc
 
 --let $file_format= Barracuda

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_compressed.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_compressed.test
@@ -1,3 +1,4 @@
+--source include/big_test.inc
 --source include/have_innodb.inc
 
 --let $file_format= Barracuda

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_dynamic.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_dynamic.test
@@ -1,3 +1,4 @@
+--source include/big_test.inc
 --source include/have_innodb.inc
 
 --let $file_format= Barracuda

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_redundant.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_consistency_barracuda_redundant.test
@@ -1,3 +1,4 @@
+--source include/big_test.inc
 --source include/have_innodb.inc
 
 --let $file_format= Barracuda

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1072,15 +1072,6 @@ innobase_col_to_mysql(
 		field->reset();
 
 		if (field->type() == MYSQL_TYPE_VARCHAR) {
-			if (field->column_format() ==
-				COLUMN_FORMAT_TYPE_COMPRESSED) {
-				/* Skip compressed varchar column when
-				reporting an erroneous row
-				during index creation or table rebuild. */
-				field->set_null();
-				break;
-			}
-
 			/* This is a >= 5.0.3 type true VARCHAR. Store the
 			length of the data to the first byte or the first
 			two bytes of dest. */


### PR DESCRIPTION
The series of 'innodb.xtradb_compressed_columns_consistency_*' MTR test cases are now marked as '--big-test'.

Added new 'omit_compressed_columns_show_extensions' DBUG keyword which can be set to exclude compressed columns extensions from 'SHOW CREATE TABLE ...' output.

Removed dead code branch from the 'innobase_col_to_mysql()' - an artifact from the original Weixiang Zhai patch.