### PR TITLE
lp1702330, PS55: unlock the mutex before returning from thread_group_close.

### DIFF
--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1044,6 +1044,7 @@ static void thread_group_close(thread_group_t *thread_group)
 
   if (pipe(thread_group->shutdown_pipe))
   {
+    mysql_mutex_unlock(&thread_group->mutex);
     DBUG_VOID_RETURN;
   }
   
@@ -1051,11 +1052,15 @@ static void thread_group_close(thread_group_t *thread_group)
   if (io_poll_associate_fd(thread_group->pollfd, 
       thread_group->shutdown_pipe[0], NULL))
   {
+    mysql_mutex_unlock(&thread_group->mutex);
     DBUG_VOID_RETURN;
   }
   char c= 0;
   if (write(thread_group->shutdown_pipe[1], &c, 1) < 0)
+  {
+    mysql_mutex_unlock(&thread_group->mutex);
     DBUG_VOID_RETURN;
+  }
 
   /* Wake all workers. */
   while(wake_thread(thread_group) == 0) 


### PR DESCRIPTION
Jenkins: http://jenkins.percona.com/job/percona-server-5.5-param/1603/

Some builds are failing because the change is based on an old commit.