### PR TITLE
MYR-103 : rocksdb.gap_lock_error fails

### DIFF
--- a/mysql-test/include/gap_lock_error_update.inc
+++ b/mysql-test/include/gap_lock_error_update.inc
@@ -24,12 +24,12 @@ insert into gap2 select * from gap1 where id1=1;
 insert into gap2 select * from gap1 where id1=1 and id2=1 and id3=1;
 
 # create table select
-create table t4 select * from gap1 where id1=1 and id2=1 and id3=1;
+eval create table t4 engine=$engine select * from gap1 where id1=1 and id2=1 and id3=1;
 drop table t4;
 --error ER_UNKNOWN_ERROR
-create table t4 select * from gap1;
+eval create table t4 engine=$engine select * from gap1;
 --error ER_UNKNOWN_ERROR
-create table t4 select * from gap1 where id1=1;
+eval create table t4 engine=$engine select * from gap1 where id1=1;
 
 # update join
 update gap1 join gap2 on gap1.id1 and gap1.id2=gap2.id2 set gap1.value=100 where gap2.id1=3
@@ -55,14 +55,14 @@ select * from gap1, gap2 limit 1 for update;
 select * from gap1 a, gap1 b limit 1 for update;
 
 # unique secondary key
-create table u1(
+eval create table u1(
  c1 int,
  c2 int,
  c3 int,
  c4 int,
  primary key (c1, c2, c3),
  unique key (c3, c1)
-);
+) engine=$engine;
 begin;
 insert into u1 values (1,1,1,1);
 commit;

--- a/mysql-test/suite/rocksdb/r/gap_lock_error.result
+++ b/mysql-test/suite/rocksdb/r/gap_lock_error.result
@@ -442,12 +442,12 @@ ERROR HY000: Using Gap Lock without full unique key in multi-table or multi-stat
 insert into gap2 select * from gap1 where id1=1;
 ERROR HY000: Using Gap Lock without full unique key in multi-table or multi-statement transactions is not allowed. You need to either rewrite queries to use all unique key columns in WHERE equal conditions, or rewrite to single-table, single-statement transaction.  Query: insert into gap2 select * from gap1 where id1=1
 insert into gap2 select * from gap1 where id1=1 and id2=1 and id3=1;
-create table t4 select * from gap1 where id1=1 and id2=1 and id3=1;
+create table t4 engine=rocksdb select * from gap1 where id1=1 and id2=1 and id3=1;
 drop table t4;
-create table t4 select * from gap1;
-ERROR HY000: Using Gap Lock without full unique key in multi-table or multi-statement transactions is not allowed. You need to either rewrite queries to use all unique key columns in WHERE equal conditions, or rewrite to single-table, single-statement transaction.  Query: create table t4 select * from gap1
-create table t4 select * from gap1 where id1=1;
-ERROR HY000: Using Gap Lock without full unique key in multi-table or multi-statement transactions is not allowed. You need to either rewrite queries to use all unique key columns in WHERE equal conditions, or rewrite to single-table, single-statement transaction.  Query: create table t4 select * from gap1 where id1=1
+create table t4 engine=rocksdb select * from gap1;
+ERROR HY000: Using Gap Lock without full unique key in multi-table or multi-statement transactions is not allowed. You need to either rewrite queries to use all unique key columns in WHERE equal conditions, or rewrite to single-table, single-statement transaction.  Query: create table t4 engine=rocksdb select * from gap1
+create table t4 engine=rocksdb select * from gap1 where id1=1;
+ERROR HY000: Using Gap Lock without full unique key in multi-table or multi-statement transactions is not allowed. You need to either rewrite queries to use all unique key columns in WHERE equal conditions, or rewrite to single-table, single-statement transaction.  Query: create table t4 engine=rocksdb select * from gap1 where id1=1
 update gap1 join gap2 on gap1.id1 and gap1.id2=gap2.id2 set gap1.value=100 where gap2.id1=3
 and gap2.id2=3 and gap2.id3=3;
 update gap1 join gap2 on gap1.id1 and gap1.id2=gap2.id2 set gap1.value=100 where gap2.id1=3;
@@ -473,7 +473,7 @@ c3 int,
 c4 int,
 primary key (c1, c2, c3),
 unique key (c3, c1)
-);
+) engine=rocksdb;
 begin;
 insert into u1 values (1,1,1,1);
 commit;


### PR DESCRIPTION
- Test components were still creating tables w/o explicit engine specifier.
- Fixed remaining CREATE TABLE statements and re-recorded affected tests.
- Cherry pick merging commit 81ba8794d1ab3015841718ccbb821fd25b90edf3 from ps-5.6/ps-5.6-MYR-103