### PR TITLE
Fix bug 1676740 (Test innodb.percona_log_arch_expire_sec is unstable)

### DIFF
--- a/mysql-test/suite/innodb/include/percona_log_archiving_check.inc
+++ b/mysql-test/suite/innodb/include/percona_log_archiving_check.inc
@@ -1,6 +1,8 @@
 # Check that there are no gaps in archived files
 
 --source percona_log_archiving_stat.inc
+--source $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
+--remove_file $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
 
 let $lsn = `SELECT (($archived_logs_count - 1) * $LOG_FILE_LSN_STEP + $first_log_file_lsn)`;
 

--- a/mysql-test/suite/innodb/include/percona_log_archiving_count.inc
+++ b/mysql-test/suite/innodb/include/percona_log_archiving_count.inc
@@ -1,9 +1,0 @@
-
---source percona_log_archiving_stat.inc
-
-let $lsn = $n_files * $LOG_FILE_LSN_STEP;
-
---echo $archived_logs_count
-
-let $LAST_ARCHIVED_LSN = $last_log_file_lsn;
-

--- a/mysql-test/suite/innodb/include/percona_log_archiving_setup.inc
+++ b/mysql-test/suite/innodb/include/percona_log_archiving_setup.inc
@@ -45,5 +45,7 @@ insert into t values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13);
 insert into t (a) select t1.a from t t1, t t2, t t3 LIMIT 40000;
 
 --source percona_log_archiving_stat.inc
+--source $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
+--remove_file $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
 
 let $LAST_ARCHIVED_LSN = $last_log_file_lsn;

--- a/mysql-test/suite/innodb/include/percona_log_archiving_stat.inc
+++ b/mysql-test/suite/innodb/include/percona_log_archiving_stat.inc
@@ -1,5 +1,12 @@
 #
-# Collect information about archived log files
+# Collect information about archived log files. The information is returned in
+# $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp which can be directly sourced
+# in MTR once or several times if not in a loop. If it has to be processed in a
+# loop, other means (such SQL LOAD DATA INFILE) must be used due to
+# https://bugs.mysql.com/bug.php?id=85825 (re-reading changed MTR source files
+# is not safe in mysqltest).
+#
+# It is up to the caller to delete the file after processing it.
 #
 
 perl;
@@ -17,6 +24,9 @@ sub get_file_stat {
   my $filename = fn($filepath);
 
   my @array = stat($filepath);
+  if (!@array) {
+    return {};
+  }
   my $filemodifytime = $array[9];
   my @t = localtime $filemodifytime;
   my $modifytime = sprintf "%04u-%02u-%02u %02u:%02u:%02u",$t[5]+1900,$t[4]+1,$t[3],$t[2],$t[1],$t[0];
@@ -49,7 +59,10 @@ sub print_file_stat {
 my @files_stat = ();
 
 foreach my $file (@files) {
-  push(@files_stat, get_file_stat($file));
+  my $file_stat = get_file_stat($file);
+  if ($file_stat) {
+    push(@files_stat, $file_stat);
+  }
 }
 
 $count = scalar(@files_stat);
@@ -66,7 +79,3 @@ printf F ("let \$archived_logs_mid = %s;\n", $mid_n);
 close F;
 
 EOF
-
---source $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
-remove_file $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp;
-

--- a/mysql-test/suite/innodb/r/percona_log_arch_expire_sec.result
+++ b/mysql-test/suite/innodb/r/percona_log_arch_expire_sec.result
@@ -16,12 +16,10 @@ insert into t values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13);
 insert into t values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13);
 insert into t values (1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13);
 insert into t (a) select t1.a from t t1, t t2, t t3 LIMIT 40000;
+CREATE TEMPORARY TABLE log_arch_status(a TEXT) ENGINE=MyISAM;
 SET @save_log_arch_expire_sec = @@innodb_log_arch_expire_sec;
 SET GLOBAL innodb_log_arch_expire_sec = 1;
 insert into t (a) select t1.a from t t1, t t2, t t3 LIMIT 40000;
 insert into t (a) select t1.a from t t1, t t2, t t3 LIMIT 40000;
-SELECT sleep(4);
-sleep(4)
-0
 SET GLOBAL innodb_log_arch_expire_sec = @save_log_arch_expire_sec;
 DROP TABLE t;

--- a/mysql-test/suite/innodb/t/percona_innodb_log_archive_func.test
+++ b/mysql-test/suite/innodb/t/percona_innodb_log_archive_func.test
@@ -21,6 +21,8 @@ let $count = $archived_logs_count;
 SET GLOBAL innodb_log_archive = ON;
 
 --source ../include/percona_log_archiving_stat.inc
+--source $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
+--remove_file $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
 
 if ($count != $archived_logs_count)
 {

--- a/mysql-test/suite/innodb/t/percona_log_arch_expire_sec.test
+++ b/mysql-test/suite/innodb/t/percona_log_arch_expire_sec.test
@@ -7,6 +7,8 @@
 
 --source ../include/percona_log_archiving_setup.inc
 
+CREATE TEMPORARY TABLE log_arch_status(a TEXT) ENGINE=MyISAM;
+
 SET @save_log_arch_expire_sec = @@innodb_log_arch_expire_sec;
 SET GLOBAL innodb_log_arch_expire_sec = 1;
 
@@ -14,16 +16,39 @@ SET GLOBAL innodb_log_arch_expire_sec = 1;
 
 --source ../include/percona_log_archiving_workload.inc
 
-SELECT sleep(4);
+real_sleep 2;
 
---source ../include/percona_log_archiving_stat.inc
-
-if ($archived_logs_count > 1)
+let $mysqld_pid_file=`SELECT @@GLOBAL.pid_file`;
+let $wait_counter= 1000;
+while ($wait_counter)
 {
-  die Test failed. Archived logs have nod been purged.;
+  --source ../include/percona_log_archiving_stat.inc
+  --disable_query_log
+  eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp'
+       INTO TABLE log_arch_status
+       LINES TERMINATED BY ';';
+  --remove_file $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
+  SELECT SUBSTRING(a, LOCATE('=', a) + 2) INTO @archived_logs_count
+         FROM log_arch_status WHERE a LIKE '%let $archived_logs_count%';
+  TRUNCATE TABLE log_arch_status;
+  --enable_query_log
+
+  if (`SELECT @archived_logs_count > 1`)
+  {
+    real_sleep 0.1;
+    dec $wait_counter;
+  }
+  if (`SELECT @archived_logs_count <= 1`)
+  {
+    let $wait_counter= 0;
+  }
+}
+
+if (`SELECT @archived_logs_count > 1`)
+{
+  die Test failed. Archived logs have not been purged.;
 }
 
 SET GLOBAL innodb_log_arch_expire_sec = @save_log_arch_expire_sec;
 
 --source ../include/percona_log_archiving_cleanup.inc
-

--- a/mysql-test/suite/innodb/t/percona_purge_archived_logs_before.test
+++ b/mysql-test/suite/innodb/t/percona_purge_archived_logs_before.test
@@ -26,6 +26,8 @@ if ($archived_logs_count == 0)
 let $count = `SELECT $archived_logs_count - $archived_logs_mid`;
 
 --source ../include/percona_log_archiving_stat.inc
+--source $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
+--remove_file $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
 
 if ($archived_logs_count != $count)
 {

--- a/mysql-test/suite/innodb/t/percona_purge_archived_logs_to.test
+++ b/mysql-test/suite/innodb/t/percona_purge_archived_logs_to.test
@@ -26,6 +26,8 @@ if ($archived_logs_count == 0)
 let $count = `SELECT $archived_logs_count - $archived_logs_mid + 1`;
 
 --source ../include/percona_log_archiving_stat.inc
+--source $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
+--remove_file $MYSQLTEST_VARDIR/tmp/percona_archived_logs.tmp
 
 if ($archived_logs_count != $count)
 {


### PR DESCRIPTION
Expired archived log purge is done in background by the InnoDB master
thread, and the testcase does not synchronize with it. Fix by:
- modifying percona_log_archiving_stat.inc not to source its resulting
  MTR file, and moving this to callers instead;
- rewriting percona_log_arch_expire_sec.test to source the above file in
  a loop, load its result file into a temporary table, and wait until the
  purge happens by monitoring the archived log file count. Fix an error
  message typo.

At the same time delete unused include file
percona_log_archiving_count.inc.

http://jenkins.percona.com/job/percona-server-5.6-param/1927/
http://jenkins.percona.com/job/percona-server-5.6-param/1928/