### PR TITLE
PS-3767: Fixed clang 4/5 warnings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ matrix:
     - env: GCC=gcc-4.8   CXX=g++-4.8     LIBTYPE=system
     - env: GCC=gcc-7     CXX=g++-7       LIBTYPE=system  PACKAGES=g++-7     PPA=ubuntu-toolchain-r/test
     - env: GCC=gcc-7     CXX=g++-7       LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1" PACKAGES=g++-7     PPA=ubuntu-toolchain-r/test
-    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=system  PACKAGES=clang-5.0 LLVM=llvm-toolchain-trusty-5.0
+    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=system  PACKAGES="clang-5.0 llvm-5.0-dev" LLVM=llvm-toolchain-trusty-5.0
     # only for pull requests
     - env: GCC=gcc-5     CXX=g++-5       LIBTYPE=system  PACKAGES=g++-5     PPA=ubuntu-toolchain-r/test
     - env: GCC=gcc-6     CXX=g++-6       LIBTYPE=system  PACKAGES=g++-6     PPA=ubuntu-toolchain-r/test
-    - env: GCC=clang-4.0 CXX=clang++-4.0 LIBTYPE=system  PACKAGES=clang-4.0 PPA=ubuntu-toolchain-r/test LLVM=llvm-toolchain-trusty-4.0
-    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1" PACKAGES=clang-5.0 LLVM=llvm-toolchain-trusty-5.0
+    - env: GCC=clang-4.0 CXX=clang++-4.0 LIBTYPE=system  PACKAGES="clang-4.0 llvm-4.0-dev" PPA=ubuntu-toolchain-r/test LLVM=llvm-toolchain-trusty-4.0
+    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1" PACKAGES="clang-5.0 llvm-5.0-dev" LLVM=llvm-toolchain-trusty-5.0
 
 script:
   - export CC=$GCC

--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -2575,7 +2575,7 @@ static my_bool contains_autoinc_column(const char *autoinc_column,
       Check only the first (for PRIMARY KEY) or the second (for secondary keys)
       quoted identifier.
     */
-    if ((idnum == 1 + test(type != KEY_TYPE_PRIMARY)))
+    if (idnum == 1 + test(type != KEY_TYPE_PRIMARY))
       break;
 
     keydef= to + 1;

--- a/cmd-line-utils/readline/history.c
+++ b/cmd-line-utils/readline/history.c
@@ -211,14 +211,14 @@ history_get (offset)
 
 HIST_ENTRY *
 alloc_history_entry (string, ts)
-     char *string;
+     const char *string;
      char *ts;
 {
   HIST_ENTRY *temp;
 
   temp = (HIST_ENTRY *)xmalloc (sizeof (HIST_ENTRY));
 
-  temp->line = string ? savestring (string) : string;
+  temp->line = string ? savestring (string) : NULL;
   temp->data = (char *)NULL;
   temp->timestamp = ts;
 

--- a/extra/yassl/include/openssl/crypto.h
+++ b/extra/yassl/include/openssl/crypto.h
@@ -19,7 +19,7 @@
 
 /* crypto.h for openSSL */
 
-#ifndef ysSSL_crypto_h__
+#ifndef yaSSL_crypto_h__
 #define yaSSL_crypto_h__
 
 #ifdef YASSL_PREFIX

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -1379,7 +1379,8 @@ void set_stmt_errmsg(MYSQL_STMT *stmt, NET *net)
   DBUG_ASSERT(stmt != 0);
 
   stmt->last_errno= net->last_errno;
-  if (net->last_error && net->last_error[0])
+  compile_time_assert(sizeof(net->last_error) / sizeof(void*) > 1);
+  if (net->last_error[0])
     strmov(stmt->last_error, net->last_error);
   strmov(stmt->sqlstate, net->sqlstate);
 

--- a/libmysqld/lib_sql.cc
+++ b/libmysqld/lib_sql.cc
@@ -442,7 +442,8 @@ static MYSQL_RES * emb_store_result(MYSQL *mysql)
 int emb_read_change_user_result(MYSQL *mysql)
 {
   mysql->net.read_pos= (uchar*)""; // fake an OK packet
-  return mysql_errno(mysql) ? packet_error : 1 /* length of the OK packet */;
+  return mysql_errno(mysql) ? static_cast<int>(packet_error) : 
+                              1 /* length of the OK packet */;
 }
 
 MYSQL_METHODS embedded_methods= 

--- a/mysys/default.c
+++ b/mysys/default.c
@@ -818,7 +818,7 @@ static int search_default_file_with_ext(Process_option_func opt_handler,
       continue;
 
     /* Configuration File Directives */
-    if ((*ptr == '!'))
+    if (*ptr == '!')
     {
       if (recursion_level >= max_recursion_level)
       {

--- a/mysys/thr_lock.c
+++ b/mysys/thr_lock.c
@@ -375,17 +375,6 @@ has_old_lock(THR_LOCK_DATA *data, THR_LOCK_INFO *owner)
   return 0;
 }
 
-static inline my_bool have_specific_lock(THR_LOCK_DATA *data,
-					 enum thr_lock_type type)
-{
-  for ( ; data ; data=data->next)
-  {
-    if (data->type == type)
-      return 1;
-  }
-  return 0;
-}
-
 
 static void wake_up_waiters(THR_LOCK *lock);
 

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -49,10 +49,6 @@
   if this file.
 */
 
-#ifdef __GNUC__
-#pragma implementation				// gcc: Class implementation
-#endif
-
 #include "sql_priv.h"
 #include "sql_parse.h"                          // append_file_to_dir
 

--- a/sql/ha_partition.h
+++ b/sql/ha_partition.h
@@ -17,10 +17,6 @@
   along with this program; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-#ifdef __GNUC__
-#pragma interface				/* gcc class implementation */
-#endif
-
 #include "sql_partition.h"      /* part_id_range, partition_element */
 #include "queues.h"             /* QUEUE */
 

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -7035,7 +7035,9 @@ bool Item_default_value::fix_fields(THD *thd, Item **items)
   }
   if (!(def_field= (Field*) sql_alloc(field_arg->field->size_of())))
     goto error;
-  memcpy(def_field, field_arg->field, field_arg->field->size_of());
+  memcpy(static_cast<void*>(def_field),
+         static_cast<void*>(field_arg->field),
+         field_arg->field->size_of());
   def_field->move_field_offset((my_ptrdiff_t)
                                (def_field->table->s->default_values -
                                 def_field->table->record[0]));
@@ -7172,7 +7174,9 @@ bool Item_insert_value::fix_fields(THD *thd, Item **items)
     Field *def_field= (Field*) sql_alloc(field_arg->field->size_of());
     if (!def_field)
       return true;
-    memcpy(def_field, field_arg->field, field_arg->field->size_of());
+    memcpy(static_cast<void*>(def_field),
+           static_cast<void*>(field_arg->field),
+           field_arg->field->size_of());
     def_field->move_field_offset((my_ptrdiff_t)
                                  (def_field->table->insert_values -
                                   def_field->table->record[0]));

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -649,7 +649,6 @@ Item_exists_subselect::Item_exists_subselect(st_select_lex *select_lex):
   Item_subselect()
 {
   DBUG_ENTER("Item_exists_subselect::Item_exists_subselect");
-  bool val_bool();
   init(select_lex, new select_exists_subselect(this));
   max_columns= UINT_MAX;
   null_value= FALSE; //can't be NULL

--- a/sql/item_xmlfunc.cc
+++ b/sql/item_xmlfunc.cc
@@ -13,10 +13,6 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
 
-#ifdef __GNUC__
-#pragma implementation
-#endif
-
 #include "sql_priv.h"
 /*
   It is necessary to include set_var.h instead of item.h because there

--- a/sql/item_xmlfunc.h
+++ b/sql/item_xmlfunc.h
@@ -20,12 +20,6 @@
 
 /* This file defines all XML functions */
 
-
-#ifdef __GNUC__
-#pragma interface			/* gcc class implementation */
-#endif
-
-
 class Item_xml_str_func: public Item_str_func
 {
 protected:

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -1236,8 +1236,9 @@ bool LOGGER::slow_log_print(THD *thd, const char *query, uint query_length,
     }
 
     /* fill in user_host value: the format is "%s[%s] @ %s [%s]" */
+    compile_time_assert(sizeof(sctx->priv_user) / sizeof(void*) > 1);
     user_host_len= (strxnmov(user_host_buff, MAX_USER_HOST_SIZE,
-                             sctx->priv_user ? sctx->priv_user : "", "[",
+                             sctx->priv_user, "[",
                              sctx->user ? sctx->user : (thd->slave_thread ? "SQL_SLAVE" : ""), "] @ ",
                              sctx->get_host()->length() ?
                              sctx->get_host()->ptr() : "", " [",
@@ -2240,7 +2241,7 @@ static int find_uniq_filename(char *name, ulong *next, bool need_next)
   my_dirend(dir_info);
 
   /* check if reached the maximum possible extension number */
-  if ((max_found == MAX_LOG_UNIQUE_FN_EXT))
+  if (max_found == MAX_LOG_UNIQUE_FN_EXT)
   {
     sql_print_error("Log filename extension number exhausted: %06lu. \
 Please fix this by archiving old logs and \

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1164,7 +1164,7 @@ failed my_b_read"));
   Log_event *res=  0;
 #ifndef max_allowed_packet
   THD *thd=current_thd;
-  uint max_allowed_packet= thd ? slave_max_allowed_packet:~(ulong)0;
+  ulong max_allowed_packet= thd ? slave_max_allowed_packet:~(ulong)0;
 #endif
 
   if (data_len > max_allowed_packet)
@@ -2400,8 +2400,9 @@ bool Query_log_event::write(IO_CACHE* file)
       user= thd->get_invoker_user();
       host= thd->get_invoker_host();
     }
-    else if (thd->security_ctx->priv_user)
+    else
     {
+      compile_time_assert(sizeof(thd->security_ctx->priv_user) / sizeof(void*) > 1);
       Security_context *ctx= thd->security_ctx;
 
       user.length= strlen(ctx->priv_user);

--- a/sql/log_event_old.cc
+++ b/sql/log_event_old.cc
@@ -1724,7 +1724,7 @@ int Old_rows_log_event::do_apply_event(Relay_log_info const *rli)
 	rli->report(ERROR_LEVEL, thd->net.last_errno,
                     "Error in %s event: row application failed. %s",
                     get_type_str(),
-                    thd->net.last_error ? thd->net.last_error : "");
+                    thd->net.last_error);
        thd->is_slave_error= 1;
 	break;
       }
@@ -1764,7 +1764,7 @@ int Old_rows_log_event::do_apply_event(Relay_log_info const *rli)
                 "on table %s.%s. %s",
                 get_type_str(), table->s->db.str,
                 table->s->table_name.str,
-                thd->net.last_error ? thd->net.last_error : "");
+                thd->net.last_error);
 
     /*
       If one day we honour --skip-slave-errors in row-based replication, and

--- a/sql/opt_sum.cc
+++ b/sql/opt_sum.cc
@@ -81,7 +81,7 @@ static ulonglong get_exact_record_count(TABLE_LIST *tables)
   for (TABLE_LIST *tl= tables; tl; tl= tl->next_leaf)
   {
     ha_rows tmp= tl->table->file->records();
-    if ((tmp == HA_POS_ERROR))
+    if (tmp == HA_POS_ERROR)
       return ULONGLONG_MAX;
     count*= tmp;
   }

--- a/sql/slave.cc
+++ b/sql/slave.cc
@@ -4109,8 +4109,8 @@ static int queue_event(Master_info* mi,const char* buf, ulong event_len)
 
        TODO: handling `when' for SHOW SLAVE STATUS' snds behind
     */
-    if ((memcmp(mi->master_log_name, hb.get_log_ident(), hb.get_ident_len())
-         && mi->master_log_name != NULL)
+    compile_time_assert(sizeof(mi->master_log_name) / sizeof(void*) > 1);
+    if (memcmp(mi->master_log_name, hb.get_log_ident(), hb.get_ident_len())
         || mi->master_log_pos != hb.log_pos)
     {
       /* missed events of heartbeat from the past */
@@ -4368,7 +4368,8 @@ static int connect_to_master(THD* thd, MYSQL* mysql, Master_info* mi,
     mysql_options(mysql, MYSQL_PLUGIN_DIR, opt_plugin_dir_ptr);
 
   /* we disallow empty users */
-  if (mi->user == NULL || mi->user[0] == 0)
+  compile_time_assert(sizeof(mi->user) / sizeof(void*) > 1);
+  if (mi->user[0] == 0)
   {
     mi->report(ERROR_LEVEL, ER_SLAVE_FATAL_ERROR,
                ER(ER_SLAVE_FATAL_ERROR),
@@ -4504,8 +4505,8 @@ MYSQL *rpl_connect_master(MYSQL *mysql)
   /* This one is not strictly needed but we have it here for completeness */
   mysql_options(mysql, MYSQL_SET_CHARSET_DIR, (char *) charsets_dir);
 
-  if (mi->user == NULL
-      || mi->user[0] == 0
+  compile_time_assert(sizeof(mi->user) / sizeof(void*) > 1);
+  if (mi->user[0] == 0
       || io_slave_killed(thd, mi)
       || !mysql_real_connect(mysql, mi->host, mi->user, mi->password, 0,
                              mi->port, 0, 0))

--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -120,9 +120,10 @@ static audit_handler_t audit_handlers[] =
   general_class_handler, connection_class_handler
 };
 
+#if !defined(DBUG_OFF) && !defined(_lint)
 static const uint audit_handlers_count=
   (sizeof(audit_handlers) / sizeof(audit_handler_t));
-
+#endif
 
 /**
   Acquire and lock any additional audit plugins as required
@@ -345,8 +346,8 @@ int initialize_audit_plugin(st_plugin_int *plugin)
 {
   st_mysql_audit *data= (st_mysql_audit*) plugin->plugin->info;
   
-  if (!data->class_mask || !data->event_notify ||
-      !data->class_mask[0])
+  compile_time_assert(sizeof(data->class_mask) / sizeof(void*) > 0);
+  if (!data->event_notify || !data->class_mask[0])
   {
     sql_print_error("Plugin '%s' has invalid data.",
                     plugin->name.str);

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4031,8 +4031,8 @@ end_with_restore_list:
     LEX_USER *grant_user= get_current_user(thd, lex->grant_user);
     if (!grant_user)
       goto error;
-    if ((thd->security_ctx->priv_user &&
-	 !strcmp(thd->security_ctx->priv_user, grant_user->user.str)) ||
+    compile_time_assert(sizeof(thd->security_ctx->priv_user) / sizeof(void*) > 1);
+    if (!strcmp(thd->security_ctx->priv_user, grant_user->user.str) ||
         !check_access(thd, SELECT_ACL, "mysql", NULL, NULL, 1, 0))
     {
       res = mysql_show_grants(thd, grant_user);

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -283,7 +283,7 @@ bool partition_default_handling(TABLE *table, partition_info *part_info,
     }
   }
   part_info->set_up_defaults_for_partitioning(table->file,
-                                              (ulonglong)0, (uint)0);
+                                              NULL, (uint)0);
   DBUG_RETURN(FALSE);
 }
 

--- a/sql/sql_partition.h
+++ b/sql/sql_partition.h
@@ -16,10 +16,6 @@
   along with this program; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
-#ifdef __GNUC__
-#pragma interface				/* gcc class implementation */
-#endif
-
 #include "sql_list.h"                           /* List */
 #include "table.h"                              /* TABLE_LIST */
 

--- a/sql/sql_signal.cc
+++ b/sql/sql_signal.cc
@@ -61,21 +61,6 @@ const LEX_STRING Diag_condition_item_names[]=
   { C_STRING_WITH_LEN("TRIGGER_SCHEMA") }
 };
 
-const LEX_STRING Diag_statement_item_names[]=
-{
-  { C_STRING_WITH_LEN("NUMBER") },
-  { C_STRING_WITH_LEN("MORE") },
-  { C_STRING_WITH_LEN("COMMAND_FUNCTION") },
-  { C_STRING_WITH_LEN("COMMAND_FUNCTION_CODE") },
-  { C_STRING_WITH_LEN("DYNAMIC_FUNCTION") },
-  { C_STRING_WITH_LEN("DYNAMIC_FUNCTION_CODE") },
-  { C_STRING_WITH_LEN("ROW_COUNT") },
-  { C_STRING_WITH_LEN("TRANSACTIONS_COMMITTED") },
-  { C_STRING_WITH_LEN("TRANSACTIONS_ROLLED_BACK") },
-  { C_STRING_WITH_LEN("TRANSACTION_ACTIVE") }
-};
-
-
 Set_signal_information::Set_signal_information(
   const Set_signal_information& set)
 {

--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -943,7 +943,6 @@ static bool pack_fields(File file, List<Create_field> &create_fields,
     recpos= field->offset+1 + (uint) data_offset;
     int3store(buff+5,recpos);
     int2store(buff+8,field->pack_flag);
-    DBUG_ASSERT(field->unireg_check < 256);
     buff[10]= (uchar) field->unireg_check;
     buff[12]= (uchar) field->interval_id;
     buff[13]= (uchar) field->sql_type; 

--- a/storage/csv/ha_tina.cc
+++ b/storage/csv/ha_tina.cc
@@ -1457,9 +1457,9 @@ int ha_tina::rnd_end()
       DBUG_RETURN(-1);
 
     /* Open the file again */
-    if (((data_file= mysql_file_open(csv_key_file_data,
+    if ((data_file= mysql_file_open(csv_key_file_data,
                                      share->data_file_name,
-                                     O_RDONLY, MYF(MY_WME))) == -1))
+                                     O_RDONLY, MYF(MY_WME))) == -1)
       DBUG_RETURN(my_errno ? my_errno : -1);
     /*
       As we reopened the data file, increase share->data_file_version 

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -401,7 +401,6 @@ static const int bulk_padding= 64;              // bytes "overhead" in packet
 
 /* Variables used when chopping off trailing characters */
 static const uint sizeof_trailing_comma= sizeof(", ") - 1;
-static const uint sizeof_trailing_closeparen= sizeof(") ") - 1;
 static const uint sizeof_trailing_and= sizeof(" AND ") - 1;
 static const uint sizeof_trailing_where= sizeof(" WHERE ") - 1;
 
@@ -827,7 +826,7 @@ static int parse_url(MEM_ROOT *mem_root, FEDERATED_SHARE *share, TABLE *table,
         user:@hostname:port/db/table
         Then password is a null string, so set to NULL
       */
-      if ((share->password[0] == '\0'))
+      if (share->password[0] == '\0')
         share->password= NULL;
     }
     else

--- a/storage/innobase/fsp/fsp0fsp.c
+++ b/storage/innobase/fsp/fsp0fsp.c
@@ -432,43 +432,6 @@ xdes_find_bit(
 }
 
 /**********************************************************************//**
-Looks for a descriptor bit having the desired value. Scans the extent in
-a direction opposite to xdes_find_bit.
-@return	bit index of the bit, ULINT_UNDEFINED if not found */
-UNIV_INLINE
-ulint
-xdes_find_bit_downward(
-/*===================*/
-	xdes_t*	descr,	/*!< in: descriptor */
-	ulint	bit,	/*!< in: XDES_FREE_BIT or XDES_CLEAN_BIT */
-	ibool	val,	/*!< in: desired bit value */
-	ulint	hint,	/*!< in: hint of which bit position would be desirable */
-	mtr_t*	mtr)	/*!< in: mtr */
-{
-	ulint	i;
-
-	ut_ad(descr && mtr);
-	ut_ad(val <= TRUE);
-	ut_ad(hint < FSP_EXTENT_SIZE);
-	ut_ad(mtr_memo_contains_page(mtr, descr, MTR_MEMO_PAGE_X_FIX));
-	for (i = hint + 1; i > 0; i--) {
-		if (val == xdes_get_bit(descr, bit, i - 1, mtr)) {
-
-			return(i - 1);
-		}
-	}
-
-	for (i = FSP_EXTENT_SIZE - 1; i > hint; i--) {
-		if (val == xdes_get_bit(descr, bit, i, mtr)) {
-
-			return(i);
-		}
-	}
-
-	return(ULINT_UNDEFINED);
-}
-
-/**********************************************************************//**
 Returns the number of used pages in a descriptor.
 @return	number of pages used */
 UNIV_INLINE

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1938,6 +1938,7 @@ trx_is_registered_for_2pc(
 
 /*********************************************************************//**
 Note that a transaction owns the prepare_commit_mutex. */
+#ifndef EXTENDED_FOR_COMMIT_ORDERED
 static inline
 void
 trx_owns_prepare_commit_mutex_set(
@@ -1947,6 +1948,7 @@ trx_owns_prepare_commit_mutex_set(
 	ut_a(trx_is_registered_for_2pc(trx));
 	trx->owns_prepare_mutex = 1;
 }
+#endif // EXTENDED_FOR_COMMIT_ORDERED
 
 /*********************************************************************//**
 Note that a transaction has been registered with MySQL 2PC coordinator. */
@@ -7648,8 +7650,6 @@ create_table_def(
 			}
 		}
 
-		ut_a(field->type() < 256); /* we assume in dtype_form_prtype()
-					   that this fits in one byte */
 		col_len = field->pack_length();
 
 		/* The MySQL pack length contains 1 or 2 bytes length field

--- a/storage/innobase/os/os0sync.c
+++ b/storage/innobase/os/os0sync.c
@@ -227,24 +227,6 @@ os_cond_broadcast(
 }
 
 /*********************************************************//**
-Wakes one thread waiting for condition variable */
-UNIV_INLINE
-void
-os_cond_signal(
-/*==========*/
-	os_cond_t*	cond)	/*!< in: condition variable. */
-{
-	ut_a(cond);
-
-#ifdef __WIN__
-	ut_a(wake_condition_variable != NULL);
-	wake_condition_variable(cond);
-#else
-	ut_a(pthread_cond_signal(cond) == 0);
-#endif
-}
-
-/*********************************************************//**
 Destroys condition variable */
 UNIV_INLINE
 void

--- a/storage/innobase/sync/sync0sync.c
+++ b/storage/innobase/sync/sync0sync.c
@@ -315,9 +315,9 @@ mutex_create_func(
 
 	/* NOTE! The very first mutexes are not put to the mutex list */
 
-	if ((mutex == &mutex_list_mutex)
+	if (mutex == &mutex_list_mutex
 #ifdef UNIV_SYNC_DEBUG
-	    || (mutex == &sync_thread_mutex)
+	    || mutex == &sync_thread_mutex
 #endif /* UNIV_SYNC_DEBUG */
 	    ) {
 

--- a/strings/decimal.c
+++ b/strings/decimal.c
@@ -737,7 +737,7 @@ int decimal_shift(decimal_t *dec, int shift)
     if (do_left)
     {
       do_mini_left_shift(dec, l_mini_shift, beg, end);
-      mini_shift=- l_mini_shift;
+      mini_shift= -l_mini_shift;
     }
     else
     {


### PR DESCRIPTION
* Removed unneccessary parantheses from conditions
* Disabled the tautological constant out of range warning (static asserts would require c++11)
* Fixed a const char* -> char* conversion
* Changed null checks of arrays to compile time assertions that they are arrays
* Added some explicit casts
* Removed unused functions / variables
* Marked functions which are only used in some configurations as possibly unused