### PR TITLE
Fix bug 1678692 (Test main.subquery_sj_none_bkaunique is unstable)

### DIFF
--- a/mysql-test/include/subquery_sj.inc
+++ b/mysql-test/include/subquery_sj.inc
@@ -4421,6 +4421,7 @@ WHERE g1 NOT IN
       AND grandparent1.col_varchar_key IS NOT NULL
     );
 
+--replace_column 9 ROWS
 eval EXPLAIN $query;
 eval $query;
 

--- a/mysql-test/r/subquery_sj_all.result
+++ b/mysql-test/r/subquery_sj_all.result
@@ -7722,11 +7722,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using index condition
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using index condition
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_all_bka.result
+++ b/mysql-test/r/subquery_sj_all_bka.result
@@ -7727,11 +7727,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using index condition; Using join buffer (Batched Key Access)
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using index condition; Using join buffer (Batched Key Access)
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_all_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_all_bka_nixbnl.result
@@ -7737,11 +7737,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using index condition; Using join buffer (Batched Key Access)
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using index condition; Using join buffer (Batched Key Access)
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_all_bkaunique.result
+++ b/mysql-test/r/subquery_sj_all_bkaunique.result
@@ -7728,11 +7728,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using index condition; Using join buffer (Batched Key Access (unique))
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using index condition; Using join buffer (Batched Key Access (unique))
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_dupsweed.result
+++ b/mysql-test/r/subquery_sj_dupsweed.result
@@ -7648,10 +7648,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_dupsweed_bka.result
+++ b/mysql-test/r/subquery_sj_dupsweed_bka.result
@@ -7649,10 +7649,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_dupsweed_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_dupsweed_bka_nixbnl.result
@@ -7659,10 +7659,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_dupsweed_bkaunique.result
+++ b/mysql-test/r/subquery_sj_dupsweed_bkaunique.result
@@ -7650,10 +7650,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_firstmatch.result
+++ b/mysql-test/r/subquery_sj_firstmatch.result
@@ -7647,10 +7647,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_firstmatch_bka.result
+++ b/mysql-test/r/subquery_sj_firstmatch_bka.result
@@ -7648,10 +7648,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_firstmatch_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_firstmatch_bka_nixbnl.result
@@ -7660,10 +7660,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_firstmatch_bkaunique.result
+++ b/mysql-test/r/subquery_sj_firstmatch_bkaunique.result
@@ -7649,10 +7649,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_loosescan.result
+++ b/mysql-test/r/subquery_sj_loosescan.result
@@ -7649,10 +7649,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_loosescan_bka.result
+++ b/mysql-test/r/subquery_sj_loosescan_bka.result
@@ -7650,10 +7650,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_loosescan_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_loosescan_bka_nixbnl.result
@@ -7660,10 +7660,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_loosescan_bkaunique.result
+++ b/mysql-test/r/subquery_sj_loosescan_bkaunique.result
@@ -7651,10 +7651,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Start temporary
-2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
-2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	1	Using where; End temporary
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Start temporary
+2	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
+2	DEPENDENT SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	test.parent1.col_varchar_nokey	ROWS	Using where; End temporary
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_mat.result
+++ b/mysql-test/r/subquery_sj_mat.result
@@ -7821,11 +7821,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using where
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using where
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_mat_bka.result
+++ b/mysql-test/r/subquery_sj_mat_bka.result
@@ -7822,11 +7822,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using where
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using where
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_mat_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_mat_bka_nixbnl.result
@@ -7810,11 +7810,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using where
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using where
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_mat_bkaunique.result
+++ b/mysql-test/r/subquery_sj_mat_bkaunique.result
@@ -7823,11 +7823,11 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	1	Using where
-3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	<subquery3>	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+2	SUBQUERY	grandparent1	ref	col_varchar_key	col_varchar_key	3	<subquery3>.p1	ROWS	Using where
+3	MATERIALIZED	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	MATERIALIZED	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_mat_nosj.result
+++ b/mysql-test/r/subquery_sj_mat_nosj.result
@@ -7607,10 +7607,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	20	Using where
-3	SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	NULL
-3	SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	ROWS	Using where
+3	SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	NULL
+3	SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_none.result
+++ b/mysql-test/r/subquery_sj_none.result
@@ -7637,10 +7637,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_none_bka.result
+++ b/mysql-test/r/subquery_sj_none_bka.result
@@ -7638,10 +7638,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_none_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_none_bka_nixbnl.result
@@ -7637,10 +7637,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN

--- a/mysql-test/r/subquery_sj_none_bkaunique.result
+++ b/mysql-test/r/subquery_sj_none_bkaunique.result
@@ -7639,10 +7639,10 @@ FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
 AND grandparent1.col_varchar_key IS NOT NULL
 );
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	2	Using where
-2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	20	Using where
-3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	1	Using index
+1	PRIMARY	t1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+2	DEPENDENT SUBQUERY	grandparent1	ALL	col_varchar_key	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent1	ALL	NULL	NULL	NULL	NULL	ROWS	Using where
+3	DEPENDENT SUBQUERY	parent2	eq_ref	PRIMARY	PRIMARY	4	test.parent1.pk	ROWS	Using index
 SELECT *
 FROM t1
 WHERE g1 NOT IN


### PR DESCRIPTION
Mask out the non-deterministic InnoDB row estimate from EXPLAIN SELECT
output.

http://jenkins.percona.com/job/percona-server-5.6-param/1825/