### PR TITLE
Fix bug 1658055 (Log tracking initialisation does not find the last g…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
@@ -7,17 +7,20 @@ ib_modified_log_1
 1st restart
 # restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+include/assert.inc [There should not be a hole in the tracked LSN range]
 ib_modified_log_1
 ib_modified_log_2
 2nd restart
 # restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+include/assert.inc [There should not be a hole in the tracked LSN range]
 ib_modified_log_1
 ib_modified_log_2
 ib_modified_log_3
 call mtr.add_suppression("last tracked LSN in");
 3rd restart
 # restart
+include/assert.inc [There should not be a hole in the tracked LSN range]
 INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
@@ -35,14 +38,12 @@ INSERT INTO t1 SELECT x FROM t1;
 INSERT INTO t1 SELECT x FROM t1;
 CREATE TABLE t2 (x INT) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
-ib_modified_log_1
-ib_modified_log_2
+include/assert.inc [There should not be a hole in the tracked LSN range]
 call mtr.add_suppression("The age of last tracked LSN exceeds log capacity");
 4th restart
 # restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 ib_modified_log_1
-ib_modified_log_2
 5th restart
 # restart
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -56,7 +57,6 @@ ib_modified_log_2
 # restart
 ib_modified_log_1
 ib_modified_log_2
-ib_modified_log_3
 DROP TABLE t1, t2;
 call mtr.add_suppression("Failed to find tablespace for table");
 call mtr.add_suppression("Allocated tablespace [0-9]+, old maximum was");

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
@@ -24,15 +24,10 @@ INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
 SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 1st restart
 # restart
-ib_modified_log_1
-ib_modified_log_2
-INSERT INTO t2 VALUES (1);
+include/assert.inc [There should not be a hole in the tracked LSN range]
 2nd restart
 # restart:-#d,crash_before_bitmap_write
 INSERT INTO t1 SELECT x FROM t1;
 ERROR HY000: Lost connection to MySQL server during query
-INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
-ib_modified_log_1
-ib_modified_log_2
-ib_modified_log_3
+include/assert.inc [There should not be a hole in the tracked LSN range]
 DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS t1;
 call mtr.add_suppression("simulating bitmap write error in log_online_write_bitmap_page");
 call mtr.add_suppression("log tracking bitmap write failed, stopping log tracking thread!");
 call mtr.add_suppression("last tracked LSN in");
@@ -54,16 +53,58 @@ SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_changed_pages=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 SET DEBUG_SYNC="now SIGNAL finish";
+# 5th restart
+# restart
+include/assert.inc [There should not be a hole in the tracked LSN range]
+DROP TABLE t1, t2;
+#
+# Bug 1658055: Log tracking initialisation does not find the last good
+# bitmap data correctly
+#
+SET GLOBAL innodb_file_per_table=OFF;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB STATS_PERSISTENT=0;
+SET GLOBAL innodb_file_per_table=ON;
+CREATE TABLE t2 (a INT) ENGINE=InnoDB;
+# 6th restart
+# restart:-#d,bitmap_page_2_write_error
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+SET @@GLOBAL.innodb_track_changed_pages=FALSE;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (2);
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_changed_pages=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+# 7th restart
+# restart
+include/assert.inc [There should not be a hole in the tracked LSN range]
 DROP TABLE t1, t2;
 RESET CHANGED_PAGE_BITMAPS;
-6th restart
+8th restart
 # restart
 #
 # Bug 1651656: Server crash if a changed page bitmap error occurs concurrently with
 # executing FLUSH CHANGED_PAGE_BITMAPS
 #
 CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
-7th restart
+9th restart
 # restart:-#d,bitmap_page_write_error
 # connection con2
 SET DEBUG_SYNC="log_online_follow_redo_log SIGNAL flush_ready WAIT_FOR finish_flush";
@@ -75,6 +116,6 @@ SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 SET DEBUG_SYNC="now SIGNAL finish_flush";
 # connection con2
-8th restart
+10th restart
 # restart
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp.test
@@ -41,8 +41,9 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
@@ -53,8 +54,9 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 file_exists $BITMAP_FILE;
 --replace_regex /_[[:digit:]]+\.xdb$//
@@ -73,6 +75,10 @@ write_file $BITMAP_FILE;
 EOF
 --echo 3rd restart
 --source include/start_mysqld.inc
+
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 #
 # Test tracking more log data than the log capacity and the second tablespace id
@@ -96,12 +102,9 @@ INSERT INTO t1 SELECT x FROM t1;
 CREATE TABLE t2 (x INT) ENGINE=InnoDB;
 INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
-
-file_exists $BITMAP_FILE;
---replace_regex /_[[:digit:]]+\.xdb$//
-list_files $MYSQLD_DATADIR ib_modified_log*;
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 #
 # Test that an empty existing bitmap file is handled properly when it's impossible to re-read the full missing range.

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -11,9 +11,6 @@ call mtr.add_suppression("last tracked LSN in");
 
 RESET CHANGED_PAGE_BITMAPS;
 
-let $MYSQLD_DATADIR= `select @@datadir`;
-let $BITMAP_FILE= $MYSQLD_DATADIR/ib_modified_log_1_0.xdb;
-
 # Generate log data that is larger than the log capacity and has two tablespace ids.
 CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -45,15 +42,9 @@ SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 --echo 1st restart
 --source include/restart_mysqld.inc
 
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
-
-file_exists $BITMAP_FILE;
---replace_regex /_[[:digit:]]+\.xdb$//
-list_files $MYSQLD_DATADIR ib_modified_log*;
-
-# Make sure the current bitmap file does not end up zero-sized and reused
-INSERT INTO t2 VALUES (1);
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 #
 # Test crash right before writing of new bitmap data
@@ -69,13 +60,8 @@ INSERT INTO t1 SELECT x FROM t1;
 --source include/wait_until_connected_again.inc
 --disable_reconnect
 
-INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
-
-file_exists $BITMAP_FILE;
---replace_regex /_[[:digit:]]+\.xdb$//
-list_files $MYSQLD_DATADIR ib_modified_log*;
-
-# TODO: check the tracked LSN range continuity once this info is exposed through
-# INFORMATION_SCHEMA.
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
 
 DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -3,11 +3,7 @@
 #
 --source include/have_debug.inc
 --source include/have_innodb.inc
---source include/count_sessions.inc
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
+--source include/not_embedded.inc
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 
@@ -122,8 +118,6 @@ disconnect con2;
 DROP TABLE t2;
 RESET CHANGED_PAGE_BITMAPS;
 
---source include/wait_until_count_sessions.inc
-
 --echo 4th restart
 --let $restart_parameters=
 --source include/restart_mysqld.inc
@@ -178,11 +172,79 @@ reap;
 --disconnect con2
 --connection default
 
+--echo # 5th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
+
+DROP TABLE t1, t2;
+
+--echo #
+--echo # Bug 1658055: Log tracking initialisation does not find the last good
+--echo # bitmap data correctly
+--echo #
+
+SET GLOBAL innodb_file_per_table=OFF;
+CREATE TABLE t1 (a INT) ENGINE=InnoDB STATS_PERSISTENT=0;
+SET GLOBAL innodb_file_per_table=ON;
+CREATE TABLE t2 (a INT) ENGINE=InnoDB;
+
+--echo # 6th restart
+--let $restart_parameters= restart:-#d,bitmap_page_2_write_error
+--source include/restart_mysqld.inc
+
+# Generate log data that is larger than the log capacity
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+INSERT INTO t1 SELECT a FROM t1;
+
+# Make sure the above is fully tracked
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Pause the log tracker
+SET @@GLOBAL.innodb_track_changed_pages=FALSE;
+
+# Prepare two pages of bitmap data
+INSERT INTO t1 VALUES (1);
+INSERT INTO t2 VALUES (2);
+
+# Resume the log tracker so it crashes after writing one page
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_changed_pages=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Reboot to re-track the missing data
+--echo # 7th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--let $assert_text= There should not be a hole in the tracked LSN range
+--let $assert_cond= COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES
+--source include/assert.inc
+
 DROP TABLE t1, t2;
 
 RESET CHANGED_PAGE_BITMAPS;
 
---echo 6th restart
+--echo 8th restart
 --let $restart_parameters=
 --source include/restart_mysqld.inc
 
@@ -193,7 +255,7 @@ RESET CHANGED_PAGE_BITMAPS;
 
 CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 
---echo 7th restart
+--echo 9th restart
 --let $restart_parameters= restart:-#d,bitmap_page_write_error
 --source include/restart_mysqld.inc
 
@@ -221,7 +283,7 @@ reap;
 disconnect con2;
 connection default;
 
---echo 8th restart
+--echo 10th restart
 --let $restart_parameters=
 --source include/restart_mysqld.inc
 


### PR DESCRIPTION
…ood bitmap data correctly)

On server startup, log tracking tries to find the last good bitmap
data, discard any later junk, and re-track its log. The intention of
the algorithm is to open the last bitmap file, read the last page,
check its checksum and last-page flag, and if either check fails,
discard it, and seek back in the file.

However, the read loop condition currently is "while (!checksum_ok &&
read_offset > 0 && !is_last_page)", that is, only read back if both
the checksum is wrong and the last page flag is set. Fix by making it
"(!checksum_ok || !is_last_page) && read_offset > 0".

Also, if the last bitmap file ends up being zero-sized (if all of its
data was junk), then a bitmap file rotation was needlessly being
performed. Fix by continuing writing to that zero-sized file instead.

Replace some of the bitmap file name listings with an
INFORMATION_SCHEMA.INNODB_CHANGED_PAGES query that reads all the
bitmaps instead as a stricter check.

For the testcase, backport the change from the higher versions where
bitmap_page_write_error fault injection triggers only for non-system
tablespaces. Do the same for the crash-injection site
crash_before_bitmap_write, upmerge of which will fix bug 1658021 (Test
innodb.percona_changed_page_bmp_crash is unstable). Fix debug
injection site bitmap_page_2_write_error to trigger only if the second
bitmap data page is indeed available.

http://jenkins.percona.com/job/mysql-5.7-param/590/

@robgolebiowski