### PR TITLE
Fix bug 1660239 (Test sys_vars.thread_cache_size_func is unstable)

### DIFF
--- a/mysql-test/suite/sys_vars/r/thread_cache_size_func.result
+++ b/mysql-test/suite/sys_vars/r/thread_cache_size_func.result
@@ -16,17 +16,13 @@ Variable_name	Value
 Threads_cached	0
 0 Expected
 ** Disconnecting conn1,conn2,conn3,conn4 **
-SHOW STATUS LIKE 'Threads_cached';
-Variable_name	Value
-Threads_cached	3
-3 Expected
+# Threads_cached must become 3
+# Active connections must become 1
 SET @@GLOBAL.thread_cache_size= 1;
 ** Connecting conn1 using username 'root' **
 ** Connecting conn2 using username 'root' **
 connection default;
 ** Disconnecting conn1,conn2 **
-SHOW STATUS LIKE 'Threads_cached';
-Variable_name	Value
-Threads_cached	1
-1 Expected
+# Threads_cached must become 1
+# Active connections must become 1
 SET @@GLOBAL.thread_cache_size = @global_thread_cache_size;

--- a/mysql-test/suite/sys_vars/t/thread_cache_size_func.test
+++ b/mysql-test/suite/sys_vars/t/thread_cache_size_func.test
@@ -75,12 +75,15 @@ DISCONNECT conn4;
 # Checking the status
 #
 
-# Wait until all disconnects ready
-let $wait_condition= SELECT COUNT(*)= 1 FROM INFORMATION_SCHEMA.PROCESSLIST;
---source include/wait_condition.inc
+--echo # Threads_cached must become 3
+--let $status_var= Threads_cached
+--let $status_var_value= 3
+--source include/wait_for_status_var.inc
 
-SHOW STATUS LIKE 'Threads_cached';
---echo 3 Expected
+--echo # Active connections must become 1
+--let $count= 1
+--let $table= INFORMATION_SCHEMA.PROCESSLIST
+--source include/wait_until_rows_count.inc
 
 #
 # Decreasing cache size to 1
@@ -103,12 +106,15 @@ let $wait_condition= SELECT COUNT(*)= 3 FROM INFORMATION_SCHEMA.PROCESSLIST;
 DISCONNECT conn1;
 DISCONNECT conn2;
 
-# Wait until all disconnects ready
-let $wait_condition= SELECT COUNT(*)= 1 FROM INFORMATION_SCHEMA.PROCESSLIST;
---source include/wait_condition.inc
+--echo # Threads_cached must become 1
+--let $status_var= Threads_cached
+--let $status_var_value= 1
+--source include/wait_for_status_var.inc
 
-SHOW STATUS LIKE 'Threads_cached';
---echo 1 Expected
+--echo # Active connections must become 1
+--let $count= 1
+--let $table= INFORMATION_SCHEMA.PROCESSLIST
+--source include/wait_until_rows_count.inc
 
 #
 # Cleanup


### PR DESCRIPTION
The testcase disconnects some threads, and waits for them to disappear
from INFORMATION_SCHEMA.PROCESSLIST before checking the Threads_cached
status variable. This introduces a race condition, as a thread will be
removed from PROCESSLIST before caching it.

Fix by waiting for the Threads_cached status variable to become equal
to its intended value instead.

http://jenkins.percona.com/job/percona-server-5.6-param/1627/