### PR TITLE
TDB-44 : tokudb.locks-select-update-3 is unstable

### DIFF
--- a/mysql-test/suite/tokudb/r/locks-select-update-3.result
+++ b/mysql-test/suite/tokudb/r/locks-select-update-3.result
@@ -1,6 +1,4 @@
-SET DEFAULT_STORAGE_ENGINE='tokudb';
-drop table if exists t;
-create table t (a int primary key, b int);
+create table t (a int primary key, b int) engine=tokudb;
 insert into t values (1,0);
 set session transaction isolation level read committed;
 begin;
@@ -8,6 +6,7 @@ select * from t where a=1 for update;
 a	b
 1	0
 update t set b=b+1 where a=1;
+set session tokudb_lock_timeout=60000;
 set session transaction isolation level read committed;
 begin;
 select * from t where a=1 for update;

--- a/mysql-test/suite/tokudb/t/locks-select-update-3.test
+++ b/mysql-test/suite/tokudb/t/locks-select-update-3.test
@@ -1,12 +1,8 @@
 source include/have_tokudb.inc;
+source include/count_sessions.inc;
 # test that select for update is executed with serializable isolation
 
-SET DEFAULT_STORAGE_ENGINE='tokudb';
-
---disable_warnings
-drop table if exists t;
---enable_warnings
-create table t (a int primary key, b int);
+create table t (a int primary key, b int) engine=tokudb;
 insert into t values (1,0);
 set session transaction isolation level read committed;
 begin;
@@ -15,6 +11,7 @@ select * from t where a=1 for update;
 # t2 update
 update t set b=b+1 where a=1;
 connect(conn1,localhost,root);
+set session tokudb_lock_timeout=60000;
 set session transaction isolation level read committed;
 begin;
 # t2 select for update, should hang until t1 commits
@@ -33,3 +30,4 @@ connection default;
 disconnect conn1;
 drop table t;
 
+source include/wait_until_count_sessions.inc;


### PR DESCRIPTION
- Increased lock wait timeout to allow for slow ystem switching time between
  concurrent mtr connections.
- Modernized test a bit introducing count_sessions.inc and removing
  'drop table .. if exists'