### PR TITLE
Fix bug 1657026 (Lack of free pages in the buffer pool is not diagnos…

### DIFF
--- a/mysql-test/include/kill_mysqld.inc
+++ b/mysql-test/include/kill_mysqld.inc
@@ -1,0 +1,7 @@
+--let $_server_id= `SELECT @@server_id`
+--let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
+
+--echo # Kill the server
+--exec echo "wait" > $_expect_file_name
+--shutdown_server 0
+--source include/wait_until_disconnected.inc

--- a/mysql-test/suite/innodb/r/percona_crash_recovery_innodb_status.result
+++ b/mysql-test/suite/innodb/r/percona_crash_recovery_innodb_status.result
@@ -1,0 +1,8 @@
+#
+# Test printing of InnoDB status during crash recovery
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+BEGIN;
+INSERT INTO t1 VALUES (1);
+# Kill the server
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/percona_lru_flusher_debug.result
+++ b/mysql-test/suite/innodb/r/percona_lru_flusher_debug.result
@@ -1,0 +1,11 @@
+#
+# Debug build tests for Percona LRU flusher and related flushing changes
+#
+#
+# Bug 1657026: Lack of free pages in the buffer pool is not diagnosed with
+# innodb_empty_free_list_algorithm=backoff
+#
+SET @@debug="+d,simulate_lack_of_pages";
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+include/assert.inc [With the bug present, Innodb_buffer_pool_wait_free stays at zero]
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_crash_recovery_innodb_status.test
+++ b/mysql-test/suite/innodb/t/percona_crash_recovery_innodb_status.test
@@ -1,0 +1,29 @@
+--source include/have_debug.inc
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+
+--echo #
+--echo # Test printing of InnoDB status during crash recovery
+--echo #
+
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/log/my_restart.err
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+
+BEGIN;
+INSERT INTO t1 VALUES (1);
+
+--source include/kill_mysqld.inc
+--error 137,3
+--exec $MYSQLD_CMD --loose-console --debug=+d,simulate_recovery_lack_of_pages > $SEARCH_FILE 2>&1
+
+--let SEARCH_PATTERN= difficult to find free blocks
+--source include/search_pattern_in_file.inc
+
+--let SEARCH_PATTERN=END OF INNODB MONITOR OUTPUT
+--source include/search_pattern_in_file.inc
+--remove_file $SEARCH_FILE
+
+--source include/start_mysqld.inc
+
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_lru_flusher_debug.test
+++ b/mysql-test/suite/innodb/t/percona_lru_flusher_debug.test
@@ -1,0 +1,37 @@
+--source include/have_debug.inc
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+
+--echo #
+--echo # Debug build tests for Percona LRU flusher and related flushing changes
+--echo #
+
+--echo #
+--echo # Bug 1657026: Lack of free pages in the buffer pool is not diagnosed with
+--echo # innodb_empty_free_list_algorithm=backoff
+--echo #
+
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/log/my_restart.err
+--let $restart_parameters=restart:--innodb_buffer_pool_size=20M --log-error=$SEARCH_FILE
+--source include/restart_mysqld.inc
+
+SET @@debug="+d,simulate_lack_of_pages";
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+
+--let $assert_text= With the bug present, Innodb_buffer_pool_wait_free stays at zero
+--let $assert_cond= VARIABLE_VALUE FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME LIKE "Innodb_buffer_pool_wait_free" > 0
+--source include/assert.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+DROP TABLE t1;
+
+# With the bug present, the "difficult to find free blocks" warning is not printed
+--let SEARCH_PATTERN= difficult to find free blocks
+--source include/search_pattern_in_file.inc
+
+--let SEARCH_PATTERN= END OF INNODB MONITOR OUTPUT
+--source include/search_pattern_in_file.inc
+--remove_file $SEARCH_FILE

--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -1301,6 +1301,71 @@ buf_LRU_check_size_of_non_data_objects(
 	}
 }
 
+/** Diagnose failure to get a free page and request InnoDB monitor output in
+the error log if more than two seconds have been spent already.
+@param[in]	n_iterations	how many buf_LRU_get_free_page iterations
+                                already completed
+@param[in]	started_ms	timestamp in ms of when the attempt to get the
+                                free page started
+@param[in]	flush_failures	how many times single-page flush, if allowed,
+                                has failed
+@param[out]	mon_value_was	previous srv_print_innodb_monitor value
+@param[out]	started_monitor	whether InnoDB monitor print has been requested
+*/
+static
+void
+buf_LRU_handle_lack_of_free_blocks(ulint n_iterations, ulint started_ms,
+				   ulint flush_failures,
+				   ibool *mon_value_was,
+				   ibool *started_monitor)
+{
+	static ulint last_printout_ms = 0;
+
+	/* Legacy algorithm started warning after at least 2 seconds, we
+	emulate	this. */
+	const ulint current_ms = ut_time_ms();
+
+	if ((current_ms > started_ms + 2000)
+	    && (current_ms > last_printout_ms + 2000)) {
+
+		ut_print_timestamp(stderr);
+		fprintf(stderr,
+			"  InnoDB: Warning: difficult to find free blocks in\n"
+			"InnoDB: the buffer pool (%lu search iterations)!\n"
+			"InnoDB: %lu failed attempts to flush a page!"
+			" Consider\n"
+			"InnoDB: increasing the buffer pool size.\n"
+			"InnoDB: It is also possible that"
+			" in your Unix version\n"
+			"InnoDB: fsync is very slow, or"
+			" completely frozen inside\n"
+			"InnoDB: the OS kernel. Then upgrading to"
+			" a newer version\n"
+			"InnoDB: of your operating system may help."
+			" Look at the\n"
+			"InnoDB: number of fsyncs in diagnostic info below.\n"
+			"InnoDB: Pending flushes (fsync) log: %lu;"
+			" buffer pool: %lu\n"
+			"InnoDB: %lu OS file reads, %lu OS file writes,"
+			" %lu OS fsyncs\n"
+			"InnoDB: Starting InnoDB Monitor to print further\n"
+			"InnoDB: diagnostics to the standard output.\n",
+			(ulong) n_iterations,
+			(ulong)	flush_failures,
+			(ulong) fil_n_pending_log_flushes,
+			(ulong) fil_n_pending_tablespace_flushes,
+			(ulong) os_n_file_reads, (ulong) os_n_file_writes,
+			(ulong) os_n_fsyncs);
+
+		last_printout_ms = current_ms;
+		*mon_value_was = srv_print_innodb_monitor;
+		*started_monitor = TRUE;
+		srv_print_innodb_monitor = TRUE;
+		os_event_set(lock_sys->timeout_event);
+	}
+
+}
+
 /** The maximum allowed backoff sleep time duration, microseconds */
 #define MAX_FREE_LIST_BACKOFF_SLEEP 10000
 
@@ -1348,6 +1413,7 @@ buf_LRU_get_free_block(
 	ulint		flush_failures	= 0;
 	ibool		mon_value_was	= FALSE;
 	ibool		started_monitor	= FALSE;
+	ulint		started_ms	= 0;
 
 	ut_ad(!mutex_own(&buf_pool->LRU_list_mutex));
 
@@ -1356,7 +1422,24 @@ loop:
 	buf_LRU_check_size_of_non_data_objects(buf_pool);
 
 	/* If there is a block in the free list, take it */
-	block = buf_LRU_get_free_only(buf_pool);
+	if (DBUG_EVALUATE_IF("simulate_lack_of_pages", true, false)) {
+
+		block = NULL;
+
+		if (srv_debug_monitor_printed)
+			DBUG_SET("-d,simulate_lack_of_pages");
+
+	} else if (DBUG_EVALUATE_IF("simulate_recovery_lack_of_pages",
+				    recv_recovery_on, false)) {
+
+		block = NULL;
+
+		if (srv_debug_monitor_printed)
+			DBUG_SUICIDE();
+	} else {
+
+		block = buf_LRU_get_free_only(buf_pool);
+	}
 
 	if (block) {
 
@@ -1370,6 +1453,9 @@ loop:
 
 		return(block);
 	}
+
+	if (!started_ms)
+		started_ms = ut_time_ms();
 
 	if (srv_empty_free_list_algorithm == SRV_EMPTY_FREE_LIST_BACKOFF
 	    && buf_lru_manager_is_active
@@ -1408,11 +1494,17 @@ loop:
 				: FREE_LIST_BACKOFF_LOW_PRIO_DIVIDER));
 		}
 
-		/* In case of backoff, do not ever attempt single page flushes
-		and wait for the cleaner to free some pages instead.  */
+		buf_LRU_handle_lack_of_free_blocks(n_iterations, started_ms,
+						   flush_failures,
+						   &mon_value_was,
+						   &started_monitor);
 
 		n_iterations++;
 
+		srv_stats.buf_pool_wait_free.add(n_iterations, 1);
+
+		/* In case of backoff, do not ever attempt single page flushes
+		and wait for the cleaner to free some pages instead.  */
 		goto loop;
 	} else {
 
@@ -1444,6 +1536,12 @@ loop:
 
 	mutex_exit(&buf_pool->flush_state_mutex);
 
+	if (DBUG_EVALUATE_IF("simulate_recovery_lack_of_pages", true, false)
+	    || DBUG_EVALUATE_IF("simulate_lack_of_pages", true, false)) {
+
+		buf_pool->try_LRU_scan = false;
+	}
+
 	freed = FALSE;
 	if (buf_pool->try_LRU_scan || n_iterations > 0) {
 
@@ -1469,41 +1567,9 @@ loop:
 
 	}
 
-	if (n_iterations > 20) {
-		ut_print_timestamp(stderr);
-		fprintf(stderr,
-			"  InnoDB: Warning: difficult to find free blocks in\n"
-			"InnoDB: the buffer pool (%lu search iterations)!\n"
-			"InnoDB: %lu failed attempts to flush a page!"
-			" Consider\n"
-			"InnoDB: increasing the buffer pool size.\n"
-			"InnoDB: It is also possible that"
-			" in your Unix version\n"
-			"InnoDB: fsync is very slow, or"
-			" completely frozen inside\n"
-			"InnoDB: the OS kernel. Then upgrading to"
-			" a newer version\n"
-			"InnoDB: of your operating system may help."
-			" Look at the\n"
-			"InnoDB: number of fsyncs in diagnostic info below.\n"
-			"InnoDB: Pending flushes (fsync) log: %lu;"
-			" buffer pool: %lu\n"
-			"InnoDB: %lu OS file reads, %lu OS file writes,"
-			" %lu OS fsyncs\n"
-			"InnoDB: Starting InnoDB Monitor to print further\n"
-			"InnoDB: diagnostics to the standard output.\n",
-			(ulong) n_iterations,
-			(ulong)	flush_failures,
-			(ulong) fil_n_pending_log_flushes,
-			(ulong) fil_n_pending_tablespace_flushes,
-			(ulong) os_n_file_reads, (ulong) os_n_file_writes,
-			(ulong) os_n_fsyncs);
-
-		mon_value_was = srv_print_innodb_monitor;
-		started_monitor = TRUE;
-		srv_print_innodb_monitor = TRUE;
-		os_event_set(lock_sys->timeout_event);
-	}
+	buf_LRU_handle_lack_of_free_blocks(n_iterations, started_ms,
+					   flush_failures, &mon_value_was,
+					   &started_monitor);
 
 	/* If we have scanned the whole LRU and still are unable to
 	find a free block then we should sleep here to let the

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1120,4 +1120,12 @@ struct srv_slot_t{
 # define srv_file_per_table			1
 #endif /* !UNIV_HOTBACKUP */
 
+#ifndef DBUG_OFF
+/** false before InnoDB monitor has been printed at least once, true
+afterwards */
+extern bool	srv_debug_monitor_printed;
+#else
+#define	srv_debug_monitor_printed	false
+#endif
+
 #endif

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1341,22 +1341,26 @@ srv_printf_innodb_monitor(
 	low level 135. Therefore we can reserve the latter mutex here without
 	a danger of a deadlock of threads. */
 
-	mutex_enter(&dict_foreign_err_mutex);
+	if (!recv_recovery_on) {
 
-	if (!srv_read_only_mode && ftell(dict_foreign_err_file) != 0L) {
-		fputs("------------------------\n"
-		      "LATEST FOREIGN KEY ERROR\n"
-		      "------------------------\n", file);
-		ut_copy_file(file, dict_foreign_err_file);
+		mutex_enter(&dict_foreign_err_mutex);
+
+		if (!srv_read_only_mode
+		    && ftell(dict_foreign_err_file) != 0L) {
+			fputs("------------------------\n"
+			      "LATEST FOREIGN KEY ERROR\n"
+			      "------------------------\n", file);
+			ut_copy_file(file, dict_foreign_err_file);
+		}
+
+		mutex_exit(&dict_foreign_err_mutex);
 	}
-
-	mutex_exit(&dict_foreign_err_mutex);
 
 	/* Only if lock_print_info_summary proceeds correctly,
 	before we call the lock_print_info_all_transactions
 	to print all the lock information. IMPORTANT NOTE: This
 	function acquires the lock mutex on success. */
-	ret = lock_print_info_summary(file, nowait);
+	ret = recv_recovery_on ? FALSE : lock_print_info_summary(file, nowait);
 
 	if (ret) {
 		if (trx_start_pos) {
@@ -1389,10 +1393,13 @@ srv_printf_innodb_monitor(
 	      "--------\n", file);
 	os_aio_print(file);
 
-	fputs("-------------------------------------\n"
-	      "INSERT BUFFER AND ADAPTIVE HASH INDEX\n"
-	      "-------------------------------------\n", file);
-	ibuf_print(file);
+	if (!recv_recovery_on) {
+
+		fputs("-------------------------------------\n"
+		      "INSERT BUFFER AND ADAPTIVE HASH INDEX\n"
+		      "-------------------------------------\n", file);
+		ibuf_print(file);
+	}
 
 
 	fprintf(file,
@@ -1404,10 +1411,13 @@ srv_printf_innodb_monitor(
 	btr_cur_n_sea_old = btr_cur_n_sea;
 	btr_cur_n_non_sea_old = btr_cur_n_non_sea;
 
-	fputs("---\n"
-	      "LOG\n"
-	      "---\n", file);
-	log_print(file);
+	if (!recv_recovery_on) {
+
+		fputs("---\n"
+		      "LOG\n"
+		      "---\n", file);
+		log_print(file);
+	}
 
 	fputs("----------------------\n"
 	      "BUFFER POOL AND MEMORY\n"
@@ -1502,8 +1512,9 @@ srv_printf_innodb_monitor(
 					? (recv_sys->addr_hash->n_cells * sizeof(hash_cell_t)) : 0),
 			recv_sys_subtotal);
 
+
 	fprintf(file, "Dictionary memory allocated " ULINTPF "\n",
-		dict_sys->size);
+		dict_sys ? dict_sys->size : 0);
 
 	buf_print_io(file);
 
@@ -1588,6 +1599,10 @@ srv_printf_innodb_monitor(
 	      "============================\n", file);
 	mutex_exit(&srv_innodb_monitor_mutex);
 	fflush(file);
+
+#ifndef DBUG_OFF
+	srv_debug_monitor_printed = true;
+#endif
 
 	return(ret);
 }
@@ -1887,6 +1902,12 @@ srv_export_innodb_status(void)
 
 	mutex_exit(&srv_innodb_monitor_mutex);
 }
+
+#ifndef DBUG_OFF
+/** false before InnoDB monitor has been printed at least once, true
+afterwards */
+bool	srv_debug_monitor_printed	= false;
+#endif
 
 /*********************************************************************//**
 A thread which prints the info output by various InnoDB monitors.

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2362,6 +2362,8 @@ files_checked:
 
 	trx_sys_create();
 
+	bool srv_monitor_thread_started = false;
+
 	if (create_new_db) {
 
 		ut_a(!srv_read_only_mode);
@@ -2436,6 +2438,20 @@ files_checked:
 		this point there will be only ONE page in the buf_LRU
 		and there must be no page in the buf_flush list. */
 		buf_pool_invalidate();
+
+		/* Start monitor thread early enough so that e.g. crash
+		recovery failing to find free pages in the buffer pool is
+		diagnosed. */
+		if (!srv_read_only_mode)
+		{
+			/* Create the thread which prints InnoDB monitor
+			info */
+			os_thread_create(
+				srv_monitor_thread,
+				NULL, thread_ids + 4 + SRV_MAX_N_IO_THREADS);
+
+			srv_monitor_thread_started = true;
+		}
 
 		/* We always try to do a recovery, even if the database had
 		been shut down normally: this is the normal startup path */
@@ -2697,9 +2713,14 @@ files_checked:
 			NULL, thread_ids + 3 + SRV_MAX_N_IO_THREADS);
 
 		/* Create the thread which prints InnoDB monitor info */
-		os_thread_create(
-			srv_monitor_thread,
-			NULL, thread_ids + 4 + SRV_MAX_N_IO_THREADS);
+		if (!srv_monitor_thread_started) {
+
+			os_thread_create(
+				srv_monitor_thread,
+				NULL, thread_ids + 4 + SRV_MAX_N_IO_THREADS);
+
+			srv_monitor_thread_started = true;
+		}
 	}
 
 	/* Create the SYS_FOREIGN and SYS_FOREIGN_COLS system tables */


### PR DESCRIPTION
…ed with innodb_empty_free_list_algorithm=backoff)

The introduction of backoff to buf_LRU_get_free_block made it skip some
of the code paths of the legacy case, including diagnostics in the error
log for the lack of free pages, enabling of the InnoDB monitor, and
Innodb_buffer_pool_wait_free status variable bump. Fix by factoring out a
helper function to print diagnostics and enable the InnoDB monitor. Bump
the status variable directly in buf_LRU_get_free_block. Add a simulated
testcase. For diagnostics, also throttle their printing to one around
every two seconds.

Also, as a related change, add diagnostics to help catch bug 1655657
(Test innodb_fts.innodb_fts_misc_debug is unstable)

If crash recovery fails to find free buffer pool pages for read, it
loops forever in buf_LRU_get_free_block waiting for a block to appear
and attempting to print the InnoDB status to the server error
log. This never happens, since the server monitor thread has not been
started yet at the crash recovery time. Thus move the thread start
earlier, and patch the status printer to skip over the parts that are
not initialized yet. Add a simulated testcase.

http://jenkins.percona.com/job/percona-server-5.6-param/1593/