### PR TITLE
PS-8129: bug in  threadpool_unix.cc  tp_set_threadpool_size() (5.7)

### DIFF
--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1717,7 +1717,6 @@ void tp_set_threadpool_size(uint size)
       if(!success)
       {
         sql_print_error("io_poll_create() failed, errno=%d\n", errno);
-        break;
       }
     }  
     mysql_mutex_unlock(&all_groups[i].mutex);


### PR DESCRIPTION
if io_poll_create failed ,we shouldn't break.we should unlock the group mutex and return i. if  break here,we don't unlock the group mutex,and 
group_count= size.So it is a bug here.