### PR TITLE
Add diagnostics for bug 1673800 (Test main.type_temporal_fractional i…

### DIFF
--- a/mysql-test/include/assert.inc
+++ b/mysql-test/include/assert.inc
@@ -9,6 +9,7 @@
 # --let $assert_text= Relay_Log_Pos must be between min_pos and max_pos
 # --let $assert_cond= [SHOW SLAVE STATUS, Relay_Log_Pos, 1] >= $min_pos AND <1> <= $max_pos
 # [--let $rpl_debug= 1]
+# [--let $assert_debug= SHOW SLAVE STATUS]
 # --source include/assert.inc
 #
 # Parameters:

--- a/mysql-test/r/type_temporal_fractional.result
+++ b/mysql-test/r/type_temporal_fractional.result
@@ -15907,10 +15907,7 @@ col_time_2_not_null time(2) NOT NULL,
 KEY col_timestamp_6_key (col_timestamp_6_key))
 ENGINE=MEMORY DEFAULT CHARSET=latin1;
 INSERT INTO t1 VALUES (current_timestamp(5),current_timestamp(6),current_time(6));
-SELECT col_datetime_5 AS c1 FROM t1
-WHERE col_time_2_not_null = GREATEST(CURRENT_DATE(),col_timestamp_6_key)
-ORDER BY 1;
-c1
+include/assert.inc [No rows should be returned]
 DROP TABLE t1;
 SET @@time_zone='+00:00';
 CREATE TABLE t1 (col_datetime_4_not_null DATETIME(4) NOT NULL);

--- a/mysql-test/t/type_temporal_fractional.test
+++ b/mysql-test/t/type_temporal_fractional.test
@@ -6538,9 +6538,12 @@ CREATE TABLE t1 (
   KEY col_timestamp_6_key (col_timestamp_6_key))
   ENGINE=MEMORY DEFAULT CHARSET=latin1;
 INSERT INTO t1 VALUES (current_timestamp(5),current_timestamp(6),current_time(6));
-SELECT col_datetime_5 AS c1 FROM t1
+let $assert_cond= COUNT(col_datetime_5) = 0 FROM t1
 WHERE col_time_2_not_null = GREATEST(CURRENT_DATE(),col_timestamp_6_key)
 ORDER BY 1;
+let $assert_text= No rows should be returned;
+let $assert_debug= SELECT * FROM t1;
+--source include/assert.inc
 DROP TABLE t1;
 
 #


### PR DESCRIPTION
…s unstable)

A possible way for the test to fail is for CURRENT_TIMESTAMP() to
happen to have four trailing zeros during execution, and then
comparing equal to an inserted TIME(2) value. To confirm, replace the
unstable query with an assert, which has a debug statement in case of
failure to dump the table.

http://jenkins.percona.com/job/percona-server-5.6-param/1830/