### PR TITLE
Use path in plugin-load(-add) option to make tokudb hotbackup tests work from build dir.

### DIFF
--- a/mysql-test/include/have_tokudb.inc
+++ b/mysql-test/include/have_tokudb.inc
@@ -8,10 +8,3 @@ if (`SELECT @@have_dynamic_loading != 'YES'`) {
 if (!$TOKUDB) {
   --skip TokuDB requires the environment variable \$TOKUDB to be set (normally done by mtr)
 }
-
-#
-# Check if --plugin-dir was setup for TokuDB
-#
-if (`SELECT CONCAT('--plugin-dir=', REPLACE(@@plugin_dir, '\\\\', '/')) != '$TOKUDB_OPT/'`) {
-  --skip TokuDB requires that --plugin-dir is set to the TokuDB plugin dir (either the .opt file does not contain \$TOKUDB_OPT or another plugin is in use)
-}

--- a/mysql-test/include/have_tokudb_backup.inc
+++ b/mysql-test/include/have_tokudb_backup.inc
@@ -3,10 +3,3 @@
 if (!$TOKUDB_BACKUP) {
   --skip TokuDB Backup requires the environment variable \$TOKUDB_BACKUP to be set (normally done by mtr)
 }
-
-#
-# Check if --plugin-dir was setup for TokuDB Backup
-#
-if (`SELECT CONCAT('--plugin-dir=', REPLACE(@@plugin_dir, '\\\\', '/')) != '$TOKUDB_BACKUP_OPT/'`) {
-  --skip TokuDB Backup requires that --plugin-dir is set to the TokuDB Backup plugin dir (either the .opt file does not contain \$TOKUDB_BACKUP_OPT or another plugin is in use)
-}

--- a/mysql-test/include/plugin.defs
+++ b/mysql-test/include/plugin.defs
@@ -91,5 +91,5 @@ scalability_metrics plugin/scalability_metrics SCALABILITY_METRICS scalability_m
 audit_log          plugin/audit_log   AUDIT_LOG             audit_log
 query_response_time plugin/query_response_time PLUGIN_QUERY_RESPONSE_TIME QUERY_RESPONSE_TIME_AUDIT,QUERY_RESPONSE_TIME,QUERY_RESPONSE_TIME_READ,QUERY_RESPONSE_TIME_WRITE
 ha_tokudb          storage/tokudb             TOKUDB            tokudb,tokudb_trx,tokudb_locks,tokudb_lock_waits,tokudb_fractal_tree_info,tokudb_background_job_status
-tokudb_backup      plugin/tokudb_backup       TOKUDB_BACKUP     tokudb_backup
+tokudb_backup      plugin/tokudb-backup-plugin       TOKUDB_BACKUP     tokudb_backup
 ha_rocksdb         storage/rocksdb            ROCKSDB           rocksdb,rocksdb_cfstats,rocksdb_dbstats,rocksdb_perf_context_global,rocksdb_cf_options,rocksdb_global_info,rocksdb_ddl,rocksdb_index_file_map

--- a/mysql-test/include/plugin.defs
+++ b/mysql-test/include/plugin.defs
@@ -58,4 +58,4 @@ handlersocket      plugin/HandlerSocket-Plugin-for-MySQL HANDLER_SOCKET
 mysql_no_login     plugin/mysql_no_login      MYSQL_NO_LOGIN    mysql_no_login
 test_udf_services  plugin/udf_services TESTUDFSERVICES
 ha_tokudb          storage/tokudb             TOKUDB            tokudb,tokudb_trx,tokudb_locks,tokudb_lock_waits,tokudb_fractal_tree_info,tokudb_background_job_status
-tokudb_backup      plugin/tokudb_backup       TOKUDB_BACKUP     tokudb_backup
+tokudb_backup      plugin/tokudb-backup-plugin       TOKUDB_BACKUP     tokudb_backup

--- a/mysql-test/suite/tokudb.backup/t/suite.opt
+++ b/mysql-test/suite/tokudb.backup/t/suite.opt
@@ -1,1 +1,1 @@
-$TOKUDB_OPT $TOKUDB_LOAD_ADD $TOKUDB_BACKUP_OPT $TOKUDB_BACKUP_LOAD_ADD --loose-tokudb-check-jemalloc=0 --loose-tokudb-cache-size=512M --loose-tokudb-block-size=1M
+$TOKUDB_OPT $TOKUDB_LOAD_ADD_PATH $TOKUDB_BACKUP_OPT $TOKUDB_BACKUP_LOAD_ADD_PATH --loose-tokudb-check-jemalloc=0 --loose-tokudb-cache-size=512M --loose-tokudb-block-size=1M

--- a/mysql-test/suite/tokudb.backup/t/tokudb_backup_exclude-master.opt
+++ b/mysql-test/suite/tokudb.backup/t/tokudb_backup_exclude-master.opt
@@ -1,0 +1,1 @@
+--loose-tokudb-dir-per-db=0


### PR DESCRIPTION
Use path in plugin-load(-add) option to make tokudb hotbackup tests work from
build dir.

http://jenkins.percona.com/job/mysql-5.7-thb-param/5/

See also https://github.com/percona/percona-server/pull/1264 .