### PR TITLE
TDB-80 : TDB-76 introduced regression in mtr tests

### DIFF
--- a/mysql-test/suite/tokudb.alter_table/r/null_bytes_add_key.result
+++ b/mysql-test/suite/tokudb.alter_table/r/null_bytes_add_key.result
@@ -43,6 +43,8 @@ Warnings:
 Warning	1265	Data truncated for column 'c19' at row 1
 UPDATE t SET c27=0;
 ALTER TABLE t ROW_FORMAT=FIXED KEY_BLOCK_SIZE=1;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
 UPDATE t SET c27=0;
 set tokudb_disable_hot_alter=0;
 set tokudb_disable_slow_alter=1;

--- a/mysql-test/suite/tokudb.alter_table/r/null_bytes_col_rename.result
+++ b/mysql-test/suite/tokudb.alter_table/r/null_bytes_col_rename.result
@@ -43,6 +43,8 @@ Warnings:
 Warning	1265	Data truncated for column 'c19' at row 1
 UPDATE t SET c27=0;
 ALTER TABLE t ROW_FORMAT=FIXED KEY_BLOCK_SIZE=1;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
 UPDATE t SET c27=0;
 set tokudb_disable_hot_alter=0;
 set tokudb_disable_slow_alter=1;

--- a/mysql-test/suite/tokudb.alter_table/r/null_bytes_drop_default.result
+++ b/mysql-test/suite/tokudb.alter_table/r/null_bytes_drop_default.result
@@ -43,6 +43,8 @@ Warnings:
 Warning	1265	Data truncated for column 'c19' at row 1
 UPDATE t SET c27=0;
 ALTER TABLE t ROW_FORMAT=FIXED KEY_BLOCK_SIZE=1;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
 UPDATE t SET c27=0;
 set tokudb_disable_hot_alter=0;
 set tokudb_disable_slow_alter=1;

--- a/mysql-test/suite/tokudb.alter_table/r/null_bytes_drop_key.result
+++ b/mysql-test/suite/tokudb.alter_table/r/null_bytes_drop_key.result
@@ -45,6 +45,8 @@ UPDATE t SET c27=0;
 ALTER TABLE t ADD KEY (c25);
 UPDATE t SET c27=0;
 ALTER TABLE t ROW_FORMAT=FIXED KEY_BLOCK_SIZE=1;
+Warnings:
+Warning	1478	TokuDB: invalid ROW_FORMAT specifier.
 UPDATE t SET c27=0;
 set tokudb_disable_hot_alter=0;
 set tokudb_disable_slow_alter=1;


### PR DESCRIPTION
- Re-recorded tests to pick up new warning when unrecognized ROW_FORMAT is passed to TokuDB
- Since this change requires the change for TDB-76 in order to test properly and GA has not yet advanced past the TDB-76 change, this will be cherry picked forward to 5.7 instead of merged