### PR TITLE
MYR-26 : rocksdb.slow_query_log fails using unsupported --log-slow-extra

### DIFF
--- a/mysql-test/suite/rocksdb/r/slow_query_log.result
+++ b/mysql-test/suite/rocksdb/r/slow_query_log.result
@@ -1,6 +1,5 @@
 SET @cur_long_query_time = @@long_query_time;
 SET @@long_query_time = 600;
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (id INT PRIMARY KEY, value INT) ENGINE=ROCKSDB;
 SET @@long_query_time = 0;
 SELECT COUNT(*) FROM t1;

--- a/mysql-test/suite/rocksdb/slow_query_log.awk
+++ b/mysql-test/suite/rocksdb/slow_query_log.awk
@@ -2,8 +2,6 @@
 
 /Query_time:/ {
   results["Rows_examined:"] = "uninit";
-  results["RocksDB_key_skipped:"] = "uninit";
-  results["RocksDB_del_skipped:"] = "uninit";
 
   for (i = 2; i <= NF; i = i+2) {
     results[$i] = $(i+1);
@@ -11,17 +9,11 @@
 
   # If the output format has changed and we don't find these keys,
   # error out.
-  if (results["Rows_examined:"] == "uninit" ||
-      results["RocksDB_key_skipped:"] == "uninit" ||
-      results["RocksDB_del_skipped:"] == "uninit") {
+  if (results["Rows_examined:"] == "uninit") {
     exit(-2);
   }
 
   if (results["Rows_examined:"] == 0) {
     next
-  }
-  if (results["RocksDB_key_skipped:"] == 0 ||
-      results["RocksDB_del_skipped:"] == 0) {
-    exit(-1);
   }
 }

--- a/mysql-test/suite/rocksdb/t/slow_query_log-master.opt
+++ b/mysql-test/suite/rocksdb/t/slow_query_log-master.opt
@@ -1,1 +1,1 @@
---log-slow-extra --rocksdb-perf-context-level=2
+--rocksdb-perf-context-level=2

--- a/mysql-test/suite/rocksdb/t/slow_query_log.test
+++ b/mysql-test/suite/rocksdb/t/slow_query_log.test
@@ -4,10 +4,6 @@ SET @cur_long_query_time = @@long_query_time;
 SET @@long_query_time = 600;
 # Test the slow query log feature
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
-
 CREATE TABLE t1 (id INT PRIMARY KEY, value INT) ENGINE=ROCKSDB;
 
 --disable_query_log


### PR DESCRIPTION
- Removed test option for unsupported option
- Ensured test does not require MyRocks as default storage engine
- Touched up awk file to not look for new slow log fields
- Re-recorded result