### PR TITLE
Bug 1626559: Test `main.audit_log_default_db' is unstable

### DIFF
--- a/mysql-test/r/audit_log_default_db.result
+++ b/mysql-test/r/audit_log_default_db.result
@@ -18,9 +18,6 @@ GRANT ALL PRIVILEGES ON ąžąžąžą.* TO 'user2'@'%';
 UNINSTALL PLUGIN audit_log;
 Warnings:
 Warning	1620	Plugin is busy and will be uninstalled on shutdown
-SELECT * FROM t;
-a
-db2
 INSTALL PLUGIN audit_log SONAME 'audit_log.so';
 SELECT * FROM t;
 a
@@ -60,7 +57,8 @@ set global audit_log_flush= ON;
 ===================================================================
 "Query","<ID>","<DATETIME>","install_plugin","<CONN_ID>",0,"INSTALL PLUGIN audit_log SONAME 'audit_log.so'","root[root] @ localhost []","localhost","","",""
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"root","root","","","localhost","","test"
-"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM t","user1[user1] @ localhost []","localhost","","",""
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","","db2"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT * FROM t","user1[user1] @ localhost []","localhost","","","db2"
 "Query","<ID>","<DATETIME>","change_db","<CONN_ID>",0,"use 	`db1`","user1[user1] @ localhost []","localhost","","","db1"
 "Change user","<ID>","<DATETIME>","<CONN_ID>",1044,"user2","user2","","","localhost","",""
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","","db1"

--- a/mysql-test/t/audit_log_default_db.test
+++ b/mysql-test/t/audit_log_default_db.test
@@ -31,21 +31,23 @@ GRANT ALL PRIVILEGES ON ąžąžąžą.* TO 'user2'@'%';
 
 # truncate audit log
 UNINSTALL PLUGIN audit_log;
+let $wait_condition=
+    SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME LIKE 'audit_log';
+--source include/wait_condition.inc
 --remove_file $log_file
-
-connect (test,localhost,user1,111,db2,);
-connection test;
-SELECT * FROM t;
 
 --source include/count_sessions.inc
 connect (root,localhost,root,,,);
 connection root;
 INSTALL PLUGIN audit_log SONAME 'audit_log.so';
 disconnect root;
-connection test;
+connection default;
 --source include/wait_until_count_sessions.inc
 
+connect (test,localhost,user1,111,db2,);
+connection test;
 SELECT * FROM t;
+
 use 	`db1`;
 --error ER_DBACCESS_DENIED_ERROR
 change_user user2,111,db1;

--- a/mysql-test/t/audit_log_echo.inc
+++ b/mysql-test/t/audit_log_echo.inc
@@ -12,8 +12,9 @@ perl;
       # change_user does automatic reconnect and messing up 'SET NAMES' around
       next;
     }
-    if ($line =~ /Threads_connected/ || $line =~ /SELECT \d <= \d/) {
-      # part of wait_until_count_sessions.inc script
+    if ($line =~ /Threads_connected/ || $line =~ /SELECT \d <= \d/
+       || /SELECT.*FROM.*INFORMATION_SCHEMA.PLUGINS/) {
+      # part of wait_until_count_sessions.inc and wait_condition.inc scripts
       next;
     }
     if ($line =~ /^"Audit"/) {


### PR DESCRIPTION
Sometimes "SHOW WARNINGS" appears in the audit log around UNINSTALL
PLUGIN / INSTALL PLUGIN. This is the warning which MySQL issue about
plugin being in use.

Normally warning should not make it to audit log because test case
truncates log after UNINSTALL PLUGIN. But sometimes mysql-test picks
this warning up after plugin has been reinstalled and it gets logged
into audit log.

This patch makes sure that test execution continues only when plugin
disappeared from the `mysql.plgins', which happens after `deinit' is
called and all plugin is fully shut down.