### PR TITLE
Add support for `UPDATE FORCE...`

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -8479,7 +8479,10 @@ int handler::ha_update_row(const uchar *old_data, uchar *new_data)
 
   MYSQL_UPDATE_ROW_DONE(error);
   if (unlikely(error))
-    DBUG_RETURN(error);
+  {
+    if (likely(error != HA_ERR_RECORD_IS_THE_SAME || !ha_thd()->lex->is_force()))
+      DBUG_RETURN(error);
+  }
   if (unlikely((error= binlog_log_row(table, old_data, new_data, log_func))))
     DBUG_RETURN(error);
   rows_changed++;

--- a/sql/parse_tree_nodes.cc
+++ b/sql/parse_tree_nodes.cc
@@ -711,6 +711,7 @@ bool PT_update::contextualize(Parse_context *pc)
   lex->duplicates= DUP_ERROR;
 
   lex->set_ignore(opt_ignore);
+  lex->set_force(opt_force);
   if (join_table_list->contextualize(pc))
     return true;
   pc->select->parsing_place= CTX_UPDATE_VALUE_LIST;

--- a/sql/parse_tree_nodes.h
+++ b/sql/parse_tree_nodes.h
@@ -2512,6 +2512,7 @@ class PT_update : public PT_statement
   PT_hint_list *opt_hints;
   thr_lock_type opt_low_priority;
   bool opt_ignore;
+  bool opt_force;
   PT_join_table_list *join_table_list;
   PT_item_list *column_list;
   PT_item_list *value_list;
@@ -2525,6 +2526,7 @@ public:
   PT_update(PT_hint_list *opt_hints_arg,
             thr_lock_type opt_low_priority_arg,
             bool opt_ignore_arg,
+            bool opt_force_arg,
             PT_join_table_list *join_table_list_arg,
             PT_item_list *column_list_arg,
             PT_item_list *value_list_arg,
@@ -2534,6 +2536,7 @@ public:
   : opt_hints(opt_hints_arg),
     opt_low_priority(opt_low_priority_arg),
     opt_ignore(opt_ignore_arg),
+    opt_force(opt_force_arg),
     join_table_list(join_table_list_arg),
     column_list(column_list_arg),
     value_list(value_list_arg),

--- a/sql/sql_lex.h
+++ b/sql/sql_lex.h
@@ -3240,9 +3240,12 @@ public:
   bool subqueries;
 private:
   bool ignore;
+  bool force;
 public:
   bool is_ignore() const { return ignore; }
+  bool is_force() const { return force; }
   void set_ignore(bool ignore_param) { ignore= ignore_param; }
+  void set_force(bool force_param) { force= force_param; }
   st_parsing_options parsing_options;
   Alter_info alter_info;
   /*

--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -818,7 +818,7 @@ bool mysql_update(THD *thd,
 
         found++;
 
-        if (!records_are_comparable(table) || compare_records(table))
+        if (!records_are_comparable(table) || compare_records(table) || thd->lex->is_force())
         {
           if ((res= table_list->view_check_option(thd)) != VIEW_CHECK_OK)
           {

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1420,7 +1420,7 @@ END_OF_INPUT
 %type <xa_option_type> opt_suspend;
 %type <xa_option_type> opt_one_phase;
 
-%type <is_not_empty> opt_convert_xid opt_ignore
+%type <is_not_empty> opt_convert_xid opt_ignore opt_force
 
 %type <NONE>
         '-' '+' '*' '/' '%' '(' ')'
@@ -8539,6 +8539,11 @@ opt_ignore:
         | IGNORE_SYM  { $$= true; }
         ;
 
+opt_force:
+          /* empty */ { $$= false; }
+        | FORCE_SYM  { $$= true; }
+        ;
+
 opt_restrict:
           /* empty */ { Lex->drop_mode= DROP_DEFAULT; }
         | RESTRICT    { Lex->drop_mode= DROP_RESTRICT; }
@@ -11757,15 +11762,16 @@ update_stmt:
           UPDATE_SYM            /* #1 */
           opt_low_priority      /* #2 */
           opt_ignore            /* #3 */
-          join_table_list       /* #4 */
-          SET                   /* #5 */
-          update_list           /* #6 */
-          opt_where_clause      /* #7 */
-          opt_order_clause      /* #8 */
-          opt_simple_limit      /* #9 */
+          opt_force             /* #4 */
+          join_table_list       /* #5 */
+          SET                   /* #6 */
+          update_list           /* #7 */
+          opt_where_clause      /* #8 */
+          opt_order_clause      /* #9 */
+          opt_simple_limit      /* #10 */
           {
-            $$= NEW_PTN PT_update($1, $2, $3, $4, $6.column_list, $6.value_list,
-                                  $7, $8, $9);
+            $$= NEW_PTN PT_update($1, $2, $3, $4, $5, $7.column_list, $7.value_list,
+                                  $8, $9, $10);
           }
         ;
 


### PR DESCRIPTION
Normally, if an `UPDATE` is a no-op, i.e., if it doesn't actually change any record values, then no row data is written to the binlog. This patch adds support for `UPDATE FORCE` which forces row data to be written in this case. This is useful in the context of a binlog-based Change Data Capture (CDC) system in which it is sometimes desirable to snapshot a table by flushing all records through the binlogs without actually modifying anything. Feedback appreciated.