### PR TITLE
MYR-66 : 5.7 mtr - assertion percona-server/include/thr_mutex.h:153: …

### DIFF
--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -202,6 +202,8 @@ void Rdb_mutex::UnLock() {
         m_old_stage_info[current_thd];
     m_old_stage_info.erase(current_thd);
     /* The following will call mysql_mutex_unlock */
+    /* GOL - not in 5.7, see commentary in sql_class.h */
+    mysql_mutex_unlock(&m_mutex);
     my_core::thd_exit_cond(current_thd, old_stage.get());
     return;
   }


### PR DESCRIPTION
…void

  safe_mutex_assert_not_owner(const my_mutex_t*): Assertion `!mp->count ||
  !my_thread_equal(my_thread_self(), mp->thread)' failed.
- 5.7 changed behavior of thd_exit_cond, which MyRocks uses for locking to
  assert if a mutex is locked where 5.6 it unlocked the mutex within
  thd_exit_cond.
- Upstream MyRocks introduced the use of this here
  https://github.com/facebook/mysql-5.6/commit/9e5daaa60fef869921978a7cd5fc27e50a33365f
- This fix unlocks the mutex prior to calling thd_exit_cond.