### PR TITLE
Bug#1687432 rpl.rpl_read_only is failing on 5.7

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_percona_userstat.result
+++ b/mysql-test/suite/rpl/r/rpl_percona_userstat.result
@@ -53,3 +53,4 @@ SET GLOBAL userstat=@master_userstat_saved;
 DROP TABLE t1, t2;
 DROP TABLE t3;
 include/rpl_end.inc
+CHANGE REPLICATION FILTER REPLICATE_DO_TABLE=();

--- a/mysql-test/suite/rpl/t/rpl_percona_userstat.test
+++ b/mysql-test/suite/rpl/t/rpl_percona_userstat.test
@@ -74,3 +74,6 @@ SET GLOBAL userstat=@master_userstat_saved;
 DROP TABLE t1, t2;
 DROP TABLE t3;
 --source include/rpl_end.inc
+
+connection slave;
+CHANGE REPLICATION FILTER REPLICATE_DO_TABLE=();


### PR DESCRIPTION
The test was failing because test run before it : rpl_percona_userstart
failed to clear REPLICATION FILTER. Thus user table was not replicated
in this test.