### PR TITLE
Fix for lp:1671125.

### DIFF
--- a/mysql-test/suite/tokudb.backup/r/rpl_safe_slave.result
+++ b/mysql-test/suite/tokudb.backup/r/rpl_safe_slave.result
@@ -53,8 +53,6 @@ Variable_name	Value
 Slave_open_temp_tables	0
 ### Continue backup
 SET DEBUG_SYNC = "now SIGNAL ttlss_continue";
-## Reset debug_sync points
-SET DEBUG_SYNC = "RESET";
 ### Wait for backup finish
 include/filter_file.inc
 ### Slave tokubackup_slave_info content:

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.inc
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.inc
@@ -59,9 +59,6 @@ SHOW STATUS LIKE 'Slave_open_temp_tables';
 --echo ### Continue backup
 SET DEBUG_SYNC = "now SIGNAL ttlss_continue";
 
---echo ## Reset debug_sync points
-SET DEBUG_SYNC = "RESET";
-
 --connection slave_2
 --echo ### Wait for backup finish
 --reap


### PR DESCRIPTION
This is the replacement of this https://github.com/percona/percona-server/pull/1740 pull request.

The issue was in reset debug_sync actions before the certain signal
was processed in the certain point. The solution it to remove debug_sync reset
from the test, the reset is not necessary in the test.

Testing: http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1933/
See also: https://github.com/percona/percona-server/pull/1786