### PR TITLE
Add diagnostics to catch bug 1628079 (Intemittent hangs on shutdown, …

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -4785,7 +4785,13 @@ static int my_kill(int pid, int sig)
   CloseHandle(proc);
   return 1;
 #else
-  return kill(pid, sig);
+  int result= kill(pid, sig);
+  if (result == -1 && errno != ESRCH)
+  {
+    log_msg("kill(%d, %d) returned errno %d (%s)", pid, sig, errno,
+            strerror(errno));
+  }
+  return result;
 #endif
 }
 


### PR DESCRIPTION
…ASan build)

Diagnose kill syscall failing in mysqltest with anything else than
ESRCH.

http://jenkins.percona.com/job/percona-server-5.6-param/1586/