### PR TITLE
Fix for bug lp:1675763.

### DIFF
--- a/storage/tokudb/tokudb_dir_cmd.cc
+++ b/storage/tokudb/tokudb_dir_cmd.cc
@@ -30,6 +30,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "sql_base.h"
 
 #include <vector>
+#include <string>
 
 namespace tokudb {
 


### PR DESCRIPTION
Add 'include' for std::string in storage/tokudb/tokudb_dir_cmd.cc.

(cherry picked from commit 6c70e8733248f912843577c79f2b4b7e05b9924f)

Testing: http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/748