### PR TITLE
Fix bug 1622985 (Successful doublewrite recovery should not be a warn…

### DIFF
--- a/storage/innobase/trx/trx0sys.c
+++ b/storage/innobase/trx/trx0sys.c
@@ -730,7 +730,7 @@ trx_sys_doublewrite_init_or_restore_pages(
 				    TRUE, read_buf, zip_size))) {
 
 				fprintf(stderr,
-					"InnoDB: Warning: database page"
+					"InnoDB: Database page"
 					" corruption or a failed\n"
 					"InnoDB: file read of"
 					" space %lu page %lu.\n"


### PR DESCRIPTION
…ing)

Downgrade diagnostics severity from warning to regular note if the
doublewrite user has been used for crash recovery.

http://jenkins.percona.com/job/percona-server-5.5-param/1551/