### PR TITLE
MYR-3 : webscale specific performance timers and table stats

### DIFF
--- a/include/atomic_stat.h
+++ b/include/atomic_stat.h
@@ -1,0 +1,94 @@
+/* This is an atomic integer abstract data type, for high-performance
+   tracking of a single stat.  It intentionally permits inconsistent
+   atomic operations and reads, for better performance.  This means
+   that, though no data should ever be lost by this stat, reads of it
+   at any time may not include all changes up to any particular point.
+
+   So, values read from these may only be approximately correct.
+
+   If your use-case will fail under these conditions, do not use this.
+
+   Copyright (C) 2012 - 2014 Steaphan Greene <steaphan@gmail.com>
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; either version 2
+   of the License, or (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the
+   Free Software Foundation, Inc.
+   51 Franklin Street, Fifth Floor
+   Boston, MA  02110-1301, USA.
+*/
+
+#ifndef _atomic_stat_h_
+#define _atomic_stat_h_
+
+#include <atomic>
+
+template < typename TYPE >
+class atomic_stat {
+public:
+  // Initialize value to the default for the type
+  atomic_stat() : value_(TYPE()) {};
+
+  // This enforces a strict order, as all absolute sets should
+  void clear() {
+    value_.store(TYPE(), std::memory_order_seq_cst);
+  };
+
+  // Reads can get any valid value, it doesn't matter which, exactly
+  TYPE load() const {
+    return value_.load(std::memory_order_relaxed);
+  };
+
+  // This only supplies relative arithmetic operations
+  // These are all done atomically, and so can show up in any order
+  void inc(const TYPE &other) {
+    value_.fetch_add(other, std::memory_order_relaxed);
+  };
+
+  void dec(const TYPE &other) {
+    value_.fetch_sub(other, std::memory_order_relaxed);
+  };
+
+  void inc() {
+    value_.fetch_add(1, std::memory_order_relaxed);
+  };
+
+  void dec() {
+    value_.fetch_sub(1, std::memory_order_relaxed);
+  };
+
+  // This will make one attempt to set the value to the max of
+  // the current value, and the passed-in value.  It can fail
+  // for any reason, and we only try it once.
+  void set_max_maybe(const TYPE &new_val) {
+    TYPE old_val = value_;
+    if (new_val > old_val) {
+      value_.compare_exchange_weak(old_val, new_val,
+                                   std::memory_order_relaxed,
+                                   std::memory_order_relaxed);
+    }
+  };
+
+  // This will make one attempt to assign the value to the passed-in
+  // value.  It can fail for any reason, and we only try it once.
+  void set_maybe(const TYPE &new_val) {
+    TYPE old_val = value_;
+    value_.compare_exchange_weak(old_val, new_val,
+                                 std::memory_order_relaxed,
+                                 std::memory_order_relaxed);
+  };
+
+private:
+  std::atomic<TYPE> value_;
+};
+
+#endif // _atomic_stat_h_

--- a/include/my_io_perf.h
+++ b/include/my_io_perf.h
@@ -1,0 +1,143 @@
+/* Copyright (c) 2016, Percona and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef _io_perf_h_
+#define _io_perf_h_
+
+#include "atomic_stat.h"
+#include <algorithm>
+
+#ifdef	__cplusplus
+extern "C" {
+#endif
+
+/* Per-table operation and IO statistics */
+
+/* Struct used for IO performance counters within a single thread */
+struct my_io_perf_struct {
+  ulonglong bytes;
+  ulonglong requests;
+  ulonglong svc_time; /*!< time to do read or write operation */
+  ulonglong svc_time_max;
+  ulonglong wait_time; /*!< total time in the request array */
+  ulonglong wait_time_max;
+  ulonglong slow_ios; /*!< requests that take too long */
+
+  /* Initialize a my_io_perf_t struct. */
+  inline void init() {
+    memset(this, 0, sizeof(*this));
+  }
+
+  /* Sets this to a - b in diff */
+  inline void diff(const my_io_perf_struct& a, const my_io_perf_struct& b) {
+    if (a.bytes > b.bytes)
+      bytes = a.bytes - b.bytes;
+    else
+      bytes = 0;
+
+    if (a.requests > b.requests)
+      requests = a.requests - b.requests;
+    else
+      requests = 0;
+
+    if (a.svc_time > b.svc_time)
+      svc_time = a.svc_time - b.svc_time;
+    else
+      svc_time = 0;
+
+    if (a.wait_time > b.wait_time)
+      wait_time = a.wait_time - b.wait_time;
+    else
+      wait_time = 0;
+
+    if (a.slow_ios > b.slow_ios)
+      slow_ios = a.slow_ios - b.slow_ios;
+    else
+      slow_ios = 0;
+
+    svc_time_max = std::max(a.svc_time_max, b.svc_time_max);
+    wait_time_max = std::max(a.wait_time_max, b.wait_time_max);
+  }
+
+  /* Accumulates io perf values */
+  inline void sum(const my_io_perf_struct& that) {
+    bytes += that.bytes;
+    requests += that.requests;
+    svc_time += that.svc_time;
+    svc_time_max = std::max(svc_time_max, that.svc_time_max);
+    wait_time += that.wait_time;
+    wait_time_max = std::max(wait_time_max, that.wait_time_max);
+    slow_ios += that.slow_ios;
+  }
+};
+typedef struct my_io_perf_struct my_io_perf_t;
+
+/* Struct used for IO performance counters, shared among multiple threads */
+struct my_io_perf_atomic_struct {
+  atomic_stat<ulonglong> bytes;
+  atomic_stat<ulonglong> requests;
+  atomic_stat<ulonglong> svc_time; /*!< time to do read or write operation */
+  atomic_stat<ulonglong> svc_time_max;
+  atomic_stat<ulonglong> wait_time; /*!< total time in the request array */
+  atomic_stat<ulonglong> wait_time_max;
+  atomic_stat<ulonglong> slow_ios; /*!< requests that take too long */
+
+  /* Initialize an my_io_perf_atomic_t struct. */
+  inline void init() {
+    bytes.clear();
+    requests.clear();
+    svc_time.clear();
+    svc_time_max.clear();
+    wait_time.clear();
+    wait_time_max.clear();
+    slow_ios.clear();
+  }
+
+  /* Accumulates io perf values using atomic operations */
+  inline void sum(const my_io_perf_struct& that) {
+    bytes.inc(that.bytes);
+    requests.inc(that.requests);
+
+    svc_time.inc(that.svc_time);
+    wait_time.inc(that.wait_time);
+
+    // In the unlikely case that two threads attempt to update the max
+    // value at the same time, only the first will succeed.  It's possible
+    // that the second thread would have set a larger max value, but we
+    // would rather error on the side of simplicity and avoid looping the
+    // compare-and-swap.
+    svc_time_max.set_max_maybe(that.svc_time);
+    wait_time_max.set_max_maybe(that.wait_time);
+
+    slow_ios.inc(that.slow_ios);
+  }
+
+  /* These assignments allow for races. That is OK. */
+  inline void set_maybe(const my_io_perf_struct& that) {
+    bytes.set_maybe(that.bytes);
+    requests.set_maybe(that.requests);
+    svc_time.set_maybe(that.svc_time);
+    svc_time_max.set_maybe(that.svc_time_max);
+    wait_time.set_maybe(that.wait_time);
+    wait_time_max.set_maybe(that.wait_time_max);
+    slow_ios.set_maybe(that.slow_ios);
+  }
+};
+typedef struct my_io_perf_atomic_struct my_io_perf_atomic_t;
+
+#ifdef	__cplusplus
+}
+#endif
+#endif

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3102,98 +3102,6 @@ static bool rocksdb_rollback_to_savepoint_can_release_mdl(handlerton *hton,
   return true;
 }
 
-/*
-  This is called for INFORMATION_SCHEMA
-*/
-static void rocksdb_update_table_stats(
-  /* per-table stats callback */
-  void (*cb)(const char* db, const char* tbl, bool is_partition,
-    my_io_perf_t* r, my_io_perf_t* w, my_io_perf_t* r_blob,
-    my_io_perf_t* r_primary, my_io_perf_t* r_secondary,
-    page_stats_t *page_stats, comp_stats_t *comp_stats,
-    int n_lock_wait, int n_lock_wait_timeout,
-    const char* engine))
-{
-  my_io_perf_t io_perf_read;
-  my_io_perf_t io_perf;
-  page_stats_t page_stats;
-  comp_stats_t comp_stats;
-  std::vector<std::string> tablenames;
-
-  /*
-    Most of these are for innodb, so setting them to 0.
-    TODO: possibly separate out primary vs. secondary index reads
-   */
-  memset(&io_perf, 0, sizeof(io_perf));
-  memset(&page_stats, 0, sizeof(page_stats));
-  memset(&comp_stats, 0, sizeof(comp_stats));
-
-  tablenames= rdb_open_tables.get_table_names();
-
-  for (const auto& it : tablenames)
-  {
-    Rdb_table_handler *table_handler;
-    std::string str, dbname, tablename, partname;
-    char dbname_sys[NAME_LEN + 1];
-    char tablename_sys[NAME_LEN + 1];
-    bool is_partition;
-
-    if (rdb_normalize_tablename(it, &str)) {
-      /* Function needs to return void because of the interface and we've
-       * detected an error which shouldn't happen. There's no way to let
-       * caller know that something failed.
-      */
-      SHIP_ASSERT(false);
-      return;
-    }
-
-    if (rdb_split_normalized_tablename(str, &dbname, &tablename, &partname))
-    {
-      continue;
-    }
-
-    is_partition= (partname.size() != 0);
-
-    table_handler= rdb_open_tables.get_table_handler(it.c_str());
-    if (table_handler == nullptr)
-    {
-      continue;
-    }
-
-    io_perf_read.bytes= table_handler->m_io_perf_read.bytes.load();
-    io_perf_read.requests= table_handler->m_io_perf_read.requests.load();
-
-    /*
-      Convert from rocksdb timer to mysql timer. RocksDB values are
-      in nanoseconds, but table statistics expect the value to be
-      in my_timer format.
-     */
-     io_perf_read.svc_time= my_core::microseconds_to_my_timer(
-         table_handler->m_io_perf_read.svc_time.load() / 1000);
-     io_perf_read.svc_time_max= my_core::microseconds_to_my_timer(
-         table_handler->m_io_perf_read.svc_time_max.load() / 1000);
-     io_perf_read.wait_time= my_core::microseconds_to_my_timer(
-         table_handler->m_io_perf_read.wait_time.load() / 1000);
-     io_perf_read.wait_time_max= my_core::microseconds_to_my_timer(
-         table_handler->m_io_perf_read.wait_time_max.load() / 1000);
-     io_perf_read.slow_ios= table_handler->m_io_perf_read.slow_ios.load();
-     rdb_open_tables.release_table_handler(table_handler);
-
-    /*
-      Table stats expects our database and table name to be in system encoding,
-      not filename format. Convert before calling callback.
-     */
-    my_core::filename_to_tablename(dbname.c_str(), dbname_sys,
-                                   sizeof(dbname_sys));
-    my_core::filename_to_tablename(tablename.c_str(), tablename_sys,
-                                   sizeof(tablename_sys));
-    (*cb)(dbname_sys, tablename_sys, is_partition, &io_perf_read, &io_perf,
-          &io_perf, &io_perf, &io_perf, &page_stats, &comp_stats, 0, 0,
-          rocksdb_hton_name);
-  }
-}
-
-
 static rocksdb::Status check_rocksdb_options_compatibility(
         const char *dbpath,
         const rocksdb::Options& main_opts,
@@ -3310,7 +3218,6 @@ static int rocksdb_init_func(void *p)
   rocksdb_hton->savepoint_rollback= rocksdb_rollback_to_savepoint;
   rocksdb_hton->savepoint_rollback_can_release_mdl=
     rocksdb_rollback_to_savepoint_can_release_mdl;
-  rocksdb_hton->update_table_stats = rocksdb_update_table_stats;
   rocksdb_hton->flush_logs= rocksdb_flush_wal;
 
   rocksdb_hton->flags= HTON_TEMPORARY_NOT_SUPPORTED |
@@ -3746,7 +3653,7 @@ Rdb_table_handler* Rdb_open_tables_map::get_table_handler(
     }
 
     thr_lock_init(&table_handler->m_thr_lock);
-    my_io_perf_atomic_init(&table_handler->m_io_perf_read);
+    table_handler->m_io_perf_read.init();
   }
   DBUG_ASSERT(table_handler->m_ref_count >= 0);
   table_handler->m_ref_count++;

--- a/storage/rocksdb/rdb_perf_context.cc
+++ b/storage/rocksdb/rdb_perf_context.cc
@@ -208,7 +208,7 @@ void Rdb_io_perf::end_and_record(uint32_t perf_context_level)
   {
     my_io_perf_t io_perf_read;
 
-    my_io_perf_init(&io_perf_read);
+    io_perf_read.init();
     io_perf_read.bytes= rocksdb::perf_context.block_read_byte;
     io_perf_read.requests= rocksdb::perf_context.block_read_count;
 
@@ -219,21 +219,7 @@ void Rdb_io_perf::end_and_record(uint32_t perf_context_level)
     io_perf_read.svc_time_max= io_perf_read.svc_time=
         rocksdb::perf_context.block_read_time;
 
-    my_io_perf_sum_atomic_helper(m_shared_io_perf_read, &io_perf_read);
-    my_io_perf_sum(&m_stats->table_io_perf_read, &io_perf_read);
-  }
-
-  if (m_stats) {
-    if (rocksdb::perf_context.internal_key_skipped_count != 0)
-    {
-      m_stats->key_skipped += rocksdb::perf_context.internal_key_skipped_count;
-    }
-
-    if (rocksdb::perf_context.internal_delete_skipped_count != 0)
-    {
-      m_stats->delete_skipped +=
-          rocksdb::perf_context.internal_delete_skipped_count;
-    }
+    m_shared_io_perf_read->sum(io_perf_read);
   }
 }
 

--- a/storage/rocksdb/rdb_perf_context.h
+++ b/storage/rocksdb/rdb_perf_context.h
@@ -24,6 +24,7 @@
 /* MySQL header files */
 #include "./handler.h"
 #include <my_global.h>
+#include <my_io_perf.h>
 
 namespace myrocks {
 


### PR DESCRIPTION
- Submitted refactor of my_io_perf to upstream, which was accepted and applied
- Copied in upstream include/atomic_stat.h and include/my_io_perf.h
- Removed portion FacebookSQL patch in MyRocks that implements handlerton function update_table_stats which is used to explose statistics in information_schema.table_statistics
- Removed updating of FacebookSQL specific additional data in ha_statistics struct.

Superseding https://github.com/percona/percona-server/pull/1187 