### PR TITLE
lp-1708033: heartbeats/fakerotate cause a forced sync_master_info

### DIFF
--- a/mysql-test/suite/rpl/r/bug85158.result
+++ b/mysql-test/suite/rpl/r/bug85158.result
@@ -1,0 +1,59 @@
+include/rpl_init.inc [topology=1->2,2->3,1->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+###
+# STOP SLAVE ON 2
+######
+[connection server_2]
+STOP SLAVE;
+###
+# CREATE TABLE AND INSERTS ON 1
+######
+[connection server_1]
+CREATE TABLE t1(f1 INT, f2 BLOB);
+###
+# SYNC 1->3
+######
+include/sync_slave_sql_with_master.inc
+###
+# MEASURE 3
+######
+STOP SLAVE;
+UPDATE performance_schema.setup_objects
+SET enabled='yes', timed='yes'
+  WHERE object_schema='mysql';
+START SLAVE;
+###
+# START SLAVES 2
+######
+[connection server_2]
+START SLAVE;
+###
+# SYNC 1->2,2->3
+######
+[connection server_1]
+include/sync_slave_sql_with_master.inc
+include/sync_slave_sql_with_master.inc
+###
+# MEASURE 3
+######
+###
+# COMPARE THE MEASUREMENT RESULTS
+######
+include/assert.inc [No more than 5 writes should have happened to slave_master_info]
+###
+# CLEANUP
+######
+UPDATE performance_schema.setup_objects
+SET enabled='no', timed='no'
+  WHERE object_schema='mysql';
+[connection server_1]
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/bug85158.cnf
+++ b/mysql-test/suite/rpl/t/bug85158.cnf
@@ -1,0 +1,24 @@
+!include ../my.cnf
+
+[mysqld.1]
+gtid_mode=ON
+enforce-gtid-consistency
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+
+[mysqld.2]
+gtid_mode=ON
+enforce-gtid-consistency
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+
+[mysqld.3]
+gtid_mode=ON
+enforce-gtid-consistency
+master-info-repository=TABLE
+relay-log-info-repository=TABLE
+sync_master_info=0
+
+[ENV]
+SERVER_MYPORT_3=@mysqld.3.port
+SERVER_MYSOCK_3=@mysqld.3.socket

--- a/mysql-test/suite/rpl/t/bug85158.test
+++ b/mysql-test/suite/rpl/t/bug85158.test
@@ -1,0 +1,108 @@
+#
+# Testcase for bug 85158.
+#
+--source include/not_group_replication_plugin.inc
+--source include/have_gtid.inc
+--source include/have_perfschema.inc
+
+--let $rpl_multi_source= 1
+--let $rpl_topology= 1->2,2->3,1->3
+--source include/rpl_init.inc
+
+# MI writes threshold, if the difference between the count of writes to
+# the MI repository before and after the actions is greater than the
+# threshold, the test failed
+--let $threshold=5
+
+# The number of inserts on server_1, if the bug is not fixed the amount
+# of the MI repository writes will be greater or equal to this value
+--let $inserts_number=50
+
+--echo ###
+--echo # STOP SLAVE ON 2
+--echo ######
+--let $rpl_connection_name= server_2
+--source include/rpl_connection.inc
+STOP SLAVE;
+
+--echo ###
+--echo # CREATE TABLE AND INSERTS ON 1
+--echo ######
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+CREATE TABLE t1(f1 INT, f2 BLOB);
+--disable_query_log
+--let $j=$inserts_number
+while($j)
+{
+--eval INSERT INTO t1(f1) VALUES($j)
+--dec $j
+}
+--enable_query_log
+
+--echo ###
+--echo # SYNC 1->3
+--echo ######
+--let $sync_slave_connection= server_3
+--source include/sync_slave_sql_with_master.inc
+
+--echo ###
+--echo # MEASURE 3
+--echo ######
+STOP SLAVE;
+UPDATE performance_schema.setup_objects
+  SET enabled='yes', timed='yes'
+  WHERE object_schema='mysql';
+START SLAVE;
+
+let $before=
+`SELECT count_write
+  FROM performance_schema.table_io_waits_summary_by_table
+  WHERE object_schema='mysql' AND object_name ='slave_master_info'`;
+
+--echo ###
+--echo # START SLAVES 2
+--echo ######
+--let $rpl_connection_name= server_2
+--source include/rpl_connection.inc
+START SLAVE;
+
+--echo ###
+--echo # SYNC 1->2,2->3
+--echo ######
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+--let $sync_slave_connection= server_2
+--source include/sync_slave_sql_with_master.inc
+--let $sync_slave_connection= server_3
+--source include/sync_slave_sql_with_master.inc
+
+--echo ###
+--echo # MEASURE 3
+--echo ######
+let $after=
+`SELECT count_write
+  FROM performance_schema.table_io_waits_summary_by_table
+  WHERE object_schema='mysql' AND object_name ='slave_master_info'`;
+
+--echo ###
+--echo # COMPARE THE MEASUREMENT RESULTS
+--echo ######
+--let $result=`SELECT (($after - $before) < $threshold)`
+--let $assert_text= No more than $threshold writes should have happened to slave_master_info
+--let $assert_cond= $result = 1
+--source include/assert.inc
+
+--echo ###
+--echo # CLEANUP
+--echo ######
+UPDATE performance_schema.setup_objects
+  SET enabled='no', timed='no'
+  WHERE object_schema='mysql';
+--let $rpl_connection_name= server_1
+--source include/rpl_connection.inc
+DROP TABLE t1;
+--disable_query_log
+--let $rpl_skip_sync= 1
+--source include/rpl_end.inc
+--enable_query_log


### PR DESCRIPTION
See also mysql-85158.

Description:

lp-1708033: heartbeats/fakerotate cause a forced sync_master_info

See also mysql-85158.

Description:

1) When slave connects to master, it sends COM_BINLOG_DUMP_GTID command with
executed gtids set, see:
```
0  Binlog_sender::Binlog_sender (this=0x7ffff1179560, thd=0x7fff94000b70, start_file=0x7ffff117a1c0 "", start_pos=4, exclude_gtids=0x7ffff1179f90, flag=0)
    at ./sql/rpl_binlog_sender.cc:55
1  0x0000000001936fcf in mysql_binlog_send (thd=0x7fff94000b70, log_ident=0x7ffff117a1c0 "", pos=4, slave_gtid_executed=0x7ffff1179f90, flags=0)
    at ./sql/rpl_master.cc:410
2  0x0000000001936e75 in com_binlog_dump_gtid (thd=0x7fff94000b70, packet=0x7fff9400a761 "", packet_length=30)
    at ./sql/rpl_master.cc:396
3  0x0000000001646634 in dispatch_command (thd=0x7fff94000b70, com_data=0x7ffff117ade0, command=COM_BINLOG_DUMP_GTID)
    at ./sql/sql_parse.cc:1709
4  0x00000000016448d6 in do_command (thd=0x7fff94000b70) at ./sql/sql_parse.cc:1021
5  0x0000000001796a22 in handle_connection (arg=0x34bd880) at ./sql/conn_handler/connection_handler_per_thread.cc:312
6  0x0000000001e7cd03 in pfs_spawn_thread (arg=0x3902460) at ./storage/perfschema/pfs.cc:2188
7  0x00007ffff6f5e6ba in start_thread (arg=0x7ffff117b700) at pthread_create.c:333
8  0x00007ffff63f33dd in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

2) Then master starts sending events, if it reads binary logs, and if gtid of
some event belongs to already executed slaves gtids set, then HEARTBEAT is sent.

See:
```
0  Binlog_sender::send_heartbeat_event (this=0x7ffff11fb560, log_pos=39340) at ./sql/rpl_binlog_sender.cc:1145
1  0x000000000193a362 in Binlog_sender::send_events (this=0x7ffff11fb560, log_cache=0x7ffff11fafa0, end_pos=39340)
    at ./sql/rpl_binlog_sender.cc:517
2  0x0000000001939b41 in Binlog_sender::send_binlog (this=0x7ffff11fb560, log_cache=0x7ffff11fafa0, start_pos=123)
    at ./sql/rpl_binlog_sender.cc:348
3  0x000000000193944a in Binlog_sender::run (this=0x7ffff11fb560) at ./sql/rpl_binlog_sender.cc:225
4  0x0000000001936fde in mysql_binlog_send (thd=0x7fff9c027e10, log_ident=0x7ffff11fc1c0 "", pos=4, slave_gtid_executed=0x7ffff11fbf90, flags=0)
    at ./sql/rpl_master.cc:412
5  0x0000000001936e75 in com_binlog_dump_gtid (thd=0x7fff9c027e10, packet=0x7fff9c0110d1 "", packet_length=86)
    at ./sql/rpl_master.cc:396
6  0x0000000001646634 in dispatch_command (thd=0x7fff9c027e10, com_data=0x7ffff11fcde0, command=COM_BINLOG_DUMP_GTID)
    at ./sql/sql_parse.cc:1709
7  0x00000000016448d6 in do_command (thd=0x7fff9c027e10) at ./sql/sql_parse.cc:1021
8  0x0000000001796a22 in handle_connection (arg=0x34bd880) at ./sql/conn_handler/connection_handler_per_thread.cc:312
9  0x0000000001e7cd03 in pfs_spawn_thread (arg=0x3902460) at ./storage/perfschema/pfs.cc:2188
10 0x00007ffff6f5e6ba in start_thread (arg=0x7ffff11fd700) at pthread_create.c:333
11 0x00007ffff63f33dd in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

If we look into:

```
int Binlog_sender::send_events(IO_CACHE *log_cache, my_off_t end_pos)
{
...
    if (m_exclude_gtid && (in_exclude_group= skip_event(event_ptr, event_len,
                                                        in_exclude_group)))
    {
...
    }
...
  if (unlikely(in_exclude_group))
  {
    if (send_heartbeat_event(log_pos))
      DBUG_RETURN(1);
  }
...
}
```

we will see how hearbeat is being sent.

See also Binlog_sender::skip_event() to understand how event is treated to be
skipped and Binlog_sender::send_heartbeat_event() to see how hearbeat is sent.

3) Slave receives the heartbeat, see

```
bool queue_event(Master_info* mi,const char* buf, ulong event_len)
{
...
  case binary_log::HEARTBEAT_LOG_EVENT:
...
}
```

and writes 'rotate log' event into relay log, see
write_ignored_events_info_to_relay_log() from which flush_master_info() is
invoked with 'force' parameter equal to true, what means mi repository will be
updated ignoring sync_master_info server option.

See also the following backtrace:

```
0  Rpl_info_table::do_flush_info (this=0x7fffa0f39950, force=true) at ./sql/rpl_info_table.cc:201
1  0x000000000196537c in Rpl_info_handler::flush_info (this=0x7fffa0f39950, force=true) at ./sql/rpl_info_handler.h:94
2  0x0000000001964182 in Master_info::flush_info (this=0x7fffa007a2c0, force=true) at ./sql/rpl_mi.cc:263
3  0x0000000001940f32 in flush_master_info (mi=0x7fffa007a2c0, force=true) at ./sql/rpl_slave.cc:1444
4  0x0000000001946a1f in write_ignored_events_info_to_relay_log (thd=0x7fff9c027e70, mi=0x7fffa007a2c0)
    at ./sql/rpl_slave.cc:3428
5  0x0000000001957203 in queue_event (mi=0x7fffa007a2c0, buf=0x7fff9c00a9f1 "", event_len=40) at ./sql/rpl_slave.cc:8467
6  0x000000000194ef74 in handle_slave_io (arg=0x7fffa007a2c0) at ./sql/rpl_slave.cc:5861
7  0x0000000001e7cd03 in pfs_spawn_thread (arg=0x7fffa0013800) at ./storage/perfschema/pfs.cc:2188
8  0x00007ffff6f5e6ba in start_thread (arg=0x7ffff11fd700) at pthread_create.c:333
9  0x00007ffff63f33dd in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
```

So if we have the following topology 1->2, 2->3, 1->3 and then stop slave 1->2,
generate events on 1, then sync 1->3, and start 1->2, we will see a lot of
hearbeats(greater or equal to the number of events, generated on 1) on 3,
and a lot of writes(greater or equal to the number of hearbeats) in
master info reposirory.

Solution:

The solution is not to force mi repository flush if hearbeat is received.