### PR TITLE
MYR-219 : rocksdb.bulk_load_unsorted_errors missing its .result file

### DIFF
--- a/mysql-test/suite/rocksdb/r/bulk_load_unsorted_errors.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_unsorted_errors.result
@@ -1,0 +1,4 @@
+SET rocksdb_bulk_load=1;
+SET rocksdb_bulk_load_allow_unsorted=1;
+ERROR HY000: Error when executing command SET: Cannot change this setting while bulk load is enabled
+SET rocksdb_bulk_load=0;


### PR DESCRIPTION
- Recorded missing result file and reviewed for proper content.