### PR TITLE
Fix bug 1659548 (innodb_buffer_pool_evict_uncompressed might attempt …

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -16319,15 +16319,17 @@ innodb_buffer_pool_evict_uncompressed(void)
 			ut_ad(block->page.in_LRU_list);
 
 			mutex_enter(&block->mutex);
-			if (!buf_LRU_free_page(&block->page, false)) {
-				mutex_exit(&block->mutex);
-				all_evicted = false;
-			} else {
-				mutex_exit(&block->mutex);
-				mutex_enter(&buf_pool->LRU_list_mutex);
-			}
+			all_evicted = buf_LRU_free_page(&block->page, false);
+			mutex_exit(&block->mutex);
 
-			block = prev_block;
+			if (all_evicted) {
+
+				mutex_enter(&buf_pool->LRU_list_mutex);
+				block = UT_LIST_GET_LAST(buf_pool->unzip_LRU);
+			} else {
+
+				block = prev_block;
+			}
 		}
 
 		mutex_exit(&buf_pool->LRU_list_mutex);


### PR DESCRIPTION
…to process non-unzip_LRU page, crashing debug build)

Fix iteration logic in innodb_buffer_pool_evict_uncompressed: if
buf_LRU_free_page returned true, relock the LRU list mutex, restart
the LRU list iteration, and, since it's restarted, reset the all pages
evicted flag back to true. If that function returned false, the LRU
list mutex has never been released, and we can safely use prev_block
pointer to iterate over the list.

http://jenkins.percona.com/job/percona-server-5.6-param/1612/