### PR TITLE
MYR-207 : Provide a way to force build MyRocks without FastCRC32 if h…

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -66,13 +66,17 @@ CHECK_CXX_SOURCE_COMPILES("
 #include <cstdint>
 #include <nmmintrin.h>
 int main() {
-  volatile uint32_t x = _mm_crc32_u32(0, 0);
+  volatile uint32_t x __attribute__((unused)) = _mm_crc32_u32(0, 0);
 }
 " HAVE_SSE42)
 IF (HAVE_SSE42)
   ADD_DEFINITIONS(-DHAVE_SSE42)
 ELSE ()
-  MESSAGE(${MYROCKS_STATUS_MODE} "No SSE42 support found. Not building MyRocks")
+  IF (ALLOW_NO_SSE42)
+    MESSAGE(WARNING "No SSE42 support found and ALLOW_NO_SSE42 specified, building MyRocks but without SSE42/FastCRC32 support")
+  ELSE ()
+    MESSAGE(FATAL_ERROR "No SSE42 support found. Not building MyRocks")
+  ENDIF ()
 ENDIF ()
 
 IF(UNIX)


### PR DESCRIPTION
…ost doesn't support it

- Added new cmake flag ALLOW_NO_SSE42 that can be specified via
  -DALLOW_NO_SSE42=1 which will allow MyRocks to compile if SSE 4.2 is not
  detected.
- Changed warning to error if SSE 4.2 is not detected and no ALLOW_NO_SSE42is
  specified.
- Fixed logic for debug builds in HAVE_SSE42 CHECK_CXX_SOURCE_COMPILES where
  debug builds emit a warning as error "x is unused"