### PR TITLE
Try to fix bug 1648737 (Testcase opt_trace.temp_table is unstable)

### DIFF
--- a/mysql-test/suite/opt_trace/r/temp_table.result
+++ b/mysql-test/suite/opt_trace/r/temp_table.result
@@ -641,6 +641,9 @@ c2 VARCHAR(250)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 INSERT INTO t1(c2) VALUES ('b'),('b');
 INSERT INTO t1(c2) SELECT t1.c2 FROM t1, t1 t2, t1 t3, t1 t4, t1 t5, t1 t6;
+ANALYZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
 SET @@max_heap_table_size=1;
 Warnings:
 Warning	1292	Truncated incorrect max_heap_table_size value: '1'

--- a/mysql-test/suite/opt_trace/t/temp_table.test
+++ b/mysql-test/suite/opt_trace/t/temp_table.test
@@ -65,6 +65,8 @@ CREATE TABLE t1 (
 INSERT INTO t1(c2) VALUES ('b'),('b');
 INSERT INTO t1(c2) SELECT t1.c2 FROM t1, t1 t2, t1 t3, t1 t4, t1 t5, t1 t6;
 
+ANALYZE TABLE t1;
+
 SET @@max_heap_table_size=1;
 SET @@group_concat_max_len= 500;
 


### PR DESCRIPTION
Table t1 is InnoDB table queried right after filling it. This creates
a race condition with background stats thread, which may result in
query plan/cost instability. Fix this by adding an ANALYZE TABLE
statement.

http://jenkins.percona.com/job/percona-server-5.6-param/1522/