### PR TITLE
Implement bp:innodb-fts-ngram-ignore-stopword-list (A new InnoDB variable to control whether InnoDB FTS NGRAM parser should ignore stopword list)

### DIFF
--- a/mysql-test/suite/innodb_fts/r/percona_ft_ignore_stopwords.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_ignore_stopwords.result
@@ -1,0 +1,65 @@
+#
+# bp:innodb-fts-ngram-ignore-stopword-list
+# "A new InnoDB variable to control whether InnoDB FTS should ignore stopword list"
+#
+# lp:1679135 "Ignore INNODB_FT_DEFAULT_STOPWORD for ngram indexes"
+# Bug #84420 "stopwords and ngram indexes"
+#
+SET innodb_ft_ignore_stopwords = 0;
+CREATE TABLE articles (
+id INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+body TEXT,
+PRIMARY KEY (id),
+FULLTEXT KEY ftx (body) WITH PARSER ngram
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+INSERT INTO articles(body) VALUES('ea');
+INSERT INTO articles(body) VALUES('east');
+INSERT INTO articles(body) VALUES('east area');
+INSERT INTO articles(body) VALUES('east job');
+INSERT INTO articles(body) VALUES('eastnation');
+INSERT INTO articles(body) VALUES('eastway, try try');
+INSERT INTO articles(body) VALUES('wa');
+INSERT INTO articles(body) VALUES('wast');
+INSERT INTO articles(body) VALUES('wast area');
+INSERT INTO articles(body) VALUES('wast job');
+INSERT INTO articles(body) VALUES('wastnation');
+INSERT INTO articles(body) VALUES('wastway, try try');
+INSERT INTO articles(body) VALUES('oz');
+INSERT INTO articles(body) VALUES('ozst');
+INSERT INTO articles(body) VALUES('ozst area');
+INSERT INTO articles(body) VALUES('ozst job');
+INSERT INTO articles(body) VALUES('ozstnation');
+INSERT INTO articles(body) VALUES('ozstway, try try');
+# ngram parser checks
+include/assert.inc ['Empty set (ngram, table created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 0)']
+SET innodb_ft_ignore_stopwords = 1;
+include/assert.inc ['Empty set (ngram, table created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 1)']
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body) WITH PARSER ngram;
+include/assert.inc ['8 matches (ngram, table changed from ft_ignore_stopwords = 0 to 1 / query run with ft_ignore_stopwords = 1)']
+SET innodb_ft_ignore_stopwords = 0;
+include/assert.inc ['Empty set (ngram, table changed from ft_ignore_stopwords = 0 to 1 / query run with ft_ignore_stopwords = 0)']
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body) WITH PARSER ngram;
+include/assert.inc ['Empty set (ngram, table changed from ft_ignore_stopwords = 1 to 0 / query run with ft_ignore_stopwords = 0)']
+SET innodb_ft_ignore_stopwords = 1;
+include/assert.inc ['Empty set (ngram, table changed from ft_ignore_stopwords = 1 to 0 / query run with ft_ignore_stopwords = 1)']
+ALTER TABLE articles ENGINE=InnoDB;
+include/assert.inc ['8 matches (ngram, table reconstructed with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 1)']
+# non-ngram parser checks
+SET innodb_ft_ignore_stopwords = 0;
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body);
+include/assert.inc ['Empty set (non-ngram (short words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 0)']
+include/assert.inc ['3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 0)']
+SET innodb_ft_ignore_stopwords = 1;
+include/assert.inc ['Empty set (non-ngram (short words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 1)']
+include/assert.inc ['3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 1)']
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body);
+include/assert.inc ['1 match (non-ngram (short words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 1)']
+include/assert.inc ['3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 1)']
+SET innodb_ft_ignore_stopwords = 0;
+include/assert.inc ['1 match (non-ngram (short words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 0)']
+include/assert.inc ['3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 0)']
+DROP TABLE articles;

--- a/mysql-test/suite/innodb_fts/t/percona_ft_ignore_stopwords.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_ignore_stopwords.test
@@ -1,0 +1,121 @@
+--source include/have_innodb.inc
+
+if (`SELECT @@global.innodb_ft_min_token_size <> 3`)
+{
+  --skip this test requires innodb_ft_min_token_size to have default value (3)
+}
+
+--echo #
+--echo # bp:innodb-fts-ngram-ignore-stopword-list
+--echo # "A new InnoDB variable to control whether InnoDB FTS should ignore stopword list"
+--echo #
+--echo # lp:1679135 "Ignore INNODB_FT_DEFAULT_STOPWORD for ngram indexes"
+--echo # Bug #84420 "stopwords and ngram indexes"
+--echo #
+
+SET innodb_ft_ignore_stopwords = 0;
+
+CREATE TABLE articles (
+  id INT(10) UNSIGNED NOT NULL AUTO_INCREMENT,
+  body TEXT,
+  PRIMARY KEY (id),
+  FULLTEXT KEY ftx (body) WITH PARSER ngram
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO articles(body) VALUES('ea');
+INSERT INTO articles(body) VALUES('east');
+INSERT INTO articles(body) VALUES('east area');
+INSERT INTO articles(body) VALUES('east job');
+INSERT INTO articles(body) VALUES('eastnation');
+INSERT INTO articles(body) VALUES('eastway, try try');
+INSERT INTO articles(body) VALUES('wa');
+INSERT INTO articles(body) VALUES('wast');
+INSERT INTO articles(body) VALUES('wast area');
+INSERT INTO articles(body) VALUES('wast job');
+INSERT INTO articles(body) VALUES('wastnation');
+INSERT INTO articles(body) VALUES('wastway, try try');
+INSERT INTO articles(body) VALUES('oz');
+INSERT INTO articles(body) VALUES('ozst');
+INSERT INTO articles(body) VALUES('ozst area');
+INSERT INTO articles(body) VALUES('ozst job');
+INSERT INTO articles(body) VALUES('ozstnation');
+INSERT INTO articles(body) VALUES('ozstway, try try');
+
+--echo # ngram parser checks
+--let $match_short_query = SELECT COUNT(*) FROM articles WHERE MATCH(body) AGAINST("ea" IN BOOLEAN MODE)
+
+--let $assert_text= 'Empty set (ngram, table created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 0)'
+--let $assert_cond= [$match_short_query] = 0
+--source include/assert.inc
+
+SET innodb_ft_ignore_stopwords = 1;
+--let $assert_text= 'Empty set (ngram, table created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_short_query] = 0
+--source include/assert.inc
+
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body) WITH PARSER ngram;
+--let $assert_text= '8 matches (ngram, table changed from ft_ignore_stopwords = 0 to 1 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_short_query] = 8
+--source include/assert.inc
+
+SET innodb_ft_ignore_stopwords = 0;
+--let $assert_text= 'Empty set (ngram, table changed from ft_ignore_stopwords = 0 to 1 / query run with ft_ignore_stopwords = 0)'
+--let $assert_cond= [$match_short_query] = 0
+--source include/assert.inc
+
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body) WITH PARSER ngram;
+--let $assert_text= 'Empty set (ngram, table changed from ft_ignore_stopwords = 1 to 0 / query run with ft_ignore_stopwords = 0)'
+--let $assert_cond= [$match_short_query] = 0
+--source include/assert.inc
+
+SET innodb_ft_ignore_stopwords = 1;
+--let $assert_text= 'Empty set (ngram, table changed from ft_ignore_stopwords = 1 to 0 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_short_query] = 0
+--source include/assert.inc
+
+ALTER TABLE articles ENGINE=InnoDB;
+--let $assert_text= '8 matches (ngram, table reconstructed with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_short_query] = 8
+--source include/assert.inc
+
+--echo # non-ngram parser checks
+--let $match_regular_query = SELECT COUNT(*) FROM articles WHERE MATCH(body) AGAINST("wast" IN BOOLEAN MODE)
+
+SET innodb_ft_ignore_stopwords = 0;
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body);
+--let $assert_text= 'Empty set (non-ngram (short words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 0)'
+--let $assert_cond= [$match_short_query] = 0
+--source include/assert.inc
+--let $assert_text= '3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 0)'
+--let $assert_cond= [$match_regular_query] = 3
+--source include/assert.inc
+
+SET innodb_ft_ignore_stopwords = 1;
+--let $assert_text= 'Empty set (non-ngram (short words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_short_query] = 0
+--source include/assert.inc
+--let $assert_text= '3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 0 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_regular_query] = 3
+--source include/assert.inc
+
+ALTER TABLE articles DROP INDEX ftx;
+ALTER TABLE articles ADD FULLTEXT KEY ftx(body);
+--let $assert_text= '1 match (non-ngram (short words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_short_query] = 1
+--source include/assert.inc
+--let $assert_text= '3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 1)'
+--let $assert_cond= [$match_regular_query] = 3
+--source include/assert.inc
+
+SET innodb_ft_ignore_stopwords = 0;
+--let $assert_text= '1 match (non-ngram (short words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 0)'
+--let $assert_cond= [$match_short_query] = 1
+--source include/assert.inc
+--let $assert_text= '3 matches (non-ngram (regular words), index created with ft_ignore_stopwords = 1 / query run with ft_ignore_stopwords = 0)'
+--let $assert_cond= [$match_regular_query] = 3
+--source include/assert.inc
+
+DROP TABLE articles;

--- a/mysql-test/suite/sys_vars/r/innodb_ft_ignore_stopwords_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_ft_ignore_stopwords_basic.result
@@ -1,0 +1,120 @@
+SET @start_global_value = @@global.innodb_ft_ignore_stopwords;
+SELECT @start_global_value;
+@start_global_value
+0
+Valid values are 'ON' and 'OFF'
+SELECT @@global.innodb_ft_ignore_stopwords IN (0, 1);
+@@global.innodb_ft_ignore_stopwords IN (0, 1)
+1
+SELECT @@global.innodb_ft_ignore_stopwords;
+@@global.innodb_ft_ignore_stopwords
+0
+SELECT @@session.innodb_ft_ignore_stopwords IN (0, 1);
+@@session.innodb_ft_ignore_stopwords IN (0, 1)
+1
+SELECT @@session.innodb_ft_ignore_stopwords;
+@@session.innodb_ft_ignore_stopwords
+0
+SHOW GLOBAL VARIABLES LIKE 'innodb_ft_ignore_stopwords';
+Variable_name	Value
+innodb_ft_ignore_stopwords	OFF
+SHOW SESSION VARIABLES LIKE 'innodb_ft_ignore_stopwords';
+Variable_name	Value
+innodb_ft_ignore_stopwords	OFF
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	OFF
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	OFF
+SET GLOBAL innodb_ft_ignore_stopwords = 'OFF';
+SET SESSION innodb_ft_ignore_stopwords = 'OFF';
+SELECT @@global.innodb_ft_ignore_stopwords;
+@@global.innodb_ft_ignore_stopwords
+0
+SELECT @@session.innodb_ft_ignore_stopwords;
+@@session.innodb_ft_ignore_stopwords
+0
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	OFF
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	OFF
+SET @@global.innodb_ft_ignore_stopwords = 1;
+SET @@session.innodb_ft_ignore_stopwords = 1;
+SELECT @@global.innodb_ft_ignore_stopwords;
+@@global.innodb_ft_ignore_stopwords
+1
+SELECT @@session.innodb_ft_ignore_stopwords;
+@@session.innodb_ft_ignore_stopwords
+1
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	ON
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	ON
+SET GLOBAL innodb_ft_ignore_stopwords = 0;
+SET SESSION innodb_ft_ignore_stopwords = 0;
+SELECT @@global.innodb_ft_ignore_stopwords;
+@@global.innodb_ft_ignore_stopwords
+0
+SELECT @@session.innodb_ft_ignore_stopwords;
+@@session.innodb_ft_ignore_stopwords
+0
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	OFF
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	OFF
+SET @@global.innodb_ft_ignore_stopwords = 'ON';
+SET @@session.innodb_ft_ignore_stopwords = 'ON';
+SELECT @@global.innodb_ft_ignore_stopwords;
+@@global.innodb_ft_ignore_stopwords
+1
+SELECT @@session.innodb_ft_ignore_stopwords;
+@@session.innodb_ft_ignore_stopwords
+1
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	ON
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	ON
+SET GLOBAL innodb_ft_ignore_stopwords = 1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_ft_ignore_stopwords'
+SET SESSION innodb_ft_ignore_stopwords = 1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_ft_ignore_stopwords'
+SET GLOBAL innodb_ft_ignore_stopwords = 1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_ft_ignore_stopwords'
+SET SESSION innodb_ft_ignore_stopwords = 1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_ft_ignore_stopwords'
+SET GLOBAL innodb_ft_ignore_stopwords = 2;
+ERROR 42000: Variable 'innodb_ft_ignore_stopwords' can't be set to the value of '2'
+SET SESSION innodb_ft_ignore_stopwords = 2;
+ERROR 42000: Variable 'innodb_ft_ignore_stopwords' can't be set to the value of '2'
+SET GLOBAL innodb_ft_ignore_stopwords = 'AUTO';
+ERROR 42000: Variable 'innodb_ft_ignore_stopwords' can't be set to the value of 'AUTO'
+SET SESSION innodb_ft_ignore_stopwords = 'AUTO';
+ERROR 42000: Variable 'innodb_ft_ignore_stopwords' can't be set to the value of 'AUTO'
+NOTE: The following should fail with ER_WRONG_VALUE_FOR_VAR (BUG#50643)
+SET GLOBAL innodb_ft_ignore_stopwords = -3;
+SET SESSION innodb_ft_ignore_stopwords = -7;
+SELECT @@global.innodb_ft_ignore_stopwords;
+@@global.innodb_ft_ignore_stopwords
+1
+SELECT @@session.innodb_ft_ignore_stopwords;
+@@session.innodb_ft_ignore_stopwords
+1
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	ON
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_ft_ignore_stopwords	ON
+SET GLOBAL innodb_ft_ignore_stopwords = @start_global_value;
+SELECT @@global.innodb_ft_ignore_stopwords;
+@@global.innodb_ft_ignore_stopwords
+0

--- a/mysql-test/suite/sys_vars/t/innodb_ft_ignore_stopwords_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_ft_ignore_stopwords_basic.test
@@ -1,0 +1,82 @@
+--source include/have_innodb.inc
+
+SET @start_global_value = @@global.innodb_ft_ignore_stopwords;
+SELECT @start_global_value;
+
+#
+# exists as global and session
+#
+--echo Valid values are 'ON' and 'OFF'
+SELECT @@global.innodb_ft_ignore_stopwords IN (0, 1);
+SELECT @@global.innodb_ft_ignore_stopwords;
+SELECT @@session.innodb_ft_ignore_stopwords IN (0, 1);
+SELECT @@session.innodb_ft_ignore_stopwords;
+SHOW GLOBAL VARIABLES LIKE 'innodb_ft_ignore_stopwords';
+SHOW SESSION VARIABLES LIKE 'innodb_ft_ignore_stopwords';
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+
+#
+# show that it's writable
+#
+SET GLOBAL innodb_ft_ignore_stopwords = 'OFF';
+SET SESSION innodb_ft_ignore_stopwords = 'OFF';
+SELECT @@global.innodb_ft_ignore_stopwords;
+SELECT @@session.innodb_ft_ignore_stopwords;
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+
+SET @@global.innodb_ft_ignore_stopwords = 1;
+SET @@session.innodb_ft_ignore_stopwords = 1;
+SELECT @@global.innodb_ft_ignore_stopwords;
+SELECT @@session.innodb_ft_ignore_stopwords;
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+
+SET GLOBAL innodb_ft_ignore_stopwords = 0;
+SET SESSION innodb_ft_ignore_stopwords = 0;
+SELECT @@global.innodb_ft_ignore_stopwords;
+SELECT @@session.innodb_ft_ignore_stopwords;
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+
+SET @@global.innodb_ft_ignore_stopwords = 'ON';
+SET @@session.innodb_ft_ignore_stopwords = 'ON';
+SELECT @@global.innodb_ft_ignore_stopwords;
+SELECT @@session.innodb_ft_ignore_stopwords;
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+
+#
+# incorrect types
+#
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL innodb_ft_ignore_stopwords = 1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+SET SESSION innodb_ft_ignore_stopwords = 1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL innodb_ft_ignore_stopwords = 1e1;
+--error ER_WRONG_TYPE_FOR_VAR
+SET SESSION innodb_ft_ignore_stopwords = 1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_ft_ignore_stopwords = 2;
+--error ER_WRONG_VALUE_FOR_VAR
+SET SESSION innodb_ft_ignore_stopwords = 2;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_ft_ignore_stopwords = 'AUTO';
+--error ER_WRONG_VALUE_FOR_VAR
+SET SESSION innodb_ft_ignore_stopwords = 'AUTO';
+--echo NOTE: The following should fail with ER_WRONG_VALUE_FOR_VAR (BUG#50643)
+SET GLOBAL innodb_ft_ignore_stopwords = -3;
+SET SESSION innodb_ft_ignore_stopwords = -7;
+SELECT @@global.innodb_ft_ignore_stopwords;
+SELECT @@session.innodb_ft_ignore_stopwords;
+SELECT * FROM performance_schema.global_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+SELECT * FROM performance_schema.session_variables WHERE variable_name = 'innodb_ft_ignore_stopwords';
+
+#
+# Cleanup
+#
+
+SET GLOBAL innodb_ft_ignore_stopwords = @start_global_value;
+SELECT @@global.innodb_ft_ignore_stopwords;

--- a/storage/innobase/fts/fts0que.cc
+++ b/storage/innobase/fts/fts0que.cc
@@ -2698,11 +2698,13 @@ fts_query_phrase_split(
 			ib_vector_push(tokens, NULL));
 		fts_string_dup(token, &result_str, heap);
 
+		ut_ad(current_thd != NULL);
 		if (fts_check_token(
 			   &result_str,
 			   cache->stopword_info.cached_stopword,
 			   query->index->is_ngram,
-			   query->fts_index_table.charset)) {
+			   query->fts_index_table.charset,
+			   thd_has_ft_ignore_stopwords(current_thd))) {
 			/* Add the word to the RB tree so that we can
 			calculate it's frequencey within a document. */
 			fts_query_add_word_freq(query, token);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -903,6 +903,10 @@ static MYSQL_THDVAR_STR(tmpdir,
   "Directory for temporary non-tablespace files.",
   innodb_tmpdir_validate, NULL, NULL);
 
+static MYSQL_THDVAR_BOOL(ft_ignore_stopwords, PLUGIN_VAR_OPCMDARG,
+  "Instruct FTS to ignore stopwords.",
+  NULL, NULL, FALSE);
+
 static SHOW_VAR innodb_status_variables[]= {
   {"background_log_sync",
   (char*) &export_vars.innodb_background_log_sync,	  SHOW_LONG, SHOW_SCOPE_GLOBAL},
@@ -1848,6 +1852,16 @@ thd_lock_wait_timeout(
 	/* According to <mysql/plugin.h>, passing thd == NULL
 	returns the global value of the session variable. */
 	return(THDVAR(thd, lock_wait_timeout));
+}
+
+/** Is FT ignore stopwords variable set.
+@param thd Thread object
+@return true if ft_ignore_stopwords is set, false otherwise. */
+bool
+thd_has_ft_ignore_stopwords(THD* thd)
+{
+	bool res = THDVAR(thd, ft_ignore_stopwords);
+	return(res);
 }
 
 /******************************************************************//**
@@ -21923,6 +21937,7 @@ static struct st_mysql_sys_var* innobase_system_variables[]= {
   MYSQL_SYSVAR(parallel_doublewrite_path),
   MYSQL_SYSVAR(compressed_columns_zip_level),
   MYSQL_SYSVAR(compressed_columns_threshold),
+  MYSQL_SYSVAR(ft_ignore_stopwords),
   NULL
 };
 

--- a/storage/innobase/include/fts0priv.h
+++ b/storage/innobase/include/fts0priv.h
@@ -223,6 +223,7 @@ or greater than fts_max_token_size.
 @param[in]	stopwords	stopwords rb tree
 @param[in]	is_ngram	is ngram parser
 @param[in]	cs		token charset
+@param[in]	skip		true if the check should be skipped
 @retval true	if it is not stopword and length in range
 @retval false	if it is stopword or length not in range */
 bool
@@ -230,7 +231,8 @@ fts_check_token(
 	const fts_string_t*	token,
 	const ib_rbt_t*		stopwords,
 	bool			is_ngram,
-	const CHARSET_INFO*	cs);
+	const CHARSET_INFO*	cs,
+	bool			skip);
 
 /*******************************************************************//**
 Tokenize a document. */

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -293,6 +293,13 @@ thd_lock_wait_timeout(
 /*==================*/
 	THD*	thd);	/*!< in: thread handle, or NULL to query
 			the global innodb_lock_wait_timeout */
+
+/** Is FT ignore stopwords variable set.
+@param thd Thread object
+@return true if ft_ignore_stopwords is set, false otherwise. */
+bool
+thd_has_ft_ignore_stopwords(THD* thd) MY_ATTRIBUTE((warn_unused_result));
+
 /******************************************************************//**
 Add up the time waited for the lock for the current query. */
 void

--- a/storage/innobase/include/row0ftsort.h
+++ b/storage/innobase/include/row0ftsort.h
@@ -117,6 +117,11 @@ struct fts_tokenize_ctx {
 	dfield_t		sort_field[FTS_NUM_FIELDS_SORT];
 						/*!< in: sort field */
 	fts_token_list_t	fts_token_list;
+	bool			ignore_stopwords;
+						/*!< in: true if token
+						stopwords checking should be
+						skipped */
+
 };
 
 typedef struct fts_tokenize_ctx fts_tokenize_ctx_t;


### PR DESCRIPTION
(https://blueprints.launchpad.net/percona-server/+spec/innodb-fts-ngram-ignore-stopword-list)

lp:1679135 "Ignore INNODB_FT_DEFAULT_STOPWORD for ngram indexes"
(https://bugs.launchpad.net/percona-server/+bug/1679135)

Bug #84420 "stopwords and ngram indexes"
(https://bugs.mysql.com/bug.php?id=84420)

Thanks to Sveta Smirnova (sveta.smirnova@percona.com) for original
contribution.

Introduced new 'innodb_ft_ignore_ngram_check' InnoDB session/global variable
which can be set to 'ON' to instruct InnoDB Full Text Search NGRAM parser to
ignore stopword list.

Added new 'innodb_fts.percona_ft_ignore_ngram_check' MTR test case to check
stopword list ignoring logic.

Added new 'sys_vars.innodb_ft_ignore_ngram_check_basic' MTR test case to check
the behavior of the introduced variable.
