### PR TITLE
TDB-76 : CREATE TABLE ... LIKE ... does not use source row_format on …

### DIFF
--- a/mysql-test/suite/tokudb/r/row_format.result
+++ b/mysql-test/suite/tokudb/r/row_format.result
@@ -1,4 +1,6 @@
 CREATE TABLE tokudb_row_format_test_1 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_DEFAULT;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
 CREATE TABLE tokudb_row_format_test_2 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_FAST;
 CREATE TABLE tokudb_row_format_test_3 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_SMALL;
 CREATE TABLE tokudb_row_format_test_4 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_UNCOMPRESSED;
@@ -6,6 +8,41 @@ CREATE TABLE tokudb_row_format_test_5 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_ZL
 CREATE TABLE tokudb_row_format_test_6 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_LZMA;
 CREATE TABLE tokudb_row_format_test_7 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_QUICKLZ;
 CREATE TABLE tokudb_row_format_test_8 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_SNAPPY;
+CREATE TABLE tdb76_1 LIKE tokudb_row_format_test_1;
+CREATE TABLE tdb76_2 LIKE tokudb_row_format_test_2;
+CREATE TABLE tdb76_3 LIKE tokudb_row_format_test_3;
+CREATE TABLE tdb76_4 LIKE tokudb_row_format_test_4;
+CREATE TABLE tdb76_5 LIKE tokudb_row_format_test_5;
+CREATE TABLE tdb76_6 LIKE tokudb_row_format_test_6;
+CREATE TABLE tdb76_7 LIKE tokudb_row_format_test_7;
+CREATE TABLE tdb76_8 LIKE tokudb_row_format_test_8;
+CREATE TABLE tdb76_compact(a INT) ENGINE=TokuDB ROW_FORMAT=COMPACT;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
+CREATE TABLE tdb76_redundant(a INT) ENGINE=TokuDB ROW_FORMAT=REDUNDANT;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
+CREATE TABLE tdb76_dynamic(a INT) ENGINE=TokuDB ROW_FORMAT=DYNAMIC;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
+CREATE TABLE tdb76_compressed(a INT) ENGINE=TokuDB ROW_FORMAT=COMPRESSED;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
+SELECT table_name, row_format, engine FROM information_schema.tables WHERE table_name like 'tdb76_%' ORDER BY table_name;
+table_name	row_format	engine
+tdb76_1	tokudb_zlib	TokuDB
+tdb76_2	tokudb_quicklz	TokuDB
+tdb76_3	tokudb_lzma	TokuDB
+tdb76_4	tokudb_uncompressed	TokuDB
+tdb76_5	tokudb_zlib	TokuDB
+tdb76_6	tokudb_lzma	TokuDB
+tdb76_7	tokudb_quicklz	TokuDB
+tdb76_8	tokudb_snappy	TokuDB
+tdb76_compact	tokudb_zlib	TokuDB
+tdb76_compressed	tokudb_zlib	TokuDB
+tdb76_dynamic	tokudb_zlib	TokuDB
+tdb76_redundant	tokudb_zlib	TokuDB
+DROP TABLE tdb76_1, tdb76_2, tdb76_3, tdb76_4, tdb76_5, tdb76_6, tdb76_7, tdb76_8, tdb76_compact, tdb76_redundant, tdb76_dynamic, tdb76_compressed;
 SELECT table_name, row_format, engine FROM information_schema.tables WHERE table_name like 'tokudb_row_format_test%' ORDER BY table_name;
 table_name	row_format	engine
 tokudb_row_format_test_1	tokudb_zlib	TokuDB
@@ -45,6 +82,8 @@ SELECT table_name, row_format, engine FROM information_schema.tables WHERE table
 table_name	row_format	engine
 tokudb_row_format_test_1	tokudb_lzma	TokuDB
 ALTER TABLE tokudb_row_format_test_1 ENGINE=TokuDB ROW_FORMAT=TOKUDB_DEFAULT;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
 SELECT table_name, row_format, engine FROM information_schema.tables WHERE table_name = 'tokudb_row_format_test_1';
 table_name	row_format	engine
 tokudb_row_format_test_1	tokudb_zlib	TokuDB

--- a/mysql-test/suite/tokudb/t/row_format.test
+++ b/mysql-test/suite/tokudb/t/row_format.test
@@ -12,6 +12,27 @@ CREATE TABLE tokudb_row_format_test_6 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_LZ
 CREATE TABLE tokudb_row_format_test_7 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_QUICKLZ;
 CREATE TABLE tokudb_row_format_test_8 (a INT) ENGINE=TokuDB ROW_FORMAT=TOKUDB_SNAPPY;
 
+# TDB-76 : CREATE TABLE ... LIKE ... does not use source row_format on target table
+CREATE TABLE tdb76_1 LIKE tokudb_row_format_test_1;
+CREATE TABLE tdb76_2 LIKE tokudb_row_format_test_2;
+CREATE TABLE tdb76_3 LIKE tokudb_row_format_test_3;
+CREATE TABLE tdb76_4 LIKE tokudb_row_format_test_4;
+CREATE TABLE tdb76_5 LIKE tokudb_row_format_test_5;
+CREATE TABLE tdb76_6 LIKE tokudb_row_format_test_6;
+CREATE TABLE tdb76_7 LIKE tokudb_row_format_test_7;
+CREATE TABLE tdb76_8 LIKE tokudb_row_format_test_8;
+
+CREATE TABLE tdb76_compact(a INT) ENGINE=TokuDB ROW_FORMAT=COMPACT;
+CREATE TABLE tdb76_redundant(a INT) ENGINE=TokuDB ROW_FORMAT=REDUNDANT;
+CREATE TABLE tdb76_dynamic(a INT) ENGINE=TokuDB ROW_FORMAT=DYNAMIC;
+CREATE TABLE tdb76_compressed(a INT) ENGINE=TokuDB ROW_FORMAT=COMPRESSED;
+
+SELECT table_name, row_format, engine FROM information_schema.tables WHERE table_name like 'tdb76_%' ORDER BY table_name;
+
+DROP TABLE tdb76_1, tdb76_2, tdb76_3, tdb76_4, tdb76_5, tdb76_6, tdb76_7, tdb76_8, tdb76_compact, tdb76_redundant, tdb76_dynamic, tdb76_compressed;
+
+
+
 SELECT table_name, row_format, engine FROM information_schema.tables WHERE table_name like 'tokudb_row_format_test%' ORDER BY table_name;
 
 ALTER TABLE tokudb_row_format_test_1 ENGINE=TokuDB ROW_FORMAT=TOKUDB_FAST;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -7227,10 +7227,28 @@ int ha_tokudb::create(
     const tokudb::sysvars::format_t row_format =
         (tokudb::sysvars::row_format_t)form->s->option_struct->row_format;
 #else
-    const tokudb::sysvars::row_format_t row_format =
-        (create_info->used_fields & HA_CREATE_USED_ROW_FORMAT)
-        ? row_type_to_row_format(create_info->row_type)
-        : tokudb::sysvars::row_format(thd);
+    // TDB-76 : CREATE TABLE ... LIKE ... does not use source row_format on
+    //          target table
+    // Original code would only use create_info->row_type if
+    // create_info->used_fields & HA_CREATE_USED_ROW_FORMAT was true. This
+    // would cause us to skip transferring the row_format for a table created
+    // via CREATE TABLE tn LIKE tn. We also take on more InnoDB like behavior
+    // and throw a warning if we get a row_format that we can't translate into
+    // a known TokuDB row_format.
+    tokudb::sysvars::row_format_t row_format =
+        tokudb::sysvars::row_format(thd);
+
+    if ((create_info->used_fields & HA_CREATE_USED_ROW_FORMAT) ||
+        create_info->row_type != ROW_TYPE_DEFAULT) {
+        row_format = row_type_to_row_format(create_info->row_type);
+        if (row_format == tokudb::sysvars::SRV_ROW_FORMAT_DEFAULT &&
+            create_info->row_type != ROW_TYPE_DEFAULT) {
+            push_warning(thd,
+                         Sql_condition::WARN_LEVEL_WARN,
+                         ER_ILLEGAL_HA_CREATE_OPTION,
+                         "TokuDB: invalid ROW_FORMAT specifier.");
+        }
+    }
 #endif
     const toku_compression_method compression_method =
         row_format_to_toku_compression_method(row_format);


### PR DESCRIPTION
…target table

- Implemented fix in TDB to take row_format if it is not the same as DEFAULT.
- Added new SQL warning if a row_format value can not be translated to a valid
  TokuDB row_format type.
- Enhanced the tokudb.row_format test to cover these cases.