### PR TITLE
MYR-79 : 5.7 mtr - re-record tests that use restart_mysqld.inc due to…

### DIFF
--- a/mysql-test/suite/rocksdb/r/collation.result
+++ b/mysql-test/suite/rocksdb/r/collation.result
@@ -48,6 +48,7 @@ CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
 ALTER TABLE t2 ADD INDEX(value);
 ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
 DROP TABLE t2;
+# restart:--log-error=LOG_FILE
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
 CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin).
@@ -58,3 +59,4 @@ CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rock
 ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin).
 DROP TABLE a, b;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
+# restart

--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -76,7 +76,8 @@ ALTER TABLE t2 ADD INDEX(value);
 DROP TABLE t2;
 
 --let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/rocksdb.collation.err
---let $restart_parameters="restart: --log-error=$SEARCH_FILE"
+--let $restart_parameters=restart:--log-error=$SEARCH_FILE
+--replace_result $SEARCH_FILE LOG_FILE
 --source include/restart_mysqld.inc
 
 # test invalid regex (missing end bracket)


### PR DESCRIPTION
… new

         comment in output
- Fixed missed instance in rocksdb.collation.result masked by other failures.
- Fixed rocksdb.collation.test to properly replace result so absolute path is
  not contained within result file.