### PR TITLE
Fix bug 1698996 (x.connection_tls_version fails on Ubuntu Precise)

### DIFF
--- a/mysql-test/include/not_ubuntu_precise.inc
+++ b/mysql-test/include/not_ubuntu_precise.inc
@@ -1,0 +1,28 @@
+#
+# Skip the testcase if running under Ubuntu Precise (12.04)
+#
+
+--let check_result_file=$MYSQL_TMP_DIR/ubuntu_precise_check.tmp
+
+--perl
+use strict;
+use warnings;
+my $ubuntu_precise = 0;
+if (open(my $FILE, '<', "/etc/lsb-release")) {
+  $ubuntu_precise = scalar grep{/DISTRIB_RELEASE=12\.04/} <$FILE>;
+  close $FILE;
+}
+
+my $result_fn = $ENV{'check_result_file'} or die "check_result_file not set";
+open(my $RESULT, ">", $result_fn) or die "Could not open $result_fn for writing";
+print $RESULT '--let $is_ubuntu_precise = ' . $ubuntu_precise . "\n";
+close $RESULT;
+EOF
+
+--source $check_result_file
+--remove_file $check_result_file
+
+if ($is_ubuntu_precise)
+{
+   --skip Ubuntu Precise (12.04) is not supported
+}

--- a/rapid/plugin/x/tests/mtr/t/connection_tls_version.test
+++ b/rapid/plugin/x/tests/mtr/t/connection_tls_version.test
@@ -1,5 +1,6 @@
 ## Test cases for mysqlx plugin TLS versions
 
+--source include/not_ubuntu_precise.inc
 --source include/have_ssl.inc
 --source ../include/have_performance_schema_threads.inc
 --source ../include/xplugin_preamble.inc


### PR DESCRIPTION
Create a MTR skip file not_ubuntu_precise.inc and use it in
x.connection_tls_version to skip this test on Ubuntu Precise.

http://jenkins.percona.com/job/mysql-5.7-param/1023/