### PR TITLE
Add diagnostics for bug 1689489 (SHOW SLAVE STATUS truncates Relay_Ma…

### DIFF
--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -3168,13 +3168,23 @@ bool show_slave_status(THD* thd, Master_info* mi)
     protocol->store(mi->get_user(), &my_charset_bin);
     protocol->store((uint32) mi->port);
     protocol->store((uint32) mi->connect_retry);
-    protocol->store(mi->get_master_log_name(), &my_charset_bin);
+    const char * const master_log_file=
+        mi->get_master_log_name();
+    protocol->store(master_log_file, &my_charset_bin);
     protocol->store((ulonglong) mi->get_master_log_pos());
     protocol->store(mi->rli->get_group_relay_log_name() +
                     dirname_length(mi->rli->get_group_relay_log_name()),
                     &my_charset_bin);
     protocol->store((ulonglong) mi->rli->get_group_relay_log_pos());
-    protocol->store(mi->rli->get_group_master_log_name(), &my_charset_bin);
+    const char * const relay_master_log_file=
+        mi->rli->get_group_master_log_name();
+#ifndef DBUG_OFF
+    const size_t master_log_file_len= strlen(master_log_file);
+    const size_t relay_master_log_file_len= strlen(relay_master_log_file);
+#endif
+    DBUG_ASSERT((relay_master_log_file_len == master_log_file_len)
+                 || !relay_master_log_file_len || !master_log_file_len);
+    protocol->store(relay_master_log_file, &my_charset_bin);
     protocol->store(mi->slave_running == MYSQL_SLAVE_RUN_CONNECT ?
                     "Yes" : (mi->slave_running == MYSQL_SLAVE_RUN_NOT_CONNECT ?
                              "Connecting" : "No"), &my_charset_bin);


### PR DESCRIPTION
…ster_Log_File intermittently)

SHOW SLAVE STATUS returned
Master_Log_File	master-bin.000004
Relay_Master_Log_File	master-bin.00000

I.e. Relay_Master_Log_File is truncated by one character. Add an
assert to catch this condition.

http://jenkins.percona.com/job/percona-server-5.6-param/1871/