### PR TITLE
MYR-16: myrocks/webscale uses different method to implement START TRA…

### DIFF
--- a/mysql-test/suite/rocksdb/r/cons_snapshot_read_committed.result
+++ b/mysql-test/suite/rocksdb/r/cons_snapshot_read_committed.result
@@ -5,7 +5,10 @@ connection con1;
 CREATE TABLE t1 (a INT, pk INT AUTO_INCREMENT PRIMARY KEY) ENGINE=ROCKSDB;
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 1105
+Warnings:
+Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
+ERROR: 0
 connection con2;
 select * from information_schema.rocksdb_dbstats where stat_type='DB_NUM_SNAPSHOTS';
 STAT_TYPE	VALUE
@@ -18,7 +21,10 @@ STAT_TYPE	VALUE
 DB_NUM_SNAPSHOTS	0
 connection con1;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 1105
+Warnings:
+Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
+ERROR: 0
 connection con2;
 INSERT INTO t1 (a) VALUES (1);
 connection con1;
@@ -69,7 +75,10 @@ id	value	value2
 5	5	5
 6	6	6
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 1105
+Warnings:
+Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
+ERROR: 0
 connection con2;
 INSERT INTO r1 values (7,7,7);
 connection con1;
@@ -107,12 +116,18 @@ id	value	value2
 7	7	7
 8	8	8
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 1105
+Warnings:
+Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
+ERROR: 0
 connection con2;
 INSERT INTO r1 values (9,9,9);
 connection con1;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 1105
+Warnings:
+Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
+ERROR: 0
 connection con2;
 INSERT INTO r1 values (10,10,10);
 connection con1;
@@ -129,9 +144,12 @@ id	value	value2
 9	9	9
 10	10	10
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 1105
-INSERT INTO r1 values (11,11,11);
+Warnings:
+Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
 ERROR: 0
+INSERT INTO r1 values (11,11,11);
+ERROR: 1105
 SELECT * FROM r1;
 id	value	value2
 1	1	1
@@ -144,7 +162,6 @@ id	value	value2
 8	8	8
 9	9	9
 10	10	10
-11	11	11
 drop table r1;
 connection default;
 disconnect con1;

--- a/mysql-test/suite/rocksdb/r/read_only_tx.result
+++ b/mysql-test/suite/rocksdb/r/read_only_tx.result
@@ -3,9 +3,11 @@ CREATE TABLE t1 (id INT, value int, PRIMARY KEY (id), INDEX (value)) ENGINE=Rock
 INSERT INTO t1 VALUES (1,1);
 select variable_value into @p from information_schema.global_status where variable_name='rocksdb_number_sst_entry_put';
 select variable_value into @s from information_schema.global_status where variable_name='rocksdb_number_sst_entry_singledelete';
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	734	uuid:1-3
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+SHOW STATUS LIKE 'binlog_snapshot_%';
+Variable_name	Value
+Binlog_snapshot_file	master-bin.000001
+Binlog_snapshot_position	770
 select case when variable_value-@p < 1000 then 'true' else variable_value-@p end from information_schema.global_status where variable_name='rocksdb_number_sst_entry_put';
 case when variable_value-@p < 1000 then 'true' else variable_value-@p end
 true
@@ -16,7 +18,7 @@ SELECT * FROM t1;
 id	value
 1	1
 INSERT INTO t1 values (2, 2);
-ERROR HY000: Can't execute updates when you started a transaction with START TRANSACTION WITH CONSISTENT [ROCKSDB] SNAPSHOT.
+ERROR HY000: Can't execute updates when you started a transaction with START TRANSACTION WITH CONSISTENT SNAPSHOT.
 ROLLBACK;
 SELECT * FROM t1;
 id	value

--- a/mysql-test/suite/rocksdb/t/read_only_tx.test
+++ b/mysql-test/suite/rocksdb/t/read_only_tx.test
@@ -20,8 +20,8 @@ INSERT INTO t1 VALUES (1,1);
 # Read-only, long-running transaction. SingleDelete/Put shouldn't increase much.
 select variable_value into @p from information_schema.global_status where variable_name='rocksdb_number_sst_entry_put';
 select variable_value into @s from information_schema.global_status where variable_name='rocksdb_number_sst_entry_singledelete';
--- replace_result $uuid uuid
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+SHOW STATUS LIKE 'binlog_snapshot_%';
 
 connection con2;
 --disable_query_log

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3015,66 +3015,41 @@ static inline void rocksdb_register_tx(handlerton *hton, THD *thd,
 }
 
 /*
-    Supporting START TRANSACTION WITH CONSISTENT [ROCKSDB] SNAPSHOT
+    Supporting START TRANSACTION WITH CONSISTENT SNAPSHOT
 
-    Features:
-    1. Supporting START TRANSACTION WITH CONSISTENT SNAPSHOT
-    2. Getting current binlog position in addition to #1.
-
-    The second feature is done by START TRANSACTION WITH
-    CONSISTENT ROCKSDB SNAPSHOT. This is Facebook's extension, and
-    it works like existing START TRANSACTION WITH CONSISTENT INNODB SNAPSHOT.
-
-    - When not setting engine, START TRANSACTION WITH CONSISTENT SNAPSHOT
+    - START TRANSACTION WITH CONSISTENT SNAPSHOT
     takes both InnoDB and RocksDB snapshots, and both InnoDB and RocksDB
     participate in transaction. When executing COMMIT, both InnoDB and
     RocksDB modifications are committed. Remember that XA is not supported yet,
     so mixing engines is not recommended anyway.
-
-    - When setting engine, START TRANSACTION WITH CONSISTENT.. takes
-    snapshot for the specified engine only. But it starts both
-    InnoDB and RocksDB transactions.
 */
 static int rocksdb_start_tx_and_assign_read_view(
         handlerton*     hton,           /*!< in: RocksDB handlerton */
-        THD*            thd,            /*!< in: MySQL thread handle of the
+        THD*            thd)            /*!< in: MySQL thread handle of the
                                         user for whom the transaction should
                                         be committed */
-        char*           binlog_file,    /* out: binlog file for last commit */
-        ulonglong*      binlog_pos,     /* out: binlog pos for last commit */
-        char**  gtid_executed,  /* out: Gtids logged until last commit */
-        int*    gtid_executed_length)   /*out: Length of gtid_executed string */
 {
   Rdb_perf_context_guard guard(thd);
 
   ulong const tx_isolation = my_core::thd_tx_isolation(thd);
 
-  if (tx_isolation != ISO_REPEATABLE_READ)
-  {
-    my_printf_error(ER_UNKNOWN_ERROR,
-                    "Only REPEATABLE READ isolation level is supported "
-                    "for START TRANSACTION WITH CONSISTENT SNAPSHOT "
-                    "in RocksDB Storage Engine.", MYF(0));
-    return 1;
-  }
-
-  if (binlog_file)
-  {
-    if (binlog_pos && mysql_bin_log_is_open())
-      mysql_bin_log_lock_commits();
-    else
-      return 1;
-  }
-
   Rdb_transaction* tx= get_or_create_tx(thd);
   DBUG_ASSERT(!tx->has_snapshot());
   tx->set_tx_read_only(true);
   rocksdb_register_tx(hton, thd, tx);
-  tx->acquire_snapshot(true);
 
-  if (binlog_file)
-    mysql_bin_log_unlock_commits(binlog_file, binlog_pos, gtid_executed,
-                                 gtid_executed_length);
+  if (tx_isolation == ISO_REPEATABLE_READ)
+  {
+    tx->acquire_snapshot(true);
+  }
+  else
+  {
+    push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN, HA_ERR_UNSUPPORTED,
+                        "Only REPEATABLE READ isolation level is supported "
+                        "for START TRANSACTION WITH CONSISTENT SNAPSHOT "
+                        "in RocksDB Storage Engine. Snapshot has not been "
+                        "taken.");
+  }
 
   return 0;
 }
@@ -8686,8 +8661,7 @@ int ha_rocksdb::external_lock(THD *thd, int lock_type)
       {
         my_printf_error(ER_UNKNOWN_ERROR,
                         "Can't execute updates when you started a transaction "
-                        "with START TRANSACTION WITH CONSISTENT [ROCKSDB] "
-                        "SNAPSHOT.",
+                        "with START TRANSACTION WITH CONSISTENT SNAPSHOT.",
                         MYF(0));
         DBUG_RETURN(HA_ERR_INTERNAL_ERROR);
       }


### PR DESCRIPTION
…NSACTION WITH CONSISTENT SNAPSHOT

1. Removed support for `START TRANSACTION WITH CONSISTENT ROCKSDB
   SNAPSHOT' and as a result all extra arguments from handlerton.
2. Changed handlerton behaviour to issue warning instead when
   transaction isolation level is not REPEATABLE READ. In this case
   transaction will be started, but snapshot will not be taken.
3. Changed test cases:
   - replaced `CONSISTENT ROCKSDB SNAPSHOT' syntax with `CONSISTENT
     SNAPSHOT' syntax, added 'binlog_snapshot_%' variables querying.
   - re-recorded test results