### PR TITLE
Bug#995624 RBR events are not reflected in userstat's Rows_updated

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_percona_bug995624.result
+++ b/mysql-test/suite/rpl/r/rpl_percona_bug995624.result
@@ -1,0 +1,47 @@
+include/master-slave.inc
+[connection master]
+set global userstat=ON;
+Rows_updated on slave - starting situation
+select ROWS_UPDATED from information_schema.client_statistics;
+ROWS_UPDATED
+0
+set global userstat=ON;
+Rows_updated on master - starting situation
+select ROWS_UPDATED from information_schema.client_statistics;
+ROWS_UPDATED
+0
+create table t1 (m int);
+3 "updates" to rows
+insert into t1 values(15),(16),(17);
+1 "update" to rows (4 in total)
+update t1 set m=20 where m=16;
+1 "update" to rows (5 in total)
+delete from t1 where m=17;
+create table t2 (n int);
+2 "updates" to rows (7 in total)
+insert into t2 values(30),(30);
+2 "updates" to rows (9 in total)
+update t2 set n=10 where n=30;
+2 "updates" to rows (11 in total)
+delete from t2 where n=10;
+2 "updates" to rows (13 in total)
+insert into t2 (n)
+select t1.m
+from t1;
+Rows_updated on master - ending situation
+select ROWS_UPDATED from information_schema.client_statistics;
+ROWS_UPDATED
+13
+set global userstat=OFF;
+Rows_updated on slave - ending situation
+select ROWS_UPDATED from information_schema.client_statistics;
+ROWS_UPDATED
+0
+13
+set global userstat=OFF;
+select * from t1 ORDER BY m;
+m
+15
+20
+drop table t1, t2;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_percona_bug995624.test
+++ b/mysql-test/suite/rpl/t/rpl_percona_bug995624.test
@@ -1,0 +1,45 @@
+source include/master-slave.inc;
+
+connection slave;
+set global userstat=ON;
+--echo Rows_updated on slave - starting situation
+select ROWS_UPDATED from information_schema.client_statistics;
+
+connection master;
+set global userstat=ON;
+--echo Rows_updated on master - starting situation
+select ROWS_UPDATED from information_schema.client_statistics;
+
+create table t1 (m int);
+--echo 3 "updates" to rows
+insert into t1 values(15),(16),(17); 
+--echo 1 "update" to rows (4 in total)
+update t1 set m=20 where m=16;
+--echo 1 "update" to rows (5 in total)
+delete from t1 where m=17;
+create table t2 (n int);
+--echo 2 "updates" to rows (7 in total)
+insert into t2 values(30),(30);
+--echo 2 "updates" to rows (9 in total)
+update t2 set n=10 where n=30;
+--echo 2 "updates" to rows (11 in total)
+delete from t2 where n=10;
+
+--echo 2 "updates" to rows (13 in total)
+insert into t2 (n)
+select t1.m
+from t1;
+--echo Rows_updated on master - ending situation
+select ROWS_UPDATED from information_schema.client_statistics;
+set global userstat=OFF;
+
+sync_slave_with_master;
+--echo Rows_updated on slave - ending situation
+select ROWS_UPDATED from information_schema.client_statistics;
+set global userstat=OFF;
+select * from t1 ORDER BY m;
+
+connection master;
+drop table t1, t2;
+sync_slave_with_master;
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -59,6 +59,8 @@
 
 #define FLAGSTR(V,F) ((V)&(F)?#F" ":"")
 
+// Uses the THD to update the global stats by user name and client IP
+void update_global_user_stats(THD* thd, bool create_user, time_t now);
 
 /*
   Size of buffer for printing a double in format %.<PREC>g
@@ -8181,6 +8183,14 @@ int Rows_log_event::do_apply_event(Relay_log_info const *rli)
           if (idempotent_error == 0)
             break;
         }
+      }
+      else
+        thd->updated_row_count++;
+
+      if (unlikely(opt_userstat))
+      {
+        thd->update_stats(false);
+        update_global_user_stats(thd, true, time(NULL));
       }
 
       /*


### PR DESCRIPTION
The Rows_updated value in the userstat feature is calculated at the statement level, i.e. in mysql_insert()/mysql_delete()/mysql_update(). However, row-based replic$
tion event operate on the lower handler level, so that value is not updated with RBR as a result.

I am updating rows_updated on slave after *each batch* of rows is replicated to slave. The other option would be to update rows_updated after *each row* is replicate to slave.