### PR TITLE
MYR-133 : rocksdb.select failing

### DIFF
--- a/mysql-test/suite/rocksdb/r/select.result
+++ b/mysql-test/suite/rocksdb/r/select.result
@@ -107,6 +107,8 @@ SUM(a)	MAX(a)	b
 602	200	NULL
 SELECT * FROM t2 WHERE a>0 PROCEDURE ANALYSE();
 Field_name	Min_value	Max_value	Min_length	Max_length	Empties_or_zeros	Nulls	Avg_value_or_avg_length	Std	Optimal_fieldtype
+Warning	1681	'PROCEDURE ANALYSE' is deprecated and will be removed in a future release.
+Warnings:
 test.t2.a	1	200	1	3	0	0	100.3333	81.2418	ENUM('1','100','200') NOT NULL
 test.t2.b	bar	z	1	6	0	0	3.3333	NULL	ENUM('bar','foobar','z') NOT NULL
 test.t2.pk	1	3	1	1	0	0	2.0000	0.8165	ENUM('1','2','3') NOT NULL


### PR DESCRIPTION
- Test uses PROCEDURE ANALYZE which is deprecated as of MySQL 5.7.18, and is
  removed in MySQL 8.0. This results in a new warning:
  Warning  1681  'PROCEDURE ANALYSE' is deprecated and will be removed in a
  future release.
- Since this is still valid syntax in 5.7, just re-recorded the test to capture
  the warning and will need to remove the use of PROCEDURE ANALYZE in 8.0