### PR TITLE
Add testcase for bug 1704056 (Enabling and disabling slow query log r…

### DIFF
--- a/mysql-test/r/percona_bug1704056.result
+++ b/mysql-test/r/percona_bug1704056.result
@@ -1,0 +1,13 @@
+#
+# Bug 1704056: Enabling and disabling slow query log rotation spuriously
+# adds version suffix to the next slow query log file name
+#
+SET @old_max_slowlog_size = @@GLOBAL.max_slowlog_size;
+SET @old_slow_query_log_file = @@GLOBAL.slow_query_log_file;
+SET GLOBAL max_slowlog_size = 10240000;
+SET GLOBAL slow_query_log_file='MYSQLTEST_VARDIR/bug1704056_1';
+SET GLOBAL max_slowlog_size = @old_max_slowlog_size;
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/bug1704056.slog';
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+bug1704056.slog

--- a/mysql-test/t/percona_bug1704056.test
+++ b/mysql-test/t/percona_bug1704056.test
@@ -1,0 +1,24 @@
+--echo #
+--echo # Bug 1704056: Enabling and disabling slow query log rotation spuriously
+--echo # adds version suffix to the next slow query log file name
+--echo #
+
+SET @old_max_slowlog_size = @@GLOBAL.max_slowlog_size;
+SET @old_slow_query_log_file = @@GLOBAL.slow_query_log_file;
+SET GLOBAL max_slowlog_size = 10240000;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+eval SET GLOBAL slow_query_log_file='$MYSQLTEST_VARDIR/bug1704056_1';
+
+SET GLOBAL max_slowlog_size = @old_max_slowlog_size;
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/bug1704056.slog';
+
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+
+# With the bug present bug1704056.slog.00001 will be be created
+list_files $MYSQLTEST_VARDIR bug1704056.slog*;
+
+--remove_files_wildcard $MYSQLTEST_VARDIR bug1704056*


### PR DESCRIPTION
…otation spuriously adds version suffix to the next slow query log file name)

5.5 is not affected by the bug, thus only add the testcase.

http://jenkins.percona.com/job/percona-server-5.5-param/1575/