### PR TITLE
Fix bug 1684012 (Test main.log_tables is unstable)

### DIFF
--- a/mysql-test/r/log_tables.result
+++ b/mysql-test/r/log_tables.result
@@ -145,7 +145,7 @@ set session long_query_time=1;
 select sleep(2);
 sleep(2)
 0
-select * from mysql.slow_log;
+select * from mysql.slow_log where sql_text="select sleep(2)";
 start_time	user_host	query_time	lock_time	rows_sent	rows_examined	db	last_insert_id	insert_id	server_id	sql_text
 TIMESTAMP	USER_HOST	QUERY_TIME	00:00:00	1	0	mysql	0	0	1	select sleep(2)
 set @@session.long_query_time = @saved_long_query_time;
@@ -225,7 +225,7 @@ TIMESTAMP	USER_HOST	THREAD_ID	1	Query	drop table bug16905
 TIMESTAMP	USER_HOST	THREAD_ID	1	Query	truncate table mysql.slow_log
 TIMESTAMP	USER_HOST	THREAD_ID	1	Query	set session long_query_time=1
 TIMESTAMP	USER_HOST	THREAD_ID	1	Query	select sleep(2)
-TIMESTAMP	USER_HOST	THREAD_ID	1	Query	select * from mysql.slow_log
+TIMESTAMP	USER_HOST	THREAD_ID	1	Query	select * from mysql.slow_log where sql_text="select sleep(2)"
 TIMESTAMP	USER_HOST	THREAD_ID	1	Query	set @@session.long_query_time = @saved_long_query_time
 TIMESTAMP	USER_HOST	THREAD_ID	1	Query	alter table mysql.general_log engine=myisam
 TIMESTAMP	USER_HOST	THREAD_ID	1	Query	alter table mysql.slow_log engine=myisam

--- a/mysql-test/t/log_tables.test
+++ b/mysql-test/t/log_tables.test
@@ -181,7 +181,7 @@ truncate table mysql.slow_log;
 set session long_query_time=1;
 select sleep(2);
 --replace_column 1 TIMESTAMP 2 USER_HOST 3 QUERY_TIME
-select * from mysql.slow_log;
+select * from mysql.slow_log where sql_text="select sleep(2)";
 set @@session.long_query_time = @saved_long_query_time;
 
 #


### PR DESCRIPTION
Make a mysql.slow_log query more specific with a WHERE to remove
arbitrarily slow neigbor queries from its result.

http://jenkins.percona.com/job/percona-server-5.5-param/1548/