### PR TITLE
Bug#1592694: Query plan temp flag set is missed in

### DIFF
--- a/mysql-test/r/percona_log_slow_query_plan.result
+++ b/mysql-test/r/percona_log_slow_query_plan.result
@@ -281,3 +281,32 @@ SET SESSION long_query_time=default;
 SET SESSION min_examined_row_limit=default;
 SET SESSION log_slow_verbosity=default;
 DROP TABLE t1, t2, t3, t4;
+#
+# Bug#1592694 Query plan temp flag set is missed in
+# create_duplicate_weedout_tmp_table
+#
+create table t1 (
+a int not null,
+b int, primary key (a)
+) ENGINE=InnoDB;
+create table t2 (
+a int not null
+) ENGINE=InnoDB;
+insert into t1 values (1,10), (2,20), (3,30),  (4,40);
+insert into t2 values (2), (2), (3), (4), (5);
+SET optimizer_switch='firstmatch=off,loosescan=off,materialization=off';
+SET SESSION long_query_time=0;
+SET SESSION min_examined_row_limit=0;
+SET SESSION log_slow_verbosity='microtime,query_plan';
+SET SESSION log_slow_filter='tmp_table';
+[log_start.inc] percona_slow_query_log.bug1592694.slog
+select t1.a from t1 where t1.a in (select a from t2);
+a
+2
+3
+4
+[log_stop.inc] percona_slow_query_log.bug1592694.slog
+[log_grep.inc] file: percona_slow_query_log.bug1592694.slog pattern: ^#.*Tmp_table: Yes  Tmp_table_on_disk: No$ expected_matches: 1
+[log_grep.inc] found expected match count: 1
+DROP TABLE t1, t2;
+# End of test for bug#1592694.

--- a/mysql-test/t/percona_log_slow_query_plan.test
+++ b/mysql-test/t/percona_log_slow_query_plan.test
@@ -332,4 +332,41 @@ SET SESSION log_slow_verbosity=default;
 
 DROP TABLE t1, t2, t3, t4;
 
+--echo #
+--echo # Bug#1592694 Query plan temp flag set is missed in
+--echo # create_duplicate_weedout_tmp_table
+--echo #
+
+create table t1 (
+  a int not null,
+  b int, primary key (a)
+) ENGINE=InnoDB;
+create table t2 (
+  a int not null
+) ENGINE=InnoDB;
+insert into t1 values (1,10), (2,20), (3,30),  (4,40);
+insert into t2 values (2), (2), (3), (4), (5); #2 as a duplicate to weed-out
+
+SET optimizer_switch='firstmatch=off,loosescan=off,materialization=off';
+
+SET SESSION long_query_time=0;
+SET SESSION min_examined_row_limit=0;
+SET SESSION log_slow_verbosity='microtime,query_plan';
+
+SET SESSION log_slow_filter='tmp_table';
+
+--let log_file=percona_slow_query_log.bug1592694.slog
+--source include/log_start.inc
+
+select t1.a from t1 where t1.a in (select a from t2);
+
+--source include/log_stop.inc
+--let grep_pattern = ^#.*Tmp_table: Yes  Tmp_table_on_disk: No\$
+--let log_expected_matches= 1
+--source include/log_grep.inc
+
+DROP TABLE t1, t2;
+
+--echo # End of test for bug#1592694.
+
 --source include/log_cleanup.inc

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4892,6 +4892,7 @@ void THD::inc_status_created_tmp_disk_tables()
 void THD::inc_status_created_tmp_tables()
 {
   status_var_increment(status_var.created_tmp_tables);
+  query_plan_flags|= QPLAN_TMP_TABLE;
 #ifdef HAVE_PSI_STATEMENT_INTERFACE
   PSI_STATEMENT_CALL(inc_statement_created_tmp_tables)(m_statement_psi, 1);
 #endif

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -485,7 +485,6 @@ create_tmp_table(THD *thd,TMP_TABLE_PARAM *param,List<Item> &fields,
               (ulong) rows_limit, MY_TEST(group)));
 
   thd->inc_status_created_tmp_tables();
-  thd->query_plan_flags|= QPLAN_TMP_TABLE;
 
   if (use_temp_pool && !(test_flags & TEST_KEEP_TMP_TABLES))
     temp_pool_slot = bitmap_lock_set_next(&temp_pool);


### PR DESCRIPTION
create_duplicate_weedout_tmp_table

Added setting QPLAN_TMP_TABLE to inc_status_created_tmp_tables
function. Removed setting the flag from create_tmp_table.