### PR TITLE
Bug#82599: slave_type_conversions messing with data which still fits

### DIFF
--- a/mysql-test/suite/rpl/r/bug82599.result
+++ b/mysql-test/suite/rpl/r/bug82599.result
@@ -1,0 +1,97 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+#
+# Bug #82599: slave_type_conversions messing with
+# data which still fits within allowed range
+#
+SET @saved_slave_type_conversions=@@global.slave_type_conversions;
+SET @@global.slave_type_conversions=ALL_NON_LOSSY;
+CREATE TABLE `type_convert` (
+`id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+`providerid`  tinyint(3) unsigned NOT NULL,
+`providerid2` tinyint(3) signed NOT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+include/sync_slave_sql_with_master.inc
+SET @@global.slave_type_conversions='ALL_NON_LOSSY';
+ALTER TABLE test.type_convert MODIFY providerid SMALLINT UNSIGNED NOT NULL;
+ALTER TABLE test.type_convert MODIFY providerid2 SMALLINT SIGNED NOT NULL;
+INSERT INTO type_convert(providerid, providerid2) VALUES (128, -12);
+include/sync_slave_sql_with_master.inc
+# The default sign conversion for ALL_NON_LOSSY is ALL_SIGNED, thus unsigned
+# values will be first converted to signed value - causing possible truncations
+SELECT * FROM type_convert;
+id	providerid	providerid2
+1	0	-12
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_UNSIGNED';
+# With ALL_UNSIGNED conversion unsigned values will not be truncated,
+# however this conversion causes singed values to be converted to
+# unsigned value, i.e. < 0 on master => 0 on slave
+INSERT INTO type_convert(providerid, providerid2) VALUES (128, -12);
+include/sync_slave_sql_with_master.inc
+SELECT * FROM type_convert;
+id	providerid	providerid2
+1	0	-12
+2	128	244
+# Thus the only option to propagate correctly table with both signed and unsigned
+# values which fields were extended on slave is to assume that the sign on master
+# is the same as on slave
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_SIGNS_AS_ON_SLAVE';
+INSERT INTO type_convert(providerid, providerid2) VALUES (128, -12);
+include/sync_slave_sql_with_master.inc
+SELECT * FROM type_convert;
+id	providerid	providerid2
+1	0	-12
+2	128	244
+3	128	-12
+SET @@global.slave_type_conversions='ALL_NON_LOSSY';
+CREATE TABLE c1 (id INT UNSIGNED NOT NULL,
+id2 INT SIGNED NOT NULL);
+include/sync_slave_sql_with_master.inc
+ALTER TABLE c1 MODIFY id BIGINT NOT NULL;
+ALTER TABLE c1 MODIFY id2 BIGINT NOT NULL;
+INSERT INTO c1 (id, id2) VALUES (1,-120),(2147483647,-120),(2147483649,-120),(2147483650,-120);
+include/sync_slave_sql_with_master.inc
+SELECT * FROM test.c1;
+id	id2
+1	-120
+2147483647	-120
+-2147483647	-120
+-2147483646	-120
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_UNSIGNED';
+INSERT INTO c1 (id, id2) VALUES (1,-120),(2147483647,-120),(2147483649,-120),(2147483650,-120);
+include/sync_slave_sql_with_master.inc
+SELECT * FROM test.c1;
+id	id2
+1	-120
+2147483647	-120
+-2147483647	-120
+-2147483646	-120
+1	4294967176
+2147483647	4294967176
+2147483649	4294967176
+2147483650	4294967176
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_SIGNS_AS_ON_SLAVE';
+INSERT INTO c1 (id, id2) VALUES (1,-120),(2147483647,-120),(2147483649,-120),(2147483650,-120);
+include/sync_slave_sql_with_master.inc
+SELECT * FROM test.c1;
+id	id2
+1	-120
+2147483647	-120
+-2147483647	-120
+-2147483646	-120
+1	4294967176
+2147483647	4294967176
+2147483649	4294967176
+2147483650	4294967176
+1	-120
+2147483647	-120
+-2147483647	-120
+-2147483646	-120
+SET GLOBAL slave_type_conversions=@saved_slave_type_conversions;
+DROP TABLE type_convert;
+DROP TABLE c1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/bug82599.test
+++ b/mysql-test/suite/rpl/t/bug82599.test
@@ -1,0 +1,103 @@
+--source include/master-slave.inc
+
+--echo #
+--echo # Bug #82599: slave_type_conversions messing with
+--echo # data which still fits within allowed range
+--echo #
+
+--source include/have_binlog_format_row.inc
+
+connection slave;
+SET @saved_slave_type_conversions=@@global.slave_type_conversions;
+SET @@global.slave_type_conversions=ALL_NON_LOSSY;
+
+connection master;
+
+CREATE TABLE `type_convert` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `providerid`  tinyint(3) unsigned NOT NULL,
+  `providerid2` tinyint(3) signed NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+--source include/sync_slave_sql_with_master.inc
+
+SET @@global.slave_type_conversions='ALL_NON_LOSSY';
+ALTER TABLE test.type_convert MODIFY providerid SMALLINT UNSIGNED NOT NULL;
+ALTER TABLE test.type_convert MODIFY providerid2 SMALLINT SIGNED NOT NULL;
+
+connection master;
+INSERT INTO type_convert(providerid, providerid2) VALUES (128, -12);
+
+--source include/sync_slave_sql_with_master.inc
+
+--echo # The default sign conversion for ALL_NON_LOSSY is ALL_SIGNED, thus unsigned
+--echo # values will be first converted to signed value - causing possible truncations
+
+SELECT * FROM type_convert;
+
+connection slave;
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_UNSIGNED';
+
+--echo # With ALL_UNSIGNED conversion unsigned values will not be truncated,
+--echo # however this conversion causes singed values to be converted to
+--echo # unsigned value, i.e. < 0 on master => 0 on slave
+
+connection master;
+INSERT INTO type_convert(providerid, providerid2) VALUES (128, -12);
+--source include/sync_slave_sql_with_master.inc
+
+SELECT * FROM type_convert;
+
+--echo # Thus the only option to propagate correctly table with both signed and unsigned
+--echo # values which fields were extended on slave is to assume that the sign on master
+--echo # is the same as on slave
+
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_SIGNS_AS_ON_SLAVE';
+
+connection master;
+INSERT INTO type_convert(providerid, providerid2) VALUES (128, -12);
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM type_convert;
+
+# Some more tests to verify the above - INT to BIGINT
+
+SET @@global.slave_type_conversions='ALL_NON_LOSSY';
+connection master;
+CREATE TABLE c1 (id INT UNSIGNED NOT NULL,
+		 id2 INT SIGNED NOT NULL);
+--source include/sync_slave_sql_with_master.inc
+
+ALTER TABLE c1 MODIFY id BIGINT NOT NULL;
+ALTER TABLE c1 MODIFY id2 BIGINT NOT NULL;
+
+connection master;
+INSERT INTO c1 (id, id2) VALUES (1,-120),(2147483647,-120),(2147483649,-120),(2147483650,-120);
+--source include/sync_slave_sql_with_master.inc
+
+SELECT * FROM test.c1;
+
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_UNSIGNED';
+
+connection master;
+INSERT INTO c1 (id, id2) VALUES (1,-120),(2147483647,-120),(2147483649,-120),(2147483650,-120);
+--source include/sync_slave_sql_with_master.inc
+
+SELECT * FROM test.c1;
+
+SET @@global.slave_type_conversions='ALL_NON_LOSSY,ALL_SIGNS_AS_ON_SLAVE';
+
+connection master;
+INSERT INTO c1 (id, id2) VALUES (1,-120),(2147483647,-120),(2147483649,-120),(2147483650,-120);
+--source include/sync_slave_sql_with_master.inc
+
+SELECT * FROM test.c1;
+
+# cleanup
+SET GLOBAL slave_type_conversions=@saved_slave_type_conversions;
+connection master;
+DROP TABLE type_convert;
+DROP TABLE c1;
+
+--source include/rpl_end.inc
+

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -145,7 +145,8 @@ enum enum_slave_exec_mode { SLAVE_EXEC_MODE_STRICT,
 enum enum_slave_type_conversions { SLAVE_TYPE_CONVERSIONS_ALL_LOSSY,
                                    SLAVE_TYPE_CONVERSIONS_ALL_NON_LOSSY,
                                    SLAVE_TYPE_CONVERSIONS_ALL_UNSIGNED,
-                                   SLAVE_TYPE_CONVERSIONS_ALL_SIGNED};
+                                   SLAVE_TYPE_CONVERSIONS_ALL_SIGNED,
+                                   SLAVE_TYPE_CONVERSIONS_ALL_SIGNS_AS_ON_SLAVE};
 enum enum_slave_rows_search_algorithms { SLAVE_ROWS_TABLE_SCAN = (1U << 0),
                                          SLAVE_ROWS_INDEX_SCAN = (1U << 1),
                                          SLAVE_ROWS_HASH_SCAN  = (1U << 2)};

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2872,7 +2872,8 @@ static Sys_var_enum Slave_exec_mode(
        GLOBAL_VAR(slave_exec_mode_options), CMD_LINE(REQUIRED_ARG),
        slave_exec_mode_names, DEFAULT(SLAVE_EXEC_MODE_STRICT));
 const char *slave_type_conversions_name[]=
-       {"ALL_LOSSY", "ALL_NON_LOSSY", "ALL_UNSIGNED", "ALL_SIGNED", 0};
+       {"ALL_LOSSY", "ALL_NON_LOSSY", "ALL_UNSIGNED", "ALL_SIGNED",
+        "ALL_SIGNS_AS_ON_SLAVE", 0};
 static Sys_var_set Slave_type_conversions(
        "slave_type_conversions",
        "Set of slave type conversions that are enabled. Legal values are:"
@@ -2880,8 +2881,10 @@ static Sys_var_set Slave_type_conversions(
        " ALL_NON_LOSSY to enable non-lossy conversions,"
        " ALL_UNSIGNED to treat all integer column type data to be unsigned values, and"
        " ALL_SIGNED to treat all integer column type data to be signed values."
+       " ALL_SIGNS_AS_ON_SLAVE to get a sign of integer column from slave."
        " Default treatment is ALL_SIGNED. If ALL_SIGNED and ALL_UNSIGNED both are"
        " specifed, ALL_SIGNED will take high priority than ALL_UNSIGNED."
+       " ALL_SIGNS_AS_ON_SLAVE will take high priority than ALL_SIGNED and ALL_UNSIGNED."
        " If the variable is assigned the empty set, no conversions are"
        " allowed and it is expected that the types match exactly.",
        GLOBAL_VAR(slave_type_conversions_options), CMD_LINE(REQUIRED_ARG),


### PR DESCRIPTION
Prior to this fix it was not possible to correctly replicate table on
master that contained both signed and unsigned columns to slave table
with these fields extended (for instance from tinyint to smallint).
Current options ALL_SINGED and ALL_UNSIGNED can cause - respectively
unsigned value truncation, sign value truncation. Thus this fix
incorporates a new option ALL_SIGNS_AS_ON_SLAVE.