### PR TITLE
Post fix for ps-5.5.57-merge

### DIFF
--- a/scripts/mysqldumpslow.sh
+++ b/scripts/mysqldumpslow.sh
@@ -1,8 +1,7 @@
-#!/usr/bin/perl
+#!@PERL_PATH@
 
-# Copyright (c) 2000-2002, 2005-2008 MySQL AB, 2008, 2009 Sun Microsystems, Inc.
-# Copyright (c) 2016, Percona Inc.
-# Use is subject to license terms.
+# Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, Percona Inc.
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Library General Public


### PR DESCRIPTION
Added '@PERL_PATH@' to 'mysqldumpslow.sh' missing in the main merge commit.