### PR TITLE
MYR-65 : rocksdb.type_text_indexes fails

### DIFF
--- a/mysql-test/r/myisam.result
+++ b/mysql-test/r/myisam.result
@@ -1077,8 +1077,8 @@ length(c1)	c1
 0	
 SELECT DISTINCT length(c1), c1 FROM t1 ORDER BY c1;
 length(c1)	c1
-0	
 2		A
+0	
 2	 B
 DROP TABLE t1;
 End of 4.1 tests

--- a/mysql-test/suite/sys_vars/r/max_sort_length_func.result
+++ b/mysql-test/suite/sys_vars/r/max_sort_length_func.result
@@ -247,10 +247,10 @@ INSERT INTO t1 set c = concat(repeat('x',28),'g','w');
 SELECT c from t1 ORDER BY c, id;
 c
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxrx
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxsy
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxgw
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxrx
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxsy
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxgw

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -8115,7 +8115,7 @@ void Field_blob::make_sort_key(uchar *to,uint length)
   uchar *blob;
   uint blob_length=get_length();
 
-  if (!blob_length)
+  if (!blob_length && field_charset->pad_char == 0)
     memset(to, 0, length);
   else
   {
@@ -8128,19 +8128,20 @@ void Field_blob::make_sort_key(uchar *to,uint length)
       */
       length-= packlength;
       pos= to+length;
+      uint key_length= MY_MIN(blob_length, length);
 
       switch (packlength) {
       case 1:
-        *pos= (char) blob_length;
+        *pos= (char) key_length;
         break;
       case 2:
-        mi_int2store(pos, blob_length);
+        mi_int2store(pos, key_length);
         break;
       case 3:
-        mi_int3store(pos, blob_length);
+        mi_int3store(pos, key_length);
         break;
       case 4:
-        mi_int4store(pos, blob_length);
+        mi_int4store(pos, key_length);
         break;
       }
     }

--- a/strings/ctype-utf8.c
+++ b/strings/ctype-utf8.c
@@ -5148,7 +5148,7 @@ my_strnxfrm_unicode(const CHARSET_INFO *cs,
   MY_UNICASE_INFO *uni_plane= (cs->state & MY_CS_BINSORT) ?
                                NULL : cs->caseinfo;
   LINT_INIT(wc);
-  DBUG_ASSERT(src);
+  DBUG_ASSERT(src || srclen == 0);
   
   for (; dst < de && nweights; nweights--)
   {
@@ -5190,7 +5190,7 @@ my_strnxfrm_unicode_full_bin(const CHARSET_INFO *cs,
   const uchar *se = src + srclen;
 
   LINT_INIT(wc);
-  DBUG_ASSERT(src);
+  DBUG_ASSERT(src || srclen == 0);
   DBUG_ASSERT(cs->state & MY_CS_BINSORT);
 
   for ( ; dst < de && nweights; nweights--)


### PR DESCRIPTION
- Imported Facebook MySQL upstream server patches:

- https://github.com/facebook/mysql-5.6/commit/3fda3eb9bc7f7c5fec6ff2edd4057b7101102d69

  Fix sort order for empty strings in 'text' columns

  Summary:
    This is a fix for an upstream bug: http://bugs.mysql.com/bug.php?id=81810

    The problem is that Field_blob::make_sort_key will memzero the sort key for
    the empty string. However, for most collations, the empty string should sort
    as spaces, not as NUL characters.

    The fix is to memzero only if the collation pad character happens to be 0
    as well.

- https://github.com/facebook/mysql-5.6/commit/fecef54c24b5b64037af1ecf2f8e6ced5a90a3ac

  Fix length in Field_blob::make_sort_key

  Summary:
    For the binary collation in Field_blob::make_sort_key, we write out the
    length of the entire blob, even though the key itself may be shorter. We can
    miss out on duplicate key errors because of this:

  Suppose key length is 1, and we want to encode "ab", "a". Then we get the
  following sort keys:

  'a' 0 2
  'a' 0 1

  We want the two of them to produce the same key instead. To fix, define key
  length to be the min of blob length and requested key length.