### PR TITLE
Fix bug 1666213 (Debug build shutdown may crash with void add_global_…

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -889,7 +889,6 @@ void add_global_thread(THD *thd)
 {
   DBUG_PRINT("info", ("add_global_thread %p", thd));
   mysql_mutex_assert_owner(&LOCK_thread_count);
-  DBUG_ASSERT(!shutdown_in_progress);
   const bool have_thread=
     global_thread_list->find(thd) != global_thread_list->end();
   if (!have_thread)


### PR DESCRIPTION
…thread(THD*): Assertion `!shutdown_in_progress' failed.)

Since there is no synchronisation between setting shutdown_in_progress
flag and wake up of cached connection handling threads, remove the
assert.

http://jenkins.percona.com/job/percona-server-5.6-param/1710/