### PR TITLE
Release notes in 5.7 are now passing doc8

### DIFF
--- a/doc/source/release-notes/Percona-Server-5.7.10-1.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.10-1.rst
@@ -1,54 +1,97 @@
 .. rn:: 5.7.10-1
 
-===========================
- |Percona Server| 5.7.10-1
-===========================
+=========================
+|Percona Server| 5.7.10-1
+=========================
 
- Percona is glad to announce the first Release Candidate release of |Percona Server| 5.7.10-1 on December 14th, 2015 (Downloads are available `here <http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-1rc1/>`_ and from the :doc:`Percona Software Repositories </installation>`).
+Percona is glad to announce the first Release Candidate release of |Percona
+Server| 5.7.10-1 on December 14th, 2015 (Downloads are available `here
+<http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-1rc1/>`_
+and from the :doc:`Percona Software Repositories </installation>`).
 
- Based on `MySQL 5.7.10 <http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-10.html>`_, including all the bug fixes in it, |Percona Server| 5.7.10-1 is the current Release Candidate release in the |Percona Server| 5.7 series. All of |Percona|'s software is open-source and free, all the details of the release can be found in the `5.7.10-1 milestone at Launchpad <https://launchpad.net/percona-server/+milestone/5.7.10-1rc1>`_
+Based on `MySQL 5.7.10
+<http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-10.html>`_, including
+all the bug fixes in it, |Percona Server| 5.7.10-1 is the current Release
+Candidate release in the |Percona Server| 5.7 series. All of |Percona|'s
+software is open-source and free, all the details of the release can be found
+in the `5.7.10-1 milestone at Launchpad
+<https://launchpad.net/percona-server/+milestone/5.7.10-1rc1>`_
 
- This release contains all the bug fixes from latest |Percona Server| 5.6 release (currently |Percona Server| `5.6.27-76.0 <http://www.percona.com/doc/percona-server/5.6/release-notes/Percona-Server-5.6.27-76.0.html>`_). 
- 
+This release contains all the bug fixes from latest |Percona Server| 5.6
+release (currently |Percona Server| `5.6.27-76.0
+<http://www.percona.com/doc/percona-server/5.6/release-notes/Percona-Server-5.6.27-76.0.html>`_).
+
 New Features
 ============
 
- |Percona Server| 5.7.10-1 is not available on *RHEL* 5 family of Linux distributions and *Debian* 6 (squeeze).
- 
- Complete list of changes between |Percona Server| 5.6 and 5.7 can be seen in :ref:`changed_in_57`.
+ |Percona Server| 5.7.10-1 is not available on *RHEL* 5 family of Linux
+ distributions and *Debian* 6 (squeeze).
+
+ Complete list of changes between |Percona Server| 5.6 and 5.7 can be seen in
+ :ref:`changed_in_57`.
 
 Known issues
 ============
 
- `MeCab Full-Text Parser Plugin <https://dev.mysql.com/doc/refman/5.7/en/fulltext-search-mecab.html>`_  has not been included in this release.
+ `MeCab Full-Text Parser Plugin
+ <https://dev.mysql.com/doc/refman/5.7/en/fulltext-search-mecab.html>`_  has
+ not been included in this release.
 
  :ref:`pam_plugin` currently isn't working correctly.
 
- Variables :variable:`innodb_show_verbose_locks` and :variable:`innodb_show_locks_held` are not working correctly.
+ Variables :variable:`innodb_show_verbose_locks` and
+ :variable:`innodb_show_locks_held` are not working correctly.
 
- In |Percona Server| 5.7 `super_read_only <https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html>`_ feature has been replaced with upstream implementation. There are currently two known issues compared to |Percona Server| 5.6 implementation: 
+ In |Percona Server| 5.7 `super_read_only
+ <https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html>`_
+ feature has been replaced with upstream implementation. There are currently
+ two known issues compared to |Percona Server| 5.6 implementation:
 
-  * Bug :mysqlbug:`78963`, :variable:`super_read_only` aborts ``STOP SLAVE`` if variable :variable:`relay_log_info_repository` is set to ``TABLE`` which could lead to a server crash in Debug builds.
+  * Bug :mysqlbug:`78963`, :variable:`super_read_only` aborts ``STOP SLAVE`` if
+    variable :variable:`relay_log_info_repository` is set to ``TABLE`` which
+    could lead to a server crash in Debug builds.
 
-  * Bug :mysqlbug:`79328`, :variable:`super_read_only` set as a server option has no effect.
+  * Bug :mysqlbug:`79328`, :variable:`super_read_only` set as a server option
+    has no effect.
 
- Using primary key with a ``BLOB`` in |TokuDB| table could lead to a server crash (:tokubug:`916`).
+ Using primary key with a ``BLOB`` in |TokuDB| table could lead to a server
+ crash (:tokubug:`916`).
 
- Using XA transactions with |TokuDB| could lead to a server crash (:tokubug:`900`).
+ Using XA transactions with |TokuDB| could lead to a server crash
+ (:tokubug:`900`).
 
  :ref:`toku_backup` has not been included in this release.
 
 Bugs Fixed
 ==========
 
- Running ``ALTER TABLE`` without specifying the storage engine (without ``ENGINE=`` clause) or ``OPTIMIZE TABLE`` when :variable:`enforce_storage_engine` was enabled could lead to unrequested and unexpected storage engine changes. If done for a system table, it would circumvent regular system table storage engine compatibility checks, resulting in crashes or otherwise broken server operation. Bug fixed :bug:`1488055`.
+ Running ``ALTER TABLE`` without specifying the storage engine (without
+ ``ENGINE=`` clause) or ``OPTIMIZE TABLE`` when
+ :variable:`enforce_storage_engine` was enabled could lead to unrequested and
+ unexpected storage engine changes. If done for a system table, it would
+ circumvent regular system table storage engine compatibility checks,
+ resulting in crashes or otherwise broken server operation. Bug fixed
+ :bug:`1488055`.
 
- Some transaction deadlocks did not increase the :table:`INFORMATION_SCHEMA.INNODB_METRICS` ``lock_deadlocks`` counter. Bug fixed :bug:`1466414` (upstream :mysqlbug:`77399`).
+ Some transaction deadlocks did not increase the
+ :table:`INFORMATION_SCHEMA.INNODB_METRICS` ``lock_deadlocks`` counter. Bug
+ fixed :bug:`1466414` (upstream :mysqlbug:`77399`).
 
- Removed excessive locking during the buffer pool resize when checking whether AHI is enabled. Bug fixed :bug:`1525215` (upstream :mysqlbug:`78894`).
+ Removed excessive locking during the buffer pool resize when checking whether
+ AHI is enabled. Bug fixed :bug:`1525215` (upstream :mysqlbug:`78894`).
 
- Removed unnecessary code in InnoDB error monitor thread. Bug fixed :bug:`1521564` (upstream :mysqlbug:`79477`).
+ Removed unnecessary code in InnoDB error monitor thread. Bug fixed
+ :bug:`1521564` (upstream :mysqlbug:`79477`).
 
- With :ref:`expanded_innodb_fast_index_creation` enabled, DDL queries involving |InnoDB| temporary tables would cause later queries on the same tables to produce warnings that their indexes were not found in the index translation table. Bug fixed :bug:`1233431`.
+ With :ref:`expanded_innodb_fast_index_creation` enabled, DDL queries involving
+ |InnoDB| temporary tables would cause later queries on the same tables to
+ produce warnings that their indexes were not found in the index translation
+ table. Bug fixed :bug:`1233431`.
 
-Other bugs fixed: :bug:`371752` (upstream :mysqlbug:`45379`), :bug:`1441362` (upstream :mysqlbug:`56155`), :bug:`1385062` (upstream :mysqlbug:`74810`), :bug:`1519201` (upstream :mysqlbug:`79391`), :bug:`1515602`, :bug:`1506697` (upstream :mysqlbug:`57552`), :bug:`1501089` (upstream :mysqlbug:`75239`), :bug:`1447527` (upstream :mysqlbug:`75368`), :bug:`1384658` (upstream :mysqlbug:`74619`), :bug:`1384656` (upstream :mysqlbug:`74584`), and :bug:`1192052`.
+Other bugs fixed: :bug:`371752` (upstream :mysqlbug:`45379`), :bug:`1441362`
+(upstream :mysqlbug:`56155`), :bug:`1385062` (upstream :mysqlbug:`74810`),
+:bug:`1519201` (upstream :mysqlbug:`79391`), :bug:`1515602`, :bug:`1506697`
+(upstream :mysqlbug:`57552`), :bug:`1501089` (upstream :mysqlbug:`75239`),
+:bug:`1447527` (upstream :mysqlbug:`75368`), :bug:`1384658` (upstream
+:mysqlbug:`74619`), :bug:`1384656` (upstream :mysqlbug:`74584`), and
+:bug:`1192052`.

--- a/doc/source/release-notes/Percona-Server-5.7.10-2.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.10-2.rst
@@ -1,80 +1,147 @@
 .. rn:: 5.7.10-2
 
-===========================
- |Percona Server| 5.7.10-2
-===========================
+=========================
+|Percona Server| 5.7.10-2
+=========================
 
-Percona is glad to announce the second Release Candidate release of |Percona Server| 5.7.10-2 on February 5th, 2016 (Downloads are available `here <http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-2rc2/>`_ and from the :doc:`Percona Software Repositories </installation>`).
+Percona is glad to announce the second Release Candidate release of |Percona
+Server| 5.7.10-2 on February 5th, 2016 (Downloads are available `here
+<http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-2rc2/>`_
+and from the :doc:`Percona Software Repositories </installation>`).
 
-Based on `MySQL 5.7.10 <http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-10.html>`_, including all the bug fixes in it, |Percona Server| 5.7.10-2 is the current Release Candidate release in the |Percona Server| 5.7 series. All of |Percona|'s software is open-source and free, all the details of the release can be found in the `5.7.10-2 milestone at Launchpad <https://launchpad.net/percona-server/+milestone/5.7.10-2rc2>`_
+Based on `MySQL 5.7.10
+<http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-10.html>`_, including
+all the bug fixes in it, |Percona Server| 5.7.10-2 is the current Release
+Candidate release in the |Percona Server| 5.7 series. All of |Percona|'s
+software is open-source and free, all the details of the release can be found
+in the `5.7.10-2 milestone at Launchpad
+<https://launchpad.net/percona-server/+milestone/5.7.10-2rc2>`_
 
 New Features
 ============
 
- Complete list of changes between |Percona Server| 5.6 and 5.7 can be seen in :ref:`changed_in_57`.
+ Complete list of changes between |Percona Server| 5.6 and 5.7 can be seen in
+ :ref:`changed_in_57`.
 
- 5.7 binlog group commit algorithm is now supported in |TokuDB| as well.  
+ 5.7 binlog group commit algorithm is now supported in |TokuDB| as well.
 
- New |TokuDB| index statistics reporting has been implemented to be compatible with the changes implemented in upstream 5.7. Following the |InnoDB| example, the default value for :variable:`tokudb_cardinality_scale_percent` has been changed from ``50%`` to ``100%``. Implementing this also addresses a server crash deep in the optimizer code. 
+ New |TokuDB| index statistics reporting has been implemented to be compatible
+ with the changes implemented in upstream 5.7. Following the |InnoDB| example,
+ the default value for :variable:`tokudb_cardinality_scale_percent` has been
+ changed from ``50%`` to ``100%``. Implementing this also addresses a server
+ crash deep in the optimizer code.
 
 Known Issues
 ============
 
- In |Percona Server| 5.7 `super_read_only <https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html>`_ feature has been replaced with upstream implementation. There are currently two known issues compared to |Percona Server| 5.6 implementation:
+ In |Percona Server| 5.7 `super_read_only
+ <https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html>`_
+ feature has been replaced with upstream implementation. There are currently
+ two known issues compared to |Percona Server| 5.6 implementation:
 
-   * Bug :mysqlbug:`78963`, :variable:`super_read_only` aborts ``STOP SLAVE`` if variable :variable:`relay_log_info_repository` is set to ``TABLE`` which could lead to a server crash in Debug builds.
+   * Bug :mysqlbug:`78963`, :variable:`super_read_only` aborts ``STOP SLAVE``
+     if variable :variable:`relay_log_info_repository` is set to ``TABLE``
+     which could lead to a server crash in Debug builds.
 
-   * Bug :mysqlbug:`79328`, :variable:`super_read_only` set as a server option has no effect.
+   * Bug :mysqlbug:`79328`, :variable:`super_read_only` set as a server option
+     has no effect.
 
- |InnoDB| crash recovery might fail if :variable:`innodb_flush_method` is set to ``ALL_O_DIRECT``. The workaround is to set this variable to a different value before starting up the crashed instance (bug :bug:`1529885`). 
+ |InnoDB| crash recovery might fail if :variable:`innodb_flush_method` is set
+ to ``ALL_O_DIRECT``. The workaround is to set this variable to a different
+ value before starting up the crashed instance (bug :bug:`1529885`).
 
 Bugs Fixed
 ==========
 
- Clustering secondary index could not be created on a partitioned |TokuDB| table. Bug fixed :bug:`1527730` (:tokubug:`720`).
+ Clustering secondary index could not be created on a partitioned |TokuDB|
+ table. Bug fixed :bug:`1527730` (:tokubug:`720`).
 
- :ref:`toku_backup` was failing to compile with |Percona Server| 5.7. Bug fixed :backupbug:`123`.
+ :ref:`toku_backup` was failing to compile with |Percona Server| 5.7. Bug fixed
+ :backupbug:`123`.
 
- Granting privileges to a user authenticating with :ref:`pam_plugin` could lead to a server crash. Bug fixed :bug:`1521474`.
+ Granting privileges to a user authenticating with :ref:`pam_plugin` could lead
+ to a server crash. Bug fixed :bug:`1521474`.
 
- |TokuDB| status variables were missing from |Percona Server| :rn:`5.7.10-1`. Bug fixed :bug:`1527364` (:tokubug:`923`).
+ |TokuDB| status variables were missing from |Percona Server| :rn:`5.7.10-1`.
+ Bug fixed :bug:`1527364` (:tokubug:`923`).
 
- Attempting to rotate the audit log file would result in audit log file name :file:`foo.log.%u` (literally) instead of a numeric suffix. Bug fixed :bug:`1528603`.
+ Attempting to rotate the audit log file would result in audit log file name
+ :file:`foo.log.%u` (literally) instead of a numeric suffix. Bug fixed
+ :bug:`1528603`.
 
- Adding an index to an |InnoDB| temporary table while :variable:`expand_fast_index_creation` was enabled could lead to server assertion. Bug fixed :bug:`1529555`.
+ Adding an index to an |InnoDB| temporary table while
+ :variable:`expand_fast_index_creation` was enabled could lead to server
+ assertion. Bug fixed :bug:`1529555`.
 
- |TokuDB| would not be upgraded on *Debian*/*Ubuntu* distributions while performing an upgrade from |Percona Server| 5.6 to |Percona Server| 5.7 even if explicitly requested. Bug fixed :bug:`1533580`.
+ |TokuDB| would not be upgraded on *Debian*/*Ubuntu* distributions while
+ performing an upgrade from |Percona Server| 5.6 to |Percona Server| 5.7 even
+ if explicitly requested. Bug fixed :bug:`1533580`.
 
- Server would assert when both |TokuDB| and |InnoDB| tables were used within one transaction on a replication slave which has binary log enabled and slave updates logging disabled. Bug fixed :bug:`1534249` (upstream bug :mysqlbug:`80053`).
+ Server would assert when both |TokuDB| and |InnoDB| tables were used within
+ one transaction on a replication slave which has binary log enabled and slave
+ updates logging disabled. Bug fixed :bug:`1534249` (upstream bug
+ :mysqlbug:`80053`).
 
- `MeCab Full-Text Parser Plugin <https://dev.mysql.com/doc/refman/5.7/en/fulltext-search-mecab.html>`_ has not been included in the previous release. Bug fixed :bug:`1534617`.
+ `MeCab Full-Text Parser Plugin
+ <https://dev.mysql.com/doc/refman/5.7/en/fulltext-search-mecab.html>`_ has not
+ been included in the previous release. Bug fixed :bug:`1534617`.
 
- Fixed server assertion caused by ``Performance Schema`` memory key mix-up in ``SET STATEMENT ... FOR ...`` statements. Bug fixed :bug:`1534874`.
+ Fixed server assertion caused by ``Performance Schema`` memory key mix-up in
+ ``SET STATEMENT ... FOR ...`` statements. Bug fixed :bug:`1534874`.
 
- Service name on *CentOS* 6 has been renamed from ``mysqld`` back to ``mysql``. This change requires manual service restart after being upgraded from |Percona Server| :rn:`5.7.10-1`. Bug fixed :bug:`1542332`.
+ Service name on *CentOS* 6 has been renamed from ``mysqld`` back to ``mysql``.
+ This change requires manual service restart after being upgraded from |Percona
+ Server| :rn:`5.7.10-1`. Bug fixed :bug:`1542332`.
 
- Setting the :variable:`innodb_sched_priority_purge` (available only in debug builds) while purge threads were stopped would cause a server crash. Bug fixed :bug:`1368552`.
+ Setting the :variable:`innodb_sched_priority_purge` (available only in debug
+ builds) while purge threads were stopped would cause a server crash. Bug fixed
+ :bug:`1368552`.
 
- Enabling |TokuDB| with ``ps_tokudb_admin`` script inside the Docker container would cause an error due to insufficient privileges even when running as root. In order for this script to be used inside docker containers this error has been changed to a warning that a check is impossible. Bug fixed :bug:`1520890`. 
+ Enabling |TokuDB| with ``ps_tokudb_admin`` script inside the Docker container
+ would cause an error due to insufficient privileges even when running as root.
+ In order for this script to be used inside docker containers this error has
+ been changed to a warning that a check is impossible. Bug
+ fixed :bug:`1520890`.
 
- Write-heavy workload with a small buffer pool could lead to a deadlock when free buffers are exhausted. Bug fixed :bug:`1521905`.
+ Write-heavy workload with a small buffer pool could lead to a deadlock when
+ free buffers are exhausted. Bug fixed :bug:`1521905`.
 
- |InnoDB| status will start printing negative values for spin rounds per wait, if the wait number, even though being accounted as a signed 64-bit integer, will not fit into a signed 32-bit integer. Bug fixed :bug:`1527160` (upstream :mysqlbug:`79703`).
+ |InnoDB| status will start printing negative values for spin rounds per wait,
+ if the wait number, even though being accounted as a signed 64-bit integer,
+ will not fit into a signed 32-bit integer. Bug fixed :bug:`1527160` (upstream
+ :mysqlbug:`79703`).
 
- |Percona Server| 5.7 couldn't be restarted after |TokuDB| has been installed with ``ps_tokudb_admin`` script. Bug fixed :bug:`1527535`.
+ |Percona Server| 5.7 couldn't be restarted after |TokuDB| has been installed
+ with ``ps_tokudb_admin`` script. Bug fixed :bug:`1527535`.
 
- Fixed memory leak when :variable:`utility_user` is enabled. Bug fixed :bug:`1530918`.
+ Fixed memory leak when :variable:`utility_user` is enabled. Bug fixed
+ :bug:`1530918`.
 
- Page cleaner worker threads were not instrumented for ``Performance Schema``. Bug fixed :bug:`1532747` (upstream bug :mysqlbug:`79894`).
+ Page cleaner worker threads were not instrumented for ``Performance Schema``.
+ Bug fixed :bug:`1532747` (upstream bug :mysqlbug:`79894`).
 
- Busy server was preferring LRU flushing over flush list flushing too strongly which could lead to performance degradation. Bug fixed :bug:`1534114`.
+ Busy server was preferring LRU flushing over flush list flushing too strongly
+ which could lead to performance degradation. Bug fixed :bug:`1534114`.
 
- :file:`libjemalloc.so.1` was missing from binary tarball. Bug fixed :bug:`1537129`.
+ :file:`libjemalloc.so.1` was missing from binary tarball. Bug fixed
+ :bug:`1537129`.
 
- When ``cmake/make/make_binary_distribution`` workflow was used to produce binary tarballs it would produce tarballs with ``mysql-...`` naming instead of ``percona-server-...``. Bug fixed :bug:`1540385`.
+ When ``cmake/make/make_binary_distribution`` workflow was used to produce
+ binary tarballs it would produce tarballs with ``mysql-...`` naming instead of
+ ``percona-server-...``. Bug fixed :bug:`1540385`.
 
- Added proper memory cleanup if for some reason a table is unable to be opened from a dead closed state. This prevents an assertion from happening the next time the table is attempted to be opened. Bug fixed :tokubug:`917`.
+ Added proper memory cleanup if for some reason a table is unable to be opened
+ from a dead closed state. This prevents an assertion from happening the next
+ time the table is attempted to be opened. Bug fixed :tokubug:`917`.
 
- Variable :variable:`tokudb_support_xa` has been modified to prevent setting it to anything but ``ON``/``ENABLED`` and to print a SQL warning anytime an attempt is made to change it, just like :variable:`innodb_support_xa`. Bug fixed :tokubug:`928`.
+ Variable :variable:`tokudb_support_xa` has been modified to prevent setting it
+ to anything but ``ON``/``ENABLED`` and to print a SQL warning anytime an
+ attempt is made to change it, just like :variable:`innodb_support_xa`. Bug
+ fixed :tokubug:`928`.
 
-Other bugs fixed: :bug:`1179451`, :bug:`1534246`, :bug:`1524763`, :bug:`1525109` (upstream :mysqlbug:`79569`), :bug:`1530102`, :tokubug:`897`, :tokubug:`898`, :tokubug:`899`, :tokubug:`900`, :tokubug:`901`, :tokubug:`902`, :tokubug:`903`, :tokubug:`905`, :tokubug:`906`, :tokubug:`907`, :tokubug:`908`, :tokubug:`909`, :tokubug:`910`, :tokubug:`911`, :tokubug:`912`, :tokubug:`913`, :tokubug:`915`, :tokubug:`919`, and :tokubug:`904`. 
+Other bugs fixed: :bug:`1179451`, :bug:`1534246`, :bug:`1524763`,
+:bug:`1525109` (upstream :mysqlbug:`79569`), :bug:`1530102`, :tokubug:`897`,
+:tokubug:`898`, :tokubug:`899`, :tokubug:`900`, :tokubug:`901`, :tokubug:`902`,
+:tokubug:`903`, :tokubug:`905`, :tokubug:`906`, :tokubug:`907`, :tokubug:`908`,
+:tokubug:`909`, :tokubug:`910`, :tokubug:`911`, :tokubug:`912`, :tokubug:`913`,
+:tokubug:`915`, :tokubug:`919`, and :tokubug:`904`.

--- a/doc/source/release-notes/Percona-Server-5.7.10-3.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.10-3.rst
@@ -1,41 +1,69 @@
 .. rn:: 5.7.10-3
 
-===========================
- |Percona Server| 5.7.10-3
-===========================
+=========================
+|Percona Server| 5.7.10-3
+=========================
 
-Percona is glad to announce the first GA (Generally Available) release of |Percona Server| 5.7.10-3 on February 23rd, 2016 (Downloads are available `here <http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-3/>`_ and from the :doc:`Percona Software Repositories </installation>`).
+Percona is glad to announce the first GA (Generally Available) release of
+|Percona Server| 5.7.10-3 on February 23rd, 2016 (Downloads are available `here
+<http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-3/>`_
+and from the :doc:`Percona Software Repositories </installation>`).
 
-Based on `MySQL 5.7.10 <http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-10.html>`_, including all the bug fixes in it, |Percona Server| 5.7.10-3 is the current Generally Available release in the |Percona Server| 5.7 series. All of |Percona|'s software is open-source and free, all the details of the release can be found in the `5.7.10-3 milestone at Launchpad <https://launchpad.net/percona-server/+milestone/5.7.10-3>`_
+Based on `MySQL 5.7.10
+<http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-10.html>`_, including
+all the bug fixes in it, |Percona Server| 5.7.10-3 is the current Generally
+Available release in the |Percona Server| 5.7 series. All of |Percona|'s
+software is open-source and free, all the details of the release can be found
+in the `5.7.10-3 milestone at Launchpad
+<https://launchpad.net/percona-server/+milestone/5.7.10-3>`_
 
 New Features
 ============
 
- Complete list of changes between |Percona Server| 5.6 and 5.7 can be seen in :ref:`changed_in_57`.
+ Complete list of changes between |Percona Server| 5.6 and 5.7 can be seen in
+ :ref:`changed_in_57`.
 
- |Percona Server| has implemented :ref:`Multi-threaded asynchronous LRU flusher <lru_manager_threads>`. This work also allows to safely use ``backoff`` value for the :variable:`innodb_empty_free_list_algorithm` server system variable, and its default has been changed accordingly.
- 
+ |Percona Server| has implemented :ref:`Multi-threaded asynchronous LRU flusher
+ <lru_manager_threads>`. This work also allows to safely use ``backoff`` value
+ for the :variable:`innodb_empty_free_list_algorithm` server system variable,
+ and its default has been changed accordingly.
+
 Known Issues
 ============
 
- In |Percona Server| 5.7 `super_read_only <https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html>`_ feature has been replaced with upstream implementation. There are currently two known issues compared to |Percona Server| 5.6 implementation:
+ In |Percona Server| 5.7 `super_read_only
+ <https://www.percona.com/doc/percona-server/5.6/management/super_read_only.html>`_
+ feature has been replaced with upstream implementation. There are currently
+ two known issues compared to |Percona Server| 5.6 implementation:
 
-   * Bug :mysqlbug:`78963`, :variable:`super_read_only` aborts ``STOP SLAVE`` if variable :variable:`relay_log_info_repository` is set to ``TABLE`` which could lead to a server crash in Debug builds.
+   * Bug :mysqlbug:`78963`, :variable:`super_read_only` aborts ``STOP SLAVE``
+     if variable :variable:`relay_log_info_repository` is set to ``TABLE``
+     which could lead to a server crash in Debug builds.
 
-   * Bug :mysqlbug:`79328`, :variable:`super_read_only` set as a server option has no effect.
+   * Bug :mysqlbug:`79328`, :variable:`super_read_only` set as a server option
+     has no effect.
 
- |InnoDB| crash recovery might fail if :variable:`innodb_flush_method` is set to ``ALL_O_DIRECT``. The workaround is to set this variable to a different value before starting up the crashed instance (bug :bug:`1529885`). 
+ |InnoDB| crash recovery might fail if :variable:`innodb_flush_method` is set
+ to ``ALL_O_DIRECT``. The workaround is to set this variable to a different
+ value before starting up the crashed instance (bug :bug:`1529885`).
 
 Bugs Fixed
 ==========
 
- |Percona Server| :rn:`5.7.10-1` didn't write the initial root password into the log file :file:`/var/log/mysqld.log` during the installation on *CentOS 6*. Bug fixed :bug:`1541769`.
+ |Percona Server| :rn:`5.7.10-1` didn't write the initial root password into
+ the log file :file:`/var/log/mysqld.log` during the installation on
+ *CentOS 6*. Bug fixed :bug:`1541769`.
 
- Cardinality of partitioned |TokuDB| tables became inaccurate after the changes introduced by :ref:`tokudb_background_analyze_table` feature in |Percona Server| :rn:`5.7.10-1`. Bug fixed :tokubug:`925`. 
+ Cardinality of partitioned |TokuDB| tables became inaccurate after the changes
+ introduced by :ref:`tokudb_background_analyze_table` feature in |Percona
+ Server| :rn:`5.7.10-1`. Bug fixed :tokubug:`925`.
 
- Running the ``TRUNCATE TABLE`` while :ref:`tokudb_background_analyze_table` is enabled could lead to a server crash once analyze job tries to access the truncated table. Bug fixed :tokubug:`938`.
+ Running the ``TRUNCATE TABLE`` while :ref:`tokudb_background_analyze_table` is
+ enabled could lead to a server crash once analyze job tries to access the
+ truncated table. Bug fixed :tokubug:`938`.
 
- :ref:`toku_backup` would fail with an unclear error if backup process found :file:`mysqld_safe.pid` file (owned by root) inside the :variable:`datadir`. Fixed by excluding the ``pid`` file by default. Bug fixed :backupbug:`125`.
+ :ref:`toku_backup` would fail with an unclear error if backup process found
+ :file:`mysqld_safe.pid` file (owned by root) inside the :variable:`datadir`.
+ Fixed by excluding the ``pid`` file by default. Bug fixed :backupbug:`125`.
 
- :ref:`pam_plugin` build warning has been fixed. Bug fixed :bug:`1541601`. 
-
+ :ref:`pam_plugin` build warning has been fixed. Bug fixed :bug:`1541601`.

--- a/doc/source/release-notes/Percona-Server-5.7.11-4.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.11-4.rst
@@ -1,34 +1,61 @@
 .. rn:: 5.7.11-4
 
-===========================
- |Percona Server| 5.7.11-4
-===========================
+=========================
+|Percona Server| 5.7.11-4
+=========================
 
-Percona is glad to announce the GA (Generally Available) release of |Percona Server| 5.7.11-4 on March 15th, 2016 (Downloads are available `here <http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.11-4/>`_ and from the :doc:`Percona Software Repositories </installation>`).
+Percona is glad to announce the GA (Generally Available) release of |Percona
+Server| 5.7.11-4 on March 15th, 2016 (Downloads are available `here
+<http://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.11-4/>`_
+and from the :doc:`Percona Software Repositories </installation>`).
 
-Based on `MySQL 5.7.11 <http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-11.html>`_, including all the bug fixes in it, |Percona Server| 5.7.11-4 is the current GA release in the |Percona Server| 5.7 series. All of |Percona|'s software is open-source and free, all the details of the release can be found in the `5.7.11-4 milestone at Launchpad <https://launchpad.net/percona-server/+milestone/5.7.11-4>`_
+Based on `MySQL 5.7.11
+<http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-11.html>`_, including
+all the bug fixes in it, |Percona Server| 5.7.11-4 is the current GA release in
+the |Percona Server| 5.7 series. All of |Percona|'s software is open-source and
+free, all the details of the release can be found in the `5.7.11-4 milestone at
+Launchpad <https://launchpad.net/percona-server/+milestone/5.7.11-4>`_
 
 New Features
 ============
 
  |Percona Server| has implemented :ref:`parallel_doublewrite_buffer`.
- 
- :ref:`tokudb_background_analyze_table` feature is now enabled by default (:variable:`tokudb_analyze_in_background` is set to ``ON`` by default). Variable :variable:`tokudb_auto_analyze` default value has been changed from ``0`` to ``30``. (:tokubug:`935`) 
 
- :ref:`log_warning_suppress` feature has been removed from |Percona Server| 5.7 because |MySQL| 5.7.11 has implemented a new system variable, `log_statements_unsafe_for_binlog <https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_log_statements_unsafe_for_binlog>`_, which implements the same effect.
+ :ref:`tokudb_background_analyze_table` feature is now enabled by default
+ (:variable:`tokudb_analyze_in_background` is set to ``ON`` by default).
+ Variable :variable:`tokudb_auto_analyze` default value has been changed from
+ ``0`` to ``30``. (:tokubug:`935`)
+
+ :ref:`log_warning_suppress` feature has been removed from |Percona Server| 5.7
+ because |MySQL| 5.7.11 has implemented a new system variable,
+ `log_statements_unsafe_for_binlog
+ <https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_log_statements_unsafe_for_binlog>`_,
+ which implements the same effect.
 
 Bugs Fixed
 ==========
 
- If ``pid-file`` option wasn't specified with the full path, *Ubuntu*/*Debian* ``sysvinit`` script wouldn't notice the server is actually running and it will timeout or in some cases even hang. Bug fixed :bug:`1549333`.
+ If ``pid-file`` option wasn't specified with the full path, *Ubuntu*/*Debian*
+ ``sysvinit`` script wouldn't notice the server is actually running and it will
+ timeout or in some cases even hang. Bug fixed :bug:`1549333`.
 
- Buffer pool may fail to remove dirty pages for a particular tablesspace from the flush list, as requested by, for example, ``DROP TABLE`` or ``TRUNCATE TABLE`` commands. This could lead to a crash. Bug fixed :bug:`1552673`.
+ Buffer pool may fail to remove dirty pages for a particular tablesspace from
+ the flush list, as requested by, for example, ``DROP TABLE`` or ``TRUNCATE
+ TABLE`` commands. This could lead to a crash. Bug fixed :bug:`1552673`.
 
- :ref:`audit_log_plugin` worker thread may crash on write call writing fewer bytes than requested. Bug fixed :bug:`1552682` (upstream :mysqlbug:`80606`).
+ :ref:`audit_log_plugin` worker thread may crash on write call writing fewer
+ bytes than requested. Bug fixed :bug:`1552682` (upstream :mysqlbug:`80606`).
 
- |Percona Server| 5.7 ``systemd`` script now takes the last option specified in :file:`my.cnf` if the same option is specified multiple times. Previously it would try to take all values which would break the script and server would fail to start. Bug fixed :bug:`1554976`.
+ |Percona Server| 5.7 ``systemd`` script now takes the last option specified in
+ :file:`my.cnf` if the same option is specified multiple times. Previously it
+ would try to take all values which would break the script and server would
+ fail to start. Bug fixed :bug:`1554976`.
 
- ``mysqldumpslow`` script has been removed because it was not compatible with |Percona Server| extended slow query log format. Please use `pt-query-digest <https://www.percona.com/doc/percona-toolkit/2.2/pt-query-digest.html>`_ from |Percona Toolkit| instead. Bug fixed :bug:`856910`.
+ ``mysqldumpslow`` script has been removed because it was not compatible with
+ |Percona Server| extended slow query log format. Please use `pt-query-digest
+ <https://www.percona.com/doc/percona-toolkit/2.2/pt-query-digest.html>`_ from
+ |Percona Toolkit| instead. Bug fixed :bug:`856910`.
 
-Other bugs fixed: :bug:`1521120`, :bug:`1549301` (upstream :mysqlbug:`80496`), and :bug:`1554043` (upstream :mysqlbug:`80607`).
+Other bugs fixed: :bug:`1521120`, :bug:`1549301` (upstream :mysqlbug:`80496`),
+and :bug:`1554043` (upstream :mysqlbug:`80607`).
 

--- a/doc/source/release-notes/Percona-Server-5.7.17-12.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.17-12.rst
@@ -11,7 +11,7 @@ and from the :doc:`Percona Software Repositories </installation>`).
 
 Based on `MySQL 5.7.17
 <http://dev.mysql.com/doc/relnotes/mysql/5.7/en/news-5-7-17.html>`_, including
-all the bug fixes in it, |Percona Server| 5.7.17-11 is the current GA release
+all the bug fixes in it, |Percona Server| 5.7.17-12 is the current GA release
 in the |Percona Server| 5.7 series. All of |Percona|'s software is open-source
 and free, all the details of the release can be found in the `5.7.17-12
 milestone at


### PR DESCRIPTION
Fixed a version number in 5.7.17-12 release notes