### PR TITLE
Fix bug 1655587 / 84381 (main.events_2 test fails because of hardcode…

### DIFF
--- a/mysql-test/r/events_2.result
+++ b/mysql-test/r/events_2.result
@@ -1,10 +1,10 @@
 drop database if exists events_test;
 create database events_test;
 use events_test;
-create event e_26 on schedule at '2017-01-01 00:00:00' disable do set @a = 5;
+create event e_26 on schedule at 'ONE_YEAR_FROM_NOW' disable do set @a = 5;
 select db, name, body, definer, convert_tz(execute_at, 'UTC', 'SYSTEM'), on_completion from mysql.event;
 db	name	body	definer	convert_tz(execute_at, 'UTC', 'SYSTEM')	on_completion
-events_test	e_26	set @a = 5	root@localhost	2017-01-01 00:00:00	DROP
+events_test	e_26	set @a = 5	root@localhost	ONE_YEAR_FROM_NOW	DROP
 drop event e_26;
 create event e_26 on schedule at NULL disable do set @a = 5;
 ERROR HY000: Incorrect AT value: 'NULL'

--- a/mysql-test/t/events_2.test
+++ b/mysql-test/t/events_2.test
@@ -13,7 +13,10 @@ use events_test;
 # mysql.event intact checking end
 #
 
-create event e_26 on schedule at '2017-01-01 00:00:00' disable do set @a = 5;
+--let $one_year_from_now = `SELECT NOW() + INTERVAL 1 YEAR`
+--replace_result $one_year_from_now ONE_YEAR_FROM_NOW
+eval create event e_26 on schedule at '$one_year_from_now' disable do set @a = 5;
+--replace_result $one_year_from_now ONE_YEAR_FROM_NOW
 select db, name, body, definer, convert_tz(execute_at, 'UTC', 'SYSTEM'), on_completion from mysql.event;
 drop event e_26;
 --error ER_WRONG_VALUE


### PR DESCRIPTION
…d 2017-01-01 date)

Replace the hardcoded date with one at one year in the future from
NOW().

http://jenkins.percona.com/job/percona-server-5.5-param/1507/