### PR TITLE
Bug#1690531: Test rpl.rpl_killed_ddl is failing on 5.7

### DIFF
--- a/mysql-test/include/kill_query_and_diff_master_slave.inc
+++ b/mysql-test/include/kill_query_and_diff_master_slave.inc
@@ -19,6 +19,7 @@
 # information
 
 source include/kill_query.inc;
+source include/sync_slave_sql_with_master.inc;
 
 # Release the debug lock if used, so that the statements in
 # rpl_diff.inc will not be blocked.

--- a/mysql-test/suite/rpl/r/rpl_killed_ddl.result
+++ b/mysql-test/suite/rpl/r/rpl_killed_ddl.result
@@ -59,44 +59,56 @@ include/sync_slave_sql_with_master.inc
 [on master1]
 CREATE DATABASE d2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 ALTER DATABASE d1
 DEFAULT CHARACTER SET = 'utf8';
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP DATABASE d1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP DATABASE IF EXISTS d2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 CREATE EVENT e2
 ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 1 DAY
 DO INSERT INTO test.t1 VALUES (2);
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 ALTER EVENT e1
 ON SCHEDULE AT CURRENT_TIMESTAMP + INTERVAL 2 DAY;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP EVENT e1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP EVENT IF EXISTS e2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 CREATE FUNCTION f2 () RETURNS INT DETERMINISTIC
 RETURN 1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 ALTER FUNCTION f1 SQL SECURITY INVOKER;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP FUNCTION f1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP FUNCTION IF EXISTS f2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 CREATE PROCEDURE p2 (OUT rows INT)
 BEGIN
@@ -104,30 +116,39 @@ SELECT COUNT(*) INTO rows FROM t2;
 END;
 //
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 ALTER PROCEDURE p1 SQL SECURITY INVOKER COMMENT 'return rows of table t1';
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP PROCEDURE p1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP PROCEDURE IF EXISTS p2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 CREATE TABLE t2 (b int);
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 ALTER TABLE t1 ADD (d int);
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 RENAME TABLE t3 TO t4;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 CREATE INDEX i2 on t1 (a);
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP INDEX i1 on t1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 CREATE TABLE IF NOT EXISTS t4 (a int);
 CREATE TRIGGER tr2 BEFORE INSERT ON t4
@@ -136,27 +157,35 @@ DELETE FROM t1 WHERE a=NEW.a;
 END;
 //
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP TRIGGER tr1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP TRIGGER IF EXISTS tr2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 CREATE VIEW v2 AS SELECT a FROM t1 WHERE a > 100;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP VIEW v1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP VIEW IF EXISTS v2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP TABLE t1;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP TABLE IF EXISTS t2;
 source include/kill_query.inc;
+include/sync_slave_sql_with_master.inc
 include/rpl_diff.inc
 DROP DATABASE IF EXISTS d1;
 DROP DATABASE IF EXISTS d2;

--- a/mysql-test/suite/rpl/t/rpl_killed_ddl.test
+++ b/mysql-test/suite/rpl/t/rpl_killed_ddl.test
@@ -37,7 +37,7 @@ source include/master-slave.inc;
 # Use the DBUG_SYNC_POINT to make sure the thread running the DDL is
 # waiting before creating the query log event
 
-let $debug_lock= "debug_lock.before_query_log_event";
+#let $debug_lock= "debug_lock.before_query_log_event"; #uncomment this line to enable debug
 
 ######## INITIALIZATION ########
 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -3851,6 +3851,9 @@ Query_log_event::Query_log_event(THD* thd_arg, const char* query_arg,
 
   exec_time= end_time.tv_sec - thd_arg->start_time.tv_sec;
 
+  DBUG_EXECUTE_IF("debug_lock_before_query_log_event",
+                  DBUG_SYNC_POINT("debug_lock.before_query_log_event", 10););
+
   /**
     @todo this means that if we have no catalog, then it is replicated
     as an existing catalog of length zero. is that safe? /sven


### PR DESCRIPTION
Event created by this test was to be executed on a date based on
CURRENT_TIMESTAMP. Later creation of this event was executed on slave
and a diff of statements between master and slave was done. This diff
resulted in failure for statement based replication, as
CURRENT_TIMESTAMP on slave was different than the CURRENT_TIMESTAMP on
master. Fixed by replacing CURRENT_TIMESTAMP with fixed timestamp.