### PR TITLE
Fix for lp:1671125.

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/rpl_safe_slave.result
+++ b/mysql-test/suite/tokudb.backup/r/rpl_safe_slave.result
@@ -53,8 +53,6 @@ Variable_name	Value
 Slave_open_temp_tables	0
 ### Continue backup
 SET DEBUG_SYNC = "now SIGNAL ttlss_continue";
-## Reset debug_sync points
-SET DEBUG_SYNC = "RESET";
 ### Wait for backup finish
 include/filter_file.inc
 ### Slave tokubackup_slave_info content:
@@ -133,8 +131,6 @@ Variable_name	Value
 Slave_open_temp_tables	0
 ### Continue backup
 SET DEBUG_SYNC = "now SIGNAL ttlss_continue";
-## Reset debug_sync points
-SET DEBUG_SYNC = "RESET";
 ### Wait for backup finish
 include/filter_file.inc
 ### Slave tokubackup_slave_info content:

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.inc
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.inc
@@ -60,9 +60,6 @@ SHOW STATUS LIKE 'Slave_open_temp_tables';
 --disable_warnings
 SET DEBUG_SYNC = "now SIGNAL ttlss_continue";
 
---echo ## Reset debug_sync points
-SET DEBUG_SYNC = "RESET";
-
 --connection slave_2
 --echo ### Wait for backup finish
 --reap


### PR DESCRIPTION
The issue was in reset debug_sync actions before the certain signal
was processed in the certain point. The solution it to remove debug_sync reset
from the test, the reset is not neccessary in the test.

(cherry picked from commit b3a941e2752da0f0e50fce546641eea5da38eff2)

See also: https://github.com/percona/percona-server/pull/1740

Testing:
http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/940/