### PR TITLE
Add diagnostics for bug 1671088 (Test main.wl6443_deprecation is unst…

### DIFF
--- a/mysql-test/r/mysql_upgrade.result
+++ b/mysql-test/r/mysql_upgrade.result
@@ -507,6 +507,8 @@ DROP USER B20023823_16hash@localhost;
 #
 Run mysql_upgrade with unauthorized access
 Warning: Using a password on the command line interface can be insecure.
+mysql_upgrade: running mysql with query "show variables like 'datadir'" returned 1
+mysql_upgrade: running mysql with query "show variables like 'version'" returned 1
 Error: Failed while fetching Server version! Could be due to unauthorized access.
 FATAL ERROR: Upgrade failed
 


### PR DESCRIPTION
…able)

Add missing error handling for child process invocation in
mysql_upgrade. Re-record main.mysql_upgrade for the expected extra
diagnostics.

http://jenkins.percona.com/job/percona-server-5.6-param/1759/