### PR TITLE
Update source and binary paths in installation.rst

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -47,7 +47,7 @@ Fetch and extract the correct binary tarball. For example for *Debian Wheezy*:
 
 .. code-block:: bash
 
-  $ wget https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-3/binary/tarball/Percona-Server-5.7.10-3-Linux.x86_64.ssl100.tar.gz
+  $ wget https://www.percona.com/downloads/Percona-Server-LATEST/Percona-Server-5.7.18-14/binary/tarball/Percona-Server-5.7.18-14-Linux.x86_64.ssl100.tar.gz
 
 
 .. _installing_from_source_tarball:
@@ -57,8 +57,8 @@ Installing |Percona Server| from a Source Tarball
 
 Fetch and extract the source tarball. For example: ::
 
-  $ wget https://www.percona.com/downloads/Percona-Server-5.7/Percona-Server-5.7.10-3/source/tarball/percona-server-5.7.10-3.tar.gz
-  $ tar xfz Percona-Server-5.7.10-3-Linux.x86_64.ssl100.tar.gz
+  $ wget https://www.percona.com/downloads/Percona-Server-LATEST/Percona-Server-5.7.18-14/source/tarball/percona-server-5.7.18-14.tar.gz
+  $ tar xfz percona-server-5.7.18-14.tar.gz
 
 Next, follow the instructions in :ref:`compile_from_source` below.
 


### PR DESCRIPTION
This also corrects the name of the source tarball in the example tar command to extract source.