### PR TITLE
lp1716844: Escaping control characters in the audit log

### DIFF
--- a/mysql-test/include/audit_log_events.inc
+++ b/mysql-test/include/audit_log_events.inc
@@ -6,6 +6,42 @@ CREATE TABLE t1
              (c1 INT,
               c2 CHAR(20));
 INSERT INTO t1 VALUES (1,'a'),(2,'b'),(3,'c');
+-- if ($test_control_chars) {
+INSERT INTO `t1` VALUES (4,NULL);
+# can't add the zero ascii character, as that's a syntax error in MySQL
+INSERT INTO `t1` VALUES (6,'');
+INSERT INTO `t1` VALUES (7,'');
+INSERT INTO `t1` VALUES (8,'');
+INSERT INTO `t1` VALUES (9,'');
+INSERT INTO `t1` VALUES (10,'');
+INSERT INTO `t1` VALUES (11,'');
+INSERT INTO `t1` VALUES (12,'');
+INSERT INTO `t1` VALUES (13,'');
+INSERT INTO `t1` VALUES (14,'	');
+INSERT INTO `t1` VALUES (15,'
+');
+INSERT INTO `t1` VALUES (16,'');
+INSERT INTO `t1` VALUES (17,'');
+INSERT INTO `t1` VALUES (18,'');
+INSERT INTO `t1` VALUES (19,'');
+INSERT INTO `t1` VALUES (20,'');
+INSERT INTO `t1` VALUES (21,'');
+INSERT INTO `t1` VALUES (22,'');
+INSERT INTO `t1` VALUES (23,'');
+INSERT INTO `t1` VALUES (24,'');
+INSERT INTO `t1` VALUES (25,'');
+INSERT INTO `t1` VALUES (26,'');
+INSERT INTO `t1` VALUES (27,'');
+INSERT INTO `t1` VALUES (28,'');
+INSERT INTO `t1` VALUES (29,'');
+INSERT INTO `t1` VALUES (30,'');
+INSERT INTO `t1` VALUES (31,'');
+INSERT INTO `t1` VALUES (32,'');
+INSERT INTO `t1` VALUES (33,'');
+INSERT INTO `t1` VALUES (34,'');
+INSERT INTO `t1` VALUES (35,'');
+INSERT INTO `t1` VALUES (36,'');
+-- }
 SELECT * FROM t1;
 --error ER_NO_SUCH_TABLE
 SELECT * FROM t2;

--- a/mysql-test/r/audit_log_json.result
+++ b/mysql-test/r/audit_log_json.result
@@ -6,11 +6,77 @@ CREATE TABLE t1
 c2 CHAR(20));
 ERROR 42S01: Table 't1' already exists
 INSERT INTO t1 VALUES (1,'a'),(2,'b'),(3,'c');
+INSERT INTO `t1` VALUES (4,NULL);
+INSERT INTO `t1` VALUES (6,'');
+INSERT INTO `t1` VALUES (7,'');
+INSERT INTO `t1` VALUES (8,'');
+INSERT INTO `t1` VALUES (9,'');
+INSERT INTO `t1` VALUES (10,'');
+INSERT INTO `t1` VALUES (11,'');
+INSERT INTO `t1` VALUES (12,'');
+INSERT INTO `t1` VALUES (13,'');
+INSERT INTO `t1` VALUES (14,'	');
+INSERT INTO `t1` VALUES (15,'
+');
+INSERT INTO `t1` VALUES (16,'');
+INSERT INTO `t1` VALUES (17,'');
+INSERT INTO `t1` VALUES (18,'');
+INSERT INTO `t1` VALUES (19,'');
+INSERT INTO `t1` VALUES (20,'');
+INSERT INTO `t1` VALUES (21,'');
+INSERT INTO `t1` VALUES (22,'');
+INSERT INTO `t1` VALUES (23,'');
+INSERT INTO `t1` VALUES (24,'');
+INSERT INTO `t1` VALUES (25,'');
+INSERT INTO `t1` VALUES (26,'');
+INSERT INTO `t1` VALUES (27,'');
+INSERT INTO `t1` VALUES (28,'');
+INSERT INTO `t1` VALUES (29,'');
+INSERT INTO `t1` VALUES (30,'');
+INSERT INTO `t1` VALUES (31,'');
+INSERT INTO `t1` VALUES (32,'');
+INSERT INTO `t1` VALUES (33,'');
+INSERT INTO `t1` VALUES (34,'');
+INSERT INTO `t1` VALUES (35,'');
+INSERT INTO `t1` VALUES (36,'');
 SELECT * FROM t1;
 c1	c2
 1	a
 2	b
 3	c
+4	NULL
+6	
+7	
+8	
+9	
+10	
+11	
+12	
+13	
+14		
+15	
+
+16	
+17	
+18	
+19	
+20	
+21	
+22	
+23	
+24	
+25	
+26	
+27	
+28	
+29	
+30	
+31	
+32	
+33	
+34	
+35	
+36	
 SELECT * FROM t2;
 ERROR 42S02: Table 'test.t2' doesn't exist
 DROP TABLE t1;

--- a/mysql-test/t/audit_log_json.test
+++ b/mysql-test/t/audit_log_json.test
@@ -7,6 +7,7 @@ SET GLOBAL audit_log_flush=ON;
 --remove_file $MYSQLD_DATADIR/test_audit.log
 SET GLOBAL audit_log_flush=ON;
 
+--let $test_control_chars=1;
 --source include/audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_json.log
@@ -14,10 +15,33 @@ set global audit_log_flush= ON;
 perl;
   eval "use JSON qw(decode_json); 1" or exit 0;
   open my $file, $ENV{'MYSQLD_DATADIR'} . '/test_audit_json.log' or die "Could not open log: $!";
+  my $found_1st_control_char = 0;
+  my $last_control_char = 0;
+  my $control_char_count = 0;
   while (my $line = <$file>) {
-      decode_json($line);
+      my $json = decode_json($line);
+      my $entry_type = $json->{audit_record}->{name};
+      if($entry_type eq "Query") {
+          my $query = $json->{audit_record}->{sqltext};
+          my @query_chars = sort($query =~ /./sg);
+          my $minimum_character = ord($query_chars[0]);
+          if ($minimum_character == 1) {
+              $found_1st_control_char = 1;
+          }
+          if ($found_1st_control_char && $control_char_count < 31) {
+              $control_char_count = $control_char_count + 1;
+              my $expected = $last_control_char + 1;
+              if ($expected != $minimum_character) {
+                   print "Incorrect control character in output: Expected $expected, got $minimum_character\n";
+                   exit l;
+              }
+              $last_control_char = $minimum_character;
+          }
+      }
+  }
+  if ($control_char_count != 31) {
+      print "Missing control characters from the output. Expected 31, got $control_char_count\n";
+      exit 2;
   }
   close $file;
 EOF
---remove_file $MYSQLD_DATADIR/test_audit.log
---remove_file $MYSQLD_DATADIR/test_audit_json.log


### PR DESCRIPTION
Implemented escaping for the JSON output format, and updated the test suite.

The other output formats are left unchanged, as they do not have a well defined method for escaping these characters.
XML does support control characters in version 1.1, but most tools only understand 1.0, and our output is 1.0.