### PR TITLE
Bug#20874411 INNODB SHUTDOWN HANGS IF INNODB_FORCE_RECOVERY>=3

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_bug-13628249.result
+++ b/mysql-test/suite/innodb/r/innodb_bug-13628249.result
@@ -9,6 +9,8 @@ call mtr.add_suppression('InnoDB: Allocated tablespace [0-9]+, old maximum was [
 CREATE TABLE t1(c1 INT PRIMARY KEY) ENGINE=InnoDB STATS_PERSISTENT=0;
 BEGIN;
 INSERT INTO t1 VALUES(1), (2), (3), (4);
+CREATE TABLE t2(c2 INT PRIMARY KEY) ENGINE=InnoDB STATS_PERSISTENT=0;
+DROP TABLE t2;
 SET SESSION debug="+d,crash_commit_before";
 COMMIT;
 ERROR HY000: Lost connection to MySQL server during query

--- a/mysql-test/suite/innodb/t/innodb_bug-13628249.test
+++ b/mysql-test/suite/innodb/t/innodb_bug-13628249.test
@@ -87,6 +87,14 @@ CREATE TABLE t1(c1 INT PRIMARY KEY) ENGINE=InnoDB STATS_PERSISTENT=0;
 BEGIN;
 INSERT INTO t1 VALUES(1), (2), (3), (4);
 
+# Ensure that the above data is flushed to the InnoDB redo log,
+# by committing transactions (which will force a log flush).
+connect (con1, localhost, root);
+CREATE TABLE t2(c2 INT PRIMARY KEY) ENGINE=InnoDB STATS_PERSISTENT=0;
+DROP TABLE t2;
+disconnect con1;
+connection default;
+
 # Request a crash on next execution of commit.
 SET SESSION debug="+d,crash_commit_before";
 

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -1245,6 +1245,33 @@ trx_sys_close(void)
 	trx_sys = NULL;
 }
 
+/** @brief Convert an undo log to TRX_UNDO_PREPARED state on shutdown.
+
+If any prepared ACTIVE transactions exist, and their rollback was
+prevented by innodb_force_recovery, we convert these transactions to
+XA PREPARE state in the main-memory data structures, so that shutdown
+will proceed normally. These transactions will again recover as ACTIVE
+on the next restart, and they will be rolled back unless
+innodb_force_recovery prevents it again.
+
+@param[in]	trx	transaction
+@param[in,out]	undo	undo log to convert to TRX_UNDO_PREPARED */
+static
+void
+trx_undo_fake_prepared(
+	const trx_t*	trx,
+	trx_undo_t*	undo)
+{
+	ut_ad(srv_force_recovery >= SRV_FORCE_NO_TRX_UNDO);
+	ut_ad(trx_state_eq(trx, TRX_STATE_ACTIVE));
+	ut_ad(trx->is_recovered);
+
+	if (undo != NULL) {
+		ut_ad(undo->state == TRX_UNDO_ACTIVE);
+		undo->state = TRX_UNDO_PREPARED;
+	}
+}
+
 /*********************************************************************
 Check if there are any active (non-prepared) transactions.
 @return total number of active transactions or 0 if none */
@@ -1253,15 +1280,42 @@ ulint
 trx_sys_any_active_transactions(void)
 /*=================================*/
 {
-	ulint	total_trx = 0;
-
 	mutex_enter(&trx_sys->mutex);
 
-	total_trx = UT_LIST_GET_LEN(trx_sys->rw_trx_list)
-		  + UT_LIST_GET_LEN(trx_sys->mysql_trx_list);
+	ulint	total_trx = UT_LIST_GET_LEN(trx_sys->mysql_trx_list);
 
-	ut_a(total_trx >= trx_sys->n_prepared_trx);
-	total_trx -= trx_sys->n_prepared_trx;
+	if (total_trx == 0) {
+		total_trx = UT_LIST_GET_LEN(trx_sys->rw_trx_list);
+		ut_a(total_trx >= trx_sys->n_prepared_trx);
+
+		if (total_trx > trx_sys->n_prepared_trx
+		    && srv_force_recovery >= SRV_FORCE_NO_TRX_UNDO) {
+			for (trx_t* trx = UT_LIST_GET_FIRST(
+				     trx_sys->rw_trx_list);
+			     trx != NULL;
+			     trx = UT_LIST_GET_NEXT(trx_list, trx)) {
+				if (!trx_state_eq(trx, TRX_STATE_ACTIVE)
+				    || !trx->is_recovered) {
+					continue;
+				}
+				/* This was a recovered transaction
+				whose rollback was disabled by
+				the innodb_force_recovery setting.
+				Pretend that it is in XA PREPARE
+				state so that shutdown will work. */
+				trx_undo_fake_prepared(
+					trx, trx->insert_undo);
+				trx_undo_fake_prepared(
+					trx, trx->update_undo);
+				trx->state = TRX_STATE_PREPARED;
+				trx_sys->n_prepared_trx++;
+				trx_sys->n_prepared_recovered_trx++;
+			}
+		}
+
+		ut_a(total_trx >= trx_sys->n_prepared_trx);
+		total_trx -= trx_sys->n_prepared_trx;
+	}
 
 	mutex_exit(&trx_sys->mutex);
 


### PR DESCRIPTION
SKIPPED ANY ROLLBACK

trx_sys_any_active_transactions(): If any prepared ACTIVE transactions
exist, and their rollback was prevented by innodb_force_recovery,
convert these transactions to XA PREPARE state in the main-memory
data structures, so that shutdown will proceed normally. These transactions
will again recover as ACTIVE on the next restart, and they will be rolled
back unless innodb_force_recovery>=3 again.

trx_undo_fake_prepared(): An auxiliary function to set an undo log to
PREPARED state.

RB: 8610
Reviewed-by: Jimmy Yang <jimmy.yang@oracle.com>

http://jenkins.percona.com/job/percona-server-5.6-param/1514/