### PR TITLE
Fix bug 1673800 (Test main.type_temporal_fractional is unstable)

### DIFF
--- a/mysql-test/r/type_temporal_fractional.result
+++ b/mysql-test/r/type_temporal_fractional.result
@@ -16001,7 +16001,14 @@ col_time_2_not_null time(2) NOT NULL,
 KEY col_timestamp_6_key (col_timestamp_6_key))
 ENGINE=MEMORY DEFAULT CHARSET=latin1;
 INSERT INTO t1 VALUES (current_timestamp(5),current_timestamp(6),current_time(6));
-include/assert.inc [No rows should be returned]
+UPDATE t1 SET col_timestamp_6_key
+= TIMESTAMPADD(MICROSECOND,
+IF(MICROSECOND(col_timestamp_6_key) % 10000, 0, 1),
+col_timestamp_6_key);
+SELECT col_datetime_5 AS c1 FROM t1
+WHERE col_time_2_not_null = GREATEST(CURRENT_DATE(),col_timestamp_6_key)
+ORDER BY 1;
+c1
 DROP TABLE t1;
 SET @@time_zone='+00:00';
 CREATE TABLE t1 (col_datetime_4_not_null DATETIME(4) NOT NULL);

--- a/mysql-test/t/type_temporal_fractional.test
+++ b/mysql-test/t/type_temporal_fractional.test
@@ -6555,12 +6555,17 @@ CREATE TABLE t1 (
   KEY col_timestamp_6_key (col_timestamp_6_key))
   ENGINE=MEMORY DEFAULT CHARSET=latin1;
 INSERT INTO t1 VALUES (current_timestamp(5),current_timestamp(6),current_time(6));
-let $assert_cond= COUNT(col_datetime_5) = 0 FROM t1
+
+# In case the inserted timestamp happened to have four trailing zeroes in microseconds,
+# it will compare equal with col_time_2_not_null, breaking the testcase
+UPDATE t1 SET col_timestamp_6_key
+       = TIMESTAMPADD(MICROSECOND,
+                      IF(MICROSECOND(col_timestamp_6_key) % 10000, 0, 1),
+                      col_timestamp_6_key);
+
+SELECT col_datetime_5 AS c1 FROM t1
 WHERE col_time_2_not_null = GREATEST(CURRENT_DATE(),col_timestamp_6_key)
 ORDER BY 1;
-let $assert_text= No rows should be returned;
-let $assert_debug= SELECT * FROM t1;
---source include/assert.inc
 DROP TABLE t1;
 
 #


### PR DESCRIPTION
The previously added asserts confirmed that the failure happens when
CURRENT_TIMESTAMP() at INSERT time has four trailing zeroes in
microseconds, comparing equal to TIME(2). Fix by checking if that's
the case and adding one microsecond.

(cherry picked from commit 116b01a347d68724c4e0545cc37304c60edf1261)

http://jenkins.percona.com/job/mysql-5.7-param/845/