### PR TITLE
Disable tokudb backup on --innodb-use-native-aio=on

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/innodb_use_native_aio_enabled.result
+++ b/mysql-test/suite/tokudb.backup/r/innodb_use_native_aio_enabled.result
@@ -1,0 +1,5 @@
+SELECT @@innodb_use_native_aio;
+@@innodb_use_native_aio
+1
+SET SESSION tokudb_backup_dir='MYSQL_TMP_DIR/tokudb_backup';
+ERROR 42000: Variable 'tokudb_backup_dir' can't be set to the value of 'MYSQL_TMP_DIR/tokudb_backup'

--- a/mysql-test/suite/tokudb.backup/t/innodb_use_native_aio_enabled-master.opt
+++ b/mysql-test/suite/tokudb.backup/t/innodb_use_native_aio_enabled-master.opt
@@ -1,0 +1,1 @@
+--innodb_use_native_aio=on

--- a/mysql-test/suite/tokudb.backup/t/innodb_use_native_aio_enabled.test
+++ b/mysql-test/suite/tokudb.backup/t/innodb_use_native_aio_enabled.test
@@ -1,0 +1,13 @@
+# Check if tokudb hot backup is prevented if innodb_use_native_aio enabled
+--source include/have_tokudb_backup.inc
+--source include/have_innodb.inc
+
+SELECT @@innodb_use_native_aio;
+
+--let $BACKUP_DIR= $MYSQL_TMP_DIR/tokudb_backup
+
+--mkdir $BACKUP_DIR
+
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+--error ER_WRONG_VALUE_FOR_VAR
+--eval SET SESSION tokudb_backup_dir='$BACKUP_DIR'

--- a/mysql-test/suite/tokudb.backup/t/suite.opt
+++ b/mysql-test/suite/tokudb.backup/t/suite.opt
@@ -1,1 +1,1 @@
-$TOKUDB_OPT $TOKUDB_LOAD_ADD_PATH $TOKUDB_BACKUP_OPT $TOKUDB_BACKUP_LOAD_ADD_PATH --loose-tokudb-check-jemalloc=0 --loose-tokudb-cache-size=512M --loose-tokudb-block-size=1M
+$TOKUDB_OPT $TOKUDB_LOAD_ADD_PATH $TOKUDB_BACKUP_OPT $TOKUDB_BACKUP_LOAD_ADD_PATH --loose-innodb_use_native_aio=off --loose-tokudb-check-jemalloc=0 --loose-tokudb-cache-size=512M --loose-tokudb-block-size=1M

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -28,6 +28,9 @@
 #define TOKUDB_BACKUP_PLUGIN_VERSION_STRING NULL
 #endif
 
+/* innodb_use_native_aio option */
+extern my_bool srv_use_native_aio;
+
 static char *tokudb_backup_plugin_version;
 
 static MYSQL_SYSVAR_STR(plugin_version, tokudb_backup_plugin_version,
@@ -544,6 +547,17 @@ private:
 static void tokudb_backup_run(THD *thd, const char *dest_dir) {
     int error = 0;
 
+    if (srv_use_native_aio) {
+        error = EINVAL;
+        tokudb_backup_set_error_string(thd,
+                                       error,
+                                       "tokudb hot backup is disabled when "
+                                       "innodb_use_native_aio is enabled",
+                                       NULL,
+                                       NULL,
+                                       NULL);
+        return;
+    }
     // check that the dest dir is a child of the tokudb_backup_allowed_prefix
     if (tokudb_backup_allowed_prefix) {
         if (!tokudb_backup_is_child_of(dest_dir, tokudb_backup_allowed_prefix)) {

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -161,7 +161,8 @@ UNIV_INTERN unsigned long long	srv_online_max_size;
 OS (provided we compiled Innobase with it in), otherwise we will
 use simulated aio we build below with threads.
 Currently we support native aio on windows and linux */
-UNIV_INTERN my_bool	srv_use_native_aio = TRUE;
+/* make srv_use_native_aio to be visible for other plugins */
+my_bool	srv_use_native_aio = TRUE;
 UNIV_INTERN my_bool	srv_numa_interleave = FALSE;
 
 #ifdef __WIN__


### PR DESCRIPTION
See https://github.com/percona/percona-server/pull/1270, https://tokutek.atlassian.net/browse/BACKUP-121.
http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/565/.