### PR TITLE
MYR-200 : Make default cf compression option to be LZ4

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_default_cf_options_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_default_cf_options_basic.result
@@ -1,7 +1,7 @@
 SET @start_global_value = @@global.ROCKSDB_DEFAULT_CF_OPTIONS;
 SELECT @start_global_value;
 @start_global_value
-
+compression=kLZ4Compression;bottommost_compression=kLZ4Compression
 "Trying to set variable @@global.ROCKSDB_DEFAULT_CF_OPTIONS to 444. It should fail because it is readonly."
 SET @@global.ROCKSDB_DEFAULT_CF_OPTIONS   = 444;
 ERROR HY000: Variable 'rocksdb_default_cf_options' is a read only variable

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -927,7 +927,7 @@ rocksdb_debug_ttl_ignore_pk	OFF
 rocksdb_debug_ttl_read_filter_ts	0
 rocksdb_debug_ttl_rec_ts	0
 rocksdb_debug_ttl_snapshot_ts	0
-rocksdb_default_cf_options	
+rocksdb_default_cf_options	compression=kLZ4Compression;bottommost_compression=kLZ4Compression
 rocksdb_delayed_write_rate	0
 rocksdb_delete_obsolete_files_period_micros	21600000000
 rocksdb_enable_bulk_load_api	ON

--- a/mysql-test/suite/rocksdb/t/index_merge_rocksdb-master.opt
+++ b/mysql-test/suite/rocksdb/t/index_merge_rocksdb-master.opt
@@ -1,1 +1,1 @@
---loose-rocksdb_strict_collation_check=off
+--loose-rocksdb_strict_collation_check=off --loose-rocksdb_default_cf_options=

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1151,7 +1151,9 @@ static MYSQL_SYSVAR_BOOL(
 
 static MYSQL_SYSVAR_STR(default_cf_options, rocksdb_default_cf_options,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-                        "default cf options for RocksDB", nullptr, nullptr, "");
+                        "default cf options for RocksDB", nullptr, nullptr,
+                        "compression=kLZ4Compression;"
+                        "bottommost_compression=kLZ4Compression");
 
 static MYSQL_SYSVAR_STR(override_cf_options, rocksdb_override_cf_options,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,


### PR DESCRIPTION
- Changed default value of rocksdb_default_cf_options to ensure that the
  'default' column family is created with options necessary to compress all
  levels of th LSM tree with lz4.
- Re-recorded tests that expose the rocksdb_default_cf_options
- Altered test options for index_merge_rocksdb to disable compression because
  test relies on 'filler' data within a table that forces the table statistics
  into a certain shape to ensure a particular query plan is chosen. The
  compression alters this shape and changes the query plan which changes the
  focus of the test.