### PR TITLE
Fix lp:1690012 (Test main.log_tables-big fails with --repeat=2 since 5.6.36 merge) (5.7)

### DIFF
--- a/mysql-test/r/log_tables-big.result
+++ b/mysql-test/r/log_tables-big.result
@@ -1,4 +1,6 @@
+set @saved_log_output = @@global.log_output;
 set @@global.log_output = 'TABLE';
+truncate table mysql.slow_log;
 set session long_query_time=10;
 select get_lock('bug27638', 1);
 get_lock('bug27638', 1)
@@ -28,4 +30,5 @@ OK	select get_lock('bug27638', 101)
 select release_lock('bug27638');
 release_lock('bug27638')
 1
-set @@global.log_output=default;
+set @@global.log_output = @saved_log_output;
+truncate table mysql.slow_log;

--- a/mysql-test/t/log_tables-big.test
+++ b/mysql-test/t/log_tables-big.test
@@ -9,7 +9,11 @@
 # Test sleeps for long times
 --source include/big_test.inc
 
+set @saved_log_output = @@global.log_output;
 set @@global.log_output = 'TABLE';
+truncate table mysql.slow_log;
+
+--source include/count_sessions.inc
 
 connect (con1,localhost,root,,);
 connect (con2,localhost,root,,);
@@ -38,4 +42,7 @@ connection default;
 disconnect con1;
 disconnect con2;
 
-set @@global.log_output=default;
+--source include/wait_until_count_sessions.inc
+
+set @@global.log_output = @saved_log_output;
+truncate table mysql.slow_log;


### PR DESCRIPTION
Added missing 'TRUNCATE TABLE mysql.slow_log' statements at the begining and
at the end of the test to guarantee that previous MTR runs do not affect
'SELECT ... FROM mysql.slow_log' statements.

As this test case uses additional connections,
'--source include/count_sessions.inc' /
'--source include/wait_until_count_sessions.inc' includes were also added.

(cherry-picked from commit ef69c09)