### PR TITLE
[BLD-719] new installation on debian/ubuntu installs the distribution my.cnf

### DIFF
--- a/build-ps/debian/percona-server-common-5.7.postinst
+++ b/build-ps/debian/percona-server-common-5.7.postinst
@@ -14,6 +14,13 @@ case "$1" in
 #      echo "Notice: configure-symlinks trigger could not be called."
 #      echo "Please manually make /etc/mysql/my.cnf a symlink that points to percona-server.cnf."
 #    fi
+    PKG=$(dpkg -S /etc/mysql/my.cnf | cut -d: -f 1)
+    if [ "$PKG" = "mysql-common" ]; then
+        MODIFIED=$(dpkg --verify mysql-common | grep /etc/mysql/my.cnf | wc -l)
+        if [ $MODIFIED = 0 ]; then
+            rm -rf /etc/mysql/my.cnf
+        fi
+    fi
     if [ ! -f /etc/mysql/my.cnf -o -L /etc/mysql/my.cnf ]
     then
       update-alternatives --install /etc/mysql/my.cnf my.cnf "/etc/mysql/percona-server.cnf" 200

--- a/build-ps/ubuntu/percona-server-common-5.7.postinst
+++ b/build-ps/ubuntu/percona-server-common-5.7.postinst
@@ -14,6 +14,13 @@ case "$1" in
 #      echo "Notice: configure-symlinks trigger could not be called."
 #      echo "Please manually make /etc/mysql/my.cnf a symlink that points to percona-server.cnf."
 #    fi
+    PKG=$(dpkg -S /etc/mysql/my.cnf | cut -d: -f 1)
+    if [ "$PKG" = "mysql-common" ]; then
+        MODIFIED=$(dpkg --verify mysql-common | grep /etc/mysql/my.cnf | wc -l)
+        if [ $MODIFIED = 0 ]; then
+            rm -rf /etc/mysql/my.cnf
+        fi
+    fi
     if [ ! -f /etc/mysql/my.cnf -o -L /etc/mysql/my.cnf ]
     then
       update-alternatives --install /etc/mysql/my.cnf my.cnf "/etc/mysql/percona-server.cnf" 200


### PR DESCRIPTION
Once installed on fresh installation:
Setting up percona-server-common-5.7 (5.7.18-14-1.trusty) ...
update-alternatives: using /etc/mysql/percona-server.cnf to provide /etc/mysql/my.cnf (my.cnf) in auto mode
