### PR TITLE
Fix bug 1706262 (innodb.bug-76142 leaves $MYSQL_TMP_DIR/test behind)

### DIFF
--- a/mysql-test/suite/innodb/t/bug-76142.test
+++ b/mysql-test/suite/innodb/t/bug-76142.test
@@ -40,3 +40,5 @@ SELECT * FROM t1;
 SELECT * FROM t2;
 
 DROP TABLE t1, t2;
+
+--rmdir $MYSQL_TMP_DIR/$DB


### PR DESCRIPTION
The testcase creates an InnoDB table with a specified data directory
$MYSQL_TMP_DIR, resulting in $MYSQL_TMP_DIR/test directory being
created, which is not removed at the end of the testcase. Remove it.

http://jenkins.percona.com/job/percona-server-5.6-param/1960/