### PR TITLE
fix allocator type in std::map

### DIFF
--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -1133,7 +1133,7 @@ innobase_build_index_translation(
 
 /** Compression dictionary id container */
 typedef std::map<uint16, ulint, std::less<uint16>,
-	ut_allocator<std::pair<uint16, const ulint> > >
+	ut_allocator<std::pair<const uint16, ulint> > >
 	zip_dict_id_container_t;
 
 /** This function checks if all the compression dictionaries referenced


### PR DESCRIPTION
With Xcode 9 on macOS 10.13, build fails due to invalid C++ code being detected by the standard C++ headers and compiler:

```
In file included from /tmp/percona-server-20170912-98780-16f1412/percona-server-5.7.18-16/storage/innobase/handler/ha_innodb.cc:37:
In file included from /tmp/percona-server-20170912-98780-16f1412/percona-server-5.7.18-16/storage/innobase/include/univ.i:600:
In file included from /tmp/percona-server-20170912-98780-16f1412/percona-server-5.7.18-16/storage/innobase/include/sync0types.h:32:
In file included from /tmp/percona-server-20170912-98780-16f1412/percona-server-5.7.18-16/storage/innobase/include/ut0new.h:125:
/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/map:820:5: error: static_assert failed "Allocator::value_type must be same type as value_type"
    static_assert((is_same<typename allocator_type::value_type, value_type>::value),
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__config:729:36: note: expanded from macro 'static_assert'
#   define static_assert(__b, __m) _Static_assert(__b, __m)
                                   ^              ~~~
/tmp/percona-server-20170912-98780-16f1412/percona-server-5.7.18-16/storage/innobase/handler/ha_innodb.cc:6266:26: note: in instantiation of template class 'std::__1::map<unsigned short, unsigned long, std::__1::less<unsigned short>, ut_allocator<std::__1::pair<unsigned short, const unsigned long> > >' requested here
        zip_dict_id_container_t local_dict_ids;
                                ^
/tmp/percona-server-20170912-98780-16f1412/percona-server-5.7.18-16/storage/innobase/handler/ha_innodb.cc:6290:12: error: no member named 'swap' in 'std::__1::map<unsigned short, unsigned long, std::__1::less<unsigned short>, ut_allocator<std::__1::pair<unsigned short, const unsigned long> > >'
                dict_ids.swap(local_dict_ids);
                ~~~~~~~~ ^
```

This pull request fixes `zip_dict_id_container_t` by putting the `const` in the right place.