### PR TITLE
Add diagnostics for bug 1677190 (Test main.percona_log_slow_verbosity…

### DIFF
--- a/mysql-test/include/percona_slow_log_verbosity_grep.inc
+++ b/mysql-test/include/percona_slow_log_verbosity_grep.inc
@@ -1,11 +1,13 @@
 # Common extensions to the slow query log
 --let grep_pattern = ^# Schema: .+  Last_errno: \d+  Killed: \d+\$
+--let log_expected_matches = $log_slow_verbosity_expected_matches
 --source include/log_grep.inc
 --let grep_pattern = ^#.*Rows_affected: \d+\$
 --source include/log_grep.inc
 --let grep_pattern = ^# Bytes_sent: \d+.*\$
 --source include/log_grep.inc
 # InnoDB
+--let log_expected_matches = $log_slow_verbosity_innodb_expected_matches
 --let grep_pattern = ^# InnoDB_trx_id: \w+\$
 --source include/log_grep.inc
 # Query plan

--- a/mysql-test/r/percona_log_slow_verbosity.result
+++ b/mysql-test/r/percona_log_slow_verbosity.result
@@ -36,12 +36,12 @@ SELECT 1;
 1
 [log_stop.inc] percona.slow_extended.log_slow_verbosity_1
 log_slow_verbosity='microtime,innodb,query_plan':
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Bytes_sent: \d+.*$
-[log_grep.inc] lines:   2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^#.*Rows_affected: \d+$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Bytes_sent: \d+.*$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# InnoDB_trx_id: \w+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
@@ -63,12 +63,12 @@ SET log_slow_verbosity='microtime';
 INSERT INTO t1 VALUE(1);
 [log_stop.inc] percona.slow_extended.log_slow_verbosity_2
 log_slow_verbosity='microtime':
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Bytes_sent: \d+.*$
-[log_grep.inc] lines:   2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^#.*Rows_affected: \d+$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Bytes_sent: \d+.*$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# InnoDB_trx_id: \w+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
@@ -90,12 +90,12 @@ SET log_slow_verbosity='microtime,query_plan';
 INSERT INTO t1 VALUE(2);
 [log_stop.inc] percona.slow_extended.log_slow_verbosity_3
 log_slow_verbosity='query_plan':
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Bytes_sent: \d+.*$
-[log_grep.inc] lines:   2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^#.*Rows_affected: \d+$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Bytes_sent: \d+.*$ expected_matches: 2
+[log_grep.inc] found expected match count: 2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# InnoDB_trx_id: \w+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$

--- a/mysql-test/t/percona_log_slow_verbosity.test
+++ b/mysql-test/t/percona_log_slow_verbosity.test
@@ -38,6 +38,8 @@ SELECT 1;
 --source include/log_stop.inc
 
 --echo log_slow_verbosity='microtime,innodb,query_plan':
+--let log_slow_verbosity_expected_matches= 2
+--let log_slow_verbosity_innodb_expected_matches= 0
 --source include/percona_slow_log_verbosity_grep.inc
 
 #


### PR DESCRIPTION
… is unstable)

Add expected grep match counts to the testcase to get more info next
time it fails.

http://jenkins.percona.com/job/percona-server-5.6-param/1806/