### PR TITLE
Fix bug 1684264 (Test innodb.monitor is unstable)

### DIFF
--- a/mysql-test/suite/innodb/t/monitor.test
+++ b/mysql-test/suite/innodb/t/monitor.test
@@ -394,40 +394,37 @@ CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 
 let $innodb_monitor_enable = `SELECT @@innodb_monitor_enable`;
 
---replace_regex /[1-9]/NNNN/
 SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME
 LIKE 'buffer_page_written_index_leaf';
 
 SET GLOBAL innodb_monitor_enable='module_buffer_page';
 INSERT INTO t1 VALUES (1), (2), (3), (4); FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
---replace_regex /[1-9]/NNNN/
+--replace_regex /[1-9]\d*/NNNN/
 SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME
 LIKE 'buffer_page_written_index_leaf';
 
 SET GLOBAL innodb_monitor_disable='module_buffer_page';
 SET GLOBAL innodb_monitor_reset_all='module_buffer_page';
---replace_regex /[1-9]/NNNN/
 SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME
 LIKE 'buffer_page_written_index_leaf';
 
 SET GLOBAL innodb_monitor_enable='%';
 INSERT INTO t1 VALUES (5), (6), (7), (8); FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
---replace_regex /[1-9]/NNNN/
+--replace_regex /[1-9]\d*/NNNN/
 SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME
 LIKE 'buffer_page_written_index_leaf';
 
 SET GLOBAL innodb_monitor_disable='%';
 SET GLOBAL innodb_monitor_reset_all='%';
---replace_regex /[1-9]/NNNN/
 SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME
 LIKE 'buffer_page_written_index_leaf';
 
 SET GLOBAL innodb_monitor_enable='ALL';
 INSERT INTO t1 VALUES (9), (10), (11), (12); FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
---replace_regex /[1-9]/NNNN/
+--replace_regex /[1-9]\d*/NNNN/
 SELECT NAME, COUNT FROM INFORMATION_SCHEMA.INNODB_METRICS WHERE NAME
 LIKE 'buffer_page_written_index_leaf';
 


### PR DESCRIPTION
Replace regexs to accept any positive integer for
buffer_page_written_index_leaf value after some workload. The exact
value is not recorded as purge from a previous testcase might be
running in parallel. Remove regexs where the expected counter value is
zero.

http://jenkins.percona.com/job/percona-server-5.6-param/1848/
