### PR TITLE
Add testcase for bug 1586262 ("Buffer pool size, bytes" always 0 in I…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
+++ b/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
@@ -75,3 +75,9 @@ connection default
 SET GLOBAL innodb_show_verbose_locks = @innodb_show_verbose_locks_save;
 SET GLOBAL innodb_show_locks_held = @innodb_show_locks_held_save;
 DROP TABLE innodb_lock_monitor, t;
+#
+# Bug 1586262: "Buffer pool size, bytes" always 0 in InnoDB status
+#
+CREATE TEMPORARY TABLE t(a TEXT);
+include/assert.inc [Buffer pool size must be reported as 32M]
+DROP TEMPORARY TABLE t;

--- a/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
+++ b/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
@@ -49,3 +49,21 @@ SET GLOBAL innodb_show_verbose_locks = @innodb_show_verbose_locks_save;
 SET GLOBAL innodb_show_locks_held = @innodb_show_locks_held_save;
 
 DROP TABLE innodb_lock_monitor, t;
+
+--echo #
+--echo # Bug 1586262: "Buffer pool size, bytes" always 0 in InnoDB status
+--echo #
+
+CREATE TEMPORARY TABLE t(a TEXT);
+
+--let $status = query_get_value(SHOW ENGINE INNODB STATUS, Status, 1)
+
+--disable_query_log
+eval INSERT INTO t VALUES("$status");
+--enable_query_log
+
+--let $assert_text= Buffer pool size must be reported as 32M
+--let $assert_cond= COUNT(*) = 1 FROM t WHERE a LIKE "%Buffer pool size, bytes 33538048%"
+--source include/assert.inc
+
+DROP TEMPORARY TABLE t;


### PR DESCRIPTION
…nnoDB status)

5.5 SHOW ENGINE INNODB STATUS reports buffer pool size in bytes
correctly, thus only add the testcase.

http://jenkins.percona.com/job/percona-server-5.5-param/1574/