### PR TITLE
BLD-862: Fixed compilation issues with gcc-7 for the 5.5 branch

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -2717,7 +2717,7 @@ You can turn off this feature to get a quicker startup with -A\n\n");
         mysql_free_result(fields);
         break;
       }
-      field_names[i][num_fields*2]= '\0';
+      field_names[i][num_fields*2]= NULL;
       j=0;
       while ((sql_field=mysql_fetch_field(fields)))
       {

--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -1026,6 +1026,7 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
         goto end;
       }
     }
+    // fallthrough
     case WRITE_ROWS_EVENT:
     case DELETE_ROWS_EVENT:
     case UPDATE_ROWS_EVENT:
@@ -1123,8 +1124,8 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
                 type_str);
         goto err;
       }
-      /* FALL THROUGH */
     }
+    // fallthrough
     default:
       ev->print(result_file, print_event_info);
       if (head->error == -1)

--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -1979,6 +1979,7 @@ static void print_xml_comment(FILE *xml_file, size_t len,
     case '-':
       if (*(comment_string + 1) == '-')         /* Only one hyphen allowed. */
         break;
+      // fallthrough
     default:
       fputc(*comment_string, xml_file);
       break;

--- a/extra/replace.c
+++ b/extra/replace.c
@@ -173,6 +173,7 @@ register char **argv[];
 	break;
       case 'V':
 	version=1;
+      // fallthrough
       case 'I':
       case '?':
 	help=1;					/* Help text written */

--- a/plugin/percona-udf/murmur_udf.cc
+++ b/plugin/percona-udf/murmur_udf.cc
@@ -97,8 +97,8 @@ MurmurHash2( const void *key, int len, unsigned int seed ) {
    }
 
    switch (len) {
-      case 3: h2 ^= ((unsigned char*)data)[2] << 16;
-      case 2: h2 ^= ((unsigned char*)data)[1] << 8;
+      case 3: h2 ^= ((unsigned char*)data)[2] << 16; // fallthrough
+      case 2: h2 ^= ((unsigned char*)data)[1] << 8; // fallthrough
       case 1: h2 ^= ((unsigned char*)data)[0];
               h2 *= m;
    };

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -1280,6 +1280,7 @@ void mysql_read_default_options(struct st_mysql_options *options,
 	  break;
         case OPT_pipe:
           options->protocol = MYSQL_PROTOCOL_PIPE;
+          break;
 	case OPT_connect_timeout:
 	case OPT_timeout:
 	  if (opt_arg)

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -241,6 +241,7 @@ common_1_lev_code:
     break;
   case INTERVAL_WEEK:
     expr/= 7;
+    // fallthrough
   default:
     close_quote= FALSE;
     break;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9528,7 +9528,7 @@ bool Create_field::init(THD *thd, char *fld_name, enum_field_types fld_type,
   case MYSQL_TYPE_DATE:
     /* Old date type. */
     sql_type= MYSQL_TYPE_NEWDATE;
-    /* fall trough */
+    // fallthrough
   case MYSQL_TYPE_NEWDATE:
     length= MAX_DATE_WIDTH;
     break;

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -7072,6 +7072,7 @@ void ha_partition::print_error(int error, myf errflag)
         m_err_rec= NULL;
         DBUG_VOID_RETURN;
       }
+      // fallthrough
     default:
       {
         if (!(thd->lex->alter_info.flags & ALTER_TRUNCATE_PARTITION))

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -5416,7 +5416,8 @@ Field *Item::tmp_table_field_from_field_type(TABLE *table, bool fixed_length)
                               collation.collation);
       break;
     }
-    /* Fall through to make_string_field() */
+    // fallthrough
+    // to make_string_field() 
   case MYSQL_TYPE_ENUM:
   case MYSQL_TYPE_SET:
   case MYSQL_TYPE_VAR_STRING:

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -1724,6 +1724,7 @@ my_decimal *Item_func_mod::decimal_op(my_decimal *decimal_value)
     return decimal_value;
   case E_DEC_DIV_ZERO:
     signal_divide_by_null();
+    // fallthrough
   default:
     null_value= 1;
     return 0;
@@ -4511,6 +4512,7 @@ String *user_var_entry::val_str(my_bool *null_value, String *str,
   case STRING_RESULT:
     if (str->copy(value, length, collation.collation))
       str= 0;					// EOM error
+    break;
   case ROW_RESULT:
     DBUG_ASSERT(1);				// Impossible
     break;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -7097,8 +7097,10 @@ void TC_LOG_MMAP::close()
     mysql_cond_destroy(&COND_active);
     mysql_cond_destroy(&COND_pool);
     mysql_cond_destroy(&COND_queue_busy);
+    // fallthrough
   case 5:
     data[0]='A'; // garble the first (signature) byte, in case mysql_file_delete fails
+    // fallthrough
   case 4:
     for (i=0; i < npages; i++)
     {
@@ -7107,10 +7109,13 @@ void TC_LOG_MMAP::close()
       mysql_mutex_destroy(&pages[i].lock);
       mysql_cond_destroy(&pages[i].cond);
     }
+    // fallthrough
   case 3:
     my_free(pages);
+    // fallthrough
   case 2:
     my_munmap((char*)data, (size_t)file_length);
+    // fallthrough
   case 1:
     mysql_file_close(fd, MYF(0));
   }

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2953,6 +2953,7 @@ Query_log_event::Query_log_event(const char* buf, uint event_len,
       CHECK_SPACE(pos, end, host.length);
       host.str= (char *)pos;
       pos+= host.length;
+      break;
     }
     default:
       /* That's why you must write status vars in growing order of code */

--- a/sql/opt_sum.cc
+++ b/sql/opt_sum.cc
@@ -994,6 +994,7 @@ static int maxmin_in_range(bool max_fl, Field* field, COND *cond)
   case Item_func::LT_FUNC:
   case Item_func::LE_FUNC:
     less_fl= 1;
+    // fallthrough
   case Item_func::GT_FUNC:
   case Item_func::GE_FUNC:
   {

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -150,7 +150,8 @@ sp_get_item_value(THD *thd, Item *item, String *str)
   case DECIMAL_RESULT:
     if (item->field_type() != MYSQL_TYPE_BIT)
       return item->val_str(str);
-    else {/* Bit type is handled as binary string */}
+    // fallthrough
+    /* Bit type is handled as binary string */
   case STRING_RESULT:
     {
       String *result= item->val_str(str);
@@ -2888,10 +2889,10 @@ sp_head::show_routine_code(THD *thd)
     */
     if (ip != i->m_ip)
     {
-      const char *format= "Instruction at position %u has m_ip=%u";
+      const char format[] = "Instruction at position %u has m_ip=%u";
       char tmp[sizeof(format) + 2*SP_INSTR_UINT_MAXLEN + 1];
 
-      sprintf(tmp, format, ip, i->m_ip);
+      snprintf(tmp, sizeof(tmp), format, ip, i->m_ip);
       /*
         Since this is for debugging purposes only, we don't bother to
         introduce a special error code for it.

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -1974,7 +1974,7 @@ def_week_frmt: %lu, in_trans: %d, autocommit: %d",
       {
         DBUG_PRINT("qcache",
                    ("Temporary table detected: '%s.%s'",
-                    table_list.db, table_list.alias));
+                    tmptable->s->db.str, tmptable->s->table_name.str));
         unlock();
         /*
           We should not store result of this query because it contain

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -969,6 +969,7 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	yylval->lex_str.length=2;
 	return NULL_SYM;
       }
+      // fallthrough
     case MY_LEX_CHAR:			// Unknown or single char token
     case MY_LEX_SKIP:			// This should not happen
       if (c == '-' && lip->yyPeek() == '-' &&
@@ -1032,12 +1033,14 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	state= MY_LEX_HEX_NUMBER;
 	break;
       }
+      // fallthrough
     case MY_LEX_IDENT_OR_BIN:
       if (lip->yyPeek() == '\'')
       {                                 // Found b'bin-number'
         state= MY_LEX_BIN_NUMBER;
         break;
       }
+      // fallthrough
     case MY_LEX_IDENT:
       const char *start;
 #if defined(USE_MB) && defined(USE_MB_IDENT)
@@ -1373,6 +1376,7 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	state= MY_LEX_USER_VARIABLE_DELIMITER;
 	break;
       }
+      // fallthrough
       /* " used for strings */
     case MY_LEX_STRING:			// Incomplete text string
       if (!(yylval->lex_str.str = get_text(lip, 1, 1)))

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2468,6 +2468,7 @@ case SQLCOM_PREPARE:
       break;
     }
   }
+  // fallthrough
   case SQLCOM_PURGE_BEFORE:
   {
     Item *it;
@@ -3107,8 +3108,8 @@ end_with_restore_list:
     /* mysql_update return 2 if we need to switch to multi-update */
     if (up_result != 2)
       break;
-    /* Fall through */
   }
+  // fallthrough
   case SQLCOM_UPDATE_MULTI:
   {
     DBUG_ASSERT(first_table == all_tables && first_table != 0);
@@ -3218,6 +3219,7 @@ end_with_restore_list:
       DBUG_PRINT("debug", ("Just after generate_incident()"));
     }
 #endif
+    // fallthrough
   case SQLCOM_INSERT:
   {
     DBUG_ASSERT(first_table == all_tables && first_table != 0);
@@ -3944,6 +3946,7 @@ end_with_restore_list:
       initialize this variable because RESET shares the same code as FLUSH
     */
     lex->no_write_to_binlog= 1;
+    // fallthrough
   case SQLCOM_FLUSH:
   {
     int write_to_binlog;

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -7637,7 +7637,7 @@ int get_part_iter_for_interval_cols_via_map(partition_info *part_info,
                                             PARTITION_ITERATOR *part_iter)
 {
   uint32 nparts;
-  get_col_endpoint_func  get_col_endpoint;
+  get_col_endpoint_func  get_col_endpoint= NULL;
   DBUG_ENTER("get_part_iter_for_interval_cols_via_map");
 
   if (part_info->part_type == RANGE_PARTITION)

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1570,10 +1570,12 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
     switch ((*(p++)= *(list++))) {
     case '\0':
       list= NULL; /* terminate the loop */
-      /* fall through */
+      // fallthrough - the later 2 comments are required by GCC
 #ifndef __WIN__
+      // fallthrough
     case ':':     /* can't use this as delimiter as it may be drive letter */
 #endif
+      // fallthrough
     case ';':
       str->str[str->length]= '\0';
       if (str == &name)  // load all plugins in named module
@@ -1621,6 +1623,7 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
         str->str= p;
         continue;
       }
+      // fallthrough
     default:
       str->length++;
       continue;

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -1991,6 +1991,8 @@ static bool check_prepared_statement(Prepared_statement *stmt)
     if (res != 2)
       break;
 
+    // fallthrough
+
   case SQLCOM_UPDATE_MULTI:
     res= mysql_test_multiupdate(stmt, tables, res == 2);
     break;

--- a/sql/sql_repl.cc
+++ b/sql/sql_repl.cc
@@ -963,6 +963,7 @@ impossible position";
           loop_breaker = (flags & BINLOG_DUMP_NON_BLOCK);
           break;
         }
+        // fallthrough
       default:
 	errmsg = "could not find next log";
 	my_errno= ER_MASTER_FATAL_ERROR_READING_BINLOG;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -675,6 +675,7 @@ public:
         is_handled= FALSE;
         break;
       }
+      // fallthrough
     case ER_COLUMNACCESS_DENIED_ERROR:
     case ER_VIEW_NO_EXPLAIN: /* Error was anonymized, ignore all the same. */
     case ER_PROCACCESS_DENIED_ERROR:

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -1007,12 +1007,13 @@ static int execute_ddl_log_action(THD *thd, DDL_LOG_ENTRY *ddl_log_entry)
           break;
       }
       DBUG_ASSERT(ddl_log_entry->action_type == DDL_LOG_REPLACE_ACTION);
-      /*
-        Fall through and perform the rename action of the replace
-        action. We have already indicated the success of the delete
-        action in the log entry by stepping up the phase.
-      */
     }
+    // fallthrough
+    /*
+    and perform the rename action of the replace
+    action. We have already indicated the success of the delete
+    action in the log entry by stepping up the phase.
+    */
     case DDL_LOG_RENAME_ACTION:
     {
       error= TRUE;
@@ -5437,7 +5438,8 @@ bool alter_table_manage_keys(TABLE *table, int indexes_were_disabled,
   case LEAVE_AS_IS:
     if (!indexes_were_disabled)
       break;
-    /* fall-through: disabled indexes */
+    // fallthrough
+    // disabled indexes
   case DISABLE:
     error= table->file->ha_disable_indexes(HA_KEY_SWITCH_NONUNIQ_SAVE);
   }

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -4210,9 +4210,11 @@ size_number:
                 case 'g':
                 case 'G':
                   text_shift_number+=10;
+                  // fallthrough
                 case 'm':
                 case 'M':
                   text_shift_number+=10;
+                  // fallthrough
                 case 'k':
                 case 'K':
                   text_shift_number+=10;

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -1418,8 +1418,8 @@ bool ha_federated::create_where_from_key(String *to,
           {
             goto err;
           }
-          break;
         }
+        break;
       case HA_READ_KEY_OR_NEXT:
         DBUG_PRINT("info", ("federated HA_READ_KEY_OR_NEXT %d", i));
         if (emit_key_part_name(&tmp, key_part) ||
@@ -1437,8 +1437,8 @@ bool ha_federated::create_where_from_key(String *to,
               emit_key_part_element(&tmp, key_part, needs_quotes, 0, ptr,
                                     part_length))
             goto err;
-          break;
         }
+        break;
       case HA_READ_KEY_OR_PREV:
         DBUG_PRINT("info", ("federated HA_READ_KEY_OR_PREV %d", i));
         if (emit_key_part_name(&tmp, key_part) ||

--- a/storage/heap/hp_extra.c
+++ b/storage/heap/hp_extra.c
@@ -34,6 +34,7 @@ int heap_extra(register HP_INFO *info, enum ha_extra_function function)
   switch (function) {
   case HA_EXTRA_RESET_STATE:
     heap_reset(info);
+    break;
   case HA_EXTRA_NO_READCHECK:
     info->opt_flag&= ~READ_CHECK_USED;	/* No readcheck */
     break;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5976,7 +5976,8 @@ ha_innobase::innobase_lock_autoinc(void)
 				break;
 			}
 		}
-		/* Fall through to old style locking. */
+		// fallthrough
+		// to old style locking.
 
 	case AUTOINC_OLD_STYLE_LOCKING:
 		error = row_lock_table_autoinc_for_mysql(prebuilt);
@@ -7995,7 +7996,8 @@ create_options_are_valid(
 	case ROW_TYPE_DYNAMIC:
 		CHECK_ERROR_ROW_TYPE_NEEDS_FILE_PER_TABLE;
 		CHECK_ERROR_ROW_TYPE_NEEDS_GT_ANTELOPE;
-		/* fall through since dynamic also shuns KBS */
+		// fallthrough
+		// since dynamic also shuns KBS 
 	case ROW_TYPE_COMPACT:
 	case ROW_TYPE_REDUNDANT:
 		if (kbs_specified) {
@@ -8241,6 +8243,7 @@ ha_innobase::create(
 			thd, MYSQL_ERROR::WARN_LEVEL_WARN,
 			ER_ILLEGAL_HA_CREATE_OPTION,
 			"InnoDB: assuming ROW_FORMAT=COMPACT.");
+		// fallthrough
 	case ROW_TYPE_DEFAULT:
 	case ROW_TYPE_COMPACT:
 		flags = DICT_TF_COMPACT;

--- a/storage/innobase/include/data0type.ic
+++ b/storage/innobase/include/data0type.ic
@@ -477,7 +477,8 @@ dtype_get_fixed_size_low(
 #else /* !UNIV_HOTBACKUP */
 		return(len);
 #endif /* !UNIV_HOTBACKUP */
-		/* fall through for variable-length charsets */
+		// fallthrough 
+		// for variable-length charsets 
 	case DATA_VARCHAR:
 	case DATA_BINARY:
 	case DATA_DECIMAL:

--- a/storage/innobase/include/log0online.h
+++ b/storage/innobase/include/log0online.h
@@ -141,7 +141,11 @@ log_online_bitmap_iterator_next(
 
 /** Struct for single bitmap file information */
 struct log_online_bitmap_file_struct {
-	char		name[FN_REFLEN];	/*!< Name with full path */
+	/** Name with full path
+	    61 is a nice magic constant for the extra space needed for the sprintf
+	    template in the cc file
+	*/
+	char		name[FN_REFLEN+61];	/*!< Name with full path */
 	os_file_t	file;			/*!< Handle to opened file */
 	ib_uint64_t	size;			/*!< Size of the file */
 	ib_uint64_t	offset;			/*!< Offset of the next read,

--- a/storage/innobase/include/page0zip.ic
+++ b/storage/innobase/include/page0zip.ic
@@ -170,7 +170,7 @@ page_zip_rec_needs_ext(
 				ignored if zip_size == 0 */
 	ulint	zip_size)	/*!< in: compressed page size in bytes, or 0 */
 {
-	ut_ad(rec_size > comp ? REC_N_NEW_EXTRA_BYTES : REC_N_OLD_EXTRA_BYTES);
+	ut_ad(rec_size > (comp ? REC_N_NEW_EXTRA_BYTES : REC_N_OLD_EXTRA_BYTES));
 	ut_ad(ut_is_2pow(zip_size));
 	ut_ad(comp || !zip_size);
 

--- a/storage/innobase/log/log0online.c
+++ b/storage/innobase/log/log0online.c
@@ -501,9 +501,9 @@ log_online_make_bitmap_name(
 /*=========================*/
 	ib_uint64_t	start_lsn)	/*!< in: the start LSN name part */
 {
-	ut_snprintf(log_bmp_sys->out.name, FN_REFLEN, bmp_file_name_template,
-		    log_bmp_sys->bmp_file_home, bmp_file_name_stem,
-		    log_bmp_sys->out_seq_num, start_lsn);
+	ut_snprintf(log_bmp_sys->out.name, sizeof(log_bmp_sys->out.name), 
+            bmp_file_name_template, log_bmp_sys->bmp_file_home,
+            bmp_file_name_stem, log_bmp_sys->out_seq_num, start_lsn);
 }
 
 /*********************************************************************//**

--- a/storage/innobase/row/row0mysql.c
+++ b/storage/innobase/row/row0mysql.c
@@ -3627,7 +3627,8 @@ check_next_foreign:
 
 		row_mysql_handle_errors(&err, trx, NULL, NULL);
 
-		/* Fall through to raise error */
+		// fallthrough
+		// to raise error
 
 	default:
 		/* No other possible error returns */
@@ -4398,7 +4399,8 @@ loop:
 		fputs("  InnoDB: Warning: CHECK TABLE on ", stderr);
 		dict_index_name_print(stderr, prebuilt->trx, index);
 		fprintf(stderr, " returned %lu\n", ret);
-		/* fall through (this error is ignored by CHECK TABLE) */
+		// fallthrough
+		// (this error is ignored by CHECK TABLE)
 	case DB_END_OF_INDEX:
 func_exit:
 		mem_free(buf);

--- a/storage/innobase/row/row0purge.c
+++ b/storage/innobase/row/row0purge.c
@@ -407,7 +407,8 @@ row_purge_remove_sec_if_poss_leaf(
 				goto func_exit;
 			}
 		}
-		/* fall through (the index entry is still needed,
+		// fallthrough
+		/* (the index entry is still needed,
 		or the deletion succeeded) */
 	case ROW_NOT_DELETED_REF:
 		/* The index entry is still needed. */

--- a/storage/innobase/row/row0sel.c
+++ b/storage/innobase/row/row0sel.c
@@ -2681,7 +2681,7 @@ row_sel_field_store_in_mysql_format(
 	case DATA_SYS:
 		/* These column types should never be shipped to MySQL. */
 		ut_ad(0);
-
+		break;
 	case DATA_CHAR:
 	case DATA_FIXBINARY:
 	case DATA_FLOAT:

--- a/storage/myisam/mi_extra.c
+++ b/storage/myisam/mi_extra.c
@@ -148,6 +148,7 @@ int mi_extra(MI_INFO *info, enum ha_extra_function function, void *extra_arg)
   case HA_EXTRA_PREPARE_FOR_UPDATE:
     if (info->s->data_file_type != DYNAMIC_RECORD)
       break;
+    // fallthrough
     /* Remove read/write cache if dynamic rows */
   case HA_EXTRA_NO_CACHE:
     if (info->opt_flag & (READ_CACHE_USED | WRITE_CACHE_USED))

--- a/storage/myisam/mi_panic.c
+++ b/storage/myisam/mi_panic.c
@@ -74,6 +74,7 @@ int mi_panic(enum ha_panic_function flag)
       info->s->kfile=info->dfile= -1;	/* Files aren't open anymore */
       break;
 #endif
+    // fallthrough
     case HA_PANIC_READ:			/* Restore to before WRITE */
 #ifdef CANT_OPEN_FILES_TWICE
       {					/* Open closed files */

--- a/storage/myisam/myisamchk.c
+++ b/storage/myisam/myisamchk.c
@@ -1365,7 +1365,7 @@ static void descript(MI_CHECK *param, register MI_INFO *info, char * name)
 	 key < share->state.header.uniques; key++, uniqueinfo++)
     {
       my_bool new_row=0;
-      char null_bit[8],null_pos[8];
+      char null_bit[8],null_pos[11];
       printf("%-8d%-5d",key+1,uniqueinfo->key+1);
       for (keyseg=uniqueinfo->seg ; keyseg->type != HA_KEYTYPE_END ; keyseg++)
       {

--- a/strings/ctype-utf8.c
+++ b/strings/ctype-utf8.c
@@ -2666,12 +2666,12 @@ static int my_uni_utf8 (CHARSET_INFO *cs __attribute__((unused)),
   switch (count) {
     /* Fall through all cases!!! */
 #ifdef UNICODE_32BIT
-    case 6: r[5] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x4000000;
-    case 5: r[4] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x200000;
-    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000;
+    case 6: r[5] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x4000000; // fallthrough
+    case 5: r[4] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x200000; // fallthrough
+    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000; // fallthrough
 #endif
-    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800;
-    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0;
+    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0] = (uchar) wc;
   }
   return count;
@@ -2698,8 +2698,8 @@ static int my_uni_utf8_no_range(CHARSET_INFO *cs __attribute__((unused)),
   switch (count)
   {
     /* Fall through all cases!!! */
-    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800;
-    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0;
+    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0]= (uchar) wc;
   }
   return count;
@@ -5185,9 +5185,9 @@ my_wc_mb_utf8mb4(CHARSET_INFO *cs __attribute__((unused)),
 
   switch (count) {
     /* Fall through all cases!!! */
-    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000;
-    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800;
-    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0;
+    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000; // fallthrough
+    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0] = (uchar) wc;
   }
   return count;
@@ -5217,9 +5217,9 @@ my_wc_mb_utf8mb4_no_range(CHARSET_INFO *cs __attribute__((unused)),
   switch (count)
   {
     /* Fall through all cases!!! */
-    case 4: r[3]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x10000;
-    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800;
-    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0;
+    case 4: r[3]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x10000; // fallthrough
+    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0]= (uchar) wc;
   }
   return count;

--- a/strings/decimal.c
+++ b/strings/decimal.c
@@ -230,17 +230,17 @@ static inline int count_leading_zeroes(int i, dec1 val)
   switch (i)
   {
   /* @note Intentional fallthrough in all case labels */
-  case 9: if (val >= 1000000000) break; ++ret;
-  case 8: if (val >= 100000000) break; ++ret;
-  case 7: if (val >= 10000000) break; ++ret;
-  case 6: if (val >= 1000000) break; ++ret;
-  case 5: if (val >= 100000) break; ++ret;
-  case 4: if (val >= 10000) break; ++ret;
-  case 3: if (val >= 1000) break; ++ret;
-  case 2: if (val >= 100) break; ++ret;
-  case 1: if (val >= 10) break; ++ret;
-  case 0: if (val >= 1) break; ++ret;
-  default: { DBUG_ASSERT(FALSE); }
+  case 9: if (val >= 1000000000) break; ++ret; // fallthrough
+  case 8: if (val >= 100000000) break; ++ret; // fallthrough
+  case 7: if (val >= 10000000) break; ++ret; // fallthrough
+  case 6: if (val >= 1000000) break; ++ret; // fallthrough
+  case 5: if (val >= 100000) break; ++ret; // fallthrough
+  case 4: if (val >= 10000) break; ++ret; // fallthrough
+  case 3: if (val >= 1000) break; ++ret; // fallthrough
+  case 2: if (val >= 100) break; ++ret; // fallthrough
+  case 1: if (val >= 10) break; ++ret; // fallthrough
+  case 0: if (val >= 1) break; ++ret; // fallthrough
+  default: { DBUG_ASSERT(FALSE); } // fallthrough
   }
   return ret;
 }
@@ -263,16 +263,16 @@ static inline int count_trailing_zeroes(int i, dec1 val)
   switch(i)
   {
   /* @note Intentional fallthrough in all case labels */
-  case 0: if ((val % 1) != 0) break; ++ret;
-  case 1: if ((val % 10) != 0) break; ++ret;
-  case 2: if ((val % 100) != 0) break; ++ret;
-  case 3: if ((val % 1000) != 0) break; ++ret;
-  case 4: if ((val % 10000) != 0) break; ++ret;
-  case 5: if ((val % 100000) != 0) break; ++ret;
-  case 6: if ((val % 1000000) != 0) break; ++ret;
-  case 7: if ((val % 10000000) != 0) break; ++ret;
-  case 8: if ((val % 100000000) != 0) break; ++ret;
-  case 9: if ((val % 1000000000) != 0) break; ++ret;
+  case 0: if ((val % 1) != 0) break; ++ret; // fallthrough
+  case 1: if ((val % 10) != 0) break; ++ret; // fallthrough
+  case 2: if ((val % 100) != 0) break; ++ret; // fallthrough
+  case 3: if ((val % 1000) != 0) break; ++ret; // fallthrough
+  case 4: if ((val % 10000) != 0) break; ++ret; // fallthrough
+  case 5: if ((val % 100000) != 0) break; ++ret; // fallthrough
+  case 6: if ((val % 1000000) != 0) break; ++ret; // fallthrough
+  case 7: if ((val % 10000000) != 0) break; ++ret; // fallthrough
+  case 8: if ((val % 100000000) != 0) break; ++ret; // fallthrough
+  case 9: if ((val % 1000000000) != 0) break; ++ret; // fallthrough
   default: { DBUG_ASSERT(FALSE); }
   }
   return ret;

--- a/strings/dtoa.c
+++ b/strings/dtoa.c
@@ -1378,7 +1378,7 @@ static double my_strtod_int(const char *s00, char **se, int *error, char *buf, s
     switch (*s) {
     case '-':
       sign= 1;
-      /* no break */
+      // fallthrough
     case '+':
       s++;
       goto break2;
@@ -1475,6 +1475,7 @@ static double my_strtod_int(const char *s00, char **se, int *error, char *buf, s
       switch (c= *s) {
       case '-':
         esign= 1;
+        // fallthrough
       case '+':
         c= *++s;
       }
@@ -2368,7 +2369,7 @@ static char *dtoa(double dd, int mode, int ndigits, int *decpt, int *sign,
     break;
   case 2:
     leftright= 0;
-    /* no break */
+    // fallthrough
   case 4:
     if (ndigits <= 0)
       ndigits= 1;
@@ -2376,7 +2377,7 @@ static char *dtoa(double dd, int mode, int ndigits, int *decpt, int *sign,
     break;
   case 3:
     leftright= 0;
-    /* no break */
+    // fallthrough
   case 5:
     i= ndigits + k + 1;
     ilim= i;

--- a/tests/bug25714.c
+++ b/tests/bug25714.c
@@ -72,6 +72,6 @@ int main (int argc, char **argv)
   mysql_close(&conn);
   my_end(0);
 
-  return 0;
+  return OK;
 }
 


### PR DESCRIPTION
Most of the changes won't result in any behavior change - I had to reformat/move some comments and breaks so GCC's fallthrough parser finds them.

I also added breaks, with the reasoning explained in the commit message - most of the time, they were present in later versions.

The other changes are about fixing issues with sprintf (buffer length/truncation issues), and some uninitialized variables in the release build.