### PR TITLE
Fix bug 1689552 (Missing synchronization between LRU manager and page…

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -2764,7 +2764,10 @@ DECLARE_THREAD(buf_flush_page_cleaner_thread)(
 	when SRV_SHUTDOWN_CLEANUP is set other threads like the master
 	and the purge threads may be working as well. We start flushing
 	the buffer pool but can't be sure that no new pages are being
-	dirtied until we enter SRV_SHUTDOWN_FLUSH_PHASE phase. */
+	dirtied until we enter SRV_SHUTDOWN_FLUSH_PHASE phase. Because
+	the LRU manager thread is also flushing at SRV_SHUTDOWN_CLEANUP
+	but not SRV_SHUTDOWN_FLUSH_PHASE, we only leave the
+	SRV_SHUTDOWN_CLEANUP loop when the LRU manager quits. */
 
 	do {
 		n_flushed = page_cleaner_do_flush_batch(PCT_IO(100), LSN_MAX);
@@ -2773,7 +2776,10 @@ DECLARE_THREAD(buf_flush_page_cleaner_thread)(
 		if (n_flushed == 0) {
 			os_thread_sleep(100000);
 		}
-	} while (srv_shutdown_state == SRV_SHUTDOWN_CLEANUP);
+
+		os_rmb;
+	} while (srv_shutdown_state == SRV_SHUTDOWN_CLEANUP
+		 || buf_lru_manager_is_active);
 
 	/* At this point all threads including the master and the purge
 	thread must have been suspended. */
@@ -2789,6 +2795,11 @@ DECLARE_THREAD(buf_flush_page_cleaner_thread)(
 	in the flush_list */
 	buf_flush_wait_batch_end(NULL, BUF_FLUSH_LIST);
 	buf_flush_wait_LRU_batch_end();
+
+#ifdef UNIV_DEBUG
+	os_rmb;
+	ut_ad(!buf_lru_manager_is_active);
+#endif
 
 	bool	success;
 
@@ -2851,6 +2862,7 @@ DECLARE_THREAD(buf_flush_lru_manager_thread)(
 #endif /* UNIV_DEBUG_THREAD_CREATION */
 
 	buf_lru_manager_is_active = true;
+	os_wmb;
 
 	/* On server shutdown, the LRU manager thread runs through cleanup
 	phase to provide free pages for the master and purge threads.  */
@@ -2869,6 +2881,7 @@ DECLARE_THREAD(buf_flush_lru_manager_thread)(
 	}
 
 	buf_lru_manager_is_active = false;
+	os_wmb;
 
 	/* We count the number of threads in os_thread_exit(). A created
 	thread should always use that to exit and not use return() to exit. */

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -3499,6 +3499,7 @@ loop:
 	before proceeding further. */
 	srv_shutdown_state = SRV_SHUTDOWN_FLUSH_PHASE;
 	count = 0;
+	os_rmb;
 	while (buf_page_cleaner_is_active || buf_lru_manager_is_active) {
 		if (srv_print_verbose_log && count == 0) {
 			ib_logf(IB_LOG_LEVEL_INFO,
@@ -3510,6 +3511,7 @@ loop:
 		if (count > 600) {
 			count = 0;
 		}
+		os_rmb;
 	}
 
 	mutex_enter(&log_sys->mutex);


### PR DESCRIPTION
… cleaner threads on shutdown)

Synchronize shutdown of LRU manager and page cleaner threads by making
the page cleaner thread loop in the SRV_SHUTDOWN_CLEANUP loop even
after srv_shutdown_state moves to SRV_SHUTDOWN_FLUSH_PHASE, until the
LRU manager thread quits. Add read/write barriers to
buf_lru_manager_is_active accesses.

http://jenkins.percona.com/job/percona-server-5.6-param/1873/