### PR TITLE
Fix bug 1658055 (Log tracking initialisation does not find the last g…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
@@ -5,15 +5,18 @@ INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 ib_modified_log_1
 1st restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+include/assert.inc [There should not be a hole in the tracked LSN range]
 ib_modified_log_1
 ib_modified_log_2
 2nd restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+include/assert.inc [There should not be a hole in the tracked LSN range]
 ib_modified_log_1
 ib_modified_log_2
 ib_modified_log_3
 3rd restart
 # restart
+include/assert.inc [There should not be a hole in the tracked LSN range]
 INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
@@ -31,13 +34,11 @@ INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
 CREATE TABLE t2 (x INT) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
-ib_modified_log_1
-ib_modified_log_2
+include/assert.inc [There should not be a hole in the tracked LSN range]
 4th restart
 # restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 ib_modified_log_1
-ib_modified_log_2
 5th restart
 # restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -51,7 +52,6 @@ ib_modified_log_2
 # restart
 ib_modified_log_1
 ib_modified_log_2
-ib_modified_log_3
 DROP TABLE t1, t2;
 8th restart
 RESET CHANGED_PAGE_BITMAPS;

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
@@ -22,15 +22,10 @@ CREATE TABLE t2 (x INT) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
 SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 1st restart
-ib_modified_log_1
-ib_modified_log_2
-INSERT INTO t2 VALUES (1);
+include/assert.inc [There should not be a hole in the tracked LSN range]
 CALL mtr.add_suppression("InnoDB: Warning: database page corruption or a failed");
 2nd restart
 INSERT INTO t1 SELECT x FROM t1;
 ERROR HY000: Lost connection to MySQL server during query
-INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
-ib_modified_log_1
-ib_modified_log_2
-ib_modified_log_3
+include/assert.inc [There should not be a hole in the tracked LSN range]
 DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS t1;
+call mtr.add_suppression("simulating bitmap write error in log_online_write_bitmap_page");
 call mtr.add_suppression("InnoDB: Error: log tracking bitmap write failed, stopping log tracking thread!");
 1st restart
 RESET CHANGED_PAGE_BITMAPS;
@@ -57,4 +57,43 @@ SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_changed_pages=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 SET DEBUG_SYNC="now SIGNAL finish";
+# 5th restart
+include/assert.inc [There should not be a hole in the tracked LSN range]
+DROP TABLE t1, t2;
+#
+# Bug 1658055: Log tracking initialisation does not find the last good
+# bitmap data correctly
+#
+SET GLOBAL innodb_file_per_table=OFF;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+SET GLOBAL innodb_file_per_table=ON;
+CREATE TABLE t2 (a INT) ENGINE=InnoDB;
+# 6th restart
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+SET @@GLOBAL.innodb_track_changed_pages=FALSE;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (2);
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_changed_pages=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+# 7th restart
+include/assert.inc [There should not be a hole in the tracked LSN range]
 DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests.result
@@ -16,18 +16,16 @@ After 2nd RESET
 ib_modified_log_1
 After RESETs and restart:
 ib_modified_log_1
-ib_modified_log_2
 PURGE CHANGED_PAGE_BITMAPS BEFORE 1;
 After PURGE ... BEFORE 1:
 ib_modified_log_1
-ib_modified_log_2
 PURGE CHANGED_PAGE_BITMAPS BEFORE 100000000;
 PURGE CHANGED_PAGE_BITMAPS BEFORE 100000000;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 After PURGE ... BEFORE 100000000 and restart:
+ib_modified_log_2
 ib_modified_log_3
 ib_modified_log_4
-ib_modified_log_5
 PURGE CHANGED_PAGE_BITMAPS BEFORE 5+5;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '+5' at line 1
 PURGE CHANGED_PAGE_BITMAPS BEFORE -12;
@@ -57,25 +55,25 @@ SELECT @@GLOBAL.innodb_track_changed_pages;
 0
 FLUSH CHANGED_PAGE_BITMAPS;
 Before the PURGE with tracking disabled
+ib_modified_log_2
 ib_modified_log_3
 ib_modified_log_4
-ib_modified_log_5
 PURGE CHANGED_PAGE_BITMAPS BEFORE 1;
 After the PURGE that deletes nothing:
+ib_modified_log_2
 ib_modified_log_3
 ib_modified_log_4
-ib_modified_log_5
 PURGE CHANGED_PAGE_BITMAPS BEFORE 100000000;
 After the PURGE that deletes everything but the last file:
-ib_modified_log_5
+ib_modified_log_4
 PURGE CHANGED_PAGE_BITMAPS BEFORE 100000000;
 After the repeated PURGE:
-ib_modified_log_5
+ib_modified_log_4
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 Before the RESET while tracking disabled:
 ib_modified_log_1
 ib_modified_log_2
-ib_modified_log_5
+ib_modified_log_4
 RESET CHANGED_PAGE_BITMAPS;
 After the RESET with tracking disabled:
 Created dummy bitmap files

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
@@ -41,8 +41,9 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
@@ -53,8 +54,9 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
@@ -71,6 +73,10 @@ write_file $BITMAP_FILE;
 EOF
 --echo 3rd restart
 --source include/start_mysqld.inc
+
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 #
 # Test tracking more log data than the log capacity and the second tablespace id
@@ -94,12 +100,9 @@ INSERT INTO t1 SELECT x FROM t1;
 CREATE TABLE t2 (x INT) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
-
-file_exists $BITMAP_FILE;
---replace_regex /_[[:digit:]]+\.xdb$//
-list_files $MYSQLD_DATADIR ib_modified_log*;
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 #
 # Test that an empty existing bitmap file is handled properly when it's impossible to re-read the full missing range.

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -9,9 +9,6 @@
 
 RESET CHANGED_PAGE_BITMAPS;
 
-let $MYSQLD_DATADIR= `select @@datadir`;
-let $BITMAP_FILE= $MYSQLD_DATADIR/ib_modified_log_1_0.xdb;
-
 # Generate log data that is larger than the log capacity and has two tablespace ids.
 CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -43,15 +40,9 @@ SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 --echo 1st restart
 --source include/restart_mysqld.inc
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
-
-file_exists $BITMAP_FILE;
---replace_regex /_[[:digit:]]+\.xdb$//
-list_files $MYSQLD_DATADIR ib_modified_log*;
-
-# Make sure the current bitmap file does not end up zero-sized and reused
-INSERT INTO t2 VALUES (1);
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 #
 # Test crash right before writing of new bitmap data
@@ -69,13 +60,8 @@ INSERT INTO t1 SELECT x FROM t1;
 --source include/wait_until_connected_again.inc
 --disable_reconnect
 
-INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
-
-file_exists $BITMAP_FILE;
---replace_regex /_[[:digit:]]+\.xdb$//
-list_files $MYSQLD_DATADIR ib_modified_log*;
-
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -3,14 +3,11 @@
 #
 --source include/have_debug.inc
 --source include/have_innodb.inc
---source include/count_sessions.inc
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
+--source include/not_embedded.inc
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 
+call mtr.add_suppression("simulating bitmap write error in log_online_write_bitmap_page");
 call mtr.add_suppression("InnoDB: Error: log tracking bitmap write failed, stopping log tracking thread!");
 
 --echo 1st restart
@@ -129,8 +126,6 @@ disconnect con2;
 DROP TABLE t2;
 RESET CHANGED_PAGE_BITMAPS;
 
---source include/wait_until_count_sessions.inc
-
 #
 # Test for bug 1193332 ([Warning] InnoDB: changed page bitmap file
 # './ib_modified_log_11_951286349.xdb' does not contain a complete run at the end.)
@@ -140,8 +135,6 @@ RESET CHANGED_PAGE_BITMAPS;
 --echo 4th restart
 --let $restart_parameters= restart:-#d,bitmap_page_2_write_error
 --source include/restart_mysqld.inc
-
---source include/count_sessions.inc
 
 --connect(con2,localhost,root,,)
 
@@ -178,6 +171,72 @@ reap;
 --disconnect con2
 --connection default
 
+--echo # 5th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
+
 DROP TABLE t1, t2;
 
---source include/wait_until_count_sessions.inc
+--echo #
+--echo # Bug 1658055: Log tracking initialisation does not find the last good
+--echo # bitmap data correctly
+--echo #
+
+SET GLOBAL innodb_file_per_table=OFF;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB;
+SET GLOBAL innodb_file_per_table=ON;
+CREATE TABLE t2 (a INT) ENGINE=InnoDB;
+
+--echo # 6th restart
+--let $restart_parameters= restart:-#d,bitmap_page_2_write_error
+--source include/restart_mysqld.inc
+
+# Generate log data that is larger than the log capacity
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+
+# Make sure the above is fully tracked
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Pause the log tracker
+SET @@GLOBAL.innodb_track_changed_pages=FALSE;
+
+# Prepare two pages of bitmap data
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (2);
+
+# Resume the log tracker so it crashes after writing one page
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_changed_pages=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Reboot to re-track the missing data
+--echo # 7th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
+
+DROP TABLE t1, t2;

--- a/storage/innobase/log/log0online.c
+++ b/storage/innobase/log/log0online.c
@@ -339,7 +339,7 @@ log_online_read_last_tracked_lsn(void)
 	ib_uint64_t	result;
 	ib_uint64_t	read_offset	= log_bmp_sys->out.offset;
 
-	while (!checksum_ok && read_offset > 0 && !is_last_page)
+	while ((!checksum_ok || !is_last_page) && read_offset > 0)
 	{
 		read_offset -= MODIFIED_PAGE_BLOCK_SIZE;
 		log_bmp_sys->out.offset = read_offset;
@@ -720,6 +720,7 @@ log_online_read_init(void)
 		ulint		size_high;
 		ib_uint64_t	last_tracked_lsn;
 		ib_uint64_t	file_start_lsn;
+		ibool		need_rotate;
 
 		success = os_file_get_size(log_bmp_sys->out.file, &size_low,
 					   &size_high);
@@ -742,7 +743,11 @@ log_online_read_init(void)
 		}
 
 		last_tracked_lsn = log_online_read_last_tracked_lsn();
+		/* Do not rotate if we truncated the file to zero length - we
+		can just start writing there */
+		need_rotate = (last_tracked_lsn != 0);
 		if (!last_tracked_lsn) {
+
 			last_tracked_lsn = last_file_start_lsn;
 		}
 
@@ -754,7 +759,10 @@ log_online_read_init(void)
 		} else {
 			file_start_lsn = tracking_start_lsn;
 		}
-		if (!log_online_rotate_bitmap_file(file_start_lsn)) {
+
+		if (need_rotate
+		    && !log_online_rotate_bitmap_file(file_start_lsn)) {
+
 			exit(1);
 		}
 
@@ -1111,7 +1119,32 @@ log_online_write_bitmap_page(
 	ut_ad(mutex_own(&log_bmp_sys->mutex));
 
 	/* Simulate a write error */
-	DBUG_EXECUTE_IF("bitmap_page_write_error", return FALSE;);
+	DBUG_EXECUTE_IF("bitmap_page_write_error",
+			{
+				ulint space_id
+					= mach_read_from_4(block
+					+ MODIFIED_PAGE_SPACE_ID);
+				if (space_id > 0) {
+					fprintf(stderr,
+						"InnoDB: Warning: simulating "
+						"bitmap write error in "
+						"log_online_write_bitmap_page "
+						"for space ID %lu\n",
+						space_id);
+					return FALSE;
+				}
+			});
+
+	/* A crash injection site that ensures last checkpoint LSN > last
+	tracked LSN, so that LSN tracking for this interval is tested. */
+	DBUG_EXECUTE_IF("crash_before_bitmap_write",
+			{
+				ulint space_id
+					= mach_read_from_4(block
+					+ MODIFIED_PAGE_SPACE_ID);
+				if (space_id > 0)
+					DBUG_SUICIDE();
+			});
 
 	success = os_file_write(log_bmp_sys->out.name, log_bmp_sys->out.file,
 				block,
@@ -1203,8 +1236,11 @@ log_online_write_bitmap(void)
 		bmp_tree_node = (ib_rbt_node_t*)
 			rbt_next(log_bmp_sys->modified_pages, bmp_tree_node);
 
-		DBUG_EXECUTE_IF("bitmap_page_2_write_error",
-				DBUG_SET("+d,bitmap_page_write_error"););
+		if (bmp_tree_node) {
+
+			DBUG_EXECUTE_IF("bitmap_page_2_write_error",
+					DBUG_SET("+d,bitmap_page_write_error"););
+		}
 	}
 
 	rbt_reset(log_bmp_sys->modified_pages);
@@ -1252,10 +1288,6 @@ log_online_follow_redo_log(void)
 		log_online_follow_log_group(group, contiguous_start_lsn);
 		group = UT_LIST_GET_NEXT(log_groups, group);
 	}
-
-	/* A crash injection site that ensures last checkpoint LSN > last
-	tracked LSN, so that LSN tracking for this interval is tested. */
-	DBUG_EXECUTE_IF("crash_before_bitmap_write", DBUG_SUICIDE(););
 
 	result = log_online_write_bitmap();
 	log_bmp_sys->start_lsn = log_bmp_sys->end_lsn;


### PR DESCRIPTION
…ood bitmap data correctly)

On server startup, log tracking tries to find the last good bitmap
data, discard any later junk, and re-track its log. The intention of
the algorithm is to open the last bitmap file, read the last page,
check its checksum and last-page flag, and if either check fails,
discard it, and seek back in the file.

However, the read loop condition currently is "while (!checksum_ok &&
read_offset > 0 && !is_last_page)", that is, only read back if both
the checksum is wrong and the last page flag is set. Fix by making it
"(!checksum_ok || !is_last_page) && read_offset > 0".

Also, if the last bitmap file ends up being zero-sized (if all of its
data was junk), then a bitmap file rotation was needlessly being
performed. Fix by continuing writing to that zero-sized file instead.

Replace some of the bitmap file name listings with an
INFORMATION_SCHEMA.INNODB_CHANGED_PAGES query that reads all the
bitmaps instead as a stricter check.

For the testcase, backport the change from the higher versions where
bitmap_page_write_error fault injection triggers only for non-system
tablespaces. Do the same for the crash-injection site
crash_before_bitmap_write, upmerge of which will fix bug 1658021 (Test
innodb.percona_changed_page_bmp_crash is unstable). Fix debug
injection site bitmap_page_2_write_error to trigger only if the second
bitmap data page is indeed available.

http://jenkins.percona.com/job/percona-server-5.5-param/1515/

@robgolebiowski