### PR TITLE
MYR-137 : Review replication testing

### DIFF
--- a/mysql-test/suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+++ b/mysql-test/suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
@@ -1,0 +1,42 @@
+#
+# This is a helper script for rpl_row_img.test. It creates
+# all combinations InnoDB / RocksDB in a three server replication
+# chain. Each engine combination is tested against the current
+# seetings for binlog_row_image (on each server).
+#
+# The test script that is executed on every combination is the
+# only argument to this wrapper script. See below.
+#
+# This script takes one parameter:
+#  - $row_img_test_script
+#    the name of the test script to include in every combination
+#
+# Sample usage:
+#   -- let $row_img_test_script= extra/rpl_tests/rpl_row_img.test
+#   -- source suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+
+
+-- let $engine_type_a= 2
+-- let $server_1_engine=  RocksDB
+while($engine_type_a)
+{
+  -- let $engine_type_b= 2
+  -- let $server_2_engine=  RocksDB
+  while($engine_type_b)
+  {
+    -- let $engine_type_c= 2
+    -- let $server_3_engine=  RocksDB
+    while($engine_type_c)
+    {
+      -- echo ### engines: $server_1_engine, $server_2_engine, $server_3_engine
+      -- source $row_img_test_script
+
+      -- let $server_3_engine= InnoDB
+      -- dec $engine_type_c
+    }
+    -- let $server_2_engine= InnoDB
+    -- dec $engine_type_b
+  }
+  -- let $server_1_engine= InnoDB
+  -- dec $engine_type_a
+}

--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_blobs.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_blobs.result
@@ -1,0 +1,4739 @@
+include/rpl_init.inc [topology=1->2->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+CON: 'server_1', IMG: 'NOBLOB', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'NOBLOB';
+SET GLOBAL binlog_row_image= 'NOBLOB';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+CON: 'server_2', IMG: 'NOBLOB', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'NOBLOB';
+SET GLOBAL binlog_row_image= 'NOBLOB';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+CON: 'server_3', IMG: 'NOBLOB', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'NOBLOB';
+SET GLOBAL binlog_row_image= 'NOBLOB';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+### engines: RocksDB, RocksDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, RocksDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+CON: 'server_1', IMG: 'MINIMAL', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'MINIMAL';
+SET GLOBAL binlog_row_image= 'MINIMAL';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+CON: 'server_2', IMG: 'MINIMAL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'MINIMAL';
+SET GLOBAL binlog_row_image= 'MINIMAL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+CON: 'server_3', IMG: 'MINIMAL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'MINIMAL';
+SET GLOBAL binlog_row_image= 'MINIMAL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+### engines: RocksDB, RocksDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, RocksDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+CON: 'server_1', IMG: 'FULL', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_2', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_3', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+### engines: RocksDB, RocksDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, RocksDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, RocksDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, InnoDB
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check when there is no key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the AI (they are not updated) 
+### will not break replication (check even if there is a key in the table)
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (UK NOT NULL exists in the table) 
+### will not break replication
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int NOT NULL, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that updates without blobs in the BI (PK exists int the table)
+### will not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob in a key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a unique (not null) key does not break replication
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Asserts that declaring a blob as part of a primary key does not break replication
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_idx_full.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_idx_full.result
@@ -1,0 +1,3505 @@
+include/rpl_init.inc [topology=1->2->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+CON: 'server_1', IMG: 'FULL', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_2', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_3', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+### engines: RocksDB, RocksDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, RocksDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_idx_min.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_idx_min.result
@@ -1,0 +1,3530 @@
+include/rpl_init.inc [topology=1->2->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+CON: 'server_1', IMG: 'MINIMAL', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'MINIMAL';
+SET GLOBAL binlog_row_image= 'MINIMAL';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+CON: 'server_2', IMG: 'MINIMAL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'MINIMAL';
+SET GLOBAL binlog_row_image= 'MINIMAL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+CON: 'server_3', IMG: 'MINIMAL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'MINIMAL';
+SET GLOBAL binlog_row_image= 'MINIMAL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+### engines: RocksDB, RocksDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, RocksDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+CON: 'server_1', IMG: 'FULL', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_2', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_3', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_idx_noblob.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_img_idx_noblob.result
@@ -1,0 +1,3530 @@
+include/rpl_init.inc [topology=1->2->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+CON: 'server_1', IMG: 'NOBLOB', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'NOBLOB';
+SET GLOBAL binlog_row_image= 'NOBLOB';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+CON: 'server_2', IMG: 'NOBLOB', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'NOBLOB';
+SET GLOBAL binlog_row_image= 'NOBLOB';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+CON: 'server_3', IMG: 'NOBLOB', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'NOBLOB';
+SET GLOBAL binlog_row_image= 'NOBLOB';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+### engines: RocksDB, RocksDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, RocksDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: RocksDB, InnoDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, RocksDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= RocksDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, RocksDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= RocksDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+### engines: InnoDB, InnoDB, InnoDB
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no keys slaves with no keys as well
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with keys
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields (first slave with UK NOT NULL, second with PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with no key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, first slave with key on different field and second slave with key on yet another different field.
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields (first slave has UK NOT NULL)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with Key, slaves with PKs on different fields
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, slaves with no keys
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NULLABLE, first slave with K on different field second slave with key on yet another different field
+CREATE TABLE t (c1 int, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL, first slave with UK NOT NULL on different field
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with UK NOT NULL and slaves with PK on different fields
+CREATE TABLE t (c1 int NOT NULL, c2 blob, c3 int, unique key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and no keys on the slaves
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Master with PK and first slave with KEY only
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c3)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, key(c2(512))) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave (which has unique NOT NULL key instead of PK)
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, unique key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob NOT NULL, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+SET SQL_LOG_BIN=0;
+### Different PKs on master and first slave
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c2(512))) engine= InnoDB;;
+CREATE TABLE t (c1 int, c2 blob, c3 int, primary key(c1)) engine= InnoDB;;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+SET SQL_LOG_BIN=1;
+INSERT INTO t VALUES (1, "a", 10);
+INSERT INTO t VALUES (2, "b", 20);
+INSERT INTO t VALUES (3, "c", 30);
+include/rpl_sync.inc
+UPDATE t SET c1=10 WHERE c2="a";
+UPDATE t SET c1=20 WHERE c1=2;
+UPDATE t SET c1=30 WHERE c3=30;
+UPDATE t SET c3=40 WHERE c1=30;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DELETE FROM t WHERE c2="a";
+DELETE FROM t WHERE c1=20;
+DELETE FROM t;
+include/rpl_sync.inc
+include/diff_tables.inc [server_1:test.t, server_2:test.t, server_3:test.t]
+DROP TABLE t;
+include/rpl_sync.inc
+CON: 'server_1', IMG: 'FULL', RESTART SLAVE: 'N'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_2', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+CON: 'server_3', IMG: 'FULL', RESTART SLAVE: 'Y'
+SET SESSION binlog_row_image= 'FULL';
+SET GLOBAL binlog_row_image= 'FULL';
+include/stop_slave.inc
+include/start_slave.inc
+FLUSH TABLES;
+SHOW VARIABLES LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_sp006.result
+++ b/mysql-test/suite/rocksdb.rpl/r/rpl_rocksdb_row_sp006.result
@@ -1,0 +1,48 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+set session collation_server=utf8_bin;
+DROP TABLE IF EXISTS t1;
+DROP TABLE IF EXISTS t2;
+DROP PROCEDURE IF EXISTS p1;
+DROP PROCEDURE IF EXISTS p2;
+CREATE TABLE IF NOT EXISTS t1(name CHAR(16), birth DATE,PRIMARY KEY(name))ENGINE=RocksDB;
+CREATE TABLE IF NOT EXISTS t2(name CHAR(16), age INT ,PRIMARY KEY(name))ENGINE=RocksDB;
+CREATE PROCEDURE p1()
+BEGIN
+DECLARE done INT DEFAULT 0;
+DECLARE spa CHAR(16);
+DECLARE spb INT;
+DECLARE cur1 CURSOR FOR SELECT name, 
+(YEAR(CURDATE())-YEAR(birth))-(RIGHT(CURDATE(),5)<RIGHT(birth,5)) 
+FROM t1;
+DECLARE CONTINUE HANDLER FOR SQLSTATE '02000' SET done = 1;
+OPEN cur1;
+SET AUTOCOMMIT=0;
+REPEAT
+FETCH cur1 INTO spa, spb;
+IF NOT done THEN
+START TRANSACTION;
+INSERT INTO t2 VALUES (spa,spb);
+COMMIT;
+END IF;
+UNTIL done END REPEAT;
+SET AUTOCOMMIT=1;
+CLOSE cur1;
+END|
+CREATE PROCEDURE p2()
+BEGIN
+INSERT INTO t1 VALUES ('MySQL','1993-02-04'),('ROCKS', '1990-08-27'),('Texas', '1999-03-30'),('kyle','2005-1-1');
+END|
+CALL p2();
+include/sync_slave_sql_with_master.inc
+CALL p1();
+include/sync_slave_sql_with_master.inc
+DROP TABLE t1;
+DROP TABLE t2;
+DROP PROCEDURE p1;
+DROP PROCEDURE p2;
+include/sync_slave_sql_with_master.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_blobs.cnf
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_blobs.cnf
@@ -1,0 +1,1 @@
+!include suite/rpl/t/rpl_row_img.cnf

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_blobs.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_blobs.test
@@ -1,0 +1,54 @@
+#Want to skip this test from daily Valgrind execution
+--source include/no_valgrind_without_big.inc
+
+-- source include/have_innodb.inc
+-- source include/have_rocksdb.inc
+-- source include/not_group_replication_plugin.inc
+#
+# This file contains tests for WL#5096.
+#
+
+-- let $rpl_topology= 1->2->3
+-- source include/rpl_init.inc
+-- source include/have_binlog_format_row.inc
+
+#
+#   WL#5096 Tests.
+# 
+
+#
+# Tests combinations of binlog-row-image against mixes of MyISAM and InnoDB
+# storage engines on all three servers.
+#
+# All the combinarions need not to be separated into their own files as
+# the tests for indexes and engines mixes are, because noblobs test script
+# does not take too long time, thence we do not risk triggering PB2 timeout
+# on valgrind runs.
+#
+
+## NOBLOB
+
+-- let $row_img_set=server_1:NOBLOB:N,server_2:NOBLOB:Y,server_3:NOBLOB:Y
+-- source include/rpl_row_img_set.inc
+
+-- let $row_img_test_script= extra/rpl_tests/rpl_row_img_blobs.test
+-- source suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+
+## MINIMAL
+
+-- let $row_img_set=server_1:MINIMAL:N,server_2:MINIMAL:Y,server_3:MINIMAL:Y
+-- source include/rpl_row_img_set.inc
+
+-- let $row_img_test_script= extra/rpl_tests/rpl_row_img_blobs.test
+-- source suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+
+## FULL
+
+-- let $row_img_set=server_1:FULL:N,server_2:FULL:Y,server_3:FULL:Y
+-- source include/rpl_row_img_set.inc
+
+-- let $row_img_test_script= extra/rpl_tests/rpl_row_img_blobs.test
+-- source suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+
+
+-- source include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_full.cnf
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_full.cnf
@@ -1,0 +1,1 @@
+!include suite/rpl/t/rpl_row_img.cnf

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_full.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_full.test
@@ -1,0 +1,30 @@
+#Want to skip this test from daily Valgrind execution
+-- source include/no_valgrind_without_big.inc
+#
+# This file contains tests for WL#5096.
+#
+-- source include/have_innodb.inc
+-- source include/have_rocksdb.inc
+-- source include/not_group_replication_plugin.inc
+-- source include/have_binlog_format_row.inc
+
+-- let $rpl_topology= 1->2->3
+-- source include/rpl_init.inc
+
+#
+#   WL#5096 Tests.
+# 
+
+#
+# Tests FULL image against a mix of MyISAM and InnoDB engines on
+# each of the three servers.
+#
+
+-- let $row_img_set=server_1:FULL:N,server_2:FULL:Y,server_3:FULL:Y
+-- source include/rpl_row_img_set.inc
+
+-- let $row_img_test_script= extra/rpl_tests/rpl_row_img_diff_indexes.test
+-- source suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+
+
+-- source include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_min.cnf
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_min.cnf
@@ -1,0 +1,1 @@
+!include suite/rpl/t/rpl_row_img.cnf

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_min.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_min.test
@@ -1,0 +1,34 @@
+#Want to skip this test from daily Valgrind execution
+--source include/no_valgrind_without_big.inc
+#
+# This file contains tests for WL#5096.
+#
+
+-- source include/have_innodb.inc
+-- source include/have_rocksdb.inc
+-- source include/not_group_replication_plugin.inc
+-- source include/have_binlog_format_row.inc
+
+-- let $rpl_topology= 1->2->3
+-- source include/rpl_init.inc
+
+#
+#   WL#5096 Tests.
+# 
+
+#
+# Tests MINIMAL image against a mix of MyISAM and InnoDB engines on
+# each of the three servers.
+#
+
+-- let $row_img_set=server_1:MINIMAL:N,server_2:MINIMAL:Y,server_3:MINIMAL:Y
+-- source include/rpl_row_img_set.inc
+
+-- let $row_img_test_script= extra/rpl_tests/rpl_row_img_diff_indexes.test
+-- source suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+
+-- let $row_img_set=server_1:FULL:N,server_2:FULL:Y,server_3:FULL:Y
+-- source include/rpl_row_img_set.inc
+
+
+-- source include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_noblob.cnf
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_noblob.cnf
@@ -1,0 +1,1 @@
+!include suite/rpl/t/rpl_row_img.cnf

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_noblob.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_img_idx_noblob.test
@@ -1,0 +1,33 @@
+#Want to skip this test from daily Valgrind execution
+-- source include/no_valgrind_without_big.inc
+#
+# This file contains tests for WL#5096.
+#
+-- source include/have_innodb.inc
+-- source include/have_rocksdb.inc
+-- source include/not_group_replication_plugin.inc
+-- source include/have_binlog_format_row.inc
+
+-- let $rpl_topology= 1->2->3
+-- source include/rpl_init.inc
+
+#
+# WL#5096
+# 
+
+#
+# Tests NOBLOB image against a mix of MyISAM and InnoDB engines on
+# each of the three servers.
+#
+
+-- let $row_img_set=server_1:NOBLOB:N,server_2:NOBLOB:Y,server_3:NOBLOB:Y
+-- source include/rpl_row_img_set.inc
+
+-- let $row_img_test_script= extra/rpl_tests/rpl_row_img_diff_indexes.test
+-- source suite/rocksdb.rpl/include/rpl_rocksdb_row_img_general_loop.inc
+
+-- let $row_img_set=server_1:FULL:N,server_2:FULL:Y,server_3:FULL:Y
+-- source include/rpl_row_img_set.inc
+
+
+-- source include/rpl_end.inc

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_sp006.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_sp006.test
@@ -1,0 +1,21 @@
+#################################
+# Wrapper for rpl_row_sp006.test#
+#################################
+########################################################
+# By JBM 2005-02-15 Wrapped to allow reuse of test code#
+# Added to skip if ndb is default                      #
+########################################################
+-- source include/not_ndb_default.inc
+-- source include/have_rocksdb.inc
+-- source include/not_group_replication_plugin.inc
+-- source include/have_binlog_format_row.inc
+-- source include/master-slave.inc
+let $engine_type=RocksDB;
+# needed for RocksDB as it does not support non-binary collations on indexed
+# character columns with rocksdb_strict_collation_check=on and collation
+# is not a part of this test, so it is more efficient to just adjust the
+# sessions collation than it is to turn off rocksdb_strict_collation_check
+# in the master and slave .opt files
+set session collation_server=utf8_bin;
+-- source extra/rpl_tests/rpl_row_sp006.test
+-- source include/rpl_end.inc


### PR DESCRIPTION
MYR-142 : MyRocks does not support UNIQUE INDEX on tables with no PRIMARY KEY
MYR-145 : Merge March 2017
- MYR-145 pulled in the upstream fix for MYR-142. This freed up the import of
  some relications tests that were held back when implementing MYR-137. This
  imports those tests with recorded results.