### PR TITLE
Fix bug 1683993 (Test main.rpl_slow_query_log is unstable)

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_slow_query_log.test
+++ b/mysql-test/suite/rpl/t/rpl_slow_query_log.test
@@ -10,12 +10,11 @@
 #     ii) On slave, set long_query_time to a small value.
 #     ii) start slave so that long_query_time variable is picked by sql thread
 #    iii) On master, do one short time query and one long time query, on slave
-#         and check that slow query is logged to slow query log but fast query 
-#         is not.
-#     iv) On slave, check that slow queries go into the slow log and fast dont,
-#         when issued through a regular client connection
-#      v) On slave, check that slow queries go into the slow log and fast dont
-#         when we use SET TIMESTAMP= 1 on a regular client connection.
+#         and check that slow query is logged to slow query log
+#     iv) On slave, check that slow queries go into the slow log, when issued
+#         through a regular client connection
+#      v) On slave, check that slow queries go into the slow log when we use
+#         SET TIMESTAMP= 1 on a regular client connection.
 #     vi) check that when setting slow_query_log= OFF in a connection 'extra2'
 #         prevents logging slow queries in a connection 'extra'
 #
@@ -53,7 +52,7 @@ connection master;
 CREATE TABLE t1 (a int, b int); 
 
 # test:
-#   check that slave logs the slow query to the slow log, but not the fast one.
+#   check that slave logs the slow query to the slow log
 
 let $slow_query= INSERT INTO t1 values(1, sleep(3));
 let $fast_query= INSERT INTO t1 values(1, 1);
@@ -64,14 +63,7 @@ eval $slow_query;
 --enable_warnings
 sync_slave_with_master;
 
-let $found_fast_query= `SELECT count(*) = 1 FROM mysql.slow_log WHERE sql_text like '$fast_query'`;
 let $found_slow_query= `SELECT count(*) = 1 FROM mysql.slow_log WHERE sql_text like '$slow_query'`;
-
-if ($found_fast_query)
-{
-  SELECT * FROM mysql.slow_log;
-  die "Assertion failed! Fast query FOUND in slow query log. Bailing out!";
-}
 
 if (!$found_slow_query)
 {
@@ -84,7 +76,6 @@ TRUNCATE mysql.slow_log;
 
 # test: 
 #   when using direct connections to the slave, check that slow query is logged 
-#   but not the fast one.
 
 connect(extra,127.0.0.1,root,,test,$SLAVE_MYPORT);
 connection extra;
@@ -95,14 +86,7 @@ let $slow_query= SELECT 1, sleep(3);
 eval $slow_query;
 eval $fast_query;
 
-let $found_fast_query= `SELECT count(*) = 1 FROM mysql.slow_log WHERE sql_text like '$fast_query'`;
 let $found_slow_query= `SELECT count(*) = 1 FROM mysql.slow_log WHERE sql_text like '$slow_query'`;
-
-if ($found_fast_query)
-{
-  SELECT * FROM mysql.slow_log;
-  die "Assertion failed! Fast query FOUND in slow query log. Bailing out!";
-}
 
 if (!$found_slow_query)
 {
@@ -113,7 +97,7 @@ TRUNCATE mysql.slow_log;
 
 # test:
 #   when using direct connections to the slave, check that when setting timestamp to 1 the 
-#   slow query is logged but the fast one is not.
+#   slow query is logged.
 
 let $fast_query= SELECT 2;
 let $slow_query= SELECT 2, sleep(3);
@@ -122,14 +106,7 @@ SET TIMESTAMP= 1;
 eval $slow_query;
 eval $fast_query;
 
-let $found_fast_query= `SELECT count(*) = 1 FROM mysql.slow_log WHERE sql_text like '$fast_query'`;
 let $found_slow_query= `SELECT count(*) = 1 FROM mysql.slow_log WHERE sql_text like '$slow_query'`;
-
-if ($found_fast_query)
-{
-  SELECT * FROM mysql.slow_log;
-  die "Assertion failed! Fast query FOUND in slow query log. Bailing out!";
-}
 
 if (!$found_slow_query)
 {


### PR DESCRIPTION
Remove checks that fast queries are fast enough not to be logged to
the slow query log, as they still might be arbitrarily slow on loaded
machines.

http://jenkins.percona.com/job/percona-server-5.5-param/1547/