### PR TITLE
Add further diagnostics for bug 1661534 (Test innodb.percona_changed_…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_pages.result
+++ b/mysql-test/suite/innodb/r/percona_changed_pages.result
@@ -25,6 +25,8 @@ log record interval end LSN should have advanced after workload
 should_be_1
 1
 INSERT INTO T1 VALUES (REPEAT('C', 255));
+SELECT VARIABLE_VALUE INTO @start_max_trx_id FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME = 'Innodb_max_trx_id';
 log record interval start LSN should remain constant after workload
 should_be_1
 1
@@ -216,6 +218,9 @@ SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
 COUNT(*)
 5
 SET GLOBAL INNODB_MAX_CHANGED_PAGES = 1000000;
+SELECT VARIABLE_VALUE INTO @end_max_trx_id FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+WHERE VARIABLE_NAME = 'Innodb_max_trx_id';
+include/assert.inc [Maximum InnoDB transaction ID should not have moved during RO workload]
 include/assert.inc [No bitmap data must exist with START_LSN > @max_end_lsn]
 include/assert.inc [No bitmap data must exist with END_LSN > @max_end_lsn]
 CREATE TABLE ICP_COPY (

--- a/mysql-test/suite/innodb/t/percona_changed_pages.test
+++ b/mysql-test/suite/innodb/t/percona_changed_pages.test
@@ -84,6 +84,9 @@ INSERT INTO T1 VALUES (REPEAT('C', 255));
 
 --source include/restart_mysqld.inc
 
+SELECT VARIABLE_VALUE INTO @start_max_trx_id FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+       WHERE VARIABLE_NAME = 'Innodb_max_trx_id';
+
 --disable_query_log
 --echo log record interval start LSN should remain constant after workload
 eval SELECT MIN(START_LSN)=$r1_start AS should_be_1 FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
@@ -325,6 +328,15 @@ eval SET GLOBAL INNODB_MAX_CHANGED_PAGES = $old_max_changed_pages;
 
 # Verify that InnoDB did not write anything during the above tests, breaking them
 # (specifically the assumption that COUNT(*) == 0 WHERE START_LSN|END_LSN > @max_end_lsn)
+
+SELECT VARIABLE_VALUE INTO @end_max_trx_id FROM INFORMATION_SCHEMA.GLOBAL_STATUS
+       WHERE VARIABLE_NAME = 'Innodb_max_trx_id';
+
+--let $assert_text= Maximum InnoDB transaction ID should not have moved during RO workload
+--let $assert_cond= @end_max_trx_id = @start_max_trx_id
+--let $assert_debug= SELECT @start_max_trx_id, @end_max_trx_id
+--source include/assert.inc
+
 --let $assert_text= No bitmap data must exist with START_LSN > @max_end_lsn
 --let $assert_cond= COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE START_LSN > @max_end_lsn
 --let $assert_debug= SELECT * FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE START_LSN > @max_end_lsn;


### PR DESCRIPTION
…pages is unstable)

Test innodb.percona_changes_pages breaks intermittently due to LSN
advacing during read-only workload. Previous diagnostics showed that
this happens due to InnoDB transaction system header rewrite in the
system tablespace. Now add diagnostics to confirm whether that rewrite
happens due to maximum InnoDB transaction ID advancing.

http://jenkins.percona.com/job/percona-server-5.6-param/1686/