### PR TITLE
MYR-64 : 5.7 mtr - rocksdb.rocksdb_checksums fails

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_checksums.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_checksums.result
@@ -1,8 +1,10 @@
+# restart:--log-error=LOG_FILE
+create database rocksdb_checksums_test;
+use rocksdb_checksums_test;
 set @save_rocksdb_store_row_debug_checksums=@@global.rocksdb_store_row_debug_checksums;
 set @save_rocksdb_verify_row_debug_checksums=@@global.rocksdb_verify_row_debug_checksums;
 set @save_rocksdb_checksums_pct=@@global.rocksdb_checksums_pct;
 set session transaction isolation level read committed;
-drop table if exists t1,t2,t3;
 show variables like 'rocksdb_%checksum%';
 Variable_name	Value
 rocksdb_checksums_pct	100
@@ -12,26 +14,14 @@ create table t1 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksd
 insert into t1 values (1,1,1),(2,2,2),(3,3,3);
 check table t1;
 Table	Op	Msg_type	Msg_text
-test.t1	check	status	OK
- CHECKTABLE t1: Checking table t1
- CHECKTABLE t1:   Checking index a
- CHECKTABLE t1:   ... 3 index entries checked (0 had checksums)
- CHECKTABLE t1:   Checking index b
- CHECKTABLE t1:   ... 3 index entries checked (0 had checksums)
- CHECKTABLE t1:   0 table records had checksums
+rocksdb_checksums_test.t1	check	status	OK
 drop table t1;
 set session rocksdb_store_row_debug_checksums=on;
 create table t2 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
 insert into t2 values (1,1,1),(2,2,2),(3,3,3);
 check table t2;
 Table	Op	Msg_type	Msg_text
-test.t2	check	status	OK
- CHECKTABLE t2: Checking table t2
- CHECKTABLE t2:   Checking index a
- CHECKTABLE t2:   ... 3 index entries checked (3 had checksums)
- CHECKTABLE t2:   Checking index b
- CHECKTABLE t2:   ... 3 index entries checked (3 had checksums)
- CHECKTABLE t2:   3 table records had checksums
+rocksdb_checksums_test.t2	check	status	OK
 # Now, make a table that has both rows with checksums and without
 create table t3 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
 insert into t3 values (1,1,1),(2,2,2),(3,3,3);
@@ -40,19 +30,13 @@ update t3 set b=3 where a=2;
 set session rocksdb_store_row_debug_checksums=on;
 check table t3;
 Table	Op	Msg_type	Msg_text
-test.t3	check	status	OK
- CHECKTABLE t3: Checking table t3
- CHECKTABLE t3:   Checking index a
- CHECKTABLE t3:   ... 3 index entries checked (3 had checksums)
- CHECKTABLE t3:   Checking index b
- CHECKTABLE t3:   ... 3 index entries checked (2 had checksums)
- CHECKTABLE t3:   2 table records had checksums
+rocksdb_checksums_test.t3	check	status	OK
 set session rocksdb_store_row_debug_checksums=on;
 set session rocksdb_checksums_pct=5;
 create table t4 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
 check table t4;
 Table	Op	Msg_type	Msg_text
-test.t4	check	status	OK
+rocksdb_checksums_test.t4	check	status	OK
 10000 index entries had around 500 checksums
 10000 index entries had around 500 checksums
 Around 500 table records had checksums
@@ -95,8 +79,10 @@ set session debug= "-d,myrocks_simulate_bad_pk_checksum2";
 # 3. Check if we catch checksum mismatches for secondary indexes
 explain
 select * from t3 force index(a) where a<4;
-id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	range	a	a	5	NULL	#	Using index condition
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	range	a	a	5	NULL	#	100.00	Using index condition
+Warnings:
+Note	1003	/* select#1 */ select `rocksdb_checksums_test`.`t3`.`pk` AS `pk`,`rocksdb_checksums_test`.`t3`.`a` AS `a`,`rocksdb_checksums_test`.`t3`.`b` AS `b` from `rocksdb_checksums_test`.`t3` FORCE INDEX (`a`) where (`rocksdb_checksums_test`.`t3`.`a` < 4)
 select * from t3 force index(a) where a<4;
 pk	a	b
 1	1	1
@@ -111,8 +97,10 @@ set session debug= "-d,myrocks_simulate_bad_key_checksum1";
 # 4. The same for index-only reads?
 explain 
 select a from t3 force index(a) where a<4;
-id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	SIMPLE	t3	index	a	a	5	NULL	#	Using where; Using index
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t3	NULL	index	a	a	5	NULL	#	100.00	Using where; Using index
+Warnings:
+Note	1003	/* select#1 */ select `rocksdb_checksums_test`.`t3`.`a` AS `a` from `rocksdb_checksums_test`.`t3` FORCE INDEX (`a`) where (`rocksdb_checksums_test`.`t3`.`a` < 4)
 select a from t3 force index(a) where a<4;
 a
 1
@@ -124,7 +112,5 @@ ERROR HY000: Internal error: Record checksum mismatch
 select a from t4 force index(a) where a<1000000;
 ERROR HY000: Internal error: Record checksum mismatch
 set session debug= "-d,myrocks_simulate_bad_key_checksum1";
-set @@global.rocksdb_store_row_debug_checksums=@save_rocksdb_store_row_debug_checksums;
-set @@global.rocksdb_verify_row_debug_checksums=@save_rocksdb_verify_row_debug_checksums;
-set @@global.rocksdb_checksums_pct=@save_rocksdb_checksums_pct;
-drop table t2,t3,t4;
+drop database rocksdb_checksums_test;
+# restart

--- a/mysql-test/suite/rocksdb/t/rocksdb_checksums.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_checksums.test
@@ -5,33 +5,57 @@
 #
 --source include/have_debug.inc
 
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/rocksdb_checksums.err
+--let $restart_parameters=restart:--log-error=$SEARCH_FILE
+--replace_result $SEARCH_FILE LOG_FILE
+--source include/restart_mysqld.inc
+
+create database rocksdb_checksums_test;
+use rocksdb_checksums_test;
+
 set @save_rocksdb_store_row_debug_checksums=@@global.rocksdb_store_row_debug_checksums;
 set @save_rocksdb_verify_row_debug_checksums=@@global.rocksdb_verify_row_debug_checksums;
 set @save_rocksdb_checksums_pct=@@global.rocksdb_checksums_pct;
 set session transaction isolation level read committed;
 
-# wiping mysql log for repeatable tests
---exec echo "" > $MYSQLTEST_VARDIR/log/mysqld.1.err
-
---disable_warnings
-drop table if exists t1,t2,t3;
---enable_warnings
--- exec echo "" > $MYSQLTEST_VARDIR/log/mysqld.1.err
-
 show variables like 'rocksdb_%checksum%';
 
 create table t1 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
 insert into t1 values (1,1,1),(2,2,2),(3,3,3);
+--exec echo "" > $SEARCH_FILE
 check table t1;
---exec grep "^[0-9-]* [0-9:]* [0-9]* \[Note\] CHECKTABLE t1" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
+--let SEARCH_PATTERN=\[Note\] CHECKTABLE t1: Checking table t1
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=\[Note\] CHECKTABLE t1:   Checking index a
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=\[Note\] CHECKTABLE t1:   \.\.\. 3 index entries checked \(0 had checksums\)
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=\[Note\] CHECKTABLE t1:   Checking index b
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=\[Note\] CHECKTABLE t1:   \.\.\. 3 index entries checked \(0 had checksums\)
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=\[Note\] CHECKTABLE t1:   0 table records had checksums
+--source include/search_pattern_in_file.inc
 
 drop table t1;
 
 set session rocksdb_store_row_debug_checksums=on;
 create table t2 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
 insert into t2 values (1,1,1),(2,2,2),(3,3,3);
+--exec echo "" > $SEARCH_FILE
 check table t2;
---exec grep "^[0-9-]* [0-9:]* [0-9]* \[Note\] CHECKTABLE t2" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t2: Checking table t2
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t2:   Checking index a
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t2:   \.\.\. 3 index entries checked \(3 had checksums\)
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t2:   Checking index b
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t2:   \.\.\. 3 index entries checked \(3 had checksums\)
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t2:   3 table records had checksums
+--source include/search_pattern_in_file.inc
 
 --echo # Now, make a table that has both rows with checksums and without
 create table t3 (pk int primary key, a int, b int, key(a), key(b)) engine=rocksdb;
@@ -39,8 +63,20 @@ insert into t3 values (1,1,1),(2,2,2),(3,3,3);
 set session rocksdb_store_row_debug_checksums=off;
 update t3 set b=3 where a=2;
 set session rocksdb_store_row_debug_checksums=on;
+--exec echo "" > $SEARCH_FILE
 check table t3;
---exec grep "^[0-9-]* [0-9:]* [0-9]* \[Note\] CHECKTABLE t3" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t3: Checking table t3
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t3:   Checking index a
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t3:   \.\.\. 3 index entries checked \(3 had checksums\)
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t3:   Checking index b
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t3:   \.\.\. 3 index entries checked \(2 had checksums\)
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN= \[Note\] CHECKTABLE t3:   2 table records had checksums
+--source include/search_pattern_in_file.inc
 
 set session rocksdb_store_row_debug_checksums=on;
 set session rocksdb_checksums_pct=5;
@@ -56,10 +92,9 @@ while ($i<10000)
   eval update t4 set pk=pk+$x where pk=$i;
 }
 --enable_query_log
+--exec echo "" > $SEARCH_FILE
 check table t4;
---exec grep "^[0-9-]* [0-9:]* [0-9]* \[Note\] CHECKTABLE t4" $MYSQLTEST_VARDIR/log/mysqld.1.err | cut -d] -f2 > $MYSQL_TMP_DIR/rocksdb_checksums.log
---exec perl suite/rocksdb/t/rocksdb_checksums.pl $MYSQL_TMP_DIR/rocksdb_checksums.log 10000 5
---remove_file $MYSQL_TMP_DIR/rocksdb_checksums.log
+--exec perl suite/rocksdb/t/rocksdb_checksums.pl $SEARCH_FILE 10000 5
 set session rocksdb_checksums_pct=100;
 
 --echo #
@@ -121,8 +156,10 @@ select a from t3 force index(a) where a<4;
 select a from t4 force index(a) where a<1000000;
 set session debug= "-d,myrocks_simulate_bad_key_checksum1";
 
-set @@global.rocksdb_store_row_debug_checksums=@save_rocksdb_store_row_debug_checksums;
-set @@global.rocksdb_verify_row_debug_checksums=@save_rocksdb_verify_row_debug_checksums;
-set @@global.rocksdb_checksums_pct=@save_rocksdb_checksums_pct;
+#cleanup
+drop database rocksdb_checksums_test;
 
-drop table t2,t3,t4;
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--remove_file $SEARCH_FILE


### PR DESCRIPTION
MYR-59 : 5.7 mtr - re-record tests for different EXPLAIN format
- Test fails due to slightly different timestamp formatting between 5.6 and 5.7
  and use of grep with explicit pattern.
- Test also needed re-recording of EXPLAIN differences due to being masked by
  failure.
- Test used grep explicitly against mysqld.err file, converted to using
  explicit log for this test and search_pattern.inc
- Removed deprecated idioms.