### PR TITLE
Fix #1651657, failback from backup for legacy for small BP instance size

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug1651657.result
+++ b/mysql-test/suite/innodb/r/percona_bug1651657.result
@@ -1,0 +1,5 @@
+include/assert.inc [Small buffer pool instances should use legacy]
+call mtr.add_suppression("InnoDB: innodb_empty_free_list_algorithm = 'backoff' requires at least 20MB buffer pool instances.");
+SET GLOBAL innodb_empty_free_list_algorithm="backoff";
+ERROR 42000: Variable 'innodb_empty_free_list_algorithm' can't be set to the value of 'backoff'
+include/assert.inc [Small buffer pool instances should use legacy]

--- a/mysql-test/suite/innodb/t/percona_bug1651657-master.opt
+++ b/mysql-test/suite/innodb/t/percona_bug1651657-master.opt
@@ -1,0 +1,1 @@
+--innodb-buffer-pool-size=1026M --innodb-buffer-pool-instances=54 --innodb-empty-free-list-algorithm=backoff

--- a/mysql-test/suite/innodb/t/percona_bug1651657.test
+++ b/mysql-test/suite/innodb/t/percona_bug1651657.test
@@ -1,0 +1,11 @@
+--source include/have_innodb.inc
+--let $assert_text= Small buffer pool instances should use legacy
+--let $assert_cond= @@innodb_empty_free_list_algorithm = "legacy"
+--source include/assert.inc
+
+call mtr.add_suppression("InnoDB: innodb_empty_free_list_algorithm = 'backoff' requires at least 20MB buffer pool instances.");
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_empty_free_list_algorithm="backoff";
+--let $assert_text= Small buffer pool instances should use legacy
+--let $assert_cond= @@innodb_empty_free_list_algorithm = "legacy"
+--source include/assert.inc

--- a/mysql-test/suite/sys_vars/t/innodb_empty_free_list_algorithm_basic-master.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_empty_free_list_algorithm_basic-master.opt
@@ -1,1 +1,1 @@
---innodb-buffer-pool-size=20M
+--innodb-buffer-pool-size=20M --innodb_buffer_pool_instances=1

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -701,6 +701,32 @@ innobase_is_fake_change(
 	THD*		thd);	/*!< in: MySQL thread handle of the user for
 				  whom the transaction is being committed */
 
+/** Empty free list algorithm.
+Checks if buffer pool is big enough to enable backoff algorithm.
+InnoDB empty free list algorithm backoff requires free pages
+from LRU for the best performance.
+buf_LRU_buf_pool_running_out cancels query if 1/4 of
+buffer pool belongs to LRU or freelist.
+At the same time buf_flush_LRU_list_batch
+keeps up to BUF_LRU_MIN_LEN in LRU.
+In order to avoid deadlock baclkoff requires buffer pool
+to be at least 4*BUF_LRU_MIN_LEN,
+but flush peformance is bad because of trashing
+and additional BUF_LRU_MIN_LEN pages are requested.
+@param[in]	algorithm	desired algorithm from srv_empty_free_list_t
+@return	true if it's possible to enable backoff. */
+static inline
+bool
+innodb_empty_free_list_algorithm_allowed(
+	srv_empty_free_list_t	algorithm)
+{
+	long long buf_pool_pages = srv_buf_pool_size / srv_page_size
+				/ srv_buf_pool_instances;
+
+	return(buf_pool_pages >= BUF_LRU_MIN_LEN * (4 + 1)
+			|| algorithm != SRV_EMPTY_FREE_LIST_BACKOFF);
+}
+
 /** Get the list of foreign keys referencing a specified table
 table.
 @param thd		The thread handle
@@ -1360,28 +1386,6 @@ normalize_table_name_low(
 	const char*     name,           /* in: table name string */
 	ibool           set_lower_case); /* in: TRUE if we want to set
 					 name to lower case */
-
-/*************************************************************//**
-Checks if buffer pool is big enough to enable backoff algorithm.
-InnoDB empty free list algorithm backoff requires free pages
-from LRU for the best performance.
-buf_LRU_buf_pool_running_out cancels query if 1/4 of 
-buffer pool belongs to LRU or freelist.
-At the same time buf_flush_LRU_list_batch
-keeps up to BUF_LRU_MIN_LEN in LRU.
-In order to avoid deadlock baclkoff requires buffer pool
-to be at least 4*BUF_LRU_MIN_LEN,
-but flush peformance is bad because of trashing
-and additional BUF_LRU_MIN_LEN pages are requested.
-@return	true if it's possible to enable backoff. */
-static
-bool
-innodb_empty_free_list_algorithm_backoff_allowed(
-	srv_empty_free_list_t
-			algorithm,		/*!< in: desired algorithm
-						from srv_empty_free_list_t */
-	long long	buf_pool_pages);	/*!< in: total number
-						of pages inside buffer pool */
 
 /*************************************************************//**
 Removes old archived transaction log files.
@@ -3877,10 +3881,9 @@ innobase_change_buffering_inited_ok:
 
 
 	/* Do not enable backoff algorithm for small buffer pool. */
-	if (!innodb_empty_free_list_algorithm_backoff_allowed(
+	if (!innodb_empty_free_list_algorithm_allowed(
 			static_cast<srv_empty_free_list_t>(
-				srv_empty_free_list_algorithm),
-			innobase_buffer_pool_size / srv_page_size)) {
+				srv_empty_free_list_algorithm))) {
 		sql_print_information(
 				"InnoDB: innodb_empty_free_list_algorithm "
 				"has been changed to legacy "
@@ -17179,32 +17182,6 @@ innodb_status_output_update(
 }
 
 /*************************************************************//**
-Empty free list algorithm.
-Checks if buffer pool is big enough to enable backoff algorithm.
-InnoDB empty free list algorithm backoff requires free pages
-from LRU for the best performance.
-buf_LRU_buf_pool_running_out cancels query if 1/4 of 
-buffer pool belongs to LRU or freelist.
-At the same time buf_flush_LRU_list_batch
-keeps up to BUF_LRU_MIN_LEN in LRU.
-In order to avoid deadlock baclkoff requires buffer pool
-to be at least 4*BUF_LRU_MIN_LEN,
-but flush peformance is bad because of trashing
-and additional BUF_LRU_MIN_LEN pages are requested.
-@return	true if it's possible to enable backoff. */
-static
-bool
-innodb_empty_free_list_algorithm_backoff_allowed(
-	srv_empty_free_list_t	algorithm,	/*!< in: desired algorithm
-						from srv_empty_free_list_t */
-	long long		buf_pool_pages)	/*!< in: total number
-						of pages inside buffer pool */
-{
-	return(buf_pool_pages >= BUF_LRU_MIN_LEN * (4 + 1)
-			|| algorithm != SRV_EMPTY_FREE_LIST_BACKOFF);
-}
-
-/*************************************************************//**
 Empty free list algorithm. This function is registered as
 a callback with MySQL. 
 @return	0 for valid algorithm */
@@ -17245,13 +17222,11 @@ innodb_srv_empty_free_list_algorithm_validate(
 		return(1);
 
 	algorithm = static_cast<srv_empty_free_list_t>(algo);
-	if (!innodb_empty_free_list_algorithm_backoff_allowed(
-				algorithm,
-				innobase_buffer_pool_size / srv_page_size)) {
+	if (!innodb_empty_free_list_algorithm_allowed(algorithm)) {
 		sql_print_warning(
 				"InnoDB: innodb_empty_free_list_algorithm "
 				"= 'backoff' requires at least"
-				" 20MB buffer pool.\n");
+				" 20MB buffer pool instances.\n");
 		return(1);
 	}
 


### PR DESCRIPTION
https://bugs.launchpad.net/percona-server/+bug/1651657
http://jenkins.percona.com/job/percona-server-5.6-param/1560/

Small buffer pool instance size and backoff algorithm causing deadlock, failback to legacy algorithm in such cases.