### PR TITLE
Bug 1666496: Server crashes on startup if plugin is unable to create …

### DIFF
--- a/mysql-test/r/audit_log_startup.result
+++ b/mysql-test/r/audit_log_startup.result
@@ -8,3 +8,5 @@ SHOW VARIABLES LIKE 'audit_log%';
 Variable_name	Value
 SHOW VARIABLES LIKE 'audit_log%';
 Variable_name	Value
+SHOW VARIABLES LIKE 'audit_log%';
+Variable_name	Value

--- a/mysql-test/t/audit_log_startup.test
+++ b/mysql-test/t/audit_log_startup.test
@@ -39,3 +39,10 @@ SHOW VARIABLES LIKE 'audit_log%';
 
 # there should be no audit_log% variables shown
 SHOW VARIABLES LIKE 'audit_log%';
+
+
+--let $restart_parameters="restart: --audit_log_exclude_accounts='user@localhost' --audit_log_file=./directory/file"
+--source include/restart_mysqld.inc
+
+# there should be no audit_log% variables shown
+SHOW VARIABLES LIKE 'audit_log%';

--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -803,12 +803,6 @@ int audit_log_plugin_init(void *arg MY_ATTRIBUTE((unused)))
 
   logger_init_mutexes();
 
-  if (init_new_log_file())
-    return(1);
-
-  if (audit_log_audit_record(buf, sizeof(buf), "Audit", time(NULL), &len))
-    audit_log_write(buf, len);
-
   audit_log_filter_init();
 
   if (audit_log_exclude_accounts != NULL && audit_log_include_accounts != NULL)
@@ -849,6 +843,12 @@ int audit_log_plugin_init(void *arg MY_ATTRIBUTE((unused)))
                                           MYF(MY_FAE));
     audit_log_set_include_commands(audit_log_include_commands);
   }
+
+  if (init_new_log_file())
+    return(1);
+
+  if (audit_log_audit_record(buf, sizeof(buf), "Audit", time(NULL), &len))
+    audit_log_write(buf, len);
 
   return 0;
 


### PR DESCRIPTION
…file pointed by --audit_log_file

In order to expose this bug we need to set both
--audit-log-exclude-commands and --audit-log-file at start up.

Second one has to be incorrect, so that plugin would refuse to start
with error:

    mysqld: File './data-dir/mysql-audit.json' not found (Errcode: 2 - No such file or directory)
    2017-02-21T11:58:42.392280Z 0 [ERROR] Plugin audit_log reported: 'Cannot open file ./data-dir/mysql-audit.json.'
    2017-02-21T11:58:42.392350Z 0 [ERROR] Plugin audit_log reported: 'Error: No such file or directory'
    2017-02-21T11:58:42.392355Z 0 [ERROR] Plugin 'audit_log' init function returned error.
    2017-02-21T11:58:42.392360Z 0 [ERROR] Plugin 'audit_log' registration as a AUDIT failed.

The cause for the crash is common with bug 1641910. MEMALLOC'ed
variables are not properly initialized by server (UPDATE and CHECK
functions aren't invoked).

The fix is to make sure that initialization of MEMALLOC'ed variables is
the very first thing we do.