### PR TITLE
The ability to kill query blocked in PerconaFT lock tree is added.

### DIFF
--- a/mysql-test/suite/tokudb/r/kill_query_blocked_in_lt.result
+++ b/mysql-test/suite/tokudb/r/kill_query_blocked_in_lt.result
@@ -1,0 +1,26 @@
+### connection default
+CREATE TABLE t (a INT PRIMARY KEY, b INT) ENGINE=TokuDB;
+INSERT INTO t (a, b) VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5),
+(6, 6), (7, 7), (8, 8), (9, 9), (10, 10),
+(11, 11), (12, 12), (13, 13), (14, 14), (15, 15),
+(16, 16), (17, 17), (18, 18), (19, 19), (20, 20);
+### connection con1
+SET DEBUG_SYNC= 'toku_range_lock_granted_immediately SIGNAL lock_granted WAIT_FOR lock_granted_continue';
+UPDATE t SET b=1 WHERE a BETWEEN 5 AND 10;
+### connection default
+SET DEBUG_SYNC= 'now WAIT_FOR lock_granted';
+### connection con2
+SET DEBUG_SYNC= 'toku_range_lock_before_wait SIGNAL lock_not_granted WAIT_FOR lock_not_granted_continue';
+SET DEBUG_SYNC= 'toku_range_lock_not_granted_after_wait SIGNAL lock_not_granted_after_wait';
+UPDATE t SET b=1 WHERE a BETWEEN 5 AND 10;
+### connection default
+SET DEBUG_SYNC= 'now SIGNAL lock_not_granted_continue WAIT_FOR lock_not_granted';
+KILL QUERY con2_id
+SET DEBUG_SYNC= 'now SIGNAL lock_granted_continue WAIT_FOR lock_not_granted_after_wait';
+### connection con1
+### reap
+### connection con2
+### reap
+ERROR 70100: Query execution was interrupted
+### connection default
+DROP TABLE t;

--- a/mysql-test/suite/tokudb/t/kill_query_blocked_in_lt.test
+++ b/mysql-test/suite/tokudb/t/kill_query_blocked_in_lt.test
@@ -1,0 +1,56 @@
+--source include/have_tokudb.inc
+--source include/have_debug_sync.inc
+
+--echo ### connection default
+
+CREATE TABLE t (a INT PRIMARY KEY, b INT) ENGINE=TokuDB;
+
+INSERT INTO t (a, b) VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, 5),
+                            (6, 6), (7, 7), (8, 8), (9, 9), (10, 10),
+                            (11, 11), (12, 12), (13, 13), (14, 14), (15, 15),
+                            (16, 16), (17, 17), (18, 18), (19, 19), (20, 20);
+
+--connect(con1, localhost, root)
+--connect(con2, localhost, root)
+
+--connection con1
+--echo ### connection con1
+SET DEBUG_SYNC= 'toku_range_lock_granted_immediately SIGNAL lock_granted WAIT_FOR lock_granted_continue';
+--send UPDATE t SET b=1 WHERE a BETWEEN 5 AND 10
+
+--connection default
+--echo ### connection default
+SET DEBUG_SYNC= 'now WAIT_FOR lock_granted';
+
+--connection con2
+--echo ### connection con2
+--let $con2_id= `SELECT CONNECTION_ID()`
+SET DEBUG_SYNC= 'toku_range_lock_before_wait SIGNAL lock_not_granted WAIT_FOR lock_not_granted_continue';
+SET DEBUG_SYNC= 'toku_range_lock_not_granted_after_wait SIGNAL lock_not_granted_after_wait';
+--send UPDATE t SET b=1 WHERE a BETWEEN 5 AND 10
+
+--connection default
+--echo ### connection default
+SET DEBUG_SYNC= 'now SIGNAL lock_not_granted_continue WAIT_FOR lock_not_granted';
+
+--disable_query_log
+--eval KILL QUERY $con2_id
+--enable_query_log
+--echo KILL QUERY con2_id
+SET DEBUG_SYNC= 'now SIGNAL lock_granted_continue WAIT_FOR lock_not_granted_after_wait';
+
+--connection con1
+--echo ### connection con1
+--echo ### reap
+--reap
+
+--connection con2
+--echo ### connection con2
+--echo ### reap
+--error ER_QUERY_INTERRUPTED
+--reap
+
+--connection default
+--echo ### connection default
+
+DROP TABLE t;

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -67,6 +67,7 @@ static bool tokudb_show_status(
 static void tokudb_handle_fatal_signal(handlerton* hton, THD* thd, int sig);
 #endif
 static int tokudb_close_connection(handlerton* hton, THD* thd);
+static void tokudb_kill_connection(handlerton *hton, THD *thd);
 static int tokudb_commit(handlerton* hton, THD* thd, bool all);
 static int tokudb_rollback(handlerton* hton, THD* thd, bool all);
 #if TOKU_INCLUDE_XA
@@ -343,6 +344,7 @@ static int tokudb_init_func(void *p) {
 
     tokudb_hton->create = tokudb_create_handler;
     tokudb_hton->close_connection = tokudb_close_connection;
+    tokudb_hton->kill_connection = tokudb_kill_connection;
 
     tokudb_hton->savepoint_offset = sizeof(SP_INFO_T);
     tokudb_hton->savepoint_set = tokudb_savepoint;
@@ -764,6 +766,12 @@ static int tokudb_close_connection(handlerton* hton, THD* thd) {
     tokudb_map_mutex.unlock();
 #endif
     return error;
+}
+
+void tokudb_kill_connection(handlerton *hton, THD *thd) {
+    TOKUDB_DBUG_ENTER("");
+    db_env->kill_waiter(db_env, thd);
+    DBUG_VOID_RETURN;
 }
 
 bool tokudb_flush_logs(handlerton * hton) {

--- a/storage/tokudb/tokudb_information_schema.cc
+++ b/storage/tokudb/tokudb_information_schema.cc
@@ -73,7 +73,8 @@ int trx_callback(
     void *extra) {
 
     uint64_t txn_id = txn->id64(txn);
-    uint64_t client_id = txn->get_client_id(txn);
+    uint64_t client_id;
+    txn->get_client_id(txn, &client_id, NULL);
     uint64_t start_time = txn->get_start_time(txn);
     trx_extra_t* e = reinterpret_cast<struct trx_extra_t*>(extra);
     THD* thd = e->thd;
@@ -312,7 +313,8 @@ int locks_callback(
     void* extra) {
 
     uint64_t txn_id = txn->id64(txn);
-    uint64_t client_id = txn->get_client_id(txn);
+    uint64_t client_id;
+    txn->get_client_id(txn, &client_id, NULL);
     locks_extra_t* e = reinterpret_cast<struct locks_extra_t*>(extra);
     THD* thd = e->thd;
     TABLE* table = e->table;

--- a/storage/tokudb/tokudb_txn.h
+++ b/storage/tokudb/tokudb_txn.h
@@ -116,7 +116,7 @@ inline int txn_begin(
     int r = env->txn_begin(env, parent, txn, flags);
     if (r == 0 && thd) {
         DB_TXN* this_txn = *txn;
-        this_txn->set_client_id(this_txn, thd_get_thread_id(thd));
+        this_txn->set_client_id(this_txn, thd_get_thread_id(thd), thd);
     }
     TOKUDB_TRACE_FOR_FLAGS(
         TOKUDB_DEBUG_TXN,


### PR DESCRIPTION
TDB-27 : Add ability to kill query that is awaiting FT locktree lock

MTR test uses DEBUG_SYNC built in PerconaFT.

See also https://github.com/percona/percona-server/pull/1739, https://github.com/percona/PerconaFT/pull/370.

Testing:
http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1896/