### PR TITLE
Fix lp:1640810 "Adding COMPRESSED attributes to InnoDB special tables fields can lead to server crashes".

### DIFF
--- a/mysql-test/suite/innodb/r/xtradb_compressed_columns.result
+++ b/mysql-test/suite/innodb/r/xtradb_compressed_columns.result
@@ -276,3 +276,11 @@ number_of_rows_after_alteration
 1
 DROP TABLE t1;
 SET GLOBAL innodb_compressed_columns_zip_level = @saved_innodb_compressed_columns_zip_level;
+call mtr.add_suppression("InnoDB: Error: Column .* in table .* has unexpected COMPRESSED attribute");
+ALTER TABLE mysql.innodb_index_stats
+MODIFY stat_description VARCHAR(1024) COLLATE utf8_bin NOT NULL COLUMN_FORMAT COMPRESSED;
+CREATE TABLE t1(i INT);
+SELECT * FROM mysql.innodb_index_stats;
+DROP TABLE t1;
+ALTER TABLE mysql.innodb_index_stats
+MODIFY stat_description VARCHAR(1024) COLLATE utf8_bin NOT NULL;

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns.test
@@ -195,3 +195,18 @@ SELECT COUNT(*) AS number_of_rows_after_alteration FROM t1 WHERE a = @inserted_v
 DROP TABLE t1;
 
 SET GLOBAL innodb_compressed_columns_zip_level = @saved_innodb_compressed_columns_zip_level;
+
+#
+# Bug lp:1640810 "Adding COMPRESSED attributes to InnoDB special tables fields can lead to server crashes"
+#
+call mtr.add_suppression("InnoDB: Error: Column .* in table .* has unexpected COMPRESSED attribute");
+
+ALTER TABLE mysql.innodb_index_stats
+  MODIFY stat_description VARCHAR(1024) COLLATE utf8_bin NOT NULL COLUMN_FORMAT COMPRESSED;
+CREATE TABLE t1(i INT);
+--disable_result_log
+SELECT * FROM mysql.innodb_index_stats;
+--enable_result_log
+DROP TABLE t1;
+ALTER TABLE mysql.innodb_index_stats
+  MODIFY stat_description VARCHAR(1024) COLLATE utf8_bin NOT NULL;

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -6269,6 +6269,20 @@ dict_table_schema_check(
 
 			return(DB_ERROR);
 		}
+
+		/* check whether column has the same COMPRESSED attriute */
+		if ((req_schema->columns[i].prtype_mask & DATA_COMPRESSED) !=
+			(table->cols[j].prtype & DATA_COMPRESSED)) {
+
+			ut_snprintf(errstr, errstr_sz,
+				"Column %s in table %s has "
+				"unexpected COMPRESSED attribute.",
+				req_schema->columns[i].name,
+				ut_format_name(req_schema->table_name,
+					TRUE, buf, sizeof(buf)));
+
+			return(DB_ERROR);
+		}
 	}
 
 	if (req_schema->n_foreign != table->foreign_set.size()) {


### PR DESCRIPTION
'dict_table_schema_check()' extended with additional logic which guarantees that there is no difference between 'COMPRESSED' attributes in column definitions.

'innodb.xtradb_compressed_columns' MTR test case extended with checks for adding 'COMPRESSED' attribute to 'stat_description' field in 'mysql.innodb_index_stats'.