### PR TITLE
Log all statements in transaction with same id, lp:897715

### DIFF
--- a/mysql-test/r/percona_log_slow_verbosity.result
+++ b/mysql-test/r/percona_log_slow_verbosity.result
@@ -5,30 +5,33 @@ SET SESSION long_query_time=0;
 SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
 [log_start.inc] percona.slow_extended.log_slow_verbosity_0
 INSERT INTO t1 VALUE(0);
+BEGIN;
+INSERT INTO t1 VALUE(1);
+ROLLBACK;
 [log_stop.inc] percona.slow_extended.log_slow_verbosity_0
 log_slow_verbosity='microtime,innodb,query_plan':
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Bytes_sent: \d+.*$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# InnoDB_trx_id: \w+$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   3
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Filesort: (Yes|No)  Filesort_on_disk: (Yes|No)  Merge_passes: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#   InnoDB_IO_r_ops: \d+  InnoDB_IO_r_bytes: \d+  InnoDB_IO_r_wait: \d*\.\d*$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#   InnoDB_rec_lock_wait: \d*\.\d*  InnoDB_queue_wait: \d*\.\d*$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#   InnoDB_pages_distinct: \d+$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# No InnoDB statistics available for this query$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   3
 SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
 [log_start.inc] percona.slow_extended.log_slow_verbosity_1
 SELECT 1;

--- a/mysql-test/t/percona_log_slow_verbosity.test
+++ b/mysql-test/t/percona_log_slow_verbosity.test
@@ -20,6 +20,9 @@ SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
 
 --source include/log_start.inc
 INSERT INTO t1 VALUE(0);
+BEGIN;
+INSERT INTO t1 VALUE(1);
+ROLLBACK;
 --source include/log_stop.inc
 
 --echo log_slow_verbosity='microtime,innodb,query_plan':

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2083,7 +2083,7 @@ bool MYSQL_QUERY_LOG::write(THD *thd, ulonglong current_utime,
     thd->profiling.print_current(&log_file);
 #endif
     if ((thd->variables.log_slow_verbosity & (1ULL << SLOG_V_INNODB))
-        && thd->innodb_was_used)
+        && thd->innodb_trx_id)
     {
       char buf[20];
       snprintf(buf, 20, "%llX", thd->innodb_trx_id);

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4733,7 +4733,8 @@ void THD::clear_slow_extended()
   tmp_tables_disk_used=         0;
   tmp_tables_size=              0;
   innodb_was_used=              FALSE;
-  innodb_trx_id=                0;
+  if (!(server_status & SERVER_STATUS_IN_TRANS))
+    innodb_trx_id= 0;
   innodb_io_reads=              0;
   innodb_io_read=               0;
   innodb_io_reads_wait_timer=   0;


### PR DESCRIPTION
https://bugs.launchpad.net/percona-server/+bug/897715
http://jenkins.percona.com/job/percona-server-5.6-param/

I have considered to use thread_id + statement start time as a uniq identifier.
Only explicit transactions are tracked.
I'm not sure if additional flag is required for log_slow_verbosity or existing one (e.g. microtime) could be used.
It could be also implemented for 5.5 in the same way.

This kind of functionality will be useful with:
- find a transactions caused  metadata lock
- find whole transaction (including non-innodb statements at transaction start) by thread id (from processlist) or innodb transaction id (from innodb status).
- find incorrect transactions usage (set auto_commit = 0, connection pool on application side, some application threads using transactions and some expecting auto_commit=1).

Mysql 5.7 has thd->get_transaction()->sequence_number but it always empty.
