### PR TITLE
ps-5.7-MYR-82 : 5.7 mtr -  rocksdb.type_bit fails

### DIFF
--- a/mysql-test/suite/rocksdb/r/type_bit.result
+++ b/mysql-test/suite/rocksdb/r/type_bit.result
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 (
 a BIT ,
 b BIT(20) ,
@@ -10,16 +9,17 @@ SHOW COLUMNS IN t1;
 Field	Type	Null	Key	Default	Extra
 a	bit(1)	YES		NULL	
 b	bit(20)	YES		NULL	
-c	bit(64)	NO	PRI	b'0'	
+c	bit(64)	NO	PRI	NULL	
 d	bit(1)	YES		NULL	
 ALTER TABLE t1 DROP COLUMN d;
 ALTER TABLE t1 ADD COLUMN d BIT(0) ;
+ERROR HY000: Invalid size for column 'd'.
 SHOW COLUMNS IN t1;
 Field	Type	Null	Key	Default	Extra
 a	bit(1)	YES		NULL	
 b	bit(20)	YES		NULL	
-c	bit(64)	NO	PRI	b'0'	
-d	bit(1)	YES		NULL	
+c	bit(64)	NO	PRI	NULL	
+ALTER TABLE t1 ADD COLUMN d BIT(1) ;
 INSERT INTO t1 (a,b,c,d) VALUES (0,POW(2,20)-1,b'1111111111111111111111111111111111111111111111111111111111111111',1);
 SELECT BIN(a), HEX(b), c+0 FROM t1 WHERE d>0;
 BIN(a)	HEX(b)	c+0

--- a/mysql-test/suite/rocksdb/t/type_bit.inc
+++ b/mysql-test/suite/rocksdb/t/type_bit.inc
@@ -2,10 +2,6 @@
 # BIT column type
 #
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
-
 # Valid values
 
 eval CREATE TABLE t1 (
@@ -19,8 +15,10 @@ eval CREATE TABLE t1 (
 SHOW COLUMNS IN t1;
 
 ALTER TABLE t1 DROP COLUMN d;
+--error ER_INVALID_FIELD_SIZE
 eval ALTER TABLE t1 ADD COLUMN d BIT(0) $extra_col_opts;
 SHOW COLUMNS IN t1;
+eval ALTER TABLE t1 ADD COLUMN d BIT(1) $extra_col_opts;
 
 INSERT INTO t1 (a,b,c,d) VALUES (0,POW(2,20)-1,b'1111111111111111111111111111111111111111111111111111111111111111',1);
 SELECT BIN(a), HEX(b), c+0 FROM t1 WHERE d>0;
@@ -49,5 +47,3 @@ DROP TABLE t1;
 
 --error ER_TOO_BIG_DISPLAYWIDTH
 eval CREATE TABLE t1 (pk INT PRIMARY KEY, a BIT(65) $extra_col_opts) ENGINE=rocksdb;
-
-

--- a/mysql-test/suite/rocksdb/t/type_bit.test
+++ b/mysql-test/suite/rocksdb/t/type_bit.test
@@ -1,4 +1,4 @@
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 
 #
 # BIT column type


### PR DESCRIPTION
- Fixed up include to expect new 5.7 error and allow test to continue as
  originally designed. Re-recorded.
- Some currently disabled tests will also need re-recording when re-enabled.
  These are rocksdb.col_opt_null and rocksdb.col_opt_not_null which are disabled
  due to gap lock error detection (MYR-15).