### PR TITLE
Fix bug 1684078 (Test rpl.rpl_server_uuid is unstable)

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_server_uuid.test
+++ b/mysql-test/suite/rpl/t/rpl_server_uuid.test
@@ -272,8 +272,8 @@ eval CHANGE MASTER TO
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
 # Grep only after the message that the server_2 has connected to the master
 --let $assert_only_after=Start binlog_dump to master_thread_id\($slave_thread_id\)
---let $assert_count= 1
 --let $assert_select=found a zombie dump thread with the same UUID
+--let $assert_match= ($assert_select)+
 --let $assert_text= Found the expected line in master's error log for server 2 disconnection
 --source include/assert_grep.inc
 
@@ -300,6 +300,8 @@ eval CHANGE MASTER TO
 # Assert only the occurrences after the last CHANGE MASTER
 --let $assert_only_after=CHANGE MASTER .* executed
 --let $assert_select= Slave .* Got fatal error .* from master .* slave with the same server_uuid/server_id as this slave
+--let $assert_match=
+--let $assert_count= 1
 --let $assert_text= Found the expected line in server 2 error log
 --source include/assert_grep.inc
 


### PR DESCRIPTION
Slaves reconnecting to master due to network I/O syscall interrupt
might result in extra zombie binlog dump threads killed on the
master.  Fix the master error log grep asserts to expect this.

http://jenkins.percona.com/job/percona-server-5.6-param/1845/