### PR TITLE
lp-1657737: Print locking transaction which cause "Lock wait timeout"…

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -642,6 +642,13 @@ void thd_set_kill_status(const MYSQL_THD thd);
 unsigned long thd_get_thread_id(const MYSQL_THD thd);
 
 /**
+  Return the query id of a thread
+  @param thd user thread
+  @return query id
+*/
+int64_t thd_get_query_id(const MYSQL_THD thd);
+
+/**
   Get the XID for this connection's transaction
 
   @param thd  user thread connection handle

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -252,6 +252,7 @@ void thd_binlog_pos(const void* thd,
                     unsigned long long *pos_var);
 void thd_set_kill_status(const void* thd);
 unsigned long thd_get_thread_id(const void* thd);
+int64_t thd_get_query_id(const void* thd);
 void thd_get_xid(const void* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(void* thd,
                                    const char *key, unsigned int key_length,

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -252,6 +252,7 @@ void thd_binlog_pos(const void* thd,
                     unsigned long long *pos_var);
 void thd_set_kill_status(const void* thd);
 unsigned long thd_get_thread_id(const void* thd);
+int64_t thd_get_query_id(const void* thd);
 void thd_get_xid(const void* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(void* thd,
                                    const char *key, unsigned int key_length,

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -205,6 +205,7 @@ void thd_binlog_pos(const void* thd,
                     unsigned long long *pos_var);
 void thd_set_kill_status(const void* thd);
 unsigned long thd_get_thread_id(const void* thd);
+int64_t thd_get_query_id(const void* thd);
 void thd_get_xid(const void* thd, MYSQL_XID *xid);
 void mysql_query_cache_invalidate4(void* thd,
                                    const char *key, unsigned int key_length,

--- a/mysql-test/suite/innodb/r/bug84563.result
+++ b/mysql-test/suite/innodb/r/bug84563.result
@@ -1,0 +1,22 @@
+SET @innodb_lock_wait_timeout_saved = @@GLOBAL.innodb_lock_wait_timeout;
+SET @innodb_print_lock_wait_timeout_info_saved =
+@@GLOBAL.innodb_print_lock_wait_timeout_info;
+SET GLOBAL innodb_lock_wait_timeout = 1;
+SET GLOBAL innodb_print_lock_wait_timeout_info = true;
+CREATE TABLE t (i INT) ENGINE = InnoDB;
+INSERT INTO t (i) VALUES(1);
+START TRANSACTION;
+SELECT * FROM t WHERE i = 1 LOCK IN SHARE MODE;
+i
+1
+START TRANSACTION;
+DELETE FROM t WHERE i = 1;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+COMMIT;
+DELETE FROM t WHERE i = 1;
+COMMIT;
+Grepping the error log for lock wait timeout info
+DROP TABLE t;
+SET GLOBAL innodb_lock_wait_timeout = @innodb_lock_wait_timeout_saved;
+SET GLOBAL innodb_print_lock_wait_timeout_info =
+@innodb_print_lock_wait_timeout_info_saved;

--- a/mysql-test/suite/innodb/t/bug84563-master.opt
+++ b/mysql-test/suite/innodb/t/bug84563-master.opt
@@ -1,0 +1,1 @@
+--log-error=$MYSQLTEST_VARDIR/tmp/bug84563.err

--- a/mysql-test/suite/innodb/t/bug84563.test
+++ b/mysql-test/suite/innodb/t/bug84563.test
@@ -1,0 +1,37 @@
+--source include/have_innodb.inc
+--source include/count_sessions.inc
+
+SET @innodb_lock_wait_timeout_saved = @@GLOBAL.innodb_lock_wait_timeout;
+SET @innodb_print_lock_wait_timeout_info_saved =
+  @@GLOBAL.innodb_print_lock_wait_timeout_info;
+
+SET GLOBAL innodb_lock_wait_timeout = 1;
+SET GLOBAL innodb_print_lock_wait_timeout_info = true;
+
+CREATE TABLE t (i INT) ENGINE = InnoDB;
+INSERT INTO t (i) VALUES(1);
+
+START TRANSACTION;
+SELECT * FROM t WHERE i = 1 LOCK IN SHARE MODE;
+
+--connect(con0, localhost, root,,)
+START TRANSACTION;
+--error ER_LOCK_WAIT_TIMEOUT
+DELETE FROM t WHERE i = 1;
+COMMIT;
+--disconnect con0
+
+--connection default
+DELETE FROM t WHERE i = 1;
+COMMIT;
+
+--echo Grepping the error log for lock wait timeout info
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/tmp/bug84563.err
+--let SEARCH_PATTERN= Lock wait timeout info:
+--source include/search_pattern_in_file.inc
+
+DROP TABLE t;
+SET GLOBAL innodb_lock_wait_timeout = @innodb_lock_wait_timeout_saved;
+SET GLOBAL innodb_print_lock_wait_timeout_info =
+  @innodb_print_lock_wait_timeout_info_saved;
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/sys_vars/r/all_vars.result
+++ b/mysql-test/suite/sys_vars/r/all_vars.result
@@ -14,5 +14,7 @@ left join t1 on variable_name=test_name where test_name is null ORDER BY variabl
 There should be *no* variables listed below:
 INNODB_FAKE_CHANGES
 INNODB_FAKE_CHANGES
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO
 drop table t1;
 drop table t2;

--- a/mysql-test/suite/sys_vars/r/innodb_print_lock_wait_timeout_info.result
+++ b/mysql-test/suite/sys_vars/r/innodb_print_lock_wait_timeout_info.result
@@ -1,0 +1,104 @@
+SET @start_global_value = @@global.innodb_print_lock_wait_timeout_info;
+SELECT @start_global_value;
+@start_global_value
+0
+Valid values are 'ON' and 'OFF'
+SELECT @@global.innodb_print_lock_wait_timeout_info in (0, 1);
+@@global.innodb_print_lock_wait_timeout_info in (0, 1)
+1
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+@@global.innodb_print_lock_wait_timeout_info
+0
+SELECT @@session.innodb_print_lock_wait_timeout_info;
+ERROR HY000: Variable 'innodb_print_lock_wait_timeout_info' is a GLOBAL variable
+SHOW global variables LIKE 'innodb_print_lock_wait_timeout_info';
+Variable_name	Value
+innodb_print_lock_wait_timeout_info	OFF
+SHOW session variables LIKE 'innodb_print_lock_wait_timeout_info';
+Variable_name	Value
+innodb_print_lock_wait_timeout_info	OFF
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	OFF
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	OFF
+SET global innodb_print_lock_wait_timeout_info='OFF';
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+@@global.innodb_print_lock_wait_timeout_info
+0
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	OFF
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	OFF
+SET @@global.innodb_print_lock_wait_timeout_info=1;
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+@@global.innodb_print_lock_wait_timeout_info
+1
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	ON
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	ON
+SET global innodb_print_lock_wait_timeout_info=0;
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+@@global.innodb_print_lock_wait_timeout_info
+0
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	OFF
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	OFF
+SET @@global.innodb_print_lock_wait_timeout_info='ON';
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+@@global.innodb_print_lock_wait_timeout_info
+1
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	ON
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	ON
+SET session innodb_print_lock_wait_timeout_info='OFF';
+ERROR HY000: Variable 'innodb_print_lock_wait_timeout_info' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.innodb_print_lock_wait_timeout_info='ON';
+ERROR HY000: Variable 'innodb_print_lock_wait_timeout_info' is a GLOBAL variable and should be set with SET GLOBAL
+SET global innodb_print_lock_wait_timeout_info=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_print_lock_wait_timeout_info'
+SET global innodb_print_lock_wait_timeout_info=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_print_lock_wait_timeout_info'
+SET global innodb_print_lock_wait_timeout_info=2;
+ERROR 42000: Variable 'innodb_print_lock_wait_timeout_info' can't be set to the value of '2'
+NOTE: The following should fail with ER_WRONG_VALUE_FOR_VAR (BUG#50643)
+SET global innodb_print_lock_wait_timeout_info=-3;
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+@@global.innodb_print_lock_wait_timeout_info
+1
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	ON
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+VARIABLE_NAME	VARIABLE_VALUE
+INNODB_PRINT_LOCK_WAIT_TIMEOUT_INFO	ON
+SET global innodb_print_lock_wait_timeout_info='AUTO';
+ERROR 42000: Variable 'innodb_print_lock_wait_timeout_info' can't be set to the value of 'AUTO'
+SET @@global.innodb_print_lock_wait_timeout_info = @start_global_value;
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+@@global.innodb_print_lock_wait_timeout_info
+0

--- a/mysql-test/suite/sys_vars/t/innodb_print_lock_wait_timeout_info.test
+++ b/mysql-test/suite/sys_vars/t/innodb_print_lock_wait_timeout_info.test
@@ -1,0 +1,93 @@
+
+# 2010-01-25 - Added
+#
+
+--source include/have_innodb.inc
+
+SET @start_global_value = @@global.innodb_print_lock_wait_timeout_info;
+SELECT @start_global_value;
+
+#
+# exists as global only
+#
+--echo Valid values are 'ON' and 'OFF'
+SELECT @@global.innodb_print_lock_wait_timeout_info in (0, 1);
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.innodb_print_lock_wait_timeout_info;
+SHOW global variables LIKE 'innodb_print_lock_wait_timeout_info';
+SHOW session variables LIKE 'innodb_print_lock_wait_timeout_info';
+--disable_warnings
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+--enable_warnings
+
+#
+# SHOW that it's writable
+#
+SET global innodb_print_lock_wait_timeout_info='OFF';
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+--disable_warnings
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+--enable_warnings
+SET @@global.innodb_print_lock_wait_timeout_info=1;
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+--disable_warnings
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+--enable_warnings
+SET global innodb_print_lock_wait_timeout_info=0;
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+--disable_warnings
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+--enable_warnings
+SET @@global.innodb_print_lock_wait_timeout_info='ON';
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+--disable_warnings
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+--enable_warnings
+--error ER_GLOBAL_VARIABLE
+SET session innodb_print_lock_wait_timeout_info='OFF';
+--error ER_GLOBAL_VARIABLE
+SET @@session.innodb_print_lock_wait_timeout_info='ON';
+
+#
+# incorrect types
+#
+--error ER_WRONG_TYPE_FOR_VAR
+SET global innodb_print_lock_wait_timeout_info=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+SET global innodb_print_lock_wait_timeout_info=1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+SET global innodb_print_lock_wait_timeout_info=2;
+--echo NOTE: The following should fail with ER_WRONG_VALUE_FOR_VAR (BUG#50643)
+SET global innodb_print_lock_wait_timeout_info=-3;
+SELECT @@global.innodb_print_lock_wait_timeout_info;
+--disable_warnings
+SELECT * FROM information_schema.global_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+SELECT * FROM information_schema.session_variables
+WHERE variable_name='innodb_print_lock_wait_timeout_info';
+--enable_warnings
+--error ER_WRONG_VALUE_FOR_VAR
+SET global innodb_print_lock_wait_timeout_info='AUTO';
+
+#
+# Cleanup
+#
+
+SET @@global.innodb_print_lock_wait_timeout_info = @start_global_value;
+SELECT @@global.innodb_print_lock_wait_timeout_info;

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -4464,6 +4464,16 @@ extern "C" unsigned long thd_get_thread_id(const MYSQL_THD thd)
 }
 
 /**
+  Return the query id of a thread
+  @param thd user thread
+  @return query id
+*/
+extern "C" int64_t thd_get_query_id(const MYSQL_THD thd)
+{
+  return(thd->query_id);
+}
+
+/**
   Check if batching is allowed for the thread
   @param thd  user thread
   @retval 1 batching allowed

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -18628,6 +18628,13 @@ static MYSQL_SYSVAR_BOOL(print_all_deadlocks, srv_print_all_deadlocks,
   "Print all deadlocks to MySQL error log (off by default)",
   NULL, NULL, FALSE);
 
+static MYSQL_SYSVAR_BOOL(
+  print_lock_wait_timeout_info,
+  srv_print_lock_wait_timeout_info,
+  PLUGIN_VAR_OPCMDARG,
+  "Print lock wait timeout info to MySQL error log (off by default)",
+  NULL, NULL, FALSE);
+
 static MYSQL_SYSVAR_ULONG(compression_failure_threshold_pct,
   zip_failure_threshold_pct, PLUGIN_VAR_OPCMDARG,
   "If the compression failure rate of a table is greater than this number"
@@ -18900,6 +18907,7 @@ static struct st_mysql_sys_var* innobase_system_variables[]= {
   MYSQL_SYSVAR(foreground_preflush),
   MYSQL_SYSVAR(empty_free_list_algorithm),
   MYSQL_SYSVAR(print_all_deadlocks),
+  MYSQL_SYSVAR(print_lock_wait_timeout_info),
   MYSQL_SYSVAR(cmp_per_index_enabled),
   MYSQL_SYSVAR(undo_logs),
   MYSQL_SYSVAR(rollback_segments),

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -586,6 +586,9 @@ extern ulong srv_sync_array_size;
 /* print all user-level transactions deadlocks to mysqld stderr */
 extern my_bool srv_print_all_deadlocks;
 
+/* print lock wait timeout info to mysqld stderr */
+extern my_bool srv_print_lock_wait_timeout_info;
+
 extern my_bool	srv_cmp_per_index_enabled;
 
 /** Number of times secondary index lookup triggered cluster lookup */

--- a/storage/innobase/lock/lock0wait.cc
+++ b/storage/innobase/lock/lock0wait.cc
@@ -32,6 +32,20 @@ Created 25/5/2010 Sunny Bains
 #include "srv0start.h"
 #include "ha_prototypes.h"
 #include "lock0priv.h"
+#include "lock0iter.h"
+
+#include <sstream>
+
+extern "C"
+LEX_STRING* thd_query_string(MYSQL_THD thd);
+
+struct blocking_trx_info {
+	uint64_t trx_id;
+	uint32_t thread_id;
+	int64_t query_id;
+};
+
+static const size_t MAX_BLOCKING_TRX_IN_REPORT = 10;
 
 /*********************************************************************//**
 Print the contents of the lock_sys_t::waiting_threads array. */
@@ -185,6 +199,45 @@ lock_wait_table_reserve_slot(
 }
 
 /***************************************************************//**
+Print lock wait timeout info to stderr. It's supposed this function
+is executed in trx's THD thread as it calls some non-thread-safe
+functions to get some info from THD. */
+void
+print_lock_wait_timeout(
+/*====================*/
+	trx_t *trx, /*!< in: requested trx */
+	blocking_trx_info *blocking, /*!< in: blocking info array */
+	size_t blocking_count) /*!< in: blocking info array size */
+{
+	std::ostringstream outs;
+
+	outs << "Lock wait timeout info:\n";
+	outs << "Requested thread id: " <<
+		thd_get_thread_id(trx->mysql_thd) <<
+		"\n";
+	outs << "Requested trx id: " << trx->id << "\n";
+	outs << "Requested query: " <<
+		thd_query_string(trx->mysql_thd)->str << "\n";
+
+	outs << "Total blocking transactions count: " <<
+		blocking_count <<
+		"\n";
+
+	for (size_t i = 0; i < blocking_count; ++i) {
+		outs << "Blocking transaction number: " << (i + 1) << "\n";
+		outs << "Blocking thread id: " <<
+			blocking[i].thread_id <<
+			"\n";
+		outs << "Blocking query id: " <<
+			blocking[i].query_id <<
+			"\n";
+		outs << "Blocking trx id: " << blocking[i].trx_id << "\n";
+	}
+	ut_print_timestamp(stderr);
+	fprintf(stderr, " %s", outs.str().c_str());
+}
+
+/***************************************************************//**
 Puts a user OS thread to wait for a lock to be released. If an error
 occurs during the wait trx->error_state associated with thr is
 != DB_SUCCESS when we return. DB_LOCK_WAIT_TIMEOUT and DB_DEADLOCK
@@ -207,6 +260,8 @@ lock_wait_suspend_thread(
 	ulint		sec;
 	ulint		ms;
 	ulong		lock_wait_timeout;
+	blocking_trx_info blocking[MAX_BLOCKING_TRX_IN_REPORT];
+	size_t blocking_count = 0;
 
 	trx = thr_get_trx(thr);
 
@@ -272,6 +327,27 @@ lock_wait_suspend_thread(
 
 	if (const lock_t* wait_lock = trx->lock.wait_lock) {
 		lock_type = lock_get_type_low(wait_lock);
+		if (srv_print_lock_wait_timeout_info) {
+			lock_queue_iterator_t	iter;
+			const lock_t*		curr_lock;
+			lock_queue_iterator_reset(&iter, wait_lock, ULINT_UNDEFINED);
+			for (curr_lock = lock_queue_iterator_get_prev(&iter);
+				curr_lock != NULL;
+				curr_lock = lock_queue_iterator_get_prev(&iter)) {
+				if (lock_has_to_wait(trx->lock.wait_lock, curr_lock)) {
+					blocking[blocking_count].trx_id = lock_get_trx_id(curr_lock);
+					blocking[blocking_count].thread_id =
+						curr_lock->trx->mysql_thd ?
+						thd_get_thread_id(curr_lock->trx->mysql_thd) : 0;
+					blocking[blocking_count].query_id =
+					curr_lock->trx->mysql_thd ?
+						thd_get_query_id(curr_lock->trx->mysql_thd) : 0;
+					/* Only limited number of blocking transaction infos is implemented*/
+					if ((++blocking_count) >= MAX_BLOCKING_TRX_IN_REPORT)
+						break;
+				}
+			}
+		}
 	}
 
 	lock_mutex_exit();
@@ -377,6 +453,8 @@ lock_wait_suspend_thread(
 	    && wait_time > (double) lock_wait_timeout) {
 
 		trx->error_state = DB_LOCK_WAIT_TIMEOUT;
+		if (srv_print_lock_wait_timeout_info)
+			print_lock_wait_timeout(trx, blocking, blocking_count);
 
 		MONITOR_INC(MONITOR_TIMEOUT);
 	}

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -428,6 +428,10 @@ UNIV_INTERN ulong	srv_force_recovery_crash;
 
 UNIV_INTERN my_bool	srv_print_all_deadlocks = FALSE;
 
+/** Print lock wait timeout info to mysqld stderr */
+
+my_bool	srv_print_lock_wait_timeout_info = FALSE;
+
 /** Enable INFORMATION_SCHEMA.innodb_cmp_per_index */
 UNIV_INTERN my_bool	srv_cmp_per_index_enabled = FALSE;
 


### PR DESCRIPTION
… errors into log file

The output format is the following:

2017-11-09T22:43:29.213401Z 5 [Note] InnoDB: Lock wait timeout info:
Requested thread id: 5
Requested trx id: 1289
Requested query: DELETE FROM t WHERE i = 1
Total blocking transactions count: 1
Blocking transaction number: 1
Blocking thread id: 4
Blocking query id: 38
Blocking trx id: 422021753699104

The execution process of blocking transaction can keep going on as opposed to
deadlock when all transactions, which take part in the deadlock, are blocked.
That is why some data in blocking transaction info can be changed(or have not
yet initialized) at the moment when we capture them. At the above example
blocking transaction has not yet initialized at the moment of capturing.

And that is why the info is captured before requested thread suspending, as
after it's waking up blocking transaction might has been already finished.

See also: https://github.com/percona/percona-server/pull/1971

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/2007/