### PR TITLE
Fix bug 1706356 5.7 (Adding index corrupts data in memory table)

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -250,7 +250,6 @@ typedef struct st_heap_create_info
   my_bool pin_share;
   uint columns;
   HP_COLUMNDEF *columndef;
-  uint fixed_key_fieldnr;
   uint fixed_data_size;
   uint keys_memory_size;
   uint max_chunk_size;

--- a/mysql-test/r/heap.result
+++ b/mysql-test/r/heap.result
@@ -839,3 +839,18 @@ c1
 bar2
 #should show one tuple!
 DROP TABLE t1;
+CREATE TABLE t1 (
+rid bigint(20) NOT NULL AUTO_INCREMENT,
+pid bigint(20) NOT NULL,
+full_name text NOT NULL,
+update_time int(11) NOT NULL DEFAULT '0',
+PRIMARY KEY (`rid`)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8;
+INSERT INTO t1 (rid, pid, full_name, update_time) VALUES ('1170618590', '-2289398025558017', '"People Get Ready" by Jeff Beck and Rod Stewart', 1471513707),
+('1170618636', '-2289398025558017', 'Rod Stewart - Da Ya Think I\'m Sexy (Dvj Gee Remix)', 1471513707);
+alter table t1 add INDEX idx_update USING BTREE (update_time ASC);
+select * from t1;
+rid	pid	full_name	update_time
+1170618590	-2289398025558017	"People Get Ready" by Jeff Beck and Rod Stewart	1471513707
+1170618636	-2289398025558017	Rod Stewart - Da Ya Think I'm Sexy (Dvj Gee Remix)	1471513707
+DROP TABLE t1;

--- a/mysql-test/t/heap.test
+++ b/mysql-test/t/heap.test
@@ -537,3 +537,23 @@ SELECT * FROM t1 WHERE c1='bar2';
 SELECT * FROM t1 IGNORE INDEX (i1) WHERE c1='bar2';
 --echo #should show one tuple!
 DROP TABLE t1;
+
+#
+# BUG 1706356: Adding Index corrupts data in memory table
+#
+CREATE TABLE t1 (
+  rid bigint(20) NOT NULL AUTO_INCREMENT,
+  pid bigint(20) NOT NULL,
+  full_name text NOT NULL,
+  update_time int(11) NOT NULL DEFAULT '0',
+PRIMARY KEY (`rid`)
+) ENGINE=MEMORY DEFAULT CHARSET=utf8;
+
+INSERT INTO t1 (rid, pid, full_name, update_time) VALUES ('1170618590', '-2289398025558017', '"People Get Ready" by Jeff Beck and Rod Stewart', 1471513707),
+('1170618636', '-2289398025558017', 'Rod Stewart - Da Ya Think I\'m Sexy (Dvj Gee Remix)', 1471513707);
+
+alter table t1 add INDEX idx_update USING BTREE (update_time ASC);
+
+select * from t1;
+
+DROP TABLE t1;

--- a/storage/heap/ha_heap.cc
+++ b/storage/heap/ha_heap.cc
@@ -663,7 +663,7 @@ heap_prepare_hp_create_info(TABLE *table_arg, bool internal_table,
 {
   uint key, parts, mem_per_row_keys= 0, keys= table_arg->s->keys;
   uint auto_key= 0, auto_key_type= 0;
-  uint fixed_key_fieldnr = 0, fixed_data_size = 0, next_field_pos = 0;
+  uint fixed_data_size = 0, next_field_pos = 0;
   uint column_idx, column_count= table_arg->s->fields;
   HP_COLUMNDEF *columndef;
   HP_KEYDEF *keydef;
@@ -856,15 +856,6 @@ heap_prepare_hp_create_info(TABLE *table_arg, bool internal_table,
       {
         fixed_data_size= next_field_pos;
       }
-
-
-      if (field->field_index >= fixed_key_fieldnr)
-      {
-        /*
-          Do not use seg->fieldnr as it's not reliable in case of temp tables
-        */
-        fixed_key_fieldnr= field->field_index + 1;
-      }
     }
   }
 
@@ -888,7 +879,6 @@ heap_prepare_hp_create_info(TABLE *table_arg, bool internal_table,
   hp_create_info->is_dynamic= (share->row_type == ROW_TYPE_DYNAMIC);
   hp_create_info->columns= column_count;
   hp_create_info->columndef= columndef;
-  hp_create_info->fixed_key_fieldnr= fixed_key_fieldnr;
   hp_create_info->fixed_data_size= fixed_data_size;
   hp_create_info->max_records= (ulong) share->max_rows;
   hp_create_info->min_records= (ulong) share->min_rows;

--- a/storage/heap/hp_create.c
+++ b/storage/heap/hp_create.c
@@ -131,9 +131,9 @@ int heap_create(const char *name, HP_CREATE_INFO *create_info,
       uint has_variable_fields= 0;
 
       fixed_data_length= create_info->fixed_data_size;
-      fixed_column_count= create_info->fixed_key_fieldnr;
+      fixed_column_count= 0;
 
-      for (i= create_info->fixed_key_fieldnr; i < create_info->columns; i++)
+      for (i= fixed_column_count; i < create_info->columns; i++)
       {
         HP_COLUMNDEF *column= create_info->columndef + i;
 	if ((column->type == MYSQL_TYPE_VARCHAR &&

--- a/storage/heap/hp_test1.c
+++ b/storage/heap/hp_test1.c
@@ -56,7 +56,6 @@ int main(int argc, char **argv)
   hp_create_info.min_records= 10UL;
   hp_create_info.columns= 2;
   hp_create_info.columndef= columndef;
-  hp_create_info.fixed_key_fieldnr= 30;
   hp_create_info.fixed_data_size= sizeof(char*) * 2;
 
   keyinfo[0].keysegs=1;

--- a/storage/heap/hp_test2.c
+++ b/storage/heap/hp_test2.c
@@ -74,7 +74,6 @@ int main(int argc, char *argv[])
   hp_create_info.min_records= (ulong) recant/2;
   hp_create_info.columns= 4;
   hp_create_info.columndef= columndef;
-  hp_create_info.fixed_key_fieldnr= 4;
   hp_create_info.fixed_data_size= 39;
 
   write_count=update=opt_delete=0;


### PR DESCRIPTION
When altering a heap table the data is being copied to a temporary table.
While creating this temporary table heap_prepare_hp_create_info function
is called, and it sets wrong value of hp_create_info.fixed_key_fieldnr.
This wrong value causes wrong behaviour of function heap_create called
after that. This commit removes using of fixed_key_fieldnr from code.