### PR TITLE
Fixed DOC-654 by documenting innodb_ft_ignore_stopwords (5.7)

### DIFF
--- a/doc/source/flexibility/innodb_fts_improvements.rst
+++ b/doc/source/flexibility/innodb_fts_improvements.rst
@@ -1,0 +1,56 @@
+.. _innodb_fts_improvements:
+
+====================================
+InnoDB Full-Text Search improvements
+====================================
+
+.. contents::
+   :local:
+
+.. _ignoring_stopword_list:
+
+======================
+Ignoring Stopword list
+======================
+
+By default all Full-Text Search indexes check the `stopwords list
+<https://dev.mysql.com/doc/refman/5.7/en/fulltext-stopwords.html>`_,
+to see if any indexed elements *contain* one of the words on that list.
+
+Using this list for n-gram indexes isn't always suitable, as an example, any
+item that contains ``a`` or ``i`` will be ignored. Another word that can't be
+searched is ``east``, this one will find no matches because ``a`` is on the
+FTS stopword list.
+
+To resolve this issue, in |Percona Server| :rn:`5.7.20-18` a new
+:variable:`innodb_ft_ignore_stopwords` variable has been implemented
+which controls whether |InnoDB| Full-Text Search should ignore stopword list.
+
+Although this variable is introduced to resolve n-gram issues, it affects
+all Full-Text Search indexes as well.
+
+Being a stopword doesn't just mean to be a one of the predefined
+words from the list. Tokens shorter than `innodb_ft_min_token_size
+<https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_ft_min_token_size>`_
+or longer than `innodb_ft_max_token_size
+<https://dev.mysql.com/doc/refman/5.7/en/innodb-parameters.html#sysvar_innodb_ft_max_token_size>`_
+are also considered stopwords. Therefore, when
+:variable:`innodb_ft_ignore_stopwords` is set to ``ON`` even for non-ngram
+FTS, ``innodb_ft_min_token_size`` / ``innodb_ft_max_token_size`` will be
+ignored meaning that in this case very short and very long words will
+also be indexed.
+
+System Variables
+================
+
+.. variable:: innodb_ft_ignore_stopwords
+
+  :cli: Yes
+  :conf: Yes
+  :scope: Session, Global
+  :dyn: Yes
+  :vartype: Boolean
+  :default: ``OFF``
+
+When enabled, this variable will instruct |InnoDB| Full Text Search
+parser to ignore the stopword list when building/updating an FTS index.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -92,6 +92,7 @@ Flexibility Improvements
    flexibility/proxy_protocol_support
    flexibility/per_session_server-id
    flexibility/compressed_columns
+   flexibility/innodb_fts_improvements
 
 Reliability Improvements
 ========================

--- a/doc/source/myrocks/variables.rst
+++ b/doc/source/myrocks/variables.rst
@@ -1748,7 +1748,7 @@ Signals the MyRocks drop index thread to wake up.
 .. variable:: rocksdb_sim_cache_size
 
   :version 5.7.20-18: Implemented
-  :cli: ``--rocksdb-sim-cache-size
+  :cli: ``--rocksdb-sim-cache-size``
   :dyn: No
   :scope: Global
   :vartype: Numeric

--- a/doc/source/release-notes/Percona-Server-5.7.18-16.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.18-16.rst
@@ -24,8 +24,8 @@ added for these distributions.
 New Feature
 ===========
 
-|Percona Server| is now available on Debian 9 (stretch). The support only covers
-the ``amd64`` architecture.
+|Percona Server| is now available on Debian 9 (stretch). The support only
+covers the ``amd64`` architecture.
 
 |Percona Server| can now be built with support of OpenSSL 1.1.
 
@@ -49,11 +49,11 @@ unnecessarily waiting for an available lock. Bug fixed :tdbbug:`3`.
 |Percona FT| could assert when opening a dictionary with no useful information
 to error log. Bug fixed :tdbbug:`23`.
 
-|Percona FT| could assert for various reasons deserializing nodes with no useful
-error output. Bug fixed :tdbbug:`24`.
+|Percona FT| could assert for various reasons deserializing nodes with no
+useful error output. Bug fixed :tdbbug:`24`.
 
 It was not possible to build |Percona Server| on Debian 9 (stretch) due to
-issues with OpenSSL 1.1. Bug fixed :bug:`1702903` (upstream :mysqlbug:`83814`). 
+issues with OpenSSL 1.1. Bug fixed :bug:`1702903` (upstream :mysqlbug:`83814`).
 
 Packaging was using the ``dpkg --verify`` command which is not available on
 wheezy/precise. Bug fixed :bug:`1694907`.
@@ -81,13 +81,13 @@ also :ref:`compatibility-matrix`.  Note that the
 Killing a stored procedure execution could result in an assert failure on a
 debug server build. Bug fixed :bug:`1689736` (upstream :mysqlbug:`86260`).
 
-The ``SET STATEMENT .. FOR`` statement changed the global instead of the session
-value of a variable if the statement occurred immediately after the ``SET
-GLOBAL`` or ``SHOW GLOBAL STATUS`` command. Bug fixed :bug:`1385352`.
+The ``SET STATEMENT .. FOR`` statement changed the global instead of the
+session value of a variable if the statement occurred immediately after the
+``SET GLOBAL`` or ``SHOW GLOBAL STATUS`` command. Bug fixed :bug:`1385352`.
 
 When running ``SHOW ENGINE INNODB STATUS``, the ``Buffer pool size, bytes``
 entry contained **0**. BUg fixed :bug:`1586262`.
-     
+
 The synchronization between the LRU manager and page cleaner threads was not
 done at shutdown. Bug fixed :bug:`1689552`.
 
@@ -124,7 +124,7 @@ Compatibility Matrix
 =======================  =======  ==================  ====================
 Feature                  YaSSL    OpenSSL < 1.0.2     OpenSSL >= 1.0.2
 =======================  =======  ==================  ====================
-'commonName' validation  Yes      Yes                 Yes         
-SAN validation           No       Yes                 Yes         
-Wildcards support        No       No                  Yes         
+'commonName' validation  Yes      Yes                 Yes
+SAN validation           No       Yes                 Yes
+Wildcards support        No       No                  Yes
 =======================  =======  ==================  ====================

--- a/doc/source/release-notes/Percona-Server-5.7.20-18.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.20-18.rst
@@ -24,6 +24,11 @@ New Features
 
  * |Percona Server| packages are now available for *Ubuntu 17.10 (Artful)*.
 
+ * As part of :ref:`innodb_fts_improvements` a new
+   :variable:`innodb_ft_ignore_stopwords` variable has been implemented which
+   controls whether |InnoDB| Full-Text Search should ignore stopword list
+   when building/updating an FTS index.
+
 Bugs Fixed
 ==========
 


### PR DESCRIPTION
fixed dep8 issues in older RNs and a build warning