### PR TITLE
Fix bug 1651656 (Server crash if a changed page bitmap error occurs c…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS t1;
+call mtr.add_suppression("simulating bitmap write error in log_online_write_bitmap_page");
 call mtr.add_suppression("InnoDB: Error: log tracking bitmap write failed, stopping log tracking thread!");
 1st restart
 RESET CHANGED_PAGE_BITMAPS;
@@ -44,6 +45,7 @@ SET DEBUG_SYNC="RESET";
 DROP TABLE t2;
 RESET CHANGED_PAGE_BITMAPS;
 4th restart
+5th restart
 SET DEBUG_SYNC="i_s_innodb_changed_pages_range_ready SIGNAL ready WAIT_FOR finish";
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
 SET DEBUG_SYNC="now WAIT_FOR ready";
@@ -58,3 +60,23 @@ SET @@GLOBAL.innodb_track_changed_pages=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 SET DEBUG_SYNC="now SIGNAL finish";
 DROP TABLE t1, t2;
+RESET CHANGED_PAGE_BITMAPS;
+6th restart
+#
+# Bug 1651656: Server crash if a changed page bitmap error occurs concurrently with
+# executing FLUSH CHANGED_PAGE_BITMAPS
+#
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+7th restart
+# connection con2
+SET DEBUG_SYNC="log_online_follow_redo_log SIGNAL flush_ready WAIT_FOR finish_flush";
+FLUSH CHANGED_PAGE_BITMAPS;
+# connection default
+SET DEBUG_SYNC="now WAIT_FOR flush_ready";
+INSERT INTO t1 VALUES (1);
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+SET DEBUG_SYNC="now SIGNAL finish_flush";
+# connection con2
+8th restart
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -11,6 +11,7 @@ DROP TABLE IF EXISTS t1;
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 
+call mtr.add_suppression("simulating bitmap write error in log_online_write_bitmap_page");
 call mtr.add_suppression("InnoDB: Error: log tracking bitmap write failed, stopping log tracking thread!");
 
 --echo 1st restart
@@ -131,17 +132,19 @@ RESET CHANGED_PAGE_BITMAPS;
 
 --source include/wait_until_count_sessions.inc
 
+--echo 4th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
 #
 # Test for bug 1193332 ([Warning] InnoDB: changed page bitmap file
 # './ib_modified_log_11_951286349.xdb' does not contain a complete run at the end.)
 #
 
 # Setup an error on the 2nd bitmap page write, so that bitmap contains an incomplete run
---echo 4th restart
+--echo 5th restart
 --let $restart_parameters= restart:-#d,bitmap_page_2_write_error
 --source include/restart_mysqld.inc
-
---source include/count_sessions.inc
 
 --connect(con2,localhost,root,,)
 
@@ -180,4 +183,49 @@ reap;
 
 DROP TABLE t1, t2;
 
---source include/wait_until_count_sessions.inc
+RESET CHANGED_PAGE_BITMAPS;
+
+--echo 6th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--echo #
+--echo # Bug 1651656: Server crash if a changed page bitmap error occurs concurrently with
+--echo # executing FLUSH CHANGED_PAGE_BITMAPS
+--echo #
+
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
+
+--echo 7th restart
+--let $restart_parameters= restart:-#d,bitmap_page_write_error
+--source include/restart_mysqld.inc
+
+--connect(con2,localhost,root,,)
+--echo # connection con2
+
+SET DEBUG_SYNC="log_online_follow_redo_log SIGNAL flush_ready WAIT_FOR finish_flush";
+send FLUSH CHANGED_PAGE_BITMAPS;
+
+--connection default
+--echo # connection default
+SET DEBUG_SYNC="now WAIT_FOR flush_ready";
+INSERT INTO t1 VALUES (1);
+
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Log tracker should have quit by now
+SET DEBUG_SYNC="now SIGNAL finish_flush";
+
+--connection con2
+--echo # connection con2
+reap;
+
+disconnect con2;
+connection default;
+
+--echo 8th restart
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+DROP TABLE t1;

--- a/sql/debug_sync.cc
+++ b/sql/debug_sync.cc
@@ -1858,6 +1858,11 @@ static void debug_sync_execute(THD *thd, st_debug_sync_action *action)
 
 void debug_sync(THD *thd, const char *sync_point_name, size_t name_len)
 {
+  if (!thd)
+  {
+    return;
+  }
+
   st_debug_sync_control *ds_control= thd->debug_sync_control;
   st_debug_sync_action  *action;
   DBUG_ENTER("debug_sync");

--- a/storage/innobase/include/log0online.h
+++ b/storage/innobase/include/log0online.h
@@ -37,19 +37,25 @@ log_online_bitmap_file_range_t;
 /** An iterator over changed page info */
 typedef struct log_bitmap_iterator_struct log_bitmap_iterator_t;
 
-/*********************************************************************//**
-Initializes the online log following subsytem. */
+/** Initialize the constant part of the log tracking subsystem */
+UNIV_INTERN
+void
+log_online_init(void);
+
+/** Initialize the dynamic part of the log tracking subsystem */
 UNIV_INTERN
 void
 log_online_read_init(void);
-/*=======================*/
 
-/*********************************************************************//**
-Shuts down the online log following subsystem. */
+/** Shut down the dynamic part of the log tracking subsystem */
 UNIV_INTERN
 void
 log_online_read_shutdown(void);
-/*===========================*/
+
+/** Shut down the constant part of the log tracking subsystem */
+UNIV_INTERN
+void
+log_online_shutdown(void);
 
 /*********************************************************************//**
 Reads and parses the redo log up to last checkpoint LSN to build the changed

--- a/storage/innobase/srv/srv0srv.c
+++ b/storage/innobase/srv/srv0srv.c
@@ -3208,10 +3208,8 @@ srv_redo_log_follow_thread(
 
 	} while (srv_shutdown_state < SRV_SHUTDOWN_LAST_PHASE);
 
-	srv_track_changed_pages = FALSE;
 	log_online_read_shutdown();
 	os_event_set(srv_redo_log_thread_finished_event);
-	srv_redo_log_thread_started = FALSE; /* Defensive, not required */
 
 	my_thread_end();
 	os_thread_exit(NULL);

--- a/storage/innobase/srv/srv0start.c
+++ b/storage/innobase/srv/srv0start.c
@@ -1619,6 +1619,7 @@ innobase_start_or_create_for_mysql(void)
 
 	fsp_init();
 	log_init();
+	log_online_init();
 
 	lock_sys_create(srv_lock_table_size);
 
@@ -2465,6 +2466,7 @@ innobase_shutdown_for_mysql(void)
 	btr_search_disable();
 
 	ibuf_close();
+	log_online_shutdown();
 	log_shutdown();
 	trx_sys_file_format_close();
 	trx_sys_close();


### PR DESCRIPTION
…oncurrently with executing FLUSH CHANGED_PAGE_BITMAPS)

If a bitmap write I/O errors happens in the background log tracking
thread while a FLUSH CHANGED_PAGE_BITMAPS is executing concurrently,
the two threads enter a race condition where the background thread
frees the mutex while the FLUSH locks/unlocks it, resulting in a
crash. Fix by pulling up the log_bmp_sys_mutex out of the dynamic
log_bmp_sys structure, and making it available throught server
lifetime, regardless of the log tracking startup or current
setting. Add new functions log_online_init and log_online_shutdown to
create and destroy the mutex. Make log_online_read_shutdown take that
mutex around log_bmp_sys deinitialisation and also protect
srv_track_changed_pages and srv_redo_log_thread_started true to false
transitions with it. Make log_online_follow_redo_log check
srv_track_changed_pages, take the mutex, and re-check the variable
before continuing operation. Likewise make
log_online_purge_changed_page_bitmaps check
srv_redo_log_thread_started, take the mutex, and re-check the variable.

At the same time replace mutex_own asserts with a helper function
in_log_bmp_sys_with_mutex that also asserts enabled log tracking
status var. Cleanup functions a bit by moving variable declarations to
initialisation statements.

At the same time remove another testcase instability by making the
bitmap_page_write_error error injection point only trigger for bitmap
data pages with tablespace ID > 0, that is, user tablespaces, as tested
by the testcases.

Backport to 5.5 undoes some of C++'ification in 5.6+ and backports a
small change to debug_sync to allow it to be called without a thd from
service threads.

(cherry picked from commit dd7f7de2a250b2fbb40785aa0462a1ac75d5079e)

http://jenkins.percona.com/job/percona-server-5.5-param/1542/