### PR TITLE
Test for bug lp:1657908 is added.

### DIFF
--- a/mysql-test/suite/tokudb/r/bug-1657908.result
+++ b/mysql-test/suite/tokudb/r/bug-1657908.result
@@ -1,0 +1,70 @@
+SET GLOBAL tokudb_dir_per_db=ON;
+CREATE PROCEDURE create_table()
+BEGIN
+CREATE TABLE test.t1 (
+a INT
+) ENGINE = TokuDB
+PARTITION BY RANGE (a)
+(PARTITION p100 VALUES LESS THAN (100) ENGINE = TokuDB,
+PARTITION p_to_del VALUES LESS THAN (200) ENGINE = TokuDB,
+PARTITION p300 VALUES LESS THAN (300) ENGINE = TokuDB,
+PARTITION p400 VALUES LESS THAN (400) ENGINE = TokuDB
+);
+END|
+### Create partitioned table
+CALL create_table();
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_P_p100_main_id.tokudb
+t1_P_p100_status_id.tokudb
+t1_P_p300_main_id.tokudb
+t1_P_p300_status_id.tokudb
+t1_P_p400_main_id.tokudb
+t1_P_p400_status_id.tokudb
+t1_P_p_to_del_main_id.tokudb
+t1_P_p_to_del_status_id.tokudb
+### Stop server
+### Remove 'main' file of one of the partitions
+### Start server
+### Make sure 'main' partition file is deleted
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_P_p100_main_id.tokudb
+t1_P_p100_status_id.tokudb
+t1_P_p300_main_id.tokudb
+t1_P_p300_status_id.tokudb
+t1_P_p400_main_id.tokudb
+t1_P_p400_status_id.tokudb
+t1_P_p_to_del_status_id.tokudb
+### Make sure the table still exists
+SHOW TABLES;
+Tables_in_test
+t1
+### Drop table
+DROP TABLE t1;
+### Make sure the table is dropped
+SHOW TABLES;
+Tables_in_test
+### Check what files still exist after DROP TABLE
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+### Remove the rest of the files
+### Make sure there are no tokudb files
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+### Create the same table once more
+CALL create_table();
+## Looking for *.tokudb files in data_dir
+## Looking for *.tokudb files in data_dir/test
+t1_P_p100_main_id.tokudb
+t1_P_p100_status_id.tokudb
+t1_P_p300_main_id.tokudb
+t1_P_p300_status_id.tokudb
+t1_P_p400_main_id.tokudb
+t1_P_p400_status_id.tokudb
+t1_P_p_to_del_main_id.tokudb
+t1_P_p_to_del_status_id.tokudb
+### Restore state
+DROP TABLE t1;
+DROP PROCEDURE create_table;
+SET GLOBAL tokudb_dir_per_db=default;

--- a/mysql-test/suite/tokudb/t/bug-1657908.test
+++ b/mysql-test/suite/tokudb/t/bug-1657908.test
@@ -1,0 +1,72 @@
+# See https://bugs.launchpad.net/percona-server/+bug/1657908
+
+source include/have_tokudb.inc;
+
+SET GLOBAL tokudb_dir_per_db=ON;
+
+--let $DB= test
+--let $DATADIR= `SELECT @@datadir`
+
+--delimiter |
+CREATE PROCEDURE create_table()
+BEGIN
+CREATE TABLE test.t1 (
+  a INT
+) ENGINE = TokuDB
+PARTITION BY RANGE (a)
+(PARTITION p100 VALUES LESS THAN (100) ENGINE = TokuDB,
+ PARTITION p_to_del VALUES LESS THAN (200) ENGINE = TokuDB,
+ PARTITION p300 VALUES LESS THAN (300) ENGINE = TokuDB,
+ PARTITION p400 VALUES LESS THAN (400) ENGINE = TokuDB
+);
+END|
+--delimiter ;
+
+--echo ### Create partitioned table
+CALL create_table();
+--source dir_per_db_show_table_files.inc
+
+--echo ### Stop server
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--shutdown_server
+--source include/wait_until_disconnected.inc
+
+--echo ### Remove 'main' file of one of the partitions
+--remove_files_wildcard $DATADIR/$DB t1_P_p_to_del_main_*.tokudb
+
+--echo ### Start server
+--enable_reconnect
+--exec echo "restart: --loose-tokudb-dir-per-db=ON" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+
+--echo ### Make sure 'main' partition file is deleted
+--source dir_per_db_show_table_files.inc
+
+--echo ### Make sure the table still exists
+SHOW TABLES;
+
+--echo ### Drop table
+# error 1051 was here before the fix
+DROP TABLE t1;
+
+--echo ### Make sure the table is dropped
+SHOW TABLES;
+
+--echo ### Check what files still exist after DROP TABLE
+--source dir_per_db_show_table_files.inc
+
+--echo ### Remove the rest of the files
+--remove_files_wildcard $DATADIR/$DB *.tokudb
+
+--echo ### Make sure there are no tokudb files
+--source dir_per_db_show_table_files.inc
+
+--echo ### Create the same table once more
+# engine error 17 (EEXIST) was here before the fix
+CALL create_table();
+--source dir_per_db_show_table_files.inc
+
+--echo ### Restore state
+DROP TABLE t1;
+DROP PROCEDURE create_table;
+SET GLOBAL tokudb_dir_per_db=default;


### PR DESCRIPTION
The bug itself is fixed on ft-index level, see https://github.com/percona/PerconaFT/pull/366, https://github.com/percona/percona-server/pull/1449.

Testing: http://jenkins.percona.com/job/percona-server-5.6-param/1717/

tokudb_exclude_backup fails because this is gca branch and I used "master" branch of TokuDB-Hotbackup for this build. Some interface of the library is changed (new callbacks were added), and old gca branch does not take it into account, The result is the test fails.