### PR TITLE
Fix bug 1713700 (Assertion `inited == INDEX' failed).

### DIFF
--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -623,13 +623,20 @@ end_sj_materialize(JOIN *join, QEP_TAB *qep_tab, bool end_of_records)
       DBUG_RETURN(NESTED_LOOP_OK);
     if ((error= table->file->ha_write_row(table->record[0])))
     {
-      /* create_ondisk_from_heap will generate error if needed */
-      if (!table->file->is_ignorable_error(error) &&
-          create_ondisk_from_heap(thd, table,
+      if (!table->file->is_ignorable_error(error)) {
+          /* create_ondisk_from_heap will generate error if needed */
+          if (create_ondisk_from_heap(thd, table,
                                   sjm->table_param.start_recinfo, 
                                   &sjm->table_param.recinfo, error,
-                                  TRUE, NULL))
-        DBUG_RETURN(NESTED_LOOP_ERROR); /* purecov: inspected */
+                                  TRUE, NULL)) {
+             DBUG_RETURN(NESTED_LOOP_ERROR); /* purecov: inspected */
+          }
+          /* create_ondisk_from_heap does not replicate any index/scan access
+           initialized on the MEMORY table. So we have to repeat index
+           initialization made prior in join_materialize_semijoin. */
+          if (table->hash_field)
+             table->file->ha_index_init(0, 0);
+      }
     }
   }
   DBUG_RETURN(NESTED_LOOP_OK);


### PR DESCRIPTION
When executing join_materialize_semijoin there is a possibility
of exceeding the size of  in-memory temporary table used to execute query.
In this case server converts it to ondisk table but misses index use
initialization because create_ondisk_from_heap function does not
perform it automatically.