### PR TITLE
MYR-9 : myrocks requires use of new class in facebook mysql Regex_lis…

### DIFF
--- a/mysql-test/suite/rocksdb/r/collation.result
+++ b/mysql-test/suite/rocksdb/r/collation.result
@@ -1,5 +1,3 @@
-SET @start_global_value = @@global.ROCKSDB_STRICT_COLLATION_EXCEPTIONS;
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
 DROP TABLE t1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
@@ -33,63 +31,7 @@ CREATE TABLE xt123 (id INT primary key, value varchar(50), index(value)) engine=
 DROP TABLE xt123;
 CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 ERROR HY000: Unsupported collation on string indexed column test.t123.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions=",s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="|s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*||t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*,";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*|";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="||||,,,,s.*,,|,,||,t.*,,|||,,,";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
@@ -107,7 +49,6 @@ ALTER TABLE t2 ADD INDEX(value);
 ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
 DROP TABLE t2;
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
- Invalid pattern in strict_collation_exceptions: [a-b
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin).
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
@@ -117,12 +58,3 @@ CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rock
 ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin).
 DROP TABLE a, b;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
- Invalid pattern in strict_collation_exceptions: abc\
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
-SET GLOBAL rocksdb_strict_collation_exceptions="abc";
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin).
-DROP TABLE abc;
-SET GLOBAL rocksdb_strict_collation_exceptions=@start_global_value;

--- a/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_0.result
+++ b/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_0.result
@@ -1,0 +1,25 @@
+SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.ABC.value Use binary collation (binary, latin1_bin, utf8_bin).
+SET GLOBAL rocksdb_strict_collation_exceptions="abc";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abc;
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.ABC.value Use binary collation (binary, latin1_bin, utf8_bin).
+SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
+CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.bcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+SET GLOBAL rocksdb_strict_collation_exceptions="^ABC";
+CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABCD;
+CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.ZABC.value Use binary collation (binary, latin1_bin, utf8_bin).
+SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_1.result
+++ b/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_1.result
@@ -1,0 +1,25 @@
+SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+SET GLOBAL rocksdb_strict_collation_exceptions="abc";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abc;
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
+CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.bcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abc;
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
+SET GLOBAL rocksdb_strict_collation_exceptions="^ABC";
+CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abcd;
+CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABCD;
+CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+ERROR HY000: Unsupported collation on string indexed column test.zabc.value Use binary collation (binary, latin1_bin, utf8_bin).
+SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -1,11 +1,7 @@
---source include/have_rocksdb_as_default.inc
---source include/have_fullregex.inc
-
-SET @start_global_value = @@global.ROCKSDB_STRICT_COLLATION_EXCEPTIONS;
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
+# tests the basic functionality of rocksdb_strict_collation,
+# rocksdb_strict_collation_exceptions, and my_regex functionality behind
+# rocksdb_strict_collation_exceptions
+--source include/have_rocksdb.inc
 
 # ci non-indexed column is allowed
 CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
@@ -58,80 +54,8 @@ DROP TABLE xt123;
 --error ER_UNKNOWN_ERROR
 CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 
-# test multiple entries in the list with commas
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
 # test multiple entries in the list with vertical bar
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra comma at the front
-SET GLOBAL rocksdb_strict_collation_exceptions=",s.*,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra vertical bar at the front
-SET GLOBAL rocksdb_strict_collation_exceptions="|s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra comma in the middle
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,,t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra vertical bar in the middle
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*||t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra comma at the end
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*,t.*,";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and extra vertical bar at the end
-SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*|";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE t1;
---error ER_UNKNOWN_ERROR
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-# test multiple entries in the list and tons of commas and vertical bars just for the fun of it
-SET GLOBAL rocksdb_strict_collation_exceptions="||||,,,,s.*,,|,,||,t.*,,|||,,,";
 CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE s1;
 CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
@@ -151,11 +75,15 @@ CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
 ALTER TABLE t2 ADD INDEX(value);
 DROP TABLE t2;
 
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/rocksdb.collation.err
+--let $restart_parameters="restart: --log-error=$SEARCH_FILE"
+--source include/restart_mysqld.inc
 
 # test invalid regex (missing end bracket)
---exec echo "" >$MYSQLTEST_VARDIR/log/mysqld.1.err
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
---exec grep "Invalid pattern" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
+--let SEARCH_PATTERN=RocksDB: Invalid pattern in strict_collation_exceptions: \[a-b
+--source include/search_pattern_in_file.inc
+
 --error ER_UNKNOWN_ERROR
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
@@ -166,16 +94,12 @@ CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rock
 DROP TABLE a, b;
 
 # test invalid regex (trailing escape)
---exec echo "" >$MYSQLTEST_VARDIR/log/mysqld.1.err
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
---exec grep "Invalid pattern" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
---error ER_UNKNOWN_ERROR
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-SET GLOBAL rocksdb_strict_collation_exceptions="abc";
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
---error ER_UNKNOWN_ERROR
-CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE abc;
+--let SEARCH_PATTERN=Invalid pattern in strict_collation_exceptions: abc\\\\
+--source include/search_pattern_in_file.inc
 
 # cleanup
-SET GLOBAL rocksdb_strict_collation_exceptions=@start_global_value;
+--let SEARCH_PATTERN=
+--let SEARCH_FILE=
+--let $restart_parameters=
+--source include/restart_mysqld.inc

--- a/mysql-test/suite/rocksdb/t/collation_exception.test
+++ b/mysql-test/suite/rocksdb/t/collation_exception.test
@@ -1,3 +1,5 @@
+--source include/have_rocksdb.inc
+
 CREATE TABLE `r1.lol` (
   `c1` int(10) NOT NULL DEFAULT '0',
   `c2` int(11) NOT NULL DEFAULT '0',
@@ -24,4 +26,3 @@ CREATE TABLE `r1.lol` (
 
 DROP INDEX i1 ON `r1.lol`;
 DROP TABLE `r1.lol`;
-

--- a/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_0-master.opt
+++ b/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_0-master.opt
@@ -1,0 +1,1 @@
+--rocksdb_strict_collation_check=ON --lower_case_table_names=0

--- a/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_0.test
+++ b/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_0.test
@@ -1,0 +1,37 @@
+# tests case sensitivity behavior as intersection between
+# rocksdb_strict_collation_exceptions and lower_case_table_names=0
+--source include/have_rocksdb.inc
+--source include/have_case_sensitive_file_system.inc
+
+SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
+
+--error ER_UNKNOWN_ERROR
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+--error ER_UNKNOWN_ERROR
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+
+SET GLOBAL rocksdb_strict_collation_exceptions="abc";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abc;
+--error ER_UNKNOWN_ERROR
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+
+SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
+--error ER_UNKNOWN_ERROR
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
+
+--error ER_UNKNOWN_ERROR
+CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+
+SET GLOBAL rocksdb_strict_collation_exceptions="^ABC";
+--error ER_UNKNOWN_ERROR
+CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABCD;
+
+--error ER_UNKNOWN_ERROR
+CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+
+SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_1-master.opt
+++ b/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_1-master.opt
@@ -1,0 +1,1 @@
+--rocksdb_strict_collation_check=ON --lower_case_table_names=1

--- a/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_1.test
+++ b/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_1.test
@@ -1,0 +1,35 @@
+# tests case sensitivity behavior as intersection between
+# rocksdb_strict_collation_exceptions and lower_case_table_names=1
+--source include/have_rocksdb.inc
+
+SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
+
+--error ER_UNKNOWN_ERROR
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+--error ER_UNKNOWN_ERROR
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+
+SET GLOBAL rocksdb_strict_collation_exceptions="abc";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abc;
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
+--error ER_UNKNOWN_ERROR
+CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+
+SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abc;
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
+
+SET GLOBAL rocksdb_strict_collation_exceptions="^ABC";
+CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abcd;
+CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABCD;
+
+--error ER_UNKNOWN_ERROR
+CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+
+SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/sql/sql_regex.h
+++ b/sql/sql_regex.h
@@ -1,0 +1,138 @@
+/* Copyright (c) 2016, Percona and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef _regex_h_
+#define _regex_h_
+
+#include <string>
+#include <algorithm>
+
+#include "my_global.h"
+#include "my_pthread.h"
+#include "my_regex.h"
+
+/*
+  Wrapper class around my_regex that manages concurrent access and the lifetime
+  of the compiled regex.
+*/
+class Regex
+{
+private:
+#if defined(HAVE_PSI_INTERFACE)
+  const PSI_rwlock_key& m_key;
+#endif
+
+  std::string m_pattern;
+  my_regex_t m_expr;
+  bool m_compiled;
+
+  mutable mysql_rwlock_t m_rwlock;
+
+  // No implementations, should never be called.
+  Regex(const Regex& other);
+  Regex& operator=(const Regex& other);
+
+  void reset()
+  {
+    // assumes object is write locked where necessary
+    if (m_compiled)
+    {
+      m_pattern.clear();
+      my_regfree(&m_expr);
+      m_compiled= false;
+    }
+  }
+
+public:
+#if defined(HAVE_PSI_INTERFACE)
+  Regex(const PSI_rwlock_key& key) :
+    m_key(key),
+#else
+  Regex() :
+#endif
+    m_pattern(""),
+    m_compiled(false)
+  {
+#if defined(HAVE_PSI_INTERFACE)
+    mysql_rwlock_init(m_key, &m_rwlock);
+#else
+    mysql_rwlock_init(nullptr, &m_rwlock);
+#endif
+  }
+
+  ~Regex()
+  {
+    reset();
+    mysql_rwlock_destroy(&m_rwlock);
+  }
+
+  bool compiled() const
+  {
+    return m_compiled;
+  }
+
+  const std::string& pattern() const
+  {
+    return m_pattern;
+  }
+
+  // Compile the pattern into an expression
+  // see regex/my_regex.h for definition of flags
+  bool compile(const char *pattern, int flags, const CHARSET_INFO *charset)
+  {
+    int error= 0;
+
+    mysql_rwlock_wrlock(&m_rwlock);
+
+    reset();
+
+    if (pattern)
+    {
+      m_pattern.assign(pattern);
+    }
+
+    if (!m_pattern.empty())
+    {
+      error= my_regcomp(&m_expr,
+                        m_pattern.c_str(),
+                        flags,
+                        charset);
+      m_compiled= !error;
+    }
+
+    mysql_rwlock_unlock(&m_rwlock);
+
+    return !error;
+  }
+
+  // See if a string matches at least one pattern
+  bool match(const std::string& str) const
+  {
+    if (!m_compiled)
+    {
+      return false;
+    }
+
+    mysql_rwlock_rdlock(&m_rwlock);
+
+    int found= my_regexec(&m_expr, str.c_str(), 0, nullptr, 0);
+
+    mysql_rwlock_unlock(&m_rwlock);
+
+    return !found;
+  }
+};
+
+#endif // _regex_h_

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -142,7 +142,7 @@ static Rdb_background_thread rdb_bg_thread;
 
 // List of table names (using regex) that are exceptions to the strict
 // collation check requirement.
-Regex_list_handler *rdb_collation_exceptions;
+Regex *rdb_collation_exceptions;
 
 static const char *const ERRSTR_ROLLBACK_ONLY =
     "This transaction was rolled back and cannot be "
@@ -473,8 +473,8 @@ static MYSQL_THDVAR_BOOL(
 
 static MYSQL_THDVAR_STR(
     read_free_rpl_tables, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
-    "List of tables that will use read-free replication on the slave "
-    "(i.e. not lookup a row during replication)",
+    "Regex that describes set of tables that will use read-free replication "
+    "on the slave (i.e. not lookup a row during replication)",
     nullptr, nullptr, "");
 
 static MYSQL_SYSVAR_BOOL(
@@ -1022,7 +1022,7 @@ static MYSQL_SYSVAR_BOOL(strict_collation_check, rocksdb_strict_collation_check,
 static MYSQL_SYSVAR_STR(strict_collation_exceptions,
                         rocksdb_strict_collation_exceptions,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
-                        "List of tables (using regex) that are excluded "
+                        "Regex that describes set of tables that are excluded "
                         "from the case sensitive collation enforcement",
                         nullptr, rocksdb_set_collation_exception_list, "");
 
@@ -3071,10 +3071,9 @@ static int rocksdb_init_func(void *const p) {
                    MY_MUTEX_INIT_FAST);
 
 #if defined(HAVE_PSI_INTERFACE)
-  rdb_collation_exceptions =
-      new Regex_list_handler(key_rwlock_collation_exception_list);
+  rdb_collation_exceptions = new Regex(key_rwlock_collation_exception_list);
 #else
-  rdb_collation_exceptions = new Regex_list_handler();
+  rdb_collation_exceptions = new Regex();
 #endif
 
   mysql_mutex_init(rdb_sysvars_psi_mutex_key, &rdb_sysvars_mutex,
@@ -4348,16 +4347,22 @@ void ha_rocksdb::set_use_read_free_rpl(const char *const whitelist) {
   DBUG_ASSERT(whitelist != nullptr);
 
 #if defined(HAVE_PSI_INTERFACE)
-  Regex_list_handler regex_handler(key_rwlock_read_free_rpl_tables);
+  Regex regex_handler(key_rwlock_read_free_rpl_tables);
 #else
-  Regex_list_handler regex_handler;
+  Regex regex_handler;
 #endif
 
-  if (!regex_handler.set_patterns(whitelist)) {
-    warn_about_bad_patterns(&regex_handler, "read_free_rpl_tables");
+  int flags = MY_REG_EXTENDED | MY_REG_NOSUB;
+  if (lower_case_table_names)
+    flags |= MY_REG_ICASE;
+
+  if (!regex_handler.compile(whitelist,
+                             flags,
+                             table_alias_charset)) {
+      warn_about_bad_patterns(regex_handler, "read_free_rpl_tables");
   }
 
-  m_use_read_free_rpl = regex_handler.matches(m_tbl_def->base_tablename());
+  m_use_read_free_rpl = regex_handler.match(m_tbl_def->base_tablename());
 }
 
 int ha_rocksdb::open(const char *const name, int mode, uint test_if_locked) {
@@ -4635,7 +4640,7 @@ int ha_rocksdb::create_cfs(
            part++) {
         if (!rdb_is_index_collation_supported(
                 table_arg->key_info[i].key_part[part].field) &&
-            !rdb_collation_exceptions->matches(tablename_sys)) {
+            !rdb_collation_exceptions->match(tablename_sys)) {
           std::string collation_err;
           for (const auto &coll : RDB_INDEX_COLLATIONS) {
             if (collation_err != "") {
@@ -9861,8 +9866,12 @@ void rocksdb_set_rate_limiter_bytes_per_sec(my_core::THD *const thd,
 void rdb_set_collation_exception_list(const char *const exception_list) {
   DBUG_ASSERT(rdb_collation_exceptions != nullptr);
 
-  if (!rdb_collation_exceptions->set_patterns(exception_list)) {
-    warn_about_bad_patterns(rdb_collation_exceptions,
+  int flags = MY_REG_EXTENDED | MY_REG_NOSUB;
+  if (lower_case_table_names)
+    flags |= MY_REG_ICASE;
+  if (!rdb_collation_exceptions->compile(
+          exception_list, flags, table_alias_charset)) {
+    warn_about_bad_patterns(*rdb_collation_exceptions,
                             "strict_collation_exceptions");
   }
 }

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -272,73 +272,14 @@ bool rdb_database_exists(const std::string &db_name) {
   return true;
 }
 
-/*
-  Set the patterns string.  If there are invalid regex patterns they will
-  be stored in m_bad_patterns and the result will be false, otherwise the
-  result will be true.
-*/
-bool Regex_list_handler::set_patterns(const std::string& pattern_str)
-{
-  bool pattern_valid= true;
-
-  // Create a normalized version of the pattern string with all delimiters
-  // replaced by the '|' character
-  std::string norm_pattern= pattern_str;
-  std::replace(norm_pattern.begin(), norm_pattern.end(), m_delimiter, '|');
-
-  // Make sure no one else is accessing the list while we are changing it.
-  mysql_rwlock_wrlock(&m_rwlock);
-
-  // Clear out any old error information
-  m_bad_pattern_str.clear();
-
-  try
-  {
-    // Replace all delimiters with the '|' operator and create the regex
-    // Note that this means the delimiter can not be part of a regular
-    // expression.  This is currently not a problem as we are using the comma
-    // character as a delimiter and commas are not valid in table names.
-    m_pattern.reset(new std::regex(norm_pattern));
-  }
-  catch (const std::regex_error& e)
-  {
-    // This pattern is invalid.
-    pattern_valid= false;
-
-    // Put the bad pattern into a member variable so it can be retrieved later.
-    m_bad_pattern_str= pattern_str;
-  }
-
-  // Release the lock
-  mysql_rwlock_unlock(&m_rwlock);
-
-  return pattern_valid;
-}
-
-bool Regex_list_handler::matches(const std::string& str) const
-{
-  DBUG_ASSERT(m_pattern != nullptr);
-
-  // Make sure no one else changes the list while we are accessing it.
-  mysql_rwlock_rdlock(&m_rwlock);
-
-  // See if the table name matches the regex we have created
-  bool found= std::regex_match(str, *m_pattern);
-
-  // Release the lock
-  mysql_rwlock_unlock(&m_rwlock);
-
-  return found;
-}
-
-void warn_about_bad_patterns(const Regex_list_handler* regex_list_handler,
-                             const char *name)
+void warn_about_bad_patterns(const Regex &regex, const char *name)
 {
   // There was some invalid regular expression data in the patterns supplied
 
   // NO_LINT_DEBUG
-  sql_print_warning("Invalid pattern in %s: %s", name,
-                    regex_list_handler->bad_pattern().c_str());
+  sql_print_warning("RocksDB: Invalid pattern in %s: %s",
+                    name,
+                    regex.pattern().c_str());
 }
 
 } // namespace myrocks


### PR DESCRIPTION
…t_handler

MYR-52: rocksdb.collation missing upstream include file have_regex.inc
lp : Implement class Regex based on my_regex
- https://blueprints.launchpad.net/percona-server/+spec/regex-list-handler-5.6
- Implemented new class Regex that is a simple wrapper around my_regex
  which manages lifecycle, concurent access, compilation, matching, and cleanup
  of a regex. located in sql/sql_regex.h
- Altered MyRocks to remove Regex_list_handler entirely and use new Regex class
- Fixed rocksdb.collation test to remove requirement for have_full_regex
- Fixed rocksdb.collation test to validate supported regex and some bad regex,
  removing Regex_list_handler semantica that replaced some delimiter in the
  option stream(',') with '|' before passing to std::regex
- Fixed rocksdb.collation test to use mtr semantics to restart the server with
  an alternate log_error file and use mtr pattern match rather than exec grep.