### PR TITLE
Fix bug 1660243 (Test rpl.rpl_semi_sync_event is unstable)

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_semi_sync_event.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_event.test
@@ -98,6 +98,9 @@ disable_warnings;
 UNINSTALL PLUGIN rpl_semi_sync_slave;
 
 connection master;
+--let $status_var= Rpl_semi_sync_master_clients
+--let $status_var_value= 0
+--source include/wait_for_status_var.inc
 UNINSTALL PLUGIN rpl_semi_sync_master;
 enable_warnings;
 


### PR DESCRIPTION
On master, wait for the Rpl_semi_sync_master_clients variable to
become zero before attempting semi sync master plugin uninstallation.

(cherry picked from commit bc8cdac38ff78a845e9ba6af67a1c78127efbcf8)

http://jenkins.percona.com/job/percona-server-5.5-param/1531/