### PR TITLE
Add TokuDB-Hotbackup option to wait until slave temp tables dissapear.

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/rpl_safe_slave.result
+++ b/mysql-test/suite/tokudb.backup/r/rpl_safe_slave.result
@@ -1,0 +1,75 @@
+###
+# Master-slave test
+####
+include/rpl_init.inc [topology=1->2]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+### Create temp table on master
+CREATE TEMPORARY TABLE t1 (a INT);
+include/sync_slave_sql_with_master.inc
+### Setup debug_sync points and prepare for slave backup
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+Variable_name	Value
+Slave_open_temp_tables	1
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_safe_slave_entered SIGNAL sse WAIT_FOR sse_continue';
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_temp_tables_loop_begin SIGNAL ttlb WAIT_FOR ttlb_continue';
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_temp_tables_loop_slave_started SIGNAL ttlss WAIT_FOR ttlss_continue EXECUTE 2';
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_temp_tables_loop_end SIGNAL ttle WAIT_FOR ttle_continue';
+### Turn-on safe-slave option
+SET GLOBAL tokudb_backup_safe_slave=ON;
+SET GLOBAL tokudb_backup_safe_slave_timeout=30;
+### Start slave backup
+### Wait for safe slave function to start
+SET DEBUG_SYNC = "now WAIT_FOR sse";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+Variable_name	Value
+Slave_open_temp_tables	1
+### Wait for safe slave loop start
+SET DEBUG_SYNC = "now SIGNAL sse_continue WAIT_FOR ttlb";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+Variable_name	Value
+Slave_open_temp_tables	1
+### Wait for safe thread loop point just after slave sql thread start 1
+SET DEBUG_SYNC = "now SIGNAL ttlb_continue WAIT_FOR ttlss";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+Variable_name	Value
+Slave_open_temp_tables	1
+### Wait for safe thread loop end
+SET DEBUG_SYNC = "now SIGNAL ttlss_continue WAIT_FOR ttle";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+Variable_name	Value
+Slave_open_temp_tables	1
+### Wait for safe thread loop point just after slave sql thread start 2
+SET DEBUG_SYNC = "now SIGNAL ttle_continue WAIT_FOR ttlss";
+### Drop temp table on master
+DROP TABLE t1;
+### and syncronize slave
+include/sync_slave_sql_with_master.inc
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+Variable_name	Value
+Slave_open_temp_tables	0
+### Continue backup
+SET DEBUG_SYNC = "now SIGNAL ttlss_continue";
+## Reset debug_sync points
+SET DEBUG_SYNC = "RESET";
+### Wait for backup finish
+include/filter_file.inc
+### Slave tokubackup_slave_info content:
+host: #.#.#.#, user: ####, port: ####, master log file: ####, relay log file: ####, exec master log pos: ####, executed gtid set: , channel name: 
+### Delete slave backup dir
+### Turn-off safe-slave option for slave
+SET GLOBAL tokudb_backup_safe_slave=default;
+SET GLOBAL tokudb_backup_safe_slave_timeout=default;
+### Turn-on safe-slave option for master
+SET GLOBAL tokudb_backup_safe_slave=ON;
+SET GLOBAL tokudb_backup_safe_slave_timeout=30;
+### Backup master
+### Turn-off safe-slave option for master
+SET GLOBAL tokudb_backup_safe_slave=default;
+SET GLOBAL tokudb_backup_safe_slave_timeout=default;
+include/filter_file.inc
+### Master tokubackup_binlog_info content:
+filename: ####, position: ####, gtid_mode: OFF, GTID of last change: 
+### Delete master backup dir
+include/rpl_end.inc

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave-master.opt
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave-master.opt
@@ -1,0 +1,1 @@
+--binlog-format=statement

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave-slave.opt
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave-slave.opt
@@ -1,0 +1,1 @@
+--master-info-repository=TABLE --relay-log-info-repository=TABLE

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.cnf
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.cnf
@@ -1,0 +1,14 @@
+!include ../../rpl/my.cnf
+
+[mysqld.1]
+
+[mysqld.2]
+
+[mysqld.3]
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+
+[ENV]
+SERVER_MYPORT_3=		@mysqld.3.port
+SERVER_MYSOCK_3=		@mysqld.3.socket
+

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.inc
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.inc
@@ -1,0 +1,110 @@
+--connection server_1
+--echo ### Create temp table on master
+CREATE TEMPORARY TABLE t1 (a INT);
+
+--let $sync_slave_connection= server_2
+--source include/sync_slave_sql_with_master.inc
+
+--echo ### Setup debug_sync points and prepare for slave backup
+--connection slave_2
+
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_safe_slave_entered SIGNAL sse WAIT_FOR sse_continue';
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_temp_tables_loop_begin SIGNAL ttlb WAIT_FOR ttlb_continue';
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_temp_tables_loop_slave_started SIGNAL ttlss WAIT_FOR ttlss_continue EXECUTE 2';
+SET DEBUG_SYNC= 'tokudb_backup_wait_for_temp_tables_loop_end SIGNAL ttle WAIT_FOR ttle_continue';
+
+--mkdir $BACKUP_DIR_SLAVE
+
+--echo ### Turn-on safe-slave option
+SET GLOBAL tokudb_backup_safe_slave=ON;
+SET GLOBAL tokudb_backup_safe_slave_timeout=30;
+
+--echo ### Start slave backup
+--disable_query_log
+--send_eval SET SESSION tokudb_backup_dir='$BACKUP_DIR_SLAVE'
+--enable_query_log
+
+--connection server_2
+
+--echo ### Wait for safe slave function to start
+SET DEBUG_SYNC = "now WAIT_FOR sse";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+--echo ### Wait for safe slave loop start
+SET DEBUG_SYNC = "now SIGNAL sse_continue WAIT_FOR ttlb";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+--echo ### Wait for safe thread loop point just after slave sql thread start 1
+SET DEBUG_SYNC = "now SIGNAL ttlb_continue WAIT_FOR ttlss";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+--echo ### Wait for safe thread loop end
+SET DEBUG_SYNC = "now SIGNAL ttlss_continue WAIT_FOR ttle";
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+
+--echo ### Wait for safe thread loop point just after slave sql thread start 2
+SET DEBUG_SYNC = "now SIGNAL ttle_continue WAIT_FOR ttlss";
+
+--connection server_1
+--echo ### Drop temp table on master
+DROP TABLE t1;
+
+--echo ### and syncronize slave
+--let $sync_slave_connection= server_2
+--source include/sync_slave_sql_with_master.inc
+
+SHOW STATUS LIKE 'Slave_open_temp_tables';
+
+--echo ### Continue backup
+SET DEBUG_SYNC = "now SIGNAL ttlss_continue";
+
+--echo ## Reset debug_sync points
+SET DEBUG_SYNC = "RESET";
+
+--connection slave_2
+--echo ### Wait for backup finish
+--reap
+
+--let $input_file = $S_SLAVE_INFO_FILE_PATH
+--source include/filter_file.inc
+--echo ### Slave $SLAVE_INFO_FILE content:
+--cat_file $S_SLAVE_INFO_FILE_PATH
+
+--echo ### Delete slave backup dir
+--perl
+use File::Path 'rmtree';
+$DDIR=$ENV{"BACKUP_DIR_SLAVE"};
+rmtree([ "$DDIR" ]);
+EOF
+
+--echo ### Turn-off safe-slave option for slave
+SET GLOBAL tokudb_backup_safe_slave=default;
+SET GLOBAL tokudb_backup_safe_slave_timeout=default;
+
+--connection server_1
+
+--echo ### Turn-on safe-slave option for master
+SET GLOBAL tokudb_backup_safe_slave=ON;
+SET GLOBAL tokudb_backup_safe_slave_timeout=30;
+
+--echo ### Backup master
+--mkdir $BACKUP_DIR_MASTER
+--disable_query_log
+--eval SET SESSION tokudb_backup_dir='$BACKUP_DIR_MASTER'
+--enable_query_log
+
+--echo ### Turn-off safe-slave option for master
+SET GLOBAL tokudb_backup_safe_slave=default;
+SET GLOBAL tokudb_backup_safe_slave_timeout=default;
+
+--let $input_file = $M_MASTER_INFO_FILE_PATH
+--source include/filter_file.inc
+--echo ### Master $MASTER_INFO_FILE content:
+--cat_file $M_MASTER_INFO_FILE_PATH
+
+--echo ### Delete master backup dir
+--perl
+use File::Path 'rmtree';
+$DDIR=$ENV{"BACKUP_DIR_MASTER"};
+rmtree([ "$DDIR" ]);
+EOF
+

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.test
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.test
@@ -1,0 +1,48 @@
+--source include/have_tokudb_backup.inc
+--source include/have_binlog_format_statement.inc
+--source include/have_debug_sync.inc
+
+--let $SLAVE_INFO_FILE=tokubackup_slave_info
+--let $MASTER_INFO_FILE=tokubackup_binlog_info
+
+--let BACKUP_DIR_SLAVE=$MYSQL_TMP_DIR/tokudb_backup_slave
+--let $S_SLAVE_INFO_FILE_PATH=$BACKUP_DIR_SLAVE/$SLAVE_INFO_FILE
+
+--let BACKUP_DIR_MASTER=$MYSQL_TMP_DIR/tokudb_backup_master
+--let $M_MASTER_INFO_FILE_PATH=$BACKUP_DIR_MASTER/$MASTER_INFO_FILE
+
+# Settings for include/filter_file.inc
+--delimiter |
+let $script=
+  s{filename: [^,]+,}{filename: ####,};
+  s{position: [^,]+,}{position: ####,};
+  s{GTID of last change: [^ ]+}{GTID of last change: #####};
+  s{host: [^,]+,}{host: #.#.#.#,};
+  s{user: [^,]+,}{user: ####,};
+  s{port: [^,]+,}{port: ####,};
+  s{master log file: [^,]+,}{master log file: ####,};
+  s{relay log file: [^,]+,}{relay log file: ####,};
+  s{exec master log pos: [^,]+,}{exec master log pos: ####,};
+  s{executed gtid set: [^,]+, }{executed gtid set: ####, };
+  s{executed gtid set: [^,]+,[^,]+, }{executed gtid set: ####,####, };
+|
+--delimiter ;
+--let $skip_column_names= 1
+
+--disable_query_log
+CALL mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
+--enable_query_log
+
+--echo ###
+--echo # Master-slave test
+--echo ####
+
+--let $rpl_server_count=3
+--let $rpl_topology=1->2
+--source include/rpl_init.inc
+
+--connect (slave_2,localhost,root,,test,$SLAVE_MYPORT,$SLAVE_MYSOCK)
+
+--source rpl_safe_slave.inc
+
+--source include/rpl_end.inc

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -25,6 +25,7 @@
 #include <rpl_rli.h>
 #include <sql_parse.h>
 #include <mysqld.h>
+#include <debug_sync.h>
 
 #include <inttypes.h>
 #include <algorithm>
@@ -115,6 +116,10 @@ static char *tokudb_backup_plugin_version;
 static const char* master_info_file_name = "tokubackup_slave_info";
 static const char* master_state_file_name = "tokubackup_binlog_info";
 
+static char tokudb_backup_safe_slave = FALSE;
+static ulonglong tokudb_backup_safe_slave_timeout = 0;
+static bool sql_thread_started = false;
+
 static MYSQL_SYSVAR_STR(plugin_version, tokudb_backup_plugin_version,
     PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_READONLY,
     "version of the tokudb backup plugin",
@@ -176,10 +181,25 @@ static MYSQL_SYSVAR_STR(allowed_prefix, tokudb_backup_allowed_prefix,
     "allowed prefix of the destination directory",
     NULL, NULL, NULL);
 
+static MYSQL_SYSVAR_BOOL(safe_slave, tokudb_backup_safe_slave,
+       PLUGIN_VAR_OPCMDARG, "Wait until there is no temporary slave tables.",
+       NULL,
+       NULL,
+       0);
+
+static MYSQL_SYSVAR_ULONGLONG(safe_slave_timeout,
+    tokudb_backup_safe_slave_timeout,
+    PLUGIN_VAR_OPCMDARG,
+    "The maximum amount of seconds to wait for slave temp tables disappear "
+    "0 - don't wait",
+    NULL, NULL, 0, 0, ULONGLONG_MAX, 0);
+
 static struct st_mysql_sys_var *tokudb_backup_system_variables[] = {
     MYSQL_SYSVAR(plugin_version),
     MYSQL_SYSVAR(version),
     MYSQL_SYSVAR(allowed_prefix),
+    MYSQL_SYSVAR(safe_slave),
+    MYSQL_SYSVAR(safe_slave_timeout),
     MYSQL_SYSVAR(throttle),
     MYSQL_SYSVAR(dir),
     MYSQL_SYSVAR(last_error),
@@ -273,9 +293,140 @@ static void tokudb_backup_error_fun(int error_number, const char *error_string, 
     }
 }
 
+static bool tokudb_backup_check_slave_sql_thread_running(THD *thd) {
+     scoped_lock_wrapper<BasicLockableMysqlMutextT>
+        with_LOCK_active_mi_locked(
+        BasicLockableMysqlMutextT(&LOCK_active_mi));
+
+    Master_info *mi = active_mi;
+
+    if (!mi || !mi->inited || !mi->host[0])
+        return false;
+
+    scoped_lock_wrapper<BasicLockableMysqlMutextT>
+        with_mi_data_locked_1(BasicLockableMysqlMutextT(
+            mi->data_lock));
+    scoped_lock_wrapper<BasicLockableMysqlMutextT>
+        with_mi_data_locked_2(BasicLockableMysqlMutextT(
+            mi->rli->data_lock));
+    scoped_lock_wrapper<BasicLockableMysqlMutextT>
+        with_mi_data_locked_3(BasicLockableMysqlMutextT(
+            mi->err_lock));
+    scoped_lock_wrapper<BasicLockableMysqlMutextT>
+        with_mi_data_locked_4(BasicLockableMysqlMutextT(
+            mi->rli->err_lock));
+
+    return mi->rli->slave_running;
+}
+
+static bool tokudb_backup_stop_slave_sql_thread(THD *thd) {
+    bool stop_slave_result;
+    bool result;
+
+    if (!active_mi)
+        return true;
+
+    thd->lex->slave_thd_opt = SLAVE_SQL;
+
+    {
+        scoped_lock_wrapper<BasicLockableMysqlMutextT>
+            with_LOCK_active_mi_locked(
+            BasicLockableMysqlMutextT(&LOCK_active_mi));
+
+        if (!active_mi || !active_mi->inited || !active_mi->host[0])
+            return true;
+
+        stop_slave_result = stop_slave(thd, active_mi, 0);
+    }
+
+    result = !stop_slave_result &&
+             !tokudb_backup_check_slave_sql_thread_running(thd);
+
+    if (!result)
+        sql_print_error("TokuDB Hotbackup: Can't stop slave sql thread\n");
+
+    return result;
+}
+
+static bool tokudb_backup_start_slave_sql_thread(THD *thd) {
+    bool start_slave_result;
+    bool result;
+
+    if (!active_mi)
+        return true;
+
+    thd->lex->slave_thd_opt = SLAVE_SQL;
+
+    {
+        scoped_lock_wrapper<BasicLockableMysqlMutextT>
+            with_LOCK_active_mi_locked(
+            BasicLockableMysqlMutextT(&LOCK_active_mi));
+
+        if (!active_mi || !active_mi->inited || !active_mi->host[0])
+            return true;
+
+        start_slave_result = start_slave(thd, active_mi, 0);
+    }
+
+    result = !start_slave_result &&
+             tokudb_backup_check_slave_sql_thread_running(thd);
+
+    if (!result)
+        sql_print_error("TokuDB Hotbackup: can't start slave sql thread");
+
+    return result;
+}
+
+static bool tokudb_backup_wait_for_safe_slave(THD *thd, uint timeout) {
+    static const uint sleep_time = 3000000;
+    size_t n_attemts = tokudb_backup_safe_slave_timeout ?
+        (1000000 * tokudb_backup_safe_slave_timeout / sleep_time) : 1;
+
+    DEBUG_SYNC(thd, "tokudb_backup_wait_for_safe_slave_entered");
+    if (!active_mi) {
+        sql_thread_started = false;
+        return false;
+    }
+
+    sql_thread_started = tokudb_backup_check_slave_sql_thread_running(thd);
+
+    if (sql_thread_started && !tokudb_backup_stop_slave_sql_thread(thd))
+        return false;
+
+    while(slave_open_temp_tables && n_attemts--) {
+        DEBUG_SYNC(thd, "tokudb_backup_wait_for_temp_tables_loop_begin");
+        if (!tokudb_backup_start_slave_sql_thread(thd))
+            return false;
+        DEBUG_SYNC(thd, "tokudb_backup_wait_for_temp_tables_loop_slave_started");
+        my_sleep(sleep_time);
+        if (!tokudb_backup_stop_slave_sql_thread(thd))
+            return false;
+        DEBUG_SYNC(thd, "tokudb_backup_wait_for_temp_tables_loop_end");
+    }
+
+    if (!n_attemts &&
+        slave_open_temp_tables) {
+
+        (sql_thread_started &&
+        !tokudb_backup_check_slave_sql_thread_running(thd) &&
+        !tokudb_backup_start_slave_sql_thread(thd));
+
+        return false;
+    }
+
+    return true;
+}
+
 static void tokudb_backup_before_stop_capt_fun(void *arg) {
     THD *thd = static_cast<THD *>(arg);
-    (void)lock_binlog_for_backup(thd);
+    if (tokudb_backup_safe_slave) {
+        if (!tokudb_backup_wait_for_safe_slave(
+                thd,tokudb_backup_safe_slave_timeout)) {
+            sql_print_error("TokuDB Hotbackup: safe slave option error");
+        }
+    }
+    else
+        (void)lock_binlog_for_backup(thd);
 }
 
 std::string tokudb_backup_get_executed_gtids_set() {
@@ -372,13 +523,38 @@ static void tokudb_backup_after_stop_capt_fun(void *arg) {
     std::vector<tokudb_backup_master_info> *master_info_channels =
         extra->master_info_channels;
     tokudb_backup_master_state *master_state = extra->master_state;
+    if (tokudb_backup_safe_slave &&
+        sql_thread_started &&
+        tokudb_backup_check_slave_sql_thread_running(thd)) {
+
+        tokudb_backup_set_error_string(thd,
+                                       EINVAL,
+                                       "Slave sql stread is not stopped",
+                                       NULL, NULL, NULL);
+        sql_print_error("TokuDB Hotbackup: "
+                        "master and slave info can't be saved "
+                        "because slave sql thread can't be stopped\n");
+
+        return;
+    }
 
     tokudb_backup_get_master_infos(thd, master_info_channels);
     tokudb_backup_get_master_state(master_state);
 
-    if (thd->backup_binlog_lock.is_acquired())
-      thd->backup_binlog_lock.release(thd);
-
+    if (tokudb_backup_safe_slave && sql_thread_started) {
+        if (!tokudb_backup_start_slave_sql_thread(thd)) {
+            tokudb_backup_set_error_string(thd,
+                                       EINVAL,
+                                       "Slave sql stread is not started",
+                                       NULL, NULL, NULL);
+            sql_print_error("TokuDB Hotbackup: "
+                            "slave sql thread can't be started\n");
+            return;
+        }
+    }
+    else if (thd->backup_binlog_lock.is_acquired()) {
+        thd->backup_binlog_lock.release(thd);
+    }
 }
 
 static char *tokudb_backup_realpath_with_slash(const char *a) {


### PR DESCRIPTION
See https://github.com/percona/percona-server/pull/1435.

In the case of mutlisource replication if safe-slave option is used sql thread
of all channels will be restarted. So if there are some channels started and
some of them are stopped before the backup, all channels will be started just
after backup stop.

The option can't be used for for group replication nodes.

Testing: http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/681/