### PR TITLE
Fixed lp:1680510 (rpl_diff.inc in 5.7 does not compare data from different servers) (5.7)

### DIFF
--- a/mysql-test/include/rpl_diff.inc
+++ b/mysql-test/include/rpl_diff.inc
@@ -112,7 +112,7 @@ while ($_rpl_diff_servers)
   --let $_rpl_diff_first= 0
 }
 --remove_file $_rpl_diff_prev_file
-
+--remove_file $_rpl_diff_statement_file
 
 --let $include_filename= rpl_diff.inc
 --source include/end_include_file.inc


### PR DESCRIPTION
Because of the changes in 5.7 'include/rpl_diff.inc' introduced by
commit mysql/mysql-server@61e2172 this MTR function used to connect to the
same server when querying data for comparison. As the result, it used to
always succeed regardless of data being different or not.

Fixed by adding '--defaults-group-suffix=' back to '--exec $MYSQL'.
