### PR TITLE
Bug 1650321: Valgrind error on main.audit_log_filter_commands

### DIFF
--- a/plugin/audit_log/filter.c
+++ b/plugin/audit_log/filter.c
@@ -360,17 +360,12 @@ void audit_log_set_exclude_commands(const char *val)
 */
 my_bool audit_log_check_command_included(const char *name, size_t length)
 {
-  command cmd;
   my_bool res;
 
-  command_init(&cmd, name, length);
-
   mysql_rwlock_rdlock(&LOCK_command_list);
-
-  res= my_hash_search(&include_commands,
-                      (const uchar*) cmd.name, cmd.length) != NULL;
-
+  res= my_hash_search(&include_commands, (const uchar*) name, length) != NULL;
   mysql_rwlock_unlock(&LOCK_command_list);
+
   return res;
 }
 
@@ -379,15 +374,11 @@ my_bool audit_log_check_command_included(const char *name, size_t length)
 */
 my_bool audit_log_check_command_excluded(const char *name, size_t length)
 {
-  command cmd;
   my_bool res;
 
-  command_init(&cmd, name, length);
-
   mysql_rwlock_rdlock(&LOCK_command_list);
-
-  res= my_hash_search(&exclude_commands,
-                      (const uchar*) cmd.name, cmd.length) != NULL;
+  res= my_hash_search(&exclude_commands, (const uchar*) name, length) != NULL;
   mysql_rwlock_unlock(&LOCK_command_list);
+
   return res;
 }


### PR DESCRIPTION
Valgrind complained about `cmd' being used uninitialized. However, I
don't see a path when it could happen, since the first command was to
initialize it unconditionally.

Still this error message pointed me to the fact that we don't need `cmd'
at all, we can simply use `name' and `length' provided as arguments.

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1674/