### PR TITLE
Bug: PS-247 - keyring_vault mtr tests should be skipped if Vault server

### DIFF
--- a/plugin/keyring_vault/tests/mtr/install_keyring_vault.test
+++ b/plugin/keyring_vault/tests/mtr/install_keyring_vault.test
@@ -5,6 +5,7 @@ call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_va
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --error ER_UNKNOWN_SYSTEM_VARIABLE

--- a/plugin/keyring_vault/tests/mtr/is_vault_server_up.inc
+++ b/plugin/keyring_vault/tests/mtr/is_vault_server_up.inc
@@ -1,0 +1,94 @@
+# In order to check whether Vault server is accessible we try to get list
+# of server backends. This list should be short.
+
+let KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1;
+let SERVER_UUID= query_get_value(SELECT @@SERVER_UUID, @@SERVER_UUID, 1);
+if (!$CURL_TIMEOUT)
+{
+  --let CURL_TIMEOUT=4
+}
+--perl
+  use strict;
+  use IO::File;
+  my $curl_timeout= $ENV{CURL_TIMEOUT} or die "Need CURL_TIMEOUT";
+  my $keyring_conf_file= $ENV{'KEYRING_CONF_FILE'} or die("KEYRING_CONF_FILE not set\n");
+  my $server_uuid= $ENV{'SERVER_UUID'} or die("SERVER_UUID not set\n");
+  my $token;
+  my $vault_url;
+  my $secret_mount_point;
+  my $vault_ca;
+  my $CONF_FILE;
+  open(CONF_FILE, "$keyring_conf_file") or die("Could not open configuration file.\n");
+  while (my $row = <CONF_FILE>)
+  {
+    if ($row =~ m/token[ ]*=[ ]*(.*)/)
+    {
+      $token=$1;
+    }
+    elsif ($row =~ m/vault_url[ ]*=[ ]*(.*)/)
+    {
+      $vault_url=$1;
+    }
+    elsif ($row =~ m/secret_mount_point[ ]*= [ ]*(.*)/)
+    {
+      $secret_mount_point=$1;
+    }
+    elsif ($row =~ m/vault_ca[ ]*= [ ]*(.*)/)
+    {
+      $vault_ca=$1;
+    }
+  }
+  close(CONF_FILE);
+
+  my $vardir= $ENV{MYSQLTEST_VARDIR} or die "Need MYSQLTEST_VARDIR";
+
+  if ($token eq "" || $vault_url eq "" || $secret_mount_point eq "")
+  {
+    die("Could not read vault credentials from configuration file.\n");
+  }
+
+  my $vault_ca_cert_opt= "";
+  if ($vault_ca)
+  {
+    $vault_ca_cert_opt= "--cacert $vault_ca";
+  }
+
+  system(qq#curl -H "X-Vault-Token: $token" --max-time $curl_timeout $vault_ca_cert_opt $vault_url/v1/sys/mounts > $vardir/tmp/curl_result#);
+
+  my $curl_conn_successful = 1;
+  my $curl_response = 0;
+
+  if (!-s "$vardir/tmp/curl_result")
+  {
+    # result file is empty, thus connection could not be established
+    $curl_conn_successful = 0;
+  }
+  else
+  {
+    # Vault server has returned errors
+    open my $file, '<', "$vardir/tmp/curl_result";
+    $curl_response = <$file>;
+    if (index($curl_response, "\"errors\":[\"") != -1)
+    {
+      $curl_conn_successful = 0;
+    }
+    close $file;
+  }
+
+  my $file_name = "$vardir/tmp/mount_list_result.inc";
+  my $F = IO::File->new($file_name, 'w') or die "Could not open '$file_name' for writing";
+  if (!$curl_conn_successful)
+  {
+    if ($curl_response)
+    {
+      print $F "--skip Cannot connect to Hashicorp Vault due to : $curl_response";
+    }
+    else
+    {
+      print $F "--skip Seems that Hashicorp Vault testing server is down";
+    }
+  }
+  $F->close();
+EOF
+
+--source $MYSQLTEST_VARDIR/tmp/mount_list_result.inc

--- a/plugin/keyring_vault/tests/mtr/key_rotation_qa.test
+++ b/plugin/keyring_vault/tests/mtr/key_rotation_qa.test
@@ -26,6 +26,7 @@ call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot open table .* from the in
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Failed to decrpt encryption information, please check key file is not changed!");
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/keyring_udf.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_udf.test
@@ -10,6 +10,7 @@ call mtr.add_suppression("Error while storing key: invalid key_type");
 call mtr.add_suppression("Error while storing key: key_id cannot be empty");
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_config.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_config.test
@@ -4,6 +4,8 @@
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
+
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR $KEYRING_PLUGIN keyring_vault.so $KEYRING_VAULT_PLUGIN_OPT KEYRING_VAULT_PLUGIN_OPT
 --let $restart_parameters="restart:$KEYRING_VAULT_PLUGIN_LOAD --loose-keyring_vault_config=$KEYRING_CONF_FILE_1 $KEYRING_VAULT_PLUGIN_OPT"
 --source include/restart_mysqld.inc

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_config_qa.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_config_qa.test
@@ -14,6 +14,7 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not 
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_thd_wait.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_thd_wait.test
@@ -4,6 +4,7 @@
 --source include/have_debug.inc
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/rpl_key_rotation.test
+++ b/plugin/keyring_vault/tests/mtr/rpl_key_rotation.test
@@ -15,6 +15,7 @@ call mtr.add_suppression("\\[Error\\] InnoDB: Can't generate new master key for 
 call mtr.add_suppression("The slave coordinator and worker threads are stopped");
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_1.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_1.test
@@ -1,5 +1,8 @@
 --source include/have_keyring_vault_plugin.inc
+
+--let $KEYRING_CONF_FILE_1=$MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault1.conf
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_2.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_2.test
@@ -7,6 +7,7 @@
 --source include/not_embedded.inc
 
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_3.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_3.test
@@ -1,5 +1,6 @@
 --source include/have_keyring_vault_plugin.inc
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_4.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_4.test
@@ -1,5 +1,6 @@
 --source include/have_keyring_vault_plugin.inc
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_5.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_5.test
@@ -3,6 +3,7 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'keyring_va
 
 --source include/have_keyring_vault_plugin.inc
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_debug.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_debug.test
@@ -1,5 +1,6 @@
 --source include/have_keyring_vault_plugin.inc
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_kill.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_kill.test
@@ -1,5 +1,6 @@
 --source include/have_keyring_vault_plugin.inc
 --source generate_default_conf_files.inc
+--source is_vault_server_up.inc
 
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE


### PR DESCRIPTION
is unavailable

Added check file is_vault_server_up.inc. This script checks if
Hashicorp Vault server that is to be used in a test is available. In
case it is not the test will be skipped. This test file was included in
all keyring_vault's MTR tests.