### PR TITLE
[TDB-9] TokuDB does not lock rows for writes with LOCK IN SHARE MODE

### DIFF
--- a/mysql-test/suite/tokudb/r/locking-read-repeatable-read-1.result
+++ b/mysql-test/suite/tokudb/r/locking-read-repeatable-read-1.result
@@ -1,0 +1,13 @@
+create table t (a int primary key, b int) ENGINE=TokuDB;
+insert into t values (1,0);
+set session transaction isolation level repeatable read;
+begin;
+select * from t where a=1 lock in share mode;
+a	b
+1	0
+set session transaction isolation level repeatable read;
+begin;
+update t set b=b+1 where a=1;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+commit;
+drop table t;

--- a/mysql-test/suite/tokudb/r/locking-read-repeatable-read-2.result
+++ b/mysql-test/suite/tokudb/r/locking-read-repeatable-read-2.result
@@ -1,0 +1,17 @@
+create table t (a int primary key, b int) ENGINE=TokuDB;
+insert into t values (1,0);
+insert into t values (2,1);
+insert into t values (3,2);
+set session transaction isolation level repeatable read;
+begin;
+select * from t lock in share mode;
+a	b
+1	0
+2	1
+3	2
+set session transaction isolation level repeatable read;
+begin;
+update t set b=b+1 where a=2;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+commit;
+drop table t;

--- a/mysql-test/suite/tokudb/t/locking-read-repeatable-read-1.test
+++ b/mysql-test/suite/tokudb/t/locking-read-repeatable-read-1.test
@@ -1,0 +1,23 @@
+source include/have_tokudb.inc;
+source include/count_sessions.inc;
+create table t (a int primary key, b int) ENGINE=TokuDB;
+insert into t values (1,0);
+set session transaction isolation level repeatable read;
+begin;
+# t1 select in share mode
+select * from t where a=1 lock in share mode;
+# t2 update
+connect(conn1,localhost,root);
+set session transaction isolation level repeatable read;
+begin;
+# t2 select for update, should hang until t1 commits
+send update t set b=b+1 where a=1;
+--error ER_LOCK_WAIT_TIMEOUT
+reap;
+# t2 update
+connection default;
+commit;
+disconnect conn1;
+drop table t;
+
+source include/wait_until_count_sessions.inc;

--- a/mysql-test/suite/tokudb/t/locking-read-repeatable-read-2.test
+++ b/mysql-test/suite/tokudb/t/locking-read-repeatable-read-2.test
@@ -1,0 +1,29 @@
+#the difference of this test from locking-read-repeatable-read-1 
+#is that this test is on range query(gap lock) which actually 
+#examines a different patch
+
+source include/have_tokudb.inc;
+source include/count_sessions.inc;
+create table t (a int primary key, b int) ENGINE=TokuDB;
+insert into t values (1,0);
+insert into t values (2,1);
+insert into t values (3,2);
+set session transaction isolation level repeatable read;
+begin;
+# t1 select in share mode
+select * from t lock in share mode;
+# t2 update
+connect(conn1,localhost,root);
+set session transaction isolation level repeatable read;
+begin;
+# t2 select for update, should hang until t1 commits
+send update t set b=b+1 where a=2;
+--error ER_LOCK_WAIT_TIMEOUT
+reap;
+# t2 update
+connection default;
+commit;
+disconnect conn1;
+drop table t;
+
+source include/wait_until_count_sessions.inc;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -4696,6 +4696,9 @@ int ha_tokudb::index_init(uint keynr, bool sorted) {
     if (tokudb::sysvars::disable_prefetching(thd)) {
         cursor_flags |= DBC_DISABLE_PREFETCHING;
     }
+    if (lock.type == TL_READ_WITH_SHARED_LOCKS) {
+       cursor_flags |= DB_LOCKING_READ;
+    }
     if ((error = share->key_file[keynr]->cursor(share->key_file[keynr],
                                                 transaction, &cursor,
                                                 cursor_flags))) {


### PR DESCRIPTION
Updated: fixed the cleanup, 
http://jenkins.percona.com/view/MySQL/job/mysql-5.7-param/1173/


Updated: (1) fixed a bunch of things in response to the comments after rebase. (2) moved the PerconaFT head of PS 5.6 to the TDB-75 (commit 938ba1d).

[TDB-9] TokuDB does not lock rows for writes with LOCK IN SHARE MODE
The changes at the PS level. Two small mtr tests are  added. The tests fail before the fixes and pass after the fixes are applied, (so does the ctest).

Jira:
https://jira.percona.com/browse/TDB-9
Jenkins:
http://jenkins.percona.com/view/MySQL/job/mysql-5.7-param/1171/