### PR TITLE
Bug 1650294: Test main.audit_log_filter_users is unstable

### DIFF
--- a/mysql-test/r/audit_log_filter_users.result
+++ b/mysql-test/r/audit_log_filter_users.result
@@ -56,9 +56,6 @@ NULL	NULL
 SET GLOBAL audit_log_flush=ON;
 SET GLOBAL audit_log_flush=ON;
 SET GLOBAL audit_log_include_accounts= '';
-SELECT 'skip this';
-skip this
-skip this
 SELECT 'user1';
 user1
 user1
@@ -77,13 +74,7 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SELECT 'skip this';
-skip this
-skip this
 SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooongusername@veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooonghostname';
-SELECT 'skip this';
-skip this
-skip this
 SELECT 'user1';
 user1
 user1
@@ -102,13 +93,7 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SELECT 'skip this';
-skip this
-skip this
 SET GLOBAL audit_log_include_accounts= NULL;
-SELECT 'skip this';
-skip this
-skip this
 SELECT 'user1';
 user1
 user1
@@ -127,13 +112,7 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SELECT 'skip this';
-skip this
-skip this
 SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%';
-SELECT 'skip this';
-skip this
-skip this
 SELECT 'user1';
 user1
 user1
@@ -152,9 +131,6 @@ admin
 SELECT 'us,er1';
 us,er1
 us,er1
-SELECT 'skip this';
-skip this
-skip this
 SET GLOBAL audit_log_exclude_accounts= NULL;
 set global audit_log_flush= ON;
 ===================================================================

--- a/mysql-test/t/audit_log_default_db.test
+++ b/mysql-test/t/audit_log_default_db.test
@@ -37,31 +37,36 @@ connect (test,localhost,user1,111,db2,);
 connection test;
 SELECT * FROM t;
 
+--source include/count_sessions.inc
 connect (root,localhost,root,,,);
 connection root;
 INSTALL PLUGIN audit_log SONAME 'audit_log.so';
 disconnect root;
---source include/wait_until_disconnected.inc
 connection test;
+--source include/wait_until_count_sessions.inc
 
 SELECT * FROM t;
 use 	`db1`;
 --error ER_DBACCESS_DENIED_ERROR
 change_user user2,111,db1;
 disconnect test;
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 --replace_result $MASTER_MYPORT MASTER_MYPORT $MASTER_MYSOCK MASTER_MYSOCK
 --error ER_DBACCESS_DENIED_ERROR
 connect (test,localhost,user2,111,db1,);
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 --replace_result $MASTER_MYPORT MASTER_MYPORT $MASTER_MYSOCK MASTER_MYSOCK
 --error ER_ACCESS_DENIED_ERROR
 connect (test,localhost,user2,112,db2,);
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 --replace_result $MASTER_MYPORT MASTER_MYPORT $MASTER_MYSOCK MASTER_MYSOCK
 --error ER_ACCESS_DENIED_ERROR
 connect (test,localhost,user3,111,db2,);
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 connect (test,localhost,user2,111,db2,);
 connection test;
 set names utf8;
@@ -77,11 +82,9 @@ SELECT * FROM t;
 use ąžąžąžą;
 SELECT * FROM t;
 disconnect test;
---source include/wait_until_disconnected.inc
-
 connection default;
+--source include/wait_until_count_sessions.inc
 
---source include/count_sessions.inc
 --exec $MYSQL --user=user1 --password=111 test -e "use db1; SELECT * FROM t;"
 --source include/wait_until_count_sessions.inc
 

--- a/mysql-test/t/audit_log_echo.inc
+++ b/mysql-test/t/audit_log_echo.inc
@@ -8,20 +8,16 @@ perl;
   print "===================================================================\n";
   open my $file, $ENV{'log_file'} . '.copy' or die "Can not open log: $!";
   while ($line = <$file>) {
-    if ($line =~ /skip this/) {
-      # skip this
-      next;
-    }
     if ($line =~ /SET NAMES/) {
       # change_user does automatic reconnect and messing up 'SET NAMES' around
       next;
     }
     if ($line =~ /Threads_connected/ || $line =~ /SELECT \d <= \d/) {
-      # part of waitwait_until_count_sessions.inc script
+      # part of wait_until_count_sessions.inc script
       next;
     }
     if ($line =~ /^"Audit"/) {
-      # skip opening log record
+      # skip opening log record and disconnect record
       next;
     }
     $line =~ s/"([a-zA-Z_ ]*)","([0-9]+)_[0-9_ :T-]*","[0-9_ :A-Z-]*"/"$1","<ID>","<DATETIME>"/;

--- a/mysql-test/t/audit_log_filter_events.inc
+++ b/mysql-test/t/audit_log_filter_events.inc
@@ -1,16 +1,18 @@
-SELECT 'skip this';
+--source include/count_sessions.inc
 
 connect (test,127.0.0.1,user1,password1,,$MASTER_PORT,);
 connection test;
 SELECT 'user1';
 disconnect test;
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 
 connect (test,localhost,user22,password1,,);
 connection test;
 SELECT 'user22';
 disconnect test;
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 
 connect (test,localhost,22user,password1,,);
 connection test;
@@ -18,19 +20,24 @@ SELECT '22user';
 change_user user22,password1;
 SELECT 'user22';
 disconnect test;
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 
 connect (test,127.0.0.1,admin,password1,,$MASTER_PORT,);
 connection test;
 SELECT 'admin';
 disconnect test;
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 
 connect (test,localhost,"us,er1",password1,,);
 connection test;
 SELECT 'us,er1';
 disconnect test;
---source include/wait_until_disconnected.inc
+connection default;
+--source include/wait_until_count_sessions.inc
 
 connection default;
-SELECT 'skip this';
+
+connection default;
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
The source of instability is the fact that event of creating new
connection and closing previous one are not synchronized. It makes
"Quit" record to appear after "Connect" one.

It cannot be easily resolved even with using debug_sync. Simplest fix is
to grep "Quit" events away.