### PR TITLE
Fix bug 1650256 (main.join_cache_bka_nixbnl)

### DIFF
--- a/mysql-test/include/join_cache.inc
+++ b/mysql-test/include/join_cache.inc
@@ -1807,6 +1807,7 @@ FROM t1
 GROUP BY field2
 ORDER BY field1;
 
+--replace_column 9 ROWS
 eval explain $query;
 eval $query;
 

--- a/mysql-test/r/join_cache_bka.result
+++ b/mysql-test/r/join_cache_bka.result
@@ -2461,8 +2461,8 @@ ON t1.col_varchar_key = t2.col_varchar_key
 GROUP BY field2
 ORDER BY field1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_varchar_key	7	NULL	3	Using index; Using temporary; Using filesort
-1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	1	Using join buffer (Batched Key Access)
+1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_varchar_key	7	NULL	ROWS	Using index; Using temporary; Using filesort
+1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	ROWS	Using join buffer (Batched Key Access)
 SELECT MIN(t2.col_datetime_key) AS field1,
 t1.col_int_key AS field2  
 FROM t1

--- a/mysql-test/r/join_cache_bka_nixbnl.result
+++ b/mysql-test/r/join_cache_bka_nixbnl.result
@@ -2461,8 +2461,8 @@ ON t1.col_varchar_key = t2.col_varchar_key
 GROUP BY field2
 ORDER BY field1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_varchar_key	7	NULL	3	Using index; Using temporary; Using filesort
-1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	1	Using join buffer (Batched Key Access)
+1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_varchar_key	7	NULL	ROWS	Using index; Using temporary; Using filesort
+1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	ROWS	Using join buffer (Batched Key Access)
 SELECT MIN(t2.col_datetime_key) AS field1,
 t1.col_int_key AS field2  
 FROM t1

--- a/mysql-test/r/join_cache_bkaunique.result
+++ b/mysql-test/r/join_cache_bkaunique.result
@@ -2462,8 +2462,8 @@ ON t1.col_varchar_key = t2.col_varchar_key
 GROUP BY field2
 ORDER BY field1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_varchar_key	7	NULL	3	Using index; Using temporary; Using filesort
-1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	1	Using join buffer (Batched Key Access (unique))
+1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_varchar_key	7	NULL	ROWS	Using index; Using temporary; Using filesort
+1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	ROWS	Using join buffer (Batched Key Access (unique))
 SELECT MIN(t2.col_datetime_key) AS field1,
 t1.col_int_key AS field2  
 FROM t1

--- a/mysql-test/r/join_cache_bnl.result
+++ b/mysql-test/r/join_cache_bnl.result
@@ -2462,8 +2462,8 @@ ON t1.col_varchar_key = t2.col_varchar_key
 GROUP BY field2
 ORDER BY field1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_int_key	4	NULL	3	Using temporary; Using filesort
-1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	1	NULL
+1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_int_key	4	NULL	ROWS	Using temporary; Using filesort
+1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	ROWS	NULL
 SELECT MIN(t2.col_datetime_key) AS field1,
 t1.col_int_key AS field2  
 FROM t1

--- a/mysql-test/r/join_cache_nojb.result
+++ b/mysql-test/r/join_cache_nojb.result
@@ -2462,8 +2462,8 @@ ON t1.col_varchar_key = t2.col_varchar_key
 GROUP BY field2
 ORDER BY field1;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_int_key	4	NULL	3	Using temporary; Using filesort
-1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	1	NULL
+1	SIMPLE	t1	index	col_int_key,col_varchar_key	col_int_key	4	NULL	ROWS	Using temporary; Using filesort
+1	SIMPLE	t2	ref	col_varchar_key	col_varchar_key	3	test.t1.col_varchar_key	ROWS	NULL
 SELECT MIN(t2.col_datetime_key) AS field1,
 t1.col_int_key AS field2  
 FROM t1


### PR DESCRIPTION
Mask unstable-for-InnoDB rows estimate from EXPLAIN SELECT output.

http://jenkins.percona.com/job/percona-server-5.6-param/1533/