### PR TITLE
MYR-30 : MyRocks uses C++ printf formatters on functions unsupported

### DIFF
--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -20,6 +20,7 @@
 #endif
 
 /* C++ standard header files */
+#include <cinttypes>
 #include <set>
 #include <string>
 #include <unordered_set>


### PR DESCRIPTION
- Added include <cinttypes> to top of ha_rocksdb.h to ensure CMakeLists macro
  and PRI get picked up before other includes.
- Cherry pick merging commit aa1ecdcf149289a17b193beb2bf822a7b2a3a03c from ps-5.6-MYR-30