### PR TITLE
Fix bug 1646100 (SHOW STATUS blocked by binlog commit)

### DIFF
--- a/mysql-test/suite/binlog/r/binlog_consistent_debug.result
+++ b/mysql-test/suite/binlog/r/binlog_consistent_debug.result
@@ -1,0 +1,27 @@
+#
+# Debug build tests for consistent binlog snapshot
+#
+RESET MASTER;
+#
+# Bug 1646100: Server becomes unresponsive during flushing after loading
+# big files through LOAD DATA INFILE
+#
+SET @saved_sync_binlog = @@sync_binlog;
+SET GLOBAL sync_binlog = 1;
+CREATE TABLE t1 (a INT);
+# connection con1
+BEGIN;
+INSERT INTO t1 VALUES (0);
+SET DEBUG_SYNC="before_sync_binlog_file SIGNAL commit_ready WAIT_FOR finish_commit";
+COMMIT;
+# connection default
+SET DEBUG_SYNC="now WAIT_FOR commit_ready";
+SHOW STATUS LIKE 'binlog_snapshot_%';
+Variable_name	Value
+Binlog_snapshot_file	master-bin.000001
+Binlog_snapshot_position	POSITION
+SET DEBUG_SYNC="now SIGNAL finish_commit";
+# connection con1
+# connection default
+DROP TABLE t1;
+SET GLOBAL sync_binlog = @saved_sync_binlog;

--- a/mysql-test/suite/binlog/t/binlog_consistent_debug.test
+++ b/mysql-test/suite/binlog/t/binlog_consistent_debug.test
@@ -1,0 +1,55 @@
+--source include/have_debug_sync.inc
+--source include/have_innodb.inc
+--source include/have_log_bin.inc
+
+--echo #
+--echo # Debug build tests for consistent binlog snapshot
+--echo #
+
+RESET MASTER;
+
+--echo #
+--echo # Bug 1646100: Server becomes unresponsive during flushing after loading
+--echo # big files through LOAD DATA INFILE
+--echo #
+
+SET @saved_sync_binlog = @@sync_binlog;
+SET GLOBAL sync_binlog = 1;
+
+CREATE TABLE t1 (a INT);
+
+--source include/count_sessions.inc
+
+--connect(con1,localhost,root,,)
+--echo # connection con1
+
+BEGIN;
+INSERT INTO t1 VALUES (0);
+
+SET DEBUG_SYNC="before_sync_binlog_file SIGNAL commit_ready WAIT_FOR finish_commit";
+
+send COMMIT;
+
+--connection default
+--echo # connection default
+
+SET DEBUG_SYNC="now WAIT_FOR commit_ready";
+
+--replace_result 405 POSITION 426 POSITION
+SHOW STATUS LIKE 'binlog_snapshot_%';
+
+SET DEBUG_SYNC="now SIGNAL finish_commit";
+
+--connection con1
+--echo # connection con1
+reap;
+
+--disconnect con1
+--connection default
+--echo # connection default
+
+DROP TABLE t1;
+
+SET GLOBAL sync_binlog = @saved_sync_binlog;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -83,6 +83,11 @@ static int binlog_start_consistent_snapshot(handlerton *hton, THD *thd);
 static int binlog_clone_consistent_snapshot(handlerton *hton, THD *thd,
                                             THD *from_thd);
 
+// The last published global binlog position
+static char binlog_global_snapshot_file[FN_REFLEN];
+static ulonglong binlog_global_snapshot_position;
+
+// Binlog position variables for SHOW STATUS
 static char binlog_snapshot_file[FN_REFLEN];
 static ulonglong binlog_snapshot_position;
 
@@ -5711,6 +5716,7 @@ int MYSQL_BIN_LOG::rotate(bool force_rotate, bool* check_purge)
   {
     error= new_file_without_locking(NULL);
     *check_purge= true;
+    publish_coordinates_for_global_status();
   }
   DBUG_RETURN(error);
 }
@@ -7486,6 +7492,8 @@ int MYSQL_BIN_LOG::ordered_commit(THD *thd, bool all, bool skip_commit)
     handle_binlog_flush_or_sync_error(thd, false /* need_lock_log */);
   }
 
+  publish_coordinates_for_global_status();
+
   /*
     Stage #2: Syncing binary log file to disk
   */
@@ -7731,41 +7739,24 @@ err1:
 */
 static void set_binlog_snapshot_file(const char *src)
 {
+  mysql_mutex_assert_owner(&LOCK_status);
+
   int dir_len = dirname_length(src);
   strmake(binlog_snapshot_file, src + dir_len,
           sizeof(binlog_snapshot_file) - 1);
 }
 
-/*
-  Copy out current values of status variables, for SHOW STATUS or
-  information_schema.global_status.
 
-  This is called only under LOCK_status, so we can fill in a static array.
-*/
-void MYSQL_BIN_LOG::set_status_variables(THD *thd)
+/** Copy the current binlog coordinates to the variables used for the
+not-in-consistent-snapshot case of SHOW STATUS */
+void MYSQL_BIN_LOG::publish_coordinates_for_global_status(void) const
 {
-  binlog_cache_mngr *cache_mngr;
+  mysql_mutex_assert_owner(&LOCK_log);
 
-  if (thd && opt_bin_log)
-    cache_mngr= (binlog_cache_mngr*) thd_get_ha_data(thd, binlog_hton);
-  else
-    cache_mngr= 0;
-
-  bool have_snapshot= (cache_mngr &&
-                       cache_mngr->binlog_info.log_file_name[0] != '\0');
-  mysql_mutex_lock(&LOCK_log);
-  if (!have_snapshot)
-  {
-    set_binlog_snapshot_file(log_file_name);
-    binlog_snapshot_position= my_b_tell(&log_file);
-  }
-  mysql_mutex_unlock(&LOCK_log);
-
-  if (have_snapshot)
-  {
-    set_binlog_snapshot_file(cache_mngr->binlog_info.log_file_name);
-    binlog_snapshot_position= cache_mngr->binlog_info.pos;
-  }
+  mysql_mutex_lock(&LOCK_status);
+  strcpy(binlog_global_snapshot_file, log_file_name);
+  binlog_global_snapshot_position= my_b_tell(&log_file);
+  mysql_mutex_unlock(&LOCK_status);
 }
 
 
@@ -9828,8 +9819,26 @@ int THD::binlog_query(THD::enum_binlog_query_type qtype, char const *query_arg,
 
 static int show_binlog_vars(THD *thd, SHOW_VAR *var, char *buff)
 {
-  if (mysql_bin_log.is_open())
-    mysql_bin_log.set_status_variables(thd);
+  mysql_mutex_assert_owner(&LOCK_status);
+
+  const binlog_cache_mngr *cache_mngr
+    = (thd && opt_bin_log)
+    ? static_cast<binlog_cache_mngr *>(thd_get_ha_data(thd, binlog_hton))
+    : NULL;
+
+  const bool have_snapshot= (cache_mngr &&
+                       cache_mngr->binlog_info.log_file_name[0] != '\0');
+
+  if (have_snapshot)
+  {
+    set_binlog_snapshot_file(cache_mngr->binlog_info.log_file_name);
+    binlog_snapshot_position= cache_mngr->binlog_info.pos;
+  }
+  else if (mysql_bin_log.is_open())
+  {
+    set_binlog_snapshot_file(binlog_global_snapshot_file);
+    binlog_snapshot_position= binlog_global_snapshot_position;
+  }
   else
   {
     binlog_snapshot_file[0]= '\0';

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -689,7 +689,8 @@ public:
   inline void unlock_index() { mysql_mutex_unlock(&LOCK_index);}
   inline IO_CACHE *get_index_file() { return &index_file;}
   inline uint32 get_open_count() { return open_count; }
-  void set_status_variables(THD *thd);
+private:
+  void publish_coordinates_for_global_status(void) const;
 };
 
 typedef struct st_load_file_info


### PR DESCRIPTION
In the existing binary log status variables implementation,
MYSQL_BIN_LOG::set_status_variables is called with locked LOCK_status
and then it attempts to lock LOCK_log. This means that e.g. a
long-running commit blocks any SHOW STATUS, and the latter then blocks
e.g. client connects/disconnects.

While MySQL has not sorted the core server locks by the required
locking order, there is no precedent in the core server of LOCK_status
owners taking any other mutexes, and most LOCK_status critical
sections there are short. This suggests that LOCK_status should come
near the end of locking order, and so fix the issue by locking
LOCK_log before LOCK_status.

For that, create two new static variables binlog_global_snapshot_file
and binlog_global_snapshot_position to binlog.cc that hold last
"published" global binary log position. Add a new method
MYSQL_BIN_LOG::publish_global_status_variables, that, under LOCK_log
taken already, locks LOCK_status, and sets the global position
variables. Call it in the group commit after flush phase, and
optionally after binlog rotate. Change show_binlog_vars to read the
global position variables if required (no snapshot; binlog open), and
avoid taking LOCK_log there.

http://jenkins.percona.com/job/percona-server-5.6-param/1595/