### PR TITLE
lp1729241, BLD-860: Fixed compilation issues with gcc-7 for the 5.7 branch

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -1317,6 +1317,7 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
       
       destroy_evt= TRUE;
     }
+    // fallthrough
           
     case binary_log::INTVAR_EVENT:
     {
@@ -1540,6 +1541,7 @@ Exit_status process_event(PRINT_EVENT_INFO *print_event_info, Log_event *ev,
         goto end;
       }
     }
+    // fallthrough
     case binary_log::ROWS_QUERY_LOG_EVENT:
     case binary_log::WRITE_ROWS_EVENT:
     case binary_log::DELETE_ROWS_EVENT:

--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -2315,6 +2315,7 @@ static void print_xml_comment(FILE *xml_file, size_t len,
     case '-':
       if (*(comment_string + 1) == '-')         /* Only one hyphen allowed. */
         break;
+      // fallthrough
     default:
       fputc(*comment_string, xml_file);
       break;

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -8835,7 +8835,7 @@ void run_explain(struct st_connection *cn, struct st_command *command,
 char *re_eprint(int err)
 {
   static char epbuf[100];
-  size_t len= my_regerror(MY_REG_ITOA | err, NULL, epbuf, sizeof(epbuf));
+  size_t len MY_ATTRIBUTE((unused))= my_regerror(MY_REG_ITOA | err, NULL, epbuf, sizeof(epbuf));
   assert(len <= sizeof(epbuf));
   return(epbuf);
 }
@@ -10110,7 +10110,8 @@ void replace_numeric_round_append(int round, DYNAMIC_STRING* result,
       */
       if (size1 < (size_t) r)
         r= size1;
-    // fallthrough: all cases till next break are executed
+    // fallthrough
+    // all cases till next break are executed
     case 'e':
     case 'E':
       if (isdigit(*(from + size + 1)))

--- a/extra/lz4/lz4frame.c
+++ b/extra/lz4/lz4frame.c
@@ -1091,6 +1091,7 @@ size_t LZ4F_decompress(LZ4F_decompressionContext_t decompressionContext,
                 dctxPtr->tmpInTarget = minFHSize;   /* minimum to attempt decode */
                 dctxPtr->dStage = dstage_storeHeader;
             }
+            // fallthrough
 
         case dstage_storeHeader:
             {

--- a/extra/replace.c
+++ b/extra/replace.c
@@ -177,6 +177,7 @@ char **argv[];
 	break;
       case 'V':
 	version=1;
+      // fallthrough
       case 'I':
       case '?':
 	help=1;					/* Help text written */

--- a/libbinlogevents/src/binlog_event.cpp
+++ b/libbinlogevents/src/binlog_event.cpp
@@ -152,6 +152,7 @@ Log_event_header(const char* buf, uint16_t binlog_version)
       */
       log_pos+= data_written; /* purecov: inspected */
     }
+    // fallthrough
 
   /* 4.0 or newer */
   /**

--- a/libbinlogevents/src/statement_events.cpp
+++ b/libbinlogevents/src/statement_events.cpp
@@ -528,12 +528,9 @@ User_var_event(const char* buf, unsigned int event_len,
   size_t bytes_read= ((val + val_len) - start);
 #ifndef DBUG_OFF
   bool old_pre_checksum_fd= description_event->is_version_before_checksum();
-  bool checksum_verify= (old_pre_checksum_fd ||
-                         (description_event->footer()->checksum_alg ==
-                          BINLOG_CHECKSUM_ALG_OFF));
-  size_t data_written= (header()->data_written- checksum_verify);
-  BAPI_ASSERT(((bytes_read == data_written) ? 0 : BINLOG_CHECKSUM_LEN)||
-              ((bytes_read == data_written - 1) ? 0 : BINLOG_CHECKSUM_LEN));
+  const int checksum_length = (old_pre_checksum_fd || description_event->footer()->checksum_alg == BINLOG_CHECKSUM_ALG_OFF) ? 0 : BINLOG_CHECKSUM_LEN;
+  size_t data_written= (header()->data_written- checksum_length);
+  BAPI_ASSERT(bytes_read == data_written || (bytes_read == data_written - 1));
 #endif
     if ((header()->data_written - bytes_read) > 0)
     {

--- a/plugin/percona-udf/murmur_udf.cc
+++ b/plugin/percona-udf/murmur_udf.cc
@@ -97,8 +97,8 @@ MurmurHash2( const void *key, int len, unsigned int seed ) {
    }
 
    switch (len) {
-      case 3: h2 ^= ((unsigned char*)data)[2] << 16;
-      case 2: h2 ^= ((unsigned char*)data)[1] << 8;
+      case 3: h2 ^= ((unsigned char*)data)[2] << 16; // fallthrough
+      case 2: h2 ^= ((unsigned char*)data)[1] << 8; // fallthrough
       case 1: h2 ^= ((unsigned char*)data)[0];
               h2 *= m;
    };

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -251,7 +251,7 @@ static int tokudb_backup_progress_fun(float progress, const char *progress_strin
                                      len,
                                      MYF(MY_FAE+MY_ALLOW_ZERO_PTR)));
     float percentage = progress * 100;
-    int r =
+    int r MY_ATTRIBUTE((unused)) =
         snprintf(be->_the_string,
         len,
         "tokudb backup about %.0f%% done: %s",
@@ -283,8 +283,7 @@ static void tokudb_backup_set_error_string(THD *thd, int error, const char *erro
     char* error_string =
         static_cast<char*>(my_malloc(tokudb_backup_mem_key, n+1, MYF(MY_FAE)));
 
-    int r = snprintf(error_string, n+1, error_fmt, s1, s2, s3);
-
+    int r MY_ATTRIBUTE((unused)) = snprintf(error_string, n+1, error_fmt, s1, s2, s3);
     assert(0 < r && (size_t)r <= n);
     tokudb_backup_set_error(thd, error, error_string);
     my_free(error_string);

--- a/rapid/plugin/x/mysqlxtest_src/common/utils_mysql_parsing.cc
+++ b/rapid/plugin/x/mysqlxtest_src/common/utils_mysql_parsing.cc
@@ -118,8 +118,8 @@ namespace shcore
                 if (!is_hidden_command && !have_content)
                   head = tail; // Skip over the comment.
 
-                break;
               }
+              break;
 
             case '-': // Possible single line comment.
             {

--- a/rapid/plugin/x/mysqlxtest_src/mysqlx_protocol.cc
+++ b/rapid/plugin/x/mysqlxtest_src/mysqlx_protocol.cc
@@ -159,7 +159,7 @@ bool mysqlx::parse_mysql_connstring(const std::string &connstring,
   return true;
 }
 
-static void throw_server_error(const Mysqlx::Error &error)
+MY_ATTRIBUTE((noreturn)) static void throw_server_error(const Mysqlx::Error &error)
 {
   throw Error(error.code(), error.msg());
 }

--- a/rapid/plugin/x/ngs/src/client.cc
+++ b/rapid/plugin/x/ngs/src/client.cc
@@ -191,7 +191,7 @@ void Client::handle_message(Request &request)
         }
         break;
       }
-      /* no break */
+      // fallthrough
 
     default:
       // invalid message at this time

--- a/rapid/plugin/x/ngs/src/protocol/row_builder.cc
+++ b/rapid/plugin/x/ngs/src/protocol/row_builder.cc
@@ -126,16 +126,16 @@ static inline int count_leading_zeroes(int i, dec1 val)
   switch (i)
   {
     /* @note Intentional fallthrough in all case labels */
-  case 9: if (val >= 1000000000) break; ++ret;
-  case 8: if (val >= 100000000) break; ++ret;
-  case 7: if (val >= 10000000) break; ++ret;
-  case 6: if (val >= 1000000) break; ++ret;
-  case 5: if (val >= 100000) break; ++ret;
-  case 4: if (val >= 10000) break; ++ret;
-  case 3: if (val >= 1000) break; ++ret;
-  case 2: if (val >= 100) break; ++ret;
-  case 1: if (val >= 10) break; ++ret;
-  case 0: if (val >= 1) break; ++ret;
+  case 9: if (val >= 1000000000) break; ++ret; //fallthrough
+  case 8: if (val >= 100000000) break; ++ret; //fallthrough
+  case 7: if (val >= 10000000) break; ++ret; //fallthrough
+  case 6: if (val >= 1000000) break; ++ret; //fallthrough
+  case 5: if (val >= 100000) break; ++ret; //fallthrough
+  case 4: if (val >= 10000) break; ++ret; //fallthrough
+  case 3: if (val >= 1000) break; ++ret; //fallthrough
+  case 2: if (val >= 100) break; ++ret; //fallthrough
+  case 1: if (val >= 10) break; ++ret; //fallthrough
+  case 0: if (val >= 1) break; ++ret; //fallthrough
   default: { DBUG_ASSERT(FALSE); }
   }
   return ret;

--- a/rapid/plugin/x/src/expr_generator.cc
+++ b/rapid/plugin/x/src/expr_generator.cc
@@ -434,7 +434,7 @@ void Expression_generator::in_expression(const Mysqlx::Expr::Operator &arg, cons
       }
       break;
     }
-    // missing "break;"? on purpose
+    // fallthrough
 
   default:
     m_qb.put("(");

--- a/regex/debug.c
+++ b/regex/debug.c
@@ -24,7 +24,7 @@ FILE *d;
 	int c;
 	int last;
 	int nincat[NC];
-	char buf[10];
+	char buf[11];
 
 	fprintf(d, "%ld states, %d categories", (long)g->nstates,
 							g->ncategories);
@@ -102,7 +102,7 @@ FILE *d;
 	int col = 0;
 	int last;
 	sopno offset = 2;
-	char buf[10];
+	char buf[13];
 #	define	GAP()	{	if (offset % 5 == 0) { \
 					if (col > 40) { \
 						fprintf(d, "\n\t"); \

--- a/regex/main.c
+++ b/regex/main.c
@@ -563,7 +563,7 @@ eprint(err)
 int err;
 {
 	static char epbuf[100];
-	size_t len;
+	size_t MY_ATTRIBUTE((unused)) len;
 
 	len = my_regerror(MY_REG_ITOA|err, (my_regex_t *)NULL, epbuf, sizeof(epbuf));
 	assert(len <= sizeof(epbuf));

--- a/sql-common/client.c
+++ b/sql-common/client.c
@@ -1823,6 +1823,7 @@ void mysql_read_default_options(struct st_mysql_options *options,
 	  break;
         case OPT_pipe:
           options->protocol = MYSQL_PROTOCOL_PIPE;
+          break;
 	case OPT_connect_timeout:
 	case OPT_timeout:
 	  if (opt_arg)

--- a/sql-common/client_authentication.cc
+++ b/sql-common/client_authentication.cc
@@ -84,7 +84,7 @@ RSA *rsa_init(MYSQL *mysql)
 
   if (mysql->options.extension != NULL &&
       mysql->options.extension->server_public_key_path != NULL &&
-      mysql->options.extension->server_public_key_path != '\0')
+      mysql->options.extension->server_public_key_path[0] != '\0')
   {
     pub_key_file= fopen(mysql->options.extension->server_public_key_path,
                         "r");

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -4342,6 +4342,7 @@ read_gtids_from_binlog(const char *filename, Gtid_set *all_gtids,
       DBUG_ASSERT(prev_gtids == NULL ? true : all_gtids != NULL ||
                                               first_gtid != NULL);
     }
+    // fallthrough
     default:
       // if we found any other event type without finding a
       // previous_gtids_log_event, then the rest of this binlog

--- a/sql/events.cc
+++ b/sql/events.cc
@@ -241,6 +241,7 @@ common_1_lev_code:
     break;
   case INTERVAL_WEEK:
     expr/= 7;
+    // fallthrough
   default:
     close_quote= FALSE;
     break;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -10922,7 +10922,7 @@ bool Create_field::init(THD *thd, const char *fld_name,
   case MYSQL_TYPE_DATE:
     /* Old date type. */
     sql_type= MYSQL_TYPE_NEWDATE;
-    /* fall trough */
+    // fallthrough
   case MYSQL_TYPE_NEWDATE:
     length= MAX_DATE_WIDTH;
     break;

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -6612,7 +6612,8 @@ Field *Item::tmp_table_field_from_field_type(TABLE *table, bool fixed_length)
                               collation.collation);
       break;
     }
-    /* Fall through to make_string_field() */
+    // fallthrough
+    // to make_string_field() 
   case MYSQL_TYPE_ENUM:
   case MYSQL_TYPE_SET:
   case MYSQL_TYPE_VAR_STRING:

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -2382,6 +2382,7 @@ my_decimal *Item_func_mod::decimal_op(my_decimal *decimal_value)
     return decimal_value;
   case E_DEC_DIV_ZERO:
     signal_divide_by_null();
+    // fallthrough
   default:
     null_value= 1;
     return 0;
@@ -6424,6 +6425,7 @@ String *user_var_entry::val_str(my_bool *null_value, String *str,
   case STRING_RESULT:
     if (str->copy(m_ptr, m_length, collation.collation))
       str= 0;					// EOM error
+    break;
   case ROW_RESULT:
     DBUG_ASSERT(1);				// Impossible
     break;

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -1381,6 +1381,7 @@ bool Item_func_geomfromgeojson::fix_fields(THD *thd, Item **ref)
       maybe_null= (args[0]->maybe_null || args[1]->maybe_null ||
                    args[2]->maybe_null);
     }
+    // fallthrough
   case 2:
     {
       // Validate options argument
@@ -1391,6 +1392,7 @@ bool Item_func_geomfromgeojson::fix_fields(THD *thd, Item **ref)
       }
       maybe_null= (args[0]->maybe_null || args[1]->maybe_null);
     }
+    // fallthrough
   case 1:
     {
       /*
@@ -1884,7 +1886,7 @@ append_geometry(Geometry::wkb_parser *parser, Json_object *geometry,
                                    add_short_crs_urn,
                                    add_long_crs_urn,
                                    geometry_srid);
-          else if (Geometry::wkb_multilinestring)
+          else if (header.wkb_type == Geometry::wkb_multilinestring)
             result= append_linestring(parser, points, mbr, calling_function,
                                       max_decimal_digits,
                                       add_bounding_box,

--- a/sql/json_dom.cc
+++ b/sql/json_dom.cc
@@ -3066,8 +3066,9 @@ int Json_wrapper::compare(const Json_wrapper &other) const
         return -compare_json_decimal_int(b_dec, get_int());
       }
     default:
-      break;
+      ;
     }
+    break;
   case Json_dom::J_UINT:
     // Unsigned integers can be compared to all other numbers.
     switch (other_type)
@@ -3086,8 +3087,9 @@ int Json_wrapper::compare(const Json_wrapper &other) const
         return -compare_json_decimal_uint(b_dec, get_uint());
       }
     default:
-      break;
+      ;
     }
+    break;
   case Json_dom::J_DOUBLE:
     // Doubles can be compared to all other numbers.
     {
@@ -3107,8 +3109,9 @@ int Json_wrapper::compare(const Json_wrapper &other) const
           return -compare_json_decimal_double(other_dec, get_double());
         }
       default:
-        break;
+        ;
       }
+      break;
     }
   case Json_dom::J_DECIMAL:
     // Decimals can be compared to all other numbers.
@@ -3136,8 +3139,9 @@ int Json_wrapper::compare(const Json_wrapper &other) const
       case Json_dom::J_DOUBLE:
         return compare_json_decimal_double(a_dec, other.get_double());
       default:
-        break;
+        ;
       }
+      break;
     }
   case Json_dom::J_BOOLEAN:
     // Booleans are only equal to other booleans. false is less than true.

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -2787,6 +2787,7 @@ bool schedule_next_event(Log_event* ev, Relay_log_info* rli)
     my_error(ER_MTS_CANT_PARALLEL, MYF(0),
     ev->get_type_str(), rli->get_event_relay_log_name(), llbuff,
              "The master event is logically timestamped incorrectly.");
+    // fallthrough
   case ER_MTS_INCONSISTENT_DATA:
     /* Don't have to do anything. */
     return true;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -7540,7 +7540,7 @@ mysqld_get_one_option(int optid,
     break;
   case 'L':
     push_deprecated_warn(NULL, "--language/-l", "'--lc-messages-dir'");
-    /* Note:  fall-through */
+    // fallthrough
   case OPT_LC_MESSAGES_DIRECTORY:
     strmake(lc_messages_dir, argument, sizeof(lc_messages_dir)-1);
     lc_messages_dir_ptr= lc_messages_dir;
@@ -7910,6 +7910,7 @@ pfs_error:
     sql_print_warning("The use of InnoDB is mandatory since MySQL 5.7. "
                       "The former options like '--innodb=0/1/OFF/ON' or "
                       "'--skip-innodb' are ignored.");
+    break;
   case OPT_AVOID_TEMPORAL_UPGRADE:
     push_deprecated_warn_no_replacement(NULL, "avoid_temporal_upgrade");
     break;

--- a/sql/opt_sum.cc
+++ b/sql/opt_sum.cc
@@ -1090,6 +1090,7 @@ static int maxmin_in_range(bool max_fl, Item_field *item_field, Item *cond)
   case Item_func::LT_FUNC:
   case Item_func::LE_FUNC:
     less_fl= 1;
+    // fallthrough
   case Item_func::GT_FUNC:
   case Item_func::GE_FUNC:
   {

--- a/sql/rpl_info_factory.cc
+++ b/sql/rpl_info_factory.cc
@@ -210,7 +210,9 @@ Relay_log_info *Rpl_info_factory::create_rli(uint rli_option,
                         worker_table_data, worker_file_data, &msg))
     goto err;
 
-  if (!(rli= new Relay_log_info(is_slave_recovery
+  try
+  {
+    rli= new Relay_log_info(is_slave_recovery
 #ifdef HAVE_PSI_INTERFACE
                                 ,&key_relay_log_info_run_lock,
                                 &key_relay_log_info_data_lock,
@@ -224,7 +226,8 @@ Relay_log_info *Rpl_info_factory::create_rli(uint rli_option,
                                 , instances, channel,
                                 (rli_option != INFO_REPOSITORY_TABLE
                                  && rli_option != INFO_REPOSITORY_FILE)
-                                )))
+                                );
+  } catch (std::bad_alloc&)  
   {
     msg= msg_alloc;
     goto err;
@@ -413,7 +416,9 @@ Slave_worker *Rpl_info_factory::create_worker(uint rli_option, uint worker_id,
   char *pos= my_stpcpy(worker_file_data.name, worker_file_data.pattern);
   sprintf(pos, "%u", worker_id + 1);
 
-  if (!(worker= new Slave_worker(rli
+  try
+  {
+    worker= new Slave_worker(rli
 #ifdef HAVE_PSI_INTERFACE
                                  ,&key_relay_log_info_run_lock,
                                  &key_relay_log_info_data_lock,
@@ -425,9 +430,11 @@ Slave_worker *Rpl_info_factory::create_worker(uint rli_option, uint worker_id,
                                  &key_relay_log_info_sleep_cond
 #endif
                                  , worker_id, rli->get_channel()
-                                )))
+                                );
+  } catch (std::bad_alloc&)
+  {
     goto err;
-
+  }
 
   if(init_repositories(worker_table_data, worker_file_data, rli_option,
                        worker_id + 1, &handler_src, &handler_dest, &msg))

--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -3087,3 +3087,17 @@ void Relay_log_info::detach_engine_ha_data(THD *thd)
   plugin_foreach(thd, detach_native_trx,
                  MYSQL_STORAGE_ENGINE_PLUGIN, NULL);
 }
+
+void* Relay_log_info::operator new(size_t request)
+{
+  void* ptr;
+  if (posix_memalign(&ptr, __alignof__(Relay_log_info), sizeof(Relay_log_info))) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void Relay_log_info::operator delete(void * ptr) {
+  free(ptr);
+}
+

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -255,6 +255,11 @@ public:
     happen when, for example, the relay log gets rotated because of
     max_binlog_size.
   */
+
+  // overridden new and delete operators for 64 byte alignment
+  static void* operator new(size_t request);
+  static void operator delete(void * ptr);
+
 protected:
   char group_relay_log_name[FN_REFLEN];
   ulonglong group_relay_log_pos;

--- a/sql/rpl_rli_pdb.cc
+++ b/sql/rpl_rli_pdb.cc
@@ -1716,6 +1716,20 @@ void Slave_worker::do_report(loglevel level, int err_code, const char *msg,
   this->va_report(level, err_code, buff_coord, msg, args);
 }
 
+void* Slave_worker::operator new(size_t request)
+{
+  void* ptr;
+  if (posix_memalign(&ptr, __alignof__(Slave_worker), sizeof(Slave_worker))) {
+    throw std::bad_alloc();
+  }
+  return ptr;
+}
+
+void Slave_worker::operator delete(void * ptr)
+{
+  free(ptr);
+}
+
 #ifndef DBUG_OFF
 static bool may_have_timestamp(Log_event *ev)
 {

--- a/sql/rpl_rli_pdb.h
+++ b/sql/rpl_rli_pdb.h
@@ -746,6 +746,11 @@ public:
     return !get_rli_description_event() ? server_version :
       get_rli_description_event()->get_product_version();
   }
+
+  // overridden new and delete operators for 64 byte alignment
+  static void* operator new(size_t request);
+  static void operator delete(void * ptr);
+
 protected:
 
   virtual void do_report(loglevel level, int err_code,

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -3748,6 +3748,7 @@ bool show_slave_status_send_data(THD *thd, Master_info *mi,
     break;
   case Relay_log_info::UNTIL_SQL_AFTER_MTS_GAPS:
     until_type= "SQL_AFTER_MTS_GAPS";
+    break;
   case Relay_log_info::UNTIL_DONE:
     until_type= "DONE";
     break;

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -2808,7 +2808,8 @@ String *sp_get_item_value(THD *thd, Item *item, String *str)
   case DECIMAL_RESULT:
     if (item->field_type() != MYSQL_TYPE_BIT)
       return item->val_str(str);
-    else {/* Bit type is handled as binary string */}
+    // fallthrough
+    /* Bit type is handled as binary string */
   case STRING_RESULT:
     {
       String *result= item->val_str(str);

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -455,6 +455,7 @@ void QueryStripComments::set(LEX_CSTRING query, uint additional_length)
           break;
         }
       }
+      // fallthrough
     case '#':
       {
         do
@@ -1848,6 +1849,7 @@ int Query_cache::send_result_to_client(THD *thd, const LEX_CSTRING &sql)
           {
             break;
           }
+          // fallthrough
         case '#':
           do
           {

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5326,8 +5326,11 @@ public:
 
   Temp_table_param()
     :copy_field(NULL), copy_field_end(NULL),
+     group_buff(NULL),
+     items_to_copy(NULL),
      recinfo(NULL), start_recinfo(NULL),
      keyinfo(NULL),
+     end_write_records(0),
      field_count(0), func_count(0), sum_func_count(0), hidden_field_count(0),
      group_parts(0), group_length(0), group_null_parts(0),
      quick_group(1),

--- a/sql/sql_digest.cc
+++ b/sql/sql_digest.cc
@@ -456,7 +456,8 @@ sql_digest_state* digest_add_token(sql_digest_state *state,
         }
       } while (found_unary);
     }
-    /* fall through, for case NULL_SYM below */
+    // fallthrough
+    // for case NULL_SYM below
     case LEX_HOSTNAME:
     case TEXT_STRING:
     case NCHAR_STRING:

--- a/sql/sql_handler.cc
+++ b/sql/sql_handler.cc
@@ -698,6 +698,7 @@ retry:
         error= table->file->ha_rnd_next(table->record[0]);
         break;
       }
+      // fallthrough
       /*
         Fall through to HANDLER ... READ ... FIRST case if we are trying
         to read next row in index order after starting reading rows in
@@ -728,7 +729,8 @@ retry:
         error= table->file->ha_index_prev(table->record[0]);
         break;
       }
-      /* else fall through, for more info, see comment before 'case RFIRST'. */
+      // fallthrough
+      // for more info, see comment before 'case RFIRST'.
     case RLAST:
       DBUG_ASSERT(m_key_name != 0);
       if (!(error= table->file->ha_index_or_rnd_end()) &&

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -1407,6 +1407,7 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	yylval->lex_str.length=2;
 	return NULL_SYM;
       }
+      // fallthrough
     case MY_LEX_CHAR:			// Unknown or single char token
     case MY_LEX_SKIP:			// This should not happen
       if (c == '-' && lip->yyPeek() == '-' &&
@@ -1481,12 +1482,14 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	state= MY_LEX_HEX_NUMBER;
 	break;
       }
+      // fallthrough
     case MY_LEX_IDENT_OR_BIN:
       if (lip->yyPeek() == '\'')
       {                                 // Found b'bin-number'
         state= MY_LEX_BIN_NUMBER;
         break;
       }
+      // fallthrough
     case MY_LEX_IDENT:
       const char *start;
       if (use_mb(cs))
@@ -1844,6 +1847,7 @@ static int lex_one_token(YYSTYPE *yylval, THD *thd)
 	state= MY_LEX_USER_VARIABLE_DELIMITER;
 	break;
       }
+      // fallthrough
       /* " used for strings */
     case MY_LEX_STRING:			// Incomplete text string
       if (!(yylval->lex_str.str = get_text(lip, 1, 1)))

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3016,6 +3016,7 @@ case SQLCOM_PREPARE:
       break;
     }
   }
+  // fallthrough
   case SQLCOM_PURGE_BEFORE:
   {
     Item *it;
@@ -4377,6 +4378,7 @@ end_with_restore_list:
       initialize this variable because RESET shares the same code as FLUSH
     */
     lex->no_write_to_binlog= 1;
+    // fallthrough
   case SQLCOM_FLUSH:
   {
     int write_to_binlog;

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -7874,7 +7874,7 @@ int get_part_iter_for_interval_cols_via_map(partition_info *part_info,
                                             PARTITION_ITERATOR *part_iter)
 {
   uint32 nparts;
-  get_col_endpoint_func  get_col_endpoint;
+  get_col_endpoint_func  get_col_endpoint= NULL;
   DBUG_ENTER("get_part_iter_for_interval_cols_via_map");
 
   if (part_info->part_type == RANGE_PARTITION)

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1755,10 +1755,12 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
     switch ((*(p++)= *(list++))) {
     case '\0':
       list= NULL; /* terminate the loop */
-      /* fall through */
+      // fallthrough - the later 2 comments are required by GCC
 #ifndef _WIN32
+      // fallthrough
     case ':':     /* can't use this as delimiter as it may be drive letter */
 #endif
+      // fallthrough
     case ';':
       str->str[str->length]= '\0';
       if (str == &name)  // load all plugins in named module
@@ -1812,6 +1814,7 @@ static bool plugin_load_list(MEM_ROOT *tmp_root, int *argc, char **argv,
         str->str= p;
         continue;
       }
+      // fallthrough
     default:
       str->length++;
       continue;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -827,6 +827,7 @@ public:
         is_handled= false;
         break;
       }
+      // fallthrough
     case ER_COLUMNACCESS_DENIED_ERROR:
     // ER_VIEW_NO_EXPLAIN cannot happen here.
     case ER_PROCACCESS_DENIED_ERROR:

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -1221,12 +1221,13 @@ static bool execute_ddl_log_action(THD *thd, DDL_LOG_ENTRY *ddl_log_entry)
           break;
       }
       DBUG_ASSERT(ddl_log_entry->action_type == DDL_LOG_REPLACE_ACTION);
-      /*
-        Fall through and perform the rename action of the replace
-        action. We have already indicated the success of the delete
-        action in the log entry by stepping up the phase.
-      */
     }
+    // fallthrough
+    /*
+    and perform the rename action of the replace
+    action. We have already indicated the success of the delete
+    action in the log entry by stepping up the phase.
+    */
     case DDL_LOG_RENAME_ACTION:
     {
       error= TRUE;
@@ -7436,7 +7437,8 @@ bool alter_table_manage_keys(TABLE *table, int indexes_were_disabled,
   case Alter_info::LEAVE_AS_IS:
     if (!indexes_were_disabled)
       break;
-    /* fall-through: disabled indexes */
+    // fallthrough
+    // disabled indexes
   case Alter_info::DISABLE:
     error= table->file->ha_disable_indexes(HA_KEY_SWITCH_NONUNIQ_SAVE);
   }

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -5090,9 +5090,11 @@ size_number:
                 case 'g':
                 case 'G':
                   text_shift_number+=10;
+                  // fallthrough
                 case 'm':
                 case 'M':
                   text_shift_number+=10;
+                  // fallthrough
                 case 'k':
                 case 'K':
                   text_shift_number+=10;

--- a/sql/sys_vars.h
+++ b/sql/sys_vars.h
@@ -2789,7 +2789,7 @@ public:
                             mi->get_channel(), mi->is_auto_position()));
         if (mi != NULL && mi->is_auto_position())
         {
-          char buf[512];
+          char buf[550];
           sprintf(buf, "replication channel '%.192s' is configured "
                   "in AUTO_POSITION mode. Execute "
                   "CHANGE MASTER TO MASTER_AUTO_POSITION = 0 "

--- a/sql/tc_log.cc
+++ b/sql/tc_log.cc
@@ -480,8 +480,10 @@ void TC_LOG_MMAP::close()
   case 6:
     mysql_mutex_destroy(&LOCK_tc);
     mysql_cond_destroy(&COND_pool);
+    // fallthrough
   case 5:
     data[0]='A'; // garble the first (signature) byte, in case mysql_file_delete fails
+    // fallthrough
   case 4:
     for (i=0; i < npages; i++)
     {
@@ -489,10 +491,13 @@ void TC_LOG_MMAP::close()
         break;
       mysql_cond_destroy(&pages[i].cond);
     }
+    // fallthrough
   case 3:
     my_free(pages);
+    // fallthrough
   case 2:
     my_munmap((char*)data, (size_t)file_length);
+    // fallthrough
   case 1:
     mysql_file_close(fd, MYF(0));
   }

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -1426,8 +1426,8 @@ bool ha_federated::create_where_from_key(String *to,
           {
             goto err;
           }
-          break;
         }
+        break;
       case HA_READ_KEY_OR_NEXT:
         DBUG_PRINT("info", ("federated HA_READ_KEY_OR_NEXT %d", i));
         if (emit_key_part_name(&tmp, key_part) ||
@@ -1445,8 +1445,8 @@ bool ha_federated::create_where_from_key(String *to,
               emit_key_part_element(&tmp, key_part, needs_quotes, 0, ptr,
                                     part_length))
             goto err;
-          break;
         }
+        break;
       case HA_READ_KEY_OR_PREV:
         DBUG_PRINT("info", ("federated HA_READ_KEY_OR_PREV %d", i));
         if (emit_key_part_name(&tmp, key_part) ||

--- a/storage/heap/hp_extra.c
+++ b/storage/heap/hp_extra.c
@@ -33,6 +33,7 @@ int heap_extra(HP_INFO *info, enum ha_extra_function function)
   switch (function) {
   case HA_EXTRA_RESET_STATE:
     heap_reset(info);
+    break;
   case HA_EXTRA_NO_READCHECK:
     info->opt_flag&= ~READ_CHECK_USED;	/* No readcheck */
     break;

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -347,7 +347,7 @@ buf_parallel_dblwr_make_path(void)
 		return(DB_SUCCESS);
 
 	char path[FN_REFLEN];
-	const char *dir;
+	const char *dir = NULL;
 
 	ut_ad(srv_parallel_doublewrite_path);
 

--- a/storage/innobase/data/data0type.cc
+++ b/storage/innobase/data/data0type.cc
@@ -225,6 +225,7 @@ dtype_print(
 
 	case DATA_VAR_POINT:
 		fputs("DATA_VAR_POINT", stderr);
+		break;
 
 	case DATA_GEOMETRY:
 		fputs("DATA_GEOMETRY", stderr);

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -4573,7 +4573,8 @@ fil_ibd_load(
 			break;
 		}
 
-		/* Fall through to error handling */
+		// fallthrough
+		// to error handling
 
 	case DB_TABLESPACE_EXISTS:
 #ifdef UNIV_HOTBACKUP

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -3227,7 +3227,7 @@ fseg_alloc_free_page_general(
 	fseg_inode_t*	inode;
 	ulint		space_id;
 	fil_space_t*	space;
-	buf_block_t*	iblock;
+	buf_block_t*	iblock = NULL;
 	buf_block_t*	block;
 	ulint		n_reserved;
 
@@ -3712,7 +3712,7 @@ fseg_free_page(
 	mtr_t*		mtr)	/*!< in/out: mini-transaction */
 {
 	fseg_inode_t*		seg_inode;
-	buf_block_t*		iblock;
+	buf_block_t*		iblock = NULL;
 	const fil_space_t*	space = mtr_x_lock_space(space_id, mtr);
 	const page_size_t	page_size(space->flags);
 

--- a/storage/innobase/fts/fts0plugin.cc
+++ b/storage/innobase/fts/fts0plugin.cc
@@ -129,6 +129,7 @@ fts_query_add_word_for_parser(
 		if (cur_node->type != FTS_AST_PARSER_PHRASE_LIST) {
 			break;
 		}
+		// fallthrough
 
 	case FT_TOKEN_WORD:
 		term_node = fts_ast_create_node_term_for_parser(

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -8058,7 +8058,8 @@ ha_innobase::innobase_lock_autoinc(void)
 				break;
 			}
 		}
-		/* Fall through to old style locking. */
+		// fallthrough
+		// to old style locking.
 
 	case AUTOINC_OLD_STYLE_LOCKING:
 		DBUG_EXECUTE_IF("die_if_autoinc_old_lock_style_used",
@@ -12297,7 +12298,8 @@ index_bad:
 			break;
 		}
 		zip_allowed = false;
-		/* fall through to set row_type = DYNAMIC */
+		// fallthrough
+		// to set row_type = DYNAMIC
 	case ROW_TYPE_NOT_USED:
 	case ROW_TYPE_FIXED:
 	case ROW_TYPE_PAGE:
@@ -12306,6 +12308,7 @@ index_bad:
 			m_thd, Sql_condition::SL_WARNING,
 			ER_ILLEGAL_HA_CREATE_OPTION,
 			"InnoDB: assuming ROW_FORMAT=DYNAMIC.");
+		// fallthrough
 	case ROW_TYPE_DYNAMIC:
 		innodb_row_format = REC_FORMAT_DYNAMIC;
 		break;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4653,6 +4653,7 @@ prepare_inplace_alter_table_dict(
 				ctx->old_table->name.m_name);
 
 			error = DB_SUCCESS;
+			// fallthrough
 
 		case DB_SUCCESS:
 			/* We need to bump up the table ref count and

--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -1298,8 +1298,8 @@ buf_page_release_zip(
 			rw_lock_s_unlock(&block->debug_latch);
 		}
 	}
-		/* Fall through */
 #endif /* UNIV_DEBUG */
+		// fallthrough
 
 	case BUF_BLOCK_ZIP_PAGE:
 	case BUF_BLOCK_ZIP_DIRTY:

--- a/storage/innobase/include/data0type.ic
+++ b/storage/innobase/include/data0type.ic
@@ -538,7 +538,8 @@ dtype_get_fixed_size_low(
 #else /* !UNIV_HOTBACKUP */
 		return(len);
 #endif /* !UNIV_HOTBACKUP */
-		/* fall through for variable-length charsets */
+		// fallthrough 
+		// for variable-length charsets 
 	case DATA_VARCHAR:
 	case DATA_BINARY:
 	case DATA_DECIMAL:

--- a/storage/innobase/include/log0online.h
+++ b/storage/innobase/include/log0online.h
@@ -128,7 +128,11 @@ log_online_bitmap_iterator_next(
 
 /** Struct for single bitmap file information */
 struct log_online_bitmap_file_struct {
-	char		name[FN_REFLEN];	/*!< Name with full path */
+	/** Name with full path
+	    61 is a nice magic constant for the extra space needed for the sprintf
+	    template in the cc file
+	*/
+	char		name[FN_REFLEN+61];
 	pfs_os_file_t	file;			/*!< Handle to opened file */
 	ib_uint64_t	size;			/*!< Size of the file */
 	os_offset_t	offset;			/*!< Offset of the next read,

--- a/storage/innobase/include/mach0data.ic
+++ b/storage/innobase/include/mach0data.ic
@@ -859,13 +859,13 @@ mach_swap_byte_order(
         dest += len;
 
         switch (len & 0x7) {
-        case 0: *--dest = *from++;
-        case 7: *--dest = *from++;
-        case 6: *--dest = *from++;
-        case 5: *--dest = *from++;
-        case 4: *--dest = *from++;
-        case 3: *--dest = *from++;
-        case 2: *--dest = *from++;
+        case 0: *--dest = *from++; // fallthrough
+        case 7: *--dest = *from++; // fallthrough
+        case 6: *--dest = *from++; // fallthrough
+        case 5: *--dest = *from++; // fallthrough
+        case 4: *--dest = *from++; // fallthrough
+        case 3: *--dest = *from++; // fallthrough
+        case 2: *--dest = *from++; // fallthrough
         case 1: *--dest = *from;
         }
 }

--- a/storage/innobase/include/page0zip.ic
+++ b/storage/innobase/include/page0zip.ic
@@ -164,7 +164,7 @@ page_zip_rec_needs_ext(
 	ulint			n_fields,
 	const page_size_t&	page_size)
 {
-	ut_ad(rec_size > comp ? REC_N_NEW_EXTRA_BYTES : REC_N_OLD_EXTRA_BYTES);
+	ut_ad(rec_size > (comp ? REC_N_NEW_EXTRA_BYTES : REC_N_OLD_EXTRA_BYTES));
 	ut_ad(comp || !page_size.is_compressed());
 
 #if UNIV_PAGE_SIZE_MAX > REC_MAX_DATA_SIZE

--- a/storage/innobase/include/ut0rnd.ic
+++ b/storage/innobase/include/ut0rnd.ic
@@ -216,17 +216,17 @@ ut_fold_binary(
 
 	switch (len & 0x7) {
 	case 7:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 6:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 5:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 4:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 3:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 2:
-		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
+		fold = ut_fold_ulint_pair(fold, (ulint)(*str++)); // fallthrough
 	case 1:
 		fold = ut_fold_ulint_pair(fold, (ulint)(*str++));
 	}

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -485,7 +485,7 @@ log_online_make_bitmap_name(
 /*=========================*/
 	lsn_t	start_lsn)	/*!< in: the start LSN name part */
 {
-	ut_snprintf(log_bmp_sys->out.name, FN_REFLEN, bmp_file_name_template,
+	ut_snprintf(log_bmp_sys->out.name, sizeof(log_bmp_sys->out.name), bmp_file_name_template,
 		    log_bmp_sys->bmp_file_home, bmp_file_name_stem,
 		    log_bmp_sys->out_seq_num, start_lsn);
 }

--- a/storage/innobase/page/page0page.cc
+++ b/storage/innobase/page/page0page.cc
@@ -2794,7 +2794,7 @@ page_warn_strict_checksum(
 	srv_checksum_algorithm_t	page_checksum,
 	const page_id_t&		page_id)
 {
-	srv_checksum_algorithm_t	curr_algo_nonstrict;
+	srv_checksum_algorithm_t	curr_algo_nonstrict = srv_checksum_algorithm_t();
 	switch (curr_algo) {
 	case SRV_CHECKSUM_ALGORITHM_STRICT_CRC32:
 		curr_algo_nonstrict = SRV_CHECKSUM_ALGORITHM_CRC32;

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -1972,6 +1972,7 @@ PageConverter::update_page(
 	case FIL_PAGE_TYPE_XDES:
 		err = set_current_xdes(
 			block->page.id.page_no(), get_frame(block));
+		// fallthrough
 	case FIL_PAGE_INODE:
 	case FIL_PAGE_TYPE_TRX_SYS:
 	case FIL_PAGE_IBUF_FREE_LIST:

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -2037,6 +2037,7 @@ row_log_table_apply_update(
 
 		When applying the subsequent ROW_T_DELETE, no matching
 		record will be found. */
+		// fallthrough
 	case DB_SUCCESS:
 		ut_ad(row != NULL);
 		break;

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -6422,8 +6422,9 @@ loop:
 		const char* doing = "CHECK TABLE";
 		ib::warn() << doing << " on index " << index->name << " of"
 			" table " << index->table->name << " returned " << ret;
-		/* fall through (this error is ignored by CHECK TABLE) */
 	}
+	// fallthrough
+	// (this error is ignored by CHECK TABLE)
 	case DB_END_OF_INDEX:
 		ret = DB_SUCCESS;
 func_exit:

--- a/storage/innobase/row/row0purge.cc
+++ b/storage/innobase/row/row0purge.cc
@@ -548,8 +548,8 @@ row_purge_remove_sec_if_poss_leaf(
 				success = false;
 			}
 		}
-		/* fall through (the index entry is still needed,
-		or the deletion succeeded) */
+		// fallthrough
+		// (the index entry is still needed, or the deletion succeeded)
 	case ROW_NOT_DELETED_REF:
 		/* The index entry is still needed. */
 	case ROW_BUFFERED:

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -5233,7 +5233,7 @@ rec_loop:
 		reporting due to search views etc. */
 		if (prev_rec != NULL
 		    && prebuilt->m_mysql_handler->end_range != NULL
-		    && prebuilt->idx_cond == false && end_loop >= 100) {
+		    && prebuilt->idx_cond == NULL && end_loop >= 100) {
 
 			dict_index_t*	key_index = prebuilt->index;
 			bool		clust_templ_for_sec = false;

--- a/storage/myisam/mi_extra.c
+++ b/storage/myisam/mi_extra.c
@@ -148,6 +148,7 @@ int mi_extra(MI_INFO *info, enum ha_extra_function function, void *extra_arg)
   case HA_EXTRA_PREPARE_FOR_UPDATE:
     if (info->s->data_file_type != DYNAMIC_RECORD)
       break;
+    // fallthrough
     /* Remove read/write cache if dynamic rows */
   case HA_EXTRA_NO_CACHE:
     if (info->opt_flag & (READ_CACHE_USED | WRITE_CACHE_USED))

--- a/storage/myisam/mi_panic.c
+++ b/storage/myisam/mi_panic.c
@@ -62,6 +62,7 @@ int mi_panic(enum ha_panic_function flag)
 	if (mi_lock_database(info,F_UNLCK))
 	  error=my_errno();
       }
+    // fallthrough
     case HA_PANIC_READ:			/* Restore to before WRITE */
       if (info->was_locked)
       {

--- a/storage/myisam/myisamchk.c
+++ b/storage/myisam/myisamchk.c
@@ -1377,7 +1377,7 @@ static void descript(MI_CHECK *param, MI_INFO *info, char * name)
 	 key < share->state.header.uniques; key++, uniqueinfo++)
     {
       my_bool new_row=0;
-      char null_bit[8],null_pos[8];
+      char null_bit[8],null_pos[11];
       printf("%-8d%-5d",key+1,uniqueinfo->key+1);
       for (keyseg=uniqueinfo->seg ; keyseg->type != HA_KEYTYPE_END ; keyseg++)
       {

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -34,6 +34,15 @@ IF ((CMAKE_CXX_COMPILER_ID STREQUAL GNU) AND
   RETURN ()
 ENDIF ()
 
+# Relax fallthrough warnings we have no control over, as it's in zstd
+IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  MY_CHECK_CXX_COMPILER_FLAG("-Wimplicit-fallthrough=0" HAVE_IMPLICIT_FALLTHROUGH)
+  IF(HAVE_IMPLICIT_FALLTHROUGH)
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wimplicit-fallthrough=0")
+    SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wimplicit-fallthrough=0")
+  ENDIF()
+ENDIF()
+
 # check that compiler supports cxx11 and set options
 INCLUDE (check_stdcxx11)
 IF (!HAVE_STDCXX11)

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1986,6 +1986,7 @@ static uint32_t pack_desc_key_length_info(uchar* buf, KEY_AND_COL_INFO* kc_info,
     case (toku_type_fixstring):
         field_length = field->pack_length();
         set_if_smaller(key_part_length, field_length);
+        // fallthrough
     case (toku_type_varbinary):
     case (toku_type_varstring):
     case (toku_type_blob):

--- a/storage/tokudb/tokudb_thread.h
+++ b/storage/tokudb/tokudb_thread.h
@@ -204,21 +204,21 @@ inline mutex_t::mutex_t(pfs_key_t key) {
     _owners = 0;
     _owner = _null_owner;
 #endif
-    int r = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
+    int  r MY_ATTRIBUTE((unused)) = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
     assert_debug(r == 0);
 }
 inline mutex_t::~mutex_t(void) {
 #ifdef TOKUDB_DEBUG
     assert_debug(_owners == 0);
 #endif
-    int r = mysql_mutex_destroy(&_mutex);
+    int  r MY_ATTRIBUTE((unused)) = mysql_mutex_destroy(&_mutex);
     assert_debug(r == 0);
 }
 inline void mutex_t::reinit(pfs_key_t key) {
 #ifdef TOKUDB_DEBUG
     assert_debug(_owners == 0);
 #endif
-    int r;
+    int  r MY_ATTRIBUTE((unused));
     r = mysql_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
@@ -231,7 +231,7 @@ inline void mutex_t::lock(
 #endif  // HAVE_PSI_MUTEX_INTERFACE
     ) {
     assert_debug(is_owned_by_me() == false);
-    int r = inline_mysql_mutex_lock(&_mutex
+    int r MY_ATTRIBUTE((unused)) = inline_mysql_mutex_lock(&_mutex
 #ifdef HAVE_PSI_MUTEX_INTERFACE
                                     ,
                                     src_file,
@@ -260,7 +260,7 @@ inline void mutex_t::unlock(
     _owners--;
     _owner = _null_owner;
 #endif
-    int r = inline_mysql_mutex_unlock(&_mutex
+    int r MY_ATTRIBUTE((unused)) = inline_mysql_mutex_unlock(&_mutex
 #ifdef SAFE_MUTEX
                                       ,
                                       src_file,
@@ -276,11 +276,11 @@ inline bool mutex_t::is_owned_by_me(void) const {
 #endif
 
 inline rwlock_t::rwlock_t(pfs_key_t key) {
-    int r = mysql_rwlock_init(key, &_rwlock);
+    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_init(key, &_rwlock);
     assert_debug(r == 0);
 }
 inline rwlock_t::~rwlock_t(void) {
-    int r = mysql_rwlock_destroy(&_rwlock);
+    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_destroy(&_rwlock);
     assert_debug(r == 0);
 }
 inline void rwlock_t::lock_read(
@@ -328,7 +328,7 @@ inline void rwlock_t::lock_write(
     assert_debug(r == 0);
 }
 inline void rwlock_t::unlock(void) {
-    int r = mysql_rwlock_unlock(&_rwlock);
+    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_unlock(&_rwlock);
     assert_debug(r == 0);
 }
 inline rwlock_t::rwlock_t(const rwlock_t&) {}
@@ -340,7 +340,7 @@ inline rwlock_t& rwlock_t::operator=(const rwlock_t&) {
 inline event_t::event_t(bool create_signalled, bool manual_reset) :
     _manual_reset(manual_reset) {
 
-    int r = pthread_mutex_init(&_mutex, NULL);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_init(&_mutex, NULL);
     assert_debug(r == 0);
     r = pthread_cond_init(&_cond, NULL);
     assert_debug(r == 0);
@@ -352,13 +352,13 @@ inline event_t::event_t(bool create_signalled, bool manual_reset) :
     _pulsed = false;
 }
 inline event_t::~event_t(void) {
-    int r = pthread_mutex_destroy(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = pthread_cond_destroy(&_cond);
     assert_debug(r == 0);
 }
 inline void event_t::wait(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     while (_signalled == false && _pulsed == false) {
         r = pthread_cond_wait(&_cond, &_mutex);
@@ -395,7 +395,7 @@ inline int event_t::wait(ulonglong microseconds) {
     return 0;
 }
 inline void event_t::signal(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = true;
     if (_manual_reset) {
@@ -409,7 +409,7 @@ inline void event_t::signal(void) {
     assert_debug(r == 0);
 }
 inline void event_t::pulse(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _pulsed = true;
     r = pthread_cond_signal(&_cond);
@@ -419,7 +419,7 @@ inline void event_t::pulse(void) {
 }
 inline bool event_t::signalled(void) {
     bool ret = false;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     ret = _signalled;
     r = pthread_mutex_unlock(&_mutex);
@@ -427,7 +427,7 @@ inline bool event_t::signalled(void) {
     return ret;
 }
 inline void event_t::reset(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = false;
     _pulsed = false;
@@ -449,21 +449,21 @@ inline semaphore_t::semaphore_t(
     _initial_count(initial_count),
     _max_count(max_count) {
 
-    int r = pthread_mutex_init(&_mutex, NULL);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_init(&_mutex, NULL);
     assert_debug(r == 0);
     r = pthread_cond_init(&_cond, NULL);
     assert_debug(r == 0);
     _signalled = _initial_count;
 }
 inline semaphore_t::~semaphore_t(void) {
-    int r = pthread_mutex_destroy(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = pthread_cond_destroy(&_cond);
     assert_debug(r == 0);
 }
 inline semaphore_t::E_WAIT semaphore_t::wait(void) {
     E_WAIT ret;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     while (_signalled == 0 && _interrupted == false) {
         r = pthread_cond_wait(&_cond, &_mutex);
@@ -506,7 +506,7 @@ inline semaphore_t::E_WAIT semaphore_t::wait(ulonglong microseconds) {
 }
 inline bool semaphore_t::signal(void) {
     bool ret = false;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     if (_signalled < _max_count) {
         _signalled++;
@@ -520,7 +520,7 @@ inline bool semaphore_t::signal(void) {
 }
 inline int semaphore_t::signalled(void) {
     int ret = 0;
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     ret = _signalled;
     r = pthread_mutex_unlock(&_mutex);
@@ -528,7 +528,7 @@ inline int semaphore_t::signalled(void) {
     return ret;
 }
 inline void semaphore_t::reset(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = 0;
     r = pthread_mutex_unlock(&_mutex);
@@ -536,7 +536,7 @@ inline void semaphore_t::reset(void) {
     return;
 }
 inline void semaphore_t::set_interrupt(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _interrupted = true;
     r = pthread_cond_broadcast(&_cond);
@@ -545,7 +545,7 @@ inline void semaphore_t::set_interrupt(void) {
     assert_debug(r == 0);
 }
 inline void semaphore_t::clear_interrupt(void) {
-    int r = pthread_mutex_lock(&_mutex);
+    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _interrupted = false;
     r = pthread_mutex_unlock(&_mutex);

--- a/strings/ctype-utf8.c
+++ b/strings/ctype-utf8.c
@@ -5460,8 +5460,8 @@ static int my_uni_utf8 (const CHARSET_INFO *cs MY_ATTRIBUTE((unused)),
 
   switch (count) {
     /* Fall through all cases!!! */
-    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800;
-    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0;
+    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0] = (uchar) wc;
   }
   return count;
@@ -5489,8 +5489,8 @@ static int my_uni_utf8_no_range(const CHARSET_INFO *cs
   switch (count)
   {
     /* Fall through all cases!!! */
-    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800;
-    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0;
+    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0]= (uchar) wc;
   }
   return count;
@@ -8011,9 +8011,9 @@ my_wc_mb_utf8mb4(const CHARSET_INFO *cs MY_ATTRIBUTE((unused)),
 
   switch (count) {
     /* Fall through all cases!!! */
-    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000;
-    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800;
-    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0;
+    case 4: r[3] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x10000; // fallthrough
+    case 3: r[2] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1] = (uchar) (0x80 | (wc & 0x3f)); wc = wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0] = (uchar) wc;
   }
   return count;
@@ -8043,9 +8043,9 @@ my_wc_mb_utf8mb4_no_range(const CHARSET_INFO *cs MY_ATTRIBUTE((unused)),
   switch (count)
   {
     /* Fall through all cases!!! */
-    case 4: r[3]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x10000;
-    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800;
-    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0;
+    case 4: r[3]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x10000; // fallthrough
+    case 3: r[2]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0x800; // fallthrough
+    case 2: r[1]= (uchar) (0x80 | (wc & 0x3f)); wc= wc >> 6; wc |= 0xc0; // fallthrough
     case 1: r[0]= (uchar) wc;
   }
   return count;

--- a/strings/decimal.c
+++ b/strings/decimal.c
@@ -225,17 +225,17 @@ static inline int count_leading_zeroes(int i, dec1 val)
   switch (i)
   {
   /* @note Intentional fallthrough in all case labels */
-  case 9: if (val >= 1000000000) break; ++ret;
-  case 8: if (val >= 100000000) break; ++ret;
-  case 7: if (val >= 10000000) break; ++ret;
-  case 6: if (val >= 1000000) break; ++ret;
-  case 5: if (val >= 100000) break; ++ret;
-  case 4: if (val >= 10000) break; ++ret;
-  case 3: if (val >= 1000) break; ++ret;
-  case 2: if (val >= 100) break; ++ret;
-  case 1: if (val >= 10) break; ++ret;
-  case 0: if (val >= 1) break; ++ret;
-  default: { DBUG_ASSERT(FALSE); }
+  case 9: if (val >= 1000000000) break; ++ret; // fallthrough
+  case 8: if (val >= 100000000) break; ++ret; // fallthrough
+  case 7: if (val >= 10000000) break; ++ret; // fallthrough
+  case 6: if (val >= 1000000) break; ++ret; // fallthrough
+  case 5: if (val >= 100000) break; ++ret; // fallthrough
+  case 4: if (val >= 10000) break; ++ret; // fallthrough
+  case 3: if (val >= 1000) break; ++ret; // fallthrough
+  case 2: if (val >= 100) break; ++ret; // fallthrough
+  case 1: if (val >= 10) break; ++ret; // fallthrough
+  case 0: if (val >= 1) break; ++ret; // fallthrough
+  default: { DBUG_ASSERT(FALSE); } // fallthrough
   }
   return ret;
 }
@@ -258,16 +258,16 @@ static inline int count_trailing_zeroes(int i, dec1 val)
   switch(i)
   {
   /* @note Intentional fallthrough in all case labels */
-  case 0: if ((val % 1) != 0) break; ++ret;
-  case 1: if ((val % 10) != 0) break; ++ret;
-  case 2: if ((val % 100) != 0) break; ++ret;
-  case 3: if ((val % 1000) != 0) break; ++ret;
-  case 4: if ((val % 10000) != 0) break; ++ret;
-  case 5: if ((val % 100000) != 0) break; ++ret;
-  case 6: if ((val % 1000000) != 0) break; ++ret;
-  case 7: if ((val % 10000000) != 0) break; ++ret;
-  case 8: if ((val % 100000000) != 0) break; ++ret;
-  case 9: if ((val % 1000000000) != 0) break; ++ret;
+  case 0: if ((val % 1) != 0) break; ++ret; // fallthrough
+  case 1: if ((val % 10) != 0) break; ++ret; // fallthrough
+  case 2: if ((val % 100) != 0) break; ++ret; // fallthrough
+  case 3: if ((val % 1000) != 0) break; ++ret; // fallthrough
+  case 4: if ((val % 10000) != 0) break; ++ret; // fallthrough
+  case 5: if ((val % 100000) != 0) break; ++ret; // fallthrough
+  case 6: if ((val % 1000000) != 0) break; ++ret; // fallthrough
+  case 7: if ((val % 10000000) != 0) break; ++ret; // fallthrough
+  case 8: if ((val % 100000000) != 0) break; ++ret; // fallthrough
+  case 9: if ((val % 1000000000) != 0) break; ++ret; // fallthrough
   default: { DBUG_ASSERT(FALSE); }
   }
   return ret;

--- a/strings/dtoa.c
+++ b/strings/dtoa.c
@@ -1378,7 +1378,7 @@ static double my_strtod_int(const char *s00, char **se, int *error, char *buf, s
     switch (*s) {
     case '-':
       sign= 1;
-      /* no break */
+      // fallthrough
     case '+':
       s++;
       goto break2;
@@ -1475,6 +1475,7 @@ static double my_strtod_int(const char *s00, char **se, int *error, char *buf, s
       switch (c= *s) {
       case '-':
         esign= 1;
+        // fallthrough
       case '+':
         if (++s < end)
           c= *s;
@@ -2322,7 +2323,7 @@ static char *dtoa(double dd, int mode, int ndigits, int *decpt, int *sign,
     break;
   case 2:
     leftright= 0;
-    /* no break */
+    // fallthrough
   case 4:
     if (ndigits <= 0)
       ndigits= 1;
@@ -2330,7 +2331,7 @@ static char *dtoa(double dd, int mode, int ndigits, int *decpt, int *sign,
     break;
   case 3:
     leftright= 0;
-    /* no break */
+    // fallthrough
   case 5:
     i= ndigits + k + 1;
     ilim= i;

--- a/unittest/gunit/opt_range-t.cc
+++ b/unittest/gunit/opt_range-t.cc
@@ -351,7 +351,9 @@ void OptRangeTest::check_use_count(SEL_TREE *tree)
   {
     SEL_ARG *cur_range= tree->keys[i];
     if (cur_range != NULL)
+    {
       EXPECT_FALSE(cur_range->test_use_count(cur_range));
+    }
   }
 
   if (!tree->merges.is_empty())


### PR DESCRIPTION
This commit is based on 59eff2e4e870f3a87ade9d4b55dea5d47a2ba62b, which contains the comilation fixes for the 5.6 branch.

* Updated the PerconaFT and Percona-TokuBackup submodules with newer versions.
  The new version contain compilation fixes for those submodules.
* Corrected an empty string check in sql-common/client_authentication.cc.
* Changed a local sprintf buffer size in sql/sys_vars.h.
* Added a missing break to the mysqld parameter checks in sql/mysqld.cc.
* Modified an assertion in libbinlogevents/src/statement_events.cpp.
  In it's previous form itw as always true, and also caused integer-bool conversion warnings.
* Added breaks in mysqlxtest_src/mysqlx_protocol.cc.
  These do not change the flow of the program, they are only needed because the compiler was unable to detect throws in called functions.
* Added a break to a case in sql/item_func.cc.
  Based on the code around this block, it looks logical that we do not wish to raise assertions for every string result - maybe only on error?
* Fixed an incorrect if in sql/item_geofunc.cc.
  Half of the condition was missing.
* Added overridden new and delete operators for Relay_log_info and Slave_worker because they require 64 byte alignment.
  These implementation currently only work on Linux, and they do contain a few lines of duplicated code.
* Added a missing break to sql/rpl_slave.cc.
  Based on the code around it, that's what makes sense.
* Added a missing break to heap/hp_extra.c
  This change is backported from 8.0
* Null initialized a local pointer in sql/sql_partition.cc.
  As it otherwise could result in uninitailized reads in release builds.
  On debug builds, this case is guarded by an assert.
* Disabled fallthrough warnings for rocksdb, as it isn't our repository.
* Corrected the length of a local sprintf buffer in storage/myisam/myisamchk.c.
* Returning the success status in tests/bug25714.c.
  This way the variable is also used in the release build, and the correctness of the execution can also be checked using the exit status of the program.
* Fixed two sprintf local buffer overflow in regex/debug.c.
* Default initialzied a local variable in storage/innobase/page/page0page.cc.
  As it otherwise could result in uninitailized reads in release builds.
  On debug builds, this case is guarded by an assert.
* Fixed some unused result or non-null warnings.
  These do not result in any behaviour change.
* Changed bool conversion to be more explict in some assertions.
  These do not result in any behaviour change.
* Added or changed fallthrough comments at many places so GCC's parser will be able to identify them.
  These do not result in any behaviour change.
* Moved a few breaks to different locations so GCC's parser will correctly identify them.
  These do not result in any behaviour change.