### PR TITLE
MYR-223 : MyRocks alter table with string indexed column to non-binar…

### DIFF
--- a/mysql-test/suite/rocksdb/r/collation.result
+++ b/mysql-test/suite/rocksdb/r/collation.result
@@ -1,63 +1,81 @@
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value Use binary collation (binary, latin1_bin, utf8_bin).
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t1.value3 Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.t1.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE t1;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value3(50))) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.t1.value3 uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE t1;
 SET GLOBAL rocksdb_strict_collation_check=0;
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value3(50))) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
 SET GLOBAL rocksdb_strict_collation_check=1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value2)) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value2)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
-CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
+CREATE TABLE t1 (id VARCHAR(20), value VARCHAR(50), value2 VARCHAR(50), value3 TEXT, PRIMARY KEY (id), INDEX(value, value2)) ENGINE=ROCKSDB CHARSET LATIN1 COLLATE LATIN1_BIN;
 DROP TABLE t1;
-CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset utf8 collate utf8_bin;
+CREATE TABLE t1 (id VARCHAR(20), value VARCHAR(50), value2 VARCHAR(50), value3 TEXT, PRIMARY KEY (id), INDEX(value, value2)) ENGINE=ROCKSDB CHARSET UTF8 COLLATE UTF8_BIN;
 DROP TABLE t1;
-CREATE TABLE t1 (id varchar(20) collate latin1_bin, value varchar(50) collate utf8_bin, value2 varchar(50) collate latin1_bin, value3 text, primary key (id), index(value, value2)) engine=rocksdb;
+CREATE TABLE t1 (id VARCHAR(20) COLLATE LATIN1_BIN, value VARCHAR(50) COLLATE UTF8_BIN, value2 VARCHAR(50) COLLATE LATIN1_BIN, value3 TEXT, PRIMARY KEY (id), INDEX(value, value2)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
 SET GLOBAL rocksdb_strict_collation_exceptions=t1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE t2 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.t2.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE t2;
 SET GLOBAL rocksdb_strict_collation_exceptions="t.*";
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t123;
-CREATE TABLE s123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.s123.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE s123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.s123.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE s123;
 SET GLOBAL rocksdb_strict_collation_exceptions=".t.*";
-CREATE TABLE xt123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE xt123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE xt123;
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.t123.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE t123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.t123.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE t123;
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE s1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.u1.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE u1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.u1.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE u1;
 SET GLOBAL rocksdb_strict_collation_exceptions='t1';
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 ALTER TABLE t1 AUTO_INCREMENT=1;
 DROP TABLE t1;
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
+CREATE TABLE t2 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.t2.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE t2;
+CREATE TABLE t2 (id INT PRIMARY KEY, value VARCHAR(50)) ENGINE=ROCKSDB CHARSET UTF8;
 ALTER TABLE t2 ADD INDEX(value);
-ERROR HY000: Unsupported collation on string indexed column test.t2.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.t2.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
 DROP TABLE t2;
 # restart:--log-error=LOG_FILE
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.a.value Use binary collation (binary, latin1_bin, utf8_bin).
+CREATE TABLE a (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.a.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE a;
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-CREATE TABLE b (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.c.value Use binary collation (binary, latin1_bin, utf8_bin).
-DROP TABLE a, b;
+CREATE TABLE a (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+CREATE TABLE b (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+CREATE TABLE c (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+Warnings:
+Warning	122	Indexed column test.c.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE a, b, c;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";
 SET GLOBAL rocksdb_strict_collation_exceptions=null;
 # restart

--- a/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_0.result
+++ b/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_0.result
@@ -1,25 +1,39 @@
 SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.abc.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.ABC.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.ABC.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE ABC;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.ABC.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.ABC.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE ABC;
 SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.abc.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABC;
 CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.bcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.bcd.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE bcd;
 SET GLOBAL rocksdb_strict_collation_exceptions="^ABC";
 CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.abcd.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE abcd;
 CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABCD;
 CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.ZABC.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.ZABC.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE ZABC;
 SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_1.result
+++ b/mysql-test/suite/rocksdb/r/collation_exceptions_lctn_1.result
@@ -1,15 +1,21 @@
 SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.abc.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.abc.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.abc.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE ABC;
 SET GLOBAL rocksdb_strict_collation_exceptions="abc";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABC;
 CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.bcd.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.bcd.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE bcd;
 SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE abc;
@@ -21,5 +27,7 @@ DROP TABLE abcd;
 CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABCD;
 CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-ERROR HY000: Unsupported collation on string indexed column test.zabc.value Use binary collation (binary, latin1_bin, utf8_bin).
+Warnings:
+Warning	122	Indexed column test.zabc.value uses a collation that does not allow index-only access in secondary key and has reduced disk space efficiency in primary key.
+DROP TABLE ZABC;
 SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/mysql-test/suite/rocksdb/t/collation.test
+++ b/mysql-test/suite/rocksdb/t/collation.test
@@ -4,74 +4,73 @@
 --source include/have_rocksdb.inc
 
 # ci non-indexed column is allowed
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
 
 # ci indexed column is not allowed
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE t1;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value3(50))) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE t1;
 # ci indexed column with rocksdb_strict_collation_check=OFF is allowed.
 SET GLOBAL rocksdb_strict_collation_check=0;
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value3(50))) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value3(50))) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
 SET GLOBAL rocksdb_strict_collation_check=1;
 
 # cs indexed column is allowed
-CREATE TABLE t1 (id INT primary key, value varchar(50), value2 varbinary(50), value3 text, index(value2)) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), value2 VARBINARY(50), value3 TEXT, INDEX(value2)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
 
 # cs latin1_bin is allowed
-CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset latin1 collate latin1_bin;
+CREATE TABLE t1 (id VARCHAR(20), value VARCHAR(50), value2 VARCHAR(50), value3 TEXT, PRIMARY KEY (id), INDEX(value, value2)) ENGINE=ROCKSDB CHARSET LATIN1 COLLATE LATIN1_BIN;
 DROP TABLE t1;
 
 # cs utf8_bin is allowed
-CREATE TABLE t1 (id varchar(20), value varchar(50), value2 varchar(50), value3 text, primary key (id), index(value, value2)) engine=rocksdb charset utf8 collate utf8_bin;
+CREATE TABLE t1 (id VARCHAR(20), value VARCHAR(50), value2 VARCHAR(50), value3 TEXT, PRIMARY KEY (id), INDEX(value, value2)) ENGINE=ROCKSDB CHARSET UTF8 COLLATE UTF8_BIN;
 DROP TABLE t1;
 
 # cs mixed latin1_bin and utf8_bin is allowed
-CREATE TABLE t1 (id varchar(20) collate latin1_bin, value varchar(50) collate utf8_bin, value2 varchar(50) collate latin1_bin, value3 text, primary key (id), index(value, value2)) engine=rocksdb;
+CREATE TABLE t1 (id VARCHAR(20) COLLATE LATIN1_BIN, value VARCHAR(50) COLLATE UTF8_BIN, value2 VARCHAR(50) COLLATE LATIN1_BIN, value3 TEXT, PRIMARY KEY (id), INDEX(value, value2)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
 
 # ci indexed column is not allowed unless table name is in exception list
 SET GLOBAL rocksdb_strict_collation_exceptions=t1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t2 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE t2;
 
 # test regex for exception list
 SET GLOBAL rocksdb_strict_collation_exceptions="t.*";
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t123;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE s123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE s123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE s123;
 
 SET GLOBAL rocksdb_strict_collation_exceptions=".t.*";
-CREATE TABLE xt123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE xt123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE xt123;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t123 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t123 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE t123;
 
 # test multiple entries in the list with vertical bar
 SET GLOBAL rocksdb_strict_collation_exceptions="s.*|t.*";
-CREATE TABLE s1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE s1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE s1;
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE u1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE u1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE u1;
 
 # test allowing alters to create temporary tables
 SET GLOBAL rocksdb_strict_collation_exceptions='t1';
-CREATE TABLE t1 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
+CREATE TABLE t1 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
 ALTER TABLE t1 AUTO_INCREMENT=1;
 DROP TABLE t1;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE t2 (id INT primary key, value varchar(50), index(value)) engine=rocksdb;
-CREATE TABLE t2 (id INT primary key, value varchar(50)) engine=rocksdb;
---error ER_UNSUPPORTED_COLLATION
+CREATE TABLE t2 (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE t2;
+CREATE TABLE t2 (id INT PRIMARY KEY, value VARCHAR(50)) ENGINE=ROCKSDB CHARSET UTF8;
 ALTER TABLE t2 ADD INDEX(value);
 DROP TABLE t2;
 
@@ -85,14 +84,13 @@ SET GLOBAL rocksdb_strict_collation_exceptions="[a-b";
 --let SEARCH_PATTERN=RocksDB: Invalid pattern in strict_collation_exceptions: \[a-b
 --source include/search_pattern_in_file.inc
 
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+CREATE TABLE a (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE a;
 SET GLOBAL rocksdb_strict_collation_exceptions="[a-b]";
-CREATE TABLE a (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-CREATE TABLE b (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE c (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-DROP TABLE a, b;
+CREATE TABLE a (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+CREATE TABLE b (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+CREATE TABLE c (id INT PRIMARY KEY, value VARCHAR(50), INDEX(value)) ENGINE=ROCKSDB CHARSET UTF8;
+DROP TABLE a, b, c;
 
 # test invalid regex (trailing escape)
 SET GLOBAL rocksdb_strict_collation_exceptions="abc\\";

--- a/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_0.test
+++ b/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_0.test
@@ -5,33 +5,33 @@
 
 SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
 
---error ER_UNSUPPORTED_COLLATION
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
+DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
 
 SET GLOBAL rocksdb_strict_collation_exceptions="abc";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE abc;
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
-
-SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
---error ER_UNSUPPORTED_COLLATION
-CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABC;
 
---error ER_UNSUPPORTED_COLLATION
+SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
+CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abc;
+CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
+
 CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE bcd;
 
 SET GLOBAL rocksdb_strict_collation_exceptions="^ABC";
---error ER_UNSUPPORTED_COLLATION
 CREATE TABLE abcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE abcd;
 CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABCD;
 
---error ER_UNSUPPORTED_COLLATION
 CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ZABC;
 
 SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_1.test
+++ b/mysql-test/suite/rocksdb/t/collation_exceptions_lctn_1.test
@@ -4,18 +4,18 @@
 
 SET @old_rocksdb_strict_collation_exceptions = @@global.rocksdb_strict_collation_exceptions;
 
---error ER_UNSUPPORTED_COLLATION
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
---error ER_UNSUPPORTED_COLLATION
+DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ABC;
 
 SET GLOBAL rocksdb_strict_collation_exceptions="abc";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE abc;
 CREATE TABLE ABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABC;
---error ER_UNSUPPORTED_COLLATION
 CREATE TABLE bcd (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE bcd;
 
 SET GLOBAL rocksdb_strict_collation_exceptions="ABC";
 CREATE TABLE abc (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
@@ -29,7 +29,7 @@ DROP TABLE abcd;
 CREATE TABLE ABCD (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
 DROP TABLE ABCD;
 
---error ER_UNSUPPORTED_COLLATION
 CREATE TABLE ZABC (id INT PRIMARY KEY, value varchar(50), index(value)) engine=rocksdb charset utf8;
+DROP TABLE ZABC;
 
 SET GLOBAL rocksdb_strict_collation_exceptions=@old_rocksdb_strict_collation_exceptions;

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2921,7 +2921,7 @@ std::array<const Rdb_collation_codec *, MY_ALL_CHARSETS_SIZE>
     rdb_collation_data;
 mysql_mutex_t rdb_collation_data_mutex;
 
-static bool rdb_is_collation_supported(const my_core::CHARSET_INFO *const cs) {
+bool rdb_is_collation_supported(const my_core::CHARSET_INFO *const cs) {
   return (cs->coll == &my_collation_8bit_simple_ci_handler);
 }
 

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1310,4 +1310,6 @@ struct Rdb_index_info {
   uint64 m_ttl_duration = 0;
 };
 
+bool rdb_is_collation_supported(const my_core::CHARSET_INFO *const cs);
+
 } // namespace myrocks


### PR DESCRIPTION
…y collation works

- Imported patch from MariaDB MDEV-14293 and touched up to use MySQL/Percona
  push_warning_printf. Patch changes error of using inefficient collation
  to a warning.
- Re-worked impacted tests to remove expected error and re-recorded to capture
  new SQL warnings.