### PR TITLE
MYR-179 : Basic Sysbench run fails with basic MyROCKS install due to …

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_open_files_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_open_files_basic.result
@@ -1,7 +1,3 @@
-SET @start_global_value = @@global.ROCKSDB_MAX_OPEN_FILES;
-SELECT @start_global_value;
-@start_global_value
-1000
-"Trying to set variable @@global.ROCKSDB_MAX_OPEN_FILES to 444. It should fail because it is readonly."
-SET @@global.ROCKSDB_MAX_OPEN_FILES   = 444;
-ERROR HY000: Variable 'rocksdb_max_open_files' is a read only variable
+show variables like 'rocksdb_max_open_files';
+Variable_name	Value
+rocksdb_max_open_files	#

--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_open_files_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_max_open_files_basic.test
@@ -1,6 +1,8 @@
 --source include/have_rocksdb.inc
 
---let $sys_var=ROCKSDB_MAX_OPEN_FILES
---let $read_only=1
---let $session=0
---source ../include/rocksdb_sys_var.inc
+# We can not use rocksdb_sys_var.inc here as this is a global, read only option
+# whose value is dependent on the servers open_files_limit. It is more fully
+# tested in the rocksdb.max_open_files test.
+
+--replace_column 2 #
+show variables like 'rocksdb_max_open_files';

--- a/mysql-test/suite/rocksdb/r/max_open_files.result
+++ b/mysql-test/suite/rocksdb/r/max_open_files.result
@@ -1,5 +1,9 @@
 CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit*");
 # restart:--log-error=MYSQLTEST_VARDIR/tmp/rocksdb.max_open_files.err --rocksdb_max_open_files=over_rocksdb_max_open_files
+# restart:--rocksdb_max_open_files=under_rocksdb_max_open_files
+SELECT @@global.open_files_limit - 1 = @@global.rocksdb_max_open_files;
+@@global.open_files_limit - 1 = @@global.rocksdb_max_open_files
+1
 # restart:--rocksdb_max_open_files=0
 SELECT @@global.rocksdb_max_open_files;
 @@global.rocksdb_max_open_files
@@ -12,4 +16,8 @@ DROP TABLE t1;
 SELECT @@global.rocksdb_max_open_files;
 @@global.rocksdb_max_open_files
 -1
+# restart:--rocksdb_max_open_files=-2
+SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
+FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files
+1
 # restart

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -889,7 +889,7 @@ ERROR 42S02: Unknown table 'test.t45'
 # Now it fails if there is data overlap with what
 # already exists
 #
-show variables like 'rocksdb%';
+show variables where variable_name like 'rocksdb%' and variable_name not like 'rocksdb_max_open_files';
 Variable_name	Value
 rocksdb_access_hint_on_compaction_start	1
 rocksdb_advise_random_on_open	ON
@@ -959,7 +959,6 @@ rocksdb_max_background_jobs	2
 rocksdb_max_latest_deadlocks	5
 rocksdb_max_log_file_size	0
 rocksdb_max_manifest_file_size	18446744073709551615
-rocksdb_max_open_files	1000
 rocksdb_max_row_locks	1073741824
 rocksdb_max_subcompactions	1
 rocksdb_max_total_wal_size	0

--- a/mysql-test/suite/rocksdb/t/max_open_files.test
+++ b/mysql-test/suite/rocksdb/t/max_open_files.test
@@ -5,7 +5,8 @@
 # test for over limit
 CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit*");
 
---let $over_rocksdb_max_open_files=`SELECT @@global.open_files_limit + 2000000`
+--let $over_rocksdb_max_open_files=`SELECT @@global.open_files_limit + 100`
+--let $under_rocksdb_max_open_files=`SELECT @@global.open_files_limit -1`
 --let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/rocksdb.max_open_files.err
 --let SEARCH_PATTERN=RocksDB: rocksdb_max_open_files should not be greater than the open_files_limit
 
@@ -13,6 +14,13 @@ CALL mtr.add_suppression("RocksDB: rocksdb_max_open_files should not be greater 
 --let $restart_parameters=restart:--log-error=$SEARCH_FILE --rocksdb_max_open_files=$over_rocksdb_max_open_files
 --source include/restart_mysqld.inc
 --source include/search_pattern_in_file.inc
+
+# test for within limit
+--replace_result $under_rocksdb_max_open_files under_rocksdb_max_open_files
+--let $restart_parameters=restart:--rocksdb_max_open_files=$under_rocksdb_max_open_files
+--source include/restart_mysqld.inc
+
+SELECT @@global.open_files_limit - 1 = @@global.rocksdb_max_open_files;
 
 # test for minimal value
 --let $restart_parameters=restart:--rocksdb_max_open_files=0
@@ -26,11 +34,17 @@ INSERT INTO t1 VALUES(0),(1),(2),(3),(4);
 SET GLOBAL rocksdb_force_flush_memtable_and_lzero_now=1;
 DROP TABLE t1;
 
-# test for unlimited (former default)
+# test for unlimited
 --let $restart_parameters=restart:--rocksdb_max_open_files=-1
 --source include/restart_mysqld.inc
 
 SELECT @@global.rocksdb_max_open_files;
+
+# test for auto-tune
+--let $restart_parameters=restart:--rocksdb_max_open_files=-2
+--source include/restart_mysqld.inc
+
+SELECT FLOOR(@@global.open_files_limit / 2) = @@global.rocksdb_max_open_files;
 
 # cleanup
 --let $restart_parameters=

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -790,7 +790,10 @@ drop table t45;
 --echo # Now it fails if there is data overlap with what
 --echo # already exists
 --echo #
-show variables like 'rocksdb%';
+# We exclude rocksdb_max_open_files here because it value is dependent on
+# the value of the servers open_file_limit and is expected to be different
+# across distros and installs
+show variables where variable_name like 'rocksdb%' and variable_name not like 'rocksdb_max_open_files';
 create table t47 (pk int primary key, col1 varchar(12)) engine=rocksdb;
 insert into t47 values (1, 'row1');
 insert into t47 values (2, 'row2');

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -508,6 +508,7 @@ static std::unique_ptr<rocksdb::DBOptions> rdb_init_rocksdb_db_options(void) {
   o->listeners.push_back(std::make_shared<Rdb_event_listener>(&ddl_manager));
   o->info_log_level = rocksdb::InfoLogLevel::INFO_LEVEL;
   o->max_subcompactions = DEFAULT_SUBCOMPACTIONS;
+  o->max_open_files = -2; // auto-tune to 50% open_files_limit
 
   o->concurrent_prepare = true;
   o->manual_wal_flush = true;
@@ -854,7 +855,8 @@ static MYSQL_SYSVAR_BOOL(
 static MYSQL_SYSVAR_INT(max_open_files, rocksdb_db_options->max_open_files,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                         "DBOptions::max_open_files for RocksDB", nullptr,
-                        nullptr, 1000, /* min */ -1, /* max */ INT_MAX, 0);
+                        nullptr, rocksdb_db_options->max_open_files,
+                        /* min */ -2, /* max */ INT_MAX, 0);
 
 static MYSQL_SYSVAR_ULONG(max_total_wal_size,
                           rocksdb_db_options->max_total_wal_size,
@@ -3581,8 +3583,10 @@ static int rocksdb_init_func(void *const p) {
     sql_print_information("RocksDB: rocksdb_max_open_files should not be "
                           "greater than the open_files_limit, effective value "
                           "of rocksdb_max_open_files is being set to "
-                          "open_files_limit.");
-    rocksdb_db_options->max_open_files = open_files_limit;
+                          "open_files_limit / 2.");
+    rocksdb_db_options->max_open_files = open_files_limit / 2;
+  } else if (rocksdb_db_options->max_open_files == -2) {
+    rocksdb_db_options->max_open_files = open_files_limit / 2;
   }
 
   rocksdb_stats = rocksdb::CreateDBStatistics();


### PR DESCRIPTION
…lack of open files

- Discussed behavior changes with upstream, previous attempts to fix this
  uncovered a 'need' to be able to pass '-1' through to rocksdb for those
  users that want to or can do extreme tuning of their environment.
- New behavior is as follows:
  * -2 : 'auto-tune', silently set rocksdb_max_open_files to 1/2 of mysql open_files_limit
  * -1 : infinite, pass -1 to rocksdb
  * >= 0 and <= open_files_limit : take value as-is
  * > open_files_lmit : set rocksdb_max_open_files to 1/2 of mysql open_files_limit and emit a warning to the mysqld error log.