### PR TITLE
Fix lp:1629257 "Creating a compression dictionary with fake changes enabled crashes | handle_fatal_signal (sig=6) in innobase_create_zip_dict" and lp:1668508 "handle_fatal_signal (sig=6) in innobase_create_zip_dict | InnoDB: Assertion failure in thread 140384186160896 in file ha_innodb.cc line 4182".

### DIFF
--- a/mysql-test/suite/innodb/r/xtradb_compressed_columns_fake_changes.result
+++ b/mysql-test/suite/innodb/r/xtradb_compressed_columns_fake_changes.result
@@ -1,0 +1,10 @@
+CREATE COMPRESSION_DICTIONARY numbers1('one' 'two' 'three');
+SET @saved_innodb_fake_changes = @@global.innodb_fake_changes;
+SET GLOBAL innodb_fake_changes = 1;
+CREATE COMPRESSION_DICTIONARY numbers2('four' 'five' 'six');
+ERROR HY000: Table storage engine for 'numbers2' doesn't have this option
+DROP COMPRESSION_DICTIONARY numbers1;
+ERROR HY000: Table storage engine for 'numbers1' doesn't have this option
+SET GLOBAL innodb_fake_changes = 0;
+DROP COMPRESSION_DICTIONARY numbers1;
+SET GLOBAL innodb_fake_changes = @saved_innodb_fake_changes;

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_fake_changes.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_fake_changes.test
@@ -1,0 +1,22 @@
+--source include/have_innodb.inc
+
+#
+# Bug lp:1629257 "Creating a compression dictionary with fake changes enabled crashes | handle_fatal_signal (sig=6) in innobase_create_zip_dict"
+# Bug lp:1668508 "handle_fatal_signal (sig=6) in innobase_create_zip_dict | InnoDB: Assertion failure in thread 140384186160896 in file ha_innodb.cc line 4182"
+#
+
+CREATE COMPRESSION_DICTIONARY numbers1('one' 'two' 'three');
+
+SET @saved_innodb_fake_changes = @@global.innodb_fake_changes;
+SET GLOBAL innodb_fake_changes = 1;
+
+--error ER_ILLEGAL_HA
+CREATE COMPRESSION_DICTIONARY numbers2('four' 'five' 'six');
+--error ER_ILLEGAL_HA
+DROP COMPRESSION_DICTIONARY numbers1;
+
+SET GLOBAL innodb_fake_changes = 0;
+
+DROP COMPRESSION_DICTIONARY numbers1;
+
+SET GLOBAL innodb_fake_changes = @saved_innodb_fake_changes;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -812,6 +812,7 @@ enum handler_create_zip_dict_result
   HA_CREATE_ZIP_DICT_NAME_TOO_LONG,  /*!< zip dict name is too long */
   HA_CREATE_ZIP_DICT_DATA_TOO_LONG,  /*!< zip dict data is too long */
   HA_CREATE_ZIP_DICT_READ_ONLY,      /*!< cannot create in read-only mode */
+  HA_CREATE_ZIP_DICT_FAKE_CHANGES,   /*!< fake changes enabled */
   HA_CREATE_ZIP_DICT_OUT_OF_MEMORY,  /*!< out of memory */
   HA_CREATE_ZIP_DICT_OUT_OF_FILE_SPACE,
                                      /*!< out of disk space */
@@ -829,6 +830,7 @@ enum handler_drop_zip_dict_result
                                         exist */
   HA_DROP_ZIP_DICT_IS_REFERENCED,  /*!< zip dict is in use */
   HA_DROP_ZIP_DICT_READ_ONLY,      /*!< cannot drop in read-only mode */
+  HA_DROP_ZIP_DICT_FAKE_CHANGES,   /*!< fake changes enabled */
   HA_DROP_ZIP_DICT_OUT_OF_MEMORY,  /*!< out of memory */
   HA_DROP_ZIP_DICT_OUT_OF_FILE_SPACE,
                                    /*!< out of disk space */

--- a/sql/sql_zip_dict.cc
+++ b/sql/sql_zip_dict.cc
@@ -41,6 +41,8 @@ Creates a new compression dictionary with the specified data.
 @retval ER_COMPRESSION_DICTIONARY_EXISTS        Dictionary with such name
                                                 already exists
 @retval ER_READ_ONLY_MODE                       Forbidden in read-only mode
+@retval ER_ILLEGAL_HA                           Forbidden when fake changes
+                                                enabled
 @retval ER_OUT_OF_RESOURCES                     Out of memory
 @retval ER_RECORD_FILE_FULL                     Out of disk space
 @retval ER_TOO_MANY_CONCURRENT_TRXS             Too many concurrent
@@ -99,6 +101,10 @@ int mysql_create_zip_dict(THD* thd, const char* name, ulong name_len,
         error= ER_READ_ONLY_MODE;
         my_error(error, MYF(0));
         break;
+      case HA_CREATE_ZIP_DICT_FAKE_CHANGES:
+        error= ER_ILLEGAL_HA;
+        my_error(error, MYF(0), name);
+        break;
       case HA_CREATE_ZIP_DICT_OUT_OF_MEMORY:
         error= ER_OUT_OF_RESOURCES;
         my_error(error, MYF(0));
@@ -140,6 +146,8 @@ Deletes a compression dictionary.
 @retval ER_COMPRESSION_DICTIONARY_IS_REFERENCED  Dictictionary is still in
                                                  use
 @retval ER_READ_ONLY_MODE                        Forbidden in read-only mode
+@retval ER_ILLEGAL_HA                            Forbidden when fake changes
+                                                 enabled
 @retval ER_OUT_OF_RESOURCES                      Out of memory
 @retval ER_RECORD_FILE_FULL                      Out of disk space
 @retval ER_TOO_MANY_CONCURRENT_TRXS              Too many concurrent
@@ -191,6 +199,10 @@ int mysql_drop_zip_dict(THD* thd, const char* name, ulong name_len,
       case HA_DROP_ZIP_DICT_READ_ONLY:
         error= ER_READ_ONLY_MODE;
         my_error(error, MYF(0));
+        break;
+      case HA_DROP_ZIP_DICT_FAKE_CHANGES:
+        error= ER_ILLEGAL_HA;
+        my_error(error, MYF(0), name);
         break;
       case HA_DROP_ZIP_DICT_OUT_OF_MEMORY:
         error= ER_OUT_OF_RESOURCES;

--- a/sql/sql_zip_dict.h
+++ b/sql/sql_zip_dict.h
@@ -42,6 +42,8 @@ class THD;
   @retval ER_COMPRESSION_DICTIONARY_EXISTS        Dictionary with such name
                                                   already exists
   @retval ER_READ_ONLY_MODE                       Forbidden in read-only mode
+  @retval ER_ILLEGAL_HA                           Forbidden when fake
+                                                  changes enabled
   @retval ER_UNKNOWN_ERROR                        Unknown error
 */
 int mysql_create_zip_dict(THD* thd, const char* name, ulong name_len,
@@ -65,6 +67,8 @@ int mysql_create_zip_dict(THD* thd, const char* name, ulong name_len,
                                                    use
   @retval ER_READ_ONLY_MODE                        Forbidden in read-only
                                                    mode
+  @retval ER_ILLEGAL_HA                            Forbidden when fake
+                                                   changes enabled
   @retval ER_UNKNOWN_ERROR                         Unknown error
 */
 int mysql_drop_zip_dict(THD* thd, const char* name, ulong name_len,

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4165,6 +4165,10 @@ innobase_create_zip_dict(
 	if (UNIV_UNLIKELY(high_level_read_only)) {
 		DBUG_RETURN(HA_CREATE_ZIP_DICT_READ_ONLY);
 	}
+	
+	if (UNIV_UNLIKELY(THDVAR(NULL, fake_changes))) {
+		DBUG_RETURN(HA_CREATE_ZIP_DICT_FAKE_CHANGES);
+	}
 
 	if (UNIV_UNLIKELY(*name_len > ZIP_DICT_MAX_NAME_LENGTH)) {
 		*name_len = ZIP_DICT_MAX_NAME_LENGTH;
@@ -4216,6 +4220,10 @@ innobase_drop_zip_dict(
 
 	if (UNIV_UNLIKELY(high_level_read_only)) {
 		DBUG_RETURN(HA_DROP_ZIP_DICT_READ_ONLY);
+	}
+
+	if (UNIV_UNLIKELY(THDVAR(NULL, fake_changes))) {
+		DBUG_RETURN(HA_DROP_ZIP_DICT_FAKE_CHANGES);
 	}
 
 	switch (dict_drop_zip_dict(name, *name_len)) {


### PR DESCRIPTION
'CREATE/DROP COMPRESSION_DICTIONARY' used to crash the server when
'innodb_fake_changes' was set to 'TRUE'.
Fixed by checking the value of the 'fake_changes' global variable in
'innobase_create_zip_dict()' / 'innobase_drop_zip_dict()'. If it is set to
'TRUE', 'ER_ILLEGAL_HA' error is reported to user.

Added 'innodb.xtradb_compressed_columns_fake_changes' MTR test case.