### PR TITLE
PS-3767: Fixed clang 4/5 warnings for PS 5.7.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ matrix:
     - env: GCC=gcc-4.8   CXX=g++-4.8     LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system"
     - env: GCC=gcc-7     CXX=g++-7       LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=g++-7     PPA=ubuntu-toolchain-r/test
     - env: GCC=gcc-7     CXX=g++-7       LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1"           PACKAGES=g++-7     PPA=ubuntu-toolchain-r/test
-    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=clang-5.0 LLVM=llvm-toolchain-trusty-5.0
+    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES="clang-5.0 llvm-5.0-dev" LLVM=llvm-toolchain-trusty-5.0
     # only for pull requests
     - env: GCC=gcc-5     CXX=g++-5       LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=g++-5     PPA=ubuntu-toolchain-r/test
     - env: GCC=gcc-6     CXX=g++-6       LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=g++-6     PPA=ubuntu-toolchain-r/test
-    - env: GCC=clang-4.0 CXX=clang++-4.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=clang-4.0 PPA=ubuntu-toolchain-r/test LLVM=llvm-toolchain-trusty-4.0
-    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1"           PACKAGES=clang-5.0 LLVM=llvm-toolchain-trusty-5.0
+    - env: GCC=clang-4.0 CXX=clang++-4.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES="clang-4.0 llvm-4.0-dev" PPA=ubuntu-toolchain-r/test LLVM=llvm-toolchain-trusty-4.0
+    - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1"           PACKAGES="clang-5.0 llvm-5.0-dev" LLVM=llvm-toolchain-trusty-5.0
 
 script:
   - export CC=$GCC

--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -1430,7 +1430,7 @@ int main(int argc,char *argv[])
     "statement.\n");
   put_info(buff,INFO_INFO);
 
-  uint protocol, ssl_mode;
+  uint protocol= 0, ssl_mode= 0;
   if (!mysql_get_option(&mysql, MYSQL_OPT_PROTOCOL, &protocol) &&
       !mysql_get_option(&mysql, MYSQL_OPT_SSL_MODE, &ssl_mode))
   {

--- a/client/mysqladmin.cc
+++ b/client/mysqladmin.cc
@@ -1093,6 +1093,7 @@ static int execute_commands(MYSQL *mysql,int argc, char **argv)
       /* Warn about password being set in non ssl connection */
 #if defined(HAVE_OPENSSL) && !defined(EMBEDDED_LIBRARY)
       uint ssl_mode;
+      ssl_mode= 0;
       if (!mysql_get_option(mysql, MYSQL_OPT_SSL_MODE, &ssl_mode) &&
           ssl_mode <= SSL_MODE_PREFERRED)
       {

--- a/mysys_ssl/yassl.cc
+++ b/mysys_ssl/yassl.cc
@@ -107,6 +107,7 @@ static int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx, const EVP_CIPHER *cipher,
   return 1;
 }
 
+#ifndef NDEBUG
 static int EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx)
 {
   return ctx->key_len;
@@ -116,6 +117,7 @@ static int EVP_CIPHER_CTX_iv_length(const EVP_CIPHER_CTX *ctx)
 {
   return ctx->flags & EVP_CIPH_ECB_MODE ? 0 : TaoCrypt::AES::BLOCK_SIZE;
 }
+#endif
 
 static void do_whole_blocks(EVP_CIPHER_CTX *ctx, uchar *out, int *outl,
                             const uchar *in, int inl)

--- a/plugin/keyring_vault/vault_curl.cc
+++ b/plugin/keyring_vault/vault_curl.cc
@@ -17,7 +17,9 @@ static const size_t max_response_size = 32000000;
 static MY_TIMER_INFO curl_timer_info;
 static ulonglong last_ping_time;
 static bool was_thd_wait_started = false;
+#ifndef NDEBUG
 static const ulonglong slow_connection_threshold = 100; // [ms]
+#endif
 
 class Thd_wait_end_guard
 {

--- a/plugin/tokudb-backup-plugin/tokudb_backup.cc
+++ b/plugin/tokudb-backup-plugin/tokudb_backup.cc
@@ -318,7 +318,8 @@ static bool tokudb_backup_check_slave_sql_thread_running(THD *thd) {
          ++it)
     {
         Master_info *mi= it->second;
-        if (mi != NULL && mi->inited && mi->host && mi->host[0]) {
+        compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+        if (mi != NULL && mi->inited && mi->host[0]) {
             have_slave = true;
             scoped_lock_wrapper<BasicLockableMysqlMutextT>
                 with_mi_data_locked_1(BasicLockableMysqlMutextT(
@@ -359,7 +360,8 @@ static bool tokudb_backup_stop_slave_sql_thread(THD *thd) {
              ++it)
         {
             Master_info *mi = it->second;
-            if (mi && mi->inited && mi->host && mi->host[0]) {
+            compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+            if (mi && mi->inited && mi->host[0]) {
                 bool temp_tables_warning = false;
                 have_slave = true;
                 result = !stop_slave(thd, mi, 0, 0, &temp_tables_warning);
@@ -398,7 +400,8 @@ static bool tokudb_backup_start_slave_sql_thread(THD *thd) {
              ++it)
         {
             Master_info *mi= it->second;
-            if (mi && mi->inited && mi->host && mi->host[0]) {
+            compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+            if (mi && mi->inited && mi->host[0]) {
                 have_slave = true;
                 result = !start_slave(thd,
                                       &thd->lex->slave_connection,
@@ -457,11 +460,10 @@ static bool tokudb_backup_wait_for_safe_slave(THD *thd, uint timeout) {
     }
 
     if (!n_attemts &&
-        slave_open_temp_tables.atomic_get()) {
-
-        (sql_thread_started &&
+        slave_open_temp_tables.atomic_get() &&
+        sql_thread_started &&
         !tokudb_backup_check_slave_sql_thread_running(thd) &&
-        !tokudb_backup_start_slave_sql_thread(thd));
+        !tokudb_backup_start_slave_sql_thread(thd)) {
 
         return false;
     }
@@ -576,7 +578,8 @@ static void tokudb_backup_get_master_infos(
          ++it)
     {
         mi= it->second;
-        if (mi != NULL && mi->host && mi->host[0])
+        compile_time_assert(sizeof(mi->host) / sizeof(void*) > 1);
+        if (mi != NULL && mi->host[0])
             tokudb_backup_get_master_info(mi,
                                           executed_gtid_set,
                                           master_info_channels);

--- a/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_state_exchange.cc
+++ b/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_state_exchange.cc
@@ -300,8 +300,10 @@ void Gcs_xcom_state_exchange::reset_with_flush()
 
 void Gcs_xcom_state_exchange::reset()
 {
+#ifndef NDEBUG
   Gcs_xcom_communication_interface *binding_broadcaster=
     static_cast<Gcs_xcom_communication_interface *>(m_broadcaster);
+#endif
   assert(binding_broadcaster->number_buffered_messages() == 0);
 
   m_configuration_id= null_synode;

--- a/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xdr_utils.h
+++ b/rapid/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xdr_utils.h
@@ -25,7 +25,9 @@ extern "C" {
 /**
     Initialize an array
  */
-#define def_init_xdr_array(name) static inline void init_##name##_array(name##_array *x)
+#define def_init_xdr_array(name) \
+  MY_ATTRIBUTE((unused)) \
+  static inline void init_##name##_array(name##_array *x)
 #define init_xdr_array(name)                                                 \
   def_init_xdr_array(name) {                                                 \
     x->name##_array_len = 2;                                                 \
@@ -35,7 +37,9 @@ extern "C" {
 /**
     Free the contents of an array
  */
-#define def_free_xdr_array(name) static inline void free_##name##_array(name##_array *x)
+#define def_free_xdr_array(name) \
+  MY_ATTRIBUTE((unused)) \
+  static inline void free_##name##_array(name##_array *x)
 #define free_xdr_array(name)\
 def_free_xdr_array(name)\
 {\
@@ -62,6 +66,7 @@ def_free_xdr_array(name)\
     Define a set function for an array
  */
 #define def_set_xdr_array(name) \
+  MY_ATTRIBUTE((unused)) \
   static inline void set_##name(name##_array *x, name a, u_int n)
 #define set_xdr_array(name)          \
   def_set_xdr_array(name) {          \
@@ -73,7 +78,9 @@ def_free_xdr_array(name)\
 /**
     Define a get function for an array
  */
-#define def_get_xdr_array(name) static inline name get_##name(name##_array *x, u_int n)
+#define def_get_xdr_array(name) \
+  MY_ATTRIBUTE((unused)) \
+  static inline name get_##name(name##_array *x, u_int n)
 #define get_xdr_array(name)                     \
   def_get_xdr_array(name)                       \
   {                                             \
@@ -87,6 +94,7 @@ def_free_xdr_array(name)\
     Define a function to clone an array
  */
 #define def_clone_xdr_array(name) \
+  MY_ATTRIBUTE((unused)) \
   static inline name##_array clone_##name##_array(name##_array x)
 #define clone_xdr_array(name)                                                \
   def_clone_xdr_array(name) {                                                \

--- a/rapid/plugin/x/mysqlxtest_src/mysqlxtest.cc
+++ b/rapid/plugin/x/mysqlxtest_src/mysqlxtest.cc
@@ -57,7 +57,6 @@
 const char * const CMD_ARG_BE_QUIET = "be-quiet";
 const char * const MYSQLXTEST_VERSION = "1.0";
 const char CMD_ARG_SEPARATOR = '\t';
-const unsigned short MYSQLX_PORT = 33060;
 
 #include <mysql/service_my_snprintf.h>
 #include <mysql.h>

--- a/sql/item_geofunc.cc
+++ b/sql/item_geofunc.cc
@@ -1867,7 +1867,7 @@ append_geometry(Geometry::wkb_parser *parser, Json_object *geometry,
         }
         else
         {
-          bool result;
+          bool result= false;
           Json_array *points= new (std::nothrow) Json_array();
           if (points == NULL || collection->append_alias(points))
             return true;

--- a/sql/sql_join_buffer.h
+++ b/sql/sql_join_buffer.h
@@ -344,7 +344,9 @@ protected:
   /* Shall calculate how much space is remaining in the join buffer */ 
   virtual ulong rem_space() 
   { 
-    return std::max<ulong>(buff_size-(end_pos-buff)-aux_buff_size, 0UL);
+    return static_cast<ulong>(
+      std::max<long>(buff_size-(end_pos-buff)-aux_buff_size, 0L)
+    );
   }
 
   /* Shall skip record from the join buffer if its match flag is on */
@@ -812,8 +814,9 @@ protected:
   */ 
   ulong rem_space() 
   { 
-    return std::max(static_cast<ulong>(last_key_entry - end_pos-aux_buff_size),
-                    0UL);
+    return static_cast<ulong>(
+      std::max<long>(last_key_entry - end_pos-aux_buff_size, 0L)
+    );
   }
 
   /* 

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -663,8 +663,8 @@ public:
 
 		/* e.g. "btr0cur", derived from "/path/to/btr0cur.cc" */
 		char		keyname[FILENAME_MAX];
-		const size_t	len = ut_basename_noext(file, keyname,
-							sizeof(keyname));
+		const size_t	len MY_ATTRIBUTE((unused)) =
+			ut_basename_noext(file, keyname, sizeof(keyname));
 		/* If sizeof(keyname) was not enough then the output would
 		be truncated, assert that this did not happen. */
 		ut_a(len < sizeof(keyname));

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -43,6 +43,10 @@ IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   ENDIF()
 ENDIF()
 
+# Relax unused variable warnings
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable")
+SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable")
+
 # check that compiler supports cxx11 and set options
 INCLUDE (check_stdcxx11)
 IF (!HAVE_STDCXX11)

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -11466,9 +11466,9 @@ const char *get_rdb_io_error_string(const RDB_IO_ERROR_TYPE err_type) {
 // In case of core dump generation we want this function NOT to be optimized
 // so that we can capture as much data as possible to debug the root cause
 // more efficiently.
-#pragma GCC push_options
-#pragma GCC optimize("O0")
-
+#if defined(DBUG_OFF)
+MY_ATTRIBUTE((optnone))
+#endif
 void rdb_handle_io_error(const rocksdb::Status status,
                          const RDB_IO_ERROR_TYPE err_type) {
   if (status.IsIOError()) {
@@ -11516,8 +11516,6 @@ void rdb_handle_io_error(const rocksdb::Status status,
     }
   }
 }
-
-#pragma GCC pop_options
 
 Rdb_dict_manager *rdb_get_dict_manager(void) { return &dict_manager; }
 

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -613,9 +613,9 @@ class ha_rocksdb : public my_core::handler {
                       Rdb_tbl_def *const tbl_def_arg,
                       const TABLE *const old_table_arg = nullptr,
                       const Rdb_tbl_def *const old_tbl_def_arg = nullptr) const
-      MY_ATTRIBUTE((__nonnull__(2, 3), __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   int secondary_index_read(const int keyno, uchar *const buf)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   void setup_iterator_for_rnd_scan();
   void setup_scan_iterator(const Rdb_key_def &kd, rocksdb::Slice *const slice)
       MY_ATTRIBUTE((__nonnull__)) {
@@ -625,8 +625,7 @@ class ha_rocksdb : public my_core::handler {
                     enum ha_rkey_function find_flag) const
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
   void setup_scan_iterator(const Rdb_key_def &kd, rocksdb::Slice *slice,
-                           const bool use_all_keys, const uint eq_cond_len)
-      MY_ATTRIBUTE((__nonnull__));
+                           const bool use_all_keys, const uint eq_cond_len);
   void release_scan_iterator(void);
 
   rocksdb::Status
@@ -637,7 +636,7 @@ class ha_rocksdb : public my_core::handler {
 
   int get_row_by_rowid(uchar *const buf, const char *const rowid,
                        const uint rowid_size, const bool skip_ttl_check = true)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   int get_row_by_rowid(uchar *const buf, const uchar *const rowid,
                        const uint rowid_size, const bool skip_ttl_check = true)
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__)) {
@@ -650,15 +649,15 @@ class ha_rocksdb : public my_core::handler {
   longlong update_hidden_pk_val();
   int load_hidden_pk_value() MY_ATTRIBUTE((__warn_unused_result__));
   int read_hidden_pk_id_from_rowkey(longlong *const hidden_pk_id)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   bool can_use_single_delete(const uint &index) const
       MY_ATTRIBUTE((__warn_unused_result__));
   bool skip_unique_check() const MY_ATTRIBUTE((__warn_unused_result__));
   bool commit_in_the_middle() MY_ATTRIBUTE((__warn_unused_result__));
   bool do_bulk_commit(Rdb_transaction *const tx)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   bool has_hidden_pk(const TABLE *const table) const
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   void update_row_stats(const operation_type &type);
 
@@ -709,7 +708,7 @@ class ha_rocksdb : public my_core::handler {
   int alloc_key_buffers(const TABLE *const table_arg,
                         const Rdb_tbl_def *const tbl_def_arg,
                         bool alloc_alter_buffers = false)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   void free_key_buffers();
 
   // the buffer size should be at least 2*Rdb_key_def::INDEX_NUMBER_SIZE
@@ -837,7 +836,7 @@ public:
   }
 
   int rename_table(const char *const from, const char *const to) override
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   int convert_blob_from_storage_format(my_core::Field_blob *const blob,
                                        Rdb_string_reader *const reader,
@@ -857,7 +856,7 @@ public:
   int convert_record_from_storage_format(const rocksdb::Slice *const key,
                                          const rocksdb::Slice *const value,
                                          uchar *const buf)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   int convert_record_from_storage_format(const rocksdb::Slice *const key,
                                          uchar *const buf)
@@ -874,27 +873,27 @@ public:
   static const char *get_key_name(const uint index,
                                   const TABLE *const table_arg,
                                   const Rdb_tbl_def *const tbl_def_arg)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   static const char *get_key_comment(const uint index,
                                      const TABLE *const table_arg,
                                      const Rdb_tbl_def *const tbl_def_arg)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   static const std::string get_table_comment(const TABLE *const table_arg)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   static bool is_hidden_pk(const uint index, const TABLE *const table_arg,
                            const Rdb_tbl_def *const tbl_def_arg)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   static uint pk_index(const TABLE *const table_arg,
                        const Rdb_tbl_def *const tbl_def_arg)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   static bool is_pk(const uint index, const TABLE *table_arg,
                     const Rdb_tbl_def *tbl_def_arg)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   /** @brief
     unireg.cc will call max_supported_record_length(), max_supported_keys(),
     max_supported_key_parts(), uint max_supported_key_length()
@@ -1070,33 +1069,32 @@ private:
 
   int create_cfs(const TABLE *const table_arg, Rdb_tbl_def *const tbl_def_arg,
                  std::array<struct key_def_cf_info, MAX_INDEXES + 1> *const cfs)
-      const MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      const MY_ATTRIBUTE((__warn_unused_result__));
 
   int create_key_def(const TABLE *const table_arg, const uint &i,
                      const Rdb_tbl_def *const tbl_def_arg,
                      std::shared_ptr<Rdb_key_def> *const new_key_def,
                      const struct key_def_cf_info &cf_info) const
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   int create_inplace_key_defs(
       const TABLE *const table_arg, Rdb_tbl_def *vtbl_def_arg,
       const TABLE *const old_table_arg,
       const Rdb_tbl_def *const old_tbl_def_arg,
       const std::array<key_def_cf_info, MAX_INDEXES + 1> &cfs) const
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   std::unordered_map<std::string, uint>
   get_old_key_positions(const TABLE *table_arg, const Rdb_tbl_def *tbl_def_arg,
                         const TABLE *old_table_arg,
-                        const Rdb_tbl_def *old_tbl_def_arg) const
-      MY_ATTRIBUTE((__nonnull__));
+                        const Rdb_tbl_def *old_tbl_def_arg) const;
 
   int compare_key_parts(const KEY *const old_key,
-                        const KEY *const new_key) const;
-  MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+                        const KEY *const new_key) const
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   int compare_keys(const KEY *const old_key, const KEY *const new_key) const
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   int convert_record_to_storage_format(const struct update_row_info &row_info,
                                        rocksdb::Slice *const packed_rec)
@@ -1111,13 +1109,13 @@ private:
                                     bool seek_backward);
 
   int index_first_intern(uchar *buf)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   int index_last_intern(uchar *buf)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   enum icp_result check_index_cond() const;
   int find_icp_matching_index_rec(const bool &move_forward, uchar *const buf)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   void calc_updated_indexes();
   int update_write_row(const uchar *const old_data, const uchar *const new_data,
@@ -1158,7 +1156,7 @@ private:
                      const bool &using_full_key,
                      const rocksdb::Slice &key_slice,
                      const int64_t ttl_filter_ts)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   int read_before_key(const Rdb_key_def &kd, const bool &using_full_key,
                       const rocksdb::Slice &key_slice,
                       const int64_t ttl_filter_ts)
@@ -1174,10 +1172,10 @@ private:
       MY_ATTRIBUTE((__warn_unused_result__));
 
   int read_row_from_primary_key(uchar *const buf)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   int read_row_from_secondary_key(uchar *const buf, const Rdb_key_def &kd,
                                   bool move_forward)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
 
   int calc_eq_cond_len(const Rdb_key_def &kd,
                        const enum ha_rkey_function &find_flag,
@@ -1188,7 +1186,7 @@ private:
       MY_ATTRIBUTE((__warn_unused_result__));
 
   Rdb_tbl_def *get_table_if_exists(const char *const tablename)
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+      MY_ATTRIBUTE((__warn_unused_result__));
   void read_thd_vars(THD *const thd) MY_ATTRIBUTE((__nonnull__));
   const char *thd_rocksdb_tmpdir()
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
@@ -1278,8 +1276,7 @@ public:
     DBUG_RETURN(FALSE);
   }
 
-  bool get_error_message(const int error, String *const buf) override
-      MY_ATTRIBUTE((__nonnull__));
+  bool get_error_message(const int error, String *const buf) override;
 
   static int rdb_error_to_mysql(const rocksdb::Status &s,
                                 const char *msg = nullptr)

--- a/storage/rocksdb/ha_rocksdb_proto.h
+++ b/storage/rocksdb/ha_rocksdb_proto.h
@@ -42,7 +42,7 @@ void rdb_handle_io_error(const rocksdb::Status status,
                          const RDB_IO_ERROR_TYPE err_type);
 
 int rdb_normalize_tablename(const std::string &tablename, std::string *str)
-    MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+    MY_ATTRIBUTE((__warn_unused_result__));
 
 int rdb_split_normalized_tablename(const std::string &fullname, std::string *db,
                                    std::string *table = nullptr,
@@ -52,11 +52,9 @@ int rdb_split_normalized_tablename(const std::string &fullname, std::string *db,
 std::vector<std::string> rdb_get_open_table_names(void);
 
 int rdb_get_table_perf_counters(const char *tablename,
-                                Rdb_perf_counters *counters)
-    MY_ATTRIBUTE((__nonnull__(2)));
+                                Rdb_perf_counters *counters);
 
-void rdb_get_global_perf_counters(Rdb_perf_counters *counters)
-    MY_ATTRIBUTE((__nonnull__(1)));
+void rdb_get_global_perf_counters(Rdb_perf_counters *counters);
 
 void rdb_queue_save_stats_request();
 

--- a/storage/rocksdb/properties_collector.h
+++ b/storage/rocksdb/properties_collector.h
@@ -85,7 +85,7 @@ public:
                                      const rocksdb::Slice &value,
                                      rocksdb::EntryType type,
                                      rocksdb::SequenceNumber seq,
-                                     uint64_t file_size);
+                                     uint64_t file_size) override;
 
   virtual rocksdb::Status
   Finish(rocksdb::UserCollectedProperties *properties) override;

--- a/storage/rocksdb/rdb_cf_options.h
+++ b/storage/rocksdb/rdb_cf_options.h
@@ -65,8 +65,7 @@ public:
   get_cf_comparator(const std::string &cf_name);
 
   void get_cf_options(const std::string &cf_name,
-                      rocksdb::ColumnFamilyOptions *const opts)
-      MY_ATTRIBUTE((__nonnull__));
+                      rocksdb::ColumnFamilyOptions *const opts);
 
   static bool parse_cf_options(const std::string &cf_options,
     Name_to_config_t *option_map);

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2962,11 +2962,11 @@ rdb_init_collation_mapping(const my_core::CHARSET_INFO *const cs) {
           }
         }
 
-        cur->m_make_unpack_info_func = {
+        cur->m_make_unpack_info_func = {{
             &Rdb_key_def::make_unpack_simple_varchar,
-            &Rdb_key_def::make_unpack_simple};
-        cur->m_unpack_func = {&Rdb_key_def::unpack_simple_varchar_space_pad,
-                              &Rdb_key_def::unpack_simple};
+            &Rdb_key_def::make_unpack_simple}};
+        cur->m_unpack_func = {{&Rdb_key_def::unpack_simple_varchar_space_pad,
+                              &Rdb_key_def::unpack_simple}};
       } else {
         // Out of luck for now.
       }

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -252,26 +252,26 @@ void rdb_log_status_error(const rocksdb::Status &s, const char *msg = nullptr);
 
 const char *rdb_skip_spaces(const struct charset_info_st *const cs,
                             const char *str)
-    MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+    MY_ATTRIBUTE((__warn_unused_result__));
 
 bool rdb_compare_strings_ic(const char *const str1, const char *const str2)
-    MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+    MY_ATTRIBUTE((__warn_unused_result__));
 
 const char *rdb_find_in_string(const char *str, const char *pattern,
                                bool *const succeeded)
-    MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+    MY_ATTRIBUTE((__warn_unused_result__));
 
 const char *rdb_check_next_token(const struct charset_info_st *const cs,
                                  const char *str, const char *const pattern,
                                  bool *const succeeded)
-    MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+    MY_ATTRIBUTE((__warn_unused_result__));
 
 const char *rdb_parse_id(const struct charset_info_st *const cs,
                          const char *str, std::string *const id)
-    MY_ATTRIBUTE((__nonnull__(1, 2), __warn_unused_result__));
+    MY_ATTRIBUTE((__warn_unused_result__));
 
 const char *rdb_skip_id(const struct charset_info_st *const cs, const char *str)
-    MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
+    MY_ATTRIBUTE((__warn_unused_result__));
 
 const std::vector<std::string> parse_into_tokens(const std::string& s,
                                                  const char delim);
@@ -281,8 +281,7 @@ const std::vector<std::string> parse_into_tokens(const std::string& s,
 */
 
 std::string rdb_hexdump(const char *data, const std::size_t data_len,
-                        const std::size_t maxsize = 0)
-    MY_ATTRIBUTE((__nonnull__));
+                        const std::size_t maxsize = 0);
 
 /*
   Helper function to see if a database exists

--- a/storage/tokudb/tokudb_information_schema.cc
+++ b/storage/tokudb/tokudb_information_schema.cc
@@ -1085,7 +1085,7 @@ ST_FIELD_INFO background_job_status_field_info[] = {
     {"scheduler", 32, MYSQL_TYPE_STRING, 0, 0, NULL, SKIP_OPEN_TABLE },
     {"scheduled_time", 0, MYSQL_TYPE_DATETIME, 0, 0, NULL, SKIP_OPEN_TABLE },
     {"started_time", 0, MYSQL_TYPE_DATETIME, 0, MY_I_S_MAYBE_NULL, NULL, SKIP_OPEN_TABLE },
-    {"status", 1024, MYSQL_TYPE_STRING, 0, MY_I_S_MAYBE_NULL, SKIP_OPEN_TABLE },
+    {"status", 1024, MYSQL_TYPE_STRING, 0, MY_I_S_MAYBE_NULL, NULL, SKIP_OPEN_TABLE },
     {NULL, 0, MYSQL_TYPE_NULL, 0, 0, NULL, SKIP_OPEN_TABLE}
 };
 

--- a/testclients/bug25714.c
+++ b/testclients/bug25714.c
@@ -71,6 +71,6 @@ int main (int argc, char **argv)
   mysql_close(&conn);
   my_end(0);
 
-  return 0;
+  return OK;
 }
 


### PR DESCRIPTION
* Initialized uninitailized variables
* Marked debug variables as possibly unused
* Marked the functions generated by the define_xdr_funcs macro possibly unused. This macro generates several functions, and only some of them is used.
* Removed the unused MYSQLX_PORT global constant
* Corrected two unsigned/signed std::max
* Disabled the unused variable warning for rocksdb, as it's in 3rd party code
* Removed unneccessary assertions from rocksdb (asserting that a non null parameter is non null)
* Added a missing override specifier
* Added additional braces to a struct initalizer
* Changed how optimization is disabled for a function