### PR TITLE
Add diagnostics for bug 1684114 (Test rpl.rpl_stm_mixed_mts_rec_crash…

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_percona_bug1092593-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_percona_bug1092593-slave.opt
@@ -1,1 +1,1 @@
---relay-log-recovery=1 --master-info-repository=TABLE --relay-log-info-repository=TABLE  --skip-core-file --skip-stack-trace
+--relay-log-recovery=1 --master-info-repository=TABLE --relay-log-info-repository=TABLE

--- a/mysql-test/suite/rpl/t/rpl_percona_crash_resistant_rpl-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_percona_crash_resistant_rpl-slave.opt
@@ -1,1 +1,1 @@
---relay-log-recovery=1 --master-info-repository=TABLE --relay-log-info-repository=TABLE  --skip-core-file --skip-stack-trace
+--relay-log-recovery=1 --master-info-repository=TABLE --relay-log-info-repository=TABLE

--- a/mysql-test/suite/rpl/t/rpl_row_crash_safe-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_row_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --innodb-buffer-pool-size=268435456
+--skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --innodb-buffer-pool-size=268435456

--- a/mysql-test/suite/rpl/t/rpl_row_mts_crash_safe-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_row_mts_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --innodb-buffer-pool-size=268435456
+--slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --innodb-buffer-pool-size=268435456

--- a/mysql-test/suite/rpl/t/rpl_row_mts_rec_crash_safe-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_row_mts_rec_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --innodb-buffer-pool-size=268435456
+--slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --innodb-buffer-pool-size=268435456

--- a/mysql-test/suite/rpl/t/rpl_stm_mixed_crash_safe-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_stm_mixed_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --innodb-buffer-pool-size=268435456
+--skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --innodb-buffer-pool-size=268435456

--- a/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_crash_safe-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --innodb-buffer-pool-size=268435456 
+--slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --innodb-buffer-pool-size=268435456

--- a/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_rec_crash_safe-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_rec_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --innodb-buffer-pool-size=268435456
+--slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --innodb-buffer-pool-size=268435456

--- a/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_rec_crash_safe_checksum-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_rec_crash_safe_checksum-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --binlog-checksum=NONE
+--slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --binlog-checksum=NONE

--- a/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_rec_crash_safe_small-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_stm_mixed_mts_rec_crash_safe_small-slave.opt
@@ -1,1 +1,1 @@
---skip-core-file --slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --innodb-buffer-pool-size=268435456
+--slave-transaction-retries=0 --relay-log-info-repository=TABLE --master-info-repository=TABLE --sync-master-info=1 --relay-log-recovery=1 --innodb-buffer-pool-size=268435456

--- a/mysql-test/suite/rpl/t/rpl_sync-slave.opt
+++ b/mysql-test/suite/rpl/t/rpl_sync-slave.opt
@@ -1,2 +1,1 @@
 --sync-relay-log-info=1 --relay-log-recovery=1 --innodb_file_format_check=1 --default-storage-engine=MyISAM --innodb-file-per-table=0
---skip-core-file


### PR DESCRIPTION
…_safe_checksum is unstable)

Remove redundant --skip-core-file options from rpl testcases that kill
the server with SIGKILL. This signal does not dump core in any case,
and it prevents other useful signals such as SIGABRT from dumping
one.