### PR TITLE
Attempt to fix bug 1671473 (Test perfschema.selects is unstable)

### DIFF
--- a/mysql-test/suite/perfschema/r/selects.result
+++ b/mysql-test/suite/perfschema/r/selects.result
@@ -1,6 +1,7 @@
 UPDATE performance_schema.setup_instruments SET enabled = 'YES', timed = 'YES';
 UPDATE performance_schema.setup_instruments SET enabled = 'NO', timed = 'NO'
   where NAME='wait/io/table/sql/handler';
+TRUNCATE TABLE performance_schema.events_waits_history_long;
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (id INT PRIMARY KEY, b CHAR(100) DEFAULT 'initial value')
 ENGINE=MyISAM;

--- a/mysql-test/suite/perfschema/t/selects.test
+++ b/mysql-test/suite/perfschema/t/selects.test
@@ -15,6 +15,8 @@ UPDATE performance_schema.setup_instruments SET enabled = 'YES', timed = 'YES';
 UPDATE performance_schema.setup_instruments SET enabled = 'NO', timed = 'NO'
   where NAME='wait/io/table/sql/handler';
 
+TRUNCATE TABLE performance_schema.events_waits_history_long;
+
 --disable_warnings
 DROP TABLE IF EXISTS t1;
 --enable_warnings


### PR DESCRIPTION
performance_schem.evetns_waits_history_long table may have arbitrary
contents at the start of the test, depending on the previous
testcases, but this one expects some queries to return deterministic
results. TRUNCATE the table at the start.

http://jenkins.percona.com/job/percona-server-5.6-param/1838/