### PR TITLE
Rpl tokudb commit sync off 5.6

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/rpl_tokudb_commit_sync.result
+++ b/mysql-test/suite/tokudb.backup/r/rpl_tokudb_commit_sync.result
@@ -1,0 +1,59 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+### Create some data on master
+CREATE TABLE t1(a INT, b INT, PRIMARY KEY (a)) ENGINE=TokuDB;
+INSERT INTO t1 SET a=100, b=100;
+INSERT INTO t1 SET a=200, b=100;
+INSERT INTO t1 SET a=300, b=100;
+INSERT INTO t1 SET a=400, b=100;
+INSERT INTO t1 SET a=500, b=100;
+UPDATE t1 SET b = 200 WHERE a = 200;
+DELETE FROM t1 WHERE a = 100;
+SELECT * FROM t1;
+a	b
+200	200
+300	100
+400	100
+500	100
+### Check for slave options
+SELECT @@tokudb_commit_sync;
+@@tokudb_commit_sync
+0
+SELECT @@tokudb_fsync_log_period;
+@@tokudb_fsync_log_period
+1000000
+### Check data on slave after sync
+SELECT * FROM t1;
+a	b
+200	200
+300	100
+400	100
+500	100
+### Do backup on slave
+### Check for errors
+SELECT @@session.tokudb_backup_last_error;
+@@session.tokudb_backup_last_error
+0
+SELECT @@session.tokudb_backup_last_error_string;
+@@session.tokudb_backup_last_error_string
+NULL
+### Stop slave server
+include/rpl_stop_server.inc [server_number=2]
+### Restore backup
+### Start slave server and slave threads
+include/rpl_start_server.inc [server_number=2]
+include/start_slave.inc
+### Sync slave with master
+### Check data on slave
+SELECT * FROM t1;
+a	b
+200	200
+300	100
+400	100
+500	100
+### Cleanup
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/tokudb.backup/t/rpl_tokudb_commit_sync-slave.opt
+++ b/mysql-test/suite/tokudb.backup/t/rpl_tokudb_commit_sync-slave.opt
@@ -1,0 +1,1 @@
+--loose-tokudb-commit-sync=OFF --loose-tokudb-fsync-log-period=1000000

--- a/mysql-test/suite/tokudb.backup/t/rpl_tokudb_commit_sync.test
+++ b/mysql-test/suite/tokudb.backup/t/rpl_tokudb_commit_sync.test
@@ -1,0 +1,72 @@
+# if --tokudb-commit-sync is off on slave tokudb log must be flushed on backup
+# to provide the ability to restore replication after backup restoring
+
+--source include/have_tokudb_backup.inc
+
+--let $BACKUP_DIR_SLAVE= $MYSQL_TMP_DIR/tokudb_backup_slave
+--let $BACKUP_MYSQL_DATA_DIR= $BACKUP_DIR_SLAVE/mysql_data_dir
+
+--mkdir $BACKUP_DIR_SLAVE
+
+--source include/master-slave.inc
+
+--echo ### Create some data on master
+--connection master
+CREATE TABLE t1(a INT, b INT, PRIMARY KEY (a)) ENGINE=TokuDB;
+INSERT INTO t1 SET a=100, b=100;
+INSERT INTO t1 SET a=200, b=100;
+INSERT INTO t1 SET a=300, b=100;
+INSERT INTO t1 SET a=400, b=100;
+INSERT INTO t1 SET a=500, b=100;
+UPDATE t1 SET b = 200 WHERE a = 200;
+DELETE FROM t1 WHERE a = 100;
+
+SELECT * FROM t1;
+
+--sync_slave_with_master
+--let $SLAVE_DATA_DIR=`SELECT @@DATADIR`
+
+--echo ### Check for slave options
+SELECT @@tokudb_commit_sync;
+SELECT @@tokudb_fsync_log_period;
+
+--echo ### Check data on slave after sync
+SELECT * FROM t1;
+
+
+--echo ### Do backup on slave
+--disable_query_log
+--eval SET SESSION tokudb_backup_dir='$BACKUP_DIR_SLAVE'
+--enable_query_log
+
+--echo ### Check for errors
+SELECT @@session.tokudb_backup_last_error;
+SELECT @@session.tokudb_backup_last_error_string;
+
+--echo ### Stop slave server
+--connection slave
+--let $rpl_server_number= 2
+--let $rpl_force_stop= 1
+--source include/rpl_stop_server.inc
+
+--echo ### Restore backup
+--exec rm -rf $SLAVE_DATA_DIR;
+--exec mv $BACKUP_MYSQL_DATA_DIR $SLAVE_DATA_DIR;
+
+--echo ### Start slave server and slave threads
+--connection slave
+--source include/rpl_start_server.inc
+--source include/start_slave.inc
+
+--echo ### Sync slave with master
+--connection master
+--sync_slave_with_master
+
+--echo ### Check data on slave
+SELECT * FROM t1;
+
+--echo ### Cleanup
+--connection master
+DROP TABLE t1;
+
+--source include/rpl_end.inc

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -273,9 +273,32 @@ static void tokudb_backup_error_fun(int error_number, const char *error_string, 
     }
 }
 
+static my_bool
+tokudb_backup_flush_log_plugin_callback(THD *,
+                                        plugin_ref plugin,
+                                        void *) {
+
+    const char *name = plugin_name(plugin)->str;
+    handlerton *hton= plugin_data(plugin, handlerton *);
+
+    if (!strcmp(name, "TokuDB") &&
+        hton->state == SHOW_OPTION_YES && hton->flush_logs &&
+        !hton->flush_logs(hton))
+        return TRUE;
+
+    return FALSE;
+}
+
+
 static void tokudb_backup_before_stop_capt_fun(void *arg) {
     THD *thd = static_cast<THD *>(arg);
     (void)lock_binlog_for_backup(thd);
+    if (!plugin_foreach(NULL,
+                        tokudb_backup_flush_log_plugin_callback,
+                        MYSQL_STORAGE_ENGINE_PLUGIN,
+                        0))
+        tokudb_backup_set_error_string(thd, EINVAL, "Can't flush TokuDB log",
+            NULL, NULL, NULL);
 }
 
 std::string tokudb_backup_get_executed_gtids_set() {


### PR DESCRIPTION
Flush tokudb log on TokuDB-Backup backup to avoid data inconsistency on slaves if tokudb_commit_sync is disabled.

See also 5.7 version: https://github.com/percona/percona-server/pull/1351

This branch is based on https://github.com/percona/percona-server/pull/1324 and https://github.com/percona/Percona-TokuBackup/pull/80, so the last two pull requests must be merged first. 

Testing: http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1640/