### PR TITLE
Fix bug 1989989 (Test innodb.percona_changed_page_bmp_requests is uns…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests.result
@@ -1,7 +1,4 @@
 RESET CHANGED_PAGE_BITMAPS;
-DROP TABLE IF EXISTS t1;
-DELETE FROM mysql.user WHERE USER='mysqltest_1';
-FLUSH PRIVILEGES;
 CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 FLUSH CHANGED_PAGE_BITMAPS;
@@ -14,6 +11,7 @@ ib_modified_log_1
 RESET CHANGED_PAGE_BITMAPS;
 After 2nd RESET
 ib_modified_log_1
+INSERT INTO t1 VALUES (6);
 After RESETs and restart:
 ib_modified_log_1
 ib_modified_log_2

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests.test
@@ -7,15 +7,7 @@
 
 RESET CHANGED_PAGE_BITMAPS;
 
---source include/count_sessions.inc
-
 let $MYSQLD_DATADIR= `select @@datadir`;
-
---disable_warnings
-DROP TABLE IF EXISTS t1;
-DELETE FROM mysql.user WHERE USER='mysqltest_1';
-FLUSH PRIVILEGES;
---enable_warnings
 
 CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -48,6 +40,9 @@ RESET CHANGED_PAGE_BITMAPS;
 --echo After 2nd RESET
 --replace_regex /_[[:digit:]]+\.xdb$//
 list_files $MYSQLD_DATADIR ib_modified_log*;
+
+# Ensure that the bitmap file is not empty at shutdown
+INSERT INTO t1 VALUES (6);
 
 # Check that the file sequence after RESET starts with 1 again
 --source include/restart_mysqld.inc
@@ -122,8 +117,6 @@ PURGE CHANGED_PAGE_BITMAPS BEFORE 100000000;
 
 connection default;
 disconnect conn1;
-
---source include/wait_until_count_sessions.inc
 
 DROP USER mysqltest_1@localhost;
 


### PR DESCRIPTION
…table)

Close to the start of the test, server restarts twice in a row with no
write workload in between. This might result in a zero-sized bitmap
file, which would then get reused on the next restart, whereas the
testcase expects a new file to be created. Fix by adding some write
workload. At the same time simplify the testcase.

http://jenkins.percona.com/job/percona-server-5.6-param/1882/