### PR TITLE
Add diagnostics for bug 1689519 (Test main.query_cache_size_functiona…

### DIFF
--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1805,6 +1805,7 @@ void plugin_shutdown(void)
       {
         sql_print_warning("Plugin '%s' will be forced to shutdown",
                           plugins[i]->name.str);
+        DBUG_ASSERT(0);
         /*
           We are forcing deinit on plugins so we don't want to do a ref_count
           check until we have processed all the plugins.


### PR DESCRIPTION
…lity is unstable)

Make the debug build crash on any plugin being in use on shutdown.

http://jenkins.percona.com/job/percona-server-5.6-param/1872/