### PR TITLE
MYR-68 : rocksdb.show_engine fails

### DIFF
--- a/mysql-test/suite/rocksdb/r/show_engine.result
+++ b/mysql-test/suite/rocksdb/r/show_engine.result
@@ -381,37 +381,3 @@ DROP TABLE t4;
 SHOW ENGINE rocksdb MUTEX;
 Type	Name	Status
 SHOW ENGINE ALL MUTEX;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
-Type	Name	Status
-SNAPSHOTS	rocksdb	
-============================================================
-TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
-============================================================
----------
-SNAPSHOTS
----------
-LIST OF SNAPSHOTS FOR EACH SESSION:
------------------------------------------
-END OF ROCKSDB TRANSACTION MONITOR OUTPUT
-=========================================
-
-START TRANSACTION WITH CONSISTENT SNAPSHOT;
-SHOW ENGINE rocksdb TRANSACTION STATUS;
-Type	Name	Status
-SNAPSHOTS	rocksdb	
-============================================================
-TIMESTAMP ROCKSDB TRANSACTION MONITOR OUTPUT
-============================================================
----------
-SNAPSHOTS
----------
-LIST OF SNAPSHOTS FOR EACH SESSION:
----SNAPSHOT, ACTIVE NUM sec
-MySQL thread id TID, OS thread handle PTR, query id QID localhost root ACTION
-SHOW ENGINE rocksdb TRANSACTION STATUS
-lock count 0, write count 0
------------------------------------------
-END OF ROCKSDB TRANSACTION MONITOR OUTPUT
-=========================================
-
-ROLLBACK;

--- a/mysql-test/suite/rocksdb/t/show_engine.test
+++ b/mysql-test/suite/rocksdb/t/show_engine.test
@@ -1,4 +1,4 @@
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 
 #
 # SHOW ENGINE STATUS command
@@ -56,21 +56,3 @@ SHOW ENGINE rocksdb MUTEX;
 --disable_result_log
 SHOW ENGINE ALL MUTEX;
 --enable_result_log
-
-# The output from SHOW ENGINE ROCKSDB TRANSACTION STATUS has some
-# non-deterministic results.  Replace the timestamp with 'TIMESTAMP', the
-# number of seconds active with 'NUM', the thread id with 'TID' and the thread
-# pointer with 'PTR'.  This test may fail in the future if it is being run in
-# parallel with other tests as the number of snapshots would then be greater
-# than expected.  We may need to turn off the result log if that is the case.
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /0x[0-9a-f]+/PTR/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
-
-START TRANSACTION WITH CONSISTENT SNAPSHOT;
-
-#select sleep(10);
---replace_regex /[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}/TIMESTAMP/ /(ACTIVE) [0-9]+ /\1 NUM / /(thread id) [0-9]+/\1 TID/ /0x[0-9a-f]+/PTR/ /(query id) [0-9]+/\1 QID/ /(root) [a-z ]+/\1 ACTION/
-SHOW ENGINE rocksdb TRANSACTION STATUS;
-
-ROLLBACK;
-


### PR DESCRIPTION
- Removed portion of the test and result irrelevant to Percona Server
  functionality.
- Audited test and changed to have_rocksdb, dropping as_default