### PR TITLE
Add option to limit write batch size

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_write_batch_max_bytes_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_write_batch_max_bytes_basic.result
@@ -1,0 +1,15 @@
+create table t (i int) engine=rocksdb;
+insert into t values (1), (2), (3), (4), (5);
+set session rocksdb_write_batch_max_bytes = 1000;
+insert into t values (1), (2), (3), (4), (5);
+set session rocksdb_write_batch_max_bytes = 10;
+insert into t values (1), (2), (3), (4), (5);
+ERROR HY000: Status error 10 received from RocksDB: Operation aborted: Memory limit reached
+set session rocksdb_write_batch_max_bytes = 0;
+insert into t values (1), (2), (3), (4), (5);
+set session rocksdb_write_batch_max_bytes = 10;
+begin;
+insert into t values (1), (2), (3), (4), (5);
+ERROR HY000: Status error 10 received from RocksDB: Operation aborted: Memory limit reached
+rollback;
+drop table t;

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_batch_max_bytes_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_write_batch_max_bytes_basic.test
@@ -1,0 +1,26 @@
+--source include/have_rocksdb.inc
+
+create table t (i int) engine=rocksdb;
+
+insert into t values (1), (2), (3), (4), (5);
+
+set session rocksdb_write_batch_max_bytes = 1000;
+
+insert into t values (1), (2), (3), (4), (5);
+
+set session rocksdb_write_batch_max_bytes = 10;
+
+--error ER_RDB_STATUS_GENERAL
+insert into t values (1), (2), (3), (4), (5);
+
+set session rocksdb_write_batch_max_bytes = 0;
+
+insert into t values (1), (2), (3), (4), (5);
+
+set session rocksdb_write_batch_max_bytes = 10;
+begin;
+--error ER_RDB_STATUS_GENERAL
+insert into t values (1), (2), (3), (4), (5);
+rollback;
+
+drop table t;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -998,6 +998,7 @@ rocksdb_wal_recovery_mode	1
 rocksdb_wal_size_limit_mb	0
 rocksdb_wal_ttl_seconds	0
 rocksdb_whole_key_filtering	ON
+rocksdb_write_batch_max_bytes	0
 rocksdb_write_disable_wal	OFF
 rocksdb_write_ignore_missing_column_families	OFF
 create table t47 (pk int primary key, col1 varchar(12)) engine=rocksdb;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -599,6 +599,11 @@ static MYSQL_THDVAR_ULONG(max_row_locks, PLUGIN_VAR_RQCMDARG,
                           /*min*/ 1,
                           /*max*/ RDB_MAX_ROW_LOCKS, 0);
 
+static MYSQL_THDVAR_ULONGLONG(
+    write_batch_max_bytes, PLUGIN_VAR_RQCMDARG,
+    "Maximum size of write batch in bytes. 0 means no limit.", nullptr, nullptr,
+    /* default */ 0, /* min */ 0, /* max */ SIZE_T_MAX, 1);
+
 static MYSQL_THDVAR_BOOL(
     lock_scanned_rows, PLUGIN_VAR_RQCMDARG,
     "Take and hold locks on rows that are scanned but not updated", nullptr,
@@ -1304,6 +1309,7 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(lock_wait_timeout),
     MYSQL_SYSVAR(deadlock_detect),
     MYSQL_SYSVAR(max_row_locks),
+    MYSQL_SYSVAR(write_batch_max_bytes),
     MYSQL_SYSVAR(lock_scanned_rows),
     MYSQL_SYSVAR(bulk_load),
     MYSQL_SYSVAR(trace_sst_api),
@@ -2133,6 +2139,7 @@ public:
     tx_opts.set_snapshot = false;
     tx_opts.lock_timeout = rdb_convert_sec_to_ms(m_timeout_sec);
     tx_opts.deadlock_detect = THDVAR(m_thd, deadlock_detect);
+    tx_opts.max_write_batch_size = THDVAR(m_thd, write_batch_max_bytes);
 
     write_opts.sync = (rocksdb_flush_log_at_trx_commit == 1);
     write_opts.disableWAL = THDVAR(m_thd, write_disable_wal);


### PR DESCRIPTION
Upstream commit ID : fb-mysql-5.6.35/ad4cb203b72c2dc44ee56b6ab1dea653a52fdba

Summary:
Add a session variable `rocksdb_write_batch_max_bytes` which determines the maximum size of a rocksdb write batch. A value of zero means no limit. A write batch may exceed the limit by a bit because 2PC markers are not checked.

update-submodule: rocksdb

Reviewed By: gunnarku

Differential Revision: D4864740

fbshipit-source-id: 66acf6e