### PR TITLE
lp1729241, BLD-861: Fixed compilation issues with gcc-7 for the 5.6 branch

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -1036,8 +1036,6 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
       if (head->error == -1)
         goto err;
       break;
-      
-      destroy_evt= TRUE;
     }
           
     case INTVAR_EVENT:
@@ -1317,6 +1315,7 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
         goto end;
       }
     }
+    // fallthrough
     case ROWS_QUERY_LOG_EVENT:
     case WRITE_ROWS_EVENT:
     case DELETE_ROWS_EVENT:

--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -2156,6 +2156,7 @@ static void print_xml_comment(FILE *xml_file, size_t len,
     case '-':
       if (*(comment_string + 1) == '-')         /* Only one hyphen allowed. */
         break;
+      // fallthrough
     default:
       fputc(*comment_string, xml_file);
       break;

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -8295,7 +8295,7 @@ void run_explain(struct st_connection *cn, struct st_command *command,
 char *re_eprint(int err)
 {
   static char epbuf[100];
-  size_t len= my_regerror(MY_REG_ITOA | err, NULL, epbuf, sizeof(epbuf));
+  size_t len MY_ATTRIBUTE((unused))= my_regerror(MY_REG_ITOA | err, NULL, epbuf, sizeof(epbuf));
   assert(len <= sizeof(epbuf));
   return(epbuf);
 }

--- a/extra/replace.c
+++ b/extra/replace.c
@@ -173,6 +173,7 @@ register char **argv[];
 	break;
       case 'V':
 	version=1;
+      // fallthrough
       case 'I':
       case '?':
 	help=1;					/* Help text written */

--- a/plugin/percona-udf/murmur_udf.cc
+++ b/plugin/percona-udf/murmur_udf.cc
@@ -97,8 +97,8 @@ MurmurHash2( const void *key, int len, unsigned int seed ) {
    }
 
    switch (len) {
-      case 3: h2 ^= ((unsigned char*)data)[2] << 16;
-      case 2: h2 ^= ((unsigned char*)data)[1] << 8;
+      case 3: h2 ^= ((unsigned char*)data)[2] << 16; // fallthrough
+      case 2: h2 ^= ((unsigned char*)data)[1] << 8; // fallthrough
       case 1: h2 ^= ((unsigned char*)data)[0];
               h2 *= m;
    };

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -240,7 +240,7 @@ static int tokudb_backup_progress_fun(float progress, const char *progress_strin
     size_t len = 100 + strlen(progress_string);
     be->_the_string = (char *) my_realloc(be->_the_string, len, MYF(MY_FAE+MY_ALLOW_ZERO_PTR));
     float percentage = progress * 100;
-    int r = snprintf(be->_the_string, len, "tokudb backup about %.0f%% done: %s", percentage, progress_string);
+    int r MY_ATTRIBUTE((unused)) = snprintf(be->_the_string, len, "tokudb backup about %.0f%% done: %s", percentage, progress_string);
     assert(0 < r && (size_t)r <= len);
     thd_proc_info(be->_thd, be->_the_string);
 
@@ -260,7 +260,7 @@ static void tokudb_backup_set_error(THD *thd,
 static void tokudb_backup_set_error_string(THD *thd, int error, const char *error_fmt, const char *s1, const char *s2, const char *s3) {
     size_t n = strlen(error_fmt) + (s1 ? strlen(s1) : 0) + (s2 ? strlen(s2) : 0) + (s3 ? strlen(s3) : 0);
     char *error_string = static_cast<char *>(my_malloc(n+1, MYF(MY_FAE)));
-    int r = snprintf(error_string, n+1, error_fmt, s1, s2, s3);
+    int r MY_ATTRIBUTE((unused)) = snprintf(error_string, n+1, error_fmt, s1, s2, s3);
     assert(0 < r && (size_t)r <= n);
     tokudb_backup_set_error(thd, error, error_string);
     my_free(error_string);

--- a/regex/debug.c
+++ b/regex/debug.c
@@ -24,7 +24,7 @@ FILE *d;
 	register int c;
 	register int last;
 	int nincat[NC];
-	char buf[10];
+	char buf[11];
 
 	fprintf(d, "%ld states, %d categories", (long)g->nstates,
 							g->ncategories);
@@ -102,7 +102,7 @@ FILE *d;
 	register int col = 0;
 	register int last;
 	register sopno offset = 2;
-	char buf[10];
+	char buf[13];
 #	define	GAP()	{	if (offset % 5 == 0) { \
 					if (col > 40) { \
 						fprintf(d, "\n\t"); \

--- a/regex/main.c
+++ b/regex/main.c
@@ -561,7 +561,7 @@ eprint(err)
 int err;
 {
 	static char epbuf[100];
-	size_t len;
+	size_t MY_ATTRIBUTE((unused)) len;
 
 	len = my_regerror(MY_REG_ITOA|err, (my_regex_t *)NULL, epbuf, sizeof(epbuf));
 	assert(len <= sizeof(epbuf));

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -1207,6 +1207,7 @@ void mysql_read_default_options(struct st_mysql_options *options,
 	  break;
         case OPT_pipe:
           options->protocol = MYSQL_PROTOCOL_PIPE;
+          break;
 	case OPT_connect_timeout:
 	case OPT_timeout:
 	  if (opt_arg)

--- a/sql-common/client_authentication.cc
+++ b/sql-common/client_authentication.cc
@@ -84,7 +84,7 @@ RSA *rsa_init(MYSQL *mysql)
 
   if (mysql->options.extension != NULL &&
       mysql->options.extension->server_public_key_path != NULL &&
-      mysql->options.extension->server_public_key_path != '\0')
+      mysql->options.extension->server_public_key_path[0] != '\0')
   {
     pub_key_file= fopen(mysql->options.extension->server_public_key_path,
                         "r");

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -241,6 +241,7 @@ common_1_lev_code:
     break;
   case INTERVAL_WEEK:
     expr/= 7;
+    // fallthrough
   default:
     close_quote= FALSE;
     break;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -10036,7 +10036,7 @@ bool Create_field::init(THD *thd, const char *fld_name,
   case MYSQL_TYPE_DATE:
     /* Old date type. */
     sql_type= MYSQL_TYPE_NEWDATE;
-    /* fall trough */
+    // fallthrough
   case MYSQL_TYPE_NEWDATE:
     length= MAX_DATE_WIDTH;
     break;

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -6201,7 +6201,8 @@ Field *Item::tmp_table_field_from_field_type(TABLE *table, bool fixed_length)
                               collation.collation);
       break;
     }
-    /* Fall through to make_string_field() */
+    // fallthrough
+    // to make_string_field() 
   case MYSQL_TYPE_ENUM:
   case MYSQL_TYPE_SET:
   case MYSQL_TYPE_VAR_STRING:

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -1911,6 +1911,7 @@ my_decimal *Item_func_mod::decimal_op(my_decimal *decimal_value)
     return decimal_value;
   case E_DEC_DIV_ZERO:
     signal_divide_by_null();
+    // fallthrough
   default:
     null_value= 1;
     return 0;
@@ -5035,6 +5036,7 @@ String *user_var_entry::val_str(my_bool *null_value, String *str,
   case STRING_RESULT:
     if (str->copy(m_ptr, m_length, collation.collation))
       str= 0;					// EOM error
+    break;
   case ROW_RESULT:
     DBUG_ASSERT(1);				// Impossible
     break;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -3241,8 +3241,10 @@ void TC_LOG_MMAP::close()
     mysql_mutex_destroy(&LOCK_active);
     mysql_mutex_destroy(&LOCK_pool);
     mysql_cond_destroy(&COND_pool);
+    // fallthrough
   case 5:
     data[0]='A'; // garble the first (signature) byte, in case mysql_file_delete fails
+    // fallthrough
   case 4:
     for (i=0; i < npages; i++)
     {
@@ -3251,10 +3253,13 @@ void TC_LOG_MMAP::close()
       mysql_mutex_destroy(&pages[i].lock);
       mysql_cond_destroy(&pages[i].cond);
     }
+    // fallthrough
   case 3:
     my_free(pages);
+    // fallthrough
   case 2:
     my_munmap((char*)data, (size_t)file_length);
+    // fallthrough
   case 1:
     mysql_file_close(fd, MYF(0));
   }

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -7839,17 +7839,17 @@ User_var_log_event(const char* buf, uint event_len,
 #ifndef DBUG_OFF
     bool old_pre_checksum_fd= description_event->is_version_before_checksum();
 #endif
-    DBUG_ASSERT((bytes_read == data_written -
-                 (old_pre_checksum_fd ||
+    DBUG_ASSERT((bytes_read == (data_written -
+                 ((old_pre_checksum_fd ||
                   (description_event->checksum_alg ==
                    BINLOG_CHECKSUM_ALG_OFF)) ?
-                 0 : BINLOG_CHECKSUM_LEN)
+                 0 : BINLOG_CHECKSUM_LEN)))
                 ||
-                (bytes_read == data_written -1 -
+                ((bytes_read == (data_written -1 -
                  (old_pre_checksum_fd ||
                   (description_event->checksum_alg ==
                    BINLOG_CHECKSUM_ALG_OFF)) ?
-                 0 : BINLOG_CHECKSUM_LEN));
+                 0 : BINLOG_CHECKSUM_LEN))));
     if ((data_written - bytes_read) > 0)
     {
       flags= (uint) *(buf + UV_VAL_IS_NULL + UV_VAL_TYPE_SIZE +

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8927,7 +8927,7 @@ mysqld_get_one_option(int optid,
     break;
   case 'L':
     WARN_DEPRECATED(NULL, "--language/-l", "'--lc-messages-dir'");
-    /* Note:  fall-through */
+    // fallthrough
   case OPT_LC_MESSAGES_DIRECTORY:
     strmake(lc_messages_dir, argument, sizeof(lc_messages_dir)-1);
     lc_messages_dir_ptr= lc_messages_dir;

--- a/sql/opt_sum.cc
+++ b/sql/opt_sum.cc
@@ -1037,6 +1037,7 @@ static int maxmin_in_range(bool max_fl, Field* field, Item *cond)
   case Item_func::LT_FUNC:
   case Item_func::LE_FUNC:
     less_fl= 1;
+    // fallthrough
   case Item_func::GT_FUNC:
   case Item_func::GE_FUNC:
   {

--- a/sql/rpl_info_factory.cc
+++ b/sql/rpl_info_factory.cc
@@ -213,7 +213,9 @@ Relay_log_info *Rpl_info_factory::create_rli(uint rli_option, bool is_slave_reco
                         worker_table_data, worker_file_data, &msg))
     goto err;
 
-  if (!(rli= new Relay_log_info(is_slave_recovery
+  try
+  {
+    rli= new Relay_log_info(is_slave_recovery
 #ifdef HAVE_PSI_INTERFACE
                                 ,&key_relay_log_info_run_lock,
                                 &key_relay_log_info_data_lock,
@@ -224,7 +226,8 @@ Relay_log_info *Rpl_info_factory::create_rli(uint rli_option, bool is_slave_reco
                                 &key_relay_log_info_sleep_cond
 #endif
                                 , instances
-                                )))
+                                );
+  } catch (std::bad_alloc&)  
   {
     msg= msg_alloc;
     goto err;
@@ -386,7 +389,9 @@ Slave_worker *Rpl_info_factory::create_worker(uint rli_option, uint worker_id,
   char *pos= strmov(worker_file_data.name, worker_file_data.pattern);
   sprintf(pos, "%u", worker_id + 1);
 
-  if (!(worker= new Slave_worker(rli
+  try
+  {
+    worker= new Slave_worker(rli
 #ifdef HAVE_PSI_INTERFACE
                                  ,&key_relay_log_info_run_lock,
                                  &key_relay_log_info_data_lock,
@@ -397,9 +402,11 @@ Slave_worker *Rpl_info_factory::create_worker(uint rli_option, uint worker_id,
                                  &key_relay_log_info_sleep_cond
 #endif
                                  , worker_id
-                                )))
+                                );
+  } catch (std::bad_alloc&)
+  {
     goto err;
-
+  }
 
   if(init_repositories(worker_table_data, worker_file_data, rli_option,
                        worker_id + 1, &handler_src, &handler_dest, &msg))

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -2493,3 +2493,17 @@ void Relay_log_info::adapt_to_master_version(Format_description_log_event *fdle)
     }
   }
 }
+
+void* Relay_log_info::operator new(size_t request)
+{
+  void* ptr;
+  if (posix_memalign(&ptr, __alignof__(Relay_log_info), sizeof(Relay_log_info))) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void Relay_log_info::operator delete(void * ptr) {
+  free(ptr);
+}
+

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -211,6 +211,11 @@ public:
     happen when, for example, the relay log gets rotated because of
     max_binlog_size.
   */
+
+  // overridden new and delete operators for 64 byte alignment
+  static void* operator new(size_t request);
+  static void operator delete(void * ptr);
+
 protected:
   char group_relay_log_name[FN_REFLEN];
   ulonglong group_relay_log_pos;

--- a/sql/rpl_rli_pdb.cc
+++ b/sql/rpl_rli_pdb.cc
@@ -1668,6 +1668,20 @@ void Slave_worker::do_report(loglevel level, int err_code, const char *msg,
   c_rli->va_report(level, err_code, buff_coord, msg, args);
 }
 
+void* Slave_worker::operator new(size_t request)
+{
+  void* ptr;
+  if (posix_memalign(&ptr, __alignof__(Slave_worker), sizeof(Slave_worker))) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void Slave_worker::operator delete(void * ptr)
+{
+  free(ptr);
+}
+
 /**
    Function is called by Coordinator when it identified an event
    requiring sequential execution.

--- a/sql/rpl_rli_pdb.h
+++ b/sql/rpl_rli_pdb.h
@@ -437,6 +437,10 @@ public:
       gaq_index= val;
   };
 
+  // overridden new and delete operators for 64 byte alignment
+  static void* operator new(size_t request);
+  static void operator delete(void * ptr);
+
 protected:
 
   virtual void do_report(loglevel level, int err_code,

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -3232,6 +3232,7 @@ bool show_slave_status(THD* thd, Master_info* mi)
       break;
     case Relay_log_info::UNTIL_SQL_AFTER_MTS_GAPS:
       until_type= "SQL_AFTER_MTS_GAPS";
+      break;
     case Relay_log_info::UNTIL_DONE:
       until_type= "DONE";
       break;

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -2713,7 +2713,8 @@ String *sp_get_item_value(THD *thd, Item *item, String *str)
   case DECIMAL_RESULT:
     if (item->field_type() != MYSQL_TYPE_BIT)
       return item->val_str(str);
-    else {/* Bit type is handled as binary string */}
+    // fallthrough
+    /* Bit type is handled as binary string */
   case STRING_RESULT:
     {
       String *result= item->val_str(str);

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -2987,7 +2987,7 @@ bool change_password(THD *thd, const char *host, const char *user,
 
   mysql_mutex_assert_owner(&acl_cache->lock);
   table->use_all_columns();
-  DBUG_ASSERT(host != '\0');
+  DBUG_ASSERT(host != NULL && host[0] != '\0');
   table->field[MYSQL_USER_FIELD_HOST]->store(host, strlen(host),
                                              system_charset_info);
   table->field[MYSQL_USER_FIELD_USER]->store(user, strlen(user),
@@ -3424,7 +3424,7 @@ update_user_table(THD *thd, TABLE *table,
   if (!is_user_table_positioned)
   {
     table->use_all_columns();
-    DBUG_ASSERT(host != '\0');
+    DBUG_ASSERT(host != NULL && host[0] != '\0');
     table->field[MYSQL_USER_FIELD_HOST]->store(host, (uint) strlen(host),
 					       system_charset_info);
     table->field[MYSQL_USER_FIELD_USER]->store(user, (uint) strlen(user),
@@ -3573,7 +3573,7 @@ static int replace_user_table(THD *thd, TABLE *table, LEX_USER *combo,
   }
 
   table->use_all_columns();
-  DBUG_ASSERT(combo->host.str != '\0');
+  DBUG_ASSERT(combo->host.str != NULL && combo->host.str[0] != '\0');
   table->field[MYSQL_USER_FIELD_HOST]->store(combo->host.str,combo->host.length,
                                              system_charset_info);
   table->field[MYSQL_USER_FIELD_USER]->store(combo->user.str,combo->user.length,
@@ -3664,7 +3664,7 @@ static int replace_user_table(THD *thd, TABLE *table, LEX_USER *combo,
 
     old_row_exists = 0;
     restore_record(table,s->default_values);
-    DBUG_ASSERT(combo->host.str != '\0');
+    DBUG_ASSERT(combo->host.str != NULL && combo->host.str[0] != '\0');
     table->field[MYSQL_USER_FIELD_HOST]->store(combo->host.str,combo->host.length,
                                                system_charset_info);
     table->field[MYSQL_USER_FIELD_USER]->store(combo->user.str,combo->user.length,
@@ -12602,7 +12602,13 @@ private:
         filesize= ftell(key_file);
         fseek(key_file, 0, SEEK_SET);
         *key_text_buffer= new char[filesize+1];
-        (void) fread(*key_text_buffer, filesize, 1, key_file);
+        const size_t read_size = fread(*key_text_buffer, filesize, 1, key_file);
+        if (read_size != 1)
+        {
+          delete[] key_text_buffer;
+          key_text_buffer= NULL;
+          return true;
+        }
         (*key_text_buffer)[filesize]= '\0';
       }
       fclose(key_file);

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -453,6 +453,7 @@ void QueryStripComments::set(const char* query, uint query_length, uint addition
           break;
         }
       }
+      // fallthrough
     case '#':
       {
         do
@@ -1754,6 +1755,7 @@ Query_cache::send_result_to_client(THD *thd, char *sql, uint query_length)
           {
             break;
           }
+          // fallthrough
         case '#':
           do
           {
@@ -2007,7 +2009,7 @@ def_week_frmt: %lu, in_trans: %d, autocommit: %d",
       {
         DBUG_PRINT("qcache",
                    ("Temporary table detected: '%s.%s'",
-                    table_list.db, table_list.alias));
+                    tmptable->s->db.str, tmptable->s->table_name.str));
         unlock();
         /*
           We should not store result of this query because it contain

--- a/sql/sql_digest.cc
+++ b/sql/sql_digest.cc
@@ -460,7 +460,8 @@ sql_digest_state* digest_add_token(sql_digest_state *state,
         }
       } while (found_unary);
     }
-    /* fall through, for case NULL_SYM below */
+    // fallthrough
+    // for case NULL_SYM below
     case LEX_HOSTNAME:
     case TEXT_STRING:
     case NCHAR_STRING:

--- a/sql/sql_handler.cc
+++ b/sql/sql_handler.cc
@@ -694,6 +694,7 @@ retry:
         error= table->file->ha_rnd_next(table->record[0]);
         break;
       }
+      // fallthrough
       /*
         Fall through to HANDLER ... READ ... FIRST case if we are trying
         to read next row in index order after starting reading rows in
@@ -724,7 +725,8 @@ retry:
         error= table->file->ha_index_prev(table->record[0]);
         break;
       }
-      /* else fall through, for more info, see comment before 'case RFIRST'. */
+      // fallthrough
+      // for more info, see comment before 'case RFIRST'.
     case RLAST:
       DBUG_ASSERT(m_key_name != 0);
       if (!(error= table->file->ha_index_or_rnd_end()) &&

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1033,6 +1033,7 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	yylval->lex_str.length=2;
 	return NULL_SYM;
       }
+      // fallthrough
     case MY_LEX_CHAR:			// Unknown or single char token
     case MY_LEX_SKIP:			// This should not happen
       if (c == '-' && lip->yyPeek() == '-' &&
@@ -1096,12 +1097,14 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	state= MY_LEX_HEX_NUMBER;
 	break;
       }
+      // fallthrough
     case MY_LEX_IDENT_OR_BIN:
       if (lip->yyPeek() == '\'')
       {                                 // Found b'bin-number'
         state= MY_LEX_BIN_NUMBER;
         break;
       }
+      // fallthrough
     case MY_LEX_IDENT:
       const char *start;
 #if defined(USE_MB) && defined(USE_MB_IDENT)
@@ -1444,6 +1447,7 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	state= MY_LEX_USER_VARIABLE_DELIMITER;
 	break;
       }
+      // fallthrough
       /* " used for strings */
     case MY_LEX_STRING:			// Incomplete text string
       if (!(yylval->lex_str.str = get_text(lip, 1, 1)))

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -9414,7 +9414,8 @@ void JOIN::optimize_fts_query()
         if (fts_item->eq(fts_result, true))
           break;
       }
-      // Fall-through when not an equivalent MATCH expression
+      // fallthrough
+      // when not an equivalent MATCH expression
     default:
       covering= false;
     }

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3132,6 +3132,7 @@ case SQLCOM_PREPARE:
       break;
     }
   }
+  // fallthrough
   case SQLCOM_PURGE_BEFORE:
   {
     Item *it;
@@ -3833,8 +3834,8 @@ end_with_restore_list:
     /* mysql_update return 2 if we need to switch to multi-update */
     if (up_result != 2)
       break;
-    /* Fall through */
   }
+  // fallthrough
   case SQLCOM_UPDATE_MULTI:
   {
     DBUG_ASSERT(first_table == all_tables && first_table != 0);
@@ -3947,6 +3948,7 @@ end_with_restore_list:
       DBUG_PRINT("debug", ("Just after generate_incident()"));
     }
 #endif
+    // fallthrough
   case SQLCOM_INSERT:
   {
     DBUG_ASSERT(first_table == all_tables && first_table != 0);
@@ -4757,6 +4759,7 @@ end_with_restore_list:
       initialize this variable because RESET shares the same code as FLUSH
     */
     lex->no_write_to_binlog= 1;
+    // fallthrough
   case SQLCOM_FLUSH:
   {
     int write_to_binlog;

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -7810,7 +7810,7 @@ int get_part_iter_for_interval_cols_via_map(partition_info *part_info,
                                             PARTITION_ITERATOR *part_iter)
 {
   uint32 nparts;
-  get_col_endpoint_func  get_col_endpoint;
+  get_col_endpoint_func  get_col_endpoint= NULL;
   DBUG_ENTER("get_part_iter_for_interval_cols_via_map");
 
   if (part_info->part_type == RANGE_PARTITION)

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1634,10 +1634,12 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
     switch ((*(p++)= *(list++))) {
     case '\0':
       list= NULL; /* terminate the loop */
-      /* fall through */
+      // fallthrough - the later 2 comments are required by GCC
 #ifndef __WIN__
+      // fallthrough
     case ':':     /* can't use this as delimiter as it may be drive letter */
 #endif
+      // fallthrough
     case ';':
       str->str[str->length]= '\0';
       if (str == &name)  // load all plugins in named module
@@ -1691,6 +1693,7 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
         str->str= p;
         continue;
       }
+      // fallthrough
     default:
       str->length++;
       continue;

--- a/sql/sql_prepare.cc
+++ b/sql/sql_prepare.cc
@@ -2091,6 +2091,8 @@ static bool check_prepared_statement(Prepared_statement *stmt)
     if (res != 2)
       break;
 
+    // fallthrough
+
   case SQLCOM_UPDATE_MULTI:
     res= mysql_test_multiupdate(stmt, tables, res == 2);
     break;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -805,6 +805,7 @@ public:
         is_handled= FALSE;
         break;
       }
+      // fallthrough
     case ER_COLUMNACCESS_DENIED_ERROR:
     case ER_VIEW_NO_EXPLAIN: /* Error was anonymized, ignore all the same. */
     case ER_PROCACCESS_DENIED_ERROR:

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -1233,12 +1233,13 @@ static int execute_ddl_log_action(THD *thd, DDL_LOG_ENTRY *ddl_log_entry)
           break;
       }
       DBUG_ASSERT(ddl_log_entry->action_type == DDL_LOG_REPLACE_ACTION);
-      /*
-        Fall through and perform the rename action of the replace
-        action. We have already indicated the success of the delete
-        action in the log entry by stepping up the phase.
-      */
     }
+    // fallthrough
+    /*
+    and perform the rename action of the replace
+    action. We have already indicated the success of the delete
+    action in the log entry by stepping up the phase.
+    */
     case DDL_LOG_RENAME_ACTION:
     {
       error= TRUE;
@@ -6712,7 +6713,8 @@ bool alter_table_manage_keys(TABLE *table, int indexes_were_disabled,
   case Alter_info::LEAVE_AS_IS:
     if (!indexes_were_disabled)
       break;
-    /* fall-through: disabled indexes */
+    // fallthrough
+    // disabled indexes
   case Alter_info::DISABLE:
     error= table->file->ha_disable_indexes(HA_KEY_SWITCH_NONUNIQ_SAVE);
   }

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -5167,9 +5167,11 @@ size_number:
                 case 'g':
                 case 'G':
                   text_shift_number+=10;
+                  // fallthrough
                 case 'm':
                 case 'M':
                   text_shift_number+=10;
+                  // fallthrough
                 case 'k':
                 case 'K':
                   text_shift_number+=10;

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -1415,8 +1415,8 @@ bool ha_federated::create_where_from_key(String *to,
           {
             goto err;
           }
-          break;
         }
+        break;
       case HA_READ_KEY_OR_NEXT:
         DBUG_PRINT("info", ("federated HA_READ_KEY_OR_NEXT %d", i));
         if (emit_key_part_name(&tmp, key_part) ||
@@ -1434,8 +1434,8 @@ bool ha_federated::create_where_from_key(String *to,
               emit_key_part_element(&tmp, key_part, needs_quotes, 0, ptr,
                                     part_length))
             goto err;
-          break;
         }
+        break;
       case HA_READ_KEY_OR_PREV:
         DBUG_PRINT("info", ("federated HA_READ_KEY_OR_PREV %d", i));
         if (emit_key_part_name(&tmp, key_part) ||

--- a/storage/heap/hp_extra.c
+++ b/storage/heap/hp_extra.c
@@ -34,6 +34,7 @@ int heap_extra(register HP_INFO *info, enum ha_extra_function function)
   switch (function) {
   case HA_EXTRA_RESET_STATE:
     heap_reset(info);
+    break;
   case HA_EXTRA_NO_READCHECK:
     info->opt_flag&= ~READ_CHECK_USED;	/* No readcheck */
     break;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7626,7 +7626,8 @@ ha_innobase::innobase_lock_autoinc(void)
 				break;
 			}
 		}
-		/* Fall through to old style locking. */
+		// fallthrough
+		// to old style locking.
 
 	case AUTOINC_OLD_STYLE_LOCKING:
 		DBUG_EXECUTE_IF("die_if_autoinc_old_lock_style_used",
@@ -10330,7 +10331,8 @@ create_options_are_invalid(
 	case ROW_TYPE_DYNAMIC:
 		CHECK_ERROR_ROW_TYPE_NEEDS_FILE_PER_TABLE(use_tablespace);
 		CHECK_ERROR_ROW_TYPE_NEEDS_GT_ANTELOPE;
-		/* fall through since dynamic also shuns KBS */
+		// fallthrough
+		// since dynamic also shuns KBS
 	case ROW_TYPE_COMPACT:
 	case ROW_TYPE_REDUNDANT:
 		if (kbs_specified) {
@@ -10718,7 +10720,8 @@ index_bad:
 			break;
 		}
 		zip_allowed = FALSE;
-		/* fall through to set row_format = COMPACT */
+		// fallthrough
+		// to set row_format = COMPACT
 	case ROW_TYPE_NOT_USED:
 	case ROW_TYPE_FIXED:
 	case ROW_TYPE_PAGE:
@@ -10727,9 +10730,11 @@ index_bad:
 			thd, Sql_condition::WARN_LEVEL_WARN,
 			ER_ILLEGAL_HA_CREATE_OPTION,
 			"InnoDB: assuming ROW_FORMAT=COMPACT.");
+		// fallthrough
 	case ROW_TYPE_DEFAULT:
 		/* If we fell through, set row format to Compact. */
 		row_format = ROW_TYPE_COMPACT;
+		// fallthrough
 	case ROW_TYPE_COMPACT:
 		break;
 	}

--- a/storage/innobase/include/data0type.ic
+++ b/storage/innobase/include/data0type.ic
@@ -575,7 +575,8 @@ dtype_get_fixed_size_low(
 #else /* !UNIV_HOTBACKUP */
 		return(len);
 #endif /* !UNIV_HOTBACKUP */
-		/* fall through for variable-length charsets */
+		// fallthrough 
+		// for variable-length charsets 
 	case DATA_VARCHAR:
 	case DATA_BINARY:
 	case DATA_DECIMAL:

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -597,7 +597,7 @@ fil_create_new_single_table_tablespace(
 	ulint		size)		/*!< in: the initial size of the
 					tablespace file in pages,
 					must be >= FIL_IBD_FILE_INITIAL_SIZE */
-	MY_ATTRIBUTE((nonnull, warn_unused_result));
+	MY_ATTRIBUTE((nonnull(2), warn_unused_result));
 #ifndef UNIV_HOTBACKUP
 /********************************************************************//**
 Tries to open a single-table tablespace and optionally checks the space id is

--- a/storage/innobase/include/log0online.h
+++ b/storage/innobase/include/log0online.h
@@ -129,7 +129,11 @@ log_online_bitmap_iterator_next(
 
 /** Struct for single bitmap file information */
 struct log_online_bitmap_file_struct {
-	char		name[FN_REFLEN];	/*!< Name with full path */
+	/** Name with full path
+	    61 is a nice magic constant for the extra space needed for the sprintf
+	    template in the cc file
+	*/
+	char		name[FN_REFLEN+61];
 	pfs_os_file_t	file;			/*!< Handle to opened file */
 	ib_uint64_t	size;			/*!< Size of the file */
 	os_offset_t	offset;			/*!< Offset of the next read,

--- a/storage/innobase/include/mach0data.ic
+++ b/storage/innobase/include/mach0data.ic
@@ -792,13 +792,13 @@ mach_swap_byte_order(
         dest += len;
 
         switch (len & 0x7) {
-        case 0: *--dest = *from++;
-        case 7: *--dest = *from++;
-        case 6: *--dest = *from++;
-        case 5: *--dest = *from++;
-        case 4: *--dest = *from++;
-        case 3: *--dest = *from++;
-        case 2: *--dest = *from++;
+        case 0: *--dest = *from++; // fallthrough
+        case 7: *--dest = *from++; // fallthrough
+        case 6: *--dest = *from++; // fallthrough
+        case 5: *--dest = *from++; // fallthrough
+        case 4: *--dest = *from++; // fallthrough
+        case 3: *--dest = *from++; // fallthrough
+        case 2: *--dest = *from++; // fallthrough
         case 1: *--dest = *from;
         }
 }

--- a/storage/innobase/include/page0zip.ic
+++ b/storage/innobase/include/page0zip.ic
@@ -172,7 +172,7 @@ page_zip_rec_needs_ext(
 				ignored if zip_size == 0 */
 	ulint	zip_size)	/*!< in: compressed page size in bytes, or 0 */
 {
-	ut_ad(rec_size > comp ? REC_N_NEW_EXTRA_BYTES : REC_N_OLD_EXTRA_BYTES);
+	ut_ad(rec_size > (comp ? REC_N_NEW_EXTRA_BYTES : REC_N_OLD_EXTRA_BYTES));
 	ut_ad(ut_is_2pow(zip_size));
 	ut_ad(comp || !zip_size);
 

--- a/storage/innobase/include/ut0rnd.ic
+++ b/storage/innobase/include/ut0rnd.ic
@@ -236,17 +236,17 @@ ut_fold_binary(
 
 	switch (len & 0x7) {
 	case 7:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 6:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 5:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 4:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 3:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 2:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 1:
 		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
 	}

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -489,7 +489,7 @@ log_online_make_bitmap_name(
 /*=========================*/
 	lsn_t	start_lsn)	/*!< in: the start LSN name part */
 {
-	ut_snprintf(log_bmp_sys->out.name, FN_REFLEN, bmp_file_name_template,
+	ut_snprintf(log_bmp_sys->out.name, sizeof(log_bmp_sys->out.name), bmp_file_name_template,
 		    log_bmp_sys->bmp_file_home, bmp_file_name_stem,
 		    log_bmp_sys->out_seq_num, start_lsn);
 }

--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -2832,7 +2832,7 @@ page_warn_strict_checksum(
 	ulint				space_id,
 	ulint				page_no)
 {
-	srv_checksum_algorithm_t	curr_algo_nonstrict;
+	srv_checksum_algorithm_t	curr_algo_nonstrict = srv_checksum_algorithm_t();
 	switch (curr_algo) {
 	case SRV_CHECKSUM_ALGORITHM_STRICT_CRC32:
 		curr_algo_nonstrict = SRV_CHECKSUM_ALGORITHM_CRC32;

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -2025,6 +2025,7 @@ PageConverter::update_page(
 	case FIL_PAGE_TYPE_XDES:
 		err = set_current_xdes(
 			buf_block_get_page_no(block), get_frame(block));
+		// fallthrough
 	case FIL_PAGE_INODE:
 	case FIL_PAGE_TYPE_TRX_SYS:
 	case FIL_PAGE_IBUF_FREE_LIST:

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -1872,6 +1872,7 @@ row_log_table_apply_update(
 
 		When applying the subsequent ROW_T_DELETE, no matching
 		record will be found. */
+		return(DB_SUCCESS);
 	case DB_SUCCESS:
 		ut_ad(row != NULL);
 		break;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -5903,7 +5903,8 @@ loop:
 		fputs("  InnoDB: Warning: CHECK TABLE on ", stderr);
 		dict_index_name_print(stderr, prebuilt->trx, index);
 		fprintf(stderr, " returned %lu\n", ret);
-		/* fall through (this error is ignored by CHECK TABLE) */
+		// fallthrough
+		// (this error is ignored by CHECK TABLE)
 	case DB_END_OF_INDEX:
 func_exit:
 		mem_free(buf);

--- a/storage/innobase/row/row0purge.cc
+++ b/storage/innobase/row/row0purge.cc
@@ -488,8 +488,8 @@ row_purge_remove_sec_if_poss_leaf(
 				success = false;
 			}
 		}
-		/* fall through (the index entry is still needed,
-		or the deletion succeeded) */
+		// fallthrough
+		// (the index entry is still needed, or the deletion succeeded)
 	case ROW_NOT_DELETED_REF:
 		/* The index entry is still needed. */
 	case ROW_BUFFERED:

--- a/storage/innobase/sync/sync0sync.cc
+++ b/storage/innobase/sync/sync0sync.cc
@@ -1230,6 +1230,7 @@ sync_thread_add_level(
 			upgrading in innobase_start_or_create_for_mysql(). */
 			break;
 		}
+		// fallthrough
 	case SYNC_MEM_POOL:
 	case SYNC_MEM_HASH:
 	case SYNC_RECV:
@@ -1293,8 +1294,8 @@ sync_thread_add_level(
 		}
 		ut_ad(found_current);
 
-		/* fallthrough */
 	}
+	// fallthrough
 	case SYNC_BUF_FLUSH_LIST:
 	case SYNC_BUF_LRU_LIST:
 	case SYNC_BUF_FREE_LIST:

--- a/storage/myisam/mi_extra.c
+++ b/storage/myisam/mi_extra.c
@@ -148,6 +148,7 @@ int mi_extra(MI_INFO *info, enum ha_extra_function function, void *extra_arg)
   case HA_EXTRA_PREPARE_FOR_UPDATE:
     if (info->s->data_file_type != DYNAMIC_RECORD)
       break;
+    // fallthrough
     /* Remove read/write cache if dynamic rows */
   case HA_EXTRA_NO_CACHE:
     if (info->opt_flag & (READ_CACHE_USED | WRITE_CACHE_USED))

--- a/storage/myisam/mi_panic.c
+++ b/storage/myisam/mi_panic.c
@@ -74,6 +74,7 @@ int mi_panic(enum ha_panic_function flag)
       info->s->kfile=info->dfile= -1;	/* Files aren't open anymore */
       break;
 #endif
+    // fallthrough
     case HA_PANIC_READ:			/* Restore to before WRITE */
 #ifdef CANT_OPEN_FILES_TWICE
       {					/* Open closed files */

--- a/storage/myisam/myisamchk.c
+++ b/storage/myisam/myisamchk.c
@@ -1366,7 +1366,7 @@ static void descript(MI_CHECK *param, register MI_INFO *info, char * name)
 	 key < share->state.header.uniques; key++, uniqueinfo++)
     {
       my_bool new_row=0;
-      char null_bit[8],null_pos[8];
+      char null_bit[8],null_pos[11];
       printf("%-8d%-5d",key+1,uniqueinfo->key+1);
       for (keyseg=uniqueinfo->seg ; keyseg->type != HA_KEYTYPE_END ; keyseg++)
       {

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1984,6 +1984,7 @@ static uint32_t pack_desc_key_length_info(uchar* buf, KEY_AND_COL_INFO* kc_info,
     case (toku_type_fixstring):
         field_length = field->pack_length();
         set_if_smaller(key_part_length, field_length);
+        // fallthrough
     case (toku_type_varbinary):
     case (toku_type_varstring):
     case (toku_type_blob):

--- a/storage/tokudb/tokudb_thread.h
+++ b/storage/tokudb/tokudb_thread.h
@@ -204,21 +204,21 @@ inline mutex_t::mutex_t(pfs_key_t key) {
     _owners = 0;
     _owner = _null_owner;
 #endif
-    int r = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
+    int  r MY_ATTRIBUTE((unused)) = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
     assert_debug(r == 0);
 }
 inline mutex_t::~mutex_t(void) {
 #ifdef TOKUDB_DEBUG
     assert_debug(_owners == 0);
 #endif
-    int r = mysql_mutex_destroy(&_mutex);
+    int  r MY_ATTRIBUTE((unused)) = mysql_mutex_destroy(&_mutex);
     assert_debug(r == 0);
 }
 inline void mutex_t::reinit(pfs_key_t key) {
 #ifdef TOKUDB_DEBUG
     assert_debug(_owners == 0);
 #endif
-    int r;
+    int  r MY_ATTRIBUTE((unused));
     r = mysql_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
@@ -231,7 +231,7 @@ inline void mutex_t::lock(
 #endif  // HAVE_PSI_MUTEX_INTERFACE
     ) {
     assert_debug(is_owned_by_me() == false);
-    int r = inline_mysql_mutex_lock(&_mutex
+    int r MY_ATTRIBUTE((unused)) = inline_mysql_mutex_lock(&_mutex
 #ifdef HAVE_PSI_MUTEX_INTERFACE
                                     ,
                                     src_file,
@@ -260,7 +260,7 @@ inline void mutex_t::unlock(
     _owners--;
     _owner = _null_owner;
 #endif
-    int r = inline_mysql_mutex_unlock(&_mutex
+    int r MY_ATTRIBUTE((unused)) = inline_mysql_mutex_unlock(&_mutex
 #ifdef SAFE_MUTEX
                                       ,
                                       src_file,
@@ -276,11 +276,11 @@ inline bool mutex_t::is_owned_by_me(void) const {
 #endif
 
 inline rwlock_t::rwlock_t(pfs_key_t key) {
-    int r = mysql_rwlock_init(key, &_rwlock);
+    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_init(key, &_rwlock);
     assert_debug(r == 0);
 }
 inline rwlock_t::~rwlock_t(void) {
-    int r = mysql_rwlock_destroy(&_rwlock);
+    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_destroy(&_rwlock);
     assert_debug(r == 0);
 }
 inline void rwlock_t::lock_read(
@@ -328,7 +328,7 @@ inline void rwlock_t::lock_write(
     assert_debug(r == 0);
 }
 inline void rwlock_t::unlock(void) {
-    int r = mysql_rwlock_unlock(&_rwlock);
+    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_unlock(&_rwlock);
     assert_debug(r == 0);
 }
 inline rwlock_t::rwlock_t(const rwlock_t&) {}
@@ -340,7 +340,7 @@ inline rwlock_t& rwlock_t::operator=(const rwlock_t&) {
 inline event_t::event_t(bool create_signalled, bool manual_reset) :
     _manual_reset(manual_reset) {
 
-    int r = pthread_mutex_init(&_mutex, NULL);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_init(&_mutex, NULL);
     assert_debug(r == 0);
     r = pthread_cond_init(&_cond, NULL);
     assert_debug(r == 0);
@@ -352,13 +352,13 @@ inline event_t::event_t(bool create_signalled, bool manual_reset) :
     _pulsed = false;
 }
 inline event_t::~event_t(void) {
-    int r = pthread_mutex_destroy(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = pthread_cond_destroy(&_cond);
     assert_debug(r == 0);
 }
 inline void event_t::wait(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     while (_signalled == false && _pulsed == false) {
         r = pthread_cond_wait(&_cond, &_mutex);
@@ -395,7 +395,7 @@ inline int event_t::wait(ulonglong microseconds) {
     return 0;
 }
 inline void event_t::signal(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = true;
     if (_manual_reset) {
@@ -409,7 +409,7 @@ inline void event_t::signal(void) {
     assert_debug(r == 0);
 }
 inline void event_t::pulse(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _pulsed = true;
     r = pthread_cond_signal(&_cond);
@@ -419,7 +419,7 @@ inline void event_t::pulse(void) {
 }
 inline bool event_t::signalled(void) {
     bool ret = false;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     ret = _signalled;
     r = pthread_mutex_unlock(&_mutex);
@@ -427,7 +427,7 @@ inline bool event_t::signalled(void) {
     return ret;
 }
 inline void event_t::reset(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = false;
     _pulsed = false;
@@ -449,21 +449,21 @@ inline semaphore_t::semaphore_t(
     _initial_count(initial_count),
     _max_count(max_count) {
 
-    int r = pthread_mutex_init(&_mutex, NULL);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_init(&_mutex, NULL);
     assert_debug(r == 0);
     r = pthread_cond_init(&_cond, NULL);
     assert_debug(r == 0);
     _signalled = _initial_count;
 }
 inline semaphore_t::~semaphore_t(void) {
-    int r = pthread_mutex_destroy(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = pthread_cond_destroy(&_cond);
     assert_debug(r == 0);
 }
 inline semaphore_t::E_WAIT semaphore_t::wait(void) {
     E_WAIT ret;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     while (_signalled == 0 && _interrupted == false) {
         r = pthread_cond_wait(&_cond, &_mutex);
@@ -506,7 +506,7 @@ inline semaphore_t::E_WAIT semaphore_t::wait(ulonglong microseconds) {
 }
 inline bool semaphore_t::signal(void) {
     bool ret = false;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     if (_signalled < _max_count) {
         _signalled++;
@@ -520,7 +520,7 @@ inline bool semaphore_t::signal(void) {
 }
 inline int semaphore_t::signalled(void) {
     int ret = 0;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     ret = _signalled;
     r = pthread_mutex_unlock(&_mutex);
@@ -528,7 +528,7 @@ inline int semaphore_t::signalled(void) {
     return ret;
 }
 inline void semaphore_t::reset(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = 0;
     r = pthread_mutex_unlock(&_mutex);
@@ -536,7 +536,7 @@ inline void semaphore_t::reset(void) {
     return;
 }
 inline void semaphore_t::set_interrupt(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _interrupted = true;
     r = pthread_cond_broadcast(&_cond);
@@ -545,7 +545,7 @@ inline void semaphore_t::set_interrupt(void) {
     assert_debug(r == 0);
 }
 inline void semaphore_t::clear_interrupt(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _interrupted = false;
     r = pthread_mutex_unlock(&_mutex);

--- a/strings/ctype-utf8.c
+++ b/strings/ctype-utf8.c
@@ -5555,12 +5555,12 @@ static int my_uni_utf8 (const CHARSET_INFO *cs MY_ATTRIBUTE((unused)),
   switch (count) {
     /* Fall through all cases!!! */
 #ifdef UNICODE_32BIT
-    case 6: r[5] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x4000000;
-    case 5: r[4] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x200000;
-    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000;
+    case 6: r[5] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x4000000; // fallthrough
+    case 5: r[4] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x200000; // fallthrough
+    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000; // fallthrough
 #endif
-    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800;
-    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0;
+    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0] = (uchar) wc;
   }
   return count;
@@ -5588,8 +5588,8 @@ static int my_uni_utf8_no_range(const CHARSET_INFO *cs
   switch (count)
   {
     /* Fall through all cases!!! */
-    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800;
-    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0;
+    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0]= (uchar) wc;
   }
   return count;
@@ -8104,9 +8104,9 @@ my_wc_mb_utf8mb4(const CHARSET_INFO *cs MY_ATTRIBUTE((unused)),
 
   switch (count) {
     /* Fall through all cases!!! */
-    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000;
-    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800;
-    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0;
+    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000; // fallthrough
+    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0] = (uchar) wc;
   }
   return count;
@@ -8136,9 +8136,9 @@ my_wc_mb_utf8mb4_no_range(const CHARSET_INFO *cs MY_ATTRIBUTE((unused)),
   switch (count)
   {
     /* Fall through all cases!!! */
-    case 4: r[3]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x10000;
-    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800;
-    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0;
+    case 4: r[3]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x10000; // fallthrough
+    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0]= (uchar) wc;
   }
   return count;

--- a/strings/decimal.c
+++ b/strings/decimal.c
@@ -230,17 +230,17 @@ static inline int count_leading_zeroes(int i, dec1 val)
   switch (i)
   {
   /* @note Intentional fallthrough in all case labels */
-  case 9: if (val >= 1000000000) break; ++ret;
-  case 8: if (val >= 100000000) break; ++ret;
-  case 7: if (val >= 10000000) break; ++ret;
-  case 6: if (val >= 1000000) break; ++ret;
-  case 5: if (val >= 100000) break; ++ret;
-  case 4: if (val >= 10000) break; ++ret;
-  case 3: if (val >= 1000) break; ++ret;
-  case 2: if (val >= 100) break; ++ret;
-  case 1: if (val >= 10) break; ++ret;
-  case 0: if (val >= 1) break; ++ret;
-  default: { DBUG_ASSERT(FALSE); }
+  case 9: if (val >= 1000000000) break; ++ret; // fallthrough
+  case 8: if (val >= 100000000) break; ++ret; // fallthrough
+  case 7: if (val >= 10000000) break; ++ret; // fallthrough
+  case 6: if (val >= 1000000) break; ++ret; // fallthrough
+  case 5: if (val >= 100000) break; ++ret; // fallthrough
+  case 4: if (val >= 10000) break; ++ret; // fallthrough
+  case 3: if (val >= 1000) break; ++ret; // fallthrough
+  case 2: if (val >= 100) break; ++ret; // fallthrough
+  case 1: if (val >= 10) break; ++ret; // fallthrough
+  case 0: if (val >= 1) break; ++ret; // fallthrough
+  default: { DBUG_ASSERT(FALSE); } // fallthrough
   }
   return ret;
 }
@@ -263,16 +263,16 @@ static inline int count_trailing_zeroes(int i, dec1 val)
   switch(i)
   {
   /* @note Intentional fallthrough in all case labels */
-  case 0: if ((val % 1) != 0) break; ++ret;
-  case 1: if ((val % 10) != 0) break; ++ret;
-  case 2: if ((val % 100) != 0) break; ++ret;
-  case 3: if ((val % 1000) != 0) break; ++ret;
-  case 4: if ((val % 10000) != 0) break; ++ret;
-  case 5: if ((val % 100000) != 0) break; ++ret;
-  case 6: if ((val % 1000000) != 0) break; ++ret;
-  case 7: if ((val % 10000000) != 0) break; ++ret;
-  case 8: if ((val % 100000000) != 0) break; ++ret;
-  case 9: if ((val % 1000000000) != 0) break; ++ret;
+  case 0: if ((val % 1) != 0) break; ++ret; // fallthrough
+  case 1: if ((val % 10) != 0) break; ++ret; // fallthrough
+  case 2: if ((val % 100) != 0) break; ++ret; // fallthrough
+  case 3: if ((val % 1000) != 0) break; ++ret; // fallthrough
+  case 4: if ((val % 10000) != 0) break; ++ret; // fallthrough
+  case 5: if ((val % 100000) != 0) break; ++ret; // fallthrough
+  case 6: if ((val % 1000000) != 0) break; ++ret; // fallthrough
+  case 7: if ((val % 10000000) != 0) break; ++ret; // fallthrough
+  case 8: if ((val % 100000000) != 0) break; ++ret; // fallthrough
+  case 9: if ((val % 1000000000) != 0) break; ++ret; // fallthrough
   default: { DBUG_ASSERT(FALSE); }
   }
   return ret;

--- a/strings/dtoa.c
+++ b/strings/dtoa.c
@@ -1378,7 +1378,7 @@ static double my_strtod_int(const char *s00, char **se, int *error, char *buf, s
     switch (*s) {
     case '-':
       sign= 1;
-      /* no break */
+      // fallthrough
     case '+':
       s++;
       goto break2;
@@ -1475,6 +1475,7 @@ static double my_strtod_int(const char *s00, char **se, int *error, char *buf, s
       switch (c= *s) {
       case '-':
         esign= 1;
+        // fallthrough
       case '+':
         c= *++s;
       }
@@ -2368,7 +2369,7 @@ static char *dtoa(double dd, int mode, int ndigits, int *decpt, int *sign,
     break;
   case 2:
     leftright= 0;
-    /* no break */
+    // fallthrough
   case 4:
     if (ndigits <= 0)
       ndigits= 1;
@@ -2376,7 +2377,7 @@ static char *dtoa(double dd, int mode, int ndigits, int *decpt, int *sign,
     break;
   case 3:
     leftright= 0;
-    /* no break */
+    // fallthrough
   case 5:
     i= ndigits + k + 1;
     ilim= i;

--- a/tests/bug25714.c
+++ b/tests/bug25714.c
@@ -72,6 +72,6 @@ int main (int argc, char **argv)
   mysql_close(&conn);
   my_end(0);
 
-  return 0;
+  return OK;
 }
 


### PR DESCRIPTION
* Removed a statement from client/mysqlbinlog.cc which was never executed
* Corrected an empty string check in sql-common/client_authentication.cc
* Added a break to a case in sql/item_func.cc.
  Based on the code around this block, it looks logical that we do not wish to raise assertions for every string result - maybe only on error?
* Added overridden new and delete operators for Relay_log_info and Slave_worker because they require 64 byte alignment. These implementation currently only work on Linux, and they do contain a few lines of duplicated code.
* Added a missing break to sql/rpl_slave.cc.
  Based on the code around it, that's what makes sense.
* Fixed an uninitailized read during debug printing in sql/sql_cache.cc.
  This change was backported from 5.7.
* Null initialized a local pointer in sql/sql_partition.cc.
  As it otherwise could result in uninitailized reads in release builds.
  On debug builds, this case is guarded by an assert.
* Added a missing return to storage/innobase/row/row0log.cc
  This change was backported from 5.7.
* Corrected the length of a local sprintf buffer in storage/myisam/myisamchk.c.
* Returning the success status in tests/bug25714.c.
  This way the variable is also used in the release build, and the correctness of the execution can also be checked using the exit status of the program.
* Fixed two sprintf local buffer overflow in regex/debug.c.
* Default initialzied a local variable in storage/innobase/page/page0page.cc.
  As it otherwise could result in uninitailized reads in release builds.
  On debug builds, this case is guarded by an assert.
* Fixed some unused result or non-null warnings.
  These do not result in any behaviour change.
* Changed bool conversion to be more explict in some assertions.
  These do not result in any behaviour change.
* Added or changed fallthrough comments at many places so GCC's parser will be able to identify them.
  These do not result in any behaviour change.
* Moved a few breaks to different locations so GCC's parser will correctly identify them.
  These do not result in any behaviour change.