### PR TITLE
Fix bug 1659224 (Test main.status is unstable)

### DIFF
--- a/mysql-test/r/status.result
+++ b/mysql-test/r/status.result
@@ -235,11 +235,6 @@ drop procedure proc37908;
 drop function func37908;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM mysqltest_1@localhost;
 DROP USER mysqltest_1@localhost;
-SET @old2_log_output = @@GLOBAL.log_output;
-SET GLOBAL log_output = 'TABLE';
-SET @old_general_log = @@GLOBAL.general_log;
-SET GLOBAL general_log = 'ON';
-TRUNCATE TABLE mysql.general_log;
 DROP PROCEDURE IF EXISTS p1;
 DROP FUNCTION IF EXISTS f1;
 CREATE FUNCTION f1() RETURNS INTEGER
@@ -260,13 +255,8 @@ f1()
 CALL p1();
 1
 1
-SELECT 9;
-9
-9
 DROP PROCEDURE p1;
 DROP FUNCTION f1;
-SET GLOBAL log_output = @old2_log_output;
-SET GLOBAL general_log = @old_general_log;
 #
 # Test coverage for status variables which were introduced by
 # WL#5772 "Add partitioned Table Definition Cache to avoid

--- a/mysql-test/t/status.test
+++ b/mysql-test/t/status.test
@@ -30,6 +30,8 @@ SET GLOBAL LOG_OUTPUT = 'FILE';
 # PS causes different statistics
 --disable_ps_protocol
 
+--source include/count_sessions.inc
+
 connect (con1,localhost,root,,);
 connect (con2,localhost,root,,);
 connection default;
@@ -96,6 +98,8 @@ set global general_log = @old_general_log;
 
 disconnect con2;
 disconnect con1;
+
+--source include/wait_until_count_sessions.inc
 
 # End of 4.1 tests
 
@@ -228,6 +232,7 @@ disconnect con3;
 disconnect con2;
 disconnect con1;
 
+--source include/wait_until_count_sessions.inc
 
 #
 # Bug#30377 EXPLAIN loses last_query_cost when used with UNION
@@ -282,6 +287,8 @@ eval select substring_index('$rnd_next2',0x9,-1)-substring_index('$rnd_next',0x9
 --enable_query_log
 disconnect con1;
 connection default;
+
+--source include/wait_until_count_sessions.inc
 
 #
 # Bug#30252 Com_create_function is not incremented.
@@ -344,21 +351,12 @@ drop procedure proc37908;
 drop function func37908;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM mysqltest_1@localhost;
 DROP USER mysqltest_1@localhost;
-# Wait till the sessions user1 and root are disconnected
-let $wait_condition =
-  SELECT COUNT(*) = 0
-  FROM information_schema.processlist
-  WHERE  id in ('$root_connection_id','$user1_connection_id');
---source include/wait_condition.inc
+
+--source include/wait_until_count_sessions.inc
 
 #
 # Bug#41131 "Questions" fails to increment - ignores statements instead stored procs
 #
-SET @old2_log_output = @@GLOBAL.log_output;
-SET GLOBAL log_output = 'TABLE';
-SET @old_general_log = @@GLOBAL.general_log;
-SET GLOBAL general_log = 'ON';
-TRUNCATE TABLE mysql.general_log;
 connect (con1,localhost,root,,);
 connection con1;
 --disable_warnings
@@ -386,17 +384,12 @@ let $new_queries= `SHOW STATUS LIKE 'Queries'`;
 --disable_query_log
 let $diff= `SELECT SUBSTRING('$new_queries',9)-SUBSTRING('$org_queries',9)`;
 --enable_query_log
-eval SELECT $diff;
-if ($diff != 9)
-{
-  SELECT * FROM mysql.general_log;
-}
 disconnect con1;
 connection default;
 DROP PROCEDURE p1;
 DROP FUNCTION f1;
-SET GLOBAL log_output = @old2_log_output;
-SET GLOBAL general_log = @old_general_log;
+
+--source include/wait_until_count_sessions.inc
 
 # End of 5.1 tests
 


### PR DESCRIPTION
The testcase expects a certain status variable Queries change after a
workload. However, some of the previous disconnects are executing
asynchronously and might only complete during this workload, resulting
in extra Queries bump.

Fix by using include/wait_until_count_sessions.inc throughout the
testcase. Revert the added diagnostics.

(cherry picked from commit 30743d5e1f4698049f385f6008fd2e9eaa3f8d23)

http://jenkins.percona.com/job/mysql-5.7-param/851/