### PR TITLE
Implemented Step 1 of bp:logical-read-ahead (Merge aio page read requests) (5.6)

### DIFF
--- a/storage/innobase/buf/buf0rea.cc
+++ b/storage/innobase/buf/buf0rea.cc
@@ -123,7 +123,12 @@ buf_read_page_low(
 			use to stop dangling page reads from a tablespace
 			which we have DISCARDed + IMPORTed back */
 	ulint	offset,	/*!< in: page number */
-	trx_t*	trx)
+	trx_t*	trx,
+	bool	should_buffer)	/*!< in: whether to buffer an aio request.
+			AIO read ahead uses this. If you plan to
+			use this parameter, make sure you remember
+			to call os_aio_dispatch_read_array_submit()
+			when you're ready to commit all your requests.*/
 {
 	buf_page_t*	bpage;
 	ulint		wake_later;
@@ -229,14 +234,15 @@ not_to_recover:
 		*err = _fil_io(OS_FILE_READ | wake_later
 			       | ignore_nonexistent_pages,
 			       sync, space, zip_size, offset, 0, zip_size,
-			       bpage->zip.data, bpage, trx);
+			       bpage->zip.data, bpage, trx, should_buffer);
 	} else {
 		ut_a(buf_page_get_state(bpage) == BUF_BLOCK_FILE_PAGE);
 
 		*err = _fil_io(OS_FILE_READ | wake_later
 			      | ignore_nonexistent_pages,
 			      sync, space, 0, offset, 0, UNIV_PAGE_SIZE,
-			      ((buf_block_t*) bpage)->frame, bpage, trx);
+			      ((buf_block_t*) bpage)->frame, bpage, trx,
+			      should_buffer);
 	}
 
 	if (sync) {
@@ -395,7 +401,7 @@ read_ahead:
 				&err, false,
 				ibuf_mode | OS_AIO_SIMULATED_WAKE_LATER,
 				space, zip_size, FALSE,
-				tablespace_version, i, trx);
+				tablespace_version, i, trx, false);
 			if (err == DB_TABLESPACE_DELETED) {
 				ut_print_timestamp(stderr);
 				fprintf(stderr,
@@ -459,7 +465,7 @@ buf_read_page(
 
 	count = buf_read_page_low(&err, true, BUF_READ_ANY_PAGE, space,
 				  zip_size, FALSE,
-				  tablespace_version, offset, trx);
+				  tablespace_version, offset, trx, false);
 	srv_stats.buf_pool_reads.add(count);
 	if (err == DB_TABLESPACE_DELETED) {
 		ut_print_timestamp(stderr);
@@ -507,7 +513,7 @@ buf_read_page_async(
 				  | OS_AIO_SIMULATED_WAKE_LATER
 				  | BUF_READ_IGNORE_NONEXISTENT_PAGES,
 				  space, zip_size, FALSE,
-				  tablespace_version, offset, NULL);
+				  tablespace_version, offset, NULL, false);
 	srv_stats.buf_pool_reads.add(count);
 
 	/* We do not increment number of I/O operations used for LRU policy
@@ -775,7 +781,8 @@ buf_read_ahead_linear(
 			count += buf_read_page_low(
 				&err, false,
 				ibuf_mode,
-				space, zip_size, FALSE, tablespace_version, i, trx);
+				space, zip_size, FALSE, tablespace_version,
+				i, trx, true);
 			if (err == DB_TABLESPACE_DELETED) {
 				ut_print_timestamp(stderr);
 				fprintf(stderr,
@@ -788,6 +795,7 @@ buf_read_ahead_linear(
 			}
 		}
 	}
+	os_aio_dispatch_read_array_submit();
 
 	/* In simulated aio we wake the aio handler threads only after
 	queuing all aio requests, in native aio the following call does
@@ -865,7 +873,7 @@ buf_read_ibuf_merge_pages(
 		buf_read_page_low(&err, sync && (i + 1 == n_stored),
 				  BUF_READ_ANY_PAGE, space_ids[i],
 				  zip_size, TRUE, space_versions[i],
-				  page_nos[i], NULL);
+				  page_nos[i], NULL, false);
 
 		if (UNIV_UNLIKELY(err == DB_TABLESPACE_DELETED)) {
 tablespace_deleted:
@@ -1005,12 +1013,13 @@ not_to_recover:
 		if ((i + 1 == n_stored) && sync) {
 			buf_read_page_low(&err, true, BUF_READ_ANY_PAGE, space,
 					  zip_size, TRUE, tablespace_version,
-					  page_nos[i], NULL);
+					  page_nos[i], NULL, false);
 		} else {
 			buf_read_page_low(&err, false, BUF_READ_ANY_PAGE
 					  | OS_AIO_SIMULATED_WAKE_LATER,
 					  space, zip_size, TRUE,
-					  tablespace_version, page_nos[i], NULL);
+					  tablespace_version, page_nos[i],
+					  NULL, false);
 		}
 	}
 

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -5253,7 +5253,7 @@ retry:
 		success = os_aio(OS_FILE_WRITE, OS_AIO_SYNC,
 				 node->name, node->handle, buf,
 				 offset, page_size * n_pages,
-				 NULL, NULL, space_id, NULL);
+				 NULL, NULL, space_id, NULL, false);
 #endif /* UNIV_HOTBACKUP */
 		if (success) {
 			os_has_said_disk_full = FALSE;
@@ -5630,7 +5630,12 @@ _fil_io(
 				appropriately aligned */
 	void*	message,	/*!< in: message for aio handler if non-sync
 				aio used, else ignored */
-	trx_t*	trx)
+	trx_t*	trx,
+	bool	should_buffer)	/*!< in: whether to buffer an aio request.
+				AIO read ahead uses this. If you plan to
+				use this parameter, make sure you remember
+				to call os_aio_dispatch_read_array_submit()
+				when you're ready to commit all your requests.*/
 {
 	ulint		mode;
 	fil_space_t*	space;
@@ -5848,7 +5853,7 @@ _fil_io(
 
 	/* Queue the aio request */
 	ret = os_aio(type, mode | wake_later, node->name, node->handle, buf,
-		offset, len, node, message, space_id, trx);
+		offset, len, node, message, space_id, trx, should_buffer);
 
 #else
 	/* In mysqlbackup do normal i/o, not aio */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1000,6 +1000,8 @@ static SHOW_VAR innodb_status_variables[]= {
   (char*) &export_vars.innodb_sec_rec_cluster_reads,	  SHOW_LONG},
   {"secondary_index_triggered_cluster_reads_avoided",
   (char*) &export_vars.innodb_sec_rec_cluster_reads_avoided, SHOW_LONG},
+  {"buffered_aio_submitted",
+  (char*) &export_vars.innodb_buffered_aio_submitted,	  SHOW_LONG},
   {NullS, NullS, SHOW_LONG}
 };
 

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -751,8 +751,10 @@ fil_space_get_n_reserved_extents(
 Reads or writes data. This operation is asynchronous (aio).
 @return DB_SUCCESS, or DB_TABLESPACE_DELETED if we are trying to do
 i/o on a tablespace which does not exist */
-#define fil_io(type, sync, space_id, zip_size, block_offset, byte_offset, len, buf, message) \
-	_fil_io(type, sync, space_id, zip_size, block_offset, byte_offset, len, buf, message, NULL)
+#define fil_io(type, sync, space_id, zip_size, block_offset,	\
+	       byte_offset, len, buf, message)			\
+	_fil_io(type, sync, space_id, zip_size, block_offset,	\
+	       byte_offset, len, buf, message, NULL, false)
 
 UNIV_INTERN
 dberr_t
@@ -783,7 +785,9 @@ _fil_io(
 				appropriately aligned */
 	void*	message,	/*!< in: message for aio handler if non-sync
 				aio used, else ignored */
-	trx_t*	trx)
+	trx_t*	trx,
+	bool	should_buffer)	/*!< in: whether to buffer an aio request.
+				Only used by aio read ahead*/
 	MY_ATTRIBUTE((nonnull(8)));
 /**********************************************************************//**
 Waits for an aio operation to complete. This function is used to write the

--- a/storage/innobase/include/os0file.ic
+++ b/storage/innobase/include/os0file.ic
@@ -246,6 +246,9 @@ pfs_os_aio_func(
                                 OS_AIO_SYNC */
 	ulint		space_id,
 	trx_t*		trx,
+	bool		should_buffer,
+				/*!< in: whether to buffer an aio request.
+				Only used by aio read ahead*/
 	const char*	src_file,/*!< in: file name where func invoked */
 	ulint		src_line)/*!< in: line where the func invoked */
 {
@@ -261,7 +264,8 @@ pfs_os_aio_func(
 				   src_file, src_line);
 
 	result = os_aio_func(type, mode, name, file, buf, offset,
-			     n, message1, message2, space_id, trx);
+			     n, message1, message2, space_id, trx,
+			     should_buffer);
 
 	register_pfs_file_io_end(locker, n);
 

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -129,6 +129,9 @@ struct srv_stats_t {
 	ulint_ctr_1_t		lock_deadlock_count;
 
 	ulint_ctr_1_t		n_lock_max_wait_time;
+
+	/** Number of buffered aio requests submitted */
+	ulint_ctr_64_t		n_aio_submitted;
 };
 
 extern const char*	srv_main_thread_op_info;
@@ -1100,6 +1103,8 @@ struct export_var_t{
 
 	ulint innodb_sec_rec_cluster_reads;	/*!< srv_sec_rec_cluster_reads */
 	ulint innodb_sec_rec_cluster_reads_avoided; /*!< srv_sec_rec_cluster_reads_avoided */
+
+	ulint innodb_buffered_aio_submitted;
 };
 
 /** Thread slot in the thread table.  */

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -247,6 +247,16 @@ struct os_aio_array_t{
 				There is one such event for each
 				possible pending IO. The size of the
 				array is equal to n_slots. */
+	struct iocb**		pending;
+				/* Array to buffer the not-submitted aio
+				requests. The array length is n_slots.
+				It is divided into n_segments segments.
+				pending requests on each segment are buffered
+				separately.*/
+	ulint*			count;
+				/* Array of length n_segments. Each element
+				counts the number of not-submitted aio
+				request on that segment.*/
 #endif /* LINUX_NATIV_AIO */
 };
 
@@ -4084,6 +4094,13 @@ os_aio_array_create(
 	memset(io_event, 0x0, sizeof(*io_event) * n);
 	array->aio_events = io_event;
 
+	array->pending = static_cast<struct iocb**>(
+		ut_malloc(n * sizeof(struct iocb*)));
+	memset(array->pending, 0x0, sizeof(struct iocb*) * n);
+	array->count = static_cast<ulint*>(
+		ut_malloc(n_segments * sizeof(ulint)));
+	memset(array->count, 0x0, sizeof(ulint) * n_segments);
+
 skip_native_aio:
 #endif /* LINUX_NATIVE_AIO */
 	for (ulint i = 0; i < n; i++) {
@@ -4140,6 +4157,16 @@ os_aio_array_free(
 	if (srv_use_native_aio) {
 		ut_free(array->aio_events);
 		ut_free(array->aio_ctx);
+
+#ifdef UNIV_DEBUG
+		for (size_t idx = 0; idx < array->n_slots; ++idx)
+			ut_ad(array->pending[idx] == NULL);
+		for (size_t idx = 0; idx < array->n_segments; ++idx)
+			ut_ad(array->count[idx] == 0);
+#endif
+
+		ut_free(array->pending);
+		ut_free(array->count);
 	}
 #endif /* LINUX_NATIVE_AIO */
 
@@ -4769,6 +4796,83 @@ readahead requests. */
 #endif /* __WIN__ */
 }
 
+/** Submit buffered AIO requests on the given segment to the kernel
+(low level function).
+@param acquire_mutex specifies whether to lock array mutex
+*/
+static
+void
+os_aio_dispatch_read_array_submit_low(bool acquire_mutex MY_ATTRIBUTE((unused)))
+{
+	if (!srv_use_native_aio) {
+		return;
+	}
+#if defined(LINUX_NATIVE_AIO)
+	os_aio_array_t*	array = os_aio_read_array;
+	ulint		total_submitted = 0;
+	if (acquire_mutex)
+		os_mutex_enter(array->mutex);
+	/* Submit aio requests buffered on all segments. */
+	for (ulint i = 0; i < array->n_segments; i++) {
+		const int	count = array->count[i];
+		int	offset = 0;
+		while (offset != count) {
+			struct iocb** const	iocb_array = array->pending
+				+ i * array->n_slots / array->n_segments
+				+ offset;
+			const int	partial_count = count - offset;
+			/* io_submit() returns number of successfully queued
+			requests or (-errno).
+			It returns 0 only if the number of iocb blocks passed
+			is also 0. */
+			const int	submitted = io_submit(array->aio_ctx[i],
+						partial_count, iocb_array);
+
+			/* This assertion prevents infinite loop in both
+			debug and release modes. */
+			ut_a(submitted != 0);
+
+			if (submitted < 0) {
+				/* Terminating with fatal error */
+				const char*	errmsg =
+					strerror(-submitted);
+				ib_logf(IB_LOG_LEVEL_FATAL,
+					"Trying to sumbit %d aio requests, "
+					"io_submit() set errno to %d: %s",
+					partial_count, -submitted,
+					errmsg ? errmsg : "<unknown>");
+			}
+			ut_ad(submitted <= partial_count);
+			if (submitted < partial_count)
+			{
+				ib_logf(IB_LOG_LEVEL_WARN,
+					"Trying to sumbit %d aio requests, "
+					"io_submit() submitted only %d",
+					partial_count, submitted);
+			}
+			offset += submitted;
+		}
+		total_submitted += count;
+	}
+	/* Reset the aio request buffer. */
+	memset(array->pending, 0x0, sizeof(struct iocb*) * array->n_slots);
+	memset(array->count, 0x0, sizeof(ulint) * array->n_segments);
+
+	if (acquire_mutex)
+		os_mutex_exit(array->mutex);
+
+	srv_stats.n_aio_submitted.add(total_submitted);
+#endif
+}
+
+/** Submit buffered AIO requests on the given segment to the kernel. */
+UNIV_INTERN
+void
+os_aio_dispatch_read_array_submit()
+{
+	os_aio_dispatch_read_array_submit_low(true);
+}
+
 #if defined(LINUX_NATIVE_AIO)
 /*******************************************************************//**
 Dispatch an AIO request to the kernel.
@@ -4778,10 +4882,11 @@ ibool
 os_aio_linux_dispatch(
 /*==================*/
 	os_aio_array_t*	array,	/*!< in: io request array. */
-	os_aio_slot_t*	slot)	/*!< in: an already reserved slot. */
+	os_aio_slot_t*	slot,	/*!< in: an already reserved slot. */
+	bool		should_buffer)	/*!< in: should buffer the request
+					rather than submit. */
 {
 	int		ret;
-	ulint		io_ctx_index;
 	struct iocb*	iocb;
 
 	ut_ad(slot != NULL);
@@ -4793,9 +4898,31 @@ os_aio_linux_dispatch(
 	The iocb struct is directly in the slot.
 	The io_context is one per segment. */
 
+	ulint	slots_per_segment = array->n_slots / array->n_segments;
 	iocb = &slot->control;
-	io_ctx_index = (slot->pos * array->n_segments) / array->n_slots;
+	ulint	io_ctx_index = slot->pos / slots_per_segment;
+	if (should_buffer) {
+		ut_ad(array == os_aio_read_array);
 
+		os_mutex_enter(array->mutex);
+		/* There are array->n_slots elements in array->pending,
+		which is divided into array->n_segments area of equal size.
+		The iocb of each segment are buffered in its corresponding area
+		in the pending array consecutively as they come.
+		array->count[i] records the number of buffered aio requests
+		in the ith segment.*/
+		ulint&	count = array->count[io_ctx_index];
+		ut_ad(count != slots_per_segment);
+		ulint	n = io_ctx_index * slots_per_segment + count;
+		array->pending[n] = iocb;
+		++count;
+		if (count == slots_per_segment) {
+			os_aio_dispatch_read_array_submit_low(false);
+		}
+		os_mutex_exit(array->mutex);
+		return(TRUE);
+	}
+	/* Submit the given request. */
 	ret = io_submit(array->aio_ctx[io_ctx_index], 1, &iocb);
 
 #if defined(UNIV_AIO_DEBUG)
@@ -4855,7 +4982,13 @@ os_aio_func(
 				aio operation); ignored if mode is
 				OS_AIO_SYNC */
 	ulint		space_id,
-	trx_t*		trx)
+	trx_t*		trx,
+	bool		should_buffer)
+				/*!< in: Whether to buffer an aio request.
+				AIO read ahead uses this. If you plan to
+				use this parameter, make sure you remember
+				to call os_aio_dispatch_read_array_submit()
+				when you're ready to commit all your requests.*/
 {
 	os_aio_array_t*	array;
 	os_aio_slot_t*	slot;
@@ -4965,7 +5098,8 @@ try_again:
 			ret = ReadFile(file.m_file, buf, (DWORD) n, &len,
 				       &(slot->control));
 #elif defined(LINUX_NATIVE_AIO)
-			if (!os_aio_linux_dispatch(array, slot)) {
+			if (!os_aio_linux_dispatch(array, slot,
+						   should_buffer)) {
 				goto err_exit;
 			}
 #endif /* WIN_ASYNC_IO */
@@ -4984,7 +5118,7 @@ try_again:
 			ret = WriteFile(file.m_file, buf, (DWORD) n, &len,
 					&(slot->control));
 #elif defined(LINUX_NATIVE_AIO)
-			if (!os_aio_linux_dispatch(array, slot)) {
+			if (!os_aio_linux_dispatch(array, slot, false)) {
 				goto err_exit;
 			}
 #endif /* WIN_ASYNC_IO */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1908,6 +1908,9 @@ srv_export_innodb_status(void)
 	export_vars.innodb_sec_rec_cluster_reads_avoided =
 		srv_sec_rec_cluster_reads_avoided;
 
+	export_vars.innodb_buffered_aio_submitted =
+		srv_stats.n_aio_submitted;
+
 	mutex_exit(&srv_innodb_monitor_mutex);
 }
 


### PR DESCRIPTION
Blueprint:
https://blueprints.launchpad.net/percona-server/+spec/logical-read-ahead

Cherry-picked "Merge aio page read requests" from Facebook
commit facebook/mysql-5.6@210450a

Summary:
WebScaleSQL Feature: Logical Read-Ahead

Tries to submit multiple aio page read requests together to improve read
performance.

This code adds an array to buffer aio requests in os_aio_array_t - though
only for os_aio_read_array, for now. A new parameter (should_buffer) is
added to indicate whether an aio request should be buffered or submitted.
If should_submit is true, it will submit all bufferred aio requests on
the os_aio_array.

Only buf_read_ahead_linear is modified to utilize this functionality so
far. All other call sites are setting should_submit to true. Other
os_aio_array_t arrays will also ignore this.

If one thread calling buf_read_ahead_linear is buffering io requests but
another thread issues a normal os_aio_request, that other request will
submit all the buffered requests from buf_read_ahead_linear. This is
still better than nothing I suppose.

Test Plan:
Initial perf tests were run manually.

Jenkins runs showed all tests should be clean.

This has been working well in production at Facebook for > 1 year.

Reviewers: darnaut, inaam-rana, steaphan, pivanof, weixiang.zhai

Reviewed By: inaam-rana, pivanof, steaphan, weixiang.zhai

Subscribers: minlizhu, rongrong, jtolmer, CalvinSun

Differential Revision: https://reviews.facebook.net/D23463
Differential Revision: https://reviews.facebook.net/D32379