### PR TITLE
MYR-111 : rocksdb mtr suite .cnf and .opt files missing --loose prefi…

### DIFF
--- a/mysql-test/suite/rocksdb/t/compression_zstd-master.opt
+++ b/mysql-test/suite/rocksdb/t/compression_zstd-master.opt
@@ -1,1 +1,1 @@
---rocksdb_default_cf_options=compression_per_level=kZSTDNotFinalCompression;compression_opts=-14:4:0
+--loose-rocksdb_default_cf_options=compression_per_level=kZSTDNotFinalCompression;compression_opts=-14:4:0

--- a/mysql-test/suite/rocksdb/t/issue100_delete-master.opt
+++ b/mysql-test/suite/rocksdb/t/issue100_delete-master.opt
@@ -1,1 +1,1 @@
---rocksdb_table_stats_sampling_pct=100
+--loose-rocksdb_table_stats_sampling_pct=100

--- a/mysql-test/suite/rocksdb/t/read_only_tx-master.opt
+++ b/mysql-test/suite/rocksdb/t/read_only_tx-master.opt
@@ -1,1 +1,1 @@
---rocksdb_default_cf_options=write_buffer_size=16k --log-bin --binlog_format=row --gtid_mode=ON --enforce_gtid_consistency --log-slave-updates
+--loose-rocksdb_default_cf_options=write_buffer_size=16k --log-bin --binlog_format=row --gtid_mode=ON --enforce_gtid_consistency --log-slave-updates

--- a/mysql-test/suite/rocksdb/t/rocksdb-master.opt
+++ b/mysql-test/suite/rocksdb/t/rocksdb-master.opt
@@ -1,1 +1,1 @@
---rocksdb_debug_optimizer_n_rows=1000 --rocksdb_records_in_range=50
+--loose-rocksdb_debug_optimizer_n_rows=1000 --loose-rocksdb_records_in_range=50

--- a/mysql-test/suite/rocksdb/t/rocksdb_range-master.opt
+++ b/mysql-test/suite/rocksdb/t/rocksdb_range-master.opt
@@ -1,1 +1,1 @@
---rocksdb_debug_optimizer_n_rows=1000 --rocksdb_records_in_range=50
+--loose-rocksdb_debug_optimizer_n_rows=1000 --loose-rocksdb_records_in_range=50

--- a/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-master.opt
@@ -1,0 +1,1 @@
+--binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-slave.opt
@@ -1,0 +1,1 @@
+--binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_rocksdb.cnf
+++ b/mysql-test/suite/rocksdb/t/rpl_row_rocksdb.cnf
@@ -1,7 +1,0 @@
-!include suite/rpl/my.cnf
-
-[mysqld.1]
-binlog_format=row
-[mysqld.2]
-binlog_format=row
-

--- a/mysql-test/suite/rocksdb/t/rpl_row_stats-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_stats-master.opt
@@ -1,0 +1,1 @@
+--binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_stats-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_stats-slave.opt
@@ -1,0 +1,1 @@
+--binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_stats.cnf
+++ b/mysql-test/suite/rocksdb/t/rpl_row_stats.cnf
@@ -1,7 +1,0 @@
-!include suite/rpl/my.cnf
-
-[mysqld.1]
-binlog_format=row
-[mysqld.2]
-binlog_format=row
-

--- a/mysql-test/suite/rocksdb/t/rpl_savepoint-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_savepoint-master.opt
@@ -1,0 +1,1 @@
+--binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_savepoint-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_savepoint-slave.opt
@@ -1,0 +1,1 @@
+--binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_savepoint.cnf
+++ b/mysql-test/suite/rocksdb/t/rpl_savepoint.cnf
@@ -1,7 +1,0 @@
-!include suite/rpl/my.cnf
-
-[mysqld.1]
-binlog_format=row
-[mysqld.2]
-binlog_format=row
-

--- a/mysql-test/suite/rocksdb/t/slow_query_log-master.opt
+++ b/mysql-test/suite/rocksdb/t/slow_query_log-master.opt
@@ -1,1 +1,1 @@
---rocksdb-perf-context-level=2
+--loose-rocksdb-perf-context-level=2

--- a/mysql-test/suite/rocksdb/t/type_binary_indexes-master.opt
+++ b/mysql-test/suite/rocksdb/t/type_binary_indexes-master.opt
@@ -1,1 +1,1 @@
---rocksdb_debug_optimizer_n_rows=1000 --rocksdb_records_in_range=50
+--loose-rocksdb_debug_optimizer_n_rows=1000 --loose-rocksdb_records_in_range=50

--- a/mysql-test/suite/rocksdb/t/type_decimal-master.opt
+++ b/mysql-test/suite/rocksdb/t/type_decimal-master.opt
@@ -1,1 +1,1 @@
---rocksdb_debug_optimizer_n_rows=10
+--loose-rocksdb_debug_optimizer_n_rows=10

--- a/mysql-test/suite/rocksdb/t/update_ignore-master.opt
+++ b/mysql-test/suite/rocksdb/t/update_ignore-master.opt
@@ -1,1 +1,1 @@
---rocksdb_debug_optimizer_n_rows=1000
+--loose-rocksdb_debug_optimizer_n_rows=1000


### PR DESCRIPTION
…x for rocksdb_* options

- Initial commit missed a few instances of .cnf splits and .opt files without
  --loose prefixes om rocksdb variables.
- Renamed and split if needed all .cnf files to -master|slave.opt files.
- Removed mysql-test/suite/rocksdb/my.cnf and moved all options into suite.opt
- Changed all instances of rocksdb_* options in .opt files to --loose