### PR TITLE
Fix bug 1671076 (Test main.mysqldump is unstable)

### DIFF
--- a/mysql-test/t/mysqldump.test
+++ b/mysql-test/t/mysqldump.test
@@ -730,7 +730,11 @@ drop table t1, t2, t3;
 
 create table t1 (a int);
 --error 2
---exec $MYSQL_DUMP --skip-comments --force test t1 --where="xx xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 2>&1
+--exec $MYSQL_DUMP --skip-comments --force test t1 --where="xx xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" 2> $MYSQLTEST_VARDIR/tmp/bug21288.err > $MYSQLTEST_VARDIR/tmp/bug21288.sql
+--cat_file $MYSQLTEST_VARDIR/tmp/bug21288.err
+--remove_file $MYSQLTEST_VARDIR/tmp/bug21288.err
+--cat_file $MYSQLTEST_VARDIR/tmp/bug21288.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/bug21288.sql
 drop table t1;
 
 


### PR DESCRIPTION
The testcase invokes a command, redirects its stderr to stdout, and
expects a certain interleaving between the two. But it is not
deterministic due to stdout buffering. Fix by redirecting the two
streams separately.

http://jenkins.percona.com/job/percona-server-5.6-param/1758/