### PR TITLE
Add diagnostics to catch bug 1658006 (Test sys_vars.rpl_init_slave_fu…

### DIFF
--- a/mysql-test/include/assert.inc
+++ b/mysql-test/include/assert.inc
@@ -28,6 +28,9 @@
 #
 # $rpl_debug
 #   Print extra debug info.
+#
+# $assert_debug
+#   If set, and the assert fails, an extra SQL statement to execute
 
 
 --let $include_filename= assert.inc [$assert_text]
@@ -63,6 +66,11 @@ if (!$eval_result)
   --echo Assertion condition: '$assert_cond'
   --echo Assertion condition, interpolated: '$_eval_expr_interp'
   --echo Assertion result: '$eval_result'
+  if ($assert_debug)
+  {
+    --echo Assertion debug statement:
+    --eval $assert_debug
+  }
   --die Test assertion failed in assert.inc
 }
 
@@ -71,6 +79,7 @@ if (!$eval_result)
 
 --let $assert_text=
 --let $assert_cond=
+--let $assert_debug=
 --let $eval_expr= $_assert_old_eval_expr
 --let $eval_result= $_assert_old_eval_result
 --let $eval_no_result= $_assert_old_eval_no_result

--- a/mysql-test/suite/sys_vars/t/rpl_init_slave_func.test
+++ b/mysql-test/suite/sys_vars/t/rpl_init_slave_func.test
@@ -66,6 +66,7 @@ let $wait_condition= SELECT @@global.max_connections = @start_max_connections;
 # check that the action in init_slave does not happen immediately
 --let $assert_text= @@global.max_connections = @start_max_connections
 --let $assert_cond= @@global.max_connections = @start_max_connections
+--let $assert_debug= SELECT @@global.max_connections, @start_max_connections
 --source include/assert.inc
 #
 # reset of the server


### PR DESCRIPTION
…nc is unstable)

Extend include/assert.inc with an optional extra SQL statement to be
executed if the assert failed. Use this in the failing test to dump
the SQL variables compared in the assert.

http://jenkins.percona.com/job/percona-server-5.6-param/1599/

@robgolebiowski