### PR TITLE
Fix bug 1646384 (ANALYZE TABLE crashes debug build on --innodb-read-o…

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_read_only_analyze.result
+++ b/mysql-test/suite/innodb/r/innodb_read_only_analyze.result
@@ -1,0 +1,6 @@
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/innodb_read_only_analyze.test
+++ b/mysql-test/suite/innodb/t/innodb_read_only_analyze.test
@@ -1,0 +1,12 @@
+--source include/have_innodb.inc
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1);
+
+--source include/restart_readonly_mysqld.inc
+
+ANALYZE TABLE t1;
+
+--source include/restart_mysqld.inc
+
+DROP TABLE t1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -11908,9 +11908,13 @@ ha_innobase::info_low(
 					/* If this table is already queued for
 					background analyze, remove it from the
 					queue as we are about to do the same */
-					dict_mutex_enter_for_mysql();
-					dict_stats_recalc_pool_del(ib_table);
-					dict_mutex_exit_for_mysql();
+					if (!srv_read_only_mode) {
+
+						dict_mutex_enter_for_mysql();
+						dict_stats_recalc_pool_del(
+							ib_table);
+						dict_mutex_exit_for_mysql();
+					}
 
 					opt = DICT_STATS_RECALC_PERSISTENT;
 				} else {


### PR DESCRIPTION
…nly instance)

Do not attempt to delete the table being analyzed from the background
stats queue on a read-only instance, as that will raise an assertion
and it's impossible for the table to be in the queue in the first
place.

http://jenkins.percona.com/job/percona-server-5.6-param/1501/