### PR TITLE
my-default.cnf is no longer exists

### DIFF
--- a/build-ps/debian/percona-server-server-5.7.install
+++ b/build-ps/debian/percona-server-server-5.7.install
@@ -104,7 +104,6 @@ usr/lib/mysql/plugin/debug/query_response_time.so
 # support files
 usr/share/mysql/dictionary.txt
 usr/share/mysql/magic
-usr/share/mysql/my-default.cnf
 usr/share/mysql/mysql-log-rotate
 usr/share/mysql/mysql-systemd-start
 usr/share/mysql/mysqld_multi.server

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -599,7 +599,6 @@ fi
 %doc %{?license_files_server}
 %doc %{src_dir}/Docs/INFO_SRC*
 %doc release/Docs/INFO_BIN*
-%doc release/support-files/my-default.cnf
 %attr(644, root, root) %{_mandir}/man1/innochecksum.1*
 %attr(644, root, root) %{_mandir}/man1/my_print_defaults.1*
 %attr(644, root, root) %{_mandir}/man1/myisam_ftdump.1*
@@ -735,7 +734,6 @@ fi
 %attr(644, root, root) %{_datadir}/percona-server/mysql_system_tables.sql
 %attr(644, root, root) %{_datadir}/percona-server/mysql_system_tables_data.sql
 %attr(644, root, root) %{_datadir}/percona-server/mysql_test_data_timezone.sql
-%attr(644, root, root) %{_datadir}/percona-server/my-*.cnf
 %attr(644, root, root) %{_datadir}/percona-server/mysql-log-rotate
 %attr(644, root, root) %{_datadir}/percona-server/mysql_security_commands.sql
 %attr(644, root, root) %{_datadir}/percona-server/dictionary.txt

--- a/build-ps/ubuntu/percona-server-server-5.7.install
+++ b/build-ps/ubuntu/percona-server-server-5.7.install
@@ -104,7 +104,6 @@ usr/lib/mysql/plugin/debug/query_response_time.so
 # support files
 usr/share/mysql/dictionary.txt
 usr/share/mysql/magic
-usr/share/mysql/my-default.cnf
 usr/share/mysql/mysql-log-rotate
 usr/share/mysql/mysql-systemd-start
 usr/share/mysql/mysqld_multi.server


### PR DESCRIPTION
The my-default.cnf.sh file (used to produce a default my-default.cnf or my-default.ini file) is no longer included in source distributions and my-default.cnf and my-default.ini are no longer included in or installed by distribution packages. (Bug #22525354)