### PR TITLE
Bug#1687386: Test innodb.create_tablespace is failing on 5.7

### DIFF
--- a/mysql-test/suite/innodb/t/create_tablespace.test
+++ b/mysql-test/suite/innodb/t/create_tablespace.test
@@ -241,10 +241,14 @@ DROP TABLESPACE `undo002`;
 --echo # Test various forms of ADD DATAFILE
 --echo #
 
---mkdir $MYSQL_TMP_DIR/tablespace.ibd
+--error 0,1
 --rmdir $MYSQL_TMP_DIR/tablespace.ibd
 --mkdir $MYSQL_TMP_DIR/tablespace.ibd
+--error 0,1
+--rmdir $MYSQL_TMP_DIR/s2_#_dir
 --mkdir $MYSQL_TMP_DIR/s2_#_dir
+--error 0,1
+--rmdir $MYSQL_TMP_DIR/test
 --mkdir $MYSQL_TMP_DIR/test
 
 CREATE TABLESPACE s_def ADD DATAFILE 's_def.ibd' ENGINE=InnoDB;


### PR DESCRIPTION
Test was failing on command mkdir $MYSQL_TMP_DIR/tablespace.ibd. The
reason is that, although we create this directory in tmp dir, the
directory itself can be already present in tmp dir. The fix is to
try remove the directory before creating it.