### PR TITLE
MYR-60 : rocksdb.rocksdb_icp fails

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_icp.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_icp.result
@@ -214,5 +214,5 @@ where table_schema=database() and table_name='t1' and stat_type='INTERNAL_KEY_SK
 # The following must be =1, or in any case not 999:
 select @count_diff as "INTERNAL_KEY_SKIPPED_COUNT increment";
 INTERNAL_KEY_SKIPPED_COUNT increment
-0
+1
 drop table t0,t1;


### PR DESCRIPTION
- This was broken during the re-record for MYR-13 here
  https://github.com/percona/percona-server/commit/757260fda1d16f05b6823d060c6dad19628ce35e
- Unsure how or why this made it into the result. This value comes from deep
  inside RocksDB (not MyRocks). I suspect there was some issue of either an
  unmatched submodule or perhaps something else. Either way, this fixes it to
  be the same as upstream Facebook MySQL 5.6.35 and on the current PS run and
  rocksdb_icp passes.
- Cherry pick merging commit ce09296b4d01d2777129ece73d71cd284d73650d from ps-5.6-MYR-60