### PR TITLE
Add a testcase for bug 1689736 / 86260 (Assert on KILL'ing a stored r…

### DIFF
--- a/mysql-test/r/bug86260.result
+++ b/mysql-test/r/bug86260.result
@@ -1,0 +1,18 @@
+#
+# Bug 86260: Assert on KILL'ing a stored routine invocation
+#
+CREATE TABLE t1 (a INT);
+CREATE FUNCTION f1() RETURNS INT
+BEGIN
+INSERT INTO t1 VALUES (1);
+RETURN 1;
+END|
+SET DEBUG_SYNC= "sp_before_exec_core SIGNAL sp_ready WAIT_FOR sp_finish";
+SELECT f1();
+SET DEBUG_SYNC= "now WAIT_FOR sp_ready";
+KILL QUERY sp_con_id;
+SET DEBUG_SYNC= "now SIGNAL sp_finish";
+ERROR 70100: Query execution was interrupted
+SET DEBUG_SYNC= 'RESET';
+DROP FUNCTION f1;
+DROP TABLE t1;

--- a/mysql-test/t/bug86260.test
+++ b/mysql-test/t/bug86260.test
@@ -1,0 +1,44 @@
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+--echo #
+--echo # Bug 86260: Assert on KILL'ing a stored routine invocation
+--echo #
+
+CREATE TABLE t1 (a INT);
+
+DELIMITER |;
+
+CREATE FUNCTION f1() RETURNS INT
+BEGIN
+  INSERT INTO t1 VALUES (1);
+  RETURN 1;
+END|
+
+DELIMITER ;|
+
+--connect(con1,localhost,root)
+
+--connection default
+--let $sp_con_id= `SELECT CONNECTION_ID()`
+SET DEBUG_SYNC= "sp_before_exec_core SIGNAL sp_ready WAIT_FOR sp_finish";
+send SELECT f1();
+
+--connection con1
+SET DEBUG_SYNC= "now WAIT_FOR sp_ready";
+--replace_result $sp_con_id sp_con_id
+--eval KILL QUERY $sp_con_id
+SET DEBUG_SYNC= "now SIGNAL sp_finish";
+
+--connection default
+--error ER_QUERY_INTERRUPTED
+reap;
+
+disconnect con1;
+
+SET DEBUG_SYNC= 'RESET';
+
+DROP FUNCTION f1;
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -40,6 +40,7 @@
 #include "sql_parse.h"                          // cleanup_items
 #include "sql_base.h"                           // close_thread_tables
 #include "transaction.h"       // trans_commit_stmt
+#include "debug_sync.h"         // DEBUG_SYNC
 
 /*
   Sufficient max length of printed destinations and frame offsets (all uints).
@@ -2988,6 +2989,8 @@ sp_lex_keeper::reset_lex_and_exec_core(THD *thd, uint *nextp,
 
   if (!res)
   {
+    DEBUG_SYNC(thd, "sp_before_exec_core");
+
     res= instr->exec_core(thd, nextp);
     DBUG_PRINT("info",("exec_core returned: %d", res));
   }


### PR DESCRIPTION
…outine invocation)

5.5 is not affected by the bug. Only add the testcase and its
associated debug sync point.

http://jenkins.percona.com/job/percona-server-5.5-param/1555/