### PR TITLE
Fix the bug of renaming to non-existen db.

### DIFF
--- a/include/my_base.h
+++ b/include/my_base.h
@@ -488,7 +488,8 @@ is the global server default. */
 #define HA_ERR_TEMP_FILE_WRITE_FAILURE	189	/* Temporary file write failure */
 #define HA_ERR_INNODB_FORCED_RECOVERY 190	/* Innodb is in force recovery mode */
 #define HA_ERR_FTS_TOO_MANY_WORDS_IN_PHRASE	191 /* Too many words in a phrase */
-#define HA_ERR_LAST               191    /* Copy of last error nr */
+#define HA_ERR_DEST_SCHEMA_NOT_EXIST   192  /* Destination schema does not exist */
+#define HA_ERR_LAST               192    /* Copy of last error nr */
 
 /* Number of different errors */
 #define HA_ERR_ERRORS            (HA_ERR_LAST - HA_ERR_FIRST + 1)

--- a/mysql-test/suite/tokudb/r/dir_per_db_rename_to_nonexisting_schema.result
+++ b/mysql-test/suite/tokudb/r/dir_per_db_rename_to_nonexisting_schema.result
@@ -1,0 +1,48 @@
+SET GLOBAL tokudb_dir_per_db=true;
+######
+# Tokudb and mysql data dirs are the same, rename to existent db
+###
+CREATE DATABASE new_db;
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+ALTER TABLE test.t1 RENAME new_db.t1;
+The content of "test" directory:
+The content of "new_db" directory:
+db.opt
+t1.frm
+t1_main_id.tokudb
+t1_status_id.tokudb
+DROP DATABASE new_db;
+######
+# Tokudb and mysql data dirs are the same, rename to nonexistent db
+###
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+CALL mtr.add_suppression("because destination db does not exist");
+ALTER TABLE test.t1 RENAME foo.t1;
+ERROR HY000: Error on rename of './test/t1' to './foo/t1' (errno: 192 - Destination schema does not exist)
+DROP TABLE t1;
+SELECT @@tokudb_data_dir;
+@@tokudb_data_dir
+CUSTOM_TOKUDB_DATA_DIR
+SELECT @@tokudb_dir_per_db;
+@@tokudb_dir_per_db
+1
+######
+# Tokudb and mysql data dirs are different, rename to existent db
+###
+CREATE DATABASE new_db;
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+ALTER TABLE test.t1 RENAME new_db.t1;
+The content of "test" direcotry:
+The content of "new_db" directory:
+t1_main_id.tokudb
+t1_status_id.tokudb
+DROP DATABASE new_db;
+######
+# Tokudb and mysql data dirs are different, rename to nonexistent db
+###
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+CALL mtr.add_suppression("because destination db does not exist");
+ALTER TABLE test.t1 RENAME foo.t1;
+ERROR HY000: Error on rename of './test/t1' to './foo/t1' (errno: 192 - Destination schema does not exist)
+DROP TABLE t1;
+SET GLOBAL tokudb_dir_per_db=default;

--- a/mysql-test/suite/tokudb/t/dir_per_db_rename_to_nonexisting_schema.test
+++ b/mysql-test/suite/tokudb/t/dir_per_db_rename_to_nonexisting_schema.test
@@ -1,0 +1,67 @@
+--source include/have_tokudb.inc
+
+SET GLOBAL tokudb_dir_per_db=true;
+--let DATADIR=`SELECT @@datadir`
+
+--echo ######
+--echo # Tokudb and mysql data dirs are the same, rename to existent db
+--echo ###
+CREATE DATABASE new_db;
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+ALTER TABLE test.t1 RENAME new_db.t1;
+--echo The content of "test" directory:
+--source include/table_files_replace_pattern.inc
+--sorted_result
+--list_files $DATADIR/test
+--echo The content of "new_db" directory:
+--source include/table_files_replace_pattern.inc
+--sorted_result
+--list_files $DATADIR/new_db
+DROP DATABASE new_db;
+
+--echo ######
+--echo # Tokudb and mysql data dirs are the same, rename to nonexistent db
+--echo ###
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+CALL mtr.add_suppression("because destination db does not exist");
+--error ER_ERROR_ON_RENAME
+ALTER TABLE test.t1 RENAME foo.t1;
+DROP TABLE t1;
+
+--let $custom_tokudb_data_dir=$MYSQL_TMP_DIR/custom_tokudb_data_dir
+--mkdir $custom_tokudb_data_dir
+--replace_result $custom_tokudb_data_dir CUSTOM_TOKUDB_DATA_DIR
+--let $restart_parameters= restart:--loose-tokudb-data-dir=$custom_tokudb_data_dir --loose-tokudb-dir-per-db=true
+--source include/restart_mysqld.inc
+
+--replace_result $custom_tokudb_data_dir CUSTOM_TOKUDB_DATA_DIR
+SELECT @@tokudb_data_dir;
+SELECT @@tokudb_dir_per_db;
+
+--echo ######
+--echo # Tokudb and mysql data dirs are different, rename to existent db
+--echo ###
+CREATE DATABASE new_db;
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+ALTER TABLE test.t1 RENAME new_db.t1;
+--echo The content of "test" direcotry:
+--source include/table_files_replace_pattern.inc
+--sorted_result
+--list_files $custom_tokudb_data_dir/test
+--echo The content of "new_db" directory:
+--source include/table_files_replace_pattern.inc
+--sorted_result
+--list_files $custom_tokudb_data_dir/new_db
+DROP DATABASE new_db;
+
+--echo ######
+--echo # Tokudb and mysql data dirs are different, rename to nonexistent db
+--echo ###
+CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY NOT NULL) ENGINE=tokudb;
+CALL mtr.add_suppression("because destination db does not exist");
+--error ER_ERROR_ON_RENAME
+ALTER TABLE test.t1 RENAME foo.t1;
+DROP TABLE t1;
+
+SET GLOBAL tokudb_dir_per_db=default;
+

--- a/mysys/my_handler_errors.h
+++ b/mysys/my_handler_errors.h
@@ -94,7 +94,8 @@ static const char *handler_error_messages[]=
   "FTS query exceeds result cache memory limit",
   "Temporary file write failure",
   "Operation not allowed when innodb_forced_recovery > 0",
-  "Too many words in a FTS phrase or proximity search"
+  "Too many words in a FTS phrase or proximity search",
+  "Destination schema does not exist"
 };
 
 extern void my_handler_error_register(void);

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -29,6 +29,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "tokudb_status.h"
 #include "tokudb_card.h"
 #include "ha_tokudb.h"
+#include "sql_db.h"
 
 
 HASH TOKUDB_SHARE::_open_tables;
@@ -7648,6 +7649,27 @@ int ha_tokudb::delete_table(const char *name) {
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
 
+static bool tokudb_check_db_dir_exist_from_table_name(const char *table_name) {
+    DBUG_ASSERT(table_name);
+    bool mysql_dir_exists;
+    char db_name[FN_REFLEN];
+    const char *db_name_begin = strchr(table_name, FN_LIBCHAR);
+    const char *db_name_end = strrchr(table_name, FN_LIBCHAR);
+    DBUG_ASSERT(db_name_begin);
+    DBUG_ASSERT(db_name_end);
+    DBUG_ASSERT(db_name_begin != db_name_end);
+
+    ++db_name_begin;
+    size_t db_name_size = db_name_end - db_name_begin;
+
+    DBUG_ASSERT(db_name_size < FN_REFLEN);
+
+    memcpy(db_name, db_name_begin, db_name_size);
+    db_name[db_name_size] = '\0';
+    mysql_dir_exists = (check_db_dir_existence(db_name) == 0);
+
+    return mysql_dir_exists;
+}
 
 //
 // renames table from "from" to "to"
@@ -7670,15 +7692,26 @@ int ha_tokudb::rename_table(const char *from, const char *to) {
         TOKUDB_SHARE::drop_share(share);
     }
     int error;
-    error = delete_or_rename_table(from, to, false);
-    if (TOKUDB_LIKELY(TOKUDB_DEBUG_FLAGS(TOKUDB_DEBUG_HIDE_DDL_LOCK_ERRORS) == 0) &&
-        error == DB_LOCK_NOTGRANTED) {
+    bool to_db_dir_exist = tokudb_check_db_dir_exist_from_table_name(to);
+    if (!to_db_dir_exist) {
         sql_print_error(
-            "Could not rename table from %s to %s because another transaction "
-            "has accessed the table. To rename the table, make sure no "
-            "transactions touch the table.",
+            "Could not rename table from %s to %s because "
+            "destination db does not exist",
             from,
             to);
+        error = HA_ERR_DEST_SCHEMA_NOT_EXIST;
+    }
+    else {
+        error = delete_or_rename_table(from, to, false);
+        if (TOKUDB_LIKELY(TOKUDB_DEBUG_FLAGS(TOKUDB_DEBUG_HIDE_DDL_LOCK_ERRORS) == 0) &&
+            error == DB_LOCK_NOTGRANTED) {
+            sql_print_error(
+                "Could not rename table from %s to %s because another transaction "
+                "has accessed the table. To rename the table, make sure no "
+                "transactions touch the table.",
+                from,
+                to);
+        }
     }
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }


### PR DESCRIPTION
It is supposed db exists if mysql data dir contains subdirectory with the same
name as the db. Before calling rename operation from storage engine it is
checked if corresponding subdirectory exists in mysql data directory.

But this check is not enough in the case if tokudb data directory is not
the same as mysql data directory. It is also supposed PerconaFT library does
not handle directory operations because the library should not know about
databases, tables etc, it's just library for work with fractal trees. And
caller should manage directories, in our case caller is mysqld. But mysqld can
work with directories only in it's data directory and it does not create or
remove db directory in tokudb data directory if it's not the same as mysql
data directory. That is why PerconaFT is also fixed to create necessary
directories for fractal tree file path like InnoDB. But There is no
transactional directory operations in PerconaFT.

See also: https://github.com/percona/percona-server/pull/1276, https://github.com/percona/PerconaFT/pull/365.

http://jenkins.percona.com/job/percona-server-5.6-param/1581/