### PR TITLE
Add diagnostics for bug 1673800 (Test main.type_temporal_fractional i…

### DIFF
--- a/mysql-test/include/assert.inc
+++ b/mysql-test/include/assert.inc
@@ -11,6 +11,7 @@
 # [--let $extra_debug_info= some text]
 # [--let $extra_debug_eval= expression parsable by include/eval.inc]
 # [--let $rpl_debug= 1]
+# [--let $assert_debug= SHOW SLAVE STATUS]
 # --source include/assert.inc
 #
 # Parameters:

--- a/mysql-test/r/type_temporal_fractional.result
+++ b/mysql-test/r/type_temporal_fractional.result
@@ -16001,10 +16001,7 @@ col_time_2_not_null time(2) NOT NULL,
 KEY col_timestamp_6_key (col_timestamp_6_key))
 ENGINE=MEMORY DEFAULT CHARSET=latin1;
 INSERT INTO t1 VALUES (current_timestamp(5),current_timestamp(6),current_time(6));
-SELECT col_datetime_5 AS c1 FROM t1
-WHERE col_time_2_not_null = GREATEST(CURRENT_DATE(),col_timestamp_6_key)
-ORDER BY 1;
-c1
+include/assert.inc [No rows should be returned]
 DROP TABLE t1;
 SET @@time_zone='+00:00';
 CREATE TABLE t1 (col_datetime_4_not_null DATETIME(4) NOT NULL);

--- a/mysql-test/t/type_temporal_fractional.test
+++ b/mysql-test/t/type_temporal_fractional.test
@@ -6555,9 +6555,12 @@ CREATE TABLE t1 (
   KEY col_timestamp_6_key (col_timestamp_6_key))
   ENGINE=MEMORY DEFAULT CHARSET=latin1;
 INSERT INTO t1 VALUES (current_timestamp(5),current_timestamp(6),current_time(6));
-SELECT col_datetime_5 AS c1 FROM t1
+let $assert_cond= COUNT(col_datetime_5) = 0 FROM t1
 WHERE col_time_2_not_null = GREATEST(CURRENT_DATE(),col_timestamp_6_key)
 ORDER BY 1;
+let $assert_text= No rows should be returned;
+let $assert_debug= SELECT * FROM t1;
+--source include/assert.inc
 DROP TABLE t1;
 
 #


### PR DESCRIPTION
…s unstable)

A possible way for the test to fail is for CURRENT_TIMESTAMP() to
happen to have four trailing zeros during execution, and then
comparing equal to an inserted TIME(2) value. To confirm, replace the
unstable query with an assert, which has a debug statement in case of
failure to dump the table.

(cherry picked from commit 7828ab7d6c7d75a36c435fd4f51b5811c60cd48a)

http://jenkins.percona.com/job/mysql-5.7-param/778/