### PR TITLE
Add the ability to use path in --plugin-load and --plugin-load-add server  command-line options.

### DIFF
--- a/mysql-test/include/plugin.defs
+++ b/mysql-test/include/plugin.defs
@@ -10,6 +10,10 @@
 # PLUGVAR_OPT: mysqld option --plugin_dir=....
 # PLUGVAR_LOAD: option --plugin_load=.... if the 4th element is present
 # PLUGVAR_LOAD_ADD: option --plugin_load_add=.... if the 4th element is present
+# PLUGVAR_LOAD_PATH: option --plugin_load=.... with library full path
+#                    if the 4th element is present
+# PLUGVAR_LOAD_ADD_PATH: option --plugin_load_add=.... with library full path
+#                        if the 4th element is present
 #
 # If a listed plugin is not found, the corresponding variables will be
 # set to empty, they will not be unset.

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -2271,21 +2271,28 @@ sub read_plugin_defs($)
     # listed in def. file but not found.
 
     if ($plugin) {
+      my $plug_dir= dirname($plugin);
       $ENV{$plug_var}= basename($plugin);
-      $ENV{$plug_var.'_DIR'}= dirname($plugin);
-      $ENV{$plug_var.'_OPT'}= "--plugin-dir=".dirname($plugin);
+      $ENV{$plug_var.'_DIR'}= $plug_dir;
+      $ENV{$plug_var.'_OPT'}= "--plugin-dir=".$plug_dir;
       if ($plug_names) {
 	my $lib_name= basename($plugin);
 	my $load_var= "--plugin_load=";
 	my $load_add_var= "--plugin_load_add=";
+	my $load_var_with_path = "--plugin_load=";
+	my $load_add_var_with_path = "--plugin_load_add=";
 	my $semi= '';
 	foreach my $plug_name (split (',', $plug_names)) {
 	  $load_var .= $semi . "$plug_name=$lib_name";
 	  $load_add_var .= $semi . "$plug_name=$lib_name";
+	  $load_var_with_path .= $semi . "$plug_name=$plug_dir/$lib_name";
+	  $load_add_var_with_path .= $semi . "$plug_name=$plug_dir/$lib_name";
 	  $semi= ';';
 	}
 	$ENV{$plug_var.'_LOAD'}= $load_var;
 	$ENV{$plug_var.'_LOAD_ADD'}= $load_add_var;
+	$ENV{$plug_var.'_LOAD_PATH'}= $load_var_with_path;
+	$ENV{$plug_var.'_LOAD_ADD_PATH'}= $load_add_var_with_path;
       }
     } else {
       $ENV{$plug_var}= "";
@@ -2293,6 +2300,8 @@ sub read_plugin_defs($)
       $ENV{$plug_var.'_OPT'}= "";
       $ENV{$plug_var.'_LOAD'}= "" if $plug_names;
       $ENV{$plug_var.'_LOAD_ADD'}= "" if $plug_names;
+      $ENV{$plug_var.'_LOAD_PATH'}= "" if $plug_names;
+      $ENV{$plug_var.'_LOAD_ADD_PATH'}= "" if $plug_names;
     }
   }
   close PLUGDEF;

--- a/mysql-test/r/plugin-load-add-with-path.result
+++ b/mysql-test/r/plugin-load-add-with-path.result
@@ -1,0 +1,60 @@
+Variable_name	Value
+have_dynamic_loading	YES
+###
+# Test for loading two plugins both with full path
+###
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+COUNT(*)
+1
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'test_plugin_server';
+COUNT(*)
+1
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'cleartext_plugin_server';
+COUNT(*)
+1
+###
+# Test for loading two plugins one with full path and another with
+# just filename
+###
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+COUNT(*)
+1
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'test_plugin_server';
+COUNT(*)
+1
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'cleartext_plugin_server';
+COUNT(*)
+1
+###
+# Test for loading the same plugin two times - both with path and
+# without one
+###
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+COUNT(*)
+1
+###
+# Test for loading plugins with 'INSTALL PLUGIN'
+###
+INSTALL PLUGIN example SONAME 'EXAMPLE_PLUGIN';
+INSTALL PLUGIN example SONAME 'EXAMPLE_PLUGIN_DIR/EXAMPLE_PLUGIN';
+ERROR HY000: No paths allowed for shared library
+INSTALL PLUGIN test_plugin_server SONAME 'auth_test_plugin.so';
+INSTALL PLUGIN cleartext_plugin_server SONAME 'auth_test_plugin.so';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+COUNT(*)
+0
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'test_plugin_server';
+COUNT(*)
+1
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'cleartext_plugin_server';
+COUNT(*)
+1
+UNINSTALL PLUGIN test_plugin_server;
+UNINSTALL PLUGIN cleartext_plugin_server;
+###
+# Test for path in UDF library loading
+###
+CREATE FUNCTION metaphon RETURNS STRING SONAME "UDF_EXAMPLE_LIB";
+DROP FUNCTION metaphon;
+CREATE FUNCTION metaphon RETURNS STRING SONAME "UDF_EXAMPLE_LIB_DIR/UDF_EXAMPLE_LIB";
+ERROR HY000: No paths allowed for shared library

--- a/mysql-test/t/plugin-load-add-with-path.test
+++ b/mysql-test/t/plugin-load-add-with-path.test
@@ -1,0 +1,107 @@
+# Test for ability to use path in --plugin-load and --plugin-load-add options
+
+--source include/have_dynamic_loading.inc
+
+# have_example_plugin.inc, have_plugin_auth.inc, have_udf.inc can't be used
+# here because they check if plugin_var variable contains the correspondent
+# plugin path what is wrong as these plugins are in different subdirs in
+# build dir
+
+#
+# Check if the variable EXAMPLE_PLUGIN is set
+#
+if (!$EXAMPLE_PLUGIN) {
+  --skip Example plugin requires the environment variable \$EXAMPLE_PLUGIN to be set (normally done by mtr)
+}
+
+#
+# Check if the variable PLUGIN_AUTH is set
+#
+if (!$PLUGIN_AUTH) {
+  --skip Example plugin requires the environment variable \$PLUGIN_AUTH to be set (normally done by mtr)
+}
+
+#
+# Check if the variable UDF_EXAMPLE_LIB is set
+#
+if (!$UDF_EXAMPLE_LIB) {
+  --skip UDF requires the environment variable \$UDF_EXAMPLE_LIB to be set (normally done by mtr)
+}
+
+--let MYSQL_BASEDIR= `select @@basedir`
+
+--echo ###
+--echo # Test for loading two plugins both with full path
+--echo ###
+--let $restart_parameters= restart:$EXAMPLE_PLUGIN_LOAD_PATH $PLUGIN_AUTH_LOAD_ADD_PATH
+--source include/restart_mysqld.inc
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'test_plugin_server';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'cleartext_plugin_server';
+
+--echo ###
+--echo # Test for loading two plugins one with full path and another with
+--echo # just filename
+--echo ###
+--let $restart_parameters= restart:$PLUGIN_AUTH_OPT $PLUGIN_AUTH_LOAD $EXAMPLE_PLUGIN_LOAD_ADD_PATH
+--source include/restart_mysqld.inc
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'test_plugin_server';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'cleartext_plugin_server';
+
+--echo ###
+--echo # Test for loading the same plugin two times - both with path and
+--echo # without one
+--echo ###
+--disable_query_log
+CALL mtr.add_suppression("Function 'EXAMPLE' already exists");
+--eval call mtr.add_suppression("Couldn't load plugin named 'EXAMPLE' with soname '$EXAMPLE_PLUGIN_DIR/$EXAMPLE_PLUGIN'")
+--enable_query_log
+--let $restart_parameters= restart:$EXAMPLE_PLUGIN_OPT $EXAMPLE_PLUGIN_LOAD $EXAMPLE_PLUGIN_LOAD_ADD_PATH
+--source include/restart_mysqld.inc
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+
+--echo ###
+--echo # Test for loading plugins with 'INSTALL PLUGIN'
+--echo ###
+--let $restart_parameters= restart:$PLUGIN_AUTH_OPT
+--source include/restart_mysqld.inc
+
+# This error message contains path and the message itself is limited by size.
+# As path can have different length depending on testing environment the
+# content of the error message can be different depending on testing
+# environment. That's why we disable result log when this error message
+# is expected.
+--disable_result_log
+--replace_result $EXAMPLE_PLUGIN EXAMPLE_PLUGIN
+--error ER_CANT_OPEN_LIBRARY
+--eval INSTALL PLUGIN example SONAME '$EXAMPLE_PLUGIN'
+--enable_result_log
+--replace_result $EXAMPLE_PLUGIN_DIR EXAMPLE_PLUGIN_DIR $EXAMPLE_PLUGIN EXAMPLE_PLUGIN
+--error ER_UDF_NO_PATHS
+--eval INSTALL PLUGIN example SONAME '$EXAMPLE_PLUGIN_DIR/$EXAMPLE_PLUGIN'
+--replace_regex /\.dll/.so/
+--eval INSTALL PLUGIN test_plugin_server SONAME '$PLUGIN_AUTH'
+--replace_regex /\.dll/.so/
+--eval INSTALL PLUGIN cleartext_plugin_server SONAME '$PLUGIN_AUTH'
+
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'EXAMPLE';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'test_plugin_server';
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = 'cleartext_plugin_server';
+
+UNINSTALL PLUGIN test_plugin_server;
+UNINSTALL PLUGIN cleartext_plugin_server;
+
+--echo ###
+--echo # Test for path in UDF library loading
+--echo ###
+--let $restart_parameters= restart:$UDF_EXAMPLE_LIB_OPT
+--source include/restart_mysqld.inc
+
+--replace_result $UDF_EXAMPLE_LIB UDF_EXAMPLE_LIB
+eval CREATE FUNCTION metaphon RETURNS STRING SONAME "$UDF_EXAMPLE_LIB";
+DROP FUNCTION metaphon;
+
+--replace_result $UDF_EXAMPLE_LIB UDF_EXAMPLE_LIB $UDF_EXAMPLE_LIB_DIR UDF_EXAMPLE_LIB_DIR
+--error ER_UDF_NO_PATHS
+eval CREATE FUNCTION metaphon RETURNS STRING SONAME "$UDF_EXAMPLE_LIB_DIR/$UDF_EXAMPLE_LIB";

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -451,30 +451,61 @@ static inline void free_plugin_mem(struct st_plugin_dl *p)
 }
 
 
-static st_plugin_dl *plugin_dl_add(const LEX_STRING *dl, int report)
+static st_plugin_dl *plugin_dl_add(const LEX_STRING *dl,
+                                   int report,
+                                   bool allow_dl_path)
 {
 #ifdef HAVE_DLOPEN
   char dlpath[FN_REFLEN];
-  uint plugin_dir_len, dummy_errors, dlpathlen, i;
+  uint dummy_errors, dlpathlen, i;
   struct st_plugin_dl *tmp, plugin_dl;
+  size_t dl_fname_pos= 0;
   void *sym;
   DBUG_ENTER("plugin_dl_add");
   DBUG_PRINT("enter", ("dl->str: '%s', dl->length: %d",
                        dl->str, (int) dl->length));
-  plugin_dir_len= strlen(opt_plugin_dir);
-  /*
-    Ensure that the dll doesn't have a path.
-    This is done to ensure that only approved libraries from the
-    plugin directory are used (to make this even remotely secure).
-  */
-  if (check_valid_path(dl->str, dl->length) ||
-      check_string_char_length((LEX_STRING *) dl, "", NAME_CHAR_LEN,
-                               system_charset_info, 1) ||
-      plugin_dir_len + dl->length + 1 >= FN_REFLEN)
-  {
-    report_error(report, ER_UDF_NO_PATHS);
-    DBUG_RETURN(0);
+
+  if (allow_dl_path)
+    dl_fname_pos = dirname_length(dl->str);
+
+  if (!dl_fname_pos) {
+    size_t plugin_dir_len= strlen(opt_plugin_dir);
+    /*
+      Ensure that the dll doesn't have a path.
+      This is done to ensure that only approved libraries from the
+      plugin directory are used (to make this even remotely secure).
+    */
+    if (check_valid_path(dl->str, dl->length) ||
+        check_string_char_length((LEX_STRING *) dl, "", NAME_CHAR_LEN,
+                                 system_charset_info, 1) ||
+        plugin_dir_len + dl->length + 1 >= FN_REFLEN)
+    {
+      report_error(report, ER_UDF_NO_PATHS);
+      DBUG_RETURN(0);
+    }
+    /* Compile dll path */
+    dlpathlen=
+      strxnmov(dlpath,
+               sizeof(dlpath) - 1,
+               opt_plugin_dir,
+               "/",
+               dl->str,
+               NullS) -
+      dlpath;
   }
+  else
+  {
+    if (dl->length + 1 >= sizeof(dlpath))
+    {
+      report_error(report, ER_UDF_NO_PATHS);
+      DBUG_RETURN(0);
+    }
+    strncpy(dlpath, dl->str, sizeof(dlpath) - 1);
+    dlpathlen= dl->length;
+  }
+
+  (void) unpack_filename(dlpath, dlpath);
+
   /* If this dll is already loaded just increase ref_count. */
   if ((tmp= plugin_dl_find(dl)))
   {
@@ -482,11 +513,6 @@ static st_plugin_dl *plugin_dl_add(const LEX_STRING *dl, int report)
     DBUG_RETURN(tmp);
   }
   memset(&plugin_dl, 0, sizeof(plugin_dl));
-  /* Compile dll path */
-  dlpathlen=
-    strxnmov(dlpath, sizeof(dlpath) - 1, opt_plugin_dir, "/", dl->str, NullS) -
-    dlpath;
-  (void) unpack_filename(dlpath, dlpath);
   plugin_dl.ref_count= 1;
   /* Open new dll handle */
   if (!(plugin_dl.handle= dlopen(dlpath, RTLD_NOW)))
@@ -839,7 +865,7 @@ static st_plugin_int *plugin_insert_or_reuse(struct st_plugin_int *plugin)
 */
 static bool plugin_add(MEM_ROOT *tmp_root,
                        const LEX_STRING *name, const LEX_STRING *dl,
-                       int *argc, char **argv, int report)
+                       int *argc, char **argv, int report, bool allow_path)
 {
   struct st_plugin_int tmp;
   struct st_mysql_plugin *plugin;
@@ -851,7 +877,7 @@ static bool plugin_add(MEM_ROOT *tmp_root,
   }
   /* Clear the whole struct to catch future extensions. */
   memset(&tmp, 0, sizeof(tmp));
-  if (! (tmp.plugin_dl= plugin_dl_add(dl, report)))
+  if (! (tmp.plugin_dl= plugin_dl_add(dl, report, allow_path)))
     DBUG_RETURN(TRUE);
   /* Find plugin by name */
   for (plugin= tmp.plugin_dl->plugins; plugin->info; plugin++)
@@ -1562,7 +1588,7 @@ static void plugin_load(MEM_ROOT *tmp_root, int *argc, char **argv)
     LEX_STRING name= {(char *)str_name.ptr(), str_name.length()};
     LEX_STRING dl= {(char *)str_dl.ptr(), str_dl.length()};
 
-    if (plugin_add(tmp_root, &name, &dl, argc, argv, REPORT_TO_LOG))
+    if (plugin_add(tmp_root, &name, &dl, argc, argv, REPORT_TO_LOG, false))
       sql_print_warning("Couldn't load plugin named '%s' with soname '%s'.",
                         str_name.c_ptr(), str_dl.c_ptr());
     free_root(tmp_root, MYF(MY_MARK_BLOCKS_FREE));
@@ -1619,7 +1645,7 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
 
         dl= name;
         mysql_mutex_lock(&LOCK_plugin);
-        if ((plugin_dl= plugin_dl_add(&dl, REPORT_TO_LOG)))
+        if ((plugin_dl= plugin_dl_add(&dl, REPORT_TO_LOG, true)))
         {
           for (plugin= plugin_dl->plugins; plugin->info; plugin++)
           {
@@ -1627,7 +1653,13 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
             name.length= strlen(name.str);
 
             free_root(tmp_root, MYF(MY_MARK_BLOCKS_FREE));
-            if (plugin_add(tmp_root, &name, &dl, argc, argv, REPORT_TO_LOG))
+            if (plugin_add(tmp_root,
+                           &name,
+                           &dl,
+                           argc,
+                           argv,
+                           REPORT_TO_LOG,
+                           true))
               goto error;
           }
           plugin_dl_del(&dl); // reduce ref count
@@ -1637,7 +1669,7 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
       {
         free_root(tmp_root, MYF(MY_MARK_BLOCKS_FREE));
         mysql_mutex_lock(&LOCK_plugin);
-        if (plugin_add(tmp_root, &name, &dl, argc, argv, REPORT_TO_LOG))
+        if (plugin_add(tmp_root, &name, &dl, argc, argv, REPORT_TO_LOG, true))
           goto error;
       }
       mysql_mutex_unlock(&LOCK_plugin);
@@ -1891,7 +1923,13 @@ bool mysql_install_plugin(THD *thd, const LEX_STRING *name, const LEX_STRING *dl
     report_error(REPORT_TO_USER, ER_PLUGIN_IS_NOT_LOADED, name->str);
     goto err;
   }
-  error= plugin_add(thd->mem_root, name, dl, &argc, argv, REPORT_TO_USER);
+  error= plugin_add(thd->mem_root,
+                    name,
+                    dl,
+                    &argc,
+                    argv,
+                    REPORT_TO_USER,
+                    false);
   if (argv)
     free_defaults(argv);
   mysql_rwlock_unlock(&LOCK_system_variables_hash);


### PR DESCRIPTION
New environment variables PLUGVAR_LOAD_PATH and PLUGVAR_LOAD_ADD_PATH are
involved in MTR to use the feature in tests. This is usefull if test uses
several plugins located in different directories like PLUGIN_AUTH and
EXAMPLE_PLUGIN (see mysql-test/include/plugin.defs").

http://jenkins.percona.com/job/percona-server-5.6-param/1519/