### PR TITLE
Fix bug 1660339 (Bogus client SSL error messages produced using SSL_g…

### DIFF
--- a/mysql-test/r/ssl_bug75311.result
+++ b/mysql-test/r/ssl_bug75311.result
@@ -1,0 +1,7 @@
+#
+# Bug 75311: Error for SSL cipher is unhelpful
+#
+SHOW STATUS LIKE 'Ssl_cipher_list';
+Variable_name	Value
+Ssl_cipher_list	DHE-RSA-AES256-SHA
+ERROR 2026 (HY000): SSL connection error: ERROR

--- a/mysql-test/t/ssl_bug75311-master.opt
+++ b/mysql-test/t/ssl_bug75311-master.opt
@@ -1,0 +1,1 @@
+--ssl-cipher=DHE-RSA-AES256-SHA

--- a/mysql-test/t/ssl_bug75311.test
+++ b/mysql-test/t/ssl_bug75311.test
@@ -1,0 +1,21 @@
+--source include/have_ssl_communication.inc
+
+--echo #
+--echo # Bug 75311: Error for SSL cipher is unhelpful
+--echo #
+
+--source include/count_sessions.inc
+
+--connect(con1,localhost,root,,,,,SSL)
+
+SHOW STATUS LIKE 'Ssl_cipher_list';
+
+--disconnect con1
+--connection default
+
+# The first error string is returned by YaSSL, the second one by OpenSSL
+--replace_result "Failed to set ciphers to use" ERROR "error:14077410:SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure" ERROR
+--error 1
+--exec $MYSQL -uroot --ssl-mode=REQUIRED --ssl-cipher='AES128-SHA256' -e "SHOW STATUS LIKE 'Ssl_cipher'" 2>&1
+
+--source include/wait_until_count_sessions.inc

--- a/vio/viossl.c
+++ b/vio/viossl.c
@@ -44,8 +44,7 @@ report_errors(SSL* ssl)
   }
 
   if (ssl)
-    DBUG_PRINT("error", ("error: %s",
-                         ERR_error_string(SSL_get_error(ssl, l), buf)));
+    DBUG_PRINT("error", ("SSL_get_error: %d", SSL_get_error(ssl, l)));
 
   DBUG_PRINT("info", ("socket_errno: %d", socket_errno));
   DBUG_VOID_RETURN;
@@ -132,6 +131,8 @@ static my_bool ssl_should_retry(Vio *vio, int ret,
   /* Retrieve the result for the SSL I/O operation. */
   ssl_error= SSL_get_error(ssl, ret);
 
+  *ssl_errno_holder= ERR_peek_error();
+
   /* Retrieve the result for the SSL I/O operation. */
   switch (ssl_error)
   {
@@ -155,8 +156,6 @@ static my_bool ssl_should_retry(Vio *vio, int ret,
     ssl_set_sys_error(ssl_error);
     break;
   }
-
-  *ssl_errno_holder= ssl_error;
 
   return should_retry;
 }


### PR DESCRIPTION
…et_error not ERR_get_error error code)

Make sure to only pass ERR_get_error and not SSL_get_error result to
ERR_error_string and ERR_error_string_n functions.

http://jenkins.percona.com/job/percona-server-5.6-param/1632/