### PR TITLE
Bug#21616632 RPL.RPL_BUG33931 HAS OCCASIONAL FAILURES ON PB2

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_bug33931.result
+++ b/mysql-test/suite/rpl/r/rpl_bug33931.result
@@ -8,6 +8,7 @@ SET GLOBAL debug="d,simulate_io_slave_error_on_init,simulate_sql_slave_error_on_
 start slave;
 include/wait_for_slave_sql_error.inc [errno=1593]
 Last_SQL_Error = 'Failed during slave thread initialization'
+include/wait_for_slave_io_to_stop.inc
 SET GLOBAL debug="";
 RESET SLAVE;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_bug33931.test
+++ b/mysql-test/suite/rpl/t/rpl_bug33931.test
@@ -36,6 +36,7 @@ start slave;
 --let $show_slave_sql_error= 1
 --source include/wait_for_slave_sql_error.inc
 
+--source include/wait_for_slave_io_to_stop.inc
 #
 # Cleanup
 #


### PR DESCRIPTION
Problem and Analysis:

The test case is failing because it forces the two replication threads to
error out once asked to start, but it is only waiting for the SQL thread to
stop reporting the error before trying to apply an "RESET SLAVE" statement.

When a not so fast server didn't stopped the I/O thread before the
"RESET SLAVE" statement be applied, the test case fails as reported.

Fix:

In order to fix the issue, the test case must also wait for the I/O thread to
be stopped before trying to reset the slave.

(cherry picked from commit 581c5a76baed872e1a139aa101847b2d7c407d4f)

http://jenkins.percona.com/job/percona-server-5.5-param/1540/