### PR TITLE
Implemented bp:innodb-page-fragmentation-counters-5.6 "InnoDB page fragmentation counters (5.6)"

### DIFF
--- a/mysql-test/suite/innodb/r/percona_page_fragmentation_counters.result
+++ b/mysql-test/suite/innodb/r/percona_page_fragmentation_counters.result
@@ -1,0 +1,32 @@
+CREATE TABLE t1(
+id VARCHAR(32) NOT NULL,
+PRIMARY KEY(id)
+) ENGINE=InnoDB;
+CREATE PROCEDURE fill_table(IN number_of_records BIGINT UNSIGNED)
+BEGIN
+DECLARE i BIGINT UNSIGNED DEFAULT 0;
+START TRANSACTION;
+WHILE i < number_of_records DO
+INSERT INTO t1 VALUES(MD5(i));
+SET i = i + 1;
+END WHILE;
+COMMIT;
+END|
+CALL fill_table(32 * 1024);
+CHECKSUM TABLE t1;
+Table	Checksum
+test.t1	67358029
+include/assert.inc [(Fragmented table) The number of disjointed pages is much greater than the number of contiguous pages]
+include/assert.inc [(Fragmented table) Average seek distance for fragmented tables is >= 2]
+ALTER TABLE t1 ENGINE=InnoDB;
+CHECKSUM TABLE t1;
+Table	Checksum
+test.t1	67358029
+include/assert.inc [(Defragmented table) The number of disjointed pages is much less than the number of contiguous pages]
+include/assert.inc [(Defragmented table) Average seek distance for fragmented tables is >= 2]
+include/assert.inc [(data + garbage) in the fragmented table is greater than (data + garbage) in the defragmented one]
+include/assert.inc [(garbage) in the fragmented table is greater than (garbage) in the defragmented one]
+FLUSH STATUS;
+include/assert.inc [All counters have been set to zero]
+DROP PROCEDURE fill_table;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_page_fragmentation_counters.test
+++ b/mysql-test/suite/innodb/t/percona_page_fragmentation_counters.test
@@ -1,0 +1,116 @@
+--source include/have_innodb.inc
+
+# creating a simple table in which MD5 hash will be the primary key
+CREATE TABLE t1(
+  id VARCHAR(32) NOT NULL,
+  PRIMARY KEY(id)
+) ENGINE=InnoDB;
+
+# defining a stored procedure which fills the table in pseudo-random order,
+# generating a big number of page splits
+--delimiter |
+CREATE PROCEDURE fill_table(IN number_of_records BIGINT UNSIGNED)
+BEGIN
+  DECLARE i BIGINT UNSIGNED DEFAULT 0;
+  START TRANSACTION;
+  WHILE i < number_of_records DO
+    INSERT INTO t1 VALUES(MD5(i));
+    SET i = i + 1;
+  END WHILE;
+  COMMIT;
+END|
+
+--delimiter ;
+
+# filling the table
+CALL fill_table(32 * 1024);
+
+--let $magnitude_factor = 10
+
+# extracting initial values of the page fragmentation counters
+--let $pages_contiguous_initial     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_contiguous'         , Value, 1)
+--let $pages_disjointed_initial     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_disjointed'         , Value, 1)
+--let $pages_total_distance_initial = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_total_seek_distance', Value, 1)
+--let $data_size_initial            = query_get_value(SHOW STATUS LIKE 'innodb_scan_data_size'                , Value, 1)
+--let $deleted_recs_size_initial    = query_get_value(SHOW STATUS LIKE 'innodb_scan_deleted_recs_size'        , Value, 1)
+
+# performing a scan operation
+CHECKSUM TABLE t1;
+
+# extracting the values of page fragmentation counters after the scan
+--let $pages_contiguous_current     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_contiguous'         , Value, 1)
+--let $pages_disjointed_current     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_disjointed'         , Value, 1)
+--let $pages_total_distance_current = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_total_seek_distance', Value, 1)
+--let $data_size_current            = query_get_value(SHOW STATUS LIKE 'innodb_scan_data_size'                , Value, 1)
+--let $deleted_recs_size_current    = query_get_value(SHOW STATUS LIKE 'innodb_scan_deleted_recs_size'        , Value, 1)
+--let $pages_contiguous_delta     = `SELECT $pages_contiguous_current     - $pages_contiguous_initial`
+--let $pages_disjointed_delta     = `SELECT $pages_disjointed_current     - $pages_disjointed_initial`
+--let $pages_total_distance_delta = `SELECT $pages_total_distance_current - $pages_total_distance_initial`
+--let $data_size_delta1           = `SELECT $data_size_current            - $data_size_initial`
+--let $deleted_recs_size_delta1   = `SELECT $deleted_recs_size_current    - $deleted_recs_size_initial`
+
+# consistency asserts
+--let $assert_text= (Fragmented table) The number of disjointed pages is much greater than the number of contiguous pages
+--let $assert_cond= $pages_disjointed_delta > $pages_contiguous_delta * $magnitude_factor
+--source include/assert.inc
+--let $assert_text= (Fragmented table) Average seek distance for fragmented tables is >= 2
+--let $assert_cond= ($pages_total_distance_delta - $pages_contiguous_delta * 1) / IF($pages_disjointed_delta != 0, $pages_disjointed_delta, 1) >= 2
+--source include/assert.inc
+
+# reordering table records by the primary key (defragmenting)
+ALTER TABLE t1 ENGINE=InnoDB;
+
+# extracting initial values of the page fragmentation counters after defragmentation
+--let $pages_contiguous_initial     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_contiguous'         , Value, 1)
+--let $pages_disjointed_initial     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_disjointed'         , Value, 1)
+--let $pages_total_distance_initial = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_total_seek_distance', Value, 1)
+--let $data_size_initial            = query_get_value(SHOW STATUS LIKE 'innodb_scan_data_size'                , Value, 1)
+--let $deleted_recs_size_initial    = query_get_value(SHOW STATUS LIKE 'innodb_scan_deleted_recs_size'        , Value, 1)
+
+# performing a scan operation
+CHECKSUM TABLE t1;
+# extracting the values of page fragmentation counters after scanning the
+# defragmented table
+--let $pages_contiguous_current     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_contiguous'         , Value, 1)
+--let $pages_disjointed_current     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_disjointed'         , Value, 1)
+--let $pages_total_distance_current = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_total_seek_distance', Value, 1)
+--let $data_size_current            = query_get_value(SHOW STATUS LIKE 'innodb_scan_data_size'                , Value, 1)
+--let $deleted_recs_size_current    = query_get_value(SHOW STATUS LIKE 'innodb_scan_deleted_recs_size'        , Value, 1)
+--let $pages_contiguous_delta     = `SELECT $pages_contiguous_current     - $pages_contiguous_initial`
+--let $pages_disjointed_delta     = `SELECT $pages_disjointed_current     - $pages_disjointed_initial`
+--let $pages_total_distance_delta = `SELECT $pages_total_distance_current - $pages_total_distance_initial`
+--let $data_size_delta2           = `SELECT $data_size_current            - $data_size_initial`
+--let $deleted_recs_size_delta2   = `SELECT $deleted_recs_size_current    - $deleted_recs_size_initial`
+
+# consistency asserts
+--let $assert_text= (Defragmented table) The number of disjointed pages is much less than the number of contiguous pages
+--let $assert_cond= $pages_disjointed_delta * $magnitude_factor < $pages_contiguous_delta
+--source include/assert.inc
+--let $assert_text= (Defragmented table) Average seek distance for fragmented tables is >= 2
+--let $assert_cond= ($pages_total_distance_delta - $pages_contiguous_delta * 1) / IF($pages_disjointed_delta != 0, $pages_disjointed_delta, 1) >= 2
+--source include/assert.inc
+--let $assert_text= (data + garbage) in the fragmented table is greater than (data + garbage) in the defragmented one
+--let $assert_cond= $data_size_delta1 + $deleted_recs_size_delta1 > $data_size_delta2 + $deleted_recs_size_delta2
+--source include/assert.inc
+--let $assert_text= (garbage) in the fragmented table is greater than (garbage) in the defragmented one
+--let $assert_cond= $deleted_recs_size_delta1 > $deleted_recs_size_delta2
+--source include/assert.inc
+
+# resetting status variables
+FLUSH STATUS;
+
+# extracting the values of page fragmentation counters after the reset
+--let $pages_contiguous_current     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_contiguous'         , Value, 1)
+--let $pages_disjointed_current     = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_disjointed'         , Value, 1)
+--let $pages_total_distance_current = query_get_value(SHOW STATUS LIKE 'innodb_scan_pages_total_seek_distance', Value, 1)
+--let $data_size_current            = query_get_value(SHOW STATUS LIKE 'innodb_scan_data_size'                , Value, 1)
+--let $deleted_recs_size_current    = query_get_value(SHOW STATUS LIKE 'innodb_scan_deleted_recs_size'        , Value, 1)
+
+# consistency asserts
+--let $assert_text= All counters have been set to zero
+--let $assert_cond= ($pages_contiguous_current = 0) AND ($pages_disjointed_current = 0) AND ($pages_total_distance_current = 0) AND ($data_size_current = 0) AND ($deleted_recs_size_current = 0)
+--source include/assert.inc
+
+# cleanup
+DROP PROCEDURE fill_table;
+DROP TABLE t1;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -5364,3 +5364,52 @@ bool THD::is_current_stmt_binlog_disabled() const
   return (!(variables.option_bits & OPTION_BIN_LOG) ||
           !mysql_bin_log.is_open());
 }
+
+/** Gets page fragmentation statistics. Assigns zeros to stats if thd is
+NULL.
+@param[in]  thd   the calling thread
+@param[out] stats a pointer to fragmentation statistics to fill */
+void thd_get_fragmentation_stats(const THD *thd,
+                                 fragmentation_stats_t* stats)
+{
+  DBUG_ASSERT(stats != NULL);
+  if (likely(thd != NULL))
+  {
+    stats->scan_pages_contiguous=
+      thd->status_var.fragmentation_stats.scan_pages_contiguous;
+    stats->scan_pages_disjointed=
+      thd->status_var.fragmentation_stats.scan_pages_disjointed;
+    stats->scan_pages_total_seek_distance=
+      thd->status_var.fragmentation_stats.scan_pages_total_seek_distance;
+    stats->scan_data_size=
+      thd->status_var.fragmentation_stats.scan_data_size;
+    stats->scan_deleted_recs_size=
+      thd->status_var.fragmentation_stats.scan_deleted_recs_size;
+  }
+  else
+  {
+    memset(stats, 0, sizeof(*stats));
+  }
+}
+
+/** Adds page scan statistics. Does nothing if thd is NULL.
+@param[in] thd   the calling thread
+@param[in] stats a pointer to fragmentation statistics to add */
+void thd_add_fragmentation_stats(THD *thd,
+                                 const fragmentation_stats_t* stats)
+{
+  DBUG_ASSERT(stats != NULL);
+  if (likely(thd != NULL))
+  {
+    thd->status_var.fragmentation_stats.scan_pages_contiguous+=
+      stats->scan_pages_contiguous;
+    thd->status_var.fragmentation_stats.scan_pages_disjointed+=
+      stats->scan_pages_disjointed;
+    thd->status_var.fragmentation_stats.scan_pages_total_seek_distance+=
+      stats->scan_pages_total_seek_distance;
+    thd->status_var.fragmentation_stats.scan_data_size+=
+      stats->scan_data_size;
+    thd->status_var.fragmentation_stats.scan_deleted_recs_size+=
+      stats->scan_deleted_recs_size;
+  }
+}

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -641,6 +641,22 @@ typedef struct system_variables
   my_bool show_old_temporals;
 } SV;
 
+/** Page fragmentation statistics */
+struct fragmentation_stats_t
+{
+  ulonglong scan_pages_contiguous;          /*!< number of contiguous InnoDB
+                                            page reads inside a query */
+  ulonglong scan_pages_disjointed;          /*!< number of disjointed InnoDB
+                                            page reads inside a query */
+  ulonglong scan_pages_total_seek_distance; /*!< total seek distance between
+                                            InnoDB pages */
+  ulonglong scan_data_size;                 /*!< size of data in all InnoDB
+                                            pages read inside a query
+                                            (in bytes) */
+  ulonglong scan_deleted_recs_size;         /*!< size of deleted records in
+                                            all InnoDB pages read inside a
+                                            query (in bytes) */
+};
 
 /**
   Per thread status variables.
@@ -722,6 +738,8 @@ typedef struct system_status_var
   ulong max_statement_time_set;
   ulong max_statement_time_set_failed;
 
+  /** fragmentation statistics */
+  fragmentation_stats_t fragmentation_stats;
 } STATUS_VAR;
 
 /*
@@ -5720,5 +5738,18 @@ extern pthread_attr_t *get_connection_attrib(void);
   @retval >= 0	a file handle that can be passed to dup or my_close
 */
 int mysql_tmpfile_path(const char* path, const char* prefix);
+
+/** Gets page fragmentation statistics. Assigns zeros to stats if thd is
+NULL.
+@param[in]  thd   the calling thread
+@param[out] stats a pointer to fragmentation statistics to fill */
+void thd_get_fragmentation_stats(const THD *thd,
+                                 fragmentation_stats_t* stats);
+
+/** Adds page scan statistics. Does nothing if thd is NULL.
+@param[in] thd   the calling thread
+@param[in] stats a pointer to fragmentation statistics to add */
+void thd_add_fragmentation_stats(THD *thd,
+                                 const fragmentation_stats_t* stats);
 
 #endif /* SQL_CLASS_INCLUDED */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1000,6 +1000,22 @@ static SHOW_VAR innodb_status_variables[]= {
   (char*) &export_vars.innodb_sec_rec_cluster_reads,	  SHOW_LONG},
   {"secondary_index_triggered_cluster_reads_avoided",
   (char*) &export_vars.innodb_sec_rec_cluster_reads_avoided, SHOW_LONG},
+
+  {"scan_pages_contiguous",
+  (char*) &export_vars.innodb_fragmentation_stats.scan_pages_contiguous,
+  SHOW_LONG},
+  {"scan_pages_disjointed",
+  (char*) &export_vars.innodb_fragmentation_stats.scan_pages_disjointed,
+  SHOW_LONG},
+  {"scan_pages_total_seek_distance",
+  (char*) &export_vars.innodb_fragmentation_stats.scan_pages_total_seek_distance,
+  SHOW_LONG},
+  {"scan_data_size",
+  (char*) &export_vars.innodb_fragmentation_stats.scan_data_size,
+  SHOW_LONG},
+  {"scan_deleted_recs_size",
+  (char*) &export_vars.innodb_fragmentation_stats.scan_deleted_recs_size,
+  SHOW_LONG},
   {NullS, NullS, SHOW_LONG}
 };
 

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -52,6 +52,8 @@ Created 10/10/1995 Heikki Tuuri
 #include "buf0checksum.h"
 #include "ut0counter.h"
 
+#include <sql_class.h>
+
 /* Global counters used inside InnoDB. */
 struct srv_stats_t {
 	typedef ib_counter_t<lsn_t, 1, single_indexer_t> lsn_ctr_1_t;
@@ -1100,6 +1102,9 @@ struct export_var_t{
 
 	ulint innodb_sec_rec_cluster_reads;	/*!< srv_sec_rec_cluster_reads */
 	ulint innodb_sec_rec_cluster_reads_avoided; /*!< srv_sec_rec_cluster_reads_avoided */
+
+	fragmentation_stats_t innodb_fragmentation_stats;/*!< Fragmentation
+						statistics */
 };
 
 /** Thread slot in the thread table.  */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1908,6 +1908,9 @@ srv_export_innodb_status(void)
 	export_vars.innodb_sec_rec_cluster_reads_avoided =
 		srv_sec_rec_cluster_reads_avoided;
 
+	thd_get_fragmentation_stats(current_thd,
+		&export_vars.innodb_fragmentation_stats);
+
 	mutex_exit(&srv_innodb_monitor_mutex);
 }
 


### PR DESCRIPTION
https://blueprints.launchpad.net/percona-server/+spec/innodb-page-fragmentation-counters-5.6

Added the following InnoDB status variables:
'innodb_scan_pages_contiguous'          - number of contiguous page reads.
'innodb_scan_pages_jumpy'               - number of jumpy page reads.
'innodb_scan_data_in_pages'             - amount of data in all pages read by
                                          the latest query.
'innodb_scan_garbages_in_pages'         - amount of garbage in all pages read
                                          by the latest query.
'innodb_scan_pages_total_jump_distance' - total jump distance performed by
                                          the latest query.