### PR TITLE
Fix bug 1648389 (Spurious unsuppressed warning on rpl.rpl_parallel_sw…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_parallel_switch_sequential.result
+++ b/mysql-test/suite/rpl/r/rpl_parallel_switch_sequential.result
@@ -7,6 +7,7 @@ SET @save_slave_parallel_workers= @@slave_parallel_workers;
 SET @save_default_storage_engine=@@global.default_storage_engine;
 SET @@global.default_storage_engine='innodb';
 SET GLOBAL slave_parallel_workers= 4;
+call mtr.add_suppression("The slave coordinator and worker threads are stopped, possibly leaving data in inconsistent state");
 call mtr.add_suppression("Request to stop slave SQL Thread received while applying a group that has non-transactional changes");
 include/stop_slave.inc
 include/start_slave.inc

--- a/mysql-test/suite/rpl/t/rpl_parallel_switch_sequential.test
+++ b/mysql-test/suite/rpl/t/rpl_parallel_switch_sequential.test
@@ -11,7 +11,7 @@ SET @save_default_storage_engine=@@global.default_storage_engine;
 SET @@global.default_storage_engine='innodb';
 
 eval SET GLOBAL slave_parallel_workers= $max_workers;
-#call mtr.add_suppression("The slave coordinator and worker threads are stopped, possibly leaving data in inconsistent state");
+call mtr.add_suppression("The slave coordinator and worker threads are stopped, possibly leaving data in inconsistent state");
 call mtr.add_suppression("Request to stop slave SQL Thread received while applying a group that has non-transactional changes");
 
 --source include/stop_slave.inc


### PR DESCRIPTION
…itch_sequential)

Whether the "slave coordinator and worker threads are stopped,
possibly leaving data in inconsistent state." warning will be printed
depends solely on timing, thus suppress it for slow hosts.

http://jenkins.percona.com/job/percona-server-5.6-param/1518/
