### PR TITLE
MYR-124 : START TRANSACTION WITH CONSISTENT SNAPSHOT behaves different

### DIFF
--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_snapshot.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_snapshot.result
@@ -23,7 +23,7 @@ INSERT INTO t1 VALUES(1);
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 Warnings:
-Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	RocksDB: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
 Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
 ROLLBACK;
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;

--- a/mysql-test/suite/rocksdb/include/consistent_snapshot.inc
+++ b/mysql-test/suite/rocksdb/include/consistent_snapshot.inc
@@ -7,10 +7,6 @@
 # Save the initial number of concurrent sessions
 --source include/count_sessions.inc
 
---disable_warnings
-DROP TABLE IF EXISTS t1;
---enable_warnings
-
 connect (con1,localhost,root,,);
 connect (con2,localhost,root,,);
 
@@ -22,10 +18,7 @@ eval SET SESSION TRANSACTION ISOLATION LEVEL $trx_isolation;
 # While a consistent snapshot transaction is executed,
 # no external inserts should be visible to the transaction.
 # But it should only work this way for REPEATABLE-READ and SERIALIZABLE
-
---error 0,ER_UNKNOWN_ERROR
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
---echo ERROR: $mysql_errno
 
 connection con2;
 select * from information_schema.rocksdb_dbstats where stat_type='DB_NUM_SNAPSHOTS';
@@ -38,9 +31,7 @@ connection con2;
 select * from information_schema.rocksdb_dbstats where stat_type='DB_NUM_SNAPSHOTS';
 
 connection con1;
---error 0,ER_UNKNOWN_ERROR
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
---echo ERROR: $mysql_errno
 
 connection con2;
 INSERT INTO t1 (a) VALUES (1);
@@ -79,9 +70,7 @@ SELECT * FROM r1; # 5
 COMMIT;
 SELECT * FROM r1; # 6
 
---error 0,ER_UNKNOWN_ERROR
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
---echo ERROR: $mysql_errno
 
 connection con2;
 INSERT INTO r1 values (7,7,7);
@@ -97,17 +86,13 @@ SELECT * FROM r1; # 6
 COMMIT;
 SELECT * FROM r1; # 8
 
---error 0,ER_UNKNOWN_ERROR
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
---echo ERROR: $mysql_errno
 
 connection con2;
 INSERT INTO r1 values (9,9,9);
 
 connection con1;
---error 0,ER_UNKNOWN_ERROR
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
---echo ERROR: $mysql_errno
 
 connection con2;
 INSERT INTO r1 values (10,10,10);
@@ -115,13 +100,10 @@ INSERT INTO r1 values (10,10,10);
 connection con1;
 SELECT * FROM r1; # 9
 
---error 0,ER_UNKNOWN_ERROR
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
---echo ERROR: $mysql_errno
-# Succeeds with Read Committed, Fails with Repeatable Read
---error 0,ER_UNKNOWN_ERROR
+
+--error ER_UNKNOWN_ERROR
 INSERT INTO r1 values (11,11,11);
---echo ERROR: $mysql_errno
 SELECT * FROM r1; # self changes should be visible
 
 
@@ -133,4 +115,3 @@ disconnect con2;
 
 
 --source include/wait_until_count_sessions.inc
-

--- a/mysql-test/suite/rocksdb/r/cons_snapshot_read_committed.result
+++ b/mysql-test/suite/rocksdb/r/cons_snapshot_read_committed.result
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS t1;
 connect  con1,localhost,root,,;
 connect  con2,localhost,root,,;
 connection con1;
@@ -6,9 +5,8 @@ CREATE TABLE t1 (a INT, pk INT AUTO_INCREMENT PRIMARY KEY) ENGINE=ROCKSDB;
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 Warnings:
-Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	RocksDB: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
 Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
-ERROR: 0
 connection con2;
 select * from information_schema.rocksdb_dbstats where stat_type='DB_NUM_SNAPSHOTS';
 STAT_TYPE	VALUE
@@ -22,9 +20,8 @@ DB_NUM_SNAPSHOTS	0
 connection con1;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 Warnings:
-Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	RocksDB: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
 Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
-ERROR: 0
 connection con2;
 INSERT INTO t1 (a) VALUES (1);
 connection con1;
@@ -76,9 +73,8 @@ id	value	value2
 6	6	6
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 Warnings:
-Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	RocksDB: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
 Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
-ERROR: 0
 connection con2;
 INSERT INTO r1 values (7,7,7);
 connection con1;
@@ -117,17 +113,15 @@ id	value	value2
 8	8	8
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 Warnings:
-Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	RocksDB: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
 Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
-ERROR: 0
 connection con2;
 INSERT INTO r1 values (9,9,9);
 connection con1;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 Warnings:
-Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	RocksDB: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
 Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
-ERROR: 0
 connection con2;
 INSERT INTO r1 values (10,10,10);
 connection con1;
@@ -145,11 +139,10 @@ id	value	value2
 10	10	10
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
 Warnings:
-Warning	138	Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
+Warning	138	RocksDB: Only REPEATABLE READ isolation level is supported for START TRANSACTION WITH CONSISTENT SNAPSHOT in RocksDB Storage Engine. Snapshot has not been taken.
 Warning	138	InnoDB: WITH CONSISTENT SNAPSHOT was ignored because this phrase can only be used with REPEATABLE READ isolation level.
-ERROR: 0
 INSERT INTO r1 values (11,11,11);
-ERROR: 1105
+ERROR HY000: Can't execute updates when you started a transaction with START TRANSACTION WITH CONSISTENT SNAPSHOT.
 SELECT * FROM r1;
 id	value	value2
 1	1	1

--- a/mysql-test/suite/rocksdb/r/cons_snapshot_repeatable_read.result
+++ b/mysql-test/suite/rocksdb/r/cons_snapshot_repeatable_read.result
@@ -1,11 +1,9 @@
-DROP TABLE IF EXISTS t1;
 connect  con1,localhost,root,,;
 connect  con2,localhost,root,,;
 connection con1;
 CREATE TABLE t1 (a INT, pk INT AUTO_INCREMENT PRIMARY KEY) ENGINE=ROCKSDB;
 SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 0
 connection con2;
 select * from information_schema.rocksdb_dbstats where stat_type='DB_NUM_SNAPSHOTS';
 STAT_TYPE	VALUE
@@ -18,7 +16,6 @@ STAT_TYPE	VALUE
 DB_NUM_SNAPSHOTS	0
 connection con1;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 0
 connection con2;
 INSERT INTO t1 (a) VALUES (1);
 connection con1;
@@ -67,7 +64,6 @@ id	value	value2
 5	5	5
 6	6	6
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 0
 connection con2;
 INSERT INTO r1 values (7,7,7);
 connection con1;
@@ -102,12 +98,10 @@ id	value	value2
 7	7	7
 8	8	8
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 0
 connection con2;
 INSERT INTO r1 values (9,9,9);
 connection con1;
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 0
 connection con2;
 INSERT INTO r1 values (10,10,10);
 connection con1;
@@ -123,9 +117,8 @@ id	value	value2
 8	8	8
 9	9	9
 START TRANSACTION WITH CONSISTENT SNAPSHOT;
-ERROR: 0
 INSERT INTO r1 values (11,11,11);
-ERROR: 1105
+ERROR HY000: Can't execute updates when you started a transaction with START TRANSACTION WITH CONSISTENT SNAPSHOT.
 SELECT * FROM r1;
 id	value	value2
 1	1	1

--- a/mysql-test/suite/rocksdb/t/cons_snapshot_read_committed.test
+++ b/mysql-test/suite/rocksdb/t/cons_snapshot_read_committed.test
@@ -1,6 +1,5 @@
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 
 let $trx_isolation = READ COMMITTED;
 
 --source suite/rocksdb/include/consistent_snapshot.inc
-

--- a/mysql-test/suite/rocksdb/t/cons_snapshot_repeatable_read.test
+++ b/mysql-test/suite/rocksdb/t/cons_snapshot_repeatable_read.test
@@ -1,6 +1,5 @@
---source include/have_rocksdb_as_default.inc
+--source include/have_rocksdb.inc
 
 let $trx_isolation = REPEATABLE READ;
 
 --source suite/rocksdb/include/consistent_snapshot.inc
-

--- a/mysql-test/suite/rocksdb/t/disabled.def
+++ b/mysql-test/suite/rocksdb/t/disabled.def
@@ -1,6 +1,4 @@
 compression_zstd : MYR-28 - Percona Server requires compilation with zstd
-cons_snapshot_read_committed : MYR-124 - Percona Server with MyRocks has different behavior of STWCS
-cons_snapshot_repeatable_read : MYR-124 - Percona Server with MyRocks has different behavior of STWCS
 cons_snapshot_serializable : MyRocks does not yet support ISO serializable
 level_read_uncommitted : MyRocks does not yet suppore ISO read uncommitted
 level_serializable : MyRocks does not yet support ISO serializable

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2863,10 +2863,10 @@ static int rocksdb_start_tx_and_assign_read_view(
     tx->acquire_snapshot(true);
   } else {
     push_warning_printf(thd, Sql_condition::SL_WARNING, HA_ERR_UNSUPPORTED,
-                        "Only REPEATABLE READ isolation level is supported "
-                        "for START TRANSACTION WITH CONSISTENT SNAPSHOT "
-                        "in RocksDB Storage Engine. Snapshot has not been "
-                        "taken.");
+                        "RocksDB: Only REPEATABLE READ isolation level is "
+                        "supported for START TRANSACTION WITH CONSISTENT "
+                        "SNAPSHOT in RocksDB Storage Engine. Snapshot has not "
+                        "been taken.");
   }
   return HA_EXIT_SUCCESS;
 }


### PR DESCRIPTION
- MYR-16 : myrocks/webscale uses different method to implement START
           TRANSACTION WITH CONSISTENT SNAPSHOT
  - This is where we diverged from upstream Facebook MySQL to make STWCS
    behave more like upstream Oracle MySQL in that is just returns SQL warning
    but not an error. Tests were unstable then so were never corrected.
- Corrected SQL warning to indicate the source of the warning is RocksDB.
- Enabled, fixed, and re-recorded snapshot tests to capture current, correct
  behavior in results.