### PR TITLE
Fix bug 1660348 (Intermittent testcase check warning on

### DIFF
--- a/mysql-test/suite/innodb_stress/include/innodb_stress.inc
+++ b/mysql-test/suite/innodb_stress/include/innodb_stress.inc
@@ -7,9 +7,11 @@
 
 --connection master
 #--let $innodb_index_cluster_optimization_save_master = `SELECT @@innodb_prefix_index_cluster_optimization`
+--let $innodb_status_output_save_master = `SELECT @@innodb_status_output`
 
 --connection slave
 #--let $innodb_index_cluster_optimization_save_slave = `SELECT @@innodb_prefix_index_cluster_optimization`
+--let $innodb_status_output_save_slave = `SELECT @@innodb_status_output`
 
 # create the directory for temporary log files.
 --exec mkdir -p $MYSQL_TMP_DIR/load_generator
@@ -174,10 +176,12 @@ connection master;
 # Restore the value of variable on slave
 --disable_query_log
 #eval SET GLOBAL innodb_prefix_index_cluster_optimization = $innodb_index_cluster_optimization_save_slave;
+eval SET GLOBAL innodb_status_output = $innodb_status_output_save_slave;
 --enable_query_log
 
 --connection master
 # Restore the value of variable on master
 --disable_query_log
 #eval SET GLOBAL innodb_prefix_index_cluster_optimization = $innodb_index_cluster_optimization_save_master;
+eval SET GLOBAL innodb_status_output = $innodb_status_output_save_master;
 --enable_query_log


### PR DESCRIPTION
innodb_stress.innodb_hugestress_blob)

Save and restore innodb_status_output variable around the
innodb_stress testcases in case InnoDB enables it internally due to an
e.g. long lock wait.

http://jenkins.percona.com/job/percona-server-5.6-param/1631/