### PR TITLE
MYR-53 : Missing tool sst_dump causes rocksdb.compact_deletes massive…

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -2563,6 +2563,16 @@ sub environment_setup {
   $ENV{'INNOCHECKSUM'}= native_path($exe_innochecksum);
 
   # ----------------------------------------------------
+  # sst_dump
+  # ----------------------------------------------------
+  my $exe_sst_dump=
+    mtr_exe_maybe_exists(
+           vs_config_dirs('storage/rocksdb', 'sst_dump'),
+           "$path_client_bindir/sst_dump",
+           "$basedir/storage/rocksdb/sst_dump");
+  $ENV{'MYSQL_SST_DUMP'}= native_path($exe_sst_dump);
+
+  # ----------------------------------------------------
   # Setup env so childs can execute myisampack and myisamchk
   # ----------------------------------------------------
   $ENV{'MYISAMCHK'}= native_path(mtr_exe_exists(

--- a/mysql-test/suite/rocksdb/r/compact_deletes.result
+++ b/mysql-test/suite/rocksdb/r/compact_deletes.result
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS r1;
 create table r1 (
 id1 int,
 id2 int,

--- a/mysql-test/suite/rocksdb/t/compact_deletes.test
+++ b/mysql-test/suite/rocksdb/t/compact_deletes.test
@@ -1,8 +1,6 @@
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 
---disable_warnings
-DROP TABLE IF EXISTS r1;
---enable_warnings
+--file_exists $MYSQL_SST_DUMP
 
 create table r1 (
  id1 int,

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -41,6 +41,7 @@ STRING(REGEX MATCHALL "[^\n]+" ROCKSDB_LIB_SOURCES ${SCRIPT_OUTPUT})
 INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb
   ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/include/rocksdb
   ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/third-party/gtest-1.7.0/fused-src
 )
 
@@ -120,19 +121,18 @@ IF(WITH_EMBEDDED_SERVER)
   ADD_SUBDIRECTORY(unittest)
 ENDIF()
 
-IF (WITH_ROCKSDB_SE_STORAGE_ENGINE)
-  # TODO: read this file list from src.mk:TOOL_SOURCES
-  SET(ROCKSDB_TOOL_SOURCES
-    ${CMAKE_SOURCE_DIR}/rocksdb/tools/ldb_tool.cc
-    ${CMAKE_SOURCE_DIR}/rocksdb/tools/ldb_cmd.cc
-    ${CMAKE_SOURCE_DIR}/rocksdb/tools/sst_dump_tool.cc
-  )
-  MYSQL_ADD_EXECUTABLE(sst_dump ${CMAKE_SOURCE_DIR}/rocksdb/tools/sst_dump.cc ${ROCKSDB_TOOL_SOURCES})
-  TARGET_LINK_LIBRARIES(sst_dump rocksdb)
+# TODO: read this file list from src.mk:TOOL_SOURCES
+SET(ROCKSDB_TOOL_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/tools/ldb_tool.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/tools/ldb_cmd.cc
+  ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/tools/sst_dump_tool.cc
+  ${ROCKSDB_LIB_SOURCES}
+)
+MYSQL_ADD_EXECUTABLE(sst_dump ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/tools/sst_dump.cc ${ROCKSDB_TOOL_SOURCES})
+TARGET_LINK_LIBRARIES(sst_dump ${rocksdb_static_libs})
 
-  MYSQL_ADD_EXECUTABLE(ldb ${CMAKE_SOURCE_DIR}/rocksdb/tools/ldb.cc ${ROCKSDB_TOOL_SOURCES})
-  TARGET_LINK_LIBRARIES(ldb rocksdb)
+MYSQL_ADD_EXECUTABLE(ldb ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/tools/ldb.cc ${ROCKSDB_TOOL_SOURCES})
+TARGET_LINK_LIBRARIES(ldb ${rocksdb_static_libs})
 
-  MYSQL_ADD_EXECUTABLE(mysql_ldb ${CMAKE_SOURCE_DIR}/storage/rocksdb/tools/mysql_ldb.cc ${ROCKSDB_TOOL_SOURCES})
-  TARGET_LINK_LIBRARIES(mysql_ldb rocksdb)
-ENDIF()
+MYSQL_ADD_EXECUTABLE(mysql_ldb ${CMAKE_CURRENT_SOURCE_DIR}/tools/mysql_ldb.cc ${ROCKSDB_TOOL_SOURCES})
+TARGET_LINK_LIBRARIES(mysql_ldb ${rocksdb_static_libs})


### PR DESCRIPTION
… failures

- Initial work on CMakeLists.txt did not correctly build extra tools. Fixed
  to build Myocks/RocksDB tools.
- Added mtr environment variable MYSQL_SST_DUMP so test(s) can access binary.
- Touched compact deletes test to audit and change to have_rocksdb.inc.
- Touched compact_deletes test to add check that MYSQL_SST_DUMP exists prioo
  to executing test.
- Removed obsolete "DROP TABLE IF EXISTS"