### PR TITLE
PS-3767: Fixed clang 4/5 warnings for PS 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ matrix:
     - env: GCC=gcc-4.8   CXX=g++-4.8     LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system"
     - env: GCC=gcc-7     CXX=g++-7       LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=g++-7     PPA=ubuntu-toolchain-r/test
     - env: GCC=gcc-7     CXX=g++-7       LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1"           PACKAGES=g++-7     PPA=ubuntu-toolchain-r/test
-    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=clang-5.0 LLVM=llvm-toolchain-trusty-5.0
+    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES="clang-5.0 llvm-5.0-dev" LLVM=llvm-toolchain-trusty-5.0
     # only for pull requests
     - env: GCC=gcc-5     CXX=g++-5       LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=g++-5     PPA=ubuntu-toolchain-r/test
     - env: GCC=gcc-6     CXX=g++-6       LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=g++-6     PPA=ubuntu-toolchain-r/test
-    - env: GCC=clang-4.0 CXX=clang++-4.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=clang-4.0 PPA=ubuntu-toolchain-r/test LLVM=llvm-toolchain-trusty-4.0
-    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1"           PACKAGES=clang-5.0 LLVM=llvm-toolchain-trusty-5.0
+    - env: GCC=clang-4.0 CXX=clang++-4.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES="clang-4.0 llvm-4.0-dev" PPA=ubuntu-toolchain-r/test LLVM=llvm-toolchain-trusty-4.0
+    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1"           PACKAGES="clang-5.0 llvm-5.0-dev" LLVM=llvm-toolchain-trusty-5.0
 
 script:
   - export CC=$GCC

--- a/client/mysqldump.c
+++ b/client/mysqldump.c
@@ -2752,7 +2752,7 @@ static my_bool contains_autoinc_column(const char *autoinc_column,
       Check only the first (for PRIMARY KEY) or the second (for secondary keys)
       quoted identifier.
     */
-    if ((idnum == 1 + MY_TEST(type != KEY_TYPE_PRIMARY)))
+    if (idnum == 1 + MY_TEST(type != KEY_TYPE_PRIMARY))
       break;
 
     keydef= to + 1;

--- a/libmysql/libmysql.c
+++ b/libmysql/libmysql.c
@@ -1398,7 +1398,8 @@ void set_stmt_errmsg(MYSQL_STMT *stmt, NET *net)
   DBUG_ASSERT(stmt != 0);
 
   stmt->last_errno= net->last_errno;
-  if (net->last_error && net->last_error[0])
+  compile_time_assert(sizeof(net->last_error) / sizeof(void*) > 1);
+  if (net->last_error[0])
     strmov(stmt->last_error, net->last_error);
   strmov(stmt->sqlstate, net->sqlstate);
 

--- a/plugin/connection_control/security_context_wrapper.cc
+++ b/plugin/connection_control/security_context_wrapper.cc
@@ -59,19 +59,15 @@ namespace connection_control
     {
       if (!strcmp(property, "priv_user"))
       {
-        if (m_thd->security_ctx->priv_user)
-        {
-          value->str= m_thd->security_ctx->priv_user;
-          value->length= strlen(value->str);
-        }
+        compile_time_assert (sizeof(m_thd->security_ctx->priv_user) / sizeof(void*) > 1);
+        value->str= m_thd->security_ctx->priv_user;
+        value->length= strlen(value->str);
       }
       else if (!strcmp(property, "priv_host"))
       {
-        if (m_thd->security_ctx->priv_host)
-        {
-          value->str= m_thd->security_ctx->priv_host;
-          value->length= strlen(value->str);
-        }
+        compile_time_assert (sizeof(m_thd->security_ctx->priv_host) / sizeof(void*) > 1);
+        value->str= m_thd->security_ctx->priv_host;
+        value->length= strlen(value->str);
       }
       else if (!strcmp(property, "user"))
       {
@@ -83,11 +79,9 @@ namespace connection_control
       }
       else if (!strcmp(property, "proxy_user"))
       {
-        if (m_thd->security_ctx->proxy_user)
-        {
-          value->str= m_thd->security_ctx->proxy_user;
-          value->length= strlen(value->str);
-        }
+        compile_time_assert (sizeof(m_thd->security_ctx->proxy_user) / sizeof(void*) > 1);
+        value->str= m_thd->security_ctx->proxy_user;
+        value->length= strlen(value->str);
       }
       else if (!strcmp(property, "host"))
       {

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -284,11 +284,12 @@ static void tokudb_backup_error_fun(int error_number, const char *error_string, 
 static bool tokudb_backup_check_slave_sql_thread_running(THD *thd) {
      scoped_lock_wrapper<BasicLockableMysqlMutextT>
         with_LOCK_active_mi_locked(
-        BasicLockableMysqlMutextT(&LOCK_active_mi));
+        (BasicLockableMysqlMutextT(LOCK_active_mi)));
 
     Master_info *mi = active_mi;
 
-    if (!mi || !mi->inited || !mi->host || !mi->host[0])
+    compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+    if (!mi || !mi->inited || !mi->host[0])
         return false;
 
     scoped_lock_wrapper<BasicLockableMysqlMutextT>
@@ -319,11 +320,12 @@ static bool tokudb_backup_stop_slave_sql_thread(THD *thd) {
     {
         scoped_lock_wrapper<BasicLockableMysqlMutextT>
             with_LOCK_active_mi_locked(
-            BasicLockableMysqlMutextT(&LOCK_active_mi));
+            (BasicLockableMysqlMutextT(LOCK_active_mi)));
 
         Master_info *mi = active_mi;
 
-        if (!mi || !mi->inited || !mi->host || !mi->host[0])
+        compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+        if (!mi || !mi->inited || !mi->host[0])
             return true;
 
         stop_slave_result = stop_slave(thd, mi, 0);
@@ -352,11 +354,12 @@ static bool tokudb_backup_start_slave_sql_thread(THD *thd) {
     {
         scoped_lock_wrapper<BasicLockableMysqlMutextT>
             with_LOCK_active_mi_locked(
-            BasicLockableMysqlMutextT(&LOCK_active_mi));
+            (BasicLockableMysqlMutextT(LOCK_active_mi)));
 
         Master_info *mi = active_mi;
 
-        if (!mi || !mi->inited || !mi->host || !mi->host[0])
+        compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+        if (!mi || !mi->inited || !mi->host[0])
             return true;
 
         start_slave_result = start_slave(thd, mi, 0);
@@ -399,11 +402,10 @@ static bool tokudb_backup_wait_for_safe_slave(THD *thd, uint timeout) {
     }
 
     if (!n_attemts &&
-        slave_open_temp_tables) {
-
-        (sql_thread_started &&
+        slave_open_temp_tables &&
+        sql_thread_started &&
         !tokudb_backup_check_slave_sql_thread_running(thd) &&
-        !tokudb_backup_start_slave_sql_thread(thd));
+        !tokudb_backup_start_slave_sql_thread(thd)) {
 
         return false;
     }
@@ -475,11 +477,12 @@ static void tokudb_backup_get_master_infos(
     {
         scoped_lock_wrapper<BasicLockableMysqlMutextT>
             with_LOCK_active_mi_locked(
-            BasicLockableMysqlMutextT(&LOCK_active_mi));
+            (BasicLockableMysqlMutextT(LOCK_active_mi)));
 
         Master_info *mi = active_mi;
 
-        if (!mi || !mi->inited || !mi->host || !mi->host[0])
+        compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+        if (!mi || !mi->inited || !mi->host[0])
             return;
 
         std::string executed_gtid_set = tokudb_backup_get_executed_gtids_set();

--- a/sql/field.h
+++ b/sql/field.h
@@ -2194,10 +2194,15 @@ protected:
   uint8 dec; // Number of fractional digits
 
   /**
-    Adjust number of decimal digits from NOT_FIXED_DEC to DATETIME_MAX_DECIMALS
+    Adjust number of decimal digits from NOT_FIXED_DEC to DATETIME_MAX_DECIMALS,
+    and store it in the data member. Then return a modified value required by Field's
+    constructor.
   */
   uint8 normalize_dec(uint8 dec_arg)
-  { return dec_arg == NOT_FIXED_DEC ? DATETIME_MAX_DECIMALS : dec_arg; }
+  { 
+    dec= dec_arg == NOT_FIXED_DEC ? DATETIME_MAX_DECIMALS : dec_arg; 
+    return dec ? dec + 1 : dec;
+  }
 
   /**
     Low level routine to store a MYSQL_TIME value into a field.
@@ -2347,7 +2352,7 @@ public:
                  enum utype unireg_check_arg, const char *field_name_arg,
                  uint32 len_arg, uint8 dec_arg)
     :Field(ptr_arg,
-           len_arg + ((dec= normalize_dec(dec_arg)) ? dec + 1 : 0),
+           len_arg + normalize_dec(dec_arg),
            null_ptr_arg, null_bit_arg,
            unireg_check_arg, field_name_arg)
     { flags|= BINARY_FLAG; }
@@ -2361,7 +2366,7 @@ public:
   Field_temporal(bool maybe_null_arg, const char *field_name_arg,
                  uint32 len_arg, uint8 dec_arg)
     :Field((uchar *) 0, 
-           len_arg + ((dec= normalize_dec(dec_arg)) ? dec + 1 : 0),
+           len_arg + normalize_dec(dec_arg),
            maybe_null_arg ? (uchar *) "" : 0, 0,
            NONE, field_name_arg)
     { flags|= BINARY_FLAG; }

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -193,6 +193,7 @@ TABLE_FIELD_TYPE mysql_db_table_fields[MYSQL_DB_FIELD_COUNT] = {
   }
 };
 
+#ifndef NO_EMBEDDED_ACCESS_CHECKS
 static const
 TABLE_FIELD_TYPE mysql_user_table_fields[MYSQL_USER_FIELD_COUNT] = {
   {
@@ -579,11 +580,13 @@ TABLE_FIELD_TYPE mysql_tables_priv_table_fields[MYSQL_TABLES_PRIV_FIELD_COUNT] =
     { C_STRING_WITH_LEN("utf8") }
   }
 };
+#endif // NO_EMBEDDED_ACCESS_CHECKS
 
 
 const TABLE_FIELD_DEF
   mysql_db_table_def= {MYSQL_DB_FIELD_COUNT, mysql_db_table_fields};
 
+#ifndef NO_EMBEDDED_ACCESS_CHECKS
 const TABLE_FIELD_DEF
   mysql_user_table_def= {MYSQL_USER_FIELD_COUNT, mysql_user_table_fields};
 
@@ -602,6 +605,7 @@ const TABLE_FIELD_DEF
 const TABLE_FIELD_DEF
   mysql_tables_priv_table_def= {MYSQL_TABLES_PRIV_FIELD_COUNT,
                                 mysql_tables_priv_table_fields};
+#endif // NO_EMBEDDED_ACCESS_CHECKS
 
 static LEX_STRING native_password_plugin_name= {
   C_STRING_WITH_LEN("mysql_native_password")

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5418,7 +5418,7 @@ public:
   inline static int get_cost_calc_buff_size(ulong nkeys, uint key_size, 
                                             ulonglong max_in_memory_size)
   {
-    register ulonglong max_elems_in_tree=
+    ulonglong max_elems_in_tree=
       (max_in_memory_size / ALIGN_SIZE(sizeof(TREE_ELEMENT)+key_size));
     return (int) (sizeof(uint)*(1 + nkeys/max_elems_in_tree));
   }

--- a/sql/sql_join_buffer.h
+++ b/sql/sql_join_buffer.h
@@ -342,7 +342,9 @@ protected:
   /* Shall calculate how much space is remaining in the join buffer */ 
   virtual ulong rem_space() 
   { 
-    return std::max<ulong>(buff_size-(end_pos-buff)-aux_buff_size, 0UL);
+    return static_cast<ulong>(
+      std::max<long>(buff_size-(end_pos-buff)-aux_buff_size, 0L)
+    );
   }
 
   /* Shall skip record from the join buffer if its match flag is on */
@@ -808,7 +810,9 @@ protected:
   */ 
   ulong rem_space() 
   { 
-    return std::max<ulong>(last_key_entry-end_pos-aux_buff_size, 0UL);
+    return static_cast<ulong>(
+      std::max<long>(last_key_entry-end_pos-aux_buff_size, 0L)
+    );
   }
 
   /* 

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -282,8 +282,7 @@ dict_mem_table_add_col(
 	const char*	name,	/*!< in: column name, or NULL */
 	ulint		mtype,	/*!< in: main datatype */
 	ulint		prtype,	/*!< in: precise type */
-	ulint		len)	/*!< in: precision */
-	MY_ATTRIBUTE((nonnull(1)));
+	ulint		len);	/*!< in: precision */
 /**********************************************************************//**
 Renames a column of a table in the data dictionary cache. */
 UNIV_INTERN

--- a/storage/tokudb/tokudb_information_schema.cc
+++ b/storage/tokudb/tokudb_information_schema.cc
@@ -1085,7 +1085,7 @@ ST_FIELD_INFO background_job_status_field_info[] = {
     {"scheduler", 32, MYSQL_TYPE_STRING, 0, 0, NULL, SKIP_OPEN_TABLE },
     {"scheduled_time", 0, MYSQL_TYPE_DATETIME, 0, 0, NULL, SKIP_OPEN_TABLE },
     {"started_time", 0, MYSQL_TYPE_DATETIME, 0, MY_I_S_MAYBE_NULL, NULL, SKIP_OPEN_TABLE },
-    {"status", 1024, MYSQL_TYPE_STRING, 0, MY_I_S_MAYBE_NULL, SKIP_OPEN_TABLE },
+    {"status", 1024, MYSQL_TYPE_STRING, 0, MY_I_S_MAYBE_NULL, NULL, SKIP_OPEN_TABLE },
     {NULL, 0, MYSQL_TYPE_NULL, 0, 0, NULL, SKIP_OPEN_TABLE}
 };
 


### PR DESCRIPTION
Not all changes for TokuDB are part of this build - only tokudb code in this repository.

* Removed unneccessary parantheses from conditions
* Changed null checks of arrays to compile time assertions that they are arrays
* Added some explicit casts
* Refactored a constructor for the Field class
* Fixed a struct initializer in tokudb_information_schema
* Fixed scoped locks in tokudb, which were treated as function declarations before.