### PR TITLE
Fix for bug lp:1675763.

### DIFF
--- a/storage/tokudb/tokudb_dir_cmd.cc
+++ b/storage/tokudb/tokudb_dir_cmd.cc
@@ -30,6 +30,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "sql_base.h"
 
 #include <vector>
+#include <string>
 
 namespace tokudb {
 


### PR DESCRIPTION
Add 'include' for std::string in storage/tokudb/tokudb_dir_cmd.cc.

Testing: http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1794/