### PR TITLE
MYR-78: rocksdb.information_schema fails

### DIFF
--- a/mysql-test/suite/rocksdb/r/information_schema.result
+++ b/mysql-test/suite/rocksdb/r/information_schema.result
@@ -1,6 +1,13 @@
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
-DROP TABLE IF EXISTS t3;
+select * from INFORMATION_SCHEMA.ROCKSDB_GLOBAL_INFO;
+TYPE	NAME	VALUE
+CF_FLAGS	0	default [0]
+CF_FLAGS	1	__system__ [0]
+select count(*) from INFORMATION_SCHEMA.ROCKSDB_GLOBAL_INFO;
+count(*)
+2
+select VALUE into @keysIn from INFORMATION_SCHEMA.ROCKSDB_COMPACTION_STATS where CF_NAME = 'default' and LEVEL = 'Sum' and TYPE = 'KeyIn';
+CREATE TABLE t1 (i1 INT, i2 INT, PRIMARY KEY (i1)) ENGINE = ROCKSDB;
+INSERT INTO t1 VALUES (1, 1), (2, 2), (3, 3);
 select * from INFORMATION_SCHEMA.ROCKSDB_GLOBAL_INFO;
 TYPE	NAME	VALUE
 MAX_INDEX_ID	MAX_INDEX_ID	max_index_id
@@ -9,20 +16,6 @@ CF_FLAGS	1	__system__ [0]
 select count(*) from INFORMATION_SCHEMA.ROCKSDB_GLOBAL_INFO;
 count(*)
 3
-select VALUE into @keysIn from INFORMATION_SCHEMA.ROCKSDB_COMPACTION_STATS where CF_NAME = 'default' and LEVEL = 'Sum' and TYPE = 'KeyIn';
-CREATE TABLE t1 (i1 INT, i2 INT, PRIMARY KEY (i1)) ENGINE = ROCKSDB;
-INSERT INTO t1 VALUES (1, 1), (2, 2), (3, 3);
-select * from INFORMATION_SCHEMA.ROCKSDB_GLOBAL_INFO;
-TYPE	NAME	VALUE
-BINLOG	FILE	master-bin.000001
-BINLOG	POS	1066
-BINLOG	GTID	uuid:5
-MAX_INDEX_ID	MAX_INDEX_ID	max_index_id
-CF_FLAGS	0	default [0]
-CF_FLAGS	1	__system__ [0]
-select count(*) from INFORMATION_SCHEMA.ROCKSDB_GLOBAL_INFO;
-count(*)
-6
 set global rocksdb_force_flush_memtable_now = true;
 set global rocksdb_compact_cf='default';
 select case when VALUE-@keysIn >= 3 then 'true' else 'false' end from INFORMATION_SCHEMA.ROCKSDB_COMPACTION_STATS where CF_NAME = 'default' and LEVEL = 'Sum' and TYPE = 'KeyIn';
@@ -69,7 +62,7 @@ SHOW GLOBAL VARIABLES LIKE 'ROCKSDB_PAUSE_BACKGROUND_WORK';
 Variable_name	Value
 rocksdb_pause_background_work	ON
 DROP TABLE t3;
-cf_id:0,index_id:268
+cf_id:0,index_id:264
 SET GLOBAL ROCKSDB_PAUSE_BACKGROUND_WORK=0;
 SHOW GLOBAL VARIABLES LIKE 'ROCKSDB_PAUSE_BACKGROUND_WORK';
 Variable_name	Value

--- a/mysql-test/suite/rocksdb/t/information_schema-master.opt
+++ b/mysql-test/suite/rocksdb/t/information_schema-master.opt
@@ -1,1 +1,1 @@
---force-restart --binlog_format=row --gtid_mode=ON --enforce_gtid_consistency --log_slave_updates
+--force-restart

--- a/mysql-test/suite/rocksdb/t/information_schema.test
+++ b/mysql-test/suite/rocksdb/t/information_schema.test
@@ -1,11 +1,4 @@
---source include/have_rocksdb_as_default.inc
---source include/have_log_bin.inc
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
-DROP TABLE IF EXISTS t2;
-DROP TABLE IF EXISTS t3;
---enable_warnings
+--source include/have_rocksdb.inc
 
 --let $max_index_id = query_get_value(SELECT * from INFORMATION_SCHEMA.ROCKSDB_GLOBAL_INFO where type = 'MAX_INDEX_ID', VALUE, 1)
 --replace_result $max_index_id max_index_id

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3308,6 +3308,17 @@ static int rocksdb_init_func(void *const p) {
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
+  for (const auto &cf_handle : cf_manager.get_all_cf()) {
+    uint flags;
+    if (!dict_manager.get_cf_flags(cf_handle->GetID(), &flags)) {
+      const std::unique_ptr<rocksdb::WriteBatch> wb = dict_manager.begin();
+      rocksdb::WriteBatch *const batch = wb.get();
+      dict_manager.add_cf_flags(batch, cf_handle->GetID(), 0);
+      dict_manager.commit(batch);
+    }
+  }
+
+
   Rdb_sst_info::init(rdb);
 
   /*

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -208,6 +208,7 @@ Rdb_cf_manager::get_all_cf(void) const {
 
   mysql_mutex_lock(&m_mutex);
   for (auto it : m_cf_id_map) {
+    DBUG_ASSERT(it.second != nullptr);
     list.push_back(it.second);
   }
   mysql_mutex_unlock(&m_mutex);

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3331,17 +3331,35 @@ int Rdb_ddl_manager::scan_for_tables(Rdb_tables_scanner *const tables_scanner) {
 
 bool Rdb_dict_manager::init(rocksdb::DB *const rdb_dict,
                             Rdb_cf_manager *const cf_manager) {
+  DBUG_ASSERT(rdb_dict != nullptr);
+  DBUG_ASSERT(cf_manager != nullptr);
+
   mysql_mutex_init(0, &m_mutex, MY_MUTEX_INIT_FAST);
+
   m_db = rdb_dict;
   bool is_automatic;
+
   m_system_cfh = cf_manager->get_or_create_cf(m_db, DEFAULT_SYSTEM_CF_NAME, "",
                                               nullptr, &is_automatic);
+
   rdb_netbuf_store_index(m_key_buf_max_index_id, Rdb_key_def::MAX_INDEX_ID);
+
   m_key_slice_max_index_id =
       rocksdb::Slice(reinterpret_cast<char *>(m_key_buf_max_index_id),
                      Rdb_key_def::INDEX_NUMBER_SIZE);
+
   resume_drop_indexes();
   rollback_ongoing_index_creation();
+
+  // If system CF was created then we need to set its flags as well to make
+  // sure that CF is properly initialized.
+  if (m_system_cfh != nullptr) {
+    const std::unique_ptr<rocksdb::WriteBatch> wb = begin();
+    rocksdb::WriteBatch *const batch = wb.get();
+
+    add_cf_flags(batch, m_system_cfh->GetID(), 0);
+    commit(batch);
+  }
 
   return (m_system_cfh == nullptr);
 }
@@ -3437,6 +3455,8 @@ void Rdb_dict_manager::add_or_update_index_cf_mapping(
 void Rdb_dict_manager::add_cf_flags(rocksdb::WriteBatch *const batch,
                                     const uint32_t &cf_id,
                                     const uint32_t &cf_flags) const {
+  DBUG_ASSERT(batch != nullptr);
+
   uchar key_buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2] = {0};
   uchar value_buf[Rdb_key_def::VERSION_SIZE + Rdb_key_def::INDEX_NUMBER_SIZE] =
       {0};
@@ -3519,22 +3539,31 @@ bool Rdb_dict_manager::get_index_info(const GL_INDEX_ID &gl_index_id,
 
 bool Rdb_dict_manager::get_cf_flags(const uint32_t &cf_id,
                                     uint32_t *const cf_flags) const {
+  DBUG_ASSERT(cf_flags != nullptr);
+
   bool found = false;
   std::string value;
   uchar key_buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2] = {0};
+
   rdb_netbuf_store_uint32(key_buf, Rdb_key_def::CF_DEFINITION);
   rdb_netbuf_store_uint32(key_buf + Rdb_key_def::INDEX_NUMBER_SIZE, cf_id);
-  const rocksdb::Slice key = rocksdb::Slice((char *)key_buf, sizeof(key_buf));
 
+  const rocksdb::Slice key =
+      rocksdb::Slice(reinterpret_cast<char *>(key_buf), sizeof(key_buf));
   const rocksdb::Status status = get_value(key, &value);
+
   if (status.ok()) {
     const uchar *val = (const uchar *)value.c_str();
-    uint16_t version = rdb_netbuf_to_uint16(val);
+    DBUG_ASSERT(val);
+
+    const uint16_t version = rdb_netbuf_to_uint16(val);
+
     if (version == Rdb_key_def::CF_DEFINITION_VERSION) {
       *cf_flags = rdb_netbuf_to_uint32(val + Rdb_key_def::VERSION_SIZE);
       found = true;
     }
   }
+
   return found;
 }
 

--- a/storage/rocksdb/rdb_i_s.cc
+++ b/storage/rocksdb/rdb_i_s.cc
@@ -759,17 +759,31 @@ static int rdb_i_s_global_info_fill_table(my_core::THD *const thd,
   char cf_id_buf[INT_BUF_LEN] = {0};
   char cf_value_buf[FN_REFLEN + 1] = {0};
   const Rdb_cf_manager &cf_manager = rdb_get_cf_manager();
+
   for (const auto &cf_handle : cf_manager.get_all_cf()) {
+    DBUG_ASSERT(cf_handle != nullptr);
+
     uint flags;
-    dict_manager->get_cf_flags(cf_handle->GetID(), &flags);
+
+    if (!dict_manager->get_cf_flags(cf_handle->GetID(), &flags)) {
+      // NO_LINT_DEBUG
+      sql_print_error("RocksDB: Failed to get column family flags "
+                      "from CF with id = %u. MyRocks data dictionary may "
+                      "be corrupted.",
+                      cf_handle->GetID());
+      abort_with_stack_traces();
+    }
+
     snprintf(cf_id_buf, INT_BUF_LEN, "%u", cf_handle->GetID());
     snprintf(cf_value_buf, FN_REFLEN, "%s [%u]", cf_handle->GetName().c_str(),
              flags);
+
     ret |= rdb_global_info_fill_row(thd, tables, "CF_FLAGS", cf_id_buf,
                                     cf_value_buf);
 
-    if (ret)
+    if (ret) {
       break;
+    }
   }
 
   /* DDL_DROP_INDEX_ONGOING */


### PR DESCRIPTION
Fixed upstream issue #589 and re-recorded test case.

Differences with upstream are:

- we don't create rocksdb tables during bootstrap
- we don't provide binlog info via ROCKSDB_GLOBAL_INFO