### PR TITLE
Fix bug 1626545 (Test perfschema.selects is unstable)

### DIFF
--- a/mysql-test/suite/perfschema/r/selects.result
+++ b/mysql-test/suite/perfschema/r/selects.result
@@ -23,38 +23,12 @@ LIMIT 1;
 EVENT_ID
 [EVENT_ID]
 SELECT DISTINCT EVENT_ID
-FROM performance_schema.events_waits_current
-JOIN performance_schema.events_waits_history USING (EVENT_ID)
+FROM performance_schema.events_waits_history
 JOIN performance_schema.events_waits_history_long USING (EVENT_ID)
 ORDER BY EVENT_ID
 LIMIT 1;
 EVENT_ID
 [EVENT_ID]
-SHOW STATUS LIKE 'perf%';
-Variable_name	Value
-Performance_schema_accounts_lost	0
-Performance_schema_cond_classes_lost	0
-Performance_schema_cond_instances_lost	0
-Performance_schema_digest_lost	0
-Performance_schema_file_classes_lost	0
-Performance_schema_file_handles_lost	0
-Performance_schema_file_instances_lost	0
-Performance_schema_hosts_lost	0
-Performance_schema_locker_lost	0
-Performance_schema_mutex_classes_lost	0
-Performance_schema_mutex_instances_lost	0
-Performance_schema_rwlock_classes_lost	0
-Performance_schema_rwlock_instances_lost	0
-Performance_schema_session_connect_attrs_lost	0
-Performance_schema_socket_classes_lost	0
-Performance_schema_socket_instances_lost	0
-Performance_schema_stage_classes_lost	0
-Performance_schema_statement_classes_lost	0
-Performance_schema_table_handles_lost	0
-Performance_schema_table_instances_lost	0
-Performance_schema_thread_classes_lost	0
-Performance_schema_thread_instances_lost	0
-Performance_schema_users_lost	0
 SELECT t1.THREAD_ID, t2.EVENT_ID, t3.EVENT_NAME, t4.TIMER_WAIT
 FROM performance_schema.events_waits_history t1
 JOIN performance_schema.events_waits_history t2 USING (EVENT_ID)

--- a/mysql-test/suite/perfschema/t/selects.test
+++ b/mysql-test/suite/perfschema/t/selects.test
@@ -46,13 +46,10 @@ LIMIT 1;
 
 --replace_column 1 [EVENT_ID]
 SELECT DISTINCT EVENT_ID
-FROM performance_schema.events_waits_current
-JOIN performance_schema.events_waits_history USING (EVENT_ID)
+FROM performance_schema.events_waits_history
 JOIN performance_schema.events_waits_history_long USING (EVENT_ID)
 ORDER BY EVENT_ID
 LIMIT 1;
-
-SHOW STATUS LIKE 'perf%';
 
 # Self JOIN
 


### PR DESCRIPTION
The unstable test bit joins performance_schema.events_waits_current
with performance_schema.events_waits_history. Such join does not have
meaningful semantics, as (thread_id; event_id) pairs in
events_waits_current are not duplicated in events_waits_history but
rather moved. So, in order for the testcase to pass, it relies that
only event_id is joined on, thus it's likely that different threads
have different IDs, and so a lower event_id by one thread in
events_waits_current will be already logged by another one that had
more events in events_waits_history. But it appears that it is not
guaranteed, with the join returning empty set.

Fix by removing events_waits_current from the join. Also remove SHOW
STATUS LIKE 'perf%' which was added earlier for diagnostics of this
bug.

http://jenkins.percona.com/job/percona-server-5.6-param/1618/