### PR TITLE
Fix bug 1659746 (Test main.index_merge_innodb is unstable)

### DIFF
--- a/mysql-test/include/index_merge_ror.inc
+++ b/mysql-test/include/index_merge_ror.inc
@@ -178,6 +178,7 @@ select key1,key2,filler1 from t1 where key2=100 and key2=200;
 
 # ROR-union(ROR-intersection) with one of ROR-intersection giving empty
 # results
+--replace_result key3 key34 key4 key34
 explain select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
 select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
 

--- a/mysql-test/r/index_merge_innodb.result
+++ b/mysql-test/r/index_merge_innodb.result
@@ -696,9 +696,9 @@ update t1 set key1=200,key2=200 where key1=100 and key2=100;
 delete from t1 where key1=200 and key2=200;
 select key1,key2,filler1 from t1 where key2=100 and key2=200;
 key1	key2	filler1
-explain select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
+explain select key1,key2,key34,key34,filler1 from t1 where key1=100 and key2=100 or key34=100 and key34=100;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index_merge	key1,key2,key3,key4	key1,key2,key3,key4	5,5,5,5	NULL	4	Using union(intersect(key1,key2),intersect(key3,key4)); Using where
+1	SIMPLE	t1	index_merge	key1,key2,key34,key34	key1,key2,key34,key34	5,5,5,5	NULL	4	Using union(intersect(key1,key2),intersect(key34,key34)); Using where
 select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
 key1	key2	key3	key4	filler1
 -1	-1	100	100	key4-key3

--- a/mysql-test/r/index_merge_myisam.result
+++ b/mysql-test/r/index_merge_myisam.result
@@ -726,9 +726,9 @@ update t1 set key1=200,key2=200 where key1=100 and key2=100;
 delete from t1 where key1=200 and key2=200;
 select key1,key2,filler1 from t1 where key2=100 and key2=200;
 key1	key2	filler1
-explain select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
+explain select key1,key2,key34,key34,filler1 from t1 where key1=100 and key2=100 or key34=100 and key34=100;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t1	index_merge	key1,key2,key3,key4	key1,key2,key3,key4	5,5,5,5	NULL	152	Using union(intersect(key1,key2),intersect(key3,key4)); Using where
+1	SIMPLE	t1	index_merge	key1,key2,key34,key34	key1,key2,key34,key34	5,5,5,5	NULL	152	Using union(intersect(key1,key2),intersect(key34,key34)); Using where
 select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
 key1	key2	key3	key4	filler1
 -1	-1	100	100	key4-key3


### PR DESCRIPTION
The previous testcase fix for bug 1625151 missed one more instability
case in the testcase, where
"union(intersect(key1,key2),intersect(key3,key4))" could be
"union(intersect(key1,key2),intersect(key4,key3))".

Previous cases were resolved by restarting the server with a slow
shutdown so that purge completes, but here, since key3 and key4 are
interchangeable in this query plan, replace them both in the output to
something common, avoiding a restart.

http://jenkins.percona.com/job/percona-server-5.6-param/1732/