### PR TITLE
5.7 ps bug897715

### DIFF
--- a/mysql-test/r/percona_log_slow_verbosity.result
+++ b/mysql-test/r/percona_log_slow_verbosity.result
@@ -5,30 +5,33 @@ SET SESSION long_query_time=0;
 SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
 [log_start.inc] percona.slow_extended.log_slow_verbosity_0
 INSERT INTO t1 VALUE(0);
+BEGIN;
+INSERT INTO t1 VALUE(1);
+ROLLBACK;
 [log_stop.inc] percona.slow_extended.log_slow_verbosity_0
 log_slow_verbosity='microtime,innodb,query_plan':
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Bytes_sent: \d+.*$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# InnoDB_trx_id: \w+$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   3
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Filesort: (Yes|No)  Filesort_on_disk: (Yes|No)  Merge_passes: \d+$
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   5
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#   InnoDB_IO_r_ops: \d+  InnoDB_IO_r_bytes: \d+  InnoDB_IO_r_wait: \d*\.\d*$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#   InnoDB_rec_lock_wait: \d*\.\d*  InnoDB_queue_wait: \d*\.\d*$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#   InnoDB_pages_distinct: \d+$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# No InnoDB statistics available for this query$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   3
 SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
 [log_start.inc] percona.slow_extended.log_slow_verbosity_1
 SELECT 1;

--- a/mysql-test/t/percona_log_slow_verbosity.test
+++ b/mysql-test/t/percona_log_slow_verbosity.test
@@ -20,6 +20,9 @@ SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
 
 --source include/log_start.inc
 INSERT INTO t1 VALUE(0);
+BEGIN;
+INSERT INTO t1 VALUE(1);
+ROLLBACK;
 --source include/log_stop.inc
 
 --echo log_slow_verbosity='microtime,innodb,query_plan':

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -927,7 +927,7 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
 #endif
 
   if ((thd->variables.log_slow_verbosity & (1ULL << SLOG_V_INNODB))
-      && thd->innodb_was_used)
+      && thd->innodb_trx_id)
   {
     char buf[20];
     snprintf(buf, 20, "%llX", thd->innodb_trx_id);

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2083,7 +2083,7 @@ bool MYSQL_QUERY_LOG::write(THD *thd, ulonglong current_utime,
     thd->profiling.print_current(&log_file);
 #endif
     if ((thd->variables.log_slow_verbosity & (1ULL << SLOG_V_INNODB))
-        && thd->innodb_was_used)
+        && thd->innodb_trx_id)
     {
       char buf[20];
       snprintf(buf, 20, "%llX", thd->innodb_trx_id);

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4733,7 +4733,8 @@ void THD::clear_slow_extended()
   tmp_tables_disk_used=         0;
   tmp_tables_size=              0;
   innodb_was_used=              FALSE;
-  innodb_trx_id=                0;
+  if (!(server_status & SERVER_STATUS_IN_TRANS))
+    innodb_trx_id= 0;
   innodb_io_reads=              0;
   innodb_io_read=               0;
   innodb_io_reads_wait_timer=   0;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4352,7 +4352,8 @@ void THD::clear_slow_extended()
   tmp_tables_disk_used=         0;
   tmp_tables_size=              0;
   innodb_was_used=              false;
-  innodb_trx_id=                0;
+  if (!(server_status & SERVER_STATUS_IN_TRANS))
+    innodb_trx_id=                0;
   innodb_io_reads=              0;
   innodb_io_read=               0;
   innodb_io_reads_wait_timer=   0;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -16475,7 +16475,7 @@ ha_innobase::external_lock(
 
 		if (UNIV_UNLIKELY(trx->take_stats)) {
 			increment_thd_innodb_stats(thd,
-						   (unsigned long long) trx->id,
+						   static_cast<unsigned long long>(trx->id ? trx->id : trx->id_saved),
 						   trx->io_reads,
 						   trx->io_read,
 						   trx->io_reads_wait_timer,
@@ -16483,6 +16483,7 @@ ha_innobase::external_lock(
 						   trx->innodb_que_wait_timer,
 						   trx->distinct_page_access);
 
+			trx->id_saved = 0;
 			trx->io_reads = 0;
 			trx->io_read = 0;
 			trx->io_reads_wait_timer = 0;

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -929,6 +929,9 @@ struct trx_t {
 
 	trx_id_t	id;		/*!< transaction id */
 
+	trx_id_t        id_saved;       /*!< save transaction id for slow
+					log tracking */
+
 	trx_id_t	preallocated_id;/*!< preallocated transaction id for a
 					RO transaction whose read view was
 					cloned. If this transaction is promoted

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -124,6 +124,8 @@ trx_init(
 	trx_t::state here to NOT_STARTED. The FORCED_ROLLBACK
 	status is required for asynchronous handling. */
 
+	trx->id_saved = trx->id;
+
 	trx->id = 0;
 
 	trx->preallocated_id = 0;


### PR DESCRIPTION
Fix for https://bugs.launchpad.net/percona-server/+bug/897715
5.6 PR: #1243 

http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/580/

The fix is the same as for 5.6 (clear innodb_trx_id after slow log actions only if transaction is not active).
For 5.7 trx->id is also cleared after each transaction by trx_init (called by trx_commit_in_memory and during init).
Thus for 5.7, bare statement trx->id is always 0 in slow log. For 5.6 all innodb statements having valid transaction id.