### PR TITLE
Fix bug 1658006 (Test sys_vars.rpl_init_slave_func is unstable)

### DIFF
--- a/mysql-test/suite/sys_vars/r/rpl_init_slave_func.result
+++ b/mysql-test/suite/sys_vars/r/rpl_init_slave_func.result
@@ -3,7 +3,10 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
+CREATE TABLE t1(a INT);
+DROP TABLE t1;
 connection slave
+include/sync_slave_sql_with_master.inc
 SET @start_max_connections= @@global.max_connections;
 SET @start_init_slave= @@global.init_slave;
 SET NAMES utf8;
@@ -22,18 +25,10 @@ SELECT @@global.init_slave = 'SET @@global.max_connections = @@global.max_connec
 1
 Expect 1
 include/assert.inc [@@global.max_connections = @start_max_connections]
-STOP SLAVE;
-RESET MASTER;
-RESET SLAVE;
-START SLAVE;
-include/wait_for_slave_to_start.inc
+include/restart_slave.inc
 include/assert.inc [@@global.max_connections = @start_max_connections + 1]
 SET @@global.init_slave = "SET @a=5";
-STOP SLAVE;
-RESET MASTER;
-RESET SLAVE;
-START SLAVE;
-include/wait_for_slave_to_start.inc
+include/restart_slave.inc
 SHOW VARIABLES LIKE 'init_slave';
 Variable_name	Value
 init_slave	SET @a=5

--- a/mysql-test/suite/sys_vars/t/rpl_init_slave_func.test
+++ b/mysql-test/suite/sys_vars/t/rpl_init_slave_func.test
@@ -29,8 +29,16 @@
 ###############################################################################
 
 source include/master-slave.inc;
+
+# Since a part of slave SQL thread initialisation happens after Slave_SQL_Running
+# has been set to Yes, there is a race condition between initialisation above and
+# init_slave setting above. Synchronise by replicating some workload.
+CREATE TABLE t1(a INT);
+DROP TABLE t1;
+
 --echo connection slave
-connection slave;
+--source include/sync_slave_sql_with_master.inc
+
 --disable_query_log
 call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
 --enable_query_log
@@ -67,14 +75,9 @@ let $wait_condition= SELECT @@global.max_connections = @start_max_connections;
 --let $assert_text= @@global.max_connections = @start_max_connections
 --let $assert_cond= @@global.max_connections = @start_max_connections
 --source include/assert.inc
-#
-# reset of the server
-STOP SLAVE;
---wait_for_slave_to_stop
-RESET MASTER;
-RESET SLAVE;
-START SLAVE;
-source include/wait_for_slave_to_start.inc;
+
+--source include/restart_slave_sql.inc
+
 #
 # wait for the slave threads have set the global variable.
 let $wait_timeout= 90;
@@ -88,12 +91,7 @@ let $wait_condition= SELECT @@global.max_connections = @start_max_connections + 
 # Setting a variable(which is local to a session) and must not be visible
 SET @@global.init_slave = "SET @a=5";
 #
-STOP SLAVE;
---wait_for_slave_to_stop
-RESET MASTER;
-RESET SLAVE;
-START SLAVE;
-source include/wait_for_slave_to_start.inc;
+--source include/restart_slave_sql.inc
 #
 SHOW VARIABLES LIKE 'init_slave';
 # expect NULL


### PR DESCRIPTION
A slave SQL thread sets its Running state to Yes very early in its
initialisation, before the majority of initialisation actions,
including executing the init_slave command, are done. Thus the
testcase has a race condition where the initial replication setup
might finish executing later than the testcase SET GLOBAL init_slave,
making the testcase see its effect where it checks for its absence.

Add synchronisation by running some workload on the master, which is
then synced to slave, ensuring that its initialisation is fully
done. Replace the apparently needless RESET MASTER / RESET SLAVE
etc. with just slave SQL restarts, as the former breaks in the
presence of added master workload.

http://jenkins.percona.com/job/percona-server-5.6-param/1747/