### PR TITLE
Fix bug 1660255 (Test innodb.innodb_mysql is unstable)

### DIFF
--- a/mysql-test/include/mix1.inc
+++ b/mysql-test/include/mix1.inc
@@ -459,9 +459,6 @@ INSERT INTO t1(id, dept, age, name) VALUES
 EXPLAIN SELECT DISTINCT t1.name, t1.dept FROM t1 WHERE t1.name='rs5';
 SELECT DISTINCT t1.name, t1.dept FROM t1 WHERE t1.name='rs5';
 DELETE FROM t1;
---echo # Masking (#) number in "rows" column of the following EXPLAIN output, as it may vary (bug#47746).
---replace_column 9 #
-EXPLAIN SELECT DISTINCT t1.name, t1.dept FROM t1 WHERE t1.name='rs5';
 SELECT DISTINCT t1.name, t1.dept FROM t1 WHERE t1.name='rs5';
 
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/innodb_mysql.result
+++ b/mysql-test/suite/innodb/r/innodb_mysql.result
@@ -386,10 +386,6 @@ name	dept
 rs5	cs10
 rs5	cs9
 DELETE FROM t1;
-# Masking (#) number in "rows" column of the following EXPLAIN output, as it may vary (bug#47746).
-EXPLAIN SELECT DISTINCT t1.name, t1.dept FROM t1 WHERE t1.name='rs5';
-id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	range	name	name	44	NULL	#	Using where; Using index for group-by
 SELECT DISTINCT t1.name, t1.dept FROM t1 WHERE t1.name='rs5';
 name	dept
 DROP TABLE t1;


### PR DESCRIPTION
The testcase creates a table with a secondary table, deletes all rows
from it, and checks the query plan. The problem is that it expects a
range access method, which it gets most of the time, because purge has
not completed yet. However, sometimes purge completes before the
query, and then the access method becomes ref, failing the testcase.

If the testcase were stabilised by fully completing purge before the
query, the access plan would be a stable ref method. But the goal of
the testcase is to test specifically range optimiser, and specifically
with a just-cleared table. To avoid making this a deterministic but a
debug-only testcase, fix by removing EXPLAIN SELECT altogether, but
leaving its SELECT, so that the absence of the crash is confirmed
regardless of the query plan.

http://jenkins.percona.com/job/percona-server-5.6-param/1633/