### PR TITLE
Add tools to edit TokuDB directory file.

### DIFF
--- a/mysql-test/include/plugin.defs
+++ b/mysql-test/include/plugin.defs
@@ -57,6 +57,6 @@ query_response_time plugin/query_response_time PLUGIN_QUERY_RESPONSE_TIME QUERY_
 handlersocket      plugin/HandlerSocket-Plugin-for-MySQL HANDLER_SOCKET
 mysql_no_login     plugin/mysql_no_login      MYSQL_NO_LOGIN    mysql_no_login
 test_udf_services  plugin/udf_services TESTUDFSERVICES
-ha_tokudb          storage/tokudb             TOKUDB            tokudb,tokudb_trx,tokudb_locks,tokudb_lock_waits,tokudb_fractal_tree_info,tokudb_background_job_status
+ha_tokudb          storage/tokudb             TOKUDB            tokudb,tokudb_trx,tokudb_locks,tokudb_lock_waits,tokudb_fractal_tree_info,tokudb_background_job_status,tokudb_file_map
 tokudb_backup      plugin/tokudb-backup-plugin       TOKUDB_BACKUP     tokudb_backup
 ha_rocksdb         storage/rocksdb            ROCKSDB           rocksdb,rocksdb_cfstats,rocksdb_dbstats,rocksdb_perf_context_global,rocksdb_cf_options,rocksdb_global_info,rocksdb_ddl,rocksdb_index_file_map

--- a/mysql-test/suite/tokudb/r/dir_cmd.result
+++ b/mysql-test/suite/tokudb/r/dir_cmd.result
@@ -1,0 +1,58 @@
+SET GLOBAL tokudb_dir_per_db = ON;
+SET tokudb_dir_cmd = "attach test_dname_1 test_iname_1";
+SET tokudb_dir_cmd = "attach test_dname_2 test_iname_2";
+SELECT dictionary_name, internal_file_name
+FROM information_schema.TokuDB_file_map;
+dictionary_name	internal_file_name
+test_dname_1	test_iname_1
+test_dname_2	test_iname_2
+SET tokudb_dir_cmd = "detach test_dname_1";
+SELECT dictionary_name, internal_file_name
+FROM information_schema.TokuDB_file_map;
+dictionary_name	internal_file_name
+test_dname_2	test_iname_2
+SET tokudb_dir_cmd = "move test_dname_2 test_dname_3";
+SELECT dictionary_name, internal_file_name
+FROM information_schema.TokuDB_file_map;
+dictionary_name	internal_file_name
+test_dname_3	test_iname_2
+SET tokudb_dir_cmd = "detach test_dname_3";
+SELECT dictionary_name, internal_file_name
+FROM information_schema.TokuDB_file_map;
+dictionary_name	internal_file_name
+CREATE TABLE t1(a int) ENGINE=tokudb;
+INSERT INTO t1 (a) VALUES (10);
+SELECT dictionary_name, internal_file_name
+FROM information_schema.TokuDB_file_map;
+dictionary_name	internal_file_name
+./test/t1-main	./test/t1_main_id.tokudb
+./test/t1-status	./test/t1_status_id.tokudb
+SET tokudb_dir_cmd = "attach ./test/t1-main test/t1-main-renamed.tokudb";
+SELECT dictionary_name, internal_file_name
+FROM information_schema.TokuDB_file_map;
+dictionary_name	internal_file_name
+./test/t1-main	test/t1-main-renamed.tokudb
+./test/t1-status	./test/t1_status_id.tokudb
+### rename t1_main_id.tokudb to t1-main-renamed.tokudb
+SELECT * FROM t1;
+a
+10
+### Test for errors notification
+SET tokudb_dir_cmd = "detach foo";
+ERROR 42000: Variable 'tokudb_dir_cmd' can't be set to the value of 'detach foo'
+SELECT @@tokudb_dir_cmd_last_error;
+@@tokudb_dir_cmd_last_error
+17
+SELECT @@tokudb_dir_cmd_last_error_string;
+@@tokudb_dir_cmd_last_error_string
+detach command error
+SET @@tokudb_dir_cmd_last_error_string = "blablabla";
+SELECT @@tokudb_dir_cmd_last_error_string;
+@@tokudb_dir_cmd_last_error_string
+blablabla
+SET STATEMENT tokudb_dir_cmd_last_error_string = "statement_blablabla" FOR
+SELECT @@tokudb_dir_cmd_last_error_string;
+@@tokudb_dir_cmd_last_error_string
+statement_blablabla
+DROP TABLE t1;
+SET GLOBAL tokudb_dir_per_db = default;

--- a/mysql-test/suite/tokudb/t/dir_cmd.test
+++ b/mysql-test/suite/tokudb/t/dir_cmd.test
@@ -1,0 +1,51 @@
+source include/have_tokudb.inc;
+
+--let $MYSQL_DATADIR=`select @@datadir`
+
+SET GLOBAL tokudb_dir_per_db = ON;
+
+SET tokudb_dir_cmd = "attach test_dname_1 test_iname_1";
+SET tokudb_dir_cmd = "attach test_dname_2 test_iname_2";
+SELECT dictionary_name, internal_file_name
+  FROM information_schema.TokuDB_file_map;
+
+SET tokudb_dir_cmd = "detach test_dname_1";
+SELECT dictionary_name, internal_file_name
+  FROM information_schema.TokuDB_file_map;
+
+SET tokudb_dir_cmd = "move test_dname_2 test_dname_3";
+SELECT dictionary_name, internal_file_name
+  FROM information_schema.TokuDB_file_map;
+
+SET tokudb_dir_cmd = "detach test_dname_3";
+SELECT dictionary_name, internal_file_name
+  FROM information_schema.TokuDB_file_map;
+
+CREATE TABLE t1(a int) ENGINE=tokudb;
+INSERT INTO t1 (a) VALUES (10);
+--source include/table_files_replace_pattern.inc
+SELECT dictionary_name, internal_file_name
+ FROM information_schema.TokuDB_file_map;
+
+SET tokudb_dir_cmd = "attach ./test/t1-main test/t1-main-renamed.tokudb";
+--source include/table_files_replace_pattern.inc
+SELECT dictionary_name, internal_file_name
+ FROM information_schema.TokuDB_file_map;
+
+--echo ### rename t1_main_id.tokudb to t1-main-renamed.tokudb
+--exec mv $MYSQL_DATADIR/test/t1_main_*.tokudb $MYSQL_DATADIR/test/t1-main-renamed.tokudb
+
+SELECT * FROM t1;
+
+--echo ### Test for errors notification
+--error 1231
+SET tokudb_dir_cmd = "detach foo";
+SELECT @@tokudb_dir_cmd_last_error;
+SELECT @@tokudb_dir_cmd_last_error_string;
+SET @@tokudb_dir_cmd_last_error_string = "blablabla";
+SELECT @@tokudb_dir_cmd_last_error_string;
+SET STATEMENT tokudb_dir_cmd_last_error_string = "statement_blablabla" FOR
+    SELECT @@tokudb_dir_cmd_last_error_string;
+
+DROP TABLE t1;
+SET GLOBAL tokudb_dir_per_db = default;

--- a/storage/tokudb/CMakeLists.txt
+++ b/storage/tokudb/CMakeLists.txt
@@ -110,7 +110,8 @@ SET(TOKUDB_SOURCES
     tokudb_background.cc
     tokudb_information_schema.cc
     tokudb_sysvars.cc
-    tokudb_thread.cc)
+    tokudb_thread.cc
+    tokudb_dir_cmd.cc)
 MYSQL_ADD_PLUGIN(tokudb ${TOKUDB_SOURCES} STORAGE_ENGINE MODULE_ONLY
     LINK_LIBRARIES tokufractaltree_static tokuportability_static ${ZLIB_LIBRARY} stdc++)
 SET(CMAKE_MODULE_LINKER_FLAGS_RELEASE "${CMAKE_MODULE_LINKER_FLAGS_RELEASE} -flto -fuse-linker-plugin")

--- a/storage/tokudb/tokudb_dir_cmd.cc
+++ b/storage/tokudb/tokudb_dir_cmd.cc
@@ -1,0 +1,330 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+/* -*- mode: C; c-basic-offset: 4 -*- */
+#ident "$Id$"
+/*======
+This file is part of TokuDB
+
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    TokuDBis is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+    TokuDB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with TokuDB.  If not, see <http://www.gnu.org/licenses/>.
+
+======= */
+
+#ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
+
+#include "hatoku_hton.h"
+#include "tokudb_dir_cmd.h"
+#include "my_dbug.h"
+#include "sql_base.h"
+
+#include <vector>
+
+namespace tokudb {
+
+const char tokens_delimiter = ' ';
+const char tokens_escape_delimiter_char = '\\';
+
+static int MDL_and_TDC(THD *thd,
+                       const char *db,
+                       const char *table,
+                       const dir_cmd_callbacks &cb) {
+    int error;
+    LEX_STRING db_arg;
+    LEX_STRING table_arg;
+
+    db_arg.str = const_cast<char *>(db);
+    db_arg.length = strlen(db);;
+    table_arg.str = const_cast<char *>(table);
+    table_arg.length = strlen(table);
+    Table_ident table_ident(thd, db_arg, table_arg, true);;
+    thd->lex->select_lex.add_table_to_list(
+        thd, &table_ident, NULL, 1, TL_UNLOCK, MDL_EXCLUSIVE, 0, 0, 0);
+    /* The lock will be released at the end of mysq_execute_command() */
+    error = lock_table_names(thd,
+                             thd->lex->select_lex.table_list.first,
+                             NULL,
+                             thd->variables.lock_wait_timeout,
+                             0);
+    if (error) {
+        if (cb.set_error)
+            cb.set_error(thd,
+                         error,
+                         "Can't lock table '%s.%s'",
+                         db,
+                         table);
+        return error;
+    }
+    tdc_remove_table(thd, TDC_RT_REMOVE_ALL, db, table, false);
+    return error;
+}
+
+static bool parse_db_and_table(const char *dname,
+                              std::string /*out*/ &db_name,
+                              std::string /*out*/ &table_name) {
+    const char *begin;
+    const char *end;
+    const char *db_name_begin;
+    const char *db_name_end;
+
+    begin = strchr(dname, '/');
+    if (!begin)
+        return false;
+    ++begin;
+    end = strchr(begin, '/');
+    if (!end)
+        return false;
+
+    db_name_begin = begin;
+    db_name_end = end;
+
+    begin = end + 1;
+
+    end = strchr(begin, '-');
+    if (!end)
+        return false;
+
+    if (strncmp(end, "-main", strlen("-main")) &&
+        strncmp(end, "-status", strlen("-status")) &&
+        strncmp(end, "-key", strlen("-key")))
+        return false;
+
+    db_name.assign(db_name_begin, db_name_end);
+    table_name.assign(begin, end);
+
+    return true;
+}
+
+static int attach(THD *thd,
+                   const std::string &dname,
+                   const std::string &iname,
+                   const dir_cmd_callbacks &cb) {
+    int error;
+    DB_TXN* txn = NULL;
+    DB_TXN *parent_txn = NULL;
+    tokudb_trx_data *trx = NULL;
+
+    std::string db_name;
+    std::string table_name;
+
+    if (parse_db_and_table(dname.c_str(), db_name, table_name)) {
+        error = MDL_and_TDC(thd, db_name.c_str(), table_name.c_str(), cb);
+        if (error)
+            goto cleanup;
+    }
+
+    trx = (tokudb_trx_data *) thd_get_ha_data(thd, tokudb_hton);
+    if (trx && trx->sub_sp_level)
+        parent_txn = trx->sub_sp_level;
+    error = txn_begin(db_env, parent_txn, &txn, 0, thd);
+    if (error)
+        goto cleanup;
+
+    error = db_env->dirtool_attach(db_env,
+                                   txn,
+                                   dname.c_str(),
+                                   iname.c_str());
+cleanup:
+    if (txn) {
+        if (error) {
+            abort_txn(txn);
+        }
+        else {
+            commit_txn(txn, 0);
+        }
+    }
+    return error;
+}
+
+static int detach(THD *thd,
+                  const std::string &dname,
+                  const dir_cmd_callbacks &cb) {
+    int error;
+    DB_TXN* txn = NULL;
+    DB_TXN *parent_txn = NULL;
+    tokudb_trx_data *trx = NULL;
+
+    std::string db_name;
+    std::string table_name;
+
+    if (parse_db_and_table(dname.c_str(), db_name, table_name)) {
+        error = MDL_and_TDC(thd, db_name.c_str(), table_name.c_str(), cb);
+        if (error)
+            goto cleanup;
+    }
+
+    trx = (tokudb_trx_data *) thd_get_ha_data(thd, tokudb_hton);
+    if (trx && trx->sub_sp_level)
+        parent_txn = trx->sub_sp_level;
+    error = txn_begin(db_env, parent_txn, &txn, 0, thd);
+    if (error)
+        goto cleanup;
+
+    error = db_env->dirtool_detach(db_env,
+                                   txn,
+                                   dname.c_str());
+cleanup:
+    if (txn) {
+        if (error) {
+            abort_txn(txn);
+        }
+        else {
+            commit_txn(txn, 0);
+        }
+    }
+    return error;
+}
+
+static int move(THD *thd,
+                const std::string &old_dname,
+                const std::string &new_dname,
+                const dir_cmd_callbacks &cb) {
+    int error;
+    DB_TXN* txn = NULL;
+    DB_TXN *parent_txn = NULL;
+    tokudb_trx_data *trx = NULL;
+
+    std::string db_name;
+    std::string table_name;
+
+    if (parse_db_and_table(old_dname.c_str(), db_name, table_name)) {
+        error = MDL_and_TDC(thd, db_name.c_str(), table_name.c_str(), cb);
+        if (error)
+            goto cleanup;
+    }
+
+    trx = (tokudb_trx_data *) thd_get_ha_data(thd, tokudb_hton);
+    if (trx && trx->sub_sp_level)
+        parent_txn = trx->sub_sp_level;
+    error = txn_begin(db_env, parent_txn, &txn, 0, thd);
+    if (error)
+        goto cleanup;
+
+    error = db_env->dirtool_move(db_env,
+                                 txn,
+                                 old_dname.c_str(),
+                                 new_dname.c_str());
+cleanup:
+    if (txn) {
+        if (error) {
+            abort_txn(txn);
+        }
+        else {
+            commit_txn(txn, 0);
+        }
+    }
+    return error;
+}
+
+static void tokenize(const char *cmd_str,
+                     std::vector<std::string> /*out*/ &tokens) {
+    DBUG_ASSERT(cmd_str);
+
+    bool was_escape = false;
+    const char *token_begin = cmd_str;
+    const char *token_end = token_begin;
+
+    while (*token_end) {
+      if (*token_end == tokens_escape_delimiter_char) {
+        was_escape = true;
+      }
+      else if (*token_end == tokens_delimiter) {
+        if (was_escape)
+          was_escape = false;
+        else {
+          if (token_begin == token_end)
+            ++token_begin;
+          else {
+            tokens.push_back(std::string(token_begin, token_end));
+            token_begin = token_end + 1;
+          }
+        }
+      }
+      else {
+        was_escape = false;
+      }
+      ++token_end;
+    }
+
+    if (token_begin != token_end)
+      tokens.push_back(std::string(token_begin, token_end));
+}
+
+void process_dir_cmd(THD *thd,
+                     const char *cmd_str,
+                     const dir_cmd_callbacks &cb) {
+
+    DBUG_ASSERT(thd);
+    DBUG_ASSERT(cmd_str);
+
+    std::vector<std::string> tokens;
+    tokenize(cmd_str, tokens);
+
+    if (tokens.empty())
+        return;
+
+    const std::string &cmd = tokens[0];
+
+    if (!cmd.compare("attach")) {
+        if (tokens.size() != 3) {
+            if (cb.set_error)
+                cb.set_error(thd,
+                             EINVAL,
+                             "attach command requires two arguments");
+        }
+        else {
+            int r = attach(thd, tokens[1], tokens[2], cb);
+            if (r && cb.set_error)
+                cb.set_error(thd, r, "Attach command error");
+        }
+    }
+    else if (!cmd.compare("detach")) {
+        if (tokens.size() != 2) {
+            if (cb.set_error)
+                cb.set_error(thd,
+                             EINVAL,
+                             "detach command requires one argument");
+        }
+        else {
+            int r = detach(thd, tokens[1], cb);
+            if (r && cb.set_error)
+                cb.set_error(thd, r, "detach command error");
+        }
+    }
+    else if (!cmd.compare("move")) {
+        if (tokens.size() != 3) {
+            if (cb.set_error)
+                cb.set_error(thd,
+                             EINVAL,
+                             "move command requires two arguments");
+        }
+        else {
+            int r = move(thd, tokens[1], tokens[2], cb);
+            if (r && cb.set_error)
+                cb.set_error(thd, r, "move command error");
+        }
+    }
+    else {
+        if (cb.set_error)
+            cb.set_error(thd,
+                         ENOENT,
+                         "Unknown command '%s'",
+                         cmd.c_str());
+    }
+
+    return;
+};
+
+
+} // namespace tokudb

--- a/storage/tokudb/tokudb_dir_cmd.h
+++ b/storage/tokudb/tokudb_dir_cmd.h
@@ -1,0 +1,46 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*======
+This file is part of TokuDB
+
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    TokuDBis is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+    TokuDB is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with TokuDB.  If not, see <http://www.gnu.org/licenses/>.
+
+======= */
+
+#ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
+
+#ifndef _TOKUDB_DIR_CMD_H
+#define _TOKUDB_DIR_CMD_H
+
+#include <sql_class.h>
+
+namespace tokudb {
+
+struct  dir_cmd_callbacks {
+  void (*set_error)(THD *thd,
+                    int error,
+                    const char *error_fmt,
+                    ...);
+};
+
+void process_dir_cmd(THD *thd,
+                     const char *cmd_str,
+                     const dir_cmd_callbacks &cb);
+
+};
+
+#endif // _TOKUDB_DIR_CMD_H

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -25,6 +25,9 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
 #include "hatoku_hton.h"
+#include "sql_acl.h"
+#include "tokudb_dir_cmd.h"
+#include "sql_parse.h"
 
 namespace tokudb {
 namespace sysvars {
@@ -39,6 +42,8 @@ namespace sysvars {
 #else
 #define TOKUDB_VERSION_STR NULL
 #endif
+
+const size_t error_buffer_max_size = 1024;
 
 ulonglong   cache_size = 0;
 uint        cachetable_pool_threads = 0;
@@ -918,7 +923,70 @@ static MYSQL_THDVAR_BOOL(
     true);
 #endif
 
+static int dir_cmd_check(THD* thd, struct st_mysql_sys_var* var,
+                         void* save, struct st_mysql_value* value) ;
 
+static MYSQL_THDVAR_INT(dir_cmd_last_error,
+    PLUGIN_VAR_THDLOCAL,
+    "error from the last dir command. 0 is success",
+    NULL, NULL, 0, 0, 0, 1);
+
+static MYSQL_THDVAR_STR(dir_cmd_last_error_string,
+    PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC,
+    "error string from the last dir command",
+    NULL, NULL, NULL);
+
+static MYSQL_THDVAR_STR(dir_cmd,
+    PLUGIN_VAR_THDLOCAL + PLUGIN_VAR_MEMALLOC,
+    "name of the directory where the backup is stored",
+    dir_cmd_check, NULL, NULL);
+
+static void dir_cmd_set_error(THD *thd,
+                              int error,
+                              const char *error_fmt,
+                              ...) {
+    char   buff[error_buffer_max_size];
+    va_list varargs;
+
+    assert(thd);
+    assert(error_fmt);
+
+    va_start(varargs, error_fmt);
+    vsnprintf(buff, sizeof(buff), error_fmt, varargs);
+    va_end(varargs);
+
+    THDVAR_SET(thd, dir_cmd_last_error, &error);
+    THDVAR_SET(thd, dir_cmd_last_error_string, buff);
+}
+
+static int dir_cmd_check(THD* thd, struct st_mysql_sys_var* var,
+                         void* save, struct st_mysql_value* value) {
+    int error = 0;
+    dir_cmd_set_error(thd, error, "");
+
+    if (check_global_access(thd, SUPER_ACL)) {
+        return 1;
+    }
+
+    char buff[STRING_BUFFER_USUAL_SIZE];
+    int length = sizeof(buff);
+    const char *str = value->val_str(value, buff, &length);
+    if (str) {
+        str = thd->strmake(str, length);
+        *(const char**)save = str;
+    }
+
+    if (str) {
+        dir_cmd_callbacks callbacks { .set_error = dir_cmd_set_error };
+        process_dir_cmd(thd, str, callbacks);
+
+        error = THDVAR(thd, dir_cmd_last_error);
+    } else {
+        error = EINVAL;
+    }
+
+    return error;
+}
 
 //******************************************************************************
 // all system variables
@@ -949,7 +1017,6 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(version),
     MYSQL_SYSVAR(write_status_frequency),
     MYSQL_SYSVAR(dir_per_db),
-
 #if TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL
     MYSQL_SYSVAR(gdb_path),
     MYSQL_SYSVAR(gdb_on_fatal),
@@ -1008,6 +1075,9 @@ st_mysql_sys_var* system_variables[] = {
 #if TOKUDB_DEBUG
    MYSQL_SYSVAR(debug_pause_background_job_manager),
 #endif // TOKUDB_DEBUG
+    MYSQL_SYSVAR(dir_cmd_last_error),
+    MYSQL_SYSVAR(dir_cmd_last_error_string),
+    MYSQL_SYSVAR(dir_cmd),
 
     NULL
 };


### PR DESCRIPTION
The new system variables are involved:

===tokudb_dir_cmd===

This variable is used to send commands to edit directory file. The format of
the command line is the following:

command arg1 arg2 .. argn

I.e, if we want to execute some command the following statement can be used:

SET tokudb_dir_cmd = "command arg1 ... argn"

Currently the following commands are availabe:

attach dname iname - attach iname to dname, if dname exists - override
                     the previous value, add new record otherwise
detach dname       - remove record with corresponding dname,
                     the corresponding iname file stays untouched
move old_dname new_dname - rename (only) dname from old_dname to new_dname

If table and database names can be parsed from dname then MDL X lock is
acquired and the table is removed from mysql table dictionary cache. When some
table is removed from TDC it's TABLE_SHARE instance is released. TABLE_SHARE
contains refereces counter, when it equal to zero, the table is closed.
At the other hand tokudb cachetable contains a list of active cachefiles and a
list of stalled cachefiles. Each cachefile contains ft_handle which in turn
has refference counter too. When TABLE_SHARE is closed it decrements
the refference counter of corresponding ft_handles (there are usually several
ft_handles associated with one TABLE_SHARE instance as one table consists of
the several ft-files like main, status and keys). When the refference counter
of some ft_handle becomes zero it's cachefile is moved from active to stalled
list in cachetable. Cachefiles from stalled list are the first candidates for
eviction.

So it's enought just to remove table from TDC and it's cachefiles will be moved
to stalled list sooner or later. Sooner or later because there can be some
other objects which use the table's TABLE_SHARE instance, for example, tokudb
storage engine gathers some statistics in background and it can hold
TABLE_SHARE instances for this purpose.

As it was said when cachefiles are placed into stalled list they will be
evicted sooner or latter unless they are reopened before eviction. When new
ft-file is opened it's file_id is obtained. file_id consists of device id and
inode number. The cachefile is searched in stalled list by this file_id. If
it's not found then new cachefiles is created.

So if some iname was changed/deleted for some dname with the commands described
above the corresponding cachefile will be moved to stalled list and evicted
eventually unless the same iname is not used for opening ft-file with some
other dname before the eviction.

===tokudb_dir_cmd_last_error===

Contains error number of the last executed command

===tokudb_dir_cmd_last_error_string===

Contains error string of the last executed command

Testing: http://jenkins.percona.com/job/percona-server-5.6-param/1730/
tokudb.backup.tokudb_backup_exclude fails because the test uses tokubackup master which has updated api while the PS GCA branch still uses the old API.

See also:
https://github.com/percona/PerconaFT/pull/367
https://github.com/percona/percona-server/pull/1459