### PR TITLE
Fix bug 1648718 (Testcase rpl.rpl_get_master_version_and_clock almost…

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_get_master_version_and_clock.test
+++ b/mysql-test/extra/rpl_tests/rpl_get_master_version_and_clock.test
@@ -44,8 +44,10 @@ if (!$debug_sync_action)
 
 eval SET @@global.debug= "+d,$dbug_sync_point";
 
---source include/start_slave.inc
+START SLAVE;
 --echo slave is going to hang in get_master_version_and_clock
+
+SET DEBUG_SYNC= "NOW WAIT_FOR in_get_master_version_and_clock";
 
 --let $rpl_server_number= 1
 --source include/rpl_stop_server.inc

--- a/mysql-test/suite/rpl/r/rpl_get_master_version_and_clock.result
+++ b/mysql-test/suite/rpl/r/rpl_get_master_version_and_clock.result
@@ -4,43 +4,44 @@ Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
 call mtr.add_suppression("Slave I/O: Master command COM_REGISTER_SLAVE failed: .*");
-call mtr.add_suppression("Slave I/O: .* failed with error: Lost connection to MySQL server at 'reading initial communication packet'");
 call mtr.add_suppression("Fatal error: The slave I/O thread stops because master and slave have equal MySQL server ids; .*");
-call mtr.add_suppression("Slave I/O thread .* register on master");
 include/stop_slave.inc
-SET @@global.debug= "+d,'debug_lock.before_get_UNIX_TIMESTAMP'";
-include/start_slave.inc
+SET @@global.debug= "+d,dbug.before_get_UNIX_TIMESTAMP";
+START SLAVE;
 slave is going to hang in get_master_version_and_clock
+SET DEBUG_SYNC= "NOW WAIT_FOR in_get_master_version_and_clock";
 include/rpl_stop_server.inc [server_number=1]
 slave is unblocked
 SET DEBUG_SYNC='now SIGNAL signal.get_unix_timestamp';
 Check network error happened here
 include/wait_for_slave_io_error.inc [errno=1040, 1053, 2002, 2003, 2006, 2013]
-set @@global.debug = "-d,'debug_lock.before_get_UNIX_TIMESTAMP'";
+set @@global.debug = "-d,dbug.before_get_UNIX_TIMESTAMP";
 include/rpl_start_server.inc [server_number=1]
 include/wait_for_slave_param.inc [Slave_IO_Running]
 include/stop_slave.inc
-SET @@global.debug= "+d,'debug_lock.before_get_SERVER_ID'";
-include/start_slave.inc
+SET @@global.debug= "+d,dbug.before_get_SERVER_ID";
+START SLAVE;
 slave is going to hang in get_master_version_and_clock
+SET DEBUG_SYNC= "NOW WAIT_FOR in_get_master_version_and_clock";
 include/rpl_stop_server.inc [server_number=1]
 slave is unblocked
 SET DEBUG_SYNC='now SIGNAL signal.get_server_id';
 Check network error happened here
 include/wait_for_slave_io_error.inc [errno=1040, 1053, 2002, 2003, 2006, 2013]
-set @@global.debug = "-d,'debug_lock.before_get_SERVER_ID'";
+set @@global.debug = "-d,dbug.before_get_SERVER_ID";
 include/rpl_start_server.inc [server_number=1]
 include/wait_for_slave_param.inc [Slave_IO_Running]
 include/stop_slave.inc
-SET @@global.debug= "+d,'dbug.before_get_MASTER_UUID'";
-include/start_slave.inc
+SET @@global.debug= "+d,dbug.before_get_MASTER_UUID";
+START SLAVE;
 slave is going to hang in get_master_version_and_clock
+SET DEBUG_SYNC= "NOW WAIT_FOR in_get_master_version_and_clock";
 include/rpl_stop_server.inc [server_number=1]
 slave is unblocked
 SET DEBUG_SYNC='now SIGNAL signal.get_master_uuid';
 Check network error happened here
 include/wait_for_slave_io_error.inc [errno=1040, 1053, 2002, 2003, 2006, 2013]
-set @@global.debug = "-d,'dbug.before_get_MASTER_UUID'";
+set @@global.debug = "-d,dbug.before_get_MASTER_UUID";
 include/rpl_start_server.inc [server_number=1]
 include/wait_for_slave_param.inc [Slave_IO_Running]
 set global debug= '';

--- a/mysql-test/suite/rpl/t/rpl_get_master_version_and_clock.test
+++ b/mysql-test/suite/rpl/t/rpl_get_master_version_and_clock.test
@@ -21,29 +21,27 @@ source include/have_binlog_format_mixed.inc;
 connection slave;
 
 call mtr.add_suppression("Slave I/O: Master command COM_REGISTER_SLAVE failed: .*");
-call mtr.add_suppression("Slave I/O: .* failed with error: Lost connection to MySQL server at 'reading initial communication packet'");
 call mtr.add_suppression("Fatal error: The slave I/O thread stops because master and slave have equal MySQL server ids; .*");
-call mtr.add_suppression("Slave I/O thread .* register on master");
 
 #Test case 1: Try to get the value of the UNIX_TIMESTAMP from master under network disconnection
 let $debug_saved= `select @@global.debug`;
 
 # set up two parameters to pass into extra/rpl_tests/rpl_get_master_version_and_clock
-let $dbug_sync_point= 'debug_lock.before_get_UNIX_TIMESTAMP';
+let $dbug_sync_point= dbug.before_get_UNIX_TIMESTAMP;
 let $debug_sync_action= 'now SIGNAL signal.get_unix_timestamp';
 source extra/rpl_tests/rpl_get_master_version_and_clock.test; 
 
 #Test case 2: Try to get the value of the SERVER_ID from master under network disconnection
 connection slave;
 
-let $dbug_sync_point= 'debug_lock.before_get_SERVER_ID';
+let $dbug_sync_point= dbug.before_get_SERVER_ID;
 let $debug_sync_action= 'now SIGNAL signal.get_server_id';
 source extra/rpl_tests/rpl_get_master_version_and_clock.test;
 
 #Test case 3: Try to get the value of the MASTER_UUID from master under network disconnection
 connection slave;
 
-let $dbug_sync_point= 'dbug.before_get_MASTER_UUID';
+let $dbug_sync_point= dbug.before_get_MASTER_UUID;
 let $debug_sync_action= 'now SIGNAL signal.get_master_uuid';
 source extra/rpl_tests/rpl_get_master_version_and_clock.test;
 

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2019,7 +2019,9 @@ static int get_master_uuid(MYSQL *mysql, Master_info *mi)
 
   DBUG_EXECUTE_IF("dbug.before_get_MASTER_UUID",
                   {
-                    const char act[]= "now wait_for signal.get_master_uuid";
+                    const char act[]
+                        = "now signal in_get_master_version_and_clock "
+                        "wait_for signal.get_master_uuid";
                     DBUG_ASSERT(opt_debug_sync_timeout > 0);
                     DBUG_ASSERT(!debug_sync_set_action(current_thd,
                                                        STRING_WITH_LEN(act)));
@@ -2278,7 +2280,7 @@ static int get_master_version_and_clock(MYSQL* mysql, Master_info* mi)
   DBUG_EXECUTE_IF("dbug.before_get_UNIX_TIMESTAMP",
                   {
                     const char act[]=
-                      "now "
+                      "now signal in_get_master_version_and_clock "
                       "wait_for signal.get_unix_timestamp";
                     DBUG_ASSERT(opt_debug_sync_timeout > 0);
                     DBUG_ASSERT(!debug_sync_set_action(current_thd,
@@ -2338,7 +2340,7 @@ static int get_master_version_and_clock(MYSQL* mysql, Master_info* mi)
   DBUG_EXECUTE_IF("dbug.before_get_SERVER_ID",
                   {
                     const char act[]=
-                      "now "
+                      "now signal in_get_master_version_and_clock "
                       "wait_for signal.get_server_id";
                     DBUG_ASSERT(opt_debug_sync_timeout > 0);
                     DBUG_ASSERT(!debug_sync_set_action(current_thd, 


### PR DESCRIPTION
… completely broken)

Fix the testcase:
- fix the debug sync point names to actually match what's in the
  source code (mostly s/debug_lock/dbug);
- remove extra quotes from dbug_sync_point variable sets, as they
  are redundant and make all the matches fail;
- for starting a slave with a debug sync point set, replace the
  --source include/start_slave.inc with a plain START SLAVE and a
  debug_sync wait. Make the testcase debug sync points signal when
  they are parked for this;
- remove redundant MTR warning suppressions.

http://jenkins.percona.com/job/percona-server-5.6-param/1518/