### PR TITLE
Fix lp:1669928 (Write/fsync amplification w/ duplicate GTIDs)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_bug85141.result
+++ b/mysql-test/suite/rpl/r/rpl_bug85141.result
@@ -1,0 +1,81 @@
+#
+# Setting up MSR server topology
+#
+# server_1(A) -------------- server_3(C)
+#            \              /
+#             - server_2(B)-
+#
+include/rpl_init.inc [topology=1->2,2->3,1->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+#
+# Step 1: stopping slave on server_2(B)
+#
+[connection server_2]
+include/stop_slave.inc
+#
+# Step 2: setting up profiling for 'slave_relay_log_info' on server_3(C)
+#
+[connection server_3]
+INSERT INTO performance_schema.setup_objects VALUES ('TABLE', 'mysql', 'slave_relay_log_info', 'YES', 'YES');
+INSERT INTO performance_schema.setup_objects VALUES ('TABLE', 'mysql', 'slave_master_info', 'YES', 'YES');
+include/stop_slave.inc
+include/start_slave.inc
+#
+# Step 3: creating a table and inserting a few records on server_1(A)
+#
+[connection server_1]
+CREATE TABLE t1 (f1 INT) ENGINE = InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+START TRANSACTION;
+INSERT INTO t1 VALUES (1), (2), (3);
+INSERT INTO t1 VALUES (1), (2), (3);
+COMMIT;
+INSERT INTO t1 VALUES (1), (2), (3);
+INSERT INTO t1 VALUES (1), (2), (3);
+INSERT INTO t1 VALUES (1), (2), (3);
+#
+# Step 4: syncing server_3(C) with server_1(A) and capturing initial value of IO waits
+#
+include/sync_slave_sql_with_master.inc
+# t1 records on server_3(C) after syncing with server_1(A) must match
+include/rpl_diff.inc
+#
+# Step 5: starting slave on server_2(B) and syncing server_2(B) with server_1(A)
+#
+[connection server_2]
+include/start_slave.inc
+[connection server_1]
+include/sync_slave_sql_with_master.inc
+# t1 records on server_2(B) after syncing with server_1(A) must match
+include/rpl_diff.inc
+#
+# Step 6: syncing server_3(C) with server_2(B)
+#
+include/sync_slave_sql_with_master.inc
+# t1 records on server_3(C) after syncing with server_2(B) must match
+include/rpl_diff.inc
+include/assert.inc [number of IO waits for "slave_relay_log_info" must not change]
+include/assert.inc [number of IO waits for "slave_master_info" must not change]
+#
+# Cleaning up and final syncing
+#
+[connection server_1]
+DROP TABLE t1;
+include/sync_slave_sql_with_master.inc
+include/sync_slave_sql_with_master.inc
+[connection server_2]
+include/sync_slave_sql_with_master.inc
+DELETE FROM performance_schema.setup_objects WHERE object_type = 'TABLE' AND object_schema = 'mysql' AND object_name = 'slave_relay_log_info';
+DELETE FROM performance_schema.setup_objects WHERE object_type = 'TABLE' AND object_schema = 'mysql' AND object_name = 'slave_master_info';
+include/rpl_end.inc
+RESET SLAVE ALL FOR CHANNEL  'channel_1';
+RESET SLAVE ALL FOR CHANNEL  'channel_2';
+RESET SLAVE ALL FOR CHANNEL  'channel_1';

--- a/mysql-test/suite/rpl/t/rpl_bug85141.cnf
+++ b/mysql-test/suite/rpl/t/rpl_bug85141.cnf
@@ -1,0 +1,24 @@
+!include ../my.cnf
+
+[mysqld.1]
+log-slave-updates
+gtid-mode=ON
+enforce-gtid-consistency
+
+[mysqld.2]
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+log-slave-updates
+gtid-mode=ON
+enforce-gtid-consistency
+
+[mysqld.3]
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+log-slave-updates
+gtid-mode=ON
+enforce-gtid-consistency
+
+[ENV]
+SERVER_MYPORT_3=        @mysqld.3.port
+SERVER_MYSOCK_3=        @mysqld.3.socket

--- a/mysql-test/suite/rpl/t/rpl_bug85141.test
+++ b/mysql-test/suite/rpl/t/rpl_bug85141.test
@@ -1,0 +1,128 @@
+#
+# Bug #85141 "Write/fsync amplification w/ duplicate GTIDs"
+#
+
+--source include/not_group_replication_plugin.inc
+--source include/have_innodb.inc
+--source include/have_gtid.inc
+--source include/have_perfschema.inc
+
+--echo #
+--echo # Setting up MSR server topology
+--echo #
+--echo # server_1(A) -------------- server_3(C)
+--echo #            \              /
+--echo #             - server_2(B)-
+--echo #
+--let $rpl_multi_source = 1
+--let $rpl_topology = 1->2,2->3,1->3
+--source include/rpl_init.inc
+
+--echo #
+--echo # Step 1: stopping slave on server_2(B)
+--echo #
+--let $rpl_connection_name = server_2
+--source include/rpl_connection.inc
+--source include/stop_slave.inc
+
+--echo #
+--echo # Step 2: setting up profiling for 'slave_relay_log_info' on server_3(C)
+--echo #
+--let $rpl_connection_name = server_3
+--source include/rpl_connection.inc
+INSERT INTO performance_schema.setup_objects VALUES ('TABLE', 'mysql', 'slave_relay_log_info', 'YES', 'YES');
+INSERT INTO performance_schema.setup_objects VALUES ('TABLE', 'mysql', 'slave_master_info', 'YES', 'YES');
+--source include/stop_slave.inc
+--source include/start_slave.inc
+
+--echo #
+--echo # Step 3: creating a table and inserting a few records on server_1(A)
+--echo #
+--let $rpl_connection_name = server_1
+--source include/rpl_connection.inc
+CREATE TABLE t1 (f1 INT) ENGINE = InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3);
+START TRANSACTION;
+INSERT INTO t1 VALUES (1), (2), (3);
+INSERT INTO t1 VALUES (1), (2), (3);
+COMMIT;
+INSERT INTO t1 VALUES (1), (2), (3);
+INSERT INTO t1 VALUES (1), (2), (3);
+INSERT INTO t1 VALUES (1), (2), (3);
+
+--echo #
+--echo # Step 4: syncing server_3(C) with server_1(A) and capturing initial value of IO waits
+--echo #
+--let $rpl_channel_name = channel_1
+--let $sync_slave_connection = server_3
+--source include/sync_slave_sql_with_master.inc
+--echo # t1 records on server_3(C) after syncing with server_1(A) must match
+--let $rpl_diff_statement = SELECT * FROM t1 ORDER BY f1
+--let $rpl_diff_servers = 3,1
+--let $rpl_skip_sync = 1
+--source include/rpl_diff.inc
+
+--let $initial_slave_relay_log_info_waits = `SELECT count_star FROM performance_schema.table_io_waits_summary_by_table WHERE object_schema = 'mysql' AND object_name = 'slave_relay_log_info'`
+--let $initial_slave_master_info = `SELECT count_star FROM performance_schema.table_io_waits_summary_by_table WHERE object_schema = 'mysql' AND object_name = 'slave_master_info'`
+
+--echo #
+--echo # Step 5: starting slave on server_2(B) and syncing server_2(B) with server_1(A)
+--echo #
+--let $rpl_connection_name = server_2
+--source include/rpl_connection.inc
+--source include/start_slave.inc
+--let $rpl_connection_name = server_1
+--source include/rpl_connection.inc
+--let $rpl_channel_name = channel_1
+--let $sync_slave_connection = server_2
+--source include/sync_slave_sql_with_master.inc
+--echo # t1 records on server_2(B) after syncing with server_1(A) must match
+--let $rpl_diff_statement = SELECT * FROM t1 ORDER BY f1
+--let $rpl_diff_servers = 2,1
+--let $rpl_skip_sync = 1
+--source include/rpl_diff.inc
+
+--echo #
+--echo # Step 6: syncing server_3(C) with server_2(B)
+--echo #
+--let $rpl_channel_name = channel_2
+--let $sync_slave_connection = server_3
+--source include/sync_slave_sql_with_master.inc
+--echo # t1 records on server_3(C) after syncing with server_2(B) must match
+--let $rpl_diff_statement = SELECT * FROM t1 ORDER BY f1
+--let $rpl_diff_servers = 3,2,1
+--let $rpl_skip_sync = 1
+--source include/rpl_diff.inc
+--let $assert_text = number of IO waits for "slave_relay_log_info" must not change
+--let $assert_cond = count_star = $initial_slave_relay_log_info_waits FROM performance_schema.table_io_waits_summary_by_table WHERE object_schema = "mysql" AND object_name = "slave_relay_log_info"
+--source include/assert.inc
+--let $assert_text = number of IO waits for "slave_master_info" must not change
+--let $assert_cond = count_star = $initial_slave_master_info FROM performance_schema.table_io_waits_summary_by_table WHERE object_schema = "mysql" AND object_name = "slave_master_info"
+--source include/assert.inc
+
+--echo #
+--echo # Cleaning up and final syncing
+--echo #
+--let $rpl_connection_name = server_1
+--source include/rpl_connection.inc
+DROP TABLE t1;
+
+--let $rpl_channel_name = channel_1
+--let $sync_slave_connection = server_2
+--source include/sync_slave_sql_with_master.inc
+
+--let $rpl_channel_name = channel_2
+--let $sync_slave_connection = server_3
+--source include/sync_slave_sql_with_master.inc
+
+--let $rpl_connection_name = server_2
+--source include/rpl_connection.inc
+--let $rpl_channel_name = channel_1
+--let $sync_slave_connection = server_3
+--source include/sync_slave_sql_with_master.inc
+
+DELETE FROM performance_schema.setup_objects WHERE object_type = 'TABLE' AND object_schema = 'mysql' AND object_name = 'slave_relay_log_info';
+DELETE FROM performance_schema.setup_objects WHERE object_type = 'TABLE' AND object_schema = 'mysql' AND object_name = 'slave_master_info';
+
+--let $rpl_skip_sync = 1
+--source include/rpl_end.inc

--- a/sql/rpl_gtid.h
+++ b/sql/rpl_gtid.h
@@ -3656,6 +3656,17 @@ int gtid_acquire_ownership_multiple(THD *thd);
 #endif
 
 /**
+  Check if current transaction should be skipped, that is, if GTID_NEXT
+  was already logged.
+
+  @param  thd    The calling thread.
+
+  @retval true   Transaction was already logged.
+  @retval false  Transaction must be executed.
+*/
+bool is_already_logged_transaction(const THD *thd);
+
+/**
   Return sidno for a given sid, see Sid_map::add_sid() for details.
 */
 rpl_sidno get_sidno_from_global_sid_map(rpl_sid sid);

--- a/sql/rpl_gtid_execution.cc
+++ b/sql/rpl_gtid_execution.cc
@@ -309,7 +309,7 @@ int gtid_acquire_ownership_multiple(THD *thd)
   @retval true   Transaction was already logged.
   @retval false  Transaction must be executed.
 */
-static inline bool is_already_logged_transaction(const THD *thd)
+bool is_already_logged_transaction(const THD *thd)
 {
   DBUG_ENTER("is_already_logged_transaction");
 


### PR DESCRIPTION
In some multi-source replications setups
'Xid_apply_log_event::do_apply_event()' method used to always update relay
log position regardless of whether the transaction being commited has already
been executed or not. In case of 'relay-log-info-repository=TABLE' this could
have had additional performance impact as updating 'slave_relay_log_info'
requires extra fsyncs. Moreover, depending on the number of channels receiving
duplicate (already executed) transactions, the situation could have become
proportionally worse.

Fixed by checking if the 'GTID_NEXT' was already logged and if so, omiting
relay log position update.

Added 'rpl.rpl_bug85141' MTR test case.