### PR TITLE
Bug#1687600 Test innodb.innodb_file_limit_check is failing on 5.7

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_file_limit_check.result
+++ b/mysql-test/suite/innodb/r/innodb_file_limit_check.result
@@ -1,7 +1,7 @@
 CALL mtr.add_suppression("innodb_open_files should not be greater than the open_files_limit.");
 CREATE TABLE t1 (a INT)ENGINE=INNODB PARTITION BY HASH(a) PARTITIONS 1024;
 # Setting innodb_open_files to a very high value to achieve synchronicity across various platforms
-# restart: --innodb_open_files=1000000
+# restart: --innodb_open_files=over_innodb_open_files_limit
 SELECT 1 UNION SELECT * FROM t1  UNION SELECT * FROM t1  UNION
 SELECT * FROM t1  UNION SELECT * FROM t1  UNION SELECT * FROM
 t1;

--- a/mysql-test/suite/innodb/t/innodb_file_limit_check.test
+++ b/mysql-test/suite/innodb/t/innodb_file_limit_check.test
@@ -5,8 +5,12 @@
 CALL mtr.add_suppression("innodb_open_files should not be greater than the open_files_limit.");
 
 CREATE TABLE t1 (a INT)ENGINE=INNODB PARTITION BY HASH(a) PARTITIONS 1024;
+
+let $over_innodb_open_files_limit=`SELECT @@global.open_files_limit + 2000000`;
+
 --echo # Setting innodb_open_files to a very high value to achieve synchronicity across various platforms
-let $restart_parameters = restart: --innodb_open_files=2000000;
+--replace_result $over_innodb_open_files_limit over_innodb_open_files_limit
+let $restart_parameters = restart: --innodb_open_files=$over_innodb_open_files_limit;
 -- source include/restart_mysqld.inc
 
 let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;


### PR DESCRIPTION
Post push fix: recorded result file. Changed the innodb_open_files to
exceed the actual open file limit taken from the machine the test is
run on.