### PR TITLE
Improve ACL cache concurrency

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -11,6 +11,7 @@ The following options may be given as the first argument:
  --abort-slave-event-count=# 
  Option used by mysql-test for debugging and testing of
  replication.
+ --acl-cache-size=#  Maximum size of the ACL cache
  --allow-suspicious-udfs 
  Allows use of UDFs consisting of only one symbol xxx()
  without corresponding xxx_init() or xxx_deinit(). That
@@ -1168,6 +1169,7 @@ The following options may be given as the first argument:
 
 Variables (--variable-name=value)
 abort-slave-event-count 0
+acl-cache-size 256
 allow-suspicious-udfs FALSE
 auto-increment-increment 1
 auto-increment-offset 1

--- a/mysql-test/suite/perfschema/r/dml_setup_instruments.result
+++ b/mysql-test/suite/perfschema/r/dml_setup_instruments.result
@@ -19,6 +19,7 @@ where name like 'Wait/Synch/Rwlock/sql/%'
   and name not in ('wait/synch/rwlock/sql/CRYPTO_dynlock_value::lock')
 order by name limit 10;
 NAME	ENABLED	TIMED
+wait/synch/rwlock/sql/acl_lock	YES	YES
 wait/synch/rwlock/sql/Binlog_relay_IO_delegate::lock	YES	YES
 wait/synch/rwlock/sql/Binlog_storage_delegate::lock	YES	YES
 wait/synch/rwlock/sql/Binlog_transmit_delegate::lock	YES	YES
@@ -28,7 +29,6 @@ wait/synch/rwlock/sql/LOCK_dboptions	YES	YES
 wait/synch/rwlock/sql/LOCK_grant	YES	YES
 wait/synch/rwlock/sql/LOCK_system_variables_hash	YES	YES
 wait/synch/rwlock/sql/LOCK_sys_init_connect	YES	YES
-wait/synch/rwlock/sql/LOCK_sys_init_slave	YES	YES
 select * from performance_schema.setup_instruments
 where name like 'Wait/Synch/Cond/sql/%'
   and name not in (

--- a/mysql-test/suite/sys_vars/r/acl_cache_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/acl_cache_size_basic.result
@@ -1,0 +1,34 @@
+show variables like 'acl_cache_size';
+Variable_name	Value
+acl_cache_size	100000
+set global acl_cache_size = 100;
+show variables like 'acl_cache_size';
+Variable_name	Value
+acl_cache_size	100
+set global acl_cache_size = 0;
+Warnings:
+Warning	1292	Truncated incorrect acl_cache_size value: '0'
+show variables like 'acl_cache_size';
+Variable_name	Value
+acl_cache_size	1
+set global acl_cache_size = -1;
+Warnings:
+Warning	1292	Truncated incorrect acl_cache_size value: '-1'
+show variables like 'acl_cache_size';
+Variable_name	Value
+acl_cache_size	1
+set global acl_cache_size = 10000000;
+Warnings:
+Warning	1292	Truncated incorrect acl_cache_size value: '10000000'
+show variables like 'acl_cache_size';
+Variable_name	Value
+acl_cache_size	1048576
+set acl_cache_size = 100000;
+ERROR HY000: Variable 'acl_cache_size' is a GLOBAL variable and should be set with SET GLOBAL
+show variables like 'acl_cache_size';
+Variable_name	Value
+acl_cache_size	1048576
+set global acl_cache_size = 100000;
+show variables like 'acl_cache_size';
+Variable_name	Value
+acl_cache_size	100000

--- a/mysql-test/suite/sys_vars/t/acl_cache_size_basic-master.opt
+++ b/mysql-test/suite/sys_vars/t/acl_cache_size_basic-master.opt
@@ -1,0 +1,1 @@
+--acl-cache-size=100000

--- a/mysql-test/suite/sys_vars/t/acl_cache_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/acl_cache_size_basic.test
@@ -1,0 +1,14 @@
+show variables like 'acl_cache_size';
+set global acl_cache_size = 100;
+show variables like 'acl_cache_size';
+set global acl_cache_size = 0;
+show variables like 'acl_cache_size';
+set global acl_cache_size = -1;
+show variables like 'acl_cache_size';
+set global acl_cache_size = 10000000;
+show variables like 'acl_cache_size';
+--error ER_GLOBAL_VARIABLE
+set acl_cache_size = 100000;
+show variables like 'acl_cache_size';
+set global acl_cache_size = 100000;
+show variables like 'acl_cache_size';

--- a/sql/hash_filo.h
+++ b/sql/hash_filo.h
@@ -147,6 +147,15 @@ public:
     return entry;
   }
 
+  hash_filo_element *search_sync(uchar* key, size_t length)
+  {
+	  hash_filo_element* r;
+	  mysql_mutex_lock(&lock);
+	  r = search(key, length);
+	  mysql_mutex_unlock(&lock);
+	  return r;
+  }
+
   my_bool add(hash_filo_element *entry)
   {
     if (!m_size) return 1;
@@ -168,7 +177,7 @@ public:
     if (my_hash_insert(&cache,(uchar*) entry))
     {
       if (free_element)
-	(*free_element)(entry);		// This should never happen
+        (*free_element)(entry);
       return 1;
     }
     entry->prev_used= NULL;
@@ -180,6 +189,15 @@ public:
     first_link= entry;
 
     return 0;
+  }
+
+  my_bool add_sync(hash_filo_element *entry)
+  {
+	  my_bool r;
+	  mysql_mutex_lock(&lock);
+	  r = add(entry);
+	  mysql_mutex_unlock(&lock);
+	  return r;
   }
 
   uint size()

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -370,6 +370,7 @@ static char *default_character_set_name;
 static char *character_set_filesystem_name;
 static char *lc_messages;
 static char *lc_time_names_name;
+ulong opt_acl_cache_size = ACL_CACHE_SIZE_DEFAULT;
 char *my_bind_addr_str;
 char *my_proxy_protocol_networks;
 static char *default_collation_name;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10313,7 +10313,7 @@ static PSI_mutex_info all_server_mutexes[]=
 PSI_rwlock_key key_rwlock_LOCK_grant, key_rwlock_LOCK_logger,
   key_rwlock_LOCK_sys_init_connect, key_rwlock_LOCK_sys_init_slave,
   key_rwlock_LOCK_system_variables_hash, key_rwlock_query_cache_query_lock,
-  key_rwlock_global_sid_lock, key_rwlock_LOCK_consistent_snapshot;
+  key_rwlock_global_sid_lock, key_rwlock_LOCK_consistent_snapshot, key_rwlock_acl_lock;
 
 PSI_rwlock_key key_rwlock_Trans_delegate_lock;
 PSI_rwlock_key key_rwlock_Binlog_storage_delegate_lock;
@@ -10324,6 +10324,7 @@ PSI_rwlock_key key_rwlock_Binlog_relay_IO_delegate_lock;
 
 static PSI_rwlock_info all_server_rwlocks[]=
 {
+  { &key_rwlock_acl_lock, "acl_lock", PSI_FLAG_GLOBAL},
 #if defined (HAVE_OPENSSL) && !defined(HAVE_YASSL)
   { &key_rwlock_openssl, "CRYPTO_dynlock_value::lock", 0},
 #endif

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -97,6 +97,7 @@ extern CHARSET_INFO *error_message_charset_info;
 extern CHARSET_INFO *character_set_filesystem;
 
 extern MY_BITMAP temp_pool;
+extern ulong opt_acl_cache_size;
 extern bool opt_large_files, server_id_supplied;
 extern bool opt_update_log, opt_bin_log, opt_error_log;
 extern my_bool opt_log, opt_slow_log, opt_log_raw;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -687,6 +687,11 @@ static bool acl_utility_user_initialized= false;
 static my_bool acl_init_utility_user(my_bool check_no_resolve);
 static void acl_free_utility_user();
 
+void acl_cache_update_size(uint size)
+{
+	acl_cache->resize(size);
+}
+
 /**
   Convert scrambled password to binary form, according to scramble type, 
   Binary form is stored in user.salt.
@@ -768,7 +773,7 @@ my_bool acl_init(bool dont_read_acl_tables)
   my_bool return_val;
   DBUG_ENTER("acl_init");
 
-  acl_cache= new hash_filo(ACL_CACHE_SIZE, 0, 0,
+  acl_cache= new hash_filo(opt_acl_cache_size, 0, 0,
                            (my_hash_get_key) acl_entry_get_key,
                            (my_hash_free_key) free,
                            &my_charset_utf8_bin);

--- a/sql/sql_acl.h
+++ b/sql/sql_acl.h
@@ -307,6 +307,8 @@ int check_password_policy(String *password);
 my_bool acl_is_utility_user(const char *user, const char *host,
                          const char *ip);
 
+void acl_cache_update_size(uint size);
+
 #ifdef NO_EMBEDDED_ACCESS_CHECKS
 #define check_grant(A,B,C,D,E,F) 0
 #define check_grant_db(A,B) 0

--- a/sql/sql_const.h
+++ b/sql/sql_const.h
@@ -110,7 +110,7 @@
   Configuration parameters
 ****************************************************************************/
 
-#define ACL_CACHE_SIZE		256
+#define ACL_CACHE_SIZE_DEFAULT		256
 #define MAX_PASSWORD_LENGTH	32
 #define HOST_CACHE_SIZE		128
 #define MAX_ACCEPT_RETRY	10	// Test accept this many times

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -543,6 +543,23 @@ static Sys_var_long Sys_pfs_connect_attrs_size(
 #endif /* EMBEDDED_LIBRARY */
 #endif /* WITH_PERFSCHEMA_STORAGE_ENGINE */
 
+#ifndef EMBEDDED_LIBRARY
+static bool update_acl_cache_size(sys_var *self, THD *thd, enum_var_type type)
+{
+  acl_cache_update_size(opt_acl_cache_size);
+  return false;
+}
+
+static Sys_var_ulong Sys_acl_cache_size(
+       "acl_cache_size",
+       "Maximum size of the ACL cache",
+       GLOBAL_VAR(opt_acl_cache_size),
+       CMD_LINE(REQUIRED_ARG), VALID_RANGE(1, 1024*1024),
+       DEFAULT(256),
+       BLOCK_SIZE(1), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(0), ON_UPDATE(update_acl_cache_size));
+#endif /* EMBEDDED_LIBRARY */
+
 static Sys_var_ulong Sys_auto_increment_increment(
        "auto_increment_increment",
        "Auto-increment columns are incremented by this",


### PR DESCRIPTION
The ACL cache is fixed size and is protected with exclusive mutex. If the lookup entry is not in the cache or the entry has a wildcard, then MySQL resorts to linear search through all the ACL entries. This change replaces exclusive mutex with RWLock and adds a configuration option to control the ACL cache size:

| **Command-Line Format** | --acl-cache-size=# | |
|---|---|---|
| **System Variable** | **Name** | acl_cache_size |
| | **Variable Scope** | Global |
| | **Dynamic Variable** | Yes |
| **Permitted Values**	| **Type** | integer |
| | **Default** | 256 |
| | **Min Value** | 1 |
| | **Max Value** | 1048576 |