### PR TITLE
Implement index-only query optimisation for prefix indexes.

### DIFF
--- a/mysql-test/suite/innodb/include/prefix_index_only_query_check.inc
+++ b/mysql-test/suite/innodb/include/prefix_index_only_query_check.inc
@@ -1,0 +1,32 @@
+#
+# A helper include file for prefix index index-only query tests
+#
+# Parameters:
+# $prefix_index_check_title - title of the test
+# $prefix_index_check_query - test query
+# $prefix_index_check_read_delta - expected change of
+#   'innodb_secondary_index_triggered_cluster_reads' status variable value after
+#   running the query
+# $prefix_index_check_read_avoided_delta - expected change of
+#   'innodb_secondary_index_triggered_cluster_reads_avoided' status variable
+#   value after running the query
+
+--let $show_count_statement = show status like 'innodb_secondary_index_triggered_cluster_reads'
+--let $show_opt_statement = show status like 'innodb_secondary_index_triggered_cluster_reads_avoided'
+
+--echo # $prefix_index_check_title
+--let $base_count = query_get_value($show_count_statement, Value, 1)
+--let $base_opt = query_get_value($show_opt_statement, Value, 1)
+
+--eval $prefix_index_check_query
+
+--let $count = query_get_value($show_count_statement, Value, 1)
+--let $assert_text= $prefix_index_check_title: $prefix_index_check_read_delta innodb_secondary_index_triggered_cluster_reads
+--let $assert_cond= $count - $base_count = $prefix_index_check_read_delta
+--source include/assert.inc
+
+--let $opt = query_get_value($show_opt_statement, Value, 1)
+--let $assert_text= $prefix_index_check_title: $prefix_index_check_read_avoided_delta innodb_secondary_index_triggered_cluster_reads_avoided
+--let $assert_cond= $opt - $base_opt = $prefix_index_check_read_avoided_delta
+--source include/assert.inc
+

--- a/mysql-test/suite/innodb/r/percona_fast_prefix_index_fetch.result
+++ b/mysql-test/suite/innodb/r/percona_fast_prefix_index_fetch.result
@@ -1,0 +1,141 @@
+# Create a table with a large varchar field that we index the prefix
+# of and ensure we only trigger cluster lookups when we expect it.
+create table prefixinno (
+id int not null,
+fake_id int not null,
+bigfield varchar(4096),
+primary key(id),
+index bigfield_idx (bigfield(32)),
+index fake_id_bigfield_prefix (fake_id, bigfield(32))
+) engine=innodb;
+insert into prefixinno values (1, 1001, repeat('a', 1)),
+(8, 1008, repeat('b', 8)),
+(24, 1024, repeat('c', 24)),
+(31, 1031, repeat('d', 31)),
+(32, 1032, repeat('x', 32)),
+(33, 1033, repeat('y', 33)),
+(128, 1128, repeat('z', 128));
+select * from prefixinno;
+id	fake_id	bigfield
+1	1001	a
+8	1008	bbbbbbbb
+24	1024	cccccccccccccccccccccccc
+31	1031	ddddddddddddddddddddddddddddddd
+32	1032	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+33	1033	yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+128	1128	zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+# Baseline sanity check
+select "no-op query";
+no-op query
+no-op query
+include/assert.inc [Baseline sanity check: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Baseline sanity check: 0 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Eligible for optimization.
+select id, bigfield from prefixinno where bigfield = repeat('d', 31);
+id	bigfield
+31	ddddddddddddddddddddddddddddddd
+include/assert.inc [Eligible for optimization.: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Eligible for optimization.: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Eligible for optimization, access via fake_id only.
+select id, bigfield from prefixinno where fake_id = 1031;
+id	bigfield
+31	ddddddddddddddddddddddddddddddd
+include/assert.inc [Eligible for optimization, access via fake_id only.: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Eligible for optimization, access via fake_id only.: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Not eligible for optimization, access via fake_id of big row.
+select id, bigfield from prefixinno where fake_id = 1033;
+id	bigfield
+33	yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+include/assert.inc [Not eligible for optimization, access via fake_id of big row.: 1 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Not eligible for optimization, access via fake_id of big row.: 0 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Not eligible for optimization.
+select id, bigfield from prefixinno where bigfield = repeat('x', 32);
+id	bigfield
+32	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+include/assert.inc [Not eligible for optimization.: 1 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Not eligible for optimization.: 0 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Not eligible for optimization.
+select id, bigfield from prefixinno where bigfield = repeat('y', 33);
+id	bigfield
+33	yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+include/assert.inc [Not eligible for optimization.: 1 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Not eligible for optimization.: 0 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Eligible, should not increment lookup counter.
+select id, bigfield from prefixinno where bigfield = repeat('b', 8);
+id	bigfield
+8	bbbbbbbb
+include/assert.inc [Eligible, should not increment lookup counter.: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Eligible, should not increment lookup counter.: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Eligible, should not increment lookup counter.
+select id, bigfield from prefixinno where bigfield = repeat('c', 24);
+id	bigfield
+24	cccccccccccccccccccccccc
+include/assert.inc [Eligible, should not increment lookup counter.: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Eligible, should not increment lookup counter.: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+# Should increment lookup counter
+select id, bigfield from prefixinno where bigfield = repeat('z', 128);
+id	bigfield
+128	zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz
+include/assert.inc [Should increment lookup counter: 1 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [Should increment lookup counter: 0 innodb_secondary_index_triggered_cluster_reads_avoided]
+DROP TABLE prefixinno;
+#
+# Test that multi-byte charsets are handled correctly
+#
+SET NAMES utf8mb4;
+CREATE TABLE t1 (
+a INT PRIMARY KEY,
+b VARCHAR(30) CHARACTER SET UTF8MB4,
+INDEX b_idx (b(3))) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, "aa");
+INSERT INTO t1 VALUES(2, "ccc");
+INSERT INTO t1 VALUES(3, "až");
+# MB charset record obviously shorter than the prefix
+SELECT * FROM t1 WHERE b = "aa";
+a	b
+1	aa
+include/assert.inc [MB charset record obviously shorter than the prefix: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [MB charset record obviously shorter than the prefix: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+# MB charset record longer than prefix
+SELECT * FROM t1 WHERE b = "ccc";
+a	b
+2	ccc
+include/assert.inc [MB charset record longer than prefix: 1 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [MB charset record longer than prefix: 0 innodb_secondary_index_triggered_cluster_reads_avoided]
+# MB charset record shorter than prefix
+SELECT * FROM t1 WHERE b = "až";
+a	b
+3	až
+include/assert.inc [MB charset record shorter than prefix: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [MB charset record shorter than prefix: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+DROP TABLE t1;
+#
+# Test that multi-byte charsets are handled correctly,
+# minimum character length > 1 case
+#
+CREATE TABLE t1 (
+a INT PRIMARY KEY,
+b VARCHAR(30) CHARACTER SET UTF16,
+INDEX b_idx (b(3))) ENGINE=InnoDB;
+INSERT INTO t1 VALUES(1, "a");
+INSERT INTO t1 VALUES(2, "ccc");
+INSERT INTO t1 VALUES(3, "až");
+# MB charset record obviously shorter than the prefix
+SELECT * FROM t1 WHERE b = "a";
+a	b
+1	a
+include/assert.inc [MB charset record obviously shorter than the prefix: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [MB charset record obviously shorter than the prefix: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+# MB charset record longer than prefix
+SELECT * FROM t1 WHERE b = "ccc";
+a	b
+2	ccc
+include/assert.inc [MB charset record longer than prefix: 1 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [MB charset record longer than prefix: 0 innodb_secondary_index_triggered_cluster_reads_avoided]
+# MB charset record shorter than prefix
+SELECT * FROM t1 WHERE b = "až";
+a	b
+3	až
+include/assert.inc [MB charset record shorter than prefix: 0 innodb_secondary_index_triggered_cluster_reads]
+include/assert.inc [MB charset record shorter than prefix: 1 innodb_secondary_index_triggered_cluster_reads_avoided]
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_fast_prefix_index_fetch.test
+++ b/mysql-test/suite/innodb/t/percona_fast_prefix_index_fetch.test
@@ -1,0 +1,147 @@
+-- source include/have_innodb.inc
+
+--echo # Create a table with a large varchar field that we index the prefix
+--echo # of and ensure we only trigger cluster lookups when we expect it.
+create table prefixinno (
+       id int not null,
+       fake_id int not null,
+       bigfield varchar(4096),
+       primary key(id),
+       index bigfield_idx (bigfield(32)),
+       index fake_id_bigfield_prefix (fake_id, bigfield(32))
+) engine=innodb;
+
+insert into prefixinno values (1, 1001, repeat('a', 1)),
+                              (8, 1008, repeat('b', 8)),
+                              (24, 1024, repeat('c', 24)),
+                              (31, 1031, repeat('d', 31)),
+                              (32, 1032, repeat('x', 32)),
+                              (33, 1033, repeat('y', 33)),
+                              (128, 1128, repeat('z', 128));
+
+select * from prefixinno;
+
+--let $prefix_index_check_title= Baseline sanity check
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 0
+--let $prefix_index_check_query= select "no-op query"
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= Eligible for optimization.
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 1
+--let $prefix_index_check_query= select id, bigfield from prefixinno where bigfield = repeat('d', 31)
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= Eligible for optimization, access via fake_id only.
+--let $prefix_index_check_query= select id, bigfield from prefixinno where fake_id = 1031
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 1
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= Not eligible for optimization, access via fake_id of big row.
+--let $prefix_index_check_query= select id, bigfield from prefixinno where fake_id = 1033
+--let $prefix_index_check_read_delta= 1
+--let $prefix_index_check_read_avoided_delta= 0
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= Not eligible for optimization.
+--let $prefix_index_check_query= select id, bigfield from prefixinno where bigfield = repeat('x', 32)
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_query= select id, bigfield from prefixinno where bigfield = repeat('y', 33)
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= Eligible, should not increment lookup counter.
+--let $prefix_index_check_query= select id, bigfield from prefixinno where bigfield = repeat('b', 8)
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 1
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_query= select id, bigfield from prefixinno where bigfield = repeat('c', 24)
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= Should increment lookup counter
+--let $prefix_index_check_query= select id, bigfield from prefixinno where bigfield = repeat('z', 128)
+--let $prefix_index_check_read_delta= 1
+--let $prefix_index_check_read_avoided_delta= 0
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+DROP TABLE prefixinno;
+
+--echo #
+--echo # Test that multi-byte charsets are handled correctly
+--echo #
+
+SET NAMES utf8mb4;
+
+CREATE TABLE t1 (
+       a INT PRIMARY KEY,
+       b VARCHAR(30) CHARACTER SET UTF8MB4,
+       INDEX b_idx (b(3))) ENGINE=InnoDB;
+
+# Records with byte representations shorter than the prefix length in chars
+INSERT INTO t1 VALUES(1, "aa");
+
+# Records which may or may not fit into the index prefix, determined by character
+# counting
+INSERT INTO t1 VALUES(2, "ccc");
+INSERT INTO t1 VALUES(3, "až");
+
+--let $prefix_index_check_title= MB charset record obviously shorter than the prefix
+--let $prefix_index_check_query= SELECT * FROM t1 WHERE b = "aa"
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 1
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= MB charset record longer than prefix
+--let $prefix_index_check_query= SELECT * FROM t1 WHERE b = "ccc"
+--let $prefix_index_check_read_delta= 1
+--let $prefix_index_check_read_avoided_delta= 0
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= MB charset record shorter than prefix
+--let $prefix_index_check_query= SELECT * FROM t1 WHERE b = "až"
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 1
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+DROP TABLE t1;
+
+--echo #
+--echo # Test that multi-byte charsets are handled correctly,
+--echo # minimum character length > 1 case
+--echo #
+
+CREATE TABLE t1 (
+       a INT PRIMARY KEY,
+       b VARCHAR(30) CHARACTER SET UTF16,
+       INDEX b_idx (b(3))) ENGINE=InnoDB;
+
+# Records with byte representations shorter than the prefix length in chars
+INSERT INTO t1 VALUES(1, "a");
+
+# Records which may or may not fit into the index prefix, determined by character
+# counting
+INSERT INTO t1 VALUES(2, "ccc");
+INSERT INTO t1 VALUES(3, "až");
+
+--let $prefix_index_check_title= MB charset record obviously shorter than the prefix
+--let $prefix_index_check_query= SELECT * FROM t1 WHERE b = "a"
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 1
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= MB charset record longer than prefix
+--let $prefix_index_check_query= SELECT * FROM t1 WHERE b = "ccc"
+--let $prefix_index_check_read_delta= 1
+--let $prefix_index_check_read_avoided_delta= 0
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+--let $prefix_index_check_title= MB charset record shorter than prefix
+--let $prefix_index_check_query= SELECT * FROM t1 WHERE b = "až"
+--let $prefix_index_check_read_delta= 0
+--let $prefix_index_check_read_avoided_delta= 1
+--source suite/innodb/include/prefix_index_only_query_check.inc
+
+DROP TABLE t1;

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -835,16 +835,24 @@ dict_index_get_nth_col_or_prefix_pos(
 /*=================================*/
 	const dict_index_t*	index,		/*!< in: index */
 	ulint			n,		/*!< in: column number */
-	ibool			inc_prefix)	/*!< in: TRUE=consider
+	ibool			inc_prefix,	/*!< in: TRUE=consider
 						column prefixes too */
+	ulint*			prefix_col_pos)	/*!< out: col num if prefix */
 {
 	const dict_field_t*	field;
 	const dict_col_t*	col;
 	ulint			pos;
 	ulint			n_fields;
+	ulint			prefixed_pos_dummy;
 
 	ut_ad(index);
 	ut_ad(index->magic_n == DICT_INDEX_MAGIC_N);
+	ut_ad((inc_prefix && !prefix_col_pos) || (!inc_prefix));
+
+	if (!prefix_col_pos) {
+		prefix_col_pos = &prefixed_pos_dummy;
+	}
+	*prefix_col_pos = ULINT_UNDEFINED;
 
 	col = dict_table_get_nth_col(index->table, n);
 
@@ -858,10 +866,11 @@ dict_index_get_nth_col_or_prefix_pos(
 	for (pos = 0; pos < n_fields; pos++) {
 		field = dict_index_get_nth_field(index, pos);
 
-		if (col == field->col
-		    && (inc_prefix || field->prefix_len == 0)) {
-
-			return(pos);
+		if (col == field->col) {
+			*prefix_col_pos = pos;
+			if (inc_prefix || field->prefix_len == 0) {
+				return(pos);
+			}
 		}
 	}
 
@@ -1005,7 +1014,7 @@ dict_table_get_nth_col_pos(
 	ulint			n)	/*!< in: column number */
 {
 	return(dict_index_get_nth_col_pos(dict_table_get_first_index(table),
-					  n));
+					  n, NULL));
 }
 
 /********************************************************************//**

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -970,6 +970,10 @@ static SHOW_VAR innodb_status_variables[]= {
   (char*) &export_vars.innodb_x_lock_spin_rounds,	  SHOW_LONGLONG},
   {"x_lock_spin_waits",
   (char*) &export_vars.innodb_x_lock_spin_waits,	  SHOW_LONGLONG},
+  {"secondary_index_triggered_cluster_reads",
+  (char*) &export_vars.innodb_sec_rec_cluster_reads,	  SHOW_LONG},
+  {"secondary_index_triggered_cluster_reads_avoided",
+  (char*) &export_vars.innodb_sec_rec_cluster_reads_avoided, SHOW_LONG},
   {NullS, NullS, SHOW_LONG}
 };
 
@@ -7181,9 +7185,31 @@ build_template_field(
 	ut_a(templ->clust_rec_field_no != ULINT_UNDEFINED);
 
 	if (dict_index_is_clust(index)) {
+		templ->rec_field_is_prefix = false;
 		templ->rec_field_no = templ->clust_rec_field_no;
+		templ->rec_prefix_field_no = ULINT_UNDEFINED;
 	} else {
-		templ->rec_field_no = dict_index_get_nth_col_pos(index, i);
+		/* If we're in a secondary index, keep track of the original
+		index position even if this is just a prefix index; we will use
+		this later to avoid a cluster index lookup in some cases.*/
+
+		templ->rec_field_no = dict_index_get_nth_col_pos(index, i,
+						&templ->rec_prefix_field_no);
+		templ->rec_field_is_prefix
+			= (templ->rec_field_no == ULINT_UNDEFINED)
+			  && (templ->rec_prefix_field_no != ULINT_UNDEFINED);
+#ifdef UNIV_DEBUG
+		if (templ->rec_prefix_field_no != ULINT_UNDEFINED)
+		{
+			const dict_field_t* field = dict_index_get_nth_field(
+				index,
+				templ->rec_prefix_field_no);
+			ut_ad(templ->rec_field_is_prefix
+			      == (field->prefix_len != 0));
+		} else {
+			ut_ad(!templ->rec_field_is_prefix);
+		}
+#endif
 	}
 
 	if (field->real_maybe_null()) {
@@ -7373,7 +7399,8 @@ ha_innobase::build_template(
 				} else {
 					templ->icp_rec_field_no
 						= dict_index_get_nth_col_pos(
-							prebuilt->index, i);
+							prebuilt->index, i,
+							NULL);
 				}
 
 				if (dict_index_is_clust(prebuilt->index)) {
@@ -7403,7 +7430,7 @@ ha_innobase::build_template(
 
 				templ->icp_rec_field_no
 					= dict_index_get_nth_col_or_prefix_pos(
-						prebuilt->index, i, TRUE);
+						prebuilt->index, i, TRUE, NULL);
 				ut_ad(templ->icp_rec_field_no
 				      != ULINT_UNDEFINED);
 

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1148,7 +1148,8 @@ innobase_rec_to_mysql(
 
 		field->reset();
 
-		ipos = dict_index_get_nth_col_or_prefix_pos(index, i, TRUE);
+		ipos = dict_index_get_nth_col_or_prefix_pos(index, i, TRUE,
+							    NULL);
 
 		if (ipos == ULINT_UNDEFINED
 		    || rec_offs_nth_extern(offsets, ipos)) {
@@ -1196,7 +1197,8 @@ innobase_fields_to_mysql(
 
 		field->reset();
 
-		ipos = dict_index_get_nth_col_or_prefix_pos(index, i, TRUE);
+		ipos = dict_index_get_nth_col_or_prefix_pos(index, i, TRUE,
+							    NULL);
 
 		if (ipos == ULINT_UNDEFINED
 		    || dfield_is_ext(&fields[ipos])

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -1142,8 +1142,9 @@ ulint
 dict_index_get_nth_col_pos(
 /*=======================*/
 	const dict_index_t*	index,	/*!< in: index */
-	ulint			n)	/*!< in: column number */
-	MY_ATTRIBUTE((nonnull, warn_unused_result));
+	ulint			n,	/*!< in: column number */
+	ulint*			prefix_col_pos) /*!< out: col num if prefix */
+	MY_ATTRIBUTE((nonnull(1), warn_unused_result));
 /********************************************************************//**
 Looks for column n in an index.
 @return position in internal representation of the index;
@@ -1154,9 +1155,11 @@ dict_index_get_nth_col_or_prefix_pos(
 /*=================================*/
 	const dict_index_t*	index,		/*!< in: index */
 	ulint			n,		/*!< in: column number */
-	ibool			inc_prefix)	/*!< in: TRUE=consider
+	ibool			inc_prefix,	/*!< in: TRUE=consider
 						column prefixes too */
-	MY_ATTRIBUTE((nonnull, warn_unused_result));
+	ulint*			prefix_col_pos)	/*!< out: col num if prefix */
+
+	MY_ATTRIBUTE((nonnull(1), warn_unused_result));
 /********************************************************************//**
 Returns TRUE if the index contains a column or a prefix of that column.
 @return	TRUE if contains the column or its prefix */

--- a/storage/innobase/include/dict0dict.ic
+++ b/storage/innobase/include/dict0dict.ic
@@ -1049,7 +1049,8 @@ dict_index_get_sys_col_pos(
 	}
 
 	return(dict_index_get_nth_col_pos(
-		       index, dict_table_get_sys_col_no(index->table, type)));
+			index, dict_table_get_sys_col_no(index->table, type),
+			NULL));
 }
 
 /*********************************************************************//**
@@ -1101,9 +1102,11 @@ ulint
 dict_index_get_nth_col_pos(
 /*=======================*/
 	const dict_index_t*	index,	/*!< in: index */
-	ulint			n)	/*!< in: column number */
+	ulint			n,	/*!< in: column number */
+	ulint*			prefix_col_pos) /*!< out: col num if prefix */
 {
-	return(dict_index_get_nth_col_or_prefix_pos(index, n, FALSE));
+	return(dict_index_get_nth_col_or_prefix_pos(index, n, FALSE,
+						    prefix_col_pos));
 }
 
 #ifndef UNIV_HOTBACKUP

--- a/storage/innobase/include/row0mysql.h
+++ b/storage/innobase/include/row0mysql.h
@@ -681,6 +681,12 @@ struct mysql_row_templ_t {
 					Innobase record in the current index;
 					not defined if template_type is
 					ROW_MYSQL_WHOLE_ROW */
+	bool	rec_field_is_prefix;	/* is this field in a prefix index? */
+	ulint	rec_prefix_field_no;	/* record field, even if just a
+					prefix; same as rec_field_no when not a
+					prefix, otherwise rec_field_no is
+					ULINT_UNDEFINED but this is the true
+					field number*/
 	ulint	clust_rec_field_no;	/*!< field number of the column in an
 					Innobase record in the clustered index;
 					not defined if template_type is
@@ -784,7 +790,9 @@ struct row_prebuilt_t {
 					columns through a secondary index
 					and at least one column is not in
 					the secondary index, then this is
-					set to TRUE */
+					set to TRUE; note that sometimes this
+					is set but we later optimize out the
+					clustered index lookup */
 	unsigned	templ_contains_blob:1;/*!< TRUE if the template contains
 					a column with DATA_BLOB ==
 					get_innobase_type_from_mysql_type();

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -587,6 +587,11 @@ extern my_bool srv_print_all_deadlocks;
 
 extern my_bool	srv_cmp_per_index_enabled;
 
+/** Number of times secondary index lookup triggered cluster lookup */
+extern ulint	srv_sec_rec_cluster_reads;
+/** Number of times prefix optimization avoided triggering cluster lookup */
+extern ulint	srv_sec_rec_cluster_reads_avoided;
+
 /** Status variables to be passed to MySQL */
 extern struct export_var_t export_vars;
 
@@ -1084,6 +1089,9 @@ struct export_var_t{
 #endif /* UNIV_DEBUG */
 	ulint innodb_column_compressed;		/*!< srv_column_compressed */
 	ulint innodb_column_decompressed;	/*!< srv_column_decompressed */
+
+	ulint innodb_sec_rec_cluster_reads;	/*!< srv_sec_rec_cluster_reads */
+	ulint innodb_sec_rec_cluster_reads_avoided; /*!< srv_sec_rec_cluster_reads_avoided */
 };
 
 /** Thread slot in the thread table.  */

--- a/storage/innobase/pars/pars0opt.cc
+++ b/storage/innobase/pars/pars0opt.cc
@@ -948,12 +948,14 @@ opt_find_all_cols(
 	/* Fill in the field_no fields in sym_node */
 
 	sym_node->field_nos[SYM_CLUST_FIELD_NO] = dict_index_get_nth_col_pos(
-		dict_table_get_first_index(index->table), sym_node->col_no);
+		dict_table_get_first_index(index->table), sym_node->col_no,
+		NULL);
 	if (!dict_index_is_clust(index)) {
 
 		ut_a(plan);
 
-		col_pos = dict_index_get_nth_col_pos(index, sym_node->col_no);
+		col_pos = dict_index_get_nth_col_pos(index, sym_node->col_no,
+						     NULL);
 
 		if (col_pos == ULINT_UNDEFINED) {
 

--- a/storage/innobase/pars/pars0pars.cc
+++ b/storage/innobase/pars/pars0pars.cc
@@ -1232,7 +1232,8 @@ pars_process_assign_list(
 		col_sym = assign_node->col;
 
 		upd_field_set_field_no(upd_field, dict_index_get_nth_col_pos(
-					       clust_index, col_sym->col_no),
+						clust_index, col_sym->col_no,
+						NULL),
 				       clust_index, NULL);
 		upd_field->exp = assign_node->val;
 

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -2733,7 +2733,8 @@ row_sel_field_store_in_mysql_format_func(
 		      || !(templ->mysql_col_len % templ->mbmaxlen));
 		ut_ad(len * templ->mbmaxlen >= templ->mysql_col_len
 		      || (field_no == templ->icp_rec_field_no
-			  && field->prefix_len > 0));
+			  && field->prefix_len > 0)
+		      || templ->rec_field_is_prefix);
 		ut_ad(!(field->prefix_len % templ->mbmaxlen));
 
 		if (templ->mbminlen == 1 && templ->mbmaxlen != 1) {
@@ -2967,9 +2968,11 @@ row_sel_store_mysql_rec(
 			? templ->clust_rec_field_no
 			: templ->rec_field_no;
 		/* We should never deliver column prefixes to MySQL,
-		except for evaluating innobase_index_cond(). */
+		except for evaluating innobase_index_cond() and if the prefix
+		index is longer than the actual row data. */
+
 		ut_ad(dict_index_get_nth_field(index, field_no)->prefix_len
-		      == 0);
+		      == 0 || templ->rec_field_is_prefix);
 
 		if (!row_sel_store_mysql_field(mysql_rec, prebuilt,
 					       rec, index, offsets,
@@ -3062,6 +3065,8 @@ row_sel_get_clust_rec_for_mysql(
 	rec_t*		old_vers;
 	dberr_t		err;
 	trx_t*		trx;
+
+	os_atomic_increment_ulint(&srv_sec_rec_cluster_reads, 1);
 
 	*out_rec = NULL;
 	trx = thr_get_trx(thr);
@@ -3653,6 +3658,29 @@ row_search_idx_cond_check(
 	return(result);
 }
 
+/** Return the record field length in characters.
+@param[in]	col		table column of the field
+@param[in]	field_no	field number
+@param[in]	rec		physical record
+@param[in]	offsets		field offsets in the physical record
+
+@return field length in characters */
+static
+size_t
+rec_field_len_in_chars(const dict_col_t &col,
+		       const ulint field_no,
+		       const rec_t *rec,
+		       const ulint *offsets)
+{
+	const ulint cset = dtype_get_charset_coll(col.prtype);
+	const CHARSET_INFO* cs = all_charsets[cset];
+	ulint rec_field_len;
+	const char* rec_field = reinterpret_cast<const char *>(
+		rec_get_nth_field(
+			rec, offsets, field_no, &rec_field_len));
+	return(cs->cset->numchars(cs, rec_field, rec_field + rec_field_len));
+}
+
 /********************************************************************//**
 Searches for rows in the database. This is used in the interface to
 MySQL. This function opens a cursor, and also implements fetch next
@@ -3715,6 +3743,7 @@ row_search_for_mysql(
 	ulint*		offsets				= offsets_;
 	ibool		table_lock_waited		= FALSE;
 	byte*		next_buf			= 0;
+	bool		use_clustered_index		= false;
 
 	rec_offs_init(offsets_);
 
@@ -4729,10 +4758,97 @@ locks_ok:
 	}
 
 	/* Get the clustered index record if needed, if we did not do the
-	search using the clustered index. */
+	search using the clustered index... */
 
-	if (index != clust_index && prebuilt->need_to_access_clustered) {
+	use_clustered_index =
+		(index != clust_index && prebuilt->need_to_access_clustered);
 
+	if (use_clustered_index && prebuilt->n_template <= index->n_fields) {
+		/* ...but, perhaps avoid the clustered index lookup if
+		all of the following are true:
+		1) all columns are in the secondary index
+		2) all values for columns that are prefix-only
+		   indexes are shorter than the prefix size
+		This optimization can avoid many IOs for certain schemas.
+		*/
+		bool row_contains_all_values = true;
+		unsigned int i;
+		for (i = 0; i < prebuilt->n_template; i++) {
+			/* Condition (1) from above: is the field in the
+			index (prefix or not)? */
+			const mysql_row_templ_t* templ =
+				prebuilt->mysql_template + i;
+			ulint secondary_index_field_no =
+				templ->rec_prefix_field_no;
+			if (secondary_index_field_no == ULINT_UNDEFINED) {
+				row_contains_all_values = false;
+				break;
+			}
+			/* Condition (2) from above: if this is a
+			prefix, is this row's value size shorter
+			than the prefix? */
+			if (templ->rec_field_is_prefix) {
+				ulint record_size = rec_offs_nth_size(
+					offsets,
+					secondary_index_field_no);
+				const dict_field_t *field =
+					dict_index_get_nth_field(
+						index,
+						secondary_index_field_no);
+				ut_a(field->prefix_len > 0);
+				if (record_size
+				    < field->prefix_len / templ->mbmaxlen) {
+
+					/* Record in bytes shorter than the
+					index prefix length in characters */
+					continue;
+
+				} else if (record_size * templ->mbminlen
+					 >= field->prefix_len) {
+
+					/* The shortest represantable string by
+					the byte length of the record is longer
+					than the maximum possible index
+					prefix. */
+					row_contains_all_values = false;
+					break;
+				} else {
+
+					/* The record could or could not fit
+					into the index prefix, calculate length
+					to find out */
+
+					if (rec_field_len_in_chars(
+						    *field->col,
+						    secondary_index_field_no,
+						    rec, offsets)
+					    >= (field->prefix_len
+						/ templ->mbmaxlen)) {
+
+						row_contains_all_values = false;
+						break;
+					}
+				}
+			}
+		}
+		/* If (1) and (2) were true for all columns above, use
+		rec_prefix_field_no instead of rec_field_no, and skip
+		the clustered lookup below. */
+		if (row_contains_all_values) {
+			for (i = 0; i < prebuilt->n_template; i++) {
+				mysql_row_templ_t* templ =
+					prebuilt->mysql_template + i;
+				templ->rec_field_no =
+					templ->rec_prefix_field_no;
+				ut_a(templ->rec_field_no != ULINT_UNDEFINED);
+			}
+			use_clustered_index = false;
+			os_atomic_increment_ulint(
+				&srv_sec_rec_cluster_reads_avoided, 1);
+		}
+	}
+
+	if (use_clustered_index) {
 requires_clust_rec:
 		ut_ad(index != clust_index);
 		/* We use a 'goto' to the preceding label if a consistent

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -573,6 +573,12 @@ static ulint		srv_main_shutdown_loops		= 0;
 /** Log writes involving flush. */
 static ulint		srv_log_writes_and_flush	= 0;
 
+/** Number of times secondary index lookup triggered cluster lookup */
+ulint	srv_sec_rec_cluster_reads		= 0;
+
+/** Number of times prefix optimization avoided triggering cluster lookup */
+ulint	srv_sec_rec_cluster_reads_avoided	= 0;
+
 /* This is only ever touched by the master thread. It records the
 time when the last flush of log file has happened. The master
 thread ensures that we flush the log files at least once per
@@ -1878,6 +1884,12 @@ srv_export_innodb_status(void)
 			(ulint) (max_trx_id - up_limit_id);
 	}
 #endif /* UNIV_DEBUG */
+
+	os_rmb;
+	export_vars.innodb_sec_rec_cluster_reads =
+		srv_sec_rec_cluster_reads;
+	export_vars.innodb_sec_rec_cluster_reads_avoided =
+		srv_sec_rec_cluster_reads_avoided;
 
 	mutex_exit(&srv_innodb_monitor_mutex);
 }

--- a/storage/innobase/trx/trx0rec.cc
+++ b/storage/innobase/trx/trx0rec.cc
@@ -781,7 +781,8 @@ trx_undo_page_report_modify(
 				}
 
 				pos = dict_index_get_nth_col_pos(index,
-								 col_no);
+								 col_no,
+								 NULL);
 				ptr += mach_write_compressed(ptr, pos);
 
 				/* Save the old value of field */


### PR DESCRIPTION
This implements
https://blueprints.launchpad.net/percona-server/+spec/index-only-prefix-index-query
by porting the feature from Facebook patch, revisions
5f9e36706fee7295b3ba736899717cf57bfb9859 and
8f784ea5ed30f796e7f16fb3fbae03e9e5ee1f74.

"Currently InnoDB will always fetch the clustered index (primary key
index) for all prefix columns in an index, even when the value of a
particular record is smaller than the prefix length. This change
optimizes that case to use the record from the secondary index and avoid
the extra lookup.

Also adds two status vars that track how effective this is:

    innodb_secondary_index_triggered_cluster_reads:
	Times secondary index lookup triggered cluster lookup.

    innodb_secondary_index_triggered_cluster_reads_avoided:
	Times prefix optimization avoided triggering cluster lookup."

Changes from Facebook version:

- Fixed multibyte character handling in the prefix index.
- The system variable to control the optimisation has been removed,
  leaving the optimisation turned on permanently.
- ibool has been replaced with bool in the source.
- Extra assert in dict_index_get_nth_col_or_prefix_pos to enforce
  caller's contract prefix_col_pos == NULL if inc_prefix == true.
- Minor cleanup in build_template_field.
- Relaxed assert in row_sel_field_store_in_mysql_format_func to accept
  prefix indexes, and restored the assert in row_sel_store_mysql_func
  with added exception for them.
- The testcase has been rewritten to use an include file and asserts,
  moved to innodb suite.

http://jenkins.percona.com/job/mysql-5.7-param/724/