### PR TITLE
MYR-97 : 5.7 missing DBUG_RETURNs on gap lock error

### DIFF
--- a/mysql-test/suite/rocksdb/r/gap_lock_error.result
+++ b/mysql-test/suite/rocksdb/r/gap_lock_error.result
@@ -10,10 +10,10 @@ PRIMARY KEY (id)) ENGINE=rocksdb
 PARTITION BY HASH(id) PARTITIONS 2;
 Warnings:
 Warning	1287	The partition engine, used by table 'test.gap4', is deprecated and will be removed in a future release. Please use native partitioning instead.
-Warnings:
-Warning	1287	The partition engine, used by table 'test.gap4', is deprecated and will be removed in a future release. Please use native partitioning instead.
 insert into gap3 values (1,1), (2,2),(3,3),(4,4),(5,5);
 insert into gap4 values (1,1), (2,2),(3,3),(4,4),(5,5);
+Warnings:
+Warning	1287	The partition engine, used by table 'test.gap4', is deprecated and will be removed in a future release. Please use native partitioning instead.
 set session autocommit=0;
 select * from gap1 limit 1 for update;
 ERROR HY000: Using Gap Lock without full unique key in multi-table or multi-statement transactions is not allowed. You need to either rewrite queries to use all unique key columns in WHERE equal conditions, or rewrite to single-table, single-statement transaction.  Query: select * from gap1 limit 1 for update

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -3448,7 +3448,7 @@ int handler::ha_index_first(uchar * buf)
 
   if (is_using_prohibited_gap_locks(table, false))
   {
-    return HA_ERR_LOCK_DEADLOCK;
+    DBUG_RETURN(HA_ERR_LOCK_DEADLOCK);
   }
 
   // Set status for the need to update generated fields
@@ -3493,7 +3493,7 @@ int handler::ha_index_last(uchar * buf)
 
   if (is_using_prohibited_gap_locks(table, false))
   {
-    return HA_ERR_LOCK_DEADLOCK;
+    DBUG_RETURN(HA_ERR_LOCK_DEADLOCK);
   }
 
   // Set status for the need to update generated fields


### PR DESCRIPTION
- Added missing DBUG_RETURNs to handler::ha_index_first and
  handler::ha_index_last
- Corrected gap_lock_error.result expected warnings revealed by fixing this
  issue.