### PR TITLE
Fix lp:1647530 "InnoDB: Failing assertion: success | InnoDB: page_zip_apply_log: 97>>1 > 1 | InnoDB: unable to decompress space 6 page 3".

### DIFF
--- a/mysql-test/suite/innodb/include/xtradb_compressed_columns_check_type.inc
+++ b/mysql-test/suite/innodb/include/xtradb_compressed_columns_check_type.inc
@@ -51,20 +51,46 @@ if($full_field_type)
   --let $max_value_length= $field_length
 }
 
+--let $number_of_selects = 1
+if($check_buffer_pool_evict)
+{
+  --let $number_of_selects = 2
+}
+
 INSERT INTO t1 VALUES(NULL);
---let $include_silent= 1
---let $assert_text= null value must match ($local_full_field_type, ROW_RORMAT = $row_format, length = $field_length)
---let $assert_cond= [SELECT COUNT(*) FROM t1 WHERE a IS NULL] = 1
---source include/assert.inc
---let $include_silent= 0
+--let $i = 0
+while($i < $number_of_selects)
+{
+  if($i == 1)
+  {
+    SET GLOBAL innodb_buffer_pool_evict = 'uncompressed';
+  }
+  --let $include_silent= 1
+  --let $assert_text= null value must match ($local_full_field_type, ROW_RORMAT = $row_format, length = $field_length)
+  --let $assert_cond= [SELECT COUNT(*) FROM t1 WHERE a IS NULL] = 1
+  --source include/assert.inc
+  --let $include_silent= 0
+
+  --inc $i
+}
 DELETE FROM t1;
 
 INSERT INTO t1 VALUES('');
---let $include_silent= 1
---let $assert_text= empty value must match ($local_full_field_type, ROW_RORMAT = $row_format, length = $field_length)
---let $assert_cond= [SELECT COUNT(*) FROM t1 WHERE a = ""] = 1
---source include/assert.inc
---let $include_silent= 0
+--let $i = 0
+while($i < $number_of_selects)
+{
+  if($i == 1)
+  {
+    SET GLOBAL innodb_buffer_pool_evict = 'uncompressed';
+  }
+  --let $include_silent= 1
+  --let $assert_text= empty value must match ($local_full_field_type, ROW_RORMAT = $row_format, length = $field_length)
+  --let $assert_cond= [SELECT COUNT(*) FROM t1 WHERE a = ""] = 1
+  --source include/assert.inc
+  --let $include_silent= 0
+
+  --inc $i
+}
 DELETE FROM t1;
 
 while($current_value_length <= $max_value_length)
@@ -73,11 +99,21 @@ while($current_value_length <= $max_value_length)
   --disable_warnings
   INSERT INTO t1 VALUES(@inserted_value);
   --enable_warnings
-  --let $include_silent= 1
-  --let $assert_text= value of $current_value_length byte(s) must match ($local_full_field_type, ROW_RORMAT = $row_format, length = $field_length, current = $current_value_length)
-  --let $assert_cond= [SELECT COUNT(*) FROM t1 WHERE a = LEFT(@inserted_value, $local_type_length_limit)] = 1
-  --source include/assert.inc
-  --let $include_silent= 0
+  --let $i = 0
+  while($i < $number_of_selects)
+  {
+    if($i == 1)
+    {
+      SET GLOBAL innodb_buffer_pool_evict = 'uncompressed';
+    }
+    --let $include_silent= 1
+    --let $assert_text= value of $current_value_length byte(s) must match ($local_full_field_type, ROW_RORMAT = $row_format, length = $field_length, current = $current_value_length)
+    --let $assert_cond= [SELECT COUNT(*) FROM t1 WHERE a = LEFT(@inserted_value, $local_type_length_limit)] = 1
+    --source include/assert.inc
+    --let $include_silent= 0
+
+    --inc $i
+  }
   DELETE FROM t1;
   --inc $current_value_length
 }

--- a/mysql-test/suite/innodb/include/xtradb_compressed_columns_check_type_superset.inc
+++ b/mysql-test/suite/innodb/include/xtradb_compressed_columns_check_type_superset.inc
@@ -20,6 +20,11 @@ call mtr.add_suppression("InnoDB: The log sequence numbers [0-9]+ and [0-9]+ in 
 --let $restart_parameters= restart:--innodb-log-file-size=256M --max-allowed-packet=48M
 --source include/restart_mysqld.inc
 
+if($row_format == 'COMPRESSED')
+{
+  --let $check_buffer_pool_evict = `SELECT version() LIKE '%debug%'`
+}
+
 # saving global variables
 SET @saved_innodb_file_format = @@global.innodb_file_format;
 SET @saved_innodb_compressed_columns_zip_level = @@global.innodb_compressed_columns_zip_level;

--- a/mysql-test/suite/innodb/r/xtradb_compressed_columns_debug.result
+++ b/mysql-test/suite/innodb/r/xtradb_compressed_columns_debug.result
@@ -1,0 +1,17 @@
+SET @old_innodb_file_format = @@global.innodb_file_format;
+SET @old_innodb_compressed_columns_zip_level = @@global.innodb_compressed_columns_zip_level;
+SET GLOBAL innodb_file_format = Barracuda;
+SET GLOBAL innodb_compressed_columns_zip_level = 0;
+CREATE TABLE t1(
+a VARBINARY(255) COLUMN_FORMAT COMPRESSED
+) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+INSERT INTO t1 VALUES(REPEAT('abc',1000));
+Warnings:
+Warning	1265	Data truncated for column 'a' at row 1
+SET GLOBAL innodb_buffer_pool_evict = 'uncompressed';
+SELECT * FROM t1;
+a
+abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc
+DROP TABLE t1;
+SET GLOBAL innodb_file_format = @old_innodb_file_format;
+SET GLOBAL innodb_compressed_columns_zip_level = @old_innodb_compressed_columns_zip_level;

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_debug.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_debug.test
@@ -1,0 +1,26 @@
+--source include/have_innodb.inc
+--source include/have_debug.inc
+
+#
+# Bug lp:1647530 "InnoDB: Failing assertion: success | InnoDB: page_zip_apply_log: 97>>1 > 1 | InnoDB: unable to decompress space 6 page 3"
+#
+SET @old_innodb_file_format = @@global.innodb_file_format;
+SET @old_innodb_compressed_columns_zip_level = @@global.innodb_compressed_columns_zip_level;
+
+SET GLOBAL innodb_file_format = Barracuda;
+SET GLOBAL innodb_compressed_columns_zip_level = 0;
+
+CREATE TABLE t1(
+  a VARBINARY(255) COLUMN_FORMAT COMPRESSED
+) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+
+INSERT INTO t1 VALUES(REPEAT('abc',1000));
+
+SET GLOBAL innodb_buffer_pool_evict = 'uncompressed';
+
+SELECT * FROM t1;
+
+DROP TABLE t1;
+
+SET GLOBAL innodb_file_format = @old_innodb_file_format;
+SET GLOBAL innodb_compressed_columns_zip_level = @old_innodb_compressed_columns_zip_level;

--- a/storage/innobase/page/page0zip.cc
+++ b/storage/innobase/page/page0zip.cc
@@ -527,7 +527,8 @@ page_zip_fields_encode(
 			const dict_col_t*	column
 				= dict_field_get_col(field);
 
-			if (UNIV_UNLIKELY(column->len > 255)
+			if (UNIV_UNLIKELY(column->len > 255 -
+				prtype_get_compression_extra(column->prtype))
 			    || UNIV_UNLIKELY(column->mtype == DATA_BLOB)) {
 				val |= 0x7e; /* max > 255 bytes */
 			}


### PR DESCRIPTION
Fixed problem with 'page_zip_fields_encode()' not taking into account additional 2 bytes header for columns with 'COLUMN_FORMAT COMPRESSED' attributes.

'innodb.xtradb_compressed_columns' MTR test case extended with checks for selecting data from a table with 'ROW_FORMAT=COMPRESSED' and 'COLUMNS_FORMAT COMPRESSED' after executing "SET GLOBAL innodb_buffer_pool_evict = 'uncompressed'".

'innodb.xtradb_compressed_columns_consistency_barracuda_compressed' MTR test case now also performs InnoDB buffer pool eviction and another identical 'SELECT' just after the original 'SELECT'.