### PR TITLE
Fixed lp:1680510 (rpl_diff.inc in 5.7 does not compare data from different servers) (5.5)

### DIFF
--- a/mysql-test/include/rpl_diff.inc
+++ b/mysql-test/include/rpl_diff.inc
@@ -112,7 +112,7 @@ while ($_rpl_diff_servers)
   --let $_rpl_diff_first= 0
 }
 --remove_file $_rpl_diff_prev_file
-
+--remove_file $_rpl_diff_statement_file
 
 --let $include_filename= rpl_diff.inc
 --source include/end_include_file.inc


### PR DESCRIPTION
This is only a temporary file cleanup fix. The original problem only exists
on 5.7. On 5.5 and 5.6 'rpl_diff.inc' works properly.