### PR TITLE
Fix bug 1664280 (Race condition between buffer pool page optimistic a…

### DIFF
--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -700,8 +700,8 @@ buf_page_get_newest_modification(
 					page frame */
 /********************************************************************//**
 Increments the modify clock of a frame by 1. The caller must (1) own the
-buf_pool->LRU_list_mutex and block bufferfix count has to be zero, (2) or own
-an x-lock on the block, (3) or the block must belong to an intrinsic table. */
+buffer page mutex and block bufferfix count has to be zero, (2) or own an
+x-lock on the block, (3) or the block must belong to an intrinsic table. */
 UNIV_INLINE
 void
 buf_block_modify_clock_inc(

--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -913,8 +913,8 @@ buf_page_get_newest_modification(
 
 /********************************************************************//**
 Increments the modify clock of a frame by 1. The caller must (1) own the
-buf_pool->LRU_list_mutex and block bufferfix count has to be zero, (2) or own
-an x-lock on the block, (3) or the block must belong to an intrinsic table. */
+buffer page mutex and block bufferfix count has to be zero, (2) or own an
+x-lock on the block, (3) or the block must belong to an intrinsic table. */
 UNIV_INLINE
 void
 buf_block_modify_clock_inc(
@@ -922,12 +922,12 @@ buf_block_modify_clock_inc(
 	buf_block_t*	block)	/*!< in: block */
 {
 #ifdef UNIV_DEBUG
-	buf_pool_t*	buf_pool = buf_pool_from_bpage((buf_page_t*) block);
+	const buf_page_t* const	bpage = &block->page;
 
 	/* No latch is acquired if block belongs to intrinsic table. */
-	if (!fsp_is_system_temporary(block->page.id.space())) {
-		ut_ad((mutex_own(&buf_pool->LRU_list_mutex)
-		       && (block->page.buf_fix_count == 0))
+	if (!fsp_is_system_temporary(bpage->id.space())) {
+		ut_ad((mutex_own(buf_page_get_mutex(bpage))
+		       && (bpage->buf_fix_count == 0))
 		      || rw_lock_own_flagged(&block->lock,
 					     RW_LOCK_FLAG_X | RW_LOCK_FLAG_SX));
 	}
@@ -1016,8 +1016,9 @@ buf_block_unfix(
 	buf_page_t*	bpage)
 {
 	ut_ad(!mutex_own(buf_page_get_mutex(bpage)));
-	ulint	count = os_atomic_decrement_uint32(&bpage->buf_fix_count, 1);
-	ut_ad(count + 1 != 0);
+	const ib_uint32_t count
+		= os_atomic_decrement_uint32(&bpage->buf_fix_count, 1);
+	ut_ad(count != UINT32_MAX);
 	return(count);
 }
 


### PR DESCRIPTION
…ccess and eviction | InnoDB: Failing assertion: buf_page_in_file(bpage) in buf_page_make_young)

buf_page_optimistic_get is passed a buffer pool block pointer with
nothing locked. Thus it is possible, for example, for the pointed
block to get evicted from the buffer pool and a different data page to
be read in. This function does not detect this condition correctly:
first, it checked whether block state is BUF_BLOCK_FILE_PAGE,
buffer-pinned the block, latched it, and then compared the
modify_clock value. The modify_clock value mismatch catches the
condition of block going to the free list and back as a data page, but
after this caught, the block is unfixed before returning. However,
when buf_page_init_for_read was called for this same block, it reset
buf_fix_count to zero in buf_page_init_low, overwriting the effect of
the previous buf_block_buf_fix_inc, and making the return unfix result
in UINT32_MAX as the fix count.

Fix by catching the block pointer pointing to evicted and/or re-read
data page earlier in the function, before the buffer pool fix
attempt, together with BUF_BLOCK_FILE_PAGE check. This is correct
because buf_LRU_block_remove_hashed bumps the modify clock while under
buffer page mutex protection, in the same critical section as
BUF_BLOCK_FILE_PAGE -> BUF_BLOCK_REMOVE_HASH transition.

Also replace the buf_fix_count reset in buf_page_init_low with a release
build assert for zero. Fix buf_block_unfix assert to actually catch
the unsigned underflow, as the previous expression type was promoted
to a wider type and thus never became zero.

At the same time move all the side effects of buf_page_optimistic_get
after the final modify_clock check, to avoid needlessly marking wrong
pages as young or accessed. Also clarify in the comments and asserts
that buf_block_modify_clock_inc may be called with the buffer page
locked instead of the  LRU list mutex.

http://jenkins.percona.com/job/mysql-5.7-param/671/