### PR TITLE
Bug 1650322: Valgrind error on main.audit_log_threadpool

### DIFF
--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -214,6 +214,7 @@ int threadpool_add_connection(THD *thd)
 
   if (!setup_connection_thread_globals(thd))
   {
+    lex_start(thd);
     bool rc= login_connection(thd);
     MYSQL_AUDIT_NOTIFY_CONNECTION_CONNECT(thd);
     if (!rc)


### PR DESCRIPTION
When connection created in thread-per-connection handle there is a
thd_prepare_connection which starts as following:

    bool rc;
    lex_start(thd);
    rc= login_connection(thd);
    MYSQL_AUDIT_NOTIFY_CONNECTION_CONNECT(thd);

In case of pool-of-threads handler, connection goes to
threadpool_add_connection which is missing the lex_start call.

    bool rc= login_connection(thd);
    MYSQL_AUDIT_NOTIFY_CONNECTION_CONNECT(thd);

The fix is to simply add missing lex_start invocation.