### PR TITLE
Add diagnostics for bug 1677195 (Test main.percona_slow_extended_erro…

### DIFF
--- a/mysql-test/r/percona_slow_extended_error_on_quit.result
+++ b/mysql-test/r/percona_slow_extended_error_on_quit.result
@@ -12,15 +12,15 @@ ERROR 42S01: Table 't' already exists
 [log_start.inc] percona.slow_extended.error_on_quit_2
 # Disconnecting (passing to Slow Query Log "# administrative command: Quit")
 [log_stop.inc] percona.slow_extended.error_on_quit_2
-[log_grep.inc] file: percona.slow_extended.error_on_quit_2 pattern: Last_errno: 0\s
-[log_grep.inc] lines:   2
+[log_grep.inc] file: percona.slow_extended.error_on_quit_2 pattern: Last_errno: 0\s expected_matches: 2
+[log_grep.inc] found expected match count: 2
 [log_start.inc] percona.slow_extended.error_on_quit_3
 SELECT * FROM t;
 a
 # Disconnecting (passing to Slow Query Log "# administrative command: Quit")
 [log_stop.inc] percona.slow_extended.error_on_quit_3
-[log_grep.inc] file: percona.slow_extended.error_on_quit_3 pattern: Last_errno: 0\s
-[log_grep.inc] lines:   3
+[log_grep.inc] file: percona.slow_extended.error_on_quit_3 pattern: Last_errno: 0\s expected_matches: 3
+[log_grep.inc] found expected match count: 3
 DROP TABLE t;
 SET GLOBAL log_slow_admin_statements=default;
 SET GLOBAL long_query_time=default;

--- a/mysql-test/t/percona_slow_extended_error_on_quit.test
+++ b/mysql-test/t/percona_slow_extended_error_on_quit.test
@@ -42,6 +42,7 @@ CREATE TABLE t(a INT) engine=InnoDB;
 --source include/log_stop.inc
 
 --let grep_pattern=Last_errno: 0\s
+--let log_expected_matches= 2
 --source include/log_grep.inc
 
 --connect(additional,localhost,root,,)
@@ -62,6 +63,7 @@ SELECT * FROM t;
 --source include/log_stop.inc
 
 --let grep_pattern= Last_errno: 0\s
+--let log_expected_matches= 3
 --source include/log_grep.inc
 
 DROP TABLE t;


### PR DESCRIPTION
…r_on_quit is unstable)

Add expected grep match counts to the testcase to get more info next
time it fails.

http://jenkins.percona.com/job/percona-server-5.6-param/1807/