### PR TITLE
Bug PS-248: keyring_udf mtr tests should be skipped if keyring_udf

### DIFF
--- a/mysql-test/include/have_keyring_udf_plugin.inc
+++ b/mysql-test/include/have_keyring_udf_plugin.inc
@@ -1,0 +1,7 @@
+#
+# Check if the variable KEYRING_UDF is set
+#
+
+if (!$KEYRING_UDF) {
+  --skip keyring_udf not available.
+}

--- a/mysql-test/suite/auth_sec/t/keyring_udf.test
+++ b/mysql-test/suite/auth_sec/t/keyring_udf.test
@@ -1,3 +1,4 @@
+--source include/have_keyring_udf_plugin.inc
 --source include/not_embedded.inc
 
 call mtr.add_suppression("Error while fetching key: key_id cannot be empty");

--- a/plugin/keyring_vault/tests/mtr/keyring_udf.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_udf.test
@@ -1,4 +1,5 @@
 --source include/have_keyring_vault_plugin.inc
+--source include/have_keyring_udf_plugin.inc
 --source include/not_embedded.inc
 
 call mtr.add_suppression("Error while fetching key: key_id cannot be empty");


### PR DESCRIPTION
plugin is unavailable

Added a check file have_keyring_udf_plugin.inc that makes a test
skip itself in case keyring_udf plugin is not available. This check
file was added to the begging of all keyring_udf mtr tests