### PR TITLE
Fix bug 1647723 (mysqltest should diagnose popen call failure)

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -3048,7 +3048,23 @@ FILE* my_popen(DYNAMIC_STRING *ds_cmd, const char *mode,
   str_to_file(tmp_sh_name, ds_cmd->str, ds_cmd->length);
   return popen(tmp_sh_cmd, mode);
 #else
-  return popen(ds_cmd->str, mode);
+  errno= 0;
+  FILE *file= popen(ds_cmd->str, mode);
+  if (file == NULL)
+  {
+    if (errno != 0)
+    {
+      fprintf(stderr, "mysqltest: popen failed with errno %d (%s)\n", errno,
+              strerror(errno));
+    }
+    else
+    {
+      fprintf(stderr,
+              "mysqltest: popen returned NULL without setting errno "
+              "(out-of-memory?)\n");
+    }
+  }
+  return file;
 #endif
 }
 


### PR DESCRIPTION
Print diagnostics for popen call returning NULL in mysqltest.

http://jenkins.percona.com/job/percona-server-5.6-param/1512/