### PR TITLE
MYR-186 : Fix for MYR-168 introduced mtr regression

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_parts.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_parts.result
@@ -97,9 +97,9 @@ drop table t1;
 # Issue #214: subqueries cause crash
 #
 create TABLE t1(a int,b int,c int,primary key(a,b)) engine=rocksdb
-partition by list (b*a) (partition x1 values in (1) tablespace ts1,
-partition x2 values in (3,11,5,7) tablespace ts2,
-partition x3 values in (16,8,5+19,70-43) tablespace ts3);
+partition by list (b*a) (partition x1 values in (1),
+partition x2 values in (3,11,5,7),
+partition x3 values in (16,8,5+19,70-43));
 Warnings:
 Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 create table t2(b binary(2)) engine=rocksdb;

--- a/mysql-test/suite/rocksdb/t/rocksdb_parts.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_parts.test
@@ -82,9 +82,9 @@ drop table t1;
 --echo # Issue #214: subqueries cause crash
 --echo #
 create TABLE t1(a int,b int,c int,primary key(a,b)) engine=rocksdb
-    partition by list (b*a) (partition x1 values in (1) tablespace ts1,
-                             partition x2 values in (3,11,5,7) tablespace ts2,
-                             partition x3 values in (16,8,5+19,70-43) tablespace ts3);
+    partition by list (b*a) (partition x1 values in (1),
+                             partition x2 values in (3,11,5,7),
+                             partition x3 values in (16,8,5+19,70-43));
 create table t2(b binary(2)) engine=rocksdb;
 set session optimizer_switch=5;
 insert into t1(a,b) values(1,7);


### PR DESCRIPTION
- Corrected test that makes use of tablespaces where MyRocks absorbed the
  invalid CREATE TABLE specifiers but now fails due to errors generated as a
  result of the fix for MYR-168. This was missed in testing as this test,
  rocksdb.rocksdb_parts is still unstable and fails occasionally elsewhere.