### PR TITLE
Fix bug 1678792 (mysql-test/include/restart_readonly_mysqld.inc waits…

### DIFF
--- a/mysql-test/include/restart_readonly_mysqld.inc
+++ b/mysql-test/include/restart_readonly_mysqld.inc
@@ -5,24 +5,9 @@
 SET GLOBAL innodb_fast_shutdown=0;
 --enable_query_log
 
-# Write file to make mysql-test-run.pl expect the "crash", but don't start
-# it until it's told to
---let $_server_id= `SELECT @@server_id`
---let $_expect_file_name= $MYSQLTEST_VARDIR/tmp/mysqld.$_server_id.expect
---exec echo "wait" > $_expect_file_name
+--let $_restart_readonly_mysqld_saved_restart_parameters= $restart_parameters
 
-# Send shutdown to the connected server and give
-# it 10 seconds to die before zapping it
-shutdown_server 10;
+--let $restart_parameters=restart: --innodb-read-only
+--source include/restart_mysqld.inc
 
-# Write file to make mysql-test-run.pl start up the server again
---exec echo "restart: --innodb-read-only " > $_expect_file_name
-
-# Turn on reconnect
---enable_reconnect
-
-# Call script that will poll the server waiting for it to be back online again
---source include/wait_until_connected_again.inc
-
-# Turn off reconnect again
---disable_reconnect
+--let $restart_parameters= $_restart_readonly_mysqld_saved_restart_parameters


### PR DESCRIPTION
… only for 10 seconds for shutdown)

Make restart_readonly_mysqld.inc use the same timeout as the rest of
MTR include files by making it use restart_mysqld.inc.

http://jenkins.percona.com/job/percona-server-5.6-param/1827/