### PR TITLE
Bugs 1654682 / 1652852 (FLUSH LOGS disabled by read_only and super_re…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_gtid_read_only_flush_logs.result
+++ b/mysql-test/suite/rpl/r/rpl_gtid_read_only_flush_logs.result
@@ -1,0 +1,38 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+include/sync_slave_sql_with_master.inc
+#
+# Bug 84350: Error 1290 executing flush logs in read-only slave
+#
+CREATE USER 'reload_user'@'localhost';
+GRANT RELOAD ON *.* TO 'reload_user'@'localhost';
+SET @saved_read_only= @@GLOBAL.read_only;
+SET GLOBAL read_only= ON;
+# slave reload_user connection
+FLUSH LOGS;
+INSERT INTO t1 VALUES (2);
+include/sync_slave_sql_with_master.inc
+FLUSH BINARY LOGS;
+#
+# Bug 84437: super-read-only does not allow FLUSH LOGS on 5.7
+#
+# slave root connection
+SET @saved_super_read_only= @@GLOBAL.super_read_only;
+SET GLOBAL super_read_only=ON;
+INSERT INTO t1 VALUES (3);
+include/sync_slave_sql_with_master.inc
+FLUSH LOGS;
+INSERT INTO t1 VALUES (4);
+include/sync_slave_sql_with_master.inc
+FLUSH BINARY LOGS;
+DROP TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL super_read_only= @saved_super_read_only;
+SET GLOBAL read_only= @saved_read_only;
+DROP USER reload_user@localhost;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_gtid_read_only_flush_logs-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_gtid_read_only_flush_logs-master.opt
@@ -1,0 +1,1 @@
+--gtid-mode=ON --enforce-gtid-consistency=ON --log-slave-updates

--- a/mysql-test/suite/rpl/t/rpl_gtid_read_only_flush_logs-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_gtid_read_only_flush_logs-slave.opt
@@ -1,0 +1,1 @@
+--gtid-mode=ON --enforce-gtid-consistency=ON --log-slave-updates

--- a/mysql-test/suite/rpl/t/rpl_gtid_read_only_flush_logs.test
+++ b/mysql-test/suite/rpl/t/rpl_gtid_read_only_flush_logs.test
@@ -1,0 +1,68 @@
+--source include/have_gtid.inc
+--source include/master-slave.inc
+--source include/count_sessions.inc
+
+CREATE TABLE t1 (a INT PRIMARY KEY);
+INSERT INTO t1 VALUES (1);
+
+--source include/sync_slave_sql_with_master.inc
+
+--echo #
+--echo # Bug 84350: Error 1290 executing flush logs in read-only slave
+--echo #
+
+CREATE USER 'reload_user'@'localhost';
+GRANT RELOAD ON *.* TO 'reload_user'@'localhost';
+
+SET @saved_read_only= @@GLOBAL.read_only;
+SET GLOBAL read_only= ON;
+
+--connect(con1,127.0.0.1,reload_user,,test,$SLAVE_MYPORT,)
+--echo # slave reload_user connection
+
+FLUSH LOGS;
+
+--connection master
+INSERT INTO t1 VALUES (2);
+--source include/sync_slave_sql_with_master.inc
+--connection con1
+
+FLUSH BINARY LOGS;
+
+--disconnect con1
+
+--echo #
+--echo # Bug 84437: super-read-only does not allow FLUSH LOGS on 5.7
+--echo #
+
+--connection slave
+--echo # slave root connection
+
+SET @saved_super_read_only= @@GLOBAL.super_read_only;
+SET GLOBAL super_read_only=ON;
+
+--connection master
+INSERT INTO t1 VALUES (3);
+--source include/sync_slave_sql_with_master.inc
+
+FLUSH LOGS;
+
+--connection master
+INSERT INTO t1 VALUES (4);
+--source include/sync_slave_sql_with_master.inc
+
+FLUSH BINARY LOGS;
+
+--connection master
+DROP TABLE t1;
+
+--source include/sync_slave_sql_with_master.inc
+
+SET GLOBAL super_read_only= @saved_super_read_only;
+SET GLOBAL read_only= @saved_read_only;
+
+DROP USER reload_user@localhost;
+
+--source include/wait_until_count_sessions.inc
+--connection master
+--source include/rpl_end.inc


### PR DESCRIPTION
…ad_only)

As 5.6 is not affected by the bugs because it does not have
mysql.gtid_executed table and thus FLUSH LOGS does not attempt to
write to it on binlog rotation, only add the testcases.

http://jenkins.percona.com/job/percona-server-5.6-param/1727/