### PR TITLE
MYR-120 : rocksdb.type_varchar unstable

### DIFF
--- a/mysql-test/suite/rocksdb/include/type_varchar_endspace.inc
+++ b/mysql-test/suite/rocksdb/include/type_varchar_endspace.inc
@@ -42,18 +42,19 @@ insert into t1 values (0, 'ab', 'a-b');
 insert into t1 values (1, 'a ', 'a-space');
 insert into t1 values (2, 'a',  'a');
 insert into t1 values (3, 'a  \t', 'a-tab');
+analyze table t1;
 
 --echo # Must show 'using index' for latin1_bin and utf8_bin:
 --replace_column 10 # 11 #
 explain
-select col1, hex(col1) from t1;
-select col1, hex(col1) from t1;
+select col1, hex(col1) from t1 order by col1;
+select col1, hex(col1) from t1 order by col1;
 
 --echo # Must show 'using index' for latin1_bin and utf8_bin:
 --replace_column 5 # 7 # 8 # 10 # 11 #
 explain
-select col1, hex(col1) from t1 where col1 < 'b';
-select col1, hex(col1) from t1 where col1 < 'b';
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 
 delete from t1;
 insert into t1 values(10, '', 'empty');
@@ -66,18 +67,18 @@ insert into t1 values(21, repeat(' ', 9), '9x-space');
 insert into t1 values(22, repeat(' ',17), '17x-space');
 insert into t1 values(23, repeat(' ',18), '18x-space');
 
---replace_column 5 # 10 # 11 #
+--replace_column 5 # 7 # 8 # 10 # 11 #
 explain
-select pk, col1, hex(col1), length(col1) from t1;
-select pk, col1, hex(col1), length(col1) from t1;
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 drop table t1;
 
 create table t1 (pk int primary key, a varchar(512), key(a)) engine=rocksdb;
 insert into t1 values (1, concat('a', repeat(' ', 300)));
 insert into t1 values (2, concat('b', repeat(' ', 300)));
 
-select pk,length(a) from t1 force index(a) where a < 'zz';
-select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz';
-select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz';
+select pk,length(a) from t1 force index(a) where a < 'zz' order by pk;
+select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz' order by pk;
+select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz' order by pk;
 
 drop table t1;

--- a/mysql-test/suite/rocksdb/r/type_varchar.result
+++ b/mysql-test/suite/rocksdb/r/type_varchar.result
@@ -221,14 +221,17 @@ insert into t1 values (0, 'ab', 'a-b');
 insert into t1 values (1, 'a ', 'a-space');
 insert into t1 values (2, 'a',  'a');
 insert into t1 values (3, 'a  \t', 'a-tab');
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1;
+select col1, hex(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	index	NULL	col1	67	NULL	#	#	Using index
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1`
-select col1, hex(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 order by col1;
 col1	hex(col1)
 a  		61202009
 a 	6120
@@ -236,12 +239,12 @@ a	61
 ab	6162
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1 where col1 < 'b';
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	#	col1	#	#	NULL	#	#	Using where; Using index
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b')
-select col1, hex(col1) from t1 where col1 < 'b';
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b') order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 col1	hex(col1)
 a  		61202009
 a 	6120
@@ -257,12 +260,12 @@ insert into t1 values(21, repeat(' ', 9), '9x-space');
 insert into t1 values(22, repeat(' ',17), '17x-space');
 insert into t1 values(23, repeat(' ',18), '18x-space');
 explain
-select pk, col1, hex(col1), length(col1) from t1;
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	#	NULL	col1	67	NULL	#	#	Using index
+1	SIMPLE	t1	NULL	#	NULL	#	#	NULL	#	#	Using index
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1`
-select pk, col1, hex(col1), length(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 pk	col1	hex(col1)	length(col1)
 10			0
 11	        	2020202020202020	8
@@ -276,15 +279,15 @@ drop table t1;
 create table t1 (pk int primary key, a varchar(512), key(a)) engine=rocksdb;
 insert into t1 values (1, concat('a', repeat(' ', 300)));
 insert into t1 values (2, concat('b', repeat(' ', 300)));
-select pk,length(a) from t1 force index(a) where a < 'zz';
+select pk,length(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)
 1	301
 2	301
-select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
-select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
@@ -339,14 +342,17 @@ insert into t1 values (0, 'ab', 'a-b');
 insert into t1 values (1, 'a ', 'a-space');
 insert into t1 values (2, 'a',  'a');
 insert into t1 values (3, 'a  \t', 'a-tab');
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1;
+select col1, hex(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	index	NULL	col1	195	NULL	#	#	Using index
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1`
-select col1, hex(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 order by col1;
 col1	hex(col1)
 a  		61202009
 a 	6120
@@ -354,12 +360,12 @@ a	61
 ab	6162
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1 where col1 < 'b';
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	#	col1	#	#	NULL	#	#	Using where; Using index
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b')
-select col1, hex(col1) from t1 where col1 < 'b';
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b') order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 col1	hex(col1)
 a  		61202009
 a 	6120
@@ -375,12 +381,12 @@ insert into t1 values(21, repeat(' ', 9), '9x-space');
 insert into t1 values(22, repeat(' ',17), '17x-space');
 insert into t1 values(23, repeat(' ',18), '18x-space');
 explain
-select pk, col1, hex(col1), length(col1) from t1;
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	#	NULL	col1	195	NULL	#	#	Using index
+1	SIMPLE	t1	NULL	#	NULL	#	#	NULL	#	#	Using index
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1`
-select pk, col1, hex(col1), length(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 pk	col1	hex(col1)	length(col1)
 10			0
 11	        	2020202020202020	8
@@ -394,15 +400,15 @@ drop table t1;
 create table t1 (pk int primary key, a varchar(512), key(a)) engine=rocksdb;
 insert into t1 values (1, concat('a', repeat(' ', 300)));
 insert into t1 values (2, concat('b', repeat(' ', 300)));
-select pk,length(a) from t1 force index(a) where a < 'zz';
+select pk,length(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)
 1	301
 2	301
-select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
-select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
@@ -457,27 +463,30 @@ insert into t1 values (0, 'ab', 'a-b');
 insert into t1 values (1, 'a ', 'a-space');
 insert into t1 values (2, 'a',  'a');
 insert into t1 values (3, 'a  \t', 'a-tab');
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1;
+select col1, hex(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	#	#	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1`
-select col1, hex(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 order by col1;
 col1	hex(col1)
-ab	00610062
+a  		0061002000200009
 a 	00610020
 a	0061
-a  		0061002000200009
+ab	00610062
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1 where col1 < 'b';
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	#	col1	#	#	NULL	#	#	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b')
-select col1, hex(col1) from t1 where col1 < 'b';
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b') order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 col1	hex(col1)
 a  		0061002000200009
 a 	00610020
@@ -493,34 +502,34 @@ insert into t1 values(21, repeat(' ', 9), '9x-space');
 insert into t1 values(22, repeat(' ',17), '17x-space');
 insert into t1 values(23, repeat(' ',18), '18x-space');
 explain
-select pk, col1, hex(col1), length(col1) from t1;
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	#	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t1	NULL	#	NULL	#	#	NULL	#	#	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1`
-select pk, col1, hex(col1), length(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 pk	col1	hex(col1)	length(col1)
 10			0
 11	        	00200020002000200020002000200020	16
 12	                	0020002000200020002000200020002000200020002000200020002000200020	32
 13	                        	002000200020002000200020002000200020002000200020002000200020002000200020002000200020002000200020	48
-14	                a	00200020002000200020002000200020002000200020002000200020002000200061	34
 21	         	002000200020002000200020002000200020	18
 22	                 	00200020002000200020002000200020002000200020002000200020002000200020	34
 23	                  	002000200020002000200020002000200020002000200020002000200020002000200020	36
+14	                a	00200020002000200020002000200020002000200020002000200020002000200061	34
 drop table t1;
 create table t1 (pk int primary key, a varchar(512), key(a)) engine=rocksdb;
 insert into t1 values (1, concat('a', repeat(' ', 300)));
 insert into t1 values (2, concat('b', repeat(' ', 300)));
-select pk,length(a) from t1 force index(a) where a < 'zz';
+select pk,length(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)
 1	301
 2	301
-select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
-select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
@@ -575,27 +584,30 @@ insert into t1 values (0, 'ab', 'a-b');
 insert into t1 values (1, 'a ', 'a-space');
 insert into t1 values (2, 'a',  'a');
 insert into t1 values (3, 'a  \t', 'a-tab');
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1;
+select col1, hex(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	#	#	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1`
-select col1, hex(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 order by col1;
 col1	hex(col1)
-ab	6162
+a  		61202009
 a 	6120
 a	61
-a  		61202009
+ab	6162
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1 where col1 < 'b';
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	#	col1	#	#	NULL	#	#	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b')
-select col1, hex(col1) from t1 where col1 < 'b';
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b') order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 col1	hex(col1)
 a  		61202009
 a 	6120
@@ -611,34 +623,34 @@ insert into t1 values(21, repeat(' ', 9), '9x-space');
 insert into t1 values(22, repeat(' ',17), '17x-space');
 insert into t1 values(23, repeat(' ',18), '18x-space');
 explain
-select pk, col1, hex(col1), length(col1) from t1;
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	#	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t1	NULL	#	NULL	#	#	NULL	#	#	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1`
-select pk, col1, hex(col1), length(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 pk	col1	hex(col1)	length(col1)
 10			0
 11	        	2020202020202020	8
 12	                	20202020202020202020202020202020	16
 13	                        	202020202020202020202020202020202020202020202020	24
-14	                a	2020202020202020202020202020202061	17
 21	         	202020202020202020	9
 22	                 	2020202020202020202020202020202020	17
 23	                  	202020202020202020202020202020202020	18
+14	                a	2020202020202020202020202020202061	17
 drop table t1;
 create table t1 (pk int primary key, a varchar(512), key(a)) engine=rocksdb;
 insert into t1 values (1, concat('a', repeat(' ', 300)));
 insert into t1 values (2, concat('b', repeat(' ', 300)));
-select pk,length(a) from t1 force index(a) where a < 'zz';
+select pk,length(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)
 1	301
 2	301
-select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
-select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
@@ -693,27 +705,30 @@ insert into t1 values (0, 'ab', 'a-b');
 insert into t1 values (1, 'a ', 'a-space');
 insert into t1 values (2, 'a',  'a');
 insert into t1 values (3, 'a  \t', 'a-tab');
+analyze table t1;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1;
+select col1, hex(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	#	#	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1`
-select col1, hex(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 order by col1;
 col1	hex(col1)
-ab	00610062
+a  		0061002000200009
 a 	00610020
 a	0061
-a  		0061002000200009
+ab	00610062
 # Must show 'using index' for latin1_bin and utf8_bin:
 explain
-select col1, hex(col1) from t1 where col1 < 'b';
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t1	NULL	#	col1	#	#	NULL	#	#	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b')
-select col1, hex(col1) from t1 where col1 < 'b';
+Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)` from `test`.`t1` where (`test`.`t1`.`col1` < 'b') order by `test`.`t1`.`col1`
+select col1, hex(col1) from t1 where col1 < 'b' order by col1;
 col1	hex(col1)
 a  		0061002000200009
 a 	00610020
@@ -729,34 +744,34 @@ insert into t1 values(21, repeat(' ', 9), '9x-space');
 insert into t1 values(22, repeat(' ',17), '17x-space');
 insert into t1 values(23, repeat(' ',18), '18x-space');
 explain
-select pk, col1, hex(col1), length(col1) from t1;
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	#	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t1	NULL	#	NULL	#	#	NULL	#	#	Using filesort
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1`
-select pk, col1, hex(col1), length(col1) from t1;
+Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `col1`,hex(`test`.`t1`.`col1`) AS `hex(col1)`,length(`test`.`t1`.`col1`) AS `length(col1)` from `test`.`t1` order by `test`.`t1`.`col1`
+select pk, col1, hex(col1), length(col1) from t1 order by col1;
 pk	col1	hex(col1)	length(col1)
 10			0
 11	        	00200020002000200020002000200020	16
 12	                	0020002000200020002000200020002000200020002000200020002000200020	32
 13	                        	002000200020002000200020002000200020002000200020002000200020002000200020002000200020002000200020	48
-14	                a	00200020002000200020002000200020002000200020002000200020002000200061	34
 21	         	002000200020002000200020002000200020	18
 22	                 	00200020002000200020002000200020002000200020002000200020002000200020	34
 23	                  	002000200020002000200020002000200020002000200020002000200020002000200020	36
+14	                a	00200020002000200020002000200020002000200020002000200020002000200061	34
 drop table t1;
 create table t1 (pk int primary key, a varchar(512), key(a)) engine=rocksdb;
 insert into t1 values (1, concat('a', repeat(' ', 300)));
 insert into t1 values (2, concat('b', repeat(' ', 300)));
-select pk,length(a) from t1 force index(a) where a < 'zz';
+select pk,length(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)
 1	301
 2	301
-select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 force index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b
-select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz';
+select pk,length(a),rtrim(a) from t1 ignore index(a) where a < 'zz' order by pk;
 pk	length(a)	rtrim(a)
 1	301	a
 2	301	b


### PR DESCRIPTION
- Fixed more non-deterministic result masks
- Added explicit ORDER BY to force results appear in deterministic order as it
  may change depending on the state of the SST and WAL files on test start.
- Added explicit ANALYZE TABLE to force cardinality updates otherwise they are
  cause query plan to float and breaks EXPLAIN SELECT.