### PR TITLE
[LP-1738742] error while stoping mysql using mysqld_safe

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -215,6 +215,7 @@ eval_log_error () {
 
   #echo "Running mysqld: [$cmd]"
   eval "$cmd"
+  ret=$?
   if [ $ret -gt 0 ] && [ $ret -lt 128 ]; then
     exit $ret
   fi


### PR DESCRIPTION
Creating var directory '/usr/lib/mysql-test/var'...
Installing system database...
Using parallel: 1

==============================================================================

TEST                                      RESULT   TIME (ms) or COMMENT
--------------------------------------------------------------------------

worker[1] Using MTR_BUILD_THREAD 300, with reserved ports 13000..13009
main.mysqld_safe                         [ pass ]  11139
--------------------------------------------------------------------------
The servers were restarted 0 times
Spent 11.139 of 17 seconds executing testcases

Completed: All 1 tests were successful.

