### PR TITLE
MYR-57 : 5.7 mtr - re-record rocksdb.mysqldump

### DIFF
--- a/mysql-test/suite/rocksdb/r/mysqldump.result
+++ b/mysql-test/suite/rocksdb/r/mysqldump.result
@@ -43,15 +43,15 @@ update r1 set value1=value1+100 where id1=1 and id2=1 and id3='1';
 /*!50112 PREPARE s FROM @enable_bulk_load */;
 /*!50112 EXECUTE s */;
 /*!50112 DEALLOCATE PREPARE s */;
--- CHANGE MASTER TO MASTER_LOG_FILE='master-bin.000001', MASTER_LOG_POS=4045;
+-- CHANGE MASTER TO MASTER_LOG_FILE='master-bin.000001', MASTER_LOG_POS=5249;
 DROP TABLE IF EXISTS `r1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `r1` (
-  `id1` int(11) NOT NULL DEFAULT '0',
-  `id2` int(11) NOT NULL DEFAULT '0',
-  `id3` varchar(100) NOT NULL DEFAULT '',
-  `id4` int(11) NOT NULL DEFAULT '0',
+  `id1` int(11) NOT NULL,
+  `id2` int(11) NOT NULL,
+  `id3` varchar(100) NOT NULL,
+  `id4` int(11) NOT NULL,
   `value1` int(11) DEFAULT NULL,
   `value2` int(11) DEFAULT NULL,
   `value3` int(11) DEFAULT NULL,
@@ -103,15 +103,15 @@ SET GLOBAL default_storage_engine=rocksdb;
 /*!50112 PREPARE s FROM @enable_bulk_load */;
 /*!50112 EXECUTE s */;
 /*!50112 DEALLOCATE PREPARE s */;
--- CHANGE MASTER TO MASTER_LOG_FILE='master-bin.000001', MASTER_LOG_POS=4045;
+-- CHANGE MASTER TO MASTER_LOG_FILE='master-bin.000001', MASTER_LOG_POS=5249;
 DROP TABLE IF EXISTS `r1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `r1` (
-  `id1` int(11) NOT NULL DEFAULT '0',
-  `id2` int(11) NOT NULL DEFAULT '0',
-  `id3` varchar(100) NOT NULL DEFAULT '',
-  `id4` int(11) NOT NULL DEFAULT '0',
+  `id1` int(11) NOT NULL,
+  `id2` int(11) NOT NULL,
+  `id3` varchar(100) NOT NULL,
+  `id4` int(11) NOT NULL,
   `value1` int(11) DEFAULT NULL,
   `value2` int(11) DEFAULT NULL,
   `value3` int(11) DEFAULT NULL,


### PR DESCRIPTION
MYR-80 : 5.7 mtr - re-record tests for different SHOW CREATE output
- Re-record rocksdb.mysqldump to account for different binlog coords in dump
  result due to differing binlog record sizes in 5.7
- Also captured re-record diffs fo different format of SHOW CREATE in 5.7.