### PR TITLE
MYR-212 : fix rocksdb_block_cachecompressed_* names to be rocksdb_blo…

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -1521,6 +1521,8 @@ rocksdb_block_cache_add	#
 rocksdb_block_cache_add_failures	#
 rocksdb_block_cache_bytes_read	#
 rocksdb_block_cache_bytes_write	#
+rocksdb_block_cache_compressed_hit	#
+rocksdb_block_cache_compressed_miss	#
 rocksdb_block_cache_data_add	#
 rocksdb_block_cache_data_bytes_insert	#
 rocksdb_block_cache_data_hit	#
@@ -1537,8 +1539,6 @@ rocksdb_block_cache_index_bytes_insert	#
 rocksdb_block_cache_index_hit	#
 rocksdb_block_cache_index_miss	#
 rocksdb_block_cache_miss	#
-rocksdb_block_cachecompressed_hit	#
-rocksdb_block_cachecompressed_miss	#
 rocksdb_bloom_filter_prefix_checked	#
 rocksdb_bloom_filter_prefix_useful	#
 rocksdb_bloom_filter_useful	#
@@ -1553,7 +1553,7 @@ rocksdb_flush_write_bytes	#
 rocksdb_get_hit_l0	#
 rocksdb_get_hit_l1	#
 rocksdb_get_hit_l2_and_up	#
-rocksdb_getupdatessince_calls	#
+rocksdb_get_updates_since_calls	#
 rocksdb_iter_bytes_read	#
 rocksdb_memtable_hit	#
 rocksdb_memtable_miss	#
@@ -1626,6 +1626,8 @@ rocksdb_block_cache_add
 rocksdb_block_cache_add_failures
 rocksdb_block_cache_bytes_read
 rocksdb_block_cache_bytes_write
+rocksdb_block_cache_compressed_hit
+rocksdb_block_cache_compressed_miss
 rocksdb_block_cache_data_add
 rocksdb_block_cache_data_bytes_insert
 rocksdb_block_cache_data_hit
@@ -1642,8 +1644,6 @@ rocksdb_block_cache_index_bytes_insert
 rocksdb_block_cache_index_hit
 rocksdb_block_cache_index_miss
 rocksdb_block_cache_miss
-rocksdb_block_cachecompressed_hit
-rocksdb_block_cachecompressed_miss
 rocksdb_bloom_filter_prefix_checked
 rocksdb_bloom_filter_prefix_useful
 rocksdb_bloom_filter_useful
@@ -1658,7 +1658,7 @@ rocksdb_flush_write_bytes
 rocksdb_get_hit_l0
 rocksdb_get_hit_l1
 rocksdb_get_hit_l2_and_up
-rocksdb_getupdatessince_calls
+rocksdb_get_updates_since_calls
 rocksdb_iter_bytes_read
 rocksdb_memtable_hit
 rocksdb_memtable_miss
@@ -1733,6 +1733,8 @@ rocksdb_block_cache_add
 rocksdb_block_cache_add_failures
 rocksdb_block_cache_bytes_read
 rocksdb_block_cache_bytes_write
+rocksdb_block_cache_compressed_hit
+rocksdb_block_cache_compressed_miss
 rocksdb_block_cache_data_add
 rocksdb_block_cache_data_bytes_insert
 rocksdb_block_cache_data_hit
@@ -1749,8 +1751,6 @@ rocksdb_block_cache_index_bytes_insert
 rocksdb_block_cache_index_hit
 rocksdb_block_cache_index_miss
 rocksdb_block_cache_miss
-rocksdb_block_cachecompressed_hit
-rocksdb_block_cachecompressed_miss
 rocksdb_bloom_filter_prefix_checked
 rocksdb_bloom_filter_prefix_useful
 rocksdb_bloom_filter_useful
@@ -1765,7 +1765,7 @@ rocksdb_flush_write_bytes
 rocksdb_get_hit_l0
 rocksdb_get_hit_l1
 rocksdb_get_hit_l2_and_up
-rocksdb_getupdatessince_calls
+rocksdb_get_updates_since_calls
 rocksdb_iter_bytes_read
 rocksdb_memtable_hit
 rocksdb_memtable_miss

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10897,9 +10897,9 @@ struct rocksdb_status_counters_t {
   uint64_t bloom_filter_prefix_checked;
   uint64_t bloom_filter_prefix_useful;
   uint64_t number_reseeks_iteration;
-  uint64_t getupdatessince_calls;
-  uint64_t block_cachecompressed_miss;
-  uint64_t block_cachecompressed_hit;
+  uint64_t get_updates_since_calls;
+  uint64_t block_cache_compressed_miss;
+  uint64_t block_cache_compressed_hit;
   uint64_t wal_synced;
   uint64_t wal_bytes;
   uint64_t write_self;
@@ -10972,9 +10972,9 @@ DEF_SHOW_FUNC(number_merge_failures, NUMBER_MERGE_FAILURES)
 DEF_SHOW_FUNC(bloom_filter_prefix_checked, BLOOM_FILTER_PREFIX_CHECKED)
 DEF_SHOW_FUNC(bloom_filter_prefix_useful, BLOOM_FILTER_PREFIX_USEFUL)
 DEF_SHOW_FUNC(number_reseeks_iteration, NUMBER_OF_RESEEKS_IN_ITERATION)
-DEF_SHOW_FUNC(getupdatessince_calls, GET_UPDATES_SINCE_CALLS)
-DEF_SHOW_FUNC(block_cachecompressed_miss, BLOCK_CACHE_COMPRESSED_MISS)
-DEF_SHOW_FUNC(block_cachecompressed_hit, BLOCK_CACHE_COMPRESSED_HIT)
+DEF_SHOW_FUNC(get_updates_since_calls, GET_UPDATES_SINCE_CALLS)
+DEF_SHOW_FUNC(block_cache_compressed_miss, BLOCK_CACHE_COMPRESSED_MISS)
+DEF_SHOW_FUNC(block_cache_compressed_hit, BLOCK_CACHE_COMPRESSED_HIT)
 DEF_SHOW_FUNC(wal_synced, WAL_FILE_SYNCED)
 DEF_SHOW_FUNC(wal_bytes, WAL_FILE_BYTES)
 DEF_SHOW_FUNC(write_self, WRITE_DONE_BY_SELF)
@@ -11201,9 +11201,9 @@ static SHOW_VAR rocksdb_status_vars[] = {
     DEF_STATUS_VAR(bloom_filter_prefix_checked),
     DEF_STATUS_VAR(bloom_filter_prefix_useful),
     DEF_STATUS_VAR(number_reseeks_iteration),
-    DEF_STATUS_VAR(getupdatessince_calls),
-    DEF_STATUS_VAR(block_cachecompressed_miss),
-    DEF_STATUS_VAR(block_cachecompressed_hit),
+    DEF_STATUS_VAR(get_updates_since_calls),
+    DEF_STATUS_VAR(block_cache_compressed_miss),
+    DEF_STATUS_VAR(block_cache_compressed_hit),
     DEF_STATUS_VAR(wal_synced),
     DEF_STATUS_VAR(wal_bytes),
     DEF_STATUS_VAR(write_self),


### PR DESCRIPTION
…ck_cache_compressed_*

- Did just as title says, also fixed getupdatessince to get_updates_since and
  re-recorded rocksdb.rocksdb.test