### PR TITLE
Fix bug 1650450 (SSL_COMP_get_compression_methods allocations suppres…

### DIFF
--- a/mysql-test/valgrind.supp
+++ b/mysql-test/valgrind.supp
@@ -888,6 +888,7 @@
    fun:malloc
    fun:CRYPTO_malloc
    fun:sk_new
+   ...
    fun:SSL_COMP_get_compression_methods
    fun:SSL_library_init
    fun:ssl_start
@@ -903,6 +904,7 @@
    fun:malloc
    fun:CRYPTO_malloc
    fun:sk_new
+   ...
    fun:SSL_COMP_get_compression_methods
    fun:SSL_library_init
    fun:ssl_start


### PR DESCRIPTION
…sed not universally for Valgrind)

Tweak the Valgrind suppressions to allow for an extra frame between
sk_new and SSL_COMP_get_compression_methods.

http://jenkins.percona.com/job/percona-server-5.6-valgrind/228/