### PR TITLE
Fix bug 1672389 (Make MTR dump server's error log in case warnings fo…

### DIFF
--- a/mysql-test/lib/mtr_report.pm
+++ b/mysql-test/lib/mtr_report.pm
@@ -164,6 +164,7 @@ sub mtr_report_test ($) {
       mtr_report("[ $retry$fail ]  Found warnings/errors in server log file!");
       mtr_report("        Test ended at $timest");
       mtr_report($warnings);
+      mtr_report("\n$tinfo->{'comment'}");
       return;
     }
     my $timeout= $tinfo->{'timeout'};


### PR DESCRIPTION
…und)

In case the testcase fails its warning check, include the "comment" in
the output too, which in turn includes servers' error logs.

(cherry picked from commit bcb50d0586f433a4d54b7c2dbe9e66b711365a12)
(cherry picked from commit f02e5bd6328612047cbf6f91b55c3d19cd8f4358)

http://jenkins.percona.com/job/mysql-5.7-param/782/