### PR TITLE
lp-1733049: Blackhole : Specified key was too long; max key length is…

### DIFF
--- a/mysql-test/r/bug53588.result
+++ b/mysql-test/r/bug53588.result
@@ -1,0 +1,5 @@
+CREATE TABLE `t` (
+`a` varchar(3000) NOT NULL default '',
+PRIMARY KEY  (`a`)
+) ENGINE=BLACKHOLE;
+DROP TABLE `t`;

--- a/mysql-test/t/bug53588.test
+++ b/mysql-test/t/bug53588.test
@@ -1,0 +1,15 @@
+#
+# Bug 53588 test case.
+#
+# Create long enough index (between 1000 and 3500). 1000 is the old value,
+# 3500 is innodb value (see ha_innobase::max_supported_key_length()). Without
+# the fix the test will fail with "Specified key was too long" error.
+#
+--source include/have_blackhole.inc
+
+CREATE TABLE `t` (
+  `a` varchar(3000) NOT NULL default '',
+  PRIMARY KEY  (`a`)
+) ENGINE=BLACKHOLE;
+
+DROP TABLE `t`;

--- a/storage/blackhole/ha_blackhole.h
+++ b/storage/blackhole/ha_blackhole.h
@@ -20,6 +20,7 @@
 #include "thr_lock.h"                           /* THR_LOCK */
 #include "handler.h"                            /* handler */
 #include "table.h"                              /* TABLE_SHARE */
+#include "sql_const.h"                          /* MAX_KEY */
 
 /*
   Shared structure for correct LOCK operation
@@ -68,9 +69,9 @@ public:
             HA_READ_ORDER | HA_KEYREAD_ONLY);
   }
   /* The following defines can be increased if necessary */
-#define BLACKHOLE_MAX_KEY	64		/* Max allowed keys */
+#define BLACKHOLE_MAX_KEY	MAX_KEY		/* Max allowed keys */
 #define BLACKHOLE_MAX_KEY_SEG	16		/* Max segments for key */
-#define BLACKHOLE_MAX_KEY_LENGTH 1000
+#define BLACKHOLE_MAX_KEY_LENGTH	3500		/* Like in InnoDB */
   uint max_supported_keys()          const { return BLACKHOLE_MAX_KEY; }
   uint max_supported_key_length()    const { return BLACKHOLE_MAX_KEY_LENGTH; }
   uint max_supported_key_part_length() const { return BLACKHOLE_MAX_KEY_LENGTH; }


### PR DESCRIPTION
… 1000 bytes

The maximum innodb key length is 3500 what is hardcoded in
ha_innobase::max_supported_key_length()). The maximum number of innodb indexes
is configured with MAX_INDEXES macro (see also MAX_KEY definition).

The same is currently implemented for blackhole storage engine.

See also: https://github.com/percona/percona-server/pull/2000, https://github.com/percona/percona-server/pull/2001.
Testing: https://jenkins.percona.com/job/percona-server-5.5-param/1604/