### PR TITLE
Fix lp:1652912 "Test main.bug80134 fails under AddressSanitizer default options" (5.5)

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -209,6 +209,9 @@ INSERT INTO global_suppressions VALUES
  */
  ("Insecure configuration for --secure-file-priv:*"),
 
+ /* ASan memory allocation warnings */
+ ("==[0-9]*== WARNING: AddressSanitizer failed to allocate 0x[0-9a-f]+ bytes"),
+
  ("THE_LAST_SUPPRESSION")||
 
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8718,3 +8718,33 @@ void init_server_psi_keys(void)
 
 #endif /* HAVE_PSI_INTERFACE */
 
+/* Detecting if being compiled with -fsanitize=address option */
+
+/* GCC has __SANITIZE_ADDRESS__ macro defined to 1 in this case */
+#ifdef __GNUC__
+  #if __SANITIZE_ADDRESS__ == 1
+    #define UNDER_ADDRESS_SANITIZER
+  #endif
+#endif
+
+/* Clang exposes __has_feature(address_sanitizer) */
+#ifdef __clang__
+  #if __has_feature(address_sanitizer)
+    #define UNDER_ADDRESS_SANITIZER
+  #endif
+#endif
+
+/*
+  As some MTR test cases check OOM, it is necessary to instruct address
+  sanitizer to not terminate the process when an allocation of a very
+  large memory block is requested and return NULL as expected. This can
+  be done by setting 'allocator_may_return_null' ASan option to 1.
+*/
+#ifdef UNDER_ADDRESS_SANITIZER
+
+extern "C" const char *__asan_default_options()
+{
+  return "allocator_may_return_null=1";
+}
+
+#endif


### PR DESCRIPTION
Under address sanitizer (both 'gcc' and 'clang') unsuccessful attempts to
allocate very large memory blocks result in printing the following warning
to stderr:
'==<PID>== WARNING: AddressSanitizer failed to allocate <NNN> bytes'.
As the result this message is added to Percona Server error log, which in
turn makes MTR test cases fail.

Unfortunately, there is no way to suppress specific ASan warnings and the
only way to resolve this issue is to add a suppression on the MTR level.
Instead of calling 'call mtr.add_suppression("...")' in individual tests,
this commit adds a new record to 'mtr.global_suppressions' table as testing
for OOM is pretty common case among existing MTR tests.

As some MTR test cases check for OOM, it is necessary to instruct address
sanitizer to not terminate the process when an allocation of a very
large memory block is requested and return NULL as expected.
This is done by defining '__asan_default_options()' ASan special function
which sets 'allocator_may_return_null' option to 1.