### PR TITLE
PS-260: The mysqld release build crashed when loading the world database

### DIFF
--- a/storage/innobase/include/trx0rec.h
+++ b/storage/innobase/include/trx0rec.h
@@ -233,7 +233,7 @@ trx_undo_report_row_operation(
 					inserted undo log record,
 					0 if BTR_NO_UNDO_LOG
 					flag was specified */
-	MY_ATTRIBUTE((nonnull(3,4,10), warn_unused_result));
+	MY_ATTRIBUTE((nonnull(4,10), warn_unused_result));
 /******************************************************************//**
 Copies an undo record to heap. This function can be called if we know that
 the undo log record exists.


### PR DESCRIPTION
btr_cur_optimistic_insert called
btr_cur_ins_lock_and_undo which called
trx_undo_report_row_operation

Because these calls had no conditions on the thr variable, and trx_undo_report_row_operation marked thr as non null, the optimizer assumed it to be non null in other conditions too.

Based on this, the compiler optimized out some thr && conditions, resulting in null pointer crashes.

trx_undo_report_row_operation can handle null thr values with the correct flags, and this attribute was already removed in the 5.7 branch.