### PR TITLE
Add diagnostics to catch bug 1661534 (Test innodb.percona_changed_pag…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_pages.result
+++ b/mysql-test/suite/innodb/r/percona_changed_pages.result
@@ -225,6 +225,8 @@ SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
 COUNT(*)
 5
 SET GLOBAL INNODB_MAX_CHANGED_PAGES = 1000000;
+include/assert.inc [No bitmap data must exist with START_LSN > @max_end_lsn]
+include/assert.inc [No bitmap data must exist with END_LSN > @max_end_lsn]
 CREATE TABLE ICP_COPY (
 space_id INT(11) NOT NULL,
 page_id INT(11) NOT NULL,

--- a/mysql-test/suite/innodb/t/percona_changed_pages.test
+++ b/mysql-test/suite/innodb/t/percona_changed_pages.test
@@ -323,6 +323,18 @@ SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
 
 eval SET GLOBAL INNODB_MAX_CHANGED_PAGES = $old_max_changed_pages;
 
+# Verify that InnoDB did not write anything during the above tests, breaking them
+# (specifically the assumption that COUNT(*) == 0 WHERE START_LSN|END_LSN > @max_end_lsn)
+--let $assert_text= No bitmap data must exist with START_LSN > @max_end_lsn
+--let $assert_cond= COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE START_LSN > @max_end_lsn
+--let $assert_debug= SELECT * FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE START_LSN > @max_end_lsn;
+--source include/assert.inc
+
+--let $assert_text= No bitmap data must exist with END_LSN > @max_end_lsn
+--let $assert_cond= COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE END_LSN > @max_end_lsn
+--let $assert_debug= SELECT * FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE END_LSN > @max_end_lsn;
+--source include/assert.inc
+
 #
 # Test that I_S.INNODB_CHANGED_PAGES can be queried with the log tracking disabled
 # (bug 1185304)


### PR DESCRIPTION
…es is unstable)

Add asserts that no new bitmap data was tracked while the ICP-testing
queries are running.

(cherry picked from commit 375641e9615183157899e0654cf6ec09e0205894)

http://jenkins.percona.com/job/mysql-5.7-param/647/