### PR TITLE
Bug#1688542: Test test_service_sql_api.test_sql_errors is failing on …

### DIFF
--- a/mysql-test/suite/test_service_sql_api/r/test_sql_errors.result
+++ b/mysql-test/suite/test_service_sql_api/r/test_sql_errors.result
@@ -101,6 +101,25 @@ ID	USER	HOST	DB	COMMAND	TIME	STATE	INFO	TIME_MS	ROWS_SENT	ROWS_EXAMINED
 ##########################################
 # Cleanup
 ##########################################
+CREATE PROCEDURE kill_sleeping_threads()
+BEGIN
+DECLARE done INT DEFAULT FALSE;
+DECLARE thread_id INT;
+DECLARE thread_id_curr CURSOR FOR SELECT ID FROM information_schema.processlist WHERE STATE = 'Sleep';
+DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+OPEN thread_id_curr;
+kill_sleeping_threads_loop: LOOP
+FETCH thread_id_curr INTO thread_id;
+IF done THEN
+LEAVE kill_sleeping_threads_loop;
+END IF;
+KILL thread_id;
+END LOOP;
+CLOSE thread_id_curr;
+END//
+CALL kill_sleeping_threads();
+DROP PROCEDURE kill_sleeping_threads;
+# Kill and restart
 # Dropping the created tables
 DROP TABLE IF EXISTS t_int;
 DROP TABLE IF EXISTS t_bigint;

--- a/mysql-test/suite/test_service_sql_api/t/test_sql_errors.test
+++ b/mysql-test/suite/test_service_sql_api/t/test_sql_errors.test
@@ -113,6 +113,34 @@ UNINSTALL PLUGIN test_sql_errors;
 --echo # Cleanup
 --echo ##########################################
 
+delimiter //;
+
+CREATE PROCEDURE kill_sleeping_threads()
+BEGIN
+  DECLARE done INT DEFAULT FALSE;
+  DECLARE thread_id INT;
+  DECLARE thread_id_curr CURSOR FOR SELECT ID FROM information_schema.processlist WHERE STATE = 'Sleep';
+  DECLARE CONTINUE HANDLER FOR NOT FOUND SET done = TRUE;
+
+  OPEN thread_id_curr;
+
+  kill_sleeping_threads_loop: LOOP
+    FETCH thread_id_curr INTO thread_id;
+    IF done THEN
+      LEAVE kill_sleeping_threads_loop;
+    END IF;
+    KILL thread_id;
+  END LOOP;
+
+  CLOSE thread_id_curr;
+END//
+
+delimiter ;//
+CALL kill_sleeping_threads();
+DROP PROCEDURE kill_sleeping_threads;
+
+--source include/kill_and_restart_mysqld.inc
+
 --echo # Dropping the created tables
 DROP TABLE IF EXISTS t_int;
 DROP TABLE IF EXISTS t_bigint;


### PR DESCRIPTION
…5.7 trunk

This test was creating 5 sessions from test plugin. These sessions were
meant to outlive the test plugin after it had been unloaded. However,
after the plugin was unloaded it was not possible to kill or close the
opened sessions, thus the check at the end of the test reported
existing threads. The fix was to remove opening of the sessions.
In test_sql_errors.cc there was a comment from upstream that suggested
that this test violets mtr post condition and was disabled from regular
test runs:

/* Disabled open without close as these 5 sessions stay open until
server shutdow, That violates the rules of a valid regression test. */