### PR TITLE
Fix bug 1385352 (SET STATEMENT does not work after SET GLOBAL / SHOW …

### DIFF
--- a/mysql-test/r/percona_statement_set.result
+++ b/mysql-test/r/percona_statement_set.result
@@ -934,3 +934,39 @@ TESTDIR
 SELECT @@innodb_tmpdir;
 @@innodb_tmpdir
 TMPDIR
+#
+# Bug 1385352: SET STATEMENT does not work after SET GLOBAL / SHOW GLOBAL STATUS
+# and affects the global value
+#
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+Variable_name	Value
+Threads_connected	1
+SELECT @@GLOBAL.sql_mode;
+@@GLOBAL.sql_mode
+NO_ENGINE_SUBSTITUTION
+SELECT @@GLOBAL.auto_increment_offset;
+@@GLOBAL.auto_increment_offset
+1
+SET STATEMENT sql_mode = 'NO_AUTO_CREATE_USER', auto_increment_offset = 123 FOR
+SELECT @@SESSION.sql_mode, @@SESSION.auto_increment_offset;
+@@SESSION.sql_mode	@@SESSION.auto_increment_offset
+NO_AUTO_CREATE_USER	123
+SELECT @@GLOBAL.sql_mode;
+@@GLOBAL.sql_mode
+NO_ENGINE_SUBSTITUTION
+SELECT @@GLOBAL.auto_increment_offset;
+@@GLOBAL.auto_increment_offset
+1
+SET @saved_general_log = @@GLOBAL.general_log;
+SET GLOBAL general_log = 0;
+SET STATEMENT sql_mode='NO_AUTO_CREATE_USER', auto_increment_offset=123 FOR
+SELECT @@SESSION.sql_mode, @@SESSION.auto_increment_offset;
+@@SESSION.sql_mode	@@SESSION.auto_increment_offset
+NO_AUTO_CREATE_USER	123
+SELECT @@GLOBAL.sql_mode;
+@@GLOBAL.sql_mode
+NO_ENGINE_SUBSTITUTION
+SELECT @@GLOBAL.auto_increment_offset;
+@@GLOBAL.auto_increment_offset
+1
+SET GLOBAL general_log = @saved_general_log;

--- a/mysql-test/t/percona_statement_set.test
+++ b/mysql-test/t/percona_statement_set.test
@@ -922,4 +922,28 @@ SELECT @@innodb_tmpdir;
 --replace_result $MYSQL_TMP_DIR TMPDIR
 SELECT @@innodb_tmpdir;
 
+--echo #
+--echo # Bug 1385352: SET STATEMENT does not work after SET GLOBAL / SHOW GLOBAL STATUS
+--echo # and affects the global value
+--echo #
+
 --source include/wait_until_count_sessions.inc
+
+SHOW GLOBAL STATUS LIKE 'Threads_connected';
+
+SELECT @@GLOBAL.sql_mode;
+SELECT @@GLOBAL.auto_increment_offset;
+SET STATEMENT sql_mode = 'NO_AUTO_CREATE_USER', auto_increment_offset = 123 FOR
+    SELECT @@SESSION.sql_mode, @@SESSION.auto_increment_offset;
+SELECT @@GLOBAL.sql_mode;
+SELECT @@GLOBAL.auto_increment_offset;
+
+SET @saved_general_log = @@GLOBAL.general_log;
+SET GLOBAL general_log = 0;
+
+SET STATEMENT sql_mode='NO_AUTO_CREATE_USER', auto_increment_offset=123 FOR
+    SELECT @@SESSION.sql_mode, @@SESSION.auto_increment_offset;
+SELECT @@GLOBAL.sql_mode;
+SELECT @@GLOBAL.auto_increment_offset;
+
+SET GLOBAL general_log = @saved_general_log;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -14775,6 +14775,7 @@ set:
             lex->one_shot_set= 0;
             lex->autocommit= 0;
             lex->set_statement= true;
+            lex->option_type= OPT_SESSION;
             sp_head *sp= lex->sphead;
             if (sp && !sp->is_invoked())
             {


### PR DESCRIPTION
…GLOBAL STATUS and affects the global value)

SET STATEMENT ... FOR ... variable assignments depended on
lex->option_type being set to OPT_SESSION for the correct operation
(setting the current session and not the global variables). However,
SET STATEMENT ... FOR ... parser never set it, resulting in the
previous statement values reused. If a previous statement was SET
GLOBAL or SHOW GLOBAL STATUS, lex->option_type was OPT_GLOBAL, making
SET STATEMENT to operate on global variables. Fix by setting
lex->option_type to OPT_SESSION in SET STATEMENT parser grammar rule.

http://jenkins.percona.com/job/percona-server-5.6-param/1936/