### PR TITLE
Fix lp:1663452 "Resource allocation failures in 'CREATE/DROP COMPRESSION_DICTIONARY' result in server crashes (debug mode) | handle_fatal_signal (sig=6) in innobase_create_zip_dict" (5.6)

### DIFF
--- a/mysql-test/suite/innodb/r/xtradb_compressed_columns_debug.result
+++ b/mysql-test/suite/innodb/r/xtradb_compressed_columns_debug.result
@@ -15,3 +15,23 @@ abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcab
 DROP TABLE t1;
 SET GLOBAL innodb_file_format = @old_innodb_file_format;
 SET GLOBAL innodb_compressed_columns_zip_level = @old_innodb_compressed_columns_zip_level;
+SET @dict_data = REPEAT('a', 16384);
+CREATE COMPRESSION_DICTIONARY d1(@dict_data);
+SET SESSION debug = "+d,btr_store_big_rec_extern";
+CREATE COMPRESSION_DICTIONARY d2(@dict_data);
+ERROR HY000: The table 'SYS_ZIP_DICT' is full
+SET SESSION debug = "-d,btr_store_big_rec_extern";
+SET debug = '+d,ib_create_table_fail_too_many_trx';
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Too many active concurrent transactions
+CREATE COMPRESSION_DICTIONARY d2(@dict_data);
+ERROR HY000: Too many active concurrent transactions
+SET debug = '-d,ib_create_table_fail_too_many_trx';
+SET debug = '+d,simulate_out_of_memory';
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Out of memory; check if mysqld or some other process uses all available memory; if not, you may have to use 'ulimit' to allow mysqld to use more memory or you can add more swap space
+SET debug = '+d,simulate_out_of_memory';
+CREATE COMPRESSION_DICTIONARY d2(@dict_data);
+ERROR HY000: Out of memory; check if mysqld or some other process uses all available memory; if not, you may have to use 'ulimit' to allow mysqld to use more memory or you can add more swap space
+SET debug = '-d,simulate_out_of_memory';
+DROP COMPRESSION_DICTIONARY d1;

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_debug.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_debug.test
@@ -24,3 +24,34 @@ DROP TABLE t1;
 
 SET GLOBAL innodb_file_format = @old_innodb_file_format;
 SET GLOBAL innodb_compressed_columns_zip_level = @old_innodb_compressed_columns_zip_level;
+
+#
+# Bug lp:1663452 "Resource allocation failures in 'CREATE/DROP COMPRESSION_DICTIONARY' result in server crashes (debug mode) | handle_fatal_signal (sig=6) in innobase_create_zip_dict"
+#
+SET @dict_data = REPEAT('a', 16384);
+CREATE COMPRESSION_DICTIONARY d1(@dict_data);
+
+# Check for out of disk space simulation.
+SET SESSION debug = "+d,btr_store_big_rec_extern";
+--error ER_RECORD_FILE_FULL
+CREATE COMPRESSION_DICTIONARY d2(@dict_data);
+SET SESSION debug = "-d,btr_store_big_rec_extern";
+
+# Check for too many concurrent transactions simulation
+SET debug = '+d,ib_create_table_fail_too_many_trx';
+--error ER_TOO_MANY_CONCURRENT_TRXS
+DROP COMPRESSION_DICTIONARY d1;
+--error ER_TOO_MANY_CONCURRENT_TRXS
+CREATE COMPRESSION_DICTIONARY d2(@dict_data);
+SET debug = '-d,ib_create_table_fail_too_many_trx';
+
+# Check for out of memory simulation
+SET debug = '+d,simulate_out_of_memory';
+--error ER_OUT_OF_RESOURCES
+DROP COMPRESSION_DICTIONARY d1;
+SET debug = '+d,simulate_out_of_memory';
+--error ER_OUT_OF_RESOURCES
+CREATE COMPRESSION_DICTIONARY d2(@dict_data);
+SET debug = '-d,simulate_out_of_memory';
+
+DROP COMPRESSION_DICTIONARY d1;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -812,6 +812,11 @@ enum handler_create_zip_dict_result
   HA_CREATE_ZIP_DICT_NAME_TOO_LONG,  /*!< zip dict name is too long */
   HA_CREATE_ZIP_DICT_DATA_TOO_LONG,  /*!< zip dict data is too long */
   HA_CREATE_ZIP_DICT_READ_ONLY,      /*!< cannot create in read-only mode */
+  HA_CREATE_ZIP_DICT_OUT_OF_MEMORY,  /*!< out of memory */
+  HA_CREATE_ZIP_DICT_OUT_OF_FILE_SPACE,
+                                     /*!< out of disk space */
+  HA_CREATE_ZIP_DICT_TOO_MANY_CONCURRENT_TRXS,
+                                     /*!< too many concurrent transactions */
   HA_CREATE_ZIP_DICT_UNKNOWN_ERROR   /*!< unknown error during zip_dict
                                           creation */
 };
@@ -824,6 +829,11 @@ enum handler_drop_zip_dict_result
                                         exist */
   HA_DROP_ZIP_DICT_IS_REFERENCED,  /*!< zip dict is in use */
   HA_DROP_ZIP_DICT_READ_ONLY,      /*!< cannot drop in read-only mode */
+  HA_DROP_ZIP_DICT_OUT_OF_MEMORY,  /*!< out of memory */
+  HA_DROP_ZIP_DICT_OUT_OF_FILE_SPACE,
+                                   /*!< out of disk space */
+  HA_DROP_ZIP_DICT_TOO_MANY_CONCURRENT_TRXS,
+                                   /*!< too many concurrent transactions */
   HA_DROP_ZIP_DICT_UNKNOWN_ERROR   /*!< unknown error during zip_dict
                                         removal */
 };

--- a/sql/sql_zip_dict.cc
+++ b/sql/sql_zip_dict.cc
@@ -41,6 +41,10 @@ Creates a new compression dictionary with the specified data.
 @retval ER_COMPRESSION_DICTIONARY_EXISTS        Dictionary with such name
                                                 already exists
 @retval ER_READ_ONLY_MODE                       Forbidden in read-only mode
+@retval ER_OUT_OF_RESOURCES                     Out of memory
+@retval ER_RECORD_FILE_FULL                     Out of disk space
+@retval ER_TOO_MANY_CONCURRENT_TRXS             Too many concurrent
+                                                transactions
 @retval ER_UNKNOWN_ERROR                        Unknown error
 */
 int mysql_create_zip_dict(THD* thd, const char* name, ulong name_len,
@@ -94,6 +98,18 @@ int mysql_create_zip_dict(THD* thd, const char* name, ulong name_len,
         error= ER_READ_ONLY_MODE;
         my_error(error, MYF(0));
         break;
+      case HA_CREATE_ZIP_DICT_OUT_OF_MEMORY:
+        error= ER_OUT_OF_RESOURCES;
+        my_error(error, MYF(0));
+        break;
+      case HA_CREATE_ZIP_DICT_OUT_OF_FILE_SPACE:
+        error= ER_RECORD_FILE_FULL;
+        my_error(error, MYF(0), "SYS_ZIP_DICT");
+        break;
+      case HA_CREATE_ZIP_DICT_TOO_MANY_CONCURRENT_TRXS:
+        error= ER_TOO_MANY_CONCURRENT_TRXS;
+        my_error(error, MYF(0));
+        break;
       default:
         DBUG_ASSERT(0);
         error= ER_UNKNOWN_ERROR;
@@ -123,6 +139,10 @@ Deletes a compression dictionary.
 @retval ER_COMPRESSION_DICTIONARY_IS_REFERENCED  Dictictionary is still in
                                                  use
 @retval ER_READ_ONLY_MODE                        Forbidden in read-only mode
+@retval ER_OUT_OF_RESOURCES                      Out of memory
+@retval ER_RECORD_FILE_FULL                      Out of disk space
+@retval ER_TOO_MANY_CONCURRENT_TRXS              Too many concurrent
+                                                 transactions
 @retval ER_UNKNOWN_ERROR                         Unknown error
 */
 int mysql_drop_zip_dict(THD* thd, const char* name, ulong name_len,
@@ -168,6 +188,18 @@ int mysql_drop_zip_dict(THD* thd, const char* name, ulong name_len,
         break;
       case HA_DROP_ZIP_DICT_READ_ONLY:
         error= ER_READ_ONLY_MODE;
+        my_error(error, MYF(0));
+        break;
+      case HA_DROP_ZIP_DICT_OUT_OF_MEMORY:
+        error= ER_OUT_OF_RESOURCES;
+        my_error(error, MYF(0));
+        break;
+      case HA_DROP_ZIP_DICT_OUT_OF_FILE_SPACE:
+        error= ER_RECORD_FILE_FULL;
+        my_error(error, MYF(0), "SYS_ZIP_DICT");
+        break;
+      case HA_DROP_ZIP_DICT_TOO_MANY_CONCURRENT_TRXS:
+        error= ER_TOO_MANY_CONCURRENT_TRXS;
         my_error(error, MYF(0));
         break;
       default:

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4178,6 +4178,15 @@ innobase_create_zip_dict(
 		case DB_DUPLICATE_KEY:
 			result = HA_CREATE_ZIP_DICT_ALREADY_EXISTS;
 			break;
+		case DB_OUT_OF_MEMORY:
+			result = HA_CREATE_ZIP_DICT_OUT_OF_MEMORY;
+			break;
+		case DB_OUT_OF_FILE_SPACE:
+			result = HA_CREATE_ZIP_DICT_OUT_OF_FILE_SPACE;
+			break;
+		case DB_TOO_MANY_CONCURRENT_TRXS:
+			result = HA_CREATE_ZIP_DICT_TOO_MANY_CONCURRENT_TRXS;
+			break;
 		default:
 			ut_ad(0);
 			result = HA_CREATE_ZIP_DICT_UNKNOWN_ERROR;
@@ -4213,6 +4222,15 @@ innobase_drop_zip_dict(
 			break;
 		case DB_ROW_IS_REFERENCED:
 			result = HA_DROP_ZIP_DICT_IS_REFERENCED;
+			break;
+		case DB_OUT_OF_MEMORY:
+			result = HA_DROP_ZIP_DICT_OUT_OF_MEMORY;
+			break;
+		case DB_OUT_OF_FILE_SPACE:
+			result = HA_DROP_ZIP_DICT_OUT_OF_FILE_SPACE;
+			break;
+		case DB_TOO_MANY_CONCURRENT_TRXS:
+			result = HA_DROP_ZIP_DICT_TOO_MANY_CONCURRENT_TRXS;
 			break;
 		default:
 			ut_ad(0);


### PR DESCRIPTION
'innobase_create_zip_dict()' / 'mysql_create_zip_dict()' and
'innobase_drop_zip_dict()' / 'mysql_drop_zip_dict()' extended with additional
error return codes ('Out of memory', 'Out of disk space' and
'Too many concurrent transactions') so that proper diagnostic messages are
printed when 'CREATE/DROP COMPRESSION_DICTIONARY' statements encounter
resource shortage problem.

'innodb.xtradb_compressed_columns_debug' extended with corresponding checks
for those three types of resource allocation problems.