### PR TITLE
Fix bug 1677162 (Test main.sp-threads is unstable)

### DIFF
--- a/mysql-test/t/sp-threads.test
+++ b/mysql-test/t/sp-threads.test
@@ -77,9 +77,14 @@ call bug9486();
 connection con2root;
 lock tables t2 write;
 connection con1root;
+--let $con1root_id=`SELECT CONNECTION_ID()`
 send call bug9486();
 connection con2root;
---sleep 2
+
+let $wait_condition=SELECT COUNT(*)=1 FROM information_schema.processlist WHERE
+                           id=$con1root_id AND state='Waiting for table metadata lock';
+--source include/wait_condition.inc
+
 # There should be call statement in locked state.
 --replace_column 1 # 3 localhost 6 # 9 # 10 #
 --replace_result "starting" STATE "init" STATE "cleaning up" STATE


### PR DESCRIPTION
Wait for the query thread to block on the metadata lock before
querying processlist.

http://jenkins.percona.com/job/percona-server-5.6-param/1804/