### PR TITLE
Bugfix #1516919

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -962,14 +962,14 @@ static bool should_write_gtids(const THD *thd) {
     return false;
   /*
     Return true (allow gtids to be generated) in the scenario where
-    gtid_deployment_step is false (Normal run after deployment procedure
+    opt_gtid_deployment_step is false (Normal run after deployment procedure
     is done).
 
     Return true in the scenario where slave sql_thread uses gtid received from
     master. This is necessary in the situation where deployment is done on
-    master, but slave still in deployment mode (gtid_deployment_step is true).
+    master, but slave still in deployment mode (opt_gtid_deployment_step is true).
   */
-  return (!gtid_deployment_step || (thd->rli_slave &&
+  return (!opt_gtid_deployment_step || (thd->rli_slave &&
           thd->variables.gtid_next.type != AUTOMATIC_GROUP));
 
 }

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5771,6 +5771,11 @@ int mysqld_main(int argc, char **argv)
   if (init_common_variables())
     unireg_abort(1);        // Will do exit
 
+  /*
+    Setting this as early as possible
+  */
+  opt_gtid_deployment_step= gtid_deployment_step;
+
   my_init_signals();
 
   size_t guardize= 0;

--- a/sql/rpl_master.cc
+++ b/sql/rpl_master.cc
@@ -1424,9 +1424,9 @@ void mysql_binlog_send(THD* thd, char* log_ident, my_off_t pos,
         {
           /*
              Skip groups in the binlogs which don't have any gtid event
-             logged before them. When gtid_deployment_step is ON, the server
+             logged before them. When opt_gtid_deployment_step is ON, the server
              doesn't generate GTID and so no gtid_event is logged before binlog
-             events. But when gtid_deployment_step is OFF, the server starts
+             events. But when opt_gtid_deployment_step is OFF, the server starts
              writing gtid_events in the middle of active binlog. When slave
              connects with gtid_protocol, master needs to skip binlog events
              which don't have corresponding gtid_event.

--- a/sql/rpl_master.cc
+++ b/sql/rpl_master.cc
@@ -141,6 +141,7 @@ int register_slave(THD* thd, uchar* packet, uint packet_length)
     return 1;
   }
 
+  si->thd= NULL;
   thd->server_id= si->server_id= uint4korr(p);
   p+= 4;
   get_object(p,si->host, "Failed to register slave: too long 'report-host'");
@@ -159,7 +160,6 @@ int register_slave(THD* thd, uchar* packet, uint packet_length)
   p += 4;
   if (!(si->master_id= uint4korr(p)))
     si->master_id= server_id;
-  si->thd= thd;
 
   mysql_mutex_lock(&LOCK_slave_list);
   unregister_slave(thd, false, false/*need_lock_slave_list=false*/);
@@ -172,6 +172,18 @@ err:
   my_message(ER_UNKNOWN_ERROR, errmsg, MYF(0)); /* purecov: inspected */
 err2:
   return 1;
+}
+
+static void register_slave_thd(THD* thd) {
+  if (thd->server_id)
+  {
+    mysql_mutex_lock(&LOCK_slave_list);
+    SLAVE_INFO* si;
+    if ((si = (SLAVE_INFO*)my_hash_search(&slave_list,
+                                         (uchar*)&thd->server_id, 4)))
+      si->thd= thd;
+    mysql_mutex_unlock(&LOCK_slave_list);
+  }
 }
 
 void unregister_slave(THD* thd, bool only_mine, bool need_lock_slave_list)
@@ -759,6 +771,7 @@ bool com_binlog_dump(THD *thd, char *packet, uint packet_length)
   DBUG_PRINT("info", ("pos=%lu flags=%d server_id=%d", pos, flags, thd->server_id));
 
   kill_zombie_dump_threads(thd);
+  register_slave_thd(thd);
 
   general_log_print(thd, thd->get_command(), "Log: '%s'  Pos: %ld",
                     packet + 10, (long) pos);
@@ -813,6 +826,7 @@ bool com_binlog_dump_gtid(THD *thd, char *packet, uint packet_length)
                       "'%s'.", thd->server_id, name, pos, gtid_string));
 
   kill_zombie_dump_threads(thd);
+  register_slave_thd(thd);
   general_log_print(thd, thd->get_command(), "Log: '%s' Pos: %llu GTIDs: '%s'",
                     name, pos, gtid_string);
   my_free(gtid_string);

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2745,7 +2745,7 @@ when it try to get the value of TIME_ZONE global variable from master.";
     }
     if ((mi->master_gtid_mode > gtid_mode + 1 ||
         gtid_mode > mi->master_gtid_mode + 1) &&
-        !gtid_deployment_step)
+        !opt_gtid_deployment_step)
     {
       mi->report(ERROR_LEVEL, ER_SLAVE_FATAL_ERROR,
                  "The slave IO thread stops because the master has "

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5205,10 +5205,8 @@ static bool fix_gtid_deployment_step(sys_var *self, THD *thd, enum_var_type type
   bool new_gtid_deployment_step= gtid_deployment_step;
   bool result= true;
 
-  if (gtid_deployment_step == FALSE ||
-      gtid_deployment_step == opt_gtid_deployment_step)
+  if (gtid_deployment_step == opt_gtid_deployment_step)
   {
-    opt_gtid_deployment_step= gtid_deployment_step;
     DBUG_RETURN(false);
   }
 


### PR DESCRIPTION
The incorrect variable (unprotected by locks) is used to judge if gtid deployment mode is ON/OFF.

Also any modifications to opt_gtid_deployment_mode should also be
protected by locks.