### PR TITLE
MYR-72 : rocksdb.rocksdb_datadir fails

### DIFF
--- a/mysql-test/suite/rocksdb/t/rocksdb_datadir.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_datadir.test
@@ -1,14 +1,14 @@
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 
-let $ddir = $MYSQL_TMP_DIR/.rocksdb_datadir.test.install.db;
-let $rdb_ddir = $MYSQL_TMP_DIR/.rocksdb_datadir.test;
-let $sql_file = $MYSQL_TMP_DIR/rocksdb_datadir.sql;
+let $ddir = $MYSQLTEST_VARDIR/.rocksdb_datadir.test.install.db;
+let $rdb_ddir = $MYSQLTEST_VARDIR/.rocksdb_datadir.test;
+let $sql_file = $MYSQLTEST_VARDIR/rocksdb_datadir.sql;
 
 --write_file $sql_file
 DROP DATABASE IF EXISTS mysqltest;
 CREATE DATABASE mysqltest;
 USE mysqltest;
-CREATE TABLE t1 (a INT PRIMARY KEY);
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
 INSERT INTO t1 VALUES(42);
 SET GLOBAL rocksdb_force_flush_memtable_now = 1;
 SELECT sleep(1);
@@ -19,12 +19,14 @@ EOF
 mkdir $ddir;
 
 # Launch mysqld with non-standard rocksdb_datadir
-exec $MYSQLD_BOOTSTRAP_CMD --datadir=$ddir --rocksdb_datadir=$rdb_ddir --default-storage-engine=rocksdb --skip-innodb --default-tmp-storage-engine=MyISAM --rocksdb < $sql_file;
+exec $MYSQLD_BOOTSTRAP_CMD --plugin-load=rocksdb=ha_rocksdb.so --datadir=$ddir --rocksdb_datadir=$rdb_ddir < $sql_file;
 
 --echo Check for the number of MANIFEST files
 exec ls $rdb_ddir/MANIFEST-0000* | wc -l;
 
 # Clean up
+remove_files_wildcard $ddir *;
 exec rm -rf $ddir;
 remove_files_wildcard $rdb_ddir *;
+exec rm -rf $rdb_ddir;
 remove_file $sql_file;


### PR DESCRIPTION
MYR-99 : Convert tests to not require have_rocksdb_as_default
- Test fails die to ha_rocksdb.so not being loaded as part of the
  MYSQL_BOOTSTRAP_CMD. Added --plugin-load=ha_rocksdb.so to satisfy and
  modernized the test a little.
- Fixed test to run without rocksdb as default engine.