### PR TITLE
Fix bug 1660591 (5.7 range optimizer crash)

### DIFF
--- a/mysql-test/r/bug84736.result
+++ b/mysql-test/r/bug84736.result
@@ -1,0 +1,24 @@
+#
+# Bug 84736: 5.7 range optimizer crash
+#
+CREATE TABLE t1 (
+col1 INT(11) NOT NULL,
+col2 INT(11) NOT NULL,
+col3 TEXT,
+PRIMARY KEY (col1, col2)
+);
+INSERT INTO t1 VALUES (2, 1, "a");
+INSERT INTO t1 VALUES (3, 10, "b");
+INSERT INTO t1 VALUES (1, 2, "c");
+INSERT INTO t1 VALUES (100, 100, "x");
+SELECT * FROM t1
+WHERE
+(col1 = 2 AND col2 = 1) OR
+(col1 IN (3, 100) AND col2 = 10) OR
+(col1 = 1 AND col2 = 2) OR
+(col1 IN (1, 2, 3) AND col2 = 2);
+col1	col2	col3
+1	2	c
+2	1	a
+3	10	b
+DROP TABLE t1;

--- a/mysql-test/t/bug84736.test
+++ b/mysql-test/t/bug84736.test
@@ -1,0 +1,24 @@
+--echo #
+--echo # Bug 84736: 5.7 range optimizer crash
+--echo #
+
+CREATE TABLE t1 (
+       col1 INT(11) NOT NULL,
+       col2 INT(11) NOT NULL,
+       col3 TEXT,
+       PRIMARY KEY (col1, col2)
+);
+
+INSERT INTO t1 VALUES (2, 1, "a");
+INSERT INTO t1 VALUES (3, 10, "b");
+INSERT INTO t1 VALUES (1, 2, "c");
+INSERT INTO t1 VALUES (100, 100, "x");
+
+SELECT * FROM t1
+       WHERE
+       (col1 = 2 AND col2 = 1) OR
+       (col1 IN (3, 100) AND col2 = 10) OR
+       (col1 = 1 AND col2 = 2) OR
+       (col1 IN (1, 2, 3) AND col2 = 2);
+
+DROP TABLE t1;

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -742,7 +742,7 @@ public:
   SEL_ARG *rb_insert(SEL_ARG *leaf);
   friend SEL_ARG *rb_delete_fixup(SEL_ARG *root,SEL_ARG *key, SEL_ARG *par);
 #ifndef DBUG_OFF
-  friend int test_rb_tree(SEL_ARG *element,SEL_ARG *parent);
+  friend int test_rb_tree(const SEL_ARG *element, const SEL_ARG *parent);
 #endif
   bool test_use_count(SEL_ARG *root);
   SEL_ARG *first();
@@ -781,6 +781,8 @@ public:
     {
       if (cur_selarg->next_key_part)
       {
+        DBUG_ASSERT(count >= 0
+                    || (long)cur_selarg->next_key_part->use_count >= count);
         cur_selarg->next_key_part->use_count+= count;
         cur_selarg->next_key_part->increment_use_count(count);
       }
@@ -8024,14 +8026,15 @@ static SEL_ARG *
 and_all_keys(RANGE_OPT_PARAM *param, SEL_ARG *key1, SEL_ARG *key2, 
              uint clone_flag)
 {
+  DBUG_ASSERT(key1->part < key2->part);
+
   SEL_ARG *next;
   ulong use_count=key1->use_count;
 
-  if (key1->elements != 1)
-  {
-    key2->use_count+=key1->elements-1; //psergey: why we don't count that key1 has n-k-p?
-    key2->increment_use_count((int) key1->elements-1);
-  }
+  DBUG_ASSERT(key1->elements > 0);
+  key2->use_count+= key1->elements;
+  key2->increment_use_count(key1->elements);
+
   if (key1->type == SEL_ARG::MAYBE_KEY)
   {
     // See todo for left/right pointers
@@ -9270,8 +9273,8 @@ SEL_ARG *rb_delete_fixup(SEL_ARG *root,SEL_ARG *key,SEL_ARG *par)
 
 #ifndef DBUG_OFF
 	/* Test that the properties for a red-black tree hold */
-
-int test_rb_tree(SEL_ARG *element,SEL_ARG *parent)
+static
+int test_rb_subtree(const SEL_ARG *element, const SEL_ARG *parent)
 {
   int count_l,count_r;
 
@@ -9294,8 +9297,8 @@ int test_rb_tree(SEL_ARG *element,SEL_ARG *parent)
     sql_print_error("Wrong tree: Found right == left");
     return -1;
   }
-  count_l=test_rb_tree(element->left,element);
-  count_r=test_rb_tree(element->right,element);
+  count_l=test_rb_subtree(element->left,element);
+  count_r=test_rb_subtree(element->right,element);
   if (count_l >= 0 && count_r >= 0)
   {
     if (count_l == count_r)
@@ -9304,6 +9307,16 @@ int test_rb_tree(SEL_ARG *element,SEL_ARG *parent)
 	    count_l,count_r);
   }
   return -1;					// Error, no more warnings
+}
+
+int test_rb_tree(const SEL_ARG *element, const SEL_ARG *parent)
+{
+  if (element->color == SEL_ARG::RED)
+  {
+    sql_print_error("Wrong tree: root node is red");
+    return -1;
+  }
+  return test_rb_subtree(element, parent);
 }
 #endif
 

--- a/unittest/gunit/opt_range-t.cc
+++ b/unittest/gunit/opt_range-t.cc
@@ -1674,7 +1674,7 @@ TEST_F(OptRangeTest, KeyOr2)
 
   EXPECT_EQ(0UL, fld1_20->keys[1]->use_count);
   EXPECT_NE(null_arg, fld1_20->keys[1]->next_key_part);
-  EXPECT_EQ(0UL, fld1_20->keys[1]->next_key_part->use_count);
+  EXPECT_EQ(1UL, fld1_20->keys[1]->next_key_part->use_count);
 }
 
 class Mock_SEL_ARG : public SEL_ARG


### PR DESCRIPTION
After upstream commit [1], which fixed
https://bugs.mysql.com/bug.php?id=70236, SEL_ARG::increment_use_count
became more correct in propagating reference counts. This included
reference decreases too, and exposed a missing reference count bump in
and_all_keys. Because of this, there was a SEL_ARG object whose count
dropped to zero prematurely, and was pointed to from a different key
part. A new interval later was inserted through this new pointer,
coloring the original RB-tree root node red. Then the tree was
inserted to through the old pointer, resulting in a crash due to
RB-tree invariant violation above.

Fix by bumping reference count by one more in and_all_keys.

http://jenkins.percona.com/job/mysql-5.7-param/642/