### PR TITLE
Fix bug 1704267 (Spurious lock_wait_timeout_thread wakeup in lock_wai…

### DIFF
--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -1334,7 +1334,7 @@ buf_LRU_check_size_of_non_data_objects(
 
 			buf_lru_switched_on_innodb_mon = true;
 			srv_print_innodb_monitor = TRUE;
-			os_event_set(lock_sys->timeout_event);
+			os_event_set(srv_monitor_event);
 		}
 
 	} else if (buf_lru_switched_on_innodb_mon) {
@@ -1400,7 +1400,7 @@ buf_LRU_handle_lack_of_free_blocks(ulint n_iterations, ulint started_ms,
 		*mon_value_was = srv_print_innodb_monitor;
 		*started_monitor = true;
 		srv_print_innodb_monitor = true;
-		os_event_set(lock_sys->timeout_event);
+		os_event_set(srv_monitor_event);
 	}
 
 }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -20420,9 +20420,8 @@ innodb_status_output_update(
 	const void*			save)
 {
 	*static_cast<my_bool*>(var_ptr) = *static_cast<const my_bool*>(save);
-	/* The lock timeout monitor thread also takes care of this
-	output. */
-	os_event_set(lock_sys->timeout_event);
+	/* Wake up server monitor thread */
+	os_event_set(srv_monitor_event);
 }
 
 /*************************************************************//**

--- a/storage/innobase/include/lock0lock.h
+++ b/storage/innobase/include/lock0lock.h
@@ -876,11 +876,6 @@ lock_trx_lock_list_init(
 /*====================*/
 	trx_lock_list_t*	lock_list);	/*!< List to initialise */
 
-/*******************************************************************//**
-Set the lock system timeout event. */
-void
-lock_set_timeout_event();
-/*====================*/
 #ifdef UNIV_DEBUG
 /*********************************************************************//**
 Checks that a transaction id is sensible, i.e., not in the future.

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -6977,15 +6977,6 @@ lock_trx_lock_list_init(
 	UT_LIST_INIT(*lock_list, &lock_t::trx_locks);
 }
 
-/*******************************************************************//**
-Set the lock system timeout event. */
-void
-lock_set_timeout_event()
-/*====================*/
-{
-	os_event_set(lock_sys->timeout_event);
-}
-
 #ifdef UNIV_DEBUG
 /*******************************************************************//**
 Check if the transaction holds any locks on the sys tables

--- a/storage/innobase/lock/lock0wait.cc
+++ b/storage/innobase/lock/lock0wait.cc
@@ -250,10 +250,6 @@ lock_wait_suspend_thread(
 		}
 	}
 
-	/* Wake the lock timeout monitor thread, if it is suspended */
-
-	os_event_set(lock_sys->timeout_event);
-
 	lock_wait_mutex_exit();
 	trx_mutex_exit(trx);
 

--- a/storage/innobase/sync/sync0arr.cc
+++ b/storage/innobase/sync/sync0arr.cc
@@ -1065,7 +1065,7 @@ sync_array_print_long_waits(
 
 		srv_print_innodb_monitor = TRUE;
 
-		lock_set_timeout_event();
+		os_event_set(srv_monitor_event);
 
 		os_thread_sleep(30000000);
 


### PR DESCRIPTION
…t_suspend_thread())

InnoDB spuriously wakes up lock_timeout thread on each lock wait
start, which is unnecessary and contributes to lock_sys_wait mutex
pressure if there are many lock waits ongoing. Also, in some cases
lock_timeout thread is woken up completely unnecessarily when the
intention is to wake up the InnoDB monitor thread instead.

Fix both of these issues by applying [1] from WebScaleSQL / MySQL
Facebook patch.

[1]:

commit 6e06bbfa315ffb97d713dd6e672d6054036ddc21
Author: Inaam Rana <irana@twitter.com>
Date:   Thu Apr 10 10:46:14 2014 -0400

    Spurious wakeup in lock_wait_suspend_thread()

    Summary:
    Feature: Performance improvement in locking subsystem

    This is a fix for upstream bug#72123

    lock_timeout thread works in a tight loop waking up every second
    and checking for lock_wait_timeout. In addition, when a mysql
    thread is forced to wait on a lock, it signals the lock_timeout thread
    as well. This call is not required. In a heavily contended workload
    each thread going to wait will signal the lock_timeout thread making
    it work all the time. As lock_timeout thread scans the array of
    waiting threads under lock_sys::wait_mutex which is already very
    hot in contneded loads, these extra scans can cause significanct
    performance regression.

    Also, in various codepaths lock_timeout thread is signalled where
    actual intention was to signal the innodb monitor thread.

    Test Plan: mtr

    Reviewers: pivanof, darnaut

    Reviewed By: darnaut

    CC: jtolmer, CalvinSun, WebScaleSQL, steaphan

    Differential Revision: https://reviews.facebook.net/D17673

http://jenkins.percona.com/job/mysql-5.7-param/1059/