### PR TITLE
TDB-72 : Can not rename table in database with non alphanum character…

### DIFF
--- a/mysql-test/suite/tokudb/r/dir_per_db.result
+++ b/mysql-test/suite/tokudb/r/dir_per_db.result
@@ -1,3 +1,4 @@
+SET @orig_tokudb_dir_per_db=@@global.tokudb_dir_per_db;
 ########
 #  tokudb_dir_per_db = 1
 ########
@@ -177,4 +178,11 @@ t1_status_id.tokudb
 DROP TABLE t2;
 ## Looking for *.tokudb files in data_dir
 ## Looking for *.tokudb files in data_dir/test
-SET GLOBAL tokudb_dir_per_db=default;
+CREATE DATABASE `a::a@@`;
+CREATE TABLE `a::a@@`.`t1` (a INT) ENGINE=TOKUDB;
+CREATE DATABASE `!@#$%^&*()`;
+ALTER TABLE `a::a@@`.`t1` RENAME `!@#$%^&*()`.`t1`;
+DROP TABLE `!@#$%^&*()`.`t1`;
+DROP DATABASE `!@#$%^&*()`;
+DROP DATABASE `a::a@@`;
+SET GLOBAL tokudb_dir_per_db=@orig_tokudb_dir_per_db;

--- a/mysql-test/suite/tokudb/t/dir_per_db.test
+++ b/mysql-test/suite/tokudb/t/dir_per_db.test
@@ -1,5 +1,7 @@
 source include/have_tokudb.inc;
 
+SET @orig_tokudb_dir_per_db=@@global.tokudb_dir_per_db;
+
 --let $DB= test
 --let $DATADIR= `select @@datadir`
 --let $i= 2
@@ -73,4 +75,17 @@ while ($i) {
   --source dir_per_db_show_table_files.inc
 }
 
-SET GLOBAL tokudb_dir_per_db=default;
+
+# test case for TDB-72 : Can not rename table in database with non alphanum
+# characters in its name.
+CREATE DATABASE `a::a@@`;
+CREATE TABLE `a::a@@`.`t1` (a INT) ENGINE=TOKUDB;
+CREATE DATABASE `!@#$%^&*()`;
+ALTER TABLE `a::a@@`.`t1` RENAME `!@#$%^&*()`.`t1`;
+
+DROP TABLE `!@#$%^&*()`.`t1`;
+DROP DATABASE `!@#$%^&*()`;
+DROP DATABASE `a::a@@`;
+
+# cleanup
+SET GLOBAL tokudb_dir_per_db=@orig_tokudb_dir_per_db;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -7646,7 +7646,13 @@ static bool tokudb_check_db_dir_exist_from_table_name(const char *table_name) {
 
     memcpy(db_name, db_name_begin, db_name_size);
     db_name[db_name_size] = '\0';
-    mysql_dir_exists = (check_db_dir_existence(db_name) == 0);
+
+    // At this point, db_name contains the MySQL formatted database name.
+    // This is exactly the same format that would come into us through a
+    // CREATE TABLE. Some charaters (like ':' for example) might be expanded
+    // into hex (':' would papear as "@003a").
+    // We need to check that the MySQL destination database directory exists.
+    mysql_dir_exists = (my_access(db_name, F_OK) == 0);
 
     return mysql_dir_exists;
 }


### PR DESCRIPTION
…s in its name.

- Fixed check for db dir existence to not use MySQL call that transforms again
  the directory name that has already been transformed.
- Added new test to validate the issue is addressed.