### PR TITLE
Fix bug 801989: Downgrade ALL_O_DIRECT to O_DIRECT if os_file_set_noc…

### DIFF
--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -515,9 +515,10 @@ os_file_create_simple_no_error_handling_func(
 				it would be enabled otherwise). */
 	ibool*		success);/*!< out: TRUE if succeed, FALSE if error */
 /****************************************************************//**
-Tries to disable OS caching on an opened file descriptor. */
+Tries to disable OS caching on an opened file descriptor.
+@return TRUE if operation is success and FALSE otherwise */
 UNIV_INTERN
-void
+ibool
 os_file_set_nocache(
 /*================*/
 	int		fd,		/*!< in: file descriptor to alter */

--- a/storage/innobase/os/os0file.c
+++ b/storage/innobase/os/os0file.c
@@ -1382,9 +1382,10 @@ os_file_create_simple_no_error_handling_func(
 }
 
 /****************************************************************//**
-Tries to disable OS caching on an opened file descriptor. */
+Tries to disable OS caching on an opened file descriptor.
+@return TRUE if operation is success and FALSE otherwise */
 UNIV_INTERN
-void
+ibool
 os_file_set_nocache(
 /*================*/
 	int		fd		/*!< in: file descriptor to alter */
@@ -1405,6 +1406,7 @@ os_file_set_nocache(
 			"  InnoDB: Failed to set DIRECTIO_ON "
 			"on file %s: %s: %s, continuing anyway\n",
 			file_name, operation_name, strerror(errno_save));
+		return FALSE;
 	}
 #elif defined(O_DIRECT)
 	if (fcntl(fd, F_SETFL, O_DIRECT) == -1) {
@@ -1422,8 +1424,10 @@ os_file_set_nocache(
 				"'Invalid argument' on Linux on tmpfs, "
 				"see MySQL Bug#26662\n");
 		}
+		return FALSE;
 	}
 #endif
+	return TRUE;
 }
 
 /****************************************************************//**
@@ -1699,7 +1703,11 @@ try_again:
 
 	/* ALL_O_DIRECT: O_DIRECT also for transaction log file */
 	if (srv_unix_file_flush_method == SRV_UNIX_ALL_O_DIRECT) {
-		os_file_set_nocache(file, name, mode_str);
+		/* Do fsync() on log files when setting O_DIRECT fails.
+		   See log_io_complete() */
+		if (!os_file_set_nocache(file, name, mode_str)) {
+			srv_unix_file_flush_method = SRV_UNIX_O_DIRECT;
+		}
 	}
 
 #ifdef USE_FILE_LOCK


### PR DESCRIPTION
Make os_file_set_nocache boolean, If it fails, change SRV_UNIX_ALL_O_DIRECT to SRV_UNIX_O_DIRECT. This flag enables fsync for redo log files in log_io_complete.
https://bugs.launchpad.net/percona-server/+bug/801989
Previous code from Vlad and discussion could be found here:
                        https://code.launchpad.net/~vlad-lesin/percona-server/5.5-bug801989/+merge/123403
                        https://code.launchpad.net/~vlad-lesin/percona-server/5.1-bug801989/+merge/124113

http://jenkins.percona.com/job/percona-server-5.5-param/1480/
