### PR TITLE
Fix #1651657, failback from backup for legacy for small BP instance size

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3880,7 +3880,8 @@ innobase_change_buffering_inited_ok:
 	if (!innodb_empty_free_list_algorithm_backoff_allowed(
 			static_cast<srv_empty_free_list_t>(
 				srv_empty_free_list_algorithm),
-			innobase_buffer_pool_size / srv_page_size)) {
+			innobase_buffer_pool_size / srv_page_size
+			/ innobase_buffer_pool_instances)) {
 		sql_print_information(
 				"InnoDB: innodb_empty_free_list_algorithm "
 				"has been changed to legacy "
@@ -17247,11 +17248,12 @@ innodb_srv_empty_free_list_algorithm_validate(
 	algorithm = static_cast<srv_empty_free_list_t>(algo);
 	if (!innodb_empty_free_list_algorithm_backoff_allowed(
 				algorithm,
-				innobase_buffer_pool_size / srv_page_size)) {
+				innobase_buffer_pool_size / srv_page_size
+				/ innobase_buffer_pool_instances)) {
 		sql_print_warning(
 				"InnoDB: innodb_empty_free_list_algorithm "
 				"= 'backoff' requires at least"
-				" 20MB buffer pool.\n");
+				" 20MB buffer pool instances.\n");
 		return(1);
 	}
 


### PR DESCRIPTION
https://bugs.launchpad.net/percona-server/+bug/1651657
http://jenkins.percona.com/job/percona-server-5.6-param/1560/

- add innobase_buffer_pool_instances in check for minimum allowed backoff value.