### PR TITLE
Fix bug 1651656 (Server crash if a changed page bitmap error occurs c…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
@@ -46,6 +46,7 @@ SET DEBUG_SYNC="RESET";
 DROP TABLE t2;
 RESET CHANGED_PAGE_BITMAPS;
 4th restart
+5th restart
 SET DEBUG_SYNC="i_s_innodb_changed_pages_range_ready SIGNAL ready WAIT_FOR finish";
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
 SET DEBUG_SYNC="now WAIT_FOR ready";
@@ -60,3 +61,23 @@ SET @@GLOBAL.innodb_track_changed_pages=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 SET DEBUG_SYNC="now SIGNAL finish";
 DROP TABLE t1, t2;
+RESET CHANGED_PAGE_BITMAPS;
+6th restart
+#
+# Bug 1651656: Server crash if a changed page bitmap error occurs concurrently with
+# executing FLUSH CHANGED_PAGE_BITMAPS
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+7th restart
+# connection con2
+SET DEBUG_SYNC="log_online_follow_redo_log SIGNAL flush_ready WAIT_FOR finish_flush";
+FLUSH CHANGED_PAGE_BITMAPS;
+# connection default
+SET DEBUG_SYNC="now WAIT_FOR flush_ready";
+INSERT INTO t1 VALUES (1);
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+SET DEBUG_SYNC="now SIGNAL finish_flush";
+# connection con2
+8th restart
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -133,17 +133,19 @@ RESET CHANGED_PAGE_BITMAPS;
 
 --source include/wait_until_count_sessions.inc
 
+--echo 4th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
 #
 # Test for bug 1193332 ([Warning] InnoDB: changed page bitmap file
 # './ib_modified_log_11_951286349.xdb' does not contain a complete run at the end.)
 #
 
 # Setup an error on the 2nd bitmap page write, so that bitmap contains an incomplete run
---echo 4th restart
+--echo 5th restart
 --let $restart_parameters= restart:-#d,bitmap_page_2_write_error
 --source include/restart_mysqld.inc
-
---source include/count_sessions.inc
 
 --connect(con2,localhost,root,,)
 
@@ -182,4 +184,49 @@ reap;
 
 DROP TABLE t1, t2;
 
---source include/wait_until_count_sessions.inc
+RESET CHANGED_PAGE_BITMAPS;
+
+--echo 6th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--echo #
+--echo # Bug 1651656: Server crash if a changed page bitmap error occurs concurrently with
+--echo # executing FLUSH CHANGED_PAGE_BITMAPS
+--echo #
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+
+--echo 7th restart
+--let $restart_parameters= restart:-#d,bitmap_page_write_error
+--source include/restart_mysqld.inc
+
+--connect(con2,localhost,root,,)
+--echo # connection con2
+
+SET DEBUG_SYNC="log_online_follow_redo_log SIGNAL flush_ready WAIT_FOR finish_flush";
+send FLUSH CHANGED_PAGE_BITMAPS;
+
+--connection default
+--echo # connection default
+SET DEBUG_SYNC="now WAIT_FOR flush_ready";
+INSERT INTO t1 VALUES (1);
+
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Log tracker should have quit by now
+SET DEBUG_SYNC="now SIGNAL finish_flush";
+
+--connection con2
+--echo # connection con2
+reap;
+
+disconnect con2;
+connection default;
+
+--echo 8th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+DROP TABLE t1;

--- a/storage/innobase/include/log0online.h
+++ b/storage/innobase/include/log0online.h
@@ -38,19 +38,25 @@ log_online_bitmap_file_range_t;
 /** An iterator over changed page info */
 typedef struct log_bitmap_iterator_struct log_bitmap_iterator_t;
 
-/*********************************************************************//**
-Initializes the online log following subsytem. */
+/** Initialize the constant part of the log tracking subsystem */
+UNIV_INTERN
+void
+log_online_init(void);
+
+/** Initialize the dynamic part of the log tracking subsystem */
 UNIV_INTERN
 void
 log_online_read_init(void);
-/*=======================*/
 
-/*********************************************************************//**
-Shuts down the online log following subsystem. */
+/** Shut down the dynamic part of the log tracking subsystem */
 UNIV_INTERN
 void
 log_online_read_shutdown(void);
-/*===========================*/
+
+/** Shut down the constant part of the log tracking subsystem */
+UNIV_INTERN
+void
+log_online_shutdown(void);
 
 /*********************************************************************//**
 Reads and parses the redo log up to last checkpoint LSN to build the changed

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -84,11 +84,13 @@ struct log_bitmap_struct {
 					both the correct type and the tree does
 					not mind its overwrite during
 					rbt_next() tree traversal. */
-	ib_mutex_t	mutex;		/*!< mutex protecting all the fields.*/
 };
 
 /* The log parsing and bitmap output struct instance */
 static struct log_bitmap_struct* log_bmp_sys;
+
+/* Mutex protecting log_bmp_sys */
+static ib_mutex_t	log_bmp_sys_mutex;
 
 /** File name stem for bitmap files. */
 static const char* bmp_file_name_stem = "ib_modified_log_";
@@ -181,28 +183,24 @@ log_online_set_page_bit(
 	ulint	space,	/*!<in: log record space id */
 	ulint	page_no)/*!<in: log record page id */
 {
-	ulint		block_start_page;
-	ulint		block_pos;
-	uint		bit_pos;
-	ib_rbt_bound_t	tree_search_pos;
-	byte		search_page[MODIFIED_PAGE_BLOCK_SIZE];
-	byte		*page_ptr;
-
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
 
 	ut_a(space != ULINT_UNDEFINED);
 	ut_a(page_no != ULINT_UNDEFINED);
 
-	block_start_page = page_no / MODIFIED_PAGE_BLOCK_ID_COUNT
+	ulint block_start_page = page_no / MODIFIED_PAGE_BLOCK_ID_COUNT
 		* MODIFIED_PAGE_BLOCK_ID_COUNT;
-	block_pos = block_start_page ? (page_no % block_start_page / 8)
+	ulint block_pos = block_start_page ? (page_no % block_start_page / 8)
 		: (page_no / 8);
-	bit_pos = page_no % 8;
+	uint bit_pos = page_no % 8;
 
+	byte search_page[MODIFIED_PAGE_BLOCK_SIZE];
 	mach_write_to_4(search_page + MODIFIED_PAGE_SPACE_ID, space);
 	mach_write_to_4(search_page + MODIFIED_PAGE_1ST_PAGE_ID,
 			block_start_page);
 
+	byte	       *page_ptr;
+	ib_rbt_bound_t  tree_search_pos;
 	if (!rbt_search(log_bmp_sys->modified_pages, &tree_search_pos,
 			search_page)) {
 		page_ptr = rbt_value(byte, tree_search_pos.last);
@@ -604,12 +602,19 @@ log_online_is_bitmap_file(
 		&& (!strcmp(stem, bmp_file_name_stem)));
 }
 
-/*********************************************************************//**
-Initialize the online log following subsytem. */
+/** Initialize the constant part of the log tracking subsystem */
+UNIV_INTERN
+void
+log_online_init(void)
+{
+	mutex_create(log_bmp_sys_mutex_key, &log_bmp_sys_mutex,
+		     SYNC_LOG_ONLINE);
+}
+
+/** Initialize the dynamic part of the log tracking subsystem */
 UNIV_INTERN
 void
 log_online_read_init(void)
-/*======================*/
 {
 	ibool	success;
 	lsn_t	tracking_start_lsn
@@ -632,9 +637,6 @@ log_online_read_init(void)
 		(ut_malloc(FOLLOW_SCAN_SIZE + OS_FILE_LOG_BLOCK_SIZE));
 	log_bmp_sys->read_buf = static_cast<byte *>
 		(ut_align(log_bmp_sys->read_buf_ptr, OS_FILE_LOG_BLOCK_SIZE));
-
-	mutex_create(log_bmp_sys_mutex_key, &log_bmp_sys->mutex,
-		     SYNC_LOG_ONLINE);
 
 	/* Initialize bitmap file directory from srv_data_home and add a path
 	separator if needed.  */
@@ -775,13 +777,15 @@ log_online_read_init(void)
 	log_set_tracked_lsn(tracking_start_lsn);
 }
 
-/*********************************************************************//**
-Shut down the online log following subsystem. */
+/** Shut down the dynamic part of the log tracking subsystem */
 UNIV_INTERN
 void
 log_online_read_shutdown(void)
-/*==========================*/
 {
+	mutex_enter(&log_bmp_sys_mutex);
+
+	srv_track_changed_pages = FALSE;
+
 	ib_rbt_node_t *free_list_node = log_bmp_sys->page_free_list;
 
 	if (log_bmp_sys->out.file != os_file_invalid) {
@@ -797,10 +801,21 @@ log_online_read_shutdown(void)
 		free_list_node = next;
 	}
 
-	mutex_free(&log_bmp_sys->mutex);
-
 	ut_free(log_bmp_sys->read_buf_ptr);
 	ut_free(log_bmp_sys);
+	log_bmp_sys = NULL;
+
+	srv_redo_log_thread_started = false;
+
+	mutex_exit(&log_bmp_sys_mutex);
+}
+
+/** Shut down the constant part of the log tracking subsystem */
+UNIV_INTERN
+void
+log_online_shutdown(void)
+{
+	mutex_free(&log_bmp_sys_mutex);
 }
 
 /*********************************************************************//**
@@ -846,12 +861,11 @@ void
 log_online_parse_redo_log(void)
 /*===========================*/
 {
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
+
 	byte *ptr = log_bmp_sys->parse_buf;
 	byte *end = log_bmp_sys->parse_buf_end;
-
 	ulint len = 0;
-
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
 
 	while (ptr != end
 	       && log_bmp_sys->next_parse_lsn < log_bmp_sys->end_lsn) {
@@ -934,6 +948,8 @@ log_online_add_to_parse_buf(
 	ulint		skip_len)	/*!< in: how much of log data to
 					skip */
 {
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
+
 	ulint start_offset = skip_len ? skip_len : LOG_BLOCK_HDR_SIZE;
 	ulint end_offset
 		= (data_len == OS_FILE_LOG_BLOCK_SIZE)
@@ -941,8 +957,6 @@ log_online_add_to_parse_buf(
 		: data_len;
 	ulint actual_data_len = (end_offset >= start_offset)
 		? end_offset - start_offset : 0;
-
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
 
 	ut_memcpy(log_bmp_sys->parse_buf_end, log_block + start_offset,
 		  actual_data_len);
@@ -966,11 +980,9 @@ log_online_parse_redo_log_block(
 						  log data should be skipped as
 						  they were parsed before */
 {
-	ulint block_data_len;
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
 
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
-
-	block_data_len = log_block_get_data_len(log_block);
+	ulint block_data_len = log_block_get_data_len(log_block);
 
 	ut_ad(block_data_len % OS_FILE_LOG_BLOCK_SIZE == 0
 	      || block_data_len < OS_FILE_LOG_BLOCK_SIZE);
@@ -990,13 +1002,13 @@ log_online_follow_log_seg(
 	lsn_t		block_start_lsn,       /*!< in: the LSN to read from */
 	lsn_t		block_end_lsn)	       /*!< in: the LSN to read to */
 {
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
+
 	/* Pointer to the current OS_FILE_LOG_BLOCK-sized chunk of the read log
 	data to parse */
 	byte* log_block = log_bmp_sys->read_buf;
 	byte* log_block_end = log_bmp_sys->read_buf
 		+ (block_end_lsn - block_start_lsn);
-
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
 
 	mutex_enter(&log_sys->mutex);
 	log_group_read_log_seg(LOG_RECOVER, log_bmp_sys->read_buf,
@@ -1057,10 +1069,10 @@ log_online_follow_log_group(
 	lsn_t		contiguous_lsn)	/*!< in: the LSN of log block start
 					containing the log_parse_start_lsn */
 {
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
+
 	lsn_t	block_start_lsn = contiguous_lsn;
 	lsn_t	block_end_lsn;
-
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
 
 	log_bmp_sys->next_parse_lsn = log_bmp_sys->start_lsn;
 	log_bmp_sys->parse_buf_end = log_bmp_sys->parse_buf;
@@ -1098,20 +1110,28 @@ log_online_write_bitmap_page(
 /*=========================*/
 	const byte *block)	/*!< in: block to write */
 {
-	ibool	success;
-
-	ut_ad(srv_track_changed_pages);
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
 
 	/* Simulate a write error */
 	DBUG_EXECUTE_IF("bitmap_page_write_error",
-			ib_logf(IB_LOG_LEVEL_ERROR,
-				"simulating bitmap write error in "
-				"log_online_write_bitmap_page");
-			return FALSE;);
+			{
+				ulint space_id
+					= mach_read_from_4(block
+					+ MODIFIED_PAGE_SPACE_ID);
+				if (space_id > 0) {
+					ib_logf(IB_LOG_LEVEL_ERROR,
+						"simulating bitmap write "
+						"error in "
+						"log_online_write_bitmap_page "
+						"for space ID %lu",
+						space_id);
+					return FALSE;
+				}
+			});
 
-	success = os_file_write(log_bmp_sys->out.name, log_bmp_sys->out.file,
-				block, log_bmp_sys->out.offset,
+	ibool success = os_file_write(log_bmp_sys->out.name,
+				log_bmp_sys->out.file, block,
+				log_bmp_sys->out.offset,
 				MODIFIED_PAGE_BLOCK_SIZE);
 	if (UNIV_UNLIKELY(!success)) {
 
@@ -1151,11 +1171,7 @@ ibool
 log_online_write_bitmap(void)
 /*=========================*/
 {
-	ib_rbt_node_t		*bmp_tree_node;
-	const ib_rbt_node_t	*last_bmp_tree_node;
-	ibool			success = TRUE;
-
-	ut_ad(mutex_own(&log_bmp_sys->mutex));
+	ut_ad(mutex_own(&log_bmp_sys_mutex));
 
 	if (log_bmp_sys->out.offset >= srv_max_bitmap_file_size) {
 		if (!log_online_rotate_bitmap_file(log_bmp_sys->start_lsn)) {
@@ -1163,9 +1179,12 @@ log_online_write_bitmap(void)
 		}
 	}
 
-	bmp_tree_node = (ib_rbt_node_t *)
-		rbt_first(log_bmp_sys->modified_pages);
-	last_bmp_tree_node = rbt_last(log_bmp_sys->modified_pages);
+	ib_rbt_node_t *bmp_tree_node
+		= (ib_rbt_node_t *)rbt_first(log_bmp_sys->modified_pages);
+	const ib_rbt_node_t * const last_bmp_tree_node
+		= rbt_last(log_bmp_sys->modified_pages);
+
+	ibool success = TRUE;
 
 	while (bmp_tree_node) {
 
@@ -1221,10 +1240,19 @@ log_online_follow_redo_log(void)
 	log_group_t*	group;
 	ibool		result;
 
-	ut_ad(srv_track_changed_pages);
 	ut_ad(!srv_read_only_mode);
 
-	mutex_enter(&log_bmp_sys->mutex);
+	if (!srv_track_changed_pages)
+		return TRUE;
+
+	DEBUG_SYNC_C("log_online_follow_redo_log");
+
+	mutex_enter(&log_bmp_sys_mutex);
+
+	if (!srv_track_changed_pages) {
+		mutex_exit(&log_bmp_sys_mutex);
+		return TRUE;
+	}
 
 	/* Grab the LSN of the last checkpoint, we will parse up to it */
 	mutex_enter(&(log_sys->mutex));
@@ -1232,7 +1260,7 @@ log_online_follow_redo_log(void)
 	mutex_exit(&(log_sys->mutex));
 
 	if (log_bmp_sys->end_lsn == log_bmp_sys->start_lsn) {
-		mutex_exit(&log_bmp_sys->mutex);
+		mutex_exit(&log_bmp_sys_mutex);
 		return TRUE;
 	}
 
@@ -1255,7 +1283,7 @@ log_online_follow_redo_log(void)
 	log_bmp_sys->start_lsn = log_bmp_sys->end_lsn;
 	log_set_tracked_lsn(log_bmp_sys->start_lsn);
 
-	mutex_exit(&log_bmp_sys->mutex);
+	mutex_exit(&log_bmp_sys_mutex);
 	return result;
 }
 
@@ -1805,15 +1833,21 @@ log_online_purge_changed_page_bitmaps(
 		lsn = LSN_MAX;
 	}
 
+	bool log_bmp_sys_inited = false;
 	if (srv_redo_log_thread_started) {
 		/* User requests might happen with both enabled and disabled
 		tracking */
-		mutex_enter(&log_bmp_sys->mutex);
+		log_bmp_sys_inited = true;
+		mutex_enter(&log_bmp_sys_mutex);
+		if (!srv_redo_log_thread_started) {
+			log_bmp_sys_inited = false;
+			mutex_exit(&log_bmp_sys_mutex);
+		}
 	}
 
 	if (!log_online_setup_bitmap_file_range(&bitmap_files, 0, LSN_MAX)) {
-		if (srv_redo_log_thread_started) {
-			mutex_exit(&log_bmp_sys->mutex);
+		if (log_bmp_sys_inited) {
+			mutex_exit(&log_bmp_sys_mutex);
 		}
 		return TRUE;
 	}
@@ -1851,7 +1885,7 @@ log_online_purge_changed_page_bitmaps(
 		}
 	}
 
-	if (srv_redo_log_thread_started) {
+	if (log_bmp_sys_inited) {
 		if (lsn > log_bmp_sys->end_lsn) {
 			lsn_t	new_file_lsn;
 			if (lsn == LSN_MAX) {
@@ -1867,7 +1901,7 @@ log_online_purge_changed_page_bitmaps(
 			}
 		}
 
-		mutex_exit(&log_bmp_sys->mutex);
+		mutex_exit(&log_bmp_sys_mutex);
 	}
 
 	free(bitmap_files.files);

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2344,10 +2344,8 @@ DECLARE_THREAD(srv_redo_log_follow_thread)(
 
 	} while (srv_shutdown_state < SRV_SHUTDOWN_LAST_PHASE);
 
-	srv_track_changed_pages = FALSE;
 	log_online_read_shutdown();
 	os_event_set(srv_redo_log_tracked_event);
-	srv_redo_log_thread_started = false; /* Defensive, not required */
 
 	my_thread_end();
 	os_thread_exit(NULL);

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2057,6 +2057,7 @@ innobase_start_or_create_for_mysql(void)
 
 	fsp_init();
 	log_init();
+	log_online_init();
 
 	lock_sys_create(srv_lock_table_size);
 
@@ -3077,6 +3078,7 @@ innobase_shutdown_for_mysql(void)
 	btr_search_disable();
 
 	ibuf_close();
+	log_online_shutdown();
 	log_shutdown();
 	trx_sys_file_format_close();
 	trx_sys_close();


### PR DESCRIPTION
…oncurrently with executing FLUSH CHANGED_PAGE_BITMAPS)

If a bitmap write I/O errors happens in the background log tracking
thread while a FLUSH CHANGED_PAGE_BITMAPS is executing concurrently,
the two threads enter a race condition where the background thread
frees the mutex while the FLUSH locks/unlocks it, resulting in a
crash. Fix by pulling up the log_bmp_sys_mutex out of the dynamic
log_bmp_sys structure, and making it available throught server
lifetime, regardless of the log tracking startup or current
setting. Add new functions log_online_init and log_online_shutdown to
create and destroy the mutex. Make log_online_read_shutdown take that
mutex around log_bmp_sys deinitialisation and also protect
srv_track_changed_pages and srv_redo_log_thread_started true to false
transitions with it. Make log_online_follow_redo_log check
srv_track_changed_pages, take the mutex, and re-check the variable
before continuing operation. Likewise make
log_online_purge_changed_page_bitmaps check
srv_redo_log_thread_started, take the mutex, and re-check the variable.

At the same time replace mutex_own asserts with a helper function
in_log_bmp_sys_with_mutex that also asserts enabled log tracking
status var. Cleanup functions a bit by moving variable declarations to
initialisation statements.

At the same time remove another testcase instability by making the
bitmap_page_write_error error injection point only trigger for bitmap
data pages with tablespace ID > 0, that is, user tablespaces, as tested
by the testcases.

http://jenkins.percona.com/job/percona-server-5.6-param/1574/