### PR TITLE
MYR-54 : rocksdb.sys_vars fails due to missing include files

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/include/correctboolvalue.inc
+++ b/mysql-test/suite/rocksdb.sys_vars/include/correctboolvalue.inc
@@ -1,0 +1,68 @@
+##
+# Maps true, True, TRUE, on, On, ON to 1
+# and false, False, FALSE, off, Off, OFF to 0
+#
+# $input the value of a boolean type
+# $output the value of int type
+##
+--let $int_value=$value
+if ($value==on)
+{
+  --let $int_value=1
+}
+
+if ($value==On)
+{
+  --let $int_value=1
+}
+
+if ($value==ON)
+{
+  --let $int_value=1
+}
+
+if ($value==off)
+{
+  --let $int_value=0
+}
+
+if ($value==Off)
+{
+  --let $int_value=0
+}
+
+if ($value==OFF)
+{
+  --let $int_value=0
+}
+
+# MySQL allows 'true' and 'false' on bool values
+if ($value==true)
+{
+  --let $int_value=1
+}
+
+if ($value==True)
+{
+  --let $int_value=1
+}
+
+if ($value==TRUE)
+{
+  --let $int_value=1
+}
+
+if ($value==false)
+{
+  --let $int_value=0
+}
+
+if ($value==False)
+{
+  --let $int_value=0
+}
+
+if ($value==FALSE)
+{
+  --let $int_value=0
+}

--- a/mysql-test/suite/rocksdb.sys_vars/include/rocksdb_sys_var.inc
+++ b/mysql-test/suite/rocksdb.sys_vars/include/rocksdb_sys_var.inc
@@ -1,0 +1,119 @@
+##
+# $sys_var name of the variable
+# $read_only - true if read-only
+# $session - true if this is session, false if global-only
+# valid_values table should contain valid values
+# invalid_values 
+##
+
+--eval SET @start_global_value = @@global.$sys_var
+SELECT @start_global_value;
+if ($session)
+{
+  --eval SET @start_session_value = @@session.$sys_var
+  SELECT @start_session_value;
+}
+
+if (!$read_only)
+{
+  --echo '# Setting to valid values in global scope#'
+
+  --let $i=1
+  --let $value=query_get_value(select value from valid_values, value, $i)
+  while ($value != 'No such row')
+  {
+    --echo "Trying to set variable @@global.$sys_var to $value"
+    --eval SET @@global.$sys_var   = $value
+    --eval SELECT @@global.$sys_var
+    --let $v=`SELECT @@global.$sys_var`
+    --source ./correctboolvalue.inc
+    if (!$sticky)
+    {
+      if ($v != $int_value)
+      {
+        --echo Set @@global.$sys_var to $value but it remained set to $v
+        --die Wrong variable value
+      }
+    }
+
+    --echo "Setting the global scope variable back to default"
+    --eval SET @@global.$sys_var = DEFAULT
+    --eval SELECT @@global.$sys_var
+
+    --inc $i
+    --let $value=query_get_value(select value from valid_values, value, $i)
+  }
+
+  if ($session)
+  {
+    --echo '# Setting to valid values in session scope#'
+
+    --let $i=1
+    --let $value=query_get_value(select value from valid_values, value, $i)
+    while ($value != 'No such row')
+    {
+      --echo "Trying to set variable @@session.$sys_var to $value"
+      --eval SET @@session.$sys_var   = $value
+      --eval SELECT @@session.$sys_var
+      --let $v=`SELECT @@session.$sys_var`
+      --source ./correctboolvalue.inc
+      if (!$sticky)
+      {
+        if ($v != $int_value)
+        {
+          --echo Set @@session.$sys_var to $value but it remained set to $v
+          --die Wrong variable value
+        }
+      }
+      --echo "Setting the session scope variable back to default"
+      --eval SET @@session.$sys_var = DEFAULT
+      --eval SELECT @@session.$sys_var
+
+      --inc $i
+      --let $value=query_get_value(select value from valid_values, value, $i)
+    }
+  }
+  if (!$session)
+  {
+    --echo "Trying to set variable @@session.$sys_var to 444. It should fail because it is not session."
+    --Error ER_GLOBAL_VARIABLE
+    --eval SET @@session.$sys_var   = 444
+  }
+
+  --echo '# Testing with invalid values in global scope #'
+  ####################################################################
+  #  Change the value of query_prealloc_size   to an invalid value   #
+  ####################################################################
+  --let $i=1
+  --let $value=query_get_value(select value from invalid_values, value, $i)
+  while ($value != 'No such row')
+  {
+    --echo "Trying to set variable @@global.$sys_var to $value"
+    --Error ER_WRONG_VALUE_FOR_VAR, ER_WRONG_TYPE_FOR_VAR
+    --eval SET @@global.$sys_var   = $value
+    --eval SELECT @@global.$sys_var
+    --inc $i
+    --let $value=query_get_value(select value from invalid_values, value, $i)
+  }
+}
+
+if ($read_only)
+{
+  --echo "Trying to set variable @@global.$sys_var to 444. It should fail because it is readonly."
+  --Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+  --eval SET @@global.$sys_var   = 444
+}
+
+####################################
+#     Restore initial value        #
+####################################
+if (!$read_only)
+{
+  --eval SET @@global.$sys_var = @start_global_value
+  --eval SELECT @@global.$sys_var
+  if ($session)
+  {
+    --eval SET @@session.$sys_var = @start_session_value
+    --eval SELECT @@session.$sys_var
+  }
+}

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_access_hint_on_compaction_start_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_access_hint_on_compaction_start_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_ACCESS_HINT_ON_COMPACTION_START
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_advise_random_on_open_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_advise_random_on_open_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_ADVISE_RANDOM_ON_OPEN
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_allow_concurrent_memtable_write_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_allow_concurrent_memtable_write_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_ALLOW_CONCURRENT_MEMTABLE_WRITE
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_allow_mmap_reads_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_allow_mmap_reads_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_ALLOW_MMAP_READS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_allow_mmap_writes_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_allow_mmap_writes_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_ALLOW_MMAP_WRITES
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_background_sync_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_background_sync_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_BACKGROUND_SYNC
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_base_background_compactions_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_base_background_compactions_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_BASE_BACKGROUND_COMPACTIONS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_cache_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_cache_size_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_BLOCK_CACHE_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_restart_interval_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_restart_interval_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_BLOCK_RESTART_INTERVAL
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_size_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_BLOCK_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_size_deviation_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_block_size_deviation_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_BLOCK_SIZE_DEVIATION
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_bulk_load_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_bulk_load_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_BULK_LOAD
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_bulk_load_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_bulk_load_size_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_BULK_LOAD_SIZE
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_bytes_per_sync_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_bytes_per_sync_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_BYTES_PER_SYNC
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_cache_index_and_filter_blocks_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_cache_index_and_filter_blocks_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_CACHE_INDEX_AND_FILTER_BLOCKS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_checksums_pct_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_checksums_pct_basic.test
@@ -11,7 +11,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_CHECKSUMS_PCT
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_collect_sst_properties_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_collect_sst_properties_basic.test
@@ -3,6 +3,6 @@
 --let $sys_var=ROCKSDB_COLLECT_SST_PROPERTIES
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_commit_in_the_middle_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_commit_in_the_middle_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_COMMIT_IN_THE_MIDDLE
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compact_cf_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compact_cf_basic.test
@@ -10,7 +10,7 @@ CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 --let $read_only=0
 --let $session=0
 --let $sticky=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_readahead_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_readahead_size_basic.test
@@ -17,7 +17,7 @@ SELECT @@global.rocksdb_compaction_readahead_size;
 --let $sys_var=ROCKSDB_COMPACTION_READAHEAD_SIZE
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'2000001\'');
 --let $sys_var=ROCKSDB_COMPACTION_SEQUENTIAL_DELETES
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_count_sd_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_count_sd_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_COMPACTION_SEQUENTIAL_DELETES_COUNT_SD
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_file_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_file_size_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_COMPACTION_SEQUENTIAL_DELETES_FILE_SIZE
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_window_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_compaction_sequential_deletes_window_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'2000001\'');
 --let $sys_var=ROCKSDB_COMPACTION_SEQUENTIAL_DELETES_WINDOW
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_create_if_missing_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_create_if_missing_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_CREATE_IF_MISSING
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_create_missing_column_families_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_create_missing_column_families_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_CREATE_MISSING_COLUMN_FAMILIES
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_datadir_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_datadir_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_DATADIR
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_db_write_buffer_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_db_write_buffer_size_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_DB_WRITE_BUFFER_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_deadlock_detect_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_deadlock_detect_basic.test
@@ -14,7 +14,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $read_only=0
 --let $session=1
 --let $sticky=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_debug_optimizer_no_zero_cardinality_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_debug_optimizer_no_zero_cardinality_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_DEBUG_OPTIMIZER_NO_ZERO_CARDINALITY
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_default_cf_options_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_default_cf_options_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_DEFAULT_CF_OPTIONS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_delete_obsolete_files_period_micros_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_delete_obsolete_files_period_micros_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_DELETE_OBSOLETE_FILES_PERIOD_MICROS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_disable_2pc_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_disable_2pc_basic.test
@@ -14,7 +14,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $read_only=0
 --let $session=0
 --let $sticky=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_disabledatasync_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_disabledatasync_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_DISABLEDATASYNC
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_enable_bulk_load_api_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_enable_bulk_load_api_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_ENABLE_BULK_LOAD_API
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_enable_thread_tracking_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_enable_thread_tracking_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_ENABLE_THREAD_TRACKING
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_enable_write_thread_adaptive_yield_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_enable_write_thread_adaptive_yield_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_ENABLE_WRITE_THREAD_ADAPTIVE_YIELD
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_error_if_exists_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_error_if_exists_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_ERROR_IF_EXISTS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_force_flush_memtable_now_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_force_flush_memtable_now_basic.test
@@ -11,7 +11,7 @@ CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 --let $read_only=0
 --let $session=0
 --let $sticky=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_force_index_records_in_range_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_force_index_records_in_range_basic.test
@@ -17,7 +17,7 @@ SELECT @@session.rocksdb_force_index_records_in_range;
 --let $sys_var=ROCKSDB_FORCE_INDEX_RECORDS_IN_RANGE
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_hash_index_allow_collision_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_hash_index_allow_collision_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_HASH_INDEX_ALLOW_COLLISION
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_index_type_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_index_type_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_INDEX_TYPE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_info_log_level_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_info_log_level_basic.test
@@ -15,7 +15,7 @@ INSERT INTO invalid_values VALUES('foo');
 --let $sys_var=ROCKSDB_INFO_LOG_LEVEL
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_is_fd_close_on_exec_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_is_fd_close_on_exec_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_IS_FD_CLOSE_ON_EXEC
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_keep_log_file_num_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_keep_log_file_num_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_KEEP_LOG_FILE_NUM
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_lock_scanned_rows_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_lock_scanned_rows_basic.test
@@ -16,7 +16,7 @@ INSERT INTO invalid_values VALUES(1000);
 --let $sys_var=ROCKSDB_LOCK_SCANNED_ROWS
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_lock_wait_timeout_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_lock_wait_timeout_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_LOCK_WAIT_TIMEOUT
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_log_file_time_to_roll_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_log_file_time_to_roll_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_LOG_FILE_TIME_TO_ROLL
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_manifest_preallocation_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_manifest_preallocation_size_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_MANIFEST_PREALLOCATION_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_background_compactions_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_background_compactions_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'abc\'');
 --let $sys_var=ROCKSDB_MAX_BACKGROUND_COMPACTIONS
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_background_flushes_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_background_flushes_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_MAX_BACKGROUND_FLUSHES
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_log_file_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_log_file_size_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_MAX_LOG_FILE_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_manifest_file_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_manifest_file_size_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_MAX_MANIFEST_FILE_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_open_files_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_open_files_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_MAX_OPEN_FILES
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_row_locks_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_row_locks_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_MAX_ROW_LOCKS
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_subcompactions_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_subcompactions_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_MAX_SUBCOMPACTIONS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_total_wal_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_total_wal_size_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_MAX_TOTAL_WAL_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_new_table_reader_for_compaction_inputs_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_new_table_reader_for_compaction_inputs_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_NEW_TABLE_READER_FOR_COMPACTION_INPUTS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_no_block_cache_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_no_block_cache_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_NO_BLOCK_CACHE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_override_cf_options_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_override_cf_options_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_OVERRIDE_CF_OPTIONS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_paranoid_checks_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_paranoid_checks_basic.test
@@ -3,5 +3,5 @@
 --let $sys_var=ROCKSDB_PARANOID_CHECKS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_pause_background_work_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_pause_background_work_basic.test
@@ -14,7 +14,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $read_only=0
 --let $session=0
 --let $sticky=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_perf_context_level_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_perf_context_level_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_PERF_CONTEXT_LEVEL
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_persistent_cache_path_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_persistent_cache_path_basic.test
@@ -10,7 +10,7 @@ CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 --let $read_only=1
 --let $session=0
 --let $sticky=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_persistent_cache_size_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_persistent_cache_size_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_PERSISTENT_CACHE_SIZE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_pin_l0_filter_and_index_blocks_in_cache_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_pin_l0_filter_and_index_blocks_in_cache_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_PIN_L0_FILTER_AND_INDEX_BLOCKS_IN_CACHE
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_print_snapshot_conflict_queries_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_print_snapshot_conflict_queries_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_PRINT_SNAPSHOT_CONFLICT_QUERIES
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_rate_limiter_bytes_per_sec_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_rate_limiter_bytes_per_sec_basic.test
@@ -36,7 +36,7 @@ INSERT INTO invalid_values VALUES('\'aaa\''), (3.14);
 # Test all the valid and invalid values
 --let $sys_var=ROCKSDB_RATE_LIMITER_BYTES_PER_SEC
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_read_free_rpl_tables_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_read_free_rpl_tables_basic.test
@@ -9,7 +9,7 @@ CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
 --let $sys_var=ROCKSDB_READ_FREE_RPL_TABLES
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_records_in_range_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_records_in_range_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_RECORDS_IN_RANGE
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_rpl_skip_tx_api_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_rpl_skip_tx_api_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_RPL_SKIP_TX_API
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_seconds_between_stat_computes_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_seconds_between_stat_computes_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_SECONDS_BETWEEN_STAT_COMPUTES
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_signal_drop_index_thread_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_signal_drop_index_thread_basic.test
@@ -13,7 +13,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $read_only=0
 --let $session=0
 --let $sticky=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_skip_bloom_filter_on_read_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_skip_bloom_filter_on_read_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_SKIP_BLOOM_FILTER_ON_READ
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_skip_fill_cache_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_skip_fill_cache_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_SKIP_FILL_CACHE
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_stats_dump_period_sec_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_stats_dump_period_sec_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_STATS_DUMP_PERIOD_SEC
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_store_row_debug_checksums_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_store_row_debug_checksums_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_STORE_ROW_DEBUG_CHECKSUMS
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_strict_collation_check_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_strict_collation_check_basic.test
@@ -13,7 +13,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_STRICT_COLLATION_CHECK
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_table_cache_numshardbits_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_table_cache_numshardbits_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_TABLE_CACHE_NUMSHARDBITS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_table_stats_sampling_pct_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_table_stats_sampling_pct_basic.test
@@ -15,7 +15,7 @@ INSERT INTO invalid_values VALUES('\'484436\'');
 --let $sys_var=ROCKSDB_TABLE_STATS_SAMPLING_PCT
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_trace_sst_api_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_trace_sst_api_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_TRACE_SST_API
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_unsafe_for_binlog_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_unsafe_for_binlog_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_UNSAFE_FOR_BINLOG
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_adaptive_mutex_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_adaptive_mutex_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_USE_ADAPTIVE_MUTEX
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_direct_reads_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_direct_reads_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_USE_DIRECT_READS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_direct_writes_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_direct_writes_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_USE_DIRECT_WRITES
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_fsync_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_use_fsync_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_USE_FSYNC
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_validate_tables_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_validate_tables_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_VALIDATE_TABLES
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_verify_row_debug_checksums_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_verify_row_debug_checksums_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_VERIFY_ROW_DEBUG_CHECKSUMS
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_bytes_per_sync_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_bytes_per_sync_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_WAL_BYTES_PER_SYNC
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_dir_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_dir_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_WAL_DIR
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_recovery_mode_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_recovery_mode_basic.test
@@ -10,7 +10,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_WAL_RECOVERY_MODE
 --let $read_only=0
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_size_limit_mb_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_size_limit_mb_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_WAL_SIZE_LIMIT_MB
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_ttl_seconds_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_wal_ttl_seconds_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_WAL_TTL_SECONDS
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_whole_key_filtering_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_whole_key_filtering_basic.test
@@ -3,4 +3,4 @@
 --let $sys_var=ROCKSDB_WHOLE_KEY_FILTERING
 --let $read_only=1
 --let $session=0
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_disable_wal_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_disable_wal_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_WRITE_DISABLE_WAL
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_ignore_missing_column_families_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_ignore_missing_column_families_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'bbb\'');
 --let $sys_var=ROCKSDB_WRITE_IGNORE_MISSING_COLUMN_FAMILIES
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_sync_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_sync_basic.test
@@ -12,7 +12,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 --let $sys_var=ROCKSDB_WRITE_SYNC
 --let $read_only=0
 --let $session=1
---source suite/sys_vars/inc/rocksdb_sys_var.inc
+--source ../include/rocksdb_sys_var.inc
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;


### PR DESCRIPTION
- Copied in upstream files to new directory mysql-test/rocksdb.sys_vars/include
- Fixed up all rocksdb.sys_vars tests to use new locations