### PR TITLE
Fix bug 1684025 (Spurious warnings on parts.partition_debug_innodb)

### DIFF
--- a/mysql-test/suite/parts/r/partition_debug_innodb.result
+++ b/mysql-test/suite/parts/r/partition_debug_innodb.result
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS t1;
+CALL mtr.add_suppression("InnoDB: Warning: database page corruption or a failed");
 #
 # Bug#12696518/Bug#11766879/60106:DIFF BETWEEN # OF INDEXES IN MYSQL
 # VS INNODB, PARTITONING, ON INDEX CREATE

--- a/mysql-test/suite/parts/t/partition_debug_innodb.test
+++ b/mysql-test/suite/parts/t/partition_debug_innodb.test
@@ -10,6 +10,8 @@
 DROP TABLE IF EXISTS t1;
 --enable_warnings
 
+CALL mtr.add_suppression("InnoDB: Warning: database page corruption or a failed");
+
 --let $DATADIR= `SELECT @@datadir;`
 
 --echo #


### PR DESCRIPTION
Suppress the warning that is produced when a page is recovered from
the doublewrite buffer correctly.

http://jenkins.percona.com/job/percona-server-5.5-param/1549/