### PR TITLE
MYR-179 : Basic Sysbench run fails with basic MyROCKS install due to …

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_open_files_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_open_files_basic.result
@@ -1,7 +1,7 @@
 SET @start_global_value = @@global.ROCKSDB_MAX_OPEN_FILES;
 SELECT @start_global_value;
 @start_global_value
--1
+1000
 "Trying to set variable @@global.ROCKSDB_MAX_OPEN_FILES to 444. It should fail because it is readonly."
 SET @@global.ROCKSDB_MAX_OPEN_FILES   = 444;
 ERROR HY000: Variable 'rocksdb_max_open_files' is a read only variable

--- a/mysql-test/suite/rocksdb/r/max_open_files.result
+++ b/mysql-test/suite/rocksdb/r/max_open_files.result
@@ -1,0 +1,15 @@
+CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit*");
+# restart:--log-error=MYSQLTEST_VARDIR/tmp/rocksdb.max_open_files.err --rocksdb_max_open_files=over_rocksdb_max_open_files
+# restart:--rocksdb_max_open_files=0
+SELECT @@global.rocksdb_max_open_files;
+@@global.rocksdb_max_open_files
+0
+CREATE TABLE t1(a INT) ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES(0),(1),(2),(3),(4);
+SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now=1;
+DROP TABLE t1;
+# restart:--rocksdb_max_open_files=-1
+SELECT @@global.rocksdb_max_open_files;
+@@global.rocksdb_max_open_files
+-1
+# restart

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -955,7 +955,7 @@ rocksdb_manual_wal_flush	ON
 rocksdb_max_background_jobs	2
 rocksdb_max_log_file_size	0
 rocksdb_max_manifest_file_size	18446744073709551615
-rocksdb_max_open_files	4294967295
+rocksdb_max_open_files	1000
 rocksdb_max_row_locks	1073741824
 rocksdb_max_subcompactions	1
 rocksdb_max_total_wal_size	0

--- a/mysql-test/suite/rocksdb/t/max_open_files.test
+++ b/mysql-test/suite/rocksdb/t/max_open_files.test
@@ -1,0 +1,38 @@
+--source include/have_rocksdb.inc
+
+# MYR-179 : Basic Sysbench run fails with basic MyROCKS install due to lack of open files
+
+# test for over limit
+CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit*");
+
+--let $over_rocksdb_max_open_files=`SELECT @@global.open_files_limit + 2000000`
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/rocksdb.max_open_files.err
+--let SEARCH_PATTERN=RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR $over_rocksdb_max_open_files over_rocksdb_max_open_files
+--let $restart_parameters=restart:--log-error=$SEARCH_FILE --rocksdb_max_open_files=$over_rocksdb_max_open_files
+--source include/restart_mysqld.inc
+--source include/search_pattern_in_file.inc
+
+# test for minimal value
+--let $restart_parameters=restart:--rocksdb_max_open_files=0
+--source include/restart_mysqld.inc
+
+SELECT @@global.rocksdb_max_open_files;
+
+# verify that we can still do work with no descriptor cache
+CREATE TABLE t1(a INT) ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES(0),(1),(2),(3),(4);
+SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now=1;
+DROP TABLE t1;
+
+# test for unlimited (former default)
+--let $restart_parameters=restart:--rocksdb_max_open_files=-1
+--source include/restart_mysqld.inc
+
+SELECT @@global.rocksdb_max_open_files;
+
+# cleanup
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+--remove_file $SEARCH_FILE


### PR DESCRIPTION
…lack of open files

- Changed default value to 1000 from infinite.
- Added detection if rocksdb_max_open_files is > open_files_limit to reduce it to open_files_limit.
- Extended rocksdb.sys_vars.rocksdb_max_open_files_basic.test to validate new behavior for minimum, maximum, and unlimited.
