### PR TITLE
Bug 1663251: ASan errors on main.audit_log_filter_commands

### DIFF
--- a/plugin/audit_log/filter.c
+++ b/plugin/audit_log/filter.c
@@ -306,6 +306,9 @@ my_bool audit_log_check_account_included(const char *user, size_t user_length,
 
   account_init(&acc, user, user_length, host, host_length);
 
+  if (acc.length == 0)
+    return FALSE;
+
   mysql_rwlock_rdlock(&LOCK_account_list);
 
   res= my_hash_search(&include_accounts,
@@ -325,6 +328,9 @@ my_bool audit_log_check_account_excluded(const char *user, size_t user_length,
   my_bool res;
 
   account_init(&acc, user, user_length, host, host_length);
+
+  if (acc.length == 0)
+    return FALSE;
 
   mysql_rwlock_rdlock(&LOCK_account_list);
 
@@ -362,6 +368,9 @@ my_bool audit_log_check_command_included(const char *name, size_t length)
 {
   my_bool res;
 
+  if (length == 0)
+    return FALSE;
+
   mysql_rwlock_rdlock(&LOCK_command_list);
   res= my_hash_search(&include_commands, (const uchar*) name, length) != NULL;
   mysql_rwlock_unlock(&LOCK_command_list);
@@ -375,6 +384,9 @@ my_bool audit_log_check_command_included(const char *name, size_t length)
 my_bool audit_log_check_command_excluded(const char *name, size_t length)
 {
   my_bool res;
+
+  if (length == 0)
+    return FALSE;
 
   mysql_rwlock_rdlock(&LOCK_command_list);
   res= my_hash_search(&exclude_commands, (const uchar*) name, length) != NULL;


### PR DESCRIPTION
`my_hash_search` takes two arguments - key to search for and it's
length. When length is 0, `my_hash_search` considers that key has the
same length as hash length.

Since this behaviour may be relied on somewhere, the fix is to avoid
calling `my_hash_search` for empty strings.