### PR TITLE
Bug #1686934: Test rpl_semi_sync_ack_thread is failing on 5.7

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_semi_sync_ack_thread.result
+++ b/mysql-test/suite/rpl/r/rpl_semi_sync_ack_thread.result
@@ -10,6 +10,7 @@ Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection server_1]
 CALL mtr.add_suppression("Semi-sync master failed on net_flush().*");
+call mtr.add_suppression("Slave SQL.*Request to stop slave SQL Thread received while applying a group that has non-transactional changes; waiting for completion of the group");
 ####################################################################
 # Test Case: semisync master can be enabled and disabled sucessfully
 # without any live slave connection and also test ON, OFF can be set
@@ -196,8 +197,9 @@ SET GLOBAL debug= 'd,dbug.before_get_MASTER_UUID';
 include/install_semisync_slave.inc
 Warnings:
 Note	3084	Replication thread(s) for channel '' are already stopped.
+SET DEBUG_SYNC= 'now WAIT_FOR in_get_master_version_and_clock';
 SET GLOBAL debug= @save_debug;
-SET debug_sync= 'now SIGNAL signal.get_master_uuid';
+SET DEBUG_SYNC= 'now SIGNAL signal.get_master_uuid';
 include/wait_for_slave_io_to_stop.inc
 CHANGE MASTER TO master_retry_count = 10,
 master_connect_retry = 1;

--- a/mysql-test/suite/rpl/t/rpl_semi_sync_ack_thread.test
+++ b/mysql-test/suite/rpl/t/rpl_semi_sync_ack_thread.test
@@ -23,6 +23,8 @@
 # "Semi-sync master failed on net_flush() before waiting for slave reply"
 CALL mtr.add_suppression("Semi-sync master failed on net_flush().*");
 
+call mtr.add_suppression("Slave SQL.*Request to stop slave SQL Thread received while applying a group that has non-transactional changes; waiting for completion of the group");
+
 --echo ####################################################################
 --echo # Test Case: semisync master can be enabled and disabled sucessfully
 --echo # without any live slave connection and also test ON, OFF can be set
@@ -240,8 +242,9 @@ SET GLOBAL debug= 'd,dbug.before_get_MASTER_UUID';
 --source include/install_semisync_slave.inc
 
 # Clear the debug point and signal IO thread to resume
+SET DEBUG_SYNC= 'now WAIT_FOR in_get_master_version_and_clock';
 SET GLOBAL debug= @save_debug;
-SET debug_sync= 'now SIGNAL signal.get_master_uuid';
+SET DEBUG_SYNC= 'now SIGNAL signal.get_master_uuid';
 
 # It should be stopped by add_slave failure
 --source include/wait_for_slave_io_to_stop.inc


### PR DESCRIPTION
Test sets up a debug sync point "before_get_MASTER_UUID". This sync
point emits signal in_get_master_version_and_clock and waits for
singal get_master_uuid. The fix is to consume signal
in_get_master_version_and_clock as we care only about "wait for" part
in this test.