### PR TITLE
Backup slave and master info for TokuDB-HotBackup.

### DIFF
--- a/mysql-test/include/filter_file.inc
+++ b/mysql-test/include/filter_file.inc
@@ -15,6 +15,7 @@
 # [--let $select_columns= <LIST OF NUMBERS>]
 # [--let $pre_script= <PERL_SCRIPT>]
 # [--let $rpl_debug= 1]
+# [--let $skip_column_names= 0]
 # --source include/filter_file.inc
 #
 # Parameters:
@@ -45,6 +46,9 @@
 #     numbers, it will print only the numbered columns, in the given
 #     order.
 #
+#   $skip_column_names
+#     If true then skip reading columns line. false by default.
+#
 #   $pre_script
 #     This script will be evaluated before starting to iterate over
 #     the lines of $input_file.  It can be useful if you need some
@@ -70,6 +74,10 @@ if ($rpl_debug)
 --let _FF_INPUT_FILE= $input_file
 --let _FF_OUTPUT_FILE= $output_file
 --let _FF_SELECT_COLUMNS= $select_columns
+if (!$skip_column_names) {
+  --let $skip_column_names= 0;
+}
+--let _FF_SKIP_COLUMN_NAMES= $skip_column_names
 --let _FF_DEBUG= $rpl_debug
 if (!$output_file)
 {
@@ -83,6 +91,7 @@ perl;
   my $input_file = $ENV{'_FF_INPUT_FILE'};
   my $output_file = $ENV{'_FF_OUTPUT_FILE'};
   my $select_columns = $ENV{'_FF_SELECT_COLUMNS'};
+  my $skip_column_names = $ENV{'_FF_SKIP_COLUMN_NAMES'};
   my $debug = $ENV{'_FF_DEBUG'};
   if ($select_columns)
   {
@@ -114,7 +123,7 @@ perl;
   {
     chomp;
     s/\015?\012?$//;
-    if (!%column_names)
+    if (!%column_names && $skip_column_names == 0)
     {
       my $n = 1;
       %column_names = map { $_ => $n++ } split(/\t/, $_);

--- a/mysql-test/suite/tokudb.backup/r/backup_master_info.result
+++ b/mysql-test/suite/tokudb.backup/r/backup_master_info.result
@@ -1,0 +1,26 @@
+###
+# Test for binlog position
+#####
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+Backup
+include/filter_file.inc
+### tokubackup_slave_info content:
+host: #.#.#.#, user: ####, port: ####, master log file: ####, relay log file: ####, exec master log pos: ####, executed gtid set: , channel name: 
+###
+# Test for gtid set
+#####
+include/rpl_set_gtid_mode.inc
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+Backup
+include/filter_file.inc
+### tokubackup_slave_info content:
+host: #.#.#.#, user: ####, port: ####, master log file: ####, relay log file: ####, exec master log pos: ####, executed gtid set: ####, channel name: 
+include/rpl_set_gtid_mode.inc
+include/rpl_end.inc

--- a/mysql-test/suite/tokudb.backup/r/backup_master_state.result
+++ b/mysql-test/suite/tokudb.backup/r/backup_master_state.result
@@ -1,0 +1,36 @@
+### Create backup dir
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+### Check for settings
+SELECT @@gtid_mode;
+@@gtid_mode
+OFF
+### Generate some binlog events
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+### Master backup
+include/filter_file.inc
+### tokubackup_binlog_info content:
+filename: ####, position: ####, gtid_mode: OFF, GTID of last change: 
+### Delete backup dir
+### Create backup dir
+### GTID-mode on
+include/rpl_set_gtid_mode.inc
+### Check for settings
+SELECT @@gtid_mode;
+@@gtid_mode
+ON
+### Generate some binlog events
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+### Master backup
+include/filter_file.inc
+### tokubackup_binlog_info content:
+filename: ####, position: ####, gtid_mode: ON, GTID of last change: #####
+### Delete backup dir
+### GTID-mode off
+include/rpl_set_gtid_mode.inc
+include/rpl_end.inc

--- a/mysql-test/suite/tokudb.backup/t/backup_master_info.test
+++ b/mysql-test/suite/tokudb.backup/t/backup_master_info.test
@@ -1,0 +1,94 @@
+--source include/have_tokudb_backup.inc
+--source include/not_gtid_enabled.inc
+
+
+--let $SLAVE_INFO_FILE=tokubackup_slave_info
+--let $BACKUP_DIR_SLAVE=$MYSQL_TMP_DIR/tokudb_backup_slave
+--let $SLAVE_INFO_FILE_PATH=$BACKUP_DIR_SLAVE/$SLAVE_INFO_FILE
+--let DDIR=$BACKUP_DIR_SLAVE
+
+# Settings for include/filter_file.inc
+
+--delimiter |
+let $script=
+  s{host: [^,]+,}{host: #.#.#.#,};
+  s{user: [^,]+,}{user: ####,};
+  s{port: [^,]+,}{port: ####,};
+  s{master log file: [^,]+,}{master log file: ####,};
+  s{relay log file: [^,]+,}{relay log file: ####,};
+  s{exec master log pos: [^,]+,}{exec master log pos: ####,};
+  s{executed gtid set: [^,]+, }{executed gtid set: ####, };
+  s{executed gtid set: [^,]+,[^,]+, }{executed gtid set: ####,####, };
+|
+--delimiter ;
+--let $input_file = $SLAVE_INFO_FILE_PATH
+--let $skip_column_names= 1
+
+--echo ###
+--echo # Test for binlog position
+--echo #####
+
+--mkdir $BACKUP_DIR_SLAVE
+
+--source include/master-slave.inc
+
+--connection master
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+
+--sync_slave_with_master
+
+--connection slave
+--echo Backup
+--disable_query_log
+--eval SET SESSION tokudb_backup_dir='$BACKUP_DIR_SLAVE'
+--enable_query_log
+
+--source include/filter_file.inc
+--echo ### $SLAVE_INFO_FILE content:
+--cat_file $SLAVE_INFO_FILE_PATH
+
+--perl
+use File::Path 'rmtree';
+$DDIR=$ENV{"DDIR"};
+rmtree([ "$DDIR" ]);
+EOF
+
+--echo ###
+--echo # Test for gtid set
+--echo #####
+
+--mkdir $BACKUP_DIR_SLAVE
+
+--let $rpl_server_numbers= 1,2
+--let $rpl_set_enforce_gtid_consistency= 1
+--source include/rpl_set_gtid_mode.inc
+
+--connection master
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+
+--sync_slave_with_master
+
+--connection slave
+--echo Backup
+--disable_query_log
+--eval SET SESSION tokudb_backup_dir='$BACKUP_DIR_SLAVE'
+--enable_query_log
+
+--source include/filter_file.inc
+--echo ### $SLAVE_INFO_FILE content:
+--cat_file $SLAVE_INFO_FILE_PATH
+
+--perl
+use File::Path 'rmtree';
+$DDIR=$ENV{"DDIR"};
+rmtree([ "$DDIR" ]);
+EOF
+
+--let $rpl_gtid_mode= OFF
+--let $rpl_set_enforce_gtid_consistency= 0
+--let $rpl_server_numbers= 1,2
+--let $rpl_skip_sync= 1
+--source include/rpl_set_gtid_mode.inc
+--source include/rpl_end.inc

--- a/mysql-test/suite/tokudb.backup/t/backup_master_state.test
+++ b/mysql-test/suite/tokudb.backup/t/backup_master_state.test
@@ -1,0 +1,87 @@
+--source include/have_tokudb_backup.inc
+--source include/not_gtid_enabled.inc
+
+--let $MASTER_STATE_FILE=tokubackup_binlog_info
+--let $BACKUP_DIR_MASTER=$MYSQL_TMP_DIR/tokudb_backup_master
+--let $MASTER_STATE_FILE_PATH=$BACKUP_DIR_MASTER/$MASTER_STATE_FILE
+--let DDIR=$BACKUP_DIR_MASTER
+
+# Settings for include/filter_file.inc
+--delimiter |
+let $script=
+  s{filename: [^,]+,}{filename: ####,};
+  s{position: [^,]+,}{position: ####,};
+  s{GTID of last change: [^ ]+}{GTID of last change: #####};
+|
+--delimiter ;
+--let $input_file = $MASTER_STATE_FILE_PATH
+--let $skip_column_names= 1
+
+--echo ### Create backup dir
+--mkdir $BACKUP_DIR_MASTER
+
+--source include/master-slave.inc
+
+--connection master
+
+--echo ### Check for settings
+SELECT @@gtid_mode;
+
+--echo ### Generate some binlog events
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+
+--echo ### Master backup
+--disable_query_log
+--eval SET SESSION tokudb_backup_dir='$BACKUP_DIR_MASTER'
+--enable_query_log
+
+--source include/filter_file.inc
+--echo ### $MASTER_STATE_FILE content:
+--cat_file $MASTER_STATE_FILE_PATH
+
+--echo ### Delete backup dir
+--perl
+use File::Path 'rmtree';
+$DDIR=$ENV{"DDIR"};
+rmtree([ "$DDIR" ]);
+EOF
+
+--echo ### Create backup dir
+--mkdir $BACKUP_DIR_MASTER
+
+--echo ### GTID-mode on
+--let $rpl_server_numbers= 1,2
+--let $rpl_set_enforce_gtid_consistency= 1
+--source include/rpl_set_gtid_mode.inc
+
+--echo ### Check for settings
+SELECT @@gtid_mode;
+
+--echo ### Generate some binlog events
+CREATE TABLE t1(a INT) ENGINE=TokuDB;
+DROP TABLE t1;
+
+--echo ### Master backup
+--disable_query_log
+--eval SET SESSION tokudb_backup_dir='$BACKUP_DIR_MASTER'
+--enable_query_log
+
+--source include/filter_file.inc
+--echo ### $MASTER_STATE_FILE content:
+--cat_file $MASTER_STATE_FILE_PATH
+
+--echo ### Delete backup dir
+--perl
+use File::Path 'rmtree';
+$DDIR=$ENV{"DDIR"};
+rmtree([ "$DDIR" ]);
+EOF
+
+--echo ### GTID-mode off
+--let $rpl_gtid_mode= OFF
+--let $rpl_set_enforce_gtid_consistency= 0
+--let $rpl_server_numbers= 1,2
+--source include/rpl_set_gtid_mode.inc
+
+--source include/rpl_end.inc

--- a/plugin/tokudb-backup-plugin/backup/backup.h
+++ b/plugin/tokudb-backup-plugin/backup/backup.h
@@ -19,10 +19,23 @@ typedef void (*backup_error_fun_t)(int error_number, const char *error_string, v
 // When it returns 0, the file is copied.  Otherwise, the file copy is skipped.
 typedef int (*backup_exclude_copy_fun_t)(const char *source_file,void *extra);
 
-int tokubackup_create_backup(const char *source_dirs[], const char *dest_dirs[], int dir_count,
-                             backup_poll_fun_t poll_fun, void *poll_extra,
-                             backup_error_fun_t error_fun, void *error_extra,
-                             backup_exclude_copy_fun_t check_fun, void *exclude_copy_extra)
+typedef void (*backup_before_stop_capt_fun_t)(void *extra);
+typedef void (*backup_after_stop_capt_fun_t)(void *extra);
+
+
+int tokubackup_create_backup(const char *source_dirs[],
+                             const char *dest_dirs[],
+                             int dir_count,
+                             backup_poll_fun_t poll_fun,
+                             void *poll_extra,
+                             backup_error_fun_t error_fun,
+                             void *error_extra,
+                             backup_exclude_copy_fun_t check_fun,
+                             void *exclude_copy_extra,
+                             backup_before_stop_capt_fun_t bsc_fun,
+                             void *bsc_extra,
+                             backup_after_stop_capt_fun_t asc_fun,
+                             void *asc_extra)
     throw() __attribute__((visibility("default")));
 // Effect: Backup the directories in source_dirs into correspnding dest_dirs.
 // Periodically call poll_fun.

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -3,6 +3,7 @@
 #ident "Copyright (c) 2014 Tokutek Inc.  All rights reserved."
 
 #define MYSQL_SERVER
+#define HAVE_REPLICATION
 #include <my_config.h>
 #include <mysql_version.h>
 #include <mysql/plugin.h>
@@ -19,6 +20,87 @@
 #include <sql_parse.h> // check_global_access
 #include "backup/backup.h"
 #include <regex.h>
+#include <rpl_mi.h>
+#include <rpl_slave.h>
+#include <rpl_rli.h>
+#include <sql_parse.h>
+#include <mysqld.h>
+
+#include <inttypes.h>
+#include <algorithm>
+#include <string>
+#include <sstream>
+#include <vector>
+
+template <typename T>
+class BasicLockableClassWrapper
+{
+    T &m_lockable;
+    void (T::*m_lock)(void);
+    void (T::*m_unlock)(void);
+public:
+    BasicLockableClassWrapper(T &a_lockable,
+                              void (T::*a_lock)(void),
+                              void (T::*a_unlock)(void)) :
+        m_lockable(a_lockable),
+        m_lock(a_lock),
+        m_unlock(a_unlock) {}
+
+    void lock() {
+        ((m_lockable).*(m_lock))();
+    }
+
+    void unlock() {
+        ((m_lockable).*(m_unlock))();
+    }
+};
+
+class BasicLockableMysqlMutextT {
+    mysql_mutex_t &m_mutex;
+    public:
+        BasicLockableMysqlMutextT(mysql_mutex_t &mutex) : m_mutex(mutex) {}
+        void lock() { mysql_mutex_lock(&m_mutex); }
+        void unlock() {mysql_mutex_unlock(&m_mutex); }
+};
+
+template <typename BasicLockableWrapper>
+class scoped_lock_wrapper
+{
+    BasicLockableWrapper m_lockable;
+public:
+    scoped_lock_wrapper(const BasicLockableWrapper &lockable) :
+        m_lockable(lockable) {
+        m_lockable.lock();
+    }
+    ~scoped_lock_wrapper() {
+        m_lockable.unlock();
+    }
+private:
+    scoped_lock_wrapper(
+        const scoped_lock_wrapper<BasicLockableWrapper> &);
+    scoped_lock_wrapper& operator=(
+        scoped_lock_wrapper<BasicLockableWrapper> &);
+};
+
+typedef BasicLockableClassWrapper<Checkable_rwlock> Checkable_rwlock_lockable;
+
+struct tokudb_backup_master_info {
+    std::string host;
+    std::string user;
+    uint32_t port;
+    std::string master_log_file;
+    std::string relay_log_file;
+    uint64_t exec_master_log_pos;
+    std::string executed_gtid_set;
+    std::string channel_name;
+};
+
+struct tokudb_backup_master_state {
+    std::string file_name;
+    my_off_t position;
+    std::string executed_gtid_set;
+    ulong gtid_mode;
+};
 
 #ifdef TOKUDB_BACKUP_PLUGIN_VERSION
 #define stringify2(x) #x
@@ -29,6 +111,9 @@
 #endif
 
 static char *tokudb_backup_plugin_version;
+
+static const char* master_info_file_name = "tokubackup_slave_info";
+static const char* master_state_file_name = "tokubackup_binlog_info";
 
 static MYSQL_SYSVAR_STR(plugin_version, tokudb_backup_plugin_version,
     PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
@@ -186,6 +271,114 @@ static void tokudb_backup_error_fun(int error_number, const char *error_string, 
         // append the new error string to the last error string
         tokudb_backup_set_error_string(be->_thd, error_number, "%s; %s", last_error_string, error_string, NULL);
     }
+}
+
+static void tokudb_backup_before_stop_capt_fun(void *arg) {
+    THD *thd = static_cast<THD *>(arg);
+    (void)lock_binlog_for_backup(thd);
+}
+
+std::string tokudb_backup_get_executed_gtids_set() {
+    char* sql_gtid_set_buffer = NULL;
+    std::string result;
+    {
+        scoped_lock_wrapper<Checkable_rwlock_lockable>
+            with_global_sid_lock_wrlock(
+                Checkable_rwlock_lockable(*global_sid_lock,
+                                     &Checkable_rwlock::wrlock,
+                                     &Checkable_rwlock::unlock));
+
+        const Gtid_set *sql_gtid_set= gtid_state->get_logged_gtids();
+        (void)sql_gtid_set->to_string(&sql_gtid_set_buffer);
+    }
+    result.assign(sql_gtid_set_buffer);
+    result.erase(std::remove(result.begin(), result.end(),'\n'), result.end());
+    return result;
+};
+
+static void tokudb_backup_get_master_infos(
+    THD *thd,
+    std::vector<tokudb_backup_master_info> *master_info_channels) {
+
+    Master_info *mi = active_mi;
+    tokudb_backup_master_info tbmi;
+
+    {
+        scoped_lock_wrapper<BasicLockableMysqlMutextT>
+            with_LOCK_active_mi_locked(
+            BasicLockableMysqlMutextT(&LOCK_active_mi));
+
+        if (!active_mi)
+            return;
+
+        std::string executed_gtid_set = tokudb_backup_get_executed_gtids_set();
+
+        {
+            scoped_lock_wrapper<BasicLockableMysqlMutextT>
+                with_mi_data_locked_1(BasicLockableMysqlMutextT(
+                    mi->data_lock));
+            scoped_lock_wrapper<BasicLockableMysqlMutextT>
+                with_mi_data_locked_2(BasicLockableMysqlMutextT(
+                    mi->rli->data_lock));
+            scoped_lock_wrapper<BasicLockableMysqlMutextT>
+                with_mi_data_locked_3(BasicLockableMysqlMutextT(
+                    mi->err_lock));
+            scoped_lock_wrapper<BasicLockableMysqlMutextT>
+                with_mi_data_locked_4(BasicLockableMysqlMutextT(
+                    mi->rli->err_lock));
+
+            tbmi.host.assign(mi->host);
+            tbmi.user.assign(mi->get_user());
+            tbmi.port = mi->port;
+            tbmi.master_log_file.assign(mi->get_master_log_name());
+            tbmi.relay_log_file.assign(mi->rli->get_group_relay_log_name() +
+                dirname_length(mi->rli->get_group_relay_log_name()));
+            tbmi.exec_master_log_pos = mi->rli->get_group_master_log_pos();
+            tbmi.executed_gtid_set.assign(executed_gtid_set);
+        }
+    }
+
+    master_info_channels->push_back(tbmi);
+}
+
+void tokudb_backup_get_master_state(
+    tokudb_backup_master_state *master_state) {
+
+    if (!mysql_bin_log.is_open())
+        return;
+
+    LOG_INFO li;
+    mysql_bin_log.get_current_log(&li);
+
+    master_state->file_name =
+        (li.log_file_name + dirname_length(li.log_file_name));
+    master_state->position = li.pos;
+    master_state->executed_gtid_set = tokudb_backup_get_executed_gtids_set();
+    master_state->gtid_mode = gtid_mode;
+
+    return;
+}
+
+struct tokudb_backup_after_stop_capt_extra {
+    THD *thd;
+    std::vector<tokudb_backup_master_info> *master_info_channels;
+    tokudb_backup_master_state *master_state;
+};
+
+static void tokudb_backup_after_stop_capt_fun(void *arg) {
+    tokudb_backup_after_stop_capt_extra *extra =
+        static_cast<tokudb_backup_after_stop_capt_extra *>(arg);
+    THD *thd = extra->thd;
+    std::vector<tokudb_backup_master_info> *master_info_channels =
+        extra->master_info_channels;
+    tokudb_backup_master_state *master_state = extra->master_state;
+
+    tokudb_backup_get_master_infos(thd, master_info_channels);
+    tokudb_backup_get_master_state(master_state);
+
+    if (thd->backup_binlog_lock.is_acquired())
+      thd->backup_binlog_lock.release(thd);
+
 }
 
 static char *tokudb_backup_realpath_with_slash(const char *a) {
@@ -541,6 +734,113 @@ private:
     destination_dirs() {};
 };
 
+int tokudb_backup_save_master_infos(
+    THD *thd,
+    const char *dest_dir,
+    const std::vector<tokudb_backup_master_info> &master_info_channels) {
+
+    int error = 0;
+    std::string mi_full_file_name(dest_dir);
+    mi_full_file_name.append("/");
+    mi_full_file_name.append(master_info_file_name);
+
+    int fd = open(mi_full_file_name.c_str(),
+                  O_WRONLY|O_CREAT,
+                  S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+    if (fd < 0) {
+        error = errno;
+        tokudb_backup_set_error_string(
+            thd, error, "Can't open master info file %s\n",
+            mi_full_file_name.c_str(), NULL, NULL);
+        return error;
+    }
+
+    for (std::vector<tokudb_backup_master_info>::const_iterator i =
+            master_info_channels.begin(), end = master_info_channels.end();
+        i != end;
+        ++i) {
+
+        std::stringstream out;
+        out << "host: " << i->host << ", "
+            << "user: " << i->user << ", "
+            << "port: " << i->port << ", "
+            << "master log file: " << i->master_log_file << ", "
+            << "relay log file: " << i->relay_log_file << ", "
+            << "exec master log pos: " << i->exec_master_log_pos << ", "
+            << "executed gtid set: " << i->executed_gtid_set << ", "
+            << "channel name: " << i->channel_name << std::endl;
+        const std::string &out_str = out.str();
+        if (write(fd, out_str.c_str(), out_str.length()) <
+            (int)out_str.length())
+        {
+            error = EINVAL;
+            tokudb_backup_set_error_string(
+                thd, error, "Master info was not written fully",
+                NULL, NULL, NULL);
+            break;
+        }
+    }
+
+    if (close(fd) < 0) {
+        error = errno;
+        tokudb_backup_set_error_string(
+            thd, error, "Can't close master info file %s\n",
+            mi_full_file_name.c_str(), NULL, NULL);
+    }
+
+    return error;
+}
+
+int tokudb_backup_save_master_state(
+    THD *thd,
+    const char *dest_dir,
+    const tokudb_backup_master_state &master_state) {
+
+    int error = 0;
+    std::string ms_full_file_name(dest_dir);
+    ms_full_file_name.append("/");
+    ms_full_file_name.append(master_state_file_name);
+
+    int fd = open(ms_full_file_name.c_str(),
+                  O_WRONLY|O_CREAT,
+                  S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+    if (fd < 0) {
+        error = errno;
+        tokudb_backup_set_error_string(
+            thd, error, "Can't open master state file %s\n",
+            ms_full_file_name.c_str(), NULL, NULL);
+        return error;
+    }
+
+    std::stringstream out;
+    out << "filename: " << master_state.file_name << ", "
+        << "position: " << master_state.position << ", "
+        << "gtid_mode: "
+        << gtid_mode_names[master_state.gtid_mode] << ", "
+        << "GTID of last change: " << master_state.executed_gtid_set
+        << std::endl;
+
+    const std::string &out_str = out.str();
+    if (write(fd, out_str.c_str(), out_str.length()) <
+        (int)out_str.length())
+    {
+        error = EINVAL;
+        tokudb_backup_set_error_string(
+            thd, error, "Master state was not written fully",
+            NULL, NULL, NULL);
+    }
+
+    if (close(fd) < 0) {
+        error = errno;
+        tokudb_backup_set_error_string(
+            thd, error, "Can't close master state file %s\n",
+            ms_full_file_name.c_str(), NULL, NULL);
+    }
+
+    return error;
+
+}
+
 static void tokudb_backup_run(THD *thd, const char *dest_dir) {
     int error = 0;
 
@@ -619,18 +919,46 @@ static void tokudb_backup_run(THD *thd, const char *dest_dir) {
     // set the throttle
     tokubackup_throttle_backup(THDVAR(thd, throttle));
 
+    std::vector<tokudb_backup_master_info> master_info_channels;
+    tokudb_backup_master_state master_state;
+
     // do the backup
     tokudb_backup_progress_extra progress_extra = { thd, NULL };
     tokudb_backup_error_extra error_extra = { thd };
     tokudb_backup_exclude_copy_extra exclude_copy_extra = { thd, exclude_string, &exclude_re };
-    error = tokubackup_create_backup(source_dirs, dest_dirs, count,
-                                     tokudb_backup_progress_fun, &progress_extra,
-                                     tokudb_backup_error_fun, &error_extra,
-                                     tokudb_backup_exclude_copy_fun, &exclude_copy_extra);
+    tokudb_backup_after_stop_capt_extra asce = {thd,
+                                                &master_info_channels,
+                                                &master_state};
+    error = tokubackup_create_backup(source_dirs,
+                                     dest_dirs,
+                                     count,
+                                     tokudb_backup_progress_fun,
+                                     &progress_extra,
+                                     tokudb_backup_error_fun,
+                                     &error_extra,
+                                     tokudb_backup_exclude_copy_fun,
+                                     &exclude_copy_extra,
+                                     tokudb_backup_before_stop_capt_fun,
+                                     thd,
+                                     tokudb_backup_after_stop_capt_fun,
+                                     &asce);
 
     if (exclude_string)
         regfree(&exclude_re);
 
+    if (!master_info_channels.empty() &&
+        (error = tokudb_backup_save_master_infos(thd,
+                                                 dest_dir,
+                                                 master_info_channels)))
+        goto exit;
+
+    if (!master_state.file_name.empty() &&
+        (error = tokudb_backup_save_master_state(thd,
+                                                 dest_dir,
+                                                 master_state)))
+        goto exit;
+
+exit:
     // cleanup
     thd_proc_info(thd, "tokudb backup done"); // must be a static string
     my_free(progress_extra._the_string);

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2572,7 +2572,7 @@ static bool lock_tables_for_backup(THD *thd)
   @return FALSE in case of success, TRUE in case of error.
 */
 
-static bool lock_binlog_for_backup(THD *thd)
+bool lock_binlog_for_backup(THD *thd)
 {
   DBUG_ENTER("lock_binlog_for_backup");
 

--- a/sql/sql_parse.h
+++ b/sql/sql_parse.h
@@ -214,4 +214,6 @@ inline bool is_supported_parser_charset(const CHARSET_INFO *cs)
 
 extern "C" bool sqlcom_can_generate_row_events(enum enum_sql_command command);
 
+bool lock_binlog_for_backup(THD *thd);
+
 #endif /* SQL_PARSE_INCLUDED */


### PR DESCRIPTION
The algorithm for getting master-info is the following:

1) LOCK BINLOG FOR BACKUP just before stop capturing.
This statement will block any queries which would change binlog position or
executed gtids set and flushes master info in innodb;
2) Stop capturing;
3) Get master and slave info and store it in separate files in backup
directory;
4) UNLOCK BINLOG

See also:
https://github.com/percona/percona-server/pull/1373
https://github.com/percona/Percona-TokuBackup/pull/80

Testing: http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1657/