### PR TITLE
Fix bug 1688698 / 86209 (audit plugin + MB collation connection + PRE…

### DIFF
--- a/mysql-test/r/bug86209.result
+++ b/mysql-test/r/bug86209.result
@@ -1,0 +1,7 @@
+INSTALL PLUGIN null_audit SONAME 'adt_null.so';
+SET collation_connection='ucs2_general_ci';
+PREPARE foo FROM @bar;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 1
+UNINSTALL PLUGIN null_audit;
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown

--- a/mysql-test/t/bug86209-master.opt
+++ b/mysql-test/t/bug86209-master.opt
@@ -1,0 +1,1 @@
+$AUDIT_NULL_OPT

--- a/mysql-test/t/bug86209.test
+++ b/mysql-test/t/bug86209.test
@@ -1,0 +1,11 @@
+--source include/have_null_audit_plugin.inc
+
+--replace_regex /\.dll/.so/
+eval INSTALL PLUGIN null_audit SONAME '$AUDIT_NULL';
+
+SET collation_connection='ucs2_general_ci';
+
+--error ER_PARSE_ERROR
+PREPARE foo FROM @bar;
+
+UNINSTALL PLUGIN null_audit;

--- a/sql/sql_digest.cc
+++ b/sql/sql_digest.cc
@@ -597,6 +597,8 @@ sql_digest_state* digest_add_token(sql_digest_state *state,
     }
     case 0:
     {
+      if (digest_storage->m_byte_count < SIZE_OF_A_TOKEN)
+        break;
       unsigned int temp_tok;
       read_token(digest_storage,
                  digest_storage->m_byte_count-SIZE_OF_A_TOKEN,


### PR DESCRIPTION
…PARE stmt parse error crash)

Upstream revision [1] introduced code to check the previous token when
0 token is encountered. In the setup above (audit plugin + MB
collation connection + PREPARE statement with a parse error), the
previous token was also 0, thus not existing in the
digest_storage->m_token_array, and causing the previous token index
computed in digest_add_token and referenced in read_token to
overflow.

Fix by not checking the previous token if there isn't any.

(cherry picked from commit 80da7bbedcd817dd51b445c9d639d91f73149661)