### PR TITLE
Fix bug 1677943 (Bug 1668602 fix did not re-record rpl_semi_sync test)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync.result
@@ -139,6 +139,7 @@ INSERT INTO t2 VALUES(22);
 COMMIT;
 DROP TABLE t2, t3;
 SET SESSION AUTOCOMMIT= 1;
+FLUSH STATUS;
 include/sync_slave_sql_with_master.inc
 #
 # Test semi-sync master will switch OFF after one transaction
@@ -156,7 +157,7 @@ Variable_name	Value
 Rpl_semi_sync_master_no_tx	0
 show status like 'Rpl_semi_sync_master_yes_tx';
 Variable_name	Value
-Rpl_semi_sync_master_yes_tx	15
+Rpl_semi_sync_master_yes_tx	1
 show status like 'Rpl_semi_sync_master_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	0
@@ -171,7 +172,7 @@ Variable_name	Value
 Rpl_semi_sync_master_no_tx	1
 show status like 'Rpl_semi_sync_master_yes_tx';
 Variable_name	Value
-Rpl_semi_sync_master_yes_tx	15
+Rpl_semi_sync_master_yes_tx	1
 insert into t1 values (100);
 [ master status should be OFF ]
 show status like 'Rpl_semi_sync_master_status';
@@ -182,7 +183,7 @@ Variable_name	Value
 Rpl_semi_sync_master_no_tx	12
 show status like 'Rpl_semi_sync_master_yes_tx';
 Variable_name	Value
-Rpl_semi_sync_master_yes_tx	15
+Rpl_semi_sync_master_yes_tx	1
 #
 # Test semi-sync status on master will be ON again when slave catches up
 #
@@ -215,7 +216,7 @@ Variable_name	Value
 Rpl_semi_sync_master_no_tx	12
 show status like 'Rpl_semi_sync_master_yes_tx';
 Variable_name	Value
-Rpl_semi_sync_master_yes_tx	15
+Rpl_semi_sync_master_yes_tx	1
 show status like 'Rpl_semi_sync_master_clients';
 Variable_name	Value
 Rpl_semi_sync_master_clients	1
@@ -235,7 +236,7 @@ Variable_name	Value
 Rpl_semi_sync_master_no_tx	12
 SHOW STATUS LIKE 'Rpl_semi_sync_master_yes_tx';
 Variable_name	Value
-Rpl_semi_sync_master_yes_tx	16
+Rpl_semi_sync_master_yes_tx	2
 FLUSH NO_WRITE_TO_BINLOG STATUS;
 [ Semi-sync master status variables after FLUSH STATUS ]
 SHOW STATUS LIKE 'Rpl_semi_sync_master_no_tx';

--- a/mysql-test/suite/rpl/t/rpl_semi_sync.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync.test
@@ -238,6 +238,11 @@ COMMIT;
 
 DROP TABLE t2, t3;
 SET SESSION AUTOCOMMIT= 1;
+
+# The temporary table above will be binlogged in statement mode only, resulting
+# in different Rpl_semi_sync_master_yes_tx values in statement vs row/mixed. Reset it.
+FLUSH STATUS;
+
 --source include/sync_slave_sql_with_master.inc
 
 


### PR DESCRIPTION
Flush status after CREATE / DROP TEMPORARY TABLE so that the testcase
has the same count of Rpl_semi_sync_master_yes_tx in all three binary
log formats.

http://jenkins.percona.com/job/mysql-5.7-param/772/