### PR TITLE
Add diagnostics for bug 1676764 (COM_STMT_CLOSE crash in Query_cache:…

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6607,6 +6607,7 @@ void THD::reset_for_next_command()
   DBUG_ENTER("mysql_reset_thd_for_next_command");
   DBUG_ASSERT(!thd->sp_runtime_ctx); /* not for substatements of routines */
   DBUG_ASSERT(! thd->in_sub_stmt);
+  DBUG_ASSERT(!thd->query_cache_tls.first_query_block);
   thd->free_list= 0;
   thd->select_number= 1;
   /*


### PR DESCRIPTION
…:end_of_result: DBUG_ASSERT(thd->get_stmt_da()->is_eof()))

For a crashing COM_STMT_CLOSE command,
thd->query_cache_tls.first_query_block != NULL as it should be. Add an
assert to THD::reset_for_next_command to see if it's a previous query
which hasn't cleaned up.

http://jenkins.percona.com/job/percona-server-5.6-param/1799/