### PR TITLE
MYR-112-113-114 : rocksdb.rpl CONSISTENT SHANSHOT mtr fixes

### DIFF
--- a/mysql-test/suite/rocksdb.rpl/r/consistent_snapshot_mixed_engines.result
+++ b/mysql-test/suite/rocksdb.rpl/r/consistent_snapshot_mixed_engines.result
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS t1;
 connect  con1,localhost,root,,;
 connect  con2,localhost,root,,;
 connection con1;
@@ -14,9 +13,7 @@ select * from i1;
 id	value
 select * from r1;
 id	value
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	1115	uuid:1-5
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 connection con2;
 insert into i1 values (2,2);
 insert into r1 values (2,2);
@@ -24,7 +21,6 @@ connection con1;
 select * from i1;
 id	value
 1	1
-2	2
 select * from r1;
 id	value
 1	1
@@ -35,13 +31,10 @@ connection con1;
 select * from i1;
 id	value
 1	1
-2	2
 select * from r1;
 id	value
 1	1
-START TRANSACTION WITH CONSISTENT INNODB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	2015	uuid:1-9
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 connection con2;
 insert into r1 values (4,4);
 connection con1;
@@ -50,7 +43,6 @@ id	value
 1	1
 2	2
 3	2
-4	4
 connection con2;
 insert into r1 values (5,5);
 connection con1;
@@ -59,7 +51,6 @@ id	value
 1	1
 2	2
 3	2
-4	4
 drop table i1;
 drop table r1;
 connection default;

--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_snapshot.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_snapshot.result
@@ -3,7 +3,6 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-DROP TABLE IF EXISTS t1;
 # Establish connection con1 (user=root)
 # Establish connection con2 (user=root)
 # Establish connection con3 (user=root)
@@ -19,18 +18,16 @@ Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 include/start_slave.inc
 # Switch to connection con1
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR HY000: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine.
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-ERROR HY000: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine.
+Warnings:
+Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
 ROLLBACK;
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	531	UUID:1-2
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 # Switch to connection con2
 INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(3);
@@ -46,20 +43,15 @@ a
 3
 DROP TABLE t1;
 # Switch to connection con1
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	1510	UUID:1-7
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	1510	UUID:1-7
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	1510	UUID:1-7
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	1510	UUID:1-7
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+UNLOCK BINLOG;
 # Switch to connection con2
 INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(3);
@@ -71,7 +63,10 @@ SELECT * INTO OUTFILE '<MYSQLTEST_VARDIR>/tmp/rpl_rocksdb_snapshot.out.file' FRO
 COMMIT;
 # Switch to slave
 CREATE TABLE t1_backup LIKE t1;
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
 include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;
@@ -80,7 +75,7 @@ LOAD DATA INFILE '<MYSQLTEST_VARDIR>/tmp/rpl_rocksdb_snapshot.out.file' INTO TAB
 SELECT * FROM t1;
 a
 1
-CHANGE MASTER TO master_host="127.0.0.1",master_port=MASTER_PORT,master_user="root",master_log_file="master-bin.000001",master_log_pos=binlog_pos;
+CHANGE MASTER TO master_host="127.0.0.1",master_port=MASTER_PORT,master_user="root",master_log_file="master-bin.000001",master_log_pos=binlog_pos,master_auto_position=0;
 Warnings:
 Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
@@ -98,13 +93,16 @@ a
 DROP TABLE t1_backup;
 DROP TABLE t1;
 # Switch to connection con1
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 # async queries from con2
 INSERT INTO t1 VALUES(2);
 # async queries from con3
 INSERT INTO t1 VALUES(21);
 # Switch to connection con1
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+UNLOCK BINLOG;
 # Switch to connection con4
 INSERT INTO t1 VALUES(9);
 # Switch to connection con1
@@ -113,7 +111,10 @@ COMMIT;
 # reap async statements
 # Switch to slave
 CREATE TABLE t1_backup LIKE t1;
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
 include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;
@@ -130,20 +131,15 @@ ShouldBeZero
 DROP TABLE t1_backup;
 DROP TABLE t1;
 # Switch to connection con1
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	3688	UUID:1-18
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	3688	UUID:1-18
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	3688	UUID:1-18
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000001	3688	UUID:1-18
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+UNLOCK BINLOG;
 # Switch to connection con2
 INSERT INTO t1 VALUES(2);
 INSERT INTO t1 VALUES(3);
@@ -155,7 +151,10 @@ SELECT * INTO OUTFILE '<MYSQLTEST_VARDIR>/tmp/rpl_rocksdb_snapshot.out.file' FRO
 COMMIT;
 # Switch to slave
 CREATE TABLE t1_backup LIKE t1;
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
 include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;
@@ -183,13 +182,16 @@ a
 DROP TABLE t1_backup;
 DROP TABLE t1;
 # Switch to connection con1
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 # async queries from con2
 INSERT INTO t1 VALUES(2);
 # async queries from con3
 INSERT INTO t1 VALUES(21);
 # Switch to connection con1
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+UNLOCK BINLOG;
 # Switch to connection con4
 INSERT INTO t1 VALUES(9);
 # Switch to connection con1
@@ -198,7 +200,10 @@ COMMIT;
 # reap async statements
 # Switch to slave
 CREATE TABLE t1_backup LIKE t1;
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
 include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;

--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_snapshot_without_gtid.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_snapshot_without_gtid.result
@@ -3,13 +3,11 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-create table t1(a int primary key);
+create table t1(a int primary key) engine=rocksdb;
 FLUSH LOGS;
 insert into t1 values(1);
 insert into t1 values(2);
 FLUSH LOGS;
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
-File	Position	Gtid_executed
-master-bin.000003	120	
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 drop table t1;
 include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/t/consistent_snapshot_mixed_engines.test
+++ b/mysql-test/suite/rocksdb.rpl/t/consistent_snapshot_mixed_engines.test
@@ -1,15 +1,12 @@
 --source include/have_log_bin.inc
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 --source include/have_innodb.inc
+
 --enable_connect_log
 -- let $uuid = `select @@server_uuid;`
 
 # Save the initial number of concurrent sessions
 --source include/count_sessions.inc
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
 
 connect (con1,localhost,root,,);
 connect (con2,localhost,root,,);
@@ -21,8 +18,7 @@ create table r1 (id int primary key , value int) engine=rocksdb;
 
 SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 
-# Without setting engine, this takes both InnoDB and RocksDB snapshots
--- replace_result $uuid uuid
+# This takes both InnoDB and RocksDB snapshots
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
 connection con2;
@@ -33,16 +29,15 @@ connection con1;
 select * from i1;
 select * from r1;
 
-# This takes RocksDB snapshot only but both InnoDB participates in transaction.
--- replace_result $uuid uuid
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
+# This takes both InnoDB and RocksDB snapshots
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
 connection con2;
 insert into i1 values (2,2);
 insert into r1 values (2,2);
 
 connection con1;
-# takes InnoDB snapshot here so changes after that not visible
+# takes snapshot here so changes after that not visible
 select * from i1;
 select * from r1;
 
@@ -54,15 +49,14 @@ connection con1;
 select * from i1;
 select * from r1;
 
-# RocksDB also partipates in transaction
--- replace_result $uuid uuid
-START TRANSACTION WITH CONSISTENT INNODB SNAPSHOT;
+# This takes both InnoDB and RocksDB snapshots
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
 connection con2;
 insert into r1 values (4,4);
 
 connection con1;
-# takes RocksDB snapshot here so changes after that are not visible
+# takes snapshot here so changes after that are not visible
 select * from r1;
 
 connection con2;

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot.test
@@ -1,10 +1,8 @@
---source include/have_rocksdb_as_default.inc
---source include/master-slave.inc
+--source include/have_rocksdb.inc
 --source include/have_binlog_format_row.inc
+--source include/master-slave.inc
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
+--source include/count_sessions.inc
 
 --echo # Establish connection con1 (user=root)
 connect (con1,localhost,root,,);
@@ -35,14 +33,13 @@ eval CHANGE MASTER TO master_host="127.0.0.1",master_port=$MASTER_MYPORT,master_
 
 --echo # Switch to connection con1
 connection con1;
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
---error ER_UNKNOWN_ERROR
+# This now behaves slightly different in Percona Server,
+# it should print Warning 138 to error log but allow txn to start
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
---error ER_UNKNOWN_ERROR
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
 ROLLBACK;
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 
@@ -51,14 +48,13 @@ SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 --disable_result_log
 let $x=1000;
 while ($x) {
-  START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
+  START TRANSACTION WITH CONSISTENT SNAPSHOT;
   dec $x;
 }
 --enable_query_log
 --enable_result_log
 
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
 --echo # Switch to connection con2
 connection con2;
@@ -79,19 +75,21 @@ DROP TABLE t1;
 
 --echo # Switch to connection con1
 connection con1;
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
+# Percona Server CONSISTENT SNAPSHOT behaves like upstream in that it does not
+# record/print binlog position as a result, so we can ignore output from these
+# and then need to go get binlog position on our own.
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
-let $binlog_pos = query_get_value(START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT, Position, 1);
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+let $binlog_pos = query_get_value(SHOW MASTER STATUS, Position, 1);
+UNLOCK BINLOG;
 
 --echo # Switch to connection con2
 connection con2;
@@ -112,7 +110,14 @@ COMMIT;
 sync_slave_with_master slave;
 
 CREATE TABLE t1_backup LIKE t1;
+# MyRocks does not support gap locks in REPEATABLE-READ mode, this part of the
+# the test does not require RR ISO to complete, so lets temporarily alter the
+# ISO to RC
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
+
 --source include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;
@@ -122,7 +127,7 @@ eval LOAD DATA INFILE '$outfile' INTO TABLE t1;
 SELECT * FROM t1;
 
 --replace_result $MASTER_MYPORT MASTER_PORT $binlog_pos binlog_pos
-eval CHANGE MASTER TO master_host="127.0.0.1",master_port=$MASTER_MYPORT,master_user="root",master_log_file="master-bin.000001",master_log_pos=$binlog_pos;
+eval CHANGE MASTER TO master_host="127.0.0.1",master_port=$MASTER_MYPORT,master_user="root",master_log_file="master-bin.000001",master_log_pos=$binlog_pos,master_auto_position=0;
 --source include/start_slave.inc
 
 connection master;
@@ -142,7 +147,7 @@ DROP TABLE t1;
 
 --echo # Switch to connection con1
 connection con1;
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 
 --echo # async queries from con2
@@ -156,7 +161,10 @@ send INSERT INTO t1 VALUES(21);
 --echo # Switch to connection con1
 connection con1;
 
-let $binlog_pos = query_get_value(START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT, Position, 1);
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+let $binlog_pos = query_get_value(SHOW MASTER STATUS, Position, 1);
+UNLOCK BINLOG;
 
 --echo # Switch to connection con4
 connection con4;
@@ -182,7 +190,14 @@ reap;
 sync_slave_with_master slave;
 
 CREATE TABLE t1_backup LIKE t1;
+# MyRocks does not support gap locks in REPEATABLE-READ mode, this part of the
+# the test does not require RR ISO to complete, so lets temporarily alter the
+# ISO to RC
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
+
 --source include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;
@@ -215,19 +230,18 @@ DROP TABLE t1;
 
 --echo # Switch to connection con1
 connection con1;
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
--- replace_regex /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/UUID/
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
-let $gtid_executed = query_get_value(START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT, Gtid_executed, 1);
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+let $gtid_executed = query_get_value(SHOW MASTER STATUS, Executed_Gtid_Set, 1);
+UNLOCK BINLOG;
 
 --echo # Switch to connection con2
 connection con2;
@@ -248,7 +262,14 @@ COMMIT;
 sync_slave_with_master slave;
 
 CREATE TABLE t1_backup LIKE t1;
+# MyRocks does not support gap locks in REPEATABLE-READ mode, this part of the
+# the test does not require RR ISO to complete, so lets temporarily alter the
+# ISO to RC
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
+
 --source include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;
@@ -280,7 +301,7 @@ DROP TABLE t1;
 
 --echo # Switch to connection con1
 connection con1;
-CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=rocksdb;
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES(1);
 
 --echo # async queries from con2
@@ -294,7 +315,10 @@ send INSERT INTO t1 VALUES(21);
 --echo # Switch to connection con1
 connection con1;
 
-let $gtid_executed = query_get_value(START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT, Gtid_executed, 1);
+LOCK BINLOG FOR BACKUP;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+let $gtid_executed = query_get_value(SHOW MASTER STATUS, Executed_Gtid_Set, 1);
+UNLOCK BINLOG;
 
 --echo # Switch to connection con4
 connection con4;
@@ -320,7 +344,14 @@ reap;
 sync_slave_with_master slave;
 
 CREATE TABLE t1_backup LIKE t1;
+# MyRocks does not support gap locks in REPEATABLE-READ mode, this part of the
+# the test does not require RR ISO to complete, so lets temporarily alter the
+# ISO to RC
+set @orig_tx_iso=@@session.tx_isolation;
+set session tx_isolation='READ-COMMITTED';
 INSERT INTO t1_backup SELECT * FROM t1;
+set session tx_isolation=@orig_tx_iso;
+
 --source include/stop_slave.inc
 RESET SLAVE;
 RESET MASTER;
@@ -370,5 +401,7 @@ sync_slave_with_master slave;
 --source include/stop_slave.inc
 CHANGE MASTER to master_auto_position=0;
 --source include/start_slave.inc
+
+--source include/wait_until_count_sessions.inc
 
 --source include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot_without_gtid.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot_without_gtid.test
@@ -1,9 +1,9 @@
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 --source include/master-slave.inc
 --source include/have_binlog_format_row.inc
 
 --connection master
-create table t1(a int primary key);
+create table t1(a int primary key) engine=rocksdb;
 
 FLUSH LOGS;
 
@@ -12,7 +12,7 @@ insert into t1 values(2);
 
 FLUSH LOGS;
 
-START TRANSACTION WITH CONSISTENT ROCKSDB SNAPSHOT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
 
 drop table t1;
 -- source include/rpl_end.inc


### PR DESCRIPTION
MYR-99 : Convert tests to not require have_rocksdb_as_default
MYR-112 : rocksdb.rpl.rpl_rocksdb_snapshot 'row' fails
MYR-113 : rocksdb.rpl.consistent_snapshot_mixed_engines 'row' fails
MYR-114 : rocksdb.rpl.rpl_rocksdb_snapshot_without_gtid 'row' fails
- Reworked tests to account for Percona Server behavior of START TRANSACTION
  WITH CONSISTENT SNAPSHOT.
  - Facebook MySQL prints the consistent binlog position as the result of
    STWCeS. This is a Facebook MySQL specific function and does not exist
    within Percona Server. This binlog position is used so that a 'backup'
    taken under STWCeS can be used to bootstrap and start a slave at a
    consistent position.
  - Fortunately in Percona Server, we have LOCK BINLOG FOR BACKUP. We can
    emulate the exact same behavior by executing the following sequence:
    >  LOCK BINLOG FOR BACKUP;
    >  START TRANSACTION WITH CONSISTENT SNAPSHOT;
    >  SHOW MASTER STATUS; # << Capture binlog position  from this
    >  UNLOCK BINLOG;
  - This test has been modified to use this sequence.
- Audited and fixed tests to not require rocksdb as default storage engine.