### PR TITLE
Bug lp:1667307 fix.

### DIFF
--- a/mysql-test/suite/rpl/r/bug85371.result
+++ b/mysql-test/suite/rpl/r/bug85371.result
@@ -1,0 +1,31 @@
+include/rpl_init.inc [topology=1->3,3->2,1->2]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+### Create some binlog events on server_1
+CREATE TABLE t1(a INT);
+INSERT INTO t1 (a) VALUES (1), (2), (3), (4), (5);
+INSERT INTO t1 (a) VALUES (6), (7), (8), (9), (10);
+DROP TABLE t1;
+### sync the server_3 with server_1
+[connection server_1]
+include/sync_slave_sql_with_master.inc
+### sync the server_2 with server_3
+[connection server_3]
+include/sync_slave_sql_with_master.inc
+### sync the server_2 with server_1
+### here crash must take place if the bug is not fixed
+[connection server_1]
+include/sync_slave_sql_with_master.inc
+### finish replication
+[connection server_1]
+include/rpl_end.inc
+RESET SLAVE ALL FOR CHANNEL  'channel_1';
+RESET SLAVE ALL FOR CHANNEL  'channel_3';
+RESET SLAVE ALL FOR CHANNEL  'channel_1';

--- a/mysql-test/suite/rpl/t/bug85371.cnf
+++ b/mysql-test/suite/rpl/t/bug85371.cnf
@@ -1,0 +1,30 @@
+!include ../my.cnf
+
+[mysqld.1]
+enforce-gtid-consistency=ON
+gtid-mode=ON
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+binlog-rows-query-log-events= ON
+log-slave-updates
+
+[mysqld.2]
+enforce-gtid-consistency=ON
+gtid-mode=ON
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+binlog-rows-query-log-events= ON
+log-slave-updates
+
+[mysqld.3]
+enforce-gtid-consistency=ON
+gtid-mode=ON
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+binlog-rows-query-log-events= ON
+log-slave-updates
+
+[ENV]
+SERVER_MYPORT_3=		@mysqld.3.port
+SERVER_MYSOCK_3=		@mysqld.3.socket
+

--- a/mysql-test/suite/rpl/t/bug85371.test
+++ b/mysql-test/suite/rpl/t/bug85371.test
@@ -1,0 +1,51 @@
+#
+# In the case if the bug is not fixed the test will crash on assert
+# in Rows_query_log_event::do_apply_event() on debug build.
+#
+--source include/have_binlog_format_row.inc
+--source include/have_gtid.inc
+--source include/not_group_replication_plugin.inc
+
+--let $rpl_topology= 1->3,3->2,1->2
+--let $rpl_multi_source= 1
+--let $use_gtids= 1
+--source include/rpl_init.inc
+
+--echo ### Create some binlog events on server_1
+--connection server_1
+CREATE TABLE t1(a INT);
+INSERT INTO t1 (a) VALUES (1), (2), (3), (4), (5);
+INSERT INTO t1 (a) VALUES (6), (7), (8), (9), (10);
+DROP TABLE t1;
+
+--echo ### sync the server_3 with server_1
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+
+--let $rpl_channel_name= channel_1
+--let $sync_slave_connection= server_3
+--source include/sync_slave_sql_with_master.inc
+
+--echo ### sync the server_2 with server_3
+--let $rpl_connection_name= server_3
+--source include/rpl_connection.inc
+
+--let $rpl_channel_name= channel_3
+--let $sync_slave_connection=server_2
+--source include/sync_slave_sql_with_master.inc
+
+--echo ### sync the server_2 with server_1
+--echo ### here crash must take place if the bug is not fixed
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+
+--let $rpl_channel_name= channel_1
+--let $sync_slave_connection= server_2
+--source include/sync_slave_sql_with_master.inc
+
+--echo ### finish replication
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+
+--let $rpl_skip_sync= 1
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -10723,7 +10723,21 @@ int Rows_log_event::do_apply_event(Relay_log_info const *rli)
       DBUG_RETURN(-1);
     }
     else if (state == GTID_STATEMENT_SKIP)
+    {
+      if (rli->rows_query_ev)
+      {
+        /*
+          thd->m_query_string now points to the data from
+          rli->rows_query_ev->m_rows_query
+          (see  Rows_query_log_event::do_apply_event()), don't let it point
+          to unallocated memory, reset query string first
+        */
+        thd->reset_query();
+        delete rli->rows_query_ev;
+        const_cast<Relay_log_info*>(rli)->rows_query_ev= NULL;
+      }
       DBUG_RETURN(0);
+    }
 
     /*
       The current statement is just about to begin and 

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -1774,9 +1774,15 @@ void Relay_log_info::cleanup_context(THD *thd, bool error)
   }
   if (rows_query_ev)
   {
+    /*
+      thd->m_query_string now points to the data from
+      rli->rows_query_ev->m_rows_query
+      (see  Rows_query_log_event::do_apply_event()), don't let it point
+      to unallocated memory, reset query string first
+    */
+    info_thd->reset_query();
     delete rows_query_ev;
     rows_query_ev= NULL;
-    info_thd->reset_query();
   }
   m_table_map.clear_tables();
   slave_close_thread_tables(thd);


### PR DESCRIPTION
Bug description:

1) When binlog_rows_query_log_events is enabled, Rows_query_log_event
is created, written to binary log on master prior Rows_log_event.

2) Slave is reading this event from relay log and applying it,
see Rows_query_log_event::do_apply_event(). When the event is applied
the event itself is stored in Relay_log_info::rows_query_ev:
```c++
int Rows_query_log_event::do_apply_event(Relay_log_info const *rli)
{
  DBUG_ENTER("Rows_query_log_event::do_apply_event");
  DBUG_ASSERT(rli->info_thd == thd);
  /* Set query for writing Rows_query log event into binlog later.*/
  thd->set_query(m_rows_query, strlen(m_rows_query));

  DBUG_ASSERT(rli->rows_query_ev == NULL);

  const_cast<Relay_log_info*>(rli)->rows_query_ev= this;
  /* Tell worker not to free the event */
  worker= NULL;
  DBUG_RETURN(0);
}
```

3) Usually Relay_log_info::rows_query_ev is removed after Rows_log_event
execution with the following stack trace:

```
#0 Rows_query_log_event::~Rows_query_log_event (this=0x7fff9401df00, __in_chrg=<optimized out>, __vtt_parm=<optimized out>)
    at ./sql/log_event.h:3795
#1 0x0000000001958d1e in Relay_log_info::cleanup_context (this=0x7fffa40413d0, thd=0x7fff94000950, error=false)
    at ./sql/rpl_rli.cc:1777
#2 0x00000000018d984b in rows_event_stmt_cleanup (rli=0x7fffa40413d0, thd=0x7fff94000950) at ./sql/log_event.cc:11297
#3 0x00000000018d9500 in Rows_log_event::do_apply_event (this=0x7fff94012fc0, rli=0x7fffa40413d0)
    at ./sql/log_event.cc:11175
#4 0x00000000018c00c7 in Log_event::apply_event (this=0x7fff94012fc0, rli=0x7fffa40413d0) at ./sql/log_event.cc:3371
#5 0x0000000001938e0f in apply_event_and_update_pos (ptr_ev=0x7ffff139e8a0, thd=0x7fff94000950, rli=0x7fffa40413d0)
    at ./sql/rpl_slave.cc:4750
#6 0x000000000193a5d7 in exec_relay_log_event (thd=0x7fff94000950, rli=0x7fffa40413d0) at ./sql/rpl_slave.cc:5265
#7 0x00000000019418eb in handle_slave_sql (arg=0x7fffa4139800) at ./sql/rpl_slave.cc:7461
#8 0x0000000001e6a679 in pfs_spawn_thread (arg=0x7fffa413d640) at ./storage/perfschema/pfs.cc:2188
#9 0x00007ffff71616ba in start_thread (arg=0x7ffff139f700) at pthread_create.c:333
#10 0x00007ffff65f682d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

But if we look into Rows_log_event::do_apply_event() the function
rows_event_stmt_cleanup() is called at the end:

```c++
int Rows_log_event::do_apply_event(Relay_log_info const *rli)
{
...
end:
  if (get_flags(STMT_END_F))
  {
    if((error= rows_event_stmt_cleanup(rli, thd)))
    {
      ...
    }
    ...
  }
...
}
```

4) But when the statement must be skipped because it has been already
applied from another channel, Rows_log_event::do_apply_event() exits before
rows_event_stmt_cleanup() call. See the following code:

```c++
int Rows_log_event::do_apply_event(Relay_log_info const *rli)
{
...
    enum_gtid_statement_status state= gtid_pre_statement_checks(thd);
    if (state == GTID_STATEMENT_EXECUTE)
    {
      if (gtid_pre_statement_post_implicit_commit_checks(thd))
        state= GTID_STATEMENT_CANCEL;
    }

    if (state == GTID_STATEMENT_CANCEL)
    {
      uint error= thd->get_stmt_da()->mysql_errno();
      DBUG_ASSERT(error != 0);
      rli->report(ERROR_LEVEL, error,
                  "Error executing row event: '%s'",
                  thd->get_stmt_da()->message_text());
      thd->is_slave_error= 1;
      DBUG_RETURN(-1);
    }
    else if (state == GTID_STATEMENT_SKIP)
      DBUG_RETURN(0);
...
end:
  if (get_flags(STMT_END_F))
  {
    if((error= rows_event_stmt_cleanup(rli, thd)))
    {
      ...
    }
    ...
  }
...
}
```

So in this case rli->rows_query_ev will not be deleted. In debug build such
case will lead to crash due to the corresponding assert in
Rows_query_log_event::do_apply_event():

```c++
int Rows_query_log_event::do_apply_event(Relay_log_info const *rli)
{
...
  DBUG_ASSERT(rli->rows_query_ev == NULL);
...
}
```

But for release build there will be just memory leak.

How to fix:

delete Rows_query_log_event instance if the next Rows_log_event instance read
from relay log must be skipped.

Testing: http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/983/
rpl_multi_source_slave_files looks very suspicious but it fails without my fix, and here is the bug report: https://bugs.mysql.com/bug.php?id=79402
See also: https://bugs.launchpad.net/percona-server/+bug/1667307