### PR TITLE
MYR-63 : rocksdb.bloomfilter3 fails

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/db233.result
+++ b/mysql-test/suite/tokudb.bugs/r/db233.result
@@ -14,16 +14,6 @@ INSERT INTO t1 VALUES(1, 1, '1', '1'), (2, 2, '2', '2'), (3, 3, '3', '3'), (4, 4
 ANALYZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
-set DEBUG_SYNC = 'tokudb_icp_desc_scan_invalidate SIGNAL hit1 WAIT_FOR done1';
-SELECT c FROM t1 WHERE id BETWEEN 5 AND 8 ORDER BY id DESC;
-set DEBUG_SYNC = 'now WAIT_FOR hit1';
-set DEBUG_SYNC = 'now SIGNAL done1';
-c
-8
-7
-6
-6
-5
 set DEBUG_SYNC = 'tokudb_icp_asc_scan_out_of_range SIGNAL hit2 WAIT_FOR done2';
 SELECT c FROM t1 WHERE id BETWEEN 5 AND 8 ORDER BY id ASC;
 set DEBUG_SYNC = 'now WAIT_FOR hit2';

--- a/mysql-test/suite/tokudb.bugs/r/simple_icp.result
+++ b/mysql-test/suite/tokudb.bugs/r/simple_icp.result
@@ -110,7 +110,7 @@ a	b	c	d	e
 5	1	10	NULL	NULL
 show status like '%Handler_read_prev%';
 Variable_name	Value
-Handler_read_prev	799
+Handler_read_prev	41
 flush status;
 show status like '%Handler_read_prev%';
 Variable_name	Value
@@ -142,7 +142,7 @@ a	b	c	d	e
 20	1	10	NULL	NULL
 show status like '%Handler_read_prev%';
 Variable_name	Value
-Handler_read_prev	399
+Handler_read_prev	21
 flush status;
 show status like '%Handler_read_next%';
 Variable_name	Value

--- a/mysql-test/suite/tokudb.bugs/t/db233.test
+++ b/mysql-test/suite/tokudb.bugs/t/db233.test
@@ -29,24 +29,6 @@ ANALYZE TABLE t1;
 # lets flip to another connection
 connect(conn1, localhost, root);
 
-# set up the DEBUG_SYNC point
-set DEBUG_SYNC = 'tokudb_icp_desc_scan_invalidate SIGNAL hit1 WAIT_FOR done1';
-
-# send the query
-send SELECT c FROM t1 WHERE id BETWEEN 5 AND 8 ORDER BY id DESC;
-
-# back to default connection
-connection default;
-
-# wait for the ICP reverse scan to invalidate
-set DEBUG_SYNC = 'now WAIT_FOR hit1';
-
-# lets release and clean up
-set DEBUG_SYNC = 'now SIGNAL done1';
-
-connection conn1;
-reap;
-
 # set up the DEBUG_SYNC point again, but for the out of range
 set DEBUG_SYNC = 'tokudb_icp_asc_scan_out_of_range SIGNAL hit2 WAIT_FOR done2';
 

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -10902,8 +10902,14 @@ int QUICK_SELECT_DESC::get_next()
       will use ha_index_prev() to read data, we need to let the
       handler know where to end the scan in order to avoid that the
       ICP implemention continues to read past the range boundary.
+
+      An addition for MyRocks:
+      MyRocks needs to know both start of the range and end of the range
+      in order to use its bloom filters. This is useful regardless of whether
+      ICP is usable (e.g. it is used for index-only scans which do not use
+      ICP). Because of that, we remove the following:
+      //  //  if (file->pushed_idx_cond)
     */
-    if (file->pushed_idx_cond)
     {
       if (!eqrange_all_keyparts)
       {

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -5254,17 +5254,17 @@ int ha_tokudb::fill_range_query_buf(
             DEBUG_SYNC(ha_thd(), "tokudb_icp_asc_scan_out_of_range");
             goto cleanup;
         } else if (result == ICP_NO_MATCH) {
-            // if we are performing a DESC ICP scan and have no end_range
-            // to compare to stop using ICP filtering as there isn't much more
-            // that we can do without going through contortions with remembering
-            // and comparing key parts.
+            // Optimizer change for MyRocks also benefits us here in TokuDB as
+            // opt_range.cc QUICK_SELECT::get_next now sets end_range during
+            // descending scan. We should not ever hit this condition, but
+            // leaving this code in to prevent any possibility of a descending
+            // scan to the beginning of an index and catch any possibility
+            // in debug builds with an assertion
+            assert_debug(!(!end_range && direction < 0));
             if (!end_range &&
                 direction < 0) {
-
                 cancel_pushed_idx_cond();
-                DEBUG_SYNC(ha_thd(), "tokudb_icp_desc_scan_invalidate");
             }
-
             error = TOKUDB_CURSOR_CONTINUE;
             goto cleanup;
         }


### PR DESCRIPTION
lp1672871 : MyRocks - missing server optimizer patch for ICP
- Percona Server is missing a small optimizer patch that was implemented in
  upstream Facebook MySQL here:
  https://github.com/facebook/mysql-5.6/commit/723bfc97c7f7309c531c410133be3acd073f8129
- This commit takes this small server side patch into Percona Server.
- The change also benefits TokuDB in that TokuDB can now properly terminate on
  out of range condition during descending range scan. Re-recorded test with
  better results, partially removed fix for DB-233, and fixed up test to remove
  conditions for case that we should never get to.