### PR TITLE
Fix bug 1677156 (Test rpl.rpl_start_stop_slave is unstable)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_start_stop_slave.result
+++ b/mysql-test/suite/rpl/r/rpl_start_stop_slave.result
@@ -6,5 +6,7 @@ set @time_before_kill := (select CURRENT_TIMESTAMP);
 kill <connection_id>;
 set @time_after_kill := (select CURRENT_TIMESTAMP);
 [Time after the query]
+include/wait_for_slave_io_to_stop.inc
 [Killing of the slave IO thread was successful]
+include/start_slave.inc
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_start_stop_slave.test
+++ b/mysql-test/suite/rpl/t/rpl_start_stop_slave.test
@@ -43,6 +43,11 @@ if(`select TIMESTAMPDIFF(SECOND,@time_after_kill, @time_before_kill) > 60`)
 --die
 }
 
+--source include/wait_for_slave_io_to_stop.inc
+
 --echo [Killing of the slave IO thread was successful]
+
+--source include/start_slave.inc
+
 # End of test
 --source include/rpl_end.inc


### PR DESCRIPTION
Fix rpl_end.inc not being able to sync slave with master by restart
the killed slave I/O thread.

http://jenkins.percona.com/job/percona-server-5.5-param/1535/