### PR TITLE
Bug #995624: RBR events are not reflected in userstat's Rows_updated

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_percona_userstat.result
+++ b/mysql-test/suite/rpl/r/rpl_percona_userstat.result
@@ -1,0 +1,51 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+#
+# Bug 995624 RBR events are not reflected in userstat's
+# Rows_updated
+#
+SET @slave_userstat_saved= @@global.userstat;
+SET GLOBAL userstat=ON;
+include/assert.inc [Rows updated on slave should be equal to 0]
+SET @master_userstat_saved= @@global.userstat;
+SET GLOBAL userstat=ON;
+include/assert.inc [Rows updated on master should be equal to 0]
+CREATE TABLE t1 (m INT);
+3 "updates" to rows
+INSERT INTO t1 VALUES(15),(16),(17);
+1 "update" to rows (4 in total)
+UPDATE t1 SET m=20 WHERE m=16;
+1 "update" to rows (5 in total)
+DELETE FROM t1 WHERE m=17;
+CREATE TABLE t2 (n INT);
+2 "updates" to rows (7 in total)
+INSERT INTO t2 VALUES(30),(30);
+2 "updates" to rows (9 in total)
+UPDATE t2 SET n=10 WHERE n=30;
+2 "updates" to rows (11 in total)
+DELETE FROM t2 WHERE n=10;
+2 "updates" to rows (13 in total)
+INSERT INTO t2 (n)
+SELECT t1.m
+FROM t1;
+include/assert.inc [Rows updated on master should be equal to 13]
+t3 is not replicated. Let us make some updates
+and check if they do not affect userstat
+CREATE TABLE t3(x INT);
+INSERT INTO t3 VALUE(1),(2),(3);
+UPDATE t3 SET x=1 WHERE x=2;
+DELETE FROM t3 WHERE x=1;
+include/sync_slave_sql_with_master.inc
+include/assert.inc [Rows updated on slave should be equal to 13 (i.e. Number of RBR rows updates replicated from master)]
+SET GLOBAL userstat=@slave_userstat_saved;
+SELECT * FROM t1 ORDER BY m;
+m
+15
+20
+SET GLOBAL userstat=@master_userstat_saved;
+DROP TABLE t1, t2;
+DROP TABLE t3;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_percona_userstat-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_percona_userstat-slave.opt
@@ -1,0 +1,2 @@
+--replicate-do-table=test.t1
+--replicate-do-table=test.t2

--- a/mysql-test/suite/rpl/t/rpl_percona_userstat.test
+++ b/mysql-test/suite/rpl/t/rpl_percona_userstat.test
@@ -1,0 +1,70 @@
+--source include/not_embedded.inc
+--source include/master-slave.inc
+
+--echo #
+--echo # Bug 995624 RBR events are not reflected in userstat's
+--echo # Rows_updated
+--echo #
+
+connection slave;
+SET @slave_userstat_saved= @@global.userstat;
+SET GLOBAL userstat=ON;
+
+--let $assert_text= Rows updated on slave should be equal to 0
+--let $assert_cond= [SELECT ROWS_UPDATED FROM information_schema.client_statistics] = 0
+--source include/assert.inc
+
+connection master;
+SET @master_userstat_saved= @@global.userstat;
+SET GLOBAL userstat=ON;
+
+--let $assert_text= Rows updated on master should be equal to 0
+--let $assert_cond= [SELECT ROWS_UPDATED FROM information_schema.client_statistics] = 0
+--source include/assert.inc
+
+CREATE TABLE t1 (m INT);
+--echo 3 "updates" to rows
+INSERT INTO t1 VALUES(15),(16),(17);
+--echo 1 "update" to rows (4 in total)
+UPDATE t1 SET m=20 WHERE m=16;
+--echo 1 "update" to rows (5 in total)
+DELETE FROM t1 WHERE m=17;
+CREATE TABLE t2 (n INT);
+--echo 2 "updates" to rows (7 in total)
+INSERT INTO t2 VALUES(30),(30);
+--echo 2 "updates" to rows (9 in total)
+UPDATE t2 SET n=10 WHERE n=30;
+--echo 2 "updates" to rows (11 in total)
+DELETE FROM t2 WHERE n=10;
+
+--echo 2 "updates" to rows (13 in total)
+INSERT INTO t2 (n)
+SELECT t1.m
+FROM t1;
+
+--let $assert_text= Rows updated on master should be equal to 13
+--let $assert_cond= [SELECT ROWS_UPDATED FROM information_schema.client_statistics] = 13
+--source include/assert.inc
+
+--echo t3 is not replicated. Let us make some updates
+--echo and check if they do not affect userstat
+CREATE TABLE t3(x INT);
+INSERT INTO t3 VALUE(1),(2),(3);
+UPDATE t3 SET x=1 WHERE x=2;
+DELETE FROM t3 WHERE x=1;
+
+--source include/sync_slave_sql_with_master.inc
+
+--let $assert_text= Rows updated on slave should be equal to 13 (i.e. Number of RBR rows updates replicated from master)
+--let $assert_cond= [SELECT ROWS_UPDATED FROM information_schema.client_statistics WHERE CLIENT != \'localhost\'] = 13
+--source include/assert.inc
+
+SET GLOBAL userstat=@slave_userstat_saved;
+
+SELECT * FROM t1 ORDER BY m;
+
+connection master;
+SET GLOBAL userstat=@master_userstat_saved;
+DROP TABLE t1, t2;
+DROP TABLE t3;
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -59,6 +59,9 @@ slave_ignored_err_throttle(window_size,
 #include "rpl_utility.h"
 
 #include "sql_digest.h"
+#ifndef EMBEDDED_LIBRARY
+#include "sql_connect.h" //update_global_user_stats
+#endif
 
 using std::min;
 using std::max;
@@ -11554,6 +11557,9 @@ int Rows_log_event::do_apply_event(Relay_log_info const *rli)
 
       error= (this->*do_apply_row_ptr)(rli);
 
+      if (!error)
+        thd->updated_row_count++;
+
       if (handle_idempotent_and_ignored_errors(rli, &error))
         break;
 
@@ -11561,6 +11567,14 @@ int Rows_log_event::do_apply_event(Relay_log_info const *rli)
       do_post_row_operations(rli, error);
 
     } while (!error && (m_curr_row != m_rows_end));
+
+    if (unlikely(opt_userstat))
+    {
+      thd->update_stats(false);
+#ifndef EMBEDDED_LIBRARY
+      update_global_user_stats(thd, true, time(NULL));
+#endif
+    }
 
 AFTER_MAIN_EXEC_ROW_LOOP:
 

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -64,9 +64,6 @@ using std::max;
 static int increment_connection_count(THD* thd, bool use_lock);
 #endif
 
-// Uses the THD to update the global stats by user name and client IP
-void update_global_user_stats(THD* thd, bool create_user, time_t now);
-
 HASH global_user_stats;
 HASH global_client_stats;
 HASH global_thread_stats;

--- a/sql/sql_connect.h
+++ b/sql/sql_connect.h
@@ -22,6 +22,7 @@
 class THD;
 typedef struct st_lex_user LEX_USER;
 typedef struct user_conn USER_CONN;
+typedef struct user_resources USER_RESOURCES;
 
 void init_max_user_conn(void);
 void free_max_user_conn(void);
@@ -49,5 +50,6 @@ void end_connection(THD *thd);
 int get_or_create_user_conn(THD *thd, const char *user,
                             const char *host, const USER_RESOURCES *mqh);
 int check_for_max_user_connections(THD *thd, const USER_CONN *uc);
-
+// Uses the THD to update the global stats by user name and client IP
+void update_global_user_stats(THD* thd, bool create_user, time_t now);
 #endif /* SQL_CONNECT_INCLUDED */

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -135,9 +135,6 @@ static bool lock_tables_precheck(THD *thd, TABLE_LIST *tables);
 
 static inline ulonglong get_query_exec_time(THD *thd, ulonglong cur_utime);
 
-// Uses the THD to update the global stats by user name and client IP
-void update_global_user_stats(THD* thd, bool create_user, time_t now);
-
 const char *any_db="*any*";	// Special symbol for check_access
 
 const LEX_STRING command_name[]={

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -110,6 +110,7 @@ When one supplies long data for a placeholder:
 #include <mysql.h>
 #else
 #include <mysql_com.h>
+#include "sql_connect.h" //update_global_user_stats
 #endif
 #include "lock.h"                               // MYSQL_OPEN_FORCE_SHARED_MDL
 #include "opt_trace.h"                          // Opt_trace_object
@@ -120,9 +121,6 @@ When one supplies long data for a placeholder:
 #include <algorithm>
 using std::max;
 using std::min;
-
-// Uses the THD to update the global stats by user name and client IP
-void update_global_user_stats(THD* thd, bool create_user, time_t now);
 
 /**
   A result class used to send cursor rows using the binary protocol.


### PR DESCRIPTION
After each batch of rows get replicated on a slave server the
rows_update gets incremented by the number of rows successfuly updated,
i.e. inserted/updated/deleted on the slave server.

I had to create another pull request, as I had to rebase my branch to exclude merge from 5.5 (we do port this bug fix to 5.5)