### PR TITLE
lp1736905: Fixing assertions modified during the artful compilation fix

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -7838,18 +7838,9 @@ User_var_log_event(const char* buf, uint event_len,
     uint bytes_read= ((val + val_len) - start);
 #ifndef DBUG_OFF
     bool old_pre_checksum_fd= description_event->is_version_before_checksum();
+    const int checksum_length = (old_pre_checksum_fd || description_event->checksum_alg == BINLOG_CHECKSUM_ALG_OFF) ? 0 : BINLOG_CHECKSUM_LEN;
 #endif
-    DBUG_ASSERT((bytes_read == (data_written -
-                 ((old_pre_checksum_fd ||
-                  (description_event->checksum_alg ==
-                   BINLOG_CHECKSUM_ALG_OFF)) ?
-                 0 : BINLOG_CHECKSUM_LEN)))
-                ||
-                ((bytes_read == (data_written -1 -
-                 (old_pre_checksum_fd ||
-                  (description_event->checksum_alg ==
-                   BINLOG_CHECKSUM_ALG_OFF)) ?
-                 0 : BINLOG_CHECKSUM_LEN))));
+    DBUG_ASSERT(bytes_read == data_written - checksum_length || bytes_read == data_written - checksum_length - 1);
     if ((data_written - bytes_read) > 0)
     {
       flags= (uint) *(buf + UV_VAL_IS_NULL + UV_VAL_TYPE_SIZE +

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -2987,7 +2987,7 @@ bool change_password(THD *thd, const char *host, const char *user,
 
   mysql_mutex_assert_owner(&acl_cache->lock);
   table->use_all_columns();
-  DBUG_ASSERT(host != NULL && host[0] != '\0');
+  DBUG_ASSERT(host != NULL);
   table->field[MYSQL_USER_FIELD_HOST]->store(host, strlen(host),
                                              system_charset_info);
   table->field[MYSQL_USER_FIELD_USER]->store(user, strlen(user),
@@ -3424,7 +3424,7 @@ update_user_table(THD *thd, TABLE *table,
   if (!is_user_table_positioned)
   {
     table->use_all_columns();
-    DBUG_ASSERT(host != NULL && host[0] != '\0');
+    DBUG_ASSERT(host != NULL);
     table->field[MYSQL_USER_FIELD_HOST]->store(host, (uint) strlen(host),
 					       system_charset_info);
     table->field[MYSQL_USER_FIELD_USER]->store(user, (uint) strlen(user),
@@ -3573,7 +3573,7 @@ static int replace_user_table(THD *thd, TABLE *table, LEX_USER *combo,
   }
 
   table->use_all_columns();
-  DBUG_ASSERT(combo->host.str != NULL && combo->host.str[0] != '\0');
+  DBUG_ASSERT(combo->host.str != NULL);
   table->field[MYSQL_USER_FIELD_HOST]->store(combo->host.str,combo->host.length,
                                              system_charset_info);
   table->field[MYSQL_USER_FIELD_USER]->store(combo->user.str,combo->user.length,
@@ -3664,7 +3664,7 @@ static int replace_user_table(THD *thd, TABLE *table, LEX_USER *combo,
 
     old_row_exists = 0;
     restore_record(table,s->default_values);
-    DBUG_ASSERT(combo->host.str != NULL && combo->host.str[0] != '\0');
+    DBUG_ASSERT(combo->host.str != NULL);
     table->field[MYSQL_USER_FIELD_HOST]->store(combo->host.str,combo->host.length,
                                                system_charset_info);
     table->field[MYSQL_USER_FIELD_USER]->store(combo->user.str,combo->user.length,


### PR DESCRIPTION
During the artful compilation fixes, an assertion checking that some pointers aren't equal to an empty string were corrected:
these asserts now checked that the pointers aren't NULL pointers and that they do not point to an empty string.

This more restrictive address caused assertation violations where it shouldn't be. This commit changes them back to the more relaxed behaviors of the original code: it only checks that the pointers aren't NULL pointers.

                                                                                                                                                  
Another assertion in log_event.cc had a similar issue, where the changed assertion didn't generate any warnings, but resulted in assertion errors.
Here the original assert always evaluated to true, and as such, had no function.                                                                  
Additional brackets were required to resolve the evaluation order, butt he original solution resulted in assertion failures.                      
This improved version correctly checks the original intention of the assertion.                                                                   
                                                                                                                                                  