### PR TITLE
Add diagnostics for bug 1677454 (Test binlog.percona_mysqlbinlog_rewr…

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -301,6 +301,10 @@ class Load_log_processor
 			    O_CREAT|O_EXCL|O_BINARY|O_WRONLY,MYF(0)))!=-1)
 	  return res;
       }
+      char errbuf[MYSYS_STRERROR_SIZE];
+      error("create_unique_file: "
+            "my_create failed on filename %s, my_errno %d (%s)",
+            filename, my_errno, my_strerror(errbuf, sizeof(errbuf), my_errno));
       return -1;
     }
 


### PR DESCRIPTION
…itedb is unstable)

In case Load_log_processor::create_unique_filename fails to create a
temp file after 1000 iterations, print the error of the last failed
create operation.

http://jenkins.percona.com/job/percona-server-5.6-param/1820/