### PR TITLE
Bug lp:1660565 fix.

### DIFF
--- a/mysql-test/valgrind.supp
+++ b/mysql-test/valgrind.supp
@@ -879,6 +879,15 @@
    fun:memalign
    fun:tls_get_addr_tail
 }
+
+{
+   tls_variables_2
+   Memcheck:Leak
+   fun:memalign
+   fun:allocate_and_init
+   fun:tls_get_addr_tail
+}
+
 #supress warnings from openssl
 
 {


### PR DESCRIPTION
Add valgrind suppression.

See also https://github.com/percona/percona-server/pull/1536 for 5.7.

The testing is in the queue http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-valgrind/ number 276. Local testing looks good.