### PR TITLE
Fix #1651657, failback from backup for legacy for small BP instance size - 5.7

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug1651657.result
+++ b/mysql-test/suite/innodb/r/percona_bug1651657.result
@@ -1,0 +1,5 @@
+include/assert.inc [Small buffer pool instances should use legacy]
+call mtr.add_suppression("InnoDB: innodb_empty_free_list_algorithm = 'backoff' requires at least 20MB buffer pool instances.");
+SET GLOBAL innodb_empty_free_list_algorithm="backoff";
+ERROR 42000: Variable 'innodb_empty_free_list_algorithm' can't be set to the value of 'backoff'
+include/assert.inc [Small buffer pool instances should use legacy]

--- a/mysql-test/suite/innodb/r/percona_bug1651657_resize.result
+++ b/mysql-test/suite/innodb/r/percona_bug1651657_resize.result
@@ -1,0 +1,5 @@
+set @old_innodb_buffer_pool_size = @@innodb_buffer_pool_size;
+set global innodb_empty_free_list_algorithm="backoff";
+SET @@GLOBAL.innodb_buffer_pool_size = 19922944;
+ERROR 42000: Variable 'innodb_buffer_pool_size' can't be set to the value of '19922944'
+SET @@GLOBAL.innodb_empty_free_list_algorithm=@old_innodb_empty_free_list_algorithm;

--- a/mysql-test/suite/innodb/t/percona_bug1651657-master.opt
+++ b/mysql-test/suite/innodb/t/percona_bug1651657-master.opt
@@ -1,0 +1,1 @@
+--innodb-buffer-pool-size=1026M --innodb-buffer-pool-instances=54 --innodb-empty-free-list-algorithm=backoff

--- a/mysql-test/suite/innodb/t/percona_bug1651657.test
+++ b/mysql-test/suite/innodb/t/percona_bug1651657.test
@@ -1,0 +1,11 @@
+--source include/have_innodb.inc
+--let $assert_text= Small buffer pool instances should use legacy
+--let $assert_cond= @@innodb_empty_free_list_algorithm = "legacy"
+--source include/assert.inc
+
+call mtr.add_suppression("InnoDB: innodb_empty_free_list_algorithm = 'backoff' requires at least 20MB buffer pool instances.");
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_empty_free_list_algorithm="backoff";
+--let $assert_text= Small buffer pool instances should use legacy
+--let $assert_cond= @@innodb_empty_free_list_algorithm = "legacy"
+--source include/assert.inc

--- a/mysql-test/suite/innodb/t/percona_bug1651657.test
+++ b/mysql-test/suite/innodb/t/percona_bug1651657.test
@@ -1,0 +1,14 @@
+--source include/have_innodb.inc
+--source include/have_multiple_buffer_pools.inc
+--source include/big_test.inc
+
+--let $assert_text= Small buffer pool instances should use legacy
+--let $assert_cond= @@innodb_empty_free_list_algorithm = "legacy"
+--source include/assert.inc
+
+call mtr.add_suppression("InnoDB: innodb_empty_free_list_algorithm = 'backoff' requires at least 20MB buffer pool instances.");
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_empty_free_list_algorithm="backoff";
+--let $assert_text= Small buffer pool instances should use legacy
+--let $assert_cond= @@innodb_empty_free_list_algorithm = "legacy"
+--source include/assert.inc

--- a/mysql-test/suite/innodb/t/percona_bug1651657_resize-master.opt
+++ b/mysql-test/suite/innodb/t/percona_bug1651657_resize-master.opt
@@ -1,0 +1,1 @@
+--innodb-buffer-pool-size=20M --innodb-buffer-pool-instances=1 --innodb-empty-free-list-algorithm=backoff --innodb_buffer_pool_chunk_size=1048576

--- a/mysql-test/suite/innodb/t/percona_bug1651657_resize.test
+++ b/mysql-test/suite/innodb/t/percona_bug1651657_resize.test
@@ -1,0 +1,27 @@
+--source include/have_innodb.inc
+
+set @old_innodb_buffer_pool_size = @@innodb_buffer_pool_size;
+
+# Test buffer pool shrink with backoff algorithm.
+--disable_query_log
+set @old_innodb_empty_free_list_algorithm = @@innodb_empty_free_list_algorithm;
+if (`select (version() like '%debug%') > 0`)
+{
+    set @old_innodb_disable_resize = @@innodb_disable_resize_buffer_pool_debug;
+    set global innodb_disable_resize_buffer_pool_debug = OFF;
+}
+--enable_query_log
+
+set global innodb_empty_free_list_algorithm="backoff";
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET @@GLOBAL.innodb_buffer_pool_size = 19922944;
+
+--disable_query_log
+if (`select (version() like '%debug%') > 0`)
+{
+    set global innodb_disable_resize_buffer_pool_debug = @old_innodb_disable_resize;
+}
+--enable_query_log
+
+SET @@GLOBAL.innodb_empty_free_list_algorithm=@old_innodb_empty_free_list_algorithm;

--- a/mysql-test/suite/sys_vars/r/innodb_buffer_pool_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_buffer_pool_size_basic.result
@@ -5,7 +5,7 @@ COUNT(@@GLOBAL.innodb_buffer_pool_size)
 1
 1 Expected
 '#---------------------BS_STVARS_022_02----------------------#'
-SET @@GLOBAL.innodb_buffer_pool_size=10485760;
+SET @@GLOBAL.innodb_buffer_pool_size=20971520;
 Expected succeeded
 SELECT COUNT(@@GLOBAL.innodb_buffer_pool_size);
 COUNT(@@GLOBAL.innodb_buffer_pool_size)

--- a/mysql-test/suite/sys_vars/t/innodb_buffer_pool_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_buffer_pool_size_basic.test
@@ -52,7 +52,7 @@ SELECT COUNT(@@GLOBAL.innodb_buffer_pool_size);
 #   Check if Value can set                                         #
 ####################################################################
 
-SET @@GLOBAL.innodb_buffer_pool_size=10485760;
+SET @@GLOBAL.innodb_buffer_pool_size=20971520;
 --echo Expected succeeded
 --source include/wait_condition.inc
 

--- a/mysql-test/suite/sys_vars/t/innodb_empty_free_list_algorithm_basic-master.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_empty_free_list_algorithm_basic-master.opt
@@ -1,1 +1,1 @@
---innodb-buffer-pool-size=20M
+--innodb-buffer-pool-size=20M --innodb_buffer_pool_instances=1

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -701,6 +701,32 @@ innobase_is_fake_change(
 	THD*		thd);	/*!< in: MySQL thread handle of the user for
 				  whom the transaction is being committed */
 
+/** Empty free list algorithm.
+Checks if buffer pool is big enough to enable backoff algorithm.
+InnoDB empty free list algorithm backoff requires free pages
+from LRU for the best performance.
+buf_LRU_buf_pool_running_out cancels query if 1/4 of
+buffer pool belongs to LRU or freelist.
+At the same time buf_flush_LRU_list_batch
+keeps up to BUF_LRU_MIN_LEN in LRU.
+In order to avoid deadlock baclkoff requires buffer pool
+to be at least 4*BUF_LRU_MIN_LEN,
+but flush peformance is bad because of trashing
+and additional BUF_LRU_MIN_LEN pages are requested.
+@param[in]	algorithm	desired algorithm from srv_empty_free_list_t
+@return	true if it's possible to enable backoff. */
+static inline
+bool
+innodb_empty_free_list_algorithm_allowed(
+	srv_empty_free_list_t	algorithm)
+{
+	long long buf_pool_pages = srv_buf_pool_size / srv_page_size
+				/ srv_buf_pool_instances;
+
+	return(buf_pool_pages >= BUF_LRU_MIN_LEN * (4 + 1)
+			|| algorithm != SRV_EMPTY_FREE_LIST_BACKOFF);
+}
+
 /** Get the list of foreign keys referencing a specified table
 table.
 @param thd		The thread handle
@@ -1360,28 +1386,6 @@ normalize_table_name_low(
 	const char*     name,           /* in: table name string */
 	ibool           set_lower_case); /* in: TRUE if we want to set
 					 name to lower case */
-
-/*************************************************************//**
-Checks if buffer pool is big enough to enable backoff algorithm.
-InnoDB empty free list algorithm backoff requires free pages
-from LRU for the best performance.
-buf_LRU_buf_pool_running_out cancels query if 1/4 of 
-buffer pool belongs to LRU or freelist.
-At the same time buf_flush_LRU_list_batch
-keeps up to BUF_LRU_MIN_LEN in LRU.
-In order to avoid deadlock baclkoff requires buffer pool
-to be at least 4*BUF_LRU_MIN_LEN,
-but flush peformance is bad because of trashing
-and additional BUF_LRU_MIN_LEN pages are requested.
-@return	true if it's possible to enable backoff. */
-static
-bool
-innodb_empty_free_list_algorithm_backoff_allowed(
-	srv_empty_free_list_t
-			algorithm,		/*!< in: desired algorithm
-						from srv_empty_free_list_t */
-	long long	buf_pool_pages);	/*!< in: total number
-						of pages inside buffer pool */
 
 /*************************************************************//**
 Removes old archived transaction log files.
@@ -3877,10 +3881,9 @@ innobase_change_buffering_inited_ok:
 
 
 	/* Do not enable backoff algorithm for small buffer pool. */
-	if (!innodb_empty_free_list_algorithm_backoff_allowed(
+	if (!innodb_empty_free_list_algorithm_allowed(
 			static_cast<srv_empty_free_list_t>(
-				srv_empty_free_list_algorithm),
-			innobase_buffer_pool_size / srv_page_size)) {
+				srv_empty_free_list_algorithm))) {
 		sql_print_information(
 				"InnoDB: innodb_empty_free_list_algorithm "
 				"has been changed to legacy "
@@ -17179,32 +17182,6 @@ innodb_status_output_update(
 }
 
 /*************************************************************//**
-Empty free list algorithm.
-Checks if buffer pool is big enough to enable backoff algorithm.
-InnoDB empty free list algorithm backoff requires free pages
-from LRU for the best performance.
-buf_LRU_buf_pool_running_out cancels query if 1/4 of 
-buffer pool belongs to LRU or freelist.
-At the same time buf_flush_LRU_list_batch
-keeps up to BUF_LRU_MIN_LEN in LRU.
-In order to avoid deadlock baclkoff requires buffer pool
-to be at least 4*BUF_LRU_MIN_LEN,
-but flush peformance is bad because of trashing
-and additional BUF_LRU_MIN_LEN pages are requested.
-@return	true if it's possible to enable backoff. */
-static
-bool
-innodb_empty_free_list_algorithm_backoff_allowed(
-	srv_empty_free_list_t	algorithm,	/*!< in: desired algorithm
-						from srv_empty_free_list_t */
-	long long		buf_pool_pages)	/*!< in: total number
-						of pages inside buffer pool */
-{
-	return(buf_pool_pages >= BUF_LRU_MIN_LEN * (4 + 1)
-			|| algorithm != SRV_EMPTY_FREE_LIST_BACKOFF);
-}
-
-/*************************************************************//**
 Empty free list algorithm. This function is registered as
 a callback with MySQL. 
 @return	0 for valid algorithm */
@@ -17245,13 +17222,11 @@ innodb_srv_empty_free_list_algorithm_validate(
 		return(1);
 
 	algorithm = static_cast<srv_empty_free_list_t>(algo);
-	if (!innodb_empty_free_list_algorithm_backoff_allowed(
-				algorithm,
-				innobase_buffer_pool_size / srv_page_size)) {
+	if (!innodb_empty_free_list_algorithm_allowed(algorithm)) {
 		sql_print_warning(
 				"InnoDB: innodb_empty_free_list_algorithm "
 				"= 'backoff' requires at least"
-				" 20MB buffer pool.\n");
+				" 20MB buffer pool instances.\n");
 		return(1);
 	}
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -776,6 +776,37 @@ innodb_tmpdir_validate(
 	return(0);
 }
 
+/** Empty free list algorithm.
+Checks if buffer pool is big enough to enable backoff algorithm.
+InnoDB empty free list algorithm backoff requires free pages
+from LRU for the best performance.
+buf_LRU_buf_pool_running_out cancels query if 1/4 of
+buffer pool belongs to LRU or freelist.
+At the same time buf_flush_LRU_list_batch
+keeps up to BUF_LRU_MIN_LEN in LRU.
+In order to avoid deadlock backoff requires buffer pool
+to be at least 4*BUF_LRU_MIN_LEN,
+but flush peformance is bad because of trashing
+and additional BUF_LRU_MIN_LEN pages are requested.
+@param[in]	algorithm	desired algorithm from srv_empty_free_list_t
+@param[in]	new_buf_pool_sz	requested buffer pool size
+@return	true if it's possible to enable backoff. */
+static
+bool
+innodb_empty_free_list_algorithm_allowed(
+	srv_empty_free_list_t	algorithm,
+	long long new_buf_pool_sz = 0)
+{
+	if (!new_buf_pool_sz)
+		new_buf_pool_sz = srv_buf_pool_size;
+
+	long long buf_pool_pages = new_buf_pool_sz / srv_page_size
+				/ srv_buf_pool_instances;
+
+	return(buf_pool_pages >= BUF_LRU_MIN_LEN * (4 + 1)
+			|| algorithm != SRV_EMPTY_FREE_LIST_BACKOFF);
+}
+
 /******************************************************************//**
 Maps a MySQL trx isolation level code to the InnoDB isolation level code
 @return	InnoDB isolation level */
@@ -1382,28 +1413,6 @@ innobase_drop_zip_dict(
 	const char*	name,	/*!< in: zip dictionary name */
 	ulint*		name_len);
 				/*!< in/out: zip dictionary name length */
-
-/*************************************************************//**
-Checks if buffer pool is big enough to enable backoff algorithm.
-InnoDB empty free list algorithm backoff requires free pages
-from LRU for the best performance.
-buf_LRU_buf_pool_running_out cancels query if 1/4 of 
-buffer pool belongs to LRU or freelist.
-At the same time buf_flush_LRU_list_batch
-keeps up to BUF_LRU_MIN_LEN in LRU.
-In order to avoid deadlock baclkoff requires buffer pool
-to be at least 4*BUF_LRU_MIN_LEN,
-but flush peformance is bad because of trashing
-and additional BUF_LRU_MIN_LEN pages are requested.
-@return	true if it's possible to enable backoff. */
-static
-bool
-innodb_empty_free_list_algorithm_backoff_allowed(
-	srv_empty_free_list_t
-			algorithm,		/*!< in: desired algorithm
-						from srv_empty_free_list_t */
-	long long	buf_pool_pages);	/*!< in: total number
-						of pages inside buffer pool */
 
 /****************************************************************//**
 Parse and enable InnoDB monitor counters during server startup.
@@ -4233,21 +4242,6 @@ innobase_change_buffering_inited_ok:
 
 	innobase_commit_concurrency_init_default();
 
-	/* Do not enable backoff algorithm for small buffer pool. */
-	if (!innodb_empty_free_list_algorithm_backoff_allowed(
-			static_cast<srv_empty_free_list_t>(
-				srv_empty_free_list_algorithm),
-			innobase_buffer_pool_size / srv_page_size)) {
-		sql_print_information(
-				"InnoDB: innodb_empty_free_list_algorithm "
-				"has been changed to legacy "
-				"because of small buffer pool size. "
-				"In order to use backoff, "
-				"increase buffer pool at least up to 20MB.\n");
-			srv_empty_free_list_algorithm
-				= SRV_EMPTY_FREE_LIST_LEGACY;
-	}
-
 #ifdef HAVE_PSI_INTERFACE
 	/* Register keys with MySQL performance schema */
 	int	count;
@@ -4312,6 +4306,19 @@ innobase_change_buffering_inited_ok:
 
 	if (err != DB_SUCCESS) {
 		DBUG_RETURN(innobase_init_abort());
+	}
+
+	/* Do not enable backoff algorithm for small buffer pool. */
+	if (!innodb_empty_free_list_algorithm_allowed(
+				static_cast<srv_empty_free_list_t>(
+					srv_empty_free_list_algorithm))) {
+		sql_print_information(
+				"InnoDB: innodb_empty_free_list_algorithm "
+				"has been changed to legacy "
+				"because of small buffer pool size. "
+				"In order to use backoff, "
+				"increase buffer pool at least up to 20MB.\n");
+		srv_empty_free_list_algorithm = SRV_EMPTY_FREE_LIST_LEGACY;
 	}
 
 	/* Create mutex to protect encryption master_key_id. */
@@ -20347,32 +20354,6 @@ innodb_status_output_update(
 }
 
 /*************************************************************//**
-Empty free list algorithm.
-Checks if buffer pool is big enough to enable backoff algorithm.
-InnoDB empty free list algorithm backoff requires free pages
-from LRU for the best performance.
-buf_LRU_buf_pool_running_out cancels query if 1/4 of 
-buffer pool belongs to LRU or freelist.
-At the same time buf_flush_LRU_list_batch
-keeps up to BUF_LRU_MIN_LEN in LRU.
-In order to avoid deadlock baclkoff requires buffer pool
-to be at least 4*BUF_LRU_MIN_LEN,
-but flush peformance is bad because of trashing
-and additional BUF_LRU_MIN_LEN pages are requested.
-@return	true if it's possible to enable backoff. */
-static
-bool
-innodb_empty_free_list_algorithm_backoff_allowed(
-	srv_empty_free_list_t	algorithm,	/*!< in: desired algorithm
-						from srv_empty_free_list_t */
-	long long		buf_pool_pages)	/*!< in: total number
-						of pages inside buffer pool */
-{
-	return(buf_pool_pages >= BUF_LRU_MIN_LEN * (4 + 1)
-			|| algorithm != SRV_EMPTY_FREE_LIST_BACKOFF);
-}
-
-/*************************************************************//**
 Empty free list algorithm. This function is registered as
 a callback with MySQL. 
 @return	0 for valid algorithm */
@@ -20413,13 +20394,11 @@ innodb_srv_empty_free_list_algorithm_validate(
 		return(1);
 
 	algorithm = static_cast<srv_empty_free_list_t>(algo);
-	if (!innodb_empty_free_list_algorithm_backoff_allowed(
-				algorithm,
-				innobase_buffer_pool_size / srv_page_size)) {
+	if (!innodb_empty_free_list_algorithm_allowed(algorithm)) {
 		sql_print_warning(
 				"InnoDB: innodb_empty_free_list_algorithm "
 				"= 'backoff' requires at least"
-				" 20MB buffer pool.\n");
+				" 20MB buffer pool instances.\n");
 		return(1);
 	}
 
@@ -22632,6 +22611,19 @@ innodb_buffer_pool_size_validate(
 				    "Cannot update innodb_buffer_pool_size"
 				    " to less than 1GB if"
 				    " innodb_buffer_pool_instances > 1.");
+		return(1);
+	}
+
+	if (!innodb_empty_free_list_algorithm_allowed(
+				static_cast<srv_empty_free_list_t>(
+					srv_empty_free_list_algorithm),
+				intbuf)) {
+		push_warning_printf(thd, Sql_condition::SL_WARNING,
+				    ER_WRONG_ARGUMENTS,
+				    "Cannot update innodb_buffer_pool_size"
+				    " to less than 20MB per instance"
+				    " innodb_empty_free_list_algorithm"
+				    " = backoff.");
 		return(1);
 	}
 


### PR DESCRIPTION
http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/561/
https://bugs.launchpad.net/percona-server/+bug/1651657
#1262 PR 5.6

If buffer pool is bigger than 1GB and there are many buffer pool instances each instance could be smaller than 20MB and causing deadlocks with backoff algorithm.