### PR TITLE
MYR-161 : MyRocks does not properly respect binlog_group_commit flag …

### DIFF
--- a/mysql-test/suite/rocksdb/r/2pc_group_commit.result
+++ b/mysql-test/suite/rocksdb/r/2pc_group_commit.result
@@ -20,11 +20,11 @@ SET GLOBAL rocksdb_flush_log_at_trx_commit=0;
 select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 select case when variable_value-@c = 0 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 case when variable_value-@c = 0 then 'true' else 'false' end
-false
+true
 select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 select case when variable_value-@c = 0 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_wal_group_syncs';
 case when variable_value-@c = 0 then 'true' else 'false' end
-false
+true
 SET GLOBAL rocksdb_flush_log_at_trx_commit=@orig_rocksdb_flush_log_at_trx_commit;
 DROP TABLE t1;
 DROP DATABASE mysqlslap;


### PR DESCRIPTION
…on reduced durability

- Fixed rocksdb_flush_wal to respect binlog_group_flush flag along with global
  setting rocksdb_flush_log_at_trx_commit, similar to InnoDB and TokuDB.
- Re-recorded 2pc_group_commit test to show correct behavior of
  rocksdb_wal_group_commit_syncs when rocksdb_flush_log_at_trx_commit=0