### PR TITLE
MYR-102 : rocksdb.rpl.rpl_crash_safe_wal_corrupt and

### DIFF
--- a/mysql-test/suite/rocksdb.rpl/t/rpl_crash_safe_wal_corrupt.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_crash_safe_wal_corrupt.test
@@ -1,4 +1,4 @@
---source suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt.inc
+--source suite/rocksdb.rpl/t/rpl_gtid_crash_safe_wal_corrupt.inc
 
 connection slave;
 --let slave_pid_file= query_get_value(SELECT @@pid_file, @@pid_file, 1)

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_gtid_crash_safe_wal_corrupt.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_gtid_crash_safe_wal_corrupt.test
@@ -1,4 +1,4 @@
--- source suite/rocksdb_rpl/t/rpl_gtid_crash_safe_wal_corrupt.inc
+-- source suite/rocksdb.rpl/t/rpl_gtid_crash_safe_wal_corrupt.inc
 
 connection slave;
 -- let _SLAVE_PID_FILE= query_get_value(SELECT @@pid_file, @@pid_file, 1)


### PR DESCRIPTION
          rocksdb.rpl.rpl_gtid_crash_safe_wal_corrupt fails
- Fixed bad include directives.