### PR TITLE
Add diagnostics to catch bug 1659224 (Test main.status is unstable)

### DIFF
--- a/mysql-test/r/status.result
+++ b/mysql-test/r/status.result
@@ -213,6 +213,11 @@ drop procedure proc37908;
 drop function func37908;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM mysqltest_1@localhost;
 DROP USER mysqltest_1@localhost;
+SET @old2_log_output = @@GLOBAL.log_output;
+SET GLOBAL log_output = 'TABLE';
+SET @old_general_log = @@GLOBAL.general_log;
+SET GLOBAL general_log = 'ON';
+TRUNCATE TABLE mysql.general_log;
 DROP PROCEDURE IF EXISTS p1;
 DROP FUNCTION IF EXISTS f1;
 CREATE FUNCTION f1() RETURNS INTEGER
@@ -238,6 +243,8 @@ SELECT 9;
 9
 DROP PROCEDURE p1;
 DROP FUNCTION f1;
+SET GLOBAL log_output = @old2_log_output;
+SET GLOBAL general_log = @old_general_log;
 #
 # Test coverage for status variables which were introduced by
 # WL#5772 "Add partitioned Table Definition Cache to avoid

--- a/mysql-test/t/status.test
+++ b/mysql-test/t/status.test
@@ -319,6 +319,11 @@ let $wait_condition =
 #
 # Bug#41131 "Questions" fails to increment - ignores statements instead stored procs
 #
+SET @old2_log_output = @@GLOBAL.log_output;
+SET GLOBAL log_output = 'TABLE';
+SET @old_general_log = @@GLOBAL.general_log;
+SET GLOBAL general_log = 'ON';
+TRUNCATE TABLE mysql.general_log;
 connect (con1,localhost,root,,);
 connection con1;
 --disable_warnings
@@ -347,10 +352,16 @@ let $new_queries= `SHOW STATUS LIKE 'Queries'`;
 let $diff= `SELECT SUBSTRING('$new_queries',9)-SUBSTRING('$org_queries',9)`;
 --enable_query_log
 eval SELECT $diff;
+if ($diff != 9)
+{
+  SELECT * FROM mysql.general_log;
+}
 disconnect con1;
 connection default;
 DROP PROCEDURE p1;
 DROP FUNCTION f1;
+SET GLOBAL log_output = @old2_log_output;
+SET GLOBAL general_log = @old_general_log;
 
 # End of 5.1 tests
 


### PR DESCRIPTION
Dump the general log in case executing "SELECT f1(); CALL p1();"
results in a different delta of Queries status variable than
expected.

http://jenkins.percona.com/job/percona-server-5.6-param/1609/