### PR TITLE
Fix bug 1662163 (innodb_fts.sync_block test unstable due to slow query

### DIFF
--- a/mysql-test/suite/innodb_fts/t/disabled.def
+++ b/mysql-test/suite/innodb_fts/t/disabled.def
@@ -9,3 +9,4 @@
 #  Do not use any TAB characters for whitespace.
 #
 ##############################################################################
+sync_block : percona disabled because the test is fundamentally unstable https://bugs.launchpad.net/percona-server/+bug/1662163


### PR DESCRIPTION
log nondeterminism)

The testcase performs some actions and attempts that only some of them
are slow and some are not, by checking the slow query log. The problem
with this approach is that the testcase might run arbitrarily slowly
on a slow machine, logging also the "fast" actions to the slow query
log.

If the testcase is fixed so that it's only verified that the queries
which must be slow are indeed slow, it becomes rather trivial, making
it hard to justify the difference against the upstream. Thus, disable
the testcase completely.

http://jenkins.percona.com/job/percona-server-5.6-param/1670/