### PR TITLE
Bug#1687600 Test innodb.innodb_file_limit_check is failing on 5.7

### DIFF
--- a/mysql-test/suite/innodb/t/innodb_file_limit_check.test
+++ b/mysql-test/suite/innodb/t/innodb_file_limit_check.test
@@ -6,7 +6,7 @@ CALL mtr.add_suppression("innodb_open_files should not be greater than the open_
 
 CREATE TABLE t1 (a INT)ENGINE=INNODB PARTITION BY HASH(a) PARTITIONS 1024;
 --echo # Setting innodb_open_files to a very high value to achieve synchronicity across various platforms
-let $restart_parameters = restart: --innodb_open_files=1000000;
+let $restart_parameters = restart: --innodb_open_files=2000000;
 -- source include/restart_mysqld.inc
 
 let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;


### PR DESCRIPTION
The test was failing when allowed number of innodb_open_files was
greater than limit set in this test i.e. 1000000. innodb_open_files
on Percona Jenkins machines can reach number higher than that.
On tested Jenkins machine it was 1048576. The fix was to set limit
to higher value i.e. 2000000.