### PR TITLE
Fix SET STATEMENT ... FOR bug 1635927 and bug 1392375.

### DIFF
--- a/mysql-test/r/percona_statement_set.result
+++ b/mysql-test/r/percona_statement_set.result
@@ -879,6 +879,34 @@ HANDLER t3 OPEN;
 SET STATEMENT max_join_size=1000 FOR SELECT * FROM t3;
 ERROR HY000: Can't reopen table: 't3'
 DROP TABLE t3;
+#
+# Bug 1392375: Crashing repeated execution of SET STATEMENT ... FOR <SELECT FROM view>
+#
+CREATE VIEW t3 AS SELECT 1 AS a;
+PREPARE stmt1 FROM 'SET STATEMENT binlog_format=row FOR SELECT * FROM t3';
+EXECUTE stmt1;
+a
+1
+EXECUTE stmt1;
+a
+1
+DEALLOCATE PREPARE stmt1;
+DROP VIEW t3;
+#
+# Bug 1635927: Memory leak when using per-query variables with subquery temp tables
+#
+CREATE TABLE t3 (row_key INT NOT NULL DEFAULT 0, ref_key BIGINT(20) NOT NULL);
+INSERT INTO t3 (ref_key) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+set @row_id := 0;
+INSERT INTO t3 (ref_key) SELECT @row_id := @row_id + 11 as ref_key
+FROM t3 a1, t3 a2, t3 a3;
+SET STATEMENT myisam_repair_threads=1 FOR
+SELECT count(1) FROM t3 s
+JOIN (SELECT row_key, ref_key AS ref_key FROM t3 t
+WHERE t.row_key IN (SELECT row_key FROM t3)) AS r;
+count(1)
+1020100
+DROP TABLE t3;
 ''
 '# Cleanup'
 DROP TABLE t1, t2;

--- a/mysql-test/t/percona_statement_set.test
+++ b/mysql-test/t/percona_statement_set.test
@@ -864,6 +864,36 @@ HANDLER t3 OPEN;
 SET STATEMENT max_join_size=1000 FOR SELECT * FROM t3;
 DROP TABLE t3;
 
+--echo #
+--echo # Bug 1392375: Crashing repeated execution of SET STATEMENT ... FOR <SELECT FROM view>
+--echo #
+
+CREATE VIEW t3 AS SELECT 1 AS a;
+PREPARE stmt1 FROM 'SET STATEMENT binlog_format=row FOR SELECT * FROM t3';
+EXECUTE stmt1;
+EXECUTE stmt1;
+
+DEALLOCATE PREPARE stmt1;
+DROP VIEW t3;
+
+--echo #
+--echo # Bug 1635927: Memory leak when using per-query variables with subquery temp tables
+--echo #
+
+CREATE TABLE t3 (row_key INT NOT NULL DEFAULT 0, ref_key BIGINT(20) NOT NULL);
+
+INSERT INTO t3 (ref_key) VALUES (1),(2),(3),(4),(5),(6),(7),(8),(9),(10);
+set @row_id := 0;
+INSERT INTO t3 (ref_key) SELECT @row_id := @row_id + 11 as ref_key
+       FROM t3 a1, t3 a2, t3 a3;
+
+SET STATEMENT myisam_repair_threads=1 FOR
+SELECT count(1) FROM t3 s
+       JOIN (SELECT row_key, ref_key AS ref_key FROM t3 t
+       WHERE t.row_key IN (SELECT row_key FROM t3)) AS r;
+
+DROP TABLE t3;
+
 --echo ''
 --echo '# Cleanup'
 DROP TABLE t1, t2;

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -551,6 +551,9 @@ sys_var *intern_find_sys_var(const char *str, uint length)
 
   @param THD            Thread id
   @param var_list       List of variables to update
+  @param free_joins     Whether to free subselect joins if any. They are
+                        freed by default, except for SET STATEMENT ... FOR ...
+                        processing
 
   @retval
     0   ok
@@ -560,7 +563,7 @@ sys_var *intern_find_sys_var(const char *str, uint length)
     -1  ERROR, message not sent
 */
 
-int sql_set_variables(THD *thd, List<set_var_base> *var_list)
+int sql_set_variables(THD *thd, List<set_var_base> *var_list, bool free_joins)
 {
   int error;
   List_iterator_fast<set_var_base> it(*var_list);
@@ -580,7 +583,8 @@ int sql_set_variables(THD *thd, List<set_var_base> *var_list)
   }
 
 err:
-  free_underlaid_joins(thd, &thd->lex->select_lex);
+  if (free_joins)
+    free_underlaid_joins(thd, &thd->lex->select_lex);
   DBUG_RETURN(error);
 }
 

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -357,7 +357,10 @@ extern SHOW_COMP_OPTION have_elliptic_curve_crypto;
 SHOW_VAR* enumerate_sys_vars(THD *thd, bool sorted, enum enum_var_type type);
 
 sys_var *find_sys_var(THD *thd, const char *str, uint length=0);
-int sql_set_variables(THD *thd, List<set_var_base> *var_list);
+
+MY_ATTRIBUTE((warn_unused_result))
+int sql_set_variables(THD *thd, List<set_var_base> *var_list,
+                      bool free_joins = true);
 
 bool fix_delay_key_write(sys_var *self, THD *thd, enum_var_type type);
 

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -427,6 +427,7 @@ void lex_start(THD *thd)
   lex->view_list.empty();
   lex->prepared_stmt_params.empty();
   lex->auxiliary_table_list.empty();
+  DBUG_ASSERT(!lex->unit.cleaned);
   lex->unit.next= lex->unit.master= lex->unit.link_next= 0;
   lex->unit.prev= lex->unit.link_prev= 0;
   lex->unit.slave= lex->unit.global_parameters= lex->current_select=

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2939,7 +2939,7 @@ mysql_execute_command(THD *thd)
   if (lex->set_statement && !lex->var_list.is_empty()) {
     per_query_variables_backup= copy_system_variables(&thd->variables,
                                                       thd->m_enable_plugins);
-    if ((res= sql_set_variables(thd, &lex->var_list)))
+    if ((res= sql_set_variables(thd, &lex->var_list, false)))
     {
       /*
          We encountered some sort of error, but no message was sent.

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -101,6 +101,7 @@ JOIN::prepare(TABLE_LIST *tables_init,
   group_list= ORDER_with_src(group_init, ESC_GROUP_BY);
   having= having_for_explain= having_init;
   tables_list= tables_init;
+  DBUG_ASSERT(!unit_arg->cleaned);
   select_lex= select_lex_arg;
   select_lex->join= this;
   join_list= &select_lex->top_join_list;

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -537,6 +537,7 @@ bool st_select_lex_unit::optimize()
 
   for (SELECT_LEX *sl= first_select(); sl; sl= sl->next_select())
   {
+    DBUG_ASSERT(!cleaned);
     DBUG_ASSERT(sl->join);
     if (optimized)
     {
@@ -835,6 +836,10 @@ bool st_select_lex_unit::cleanup()
 
   if (cleaned)
   {
+#ifndef DBUG_OFF
+    for (SELECT_LEX *sl= first_select(); sl; sl= sl->next_select())
+      DBUG_ASSERT(!sl->join);
+#endif
     DBUG_RETURN(FALSE);
   }
   cleaned= true;


### PR DESCRIPTION
Bug 1392375 is that repeated execution of SET STATEMENT ... FOR
<SELECT FROM view> crashes and bug 1635927 is a memory leak when using
per-query variables with subquery temp tables.

Both bugs share the root cause which is that SET STATEMENT query
variables were set with a sql_set_variables call before main query
execution. This function frees subselect joins, if any, at its end,
which is premature as they are needed for main query execution. As
the subselect lex object is marked as already freed, any subsequent
free attempts will be no-ops, resulting in either a memory leak or a
crash that the lex already has a join associated. Fix by not freeing
subselect joins for SET STATEMENT variable setting part.

At the same time add invariant asserts to st_select_lex_unit methods
that the object is in cleaned state iff it has no associated joins.

http://jenkins.percona.com/job/percona-server-5.6-param/1577/