### PR TITLE
Fix bug 1676847 / 85671 (segfault-t failing under recent AddressSanit…

### DIFF
--- a/unittest/gunit/segfault-t.cc
+++ b/unittest/gunit/segfault-t.cc
@@ -62,8 +62,8 @@ TEST_F(FatalSignalDeathTest, Segfault)
   */
   EXPECT_DEATH_IF_SUPPORTED(*pint= 42, "");
 #elif defined(__SANITIZE_ADDRESS__)
-  /* gcc 4.8.1 with '-fsanitize=address -O1' */
-  EXPECT_DEATH_IF_SUPPORTED(*pint= 42, ".*ASAN:SIGSEGV.*");
+  /* AddressSanitizer */
+  EXPECT_DEATH_IF_SUPPORTED(*pint= 42, ".*ASAN:(DEADLYSIGNAL|SIGSEGV).*");
 #else
   /*
    On most platforms we get SIGSEGV == 11, but SIGBUS == 10 is also possible.


### PR DESCRIPTION
…izer)

Expect both ASAN:DEADLYSIGNAL and ASAN:SIGSEGV as AddressSanitizer
diagnostics for a NULL pointer dereference.

http://jenkins.percona.com/job/percona-server-5.6-asan-param/149/