### PR TITLE
Fix bug 1674286 / 85678 (field-t deletes Fake_TABLE objects through b…

### DIFF
--- a/unittest/gunit/field-t.cc
+++ b/unittest/gunit/field-t.cc
@@ -400,8 +400,8 @@ TEST_F(FieldTest, CopyFieldSet)
   // Copy_field DTOR is not invoked in all contexts, so we may leak memory.
   EXPECT_FALSE(cf->tmp.is_alloced());
 
-  delete f_to->table;
-  delete f_from->table;
+  delete static_cast<Fake_TABLE *>(f_to->table);
+  delete static_cast<Fake_TABLE *>(f_from->table);
 }
 
 

--- a/unittest/gunit/mock_field_timestamp.h
+++ b/unittest/gunit/mock_field_timestamp.h
@@ -81,7 +81,7 @@ public:
     store_timestamp_called= true;
   }
 
-  ~Mock_field_timestamp() { delete table; }
+  ~Mock_field_timestamp() { delete static_cast<Fake_TABLE *>(table); }
 };
 
 #endif // MOCK_FIELD_TIMESTAMP_H

--- a/unittest/gunit/mock_field_timestampf.h
+++ b/unittest/gunit/mock_field_timestampf.h
@@ -65,7 +65,7 @@ public:
     return Field_timestampf::store_timestamp_internal(tm);
   }
 
-  ~Mock_field_timestampf() { delete table; }
+  ~Mock_field_timestampf() { delete static_cast<Fake_TABLE *>(table); }
 };
 
 #endif // MOCK_FIELD_TIMESTAMPF_H


### PR DESCRIPTION
…ase TABLE pointer w/o virtual dtor)

Avoid deleting child class objects through a base class pointer, since
the base class does not have a virtual destructor and we do not want
to add one. Instead, typecast the pointers to the child class when
passing to delete.

Tested together with another unit test fix at http://jenkins.percona.com/job/percona-server-5.6-asan-param/149/