### PR TITLE
MYR-35 : Alter gap lock error logic to account for ISO mode

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -7958,6 +7958,7 @@ bool handler::is_using_prohibited_gap_locks(TABLE* table,
   if (!using_full_primary_key
       && has_transactions()
       && !has_gap_locks()
+      && thd_tx_isolation(thd) >= ISO_REPEATABLE_READ
       && !thd->rli_slave
       && (thd->lex->table_count >= 2 || thd->in_multi_stmt_transaction_mode())
       && (lock_type >= TL_WRITE_ALLOW_WRITE ||


### PR DESCRIPTION
- Our gap lock error implementation (from MYR-15) currently is not taking into
  account the current ISO mode. This commit fixes this logic to amend an
  additional condition before deciding to error to the client:
    && thd_tx_isolation(thd) >= ISO_REPEATABLE_READ
  Therefore, if the ISO is <= READ COMMITTED, the gap lock error will not be
  raised in the condition of a gap lock, but as the ISO mode moves any further
  north in the consistency scale to REPEATABLE READ or SERIALIZABLE, then the
  gap lock error will be raised when conditions are met.