### PR TITLE
Fix: data directory not empty when initializing mysqld

### DIFF
--- a/build-ps/debian/extra/mysql-systemd-start
+++ b/build-ps/debian/extra/mysql-systemd-start
@@ -53,11 +53,6 @@ sanity () {
                 install -d -m 0750 -o mysql -g mysql ${MYSQLKEYRING}
 	fi
 
-	if [ ! -d "${MYSQLDATA}/mysql" -a ! -L "${MYSQLDATA}/mysql" ];
-	then
-                install -d -m 0750 -o mysql -g mysql ${MYSQLDATA}/mysql
-	fi
-
 	if [ ! "$(ls -A ${MYSQLDATA}/mysql)" ];
 	then
 		su - mysql -s /bin/bash -c "/usr/sbin/mysqld --initialize-insecure=on 2>&1 > /dev/null"


### PR DESCRIPTION
On debian jessie, with percona-server-server 5.7.18-15-1.jessie

The script creates a subfolder called mysql in datadir just before
calling initialize. This produces the following error:

[ERROR] --initialize specified but the data directory exists.

Launching the script without creating the subfolder initializes mysql
files and databases correctly.