### PR TITLE
Fix bug 1671123 (Test innodb.innodb-wl6445 is unstable)

### DIFF
--- a/mysql-test/suite/innodb/r/innodb-wl6445.result
+++ b/mysql-test/suite/innodb/r/innodb-wl6445.result
@@ -8,9 +8,6 @@ t1	CREATE TABLE `t1` (
   `c2` int(11) DEFAULT NULL,
   KEY `sec_idx` (`c2`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
-# Request clean shutdown
-# Wait for disconect
-# Restart server.
 # Restarted
 SELECT COUNT(*) FROM WL6445.t1;
 COUNT(*)
@@ -46,9 +43,6 @@ t1	CREATE TABLE `t1` (
   `c2` int(11) DEFAULT NULL,
   KEY `sec_idx` (`c2`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1
-# Request clean shutdown
-# Wait for disconect
-# Restart server.
 # Restarted
 DROP TABLE WL6445.t1;
 DROP DATABASE WL6445;

--- a/mysql-test/suite/innodb/t/innodb-wl6445.test
+++ b/mysql-test/suite/innodb/t/innodb-wl6445.test
@@ -13,22 +13,7 @@ INSERT INTO WL6445.t1 VALUES(0,0),(1,1),(2,2);
 
 SHOW CREATE TABLE WL6445.t1;
 
-# Write file to make mysql-test-run.pl wait for the server to stop
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-
---echo # Request clean shutdown
---send_shutdown
-
---echo # Wait for disconect
---source include/wait_until_disconnected.inc
-
---echo # Restart server.
---exec echo "restart:--innodb-read-only" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-
---enable_reconnect
---source include/wait_until_connected_again.inc
---disable_reconnect
-
+--source include/restart_readonly_mysqld.inc
 --echo # Restarted
 
 ## DDL
@@ -80,22 +65,7 @@ DROP DATABASE WL6445;
 SHOW CREATE TABLE WL6445.t1;
 
 # Restart in RW mode so that we can drop the test data
-# Write file to make mysql-test-run.pl wait for the server to stop
---exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-
---echo # Request clean shutdown
---send_shutdown
-
---echo # Wait for disconect
---source include/wait_until_disconnected.inc
-
---echo # Restart server.
---exec echo "restart:" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-
---enable_reconnect
---source include/wait_until_connected_again.inc
---disable_reconnect
-
+--source include/restart_mysqld.inc
 --echo # Restarted
 
 DROP TABLE WL6445.t1;


### PR DESCRIPTION
Replace the custom server restart sequences which use asynchronous
send_shutdown with the right include files.

http://jenkins.percona.com/job/percona-server-5.6-param/1760/