### PR TITLE
Add group_replication to the default MTR suite list

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -170,6 +170,7 @@ my $DEFAULT_SUITES= "main,sys_vars,binlog,federated,gis,rpl,innodb,innodb_gis,"
   ."innodb_fts,innodb_zip,innodb_undo,innodb_stress,perfschema,funcs_1,"
   ."funcs_2,opt_trace,parts,auth_sec,query_rewrite_plugins,gcol,sysschema,"
   ."test_service_sql_api,jp,stress,engines/iuds,engines/funcs,"
+  ."group_replication,"
   ."query_response_time,audit_log,json,connection_control,"
   ."tokudb.add_index,tokudb.alter_table,tokudb,tokudb.bugs,tokudb.parts,"
   ."tokudb.rpl";


### PR DESCRIPTION
This implements
https://blueprints.launchpad.net/percona-server/+spec/gr-default-testing.

http://jenkins.percona.com/job/mysql-5.7-param/997/

It adds 1-2h of test time to trunk jobs, which include --big-test. For param jobs the overhead can be fully avoided by -DWITH_RAPID=OFF, which should be OK to apply almost always in our work (with the exception of upstream merges)