### PR TITLE
Fix bug 1669414 (Failed to set O_DIRECT on xb_doublewrite when runnin…

### DIFF
--- a/storage/innobase/include/buf0dblwr.h
+++ b/storage/innobase/include/buf0dblwr.h
@@ -199,6 +199,9 @@ class parallel_dblwr_t {
 public:
 	/** Parallel doublewrite buffer file handle */
 	pfs_os_file_t		file;
+	/** Whether the doublewrite buffer file needs flushing after each
+	write */
+	bool			needs_flush;
 	/** Path to the parallel doublewrite buffer */
 	char*			path;
 	/** Individual parallel doublewrite partitions */

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -1059,25 +1059,31 @@ os_file_create_simple_no_error_handling_func(
 @param[in]	file_name	file name, used in the diagnostic message
 @param[in]	name		"open" or "create"; used in the diagnostic
 				message
+@param[in]	failure_warning	if true (the default), the failure to disable
+caching is diagnosed at warning severity, and at note severity otherwise
 @return true if operation is success and false */
 bool
 os_file_set_nocache(
 	int		fd,
 	const char*	file_name,
-	const char*	operation_name);
+	const char*	operation_name,
+	bool		failure_warning = true);
 
 /** Tries to disable OS caching on an opened file file.
 @param[in]	file		file to alter
 @param[in]	file_name	file name, used in the diagnostic message
 @param[in]	name		"open" or "create"; used in the diagnostic
 message
+@param[in]	failure_warning	if true (the default), the failure to disable
+caching is diagnosed at warning severity, and at note severity otherwise
 @return true if operation is success and false */
 UNIV_INLINE
 bool
 os_file_set_nocache(
 	pfs_os_file_t	file,
 	const char*	file_name,
-	const char*	operation_name);
+	const char*	operation_name,
+	bool		failure_warning = true);
 
 /** NOTE! Use the corresponding macro os_file_create(), not directly
 this function!

--- a/storage/innobase/include/os0file.ic
+++ b/storage/innobase/include/os0file.ic
@@ -673,13 +673,17 @@ pfs_os_file_set_eof_at_func(
 @param[in]	file_name	file name, used in the diagnostic message
 @param[in]	name		"open" or "create"; used in the diagnostic
 message
+@param[in]	failure_warning	if true (the default), the failure to disable
+caching is diagnosed at warning severity, and at note severity otherwise
 @return true if operation is success and false */
 UNIV_INLINE
 bool
 os_file_set_nocache(
 	pfs_os_file_t	file,
 	const char*	file_name,
-	const char*	operation_name)
+	const char*	operation_name,
+	bool		failure_warning)
 {
-	return os_file_set_nocache(file.m_file, file_name, operation_name);
+	return os_file_set_nocache(file.m_file, file_name, operation_name,
+				   failure_warning);
 }

--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -614,6 +614,19 @@ private:
 	const bool	m_fatal;
 };
 
+/** Emit a warning message if the given predicate is true, otherwise emit an
+informational message. */
+class warn_or_info : public logger {
+public:
+	warn_or_info(bool	pred)
+	: m_warn(pred)
+	{}
+
+	~warn_or_info();
+private:
+	const bool	m_warn;
+};
+
 } // namespace ib
 
 #ifndef UNIV_NONINL

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -932,6 +932,15 @@ fatal_or_error::~fatal_or_error()
 	ut_a(!m_fatal);
 }
 
+warn_or_info::~warn_or_info()
+{
+	if (m_warn) {
+		sql_print_warning("InnoDB: %s", m_oss.str().c_str());
+	} else {
+		sql_print_information("InnoDB: %s", m_oss.str().c_str());
+	}
+}
+
 } // namespace ib
 
 #endif /* !UNIV_INNOCHECKSUM */


### PR DESCRIPTION
…g MTR test cases)

Fix handling of failure to set O_DIRECT on the parallel doublewrite
buffer by the following:
- downgrade diagnostics severity from warning to note by introducing
  an extra flag to os_file_setnocache;
- introduce new flag parallel_dblwr_t::needs_flush. Initialize it in
  buf_parallel_dblwr_file_create according to innodb_flush_method
  value and whether setting O_DIRECT succeeded. Use it instead of
  innodb_flush_method value in buf_dblwr_flush_buffered_writes.
- fix an incorrect comment at os_file_create_func.

http://jenkins.percona.com/job/mysql-5.7-param/1054/