### PR TITLE
MYR-19 : webscale/facebook binlog group commit interfaces and interac…

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2432,8 +2432,6 @@ static std::string rdb_xid_to_string(const XID &src) {
   transactions.
 */
 static bool rocksdb_flush_wal(handlerton *const hton
-                              __attribute__((__unused__)),
-                              ulonglong target_lsn
                               __attribute__((__unused__))) {
   DBUG_ASSERT(rdb != nullptr);
   rocksdb_wal_group_syncs++;


### PR DESCRIPTION
…ts with SE

         differently
- MyRocks 5.6 has equivalent of PS 5.7 interface with small variance, but is
  not compatible with PS 5.6 at all.
- For PS 5.6, stripped out uncommon functionality. Cherry picking to 5.7 should
  properly re-introduce the group commit logic.
- Cherry picked to 5.7 reverted the change so MyRocks interacts with
  thd_store_lsn during prepare.
- Cherry pick merging commit e05afd2bd340f70eeb5ce29e44f57573f352f650 from ps-5.6-MYR-19