### PR TITLE
Fix lp:1659992 "Function over userstat tables cause mysql to crash" (5.5)

### DIFF
--- a/mysql-test/r/percona_userstat.result
+++ b/mysql-test/r/percona_userstat.result
@@ -144,4 +144,19 @@ INFORMATION_SCHEMA.USER_STATISTICS
 ;
 select_must_be_true_6	update_must_be_true_6	other_must_be_true_6	rows_must_be_true_6
 1	1	1	1
+# Bug lp:1659992 "Function over userstat tables cause mysql to crash"
+CREATE FUNCTION utility_get_global_variable(in_name VARCHAR(64)) RETURNS VARCHAR(1024) CHARSET utf8 DETERMINISTIC SQL SECURITY INVOKER
+BEGIN
+DECLARE var_value VARCHAR(1024);
+IF @@global.version LIKE '5.7.%' THEN
+SELECT v.variable_value FROM performance_schema.global_variables v WHERE v.variable_name = in_name INTO var_value;
+ELSE
+SELECT v.variable_value FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES v WHERE v.variable_name = in_name INTO var_value;
+END IF;
+RETURN var_value;
+END|
+SELECT *
+FROM INFORMATION_SCHEMA.TABLE_STATISTICS s
+WHERE utility_get_global_variable('userstat') = 'ON';
+DROP FUNCTION utility_get_global_variable;
 SET GLOBAL userstat= @userstat_old;

--- a/mysql-test/t/percona_userstat.test
+++ b/mysql-test/t/percona_userstat.test
@@ -177,4 +177,27 @@ FROM
   INFORMATION_SCHEMA.USER_STATISTICS
 ;
 
+--echo # Bug lp:1659992 "Function over userstat tables cause mysql to crash"
+
+delimiter |;
+CREATE FUNCTION utility_get_global_variable(in_name VARCHAR(64)) RETURNS VARCHAR(1024) CHARSET utf8 DETERMINISTIC SQL SECURITY INVOKER
+BEGIN
+  DECLARE var_value VARCHAR(1024);
+  IF @@global.version LIKE '5.7.%' THEN
+    SELECT v.variable_value FROM performance_schema.global_variables v WHERE v.variable_name = in_name INTO var_value;
+  ELSE
+    SELECT v.variable_value FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES v WHERE v.variable_name = in_name INTO var_value;
+  END IF;
+  RETURN var_value;
+END|
+delimiter ;|
+
+--disable_result_log
+SELECT *
+  FROM INFORMATION_SCHEMA.TABLE_STATISTICS s
+  WHERE utility_get_global_variable('userstat') = 'ON';
+--enable_result_log
+
+DROP FUNCTION utility_get_global_variable;
+
 SET GLOBAL userstat= @userstat_old;

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -4863,7 +4863,7 @@ bool check_grant(THD *thd, ulong want_access, TABLE_LIST *tables,
     of other queries). For simple queries first_not_own_table is 0.
   */
   for (i= 0, tl= tables;
-       i < number  && tl != first_not_own_table;
+       tl != 0 && i < number  && tl != first_not_own_table;
        tl= tl->next_global, i++)
   {
     /*


### PR DESCRIPTION
Some 'SELECT' statements over 'table_statistics' IS table used to call
'check_grant()' from 'fill_schema_table_stats()' with 'table_list' parameter
which did not include any element that would have 'next_global' pointing to
'thd->lex->query_tables_own_last'. This was a violation of 'check_grant()'
pre-conditions.

Fixed by backporting part of the 5.7
"wl#6960: Refactoring auth code: milestone 1, new physical file structure"
(commit 0ed74a1) which added additional 'NULL' check to 'TABLE_LIST'
iteration in 'check_grant()'.

Added 'main.percona_bug1659992' MTR test case.