### PR TITLE
Bug: PS-283: keyring_vault is too quiet when plugin installation

### DIFF
--- a/plugin/keyring_vault/CMakeLists.txt
+++ b/plugin/keyring_vault/CMakeLists.txt
@@ -30,11 +30,13 @@ INCLUDE_DIRECTORIES(${BOOST_PATCHES_DIR})
 INCLUDE_DIRECTORIES(SYSTEM ${BOOST_INCLUDE_DIR} ${CURL_INCLUDE_DIRS})
 
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/plugin/keyring/common)
+INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/plugin/keyring)
 
 MYSQL_ADD_PLUGIN(keyring_vault
                  ${CMAKE_SOURCE_DIR}/plugin/keyring/common/keyring_key.cc
                  ${CMAKE_SOURCE_DIR}/plugin/keyring/common/keys_container.cc
                  ${CMAKE_SOURCE_DIR}/plugin/keyring/common/keyring_impl.cc
+                 ${CMAKE_SOURCE_DIR}/plugin/keyring/file_io.cc
                  vault_io.cc
                  vault_key.cc
                  vault_base64.cc

--- a/plugin/keyring_vault/tests/mtr/install_keyring_vault.result
+++ b/plugin/keyring_vault/tests/mtr/install_keyring_vault.result
@@ -1,8 +1,12 @@
 call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 SET @@global.keyring_vault_config='MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault1.conf';
 ERROR HY000: Unknown system variable 'keyring_vault_config'
 INSTALL PLUGIN keyring_vault SONAME 'keyring_vault.so';
+Warnings:
+Warning	29	File '' not found (Errcode: 2 - No such file or directory)
+Warning	42000	keyring_vault initialization failure. Please check the server log.
 SET @@global.keyring_vault_config='MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault2.conf';
 SET @@global.keyring_vault_config='MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault1.conf';
 UNINSTALL PLUGIN keyring_vault;

--- a/plugin/keyring_vault/tests/mtr/install_keyring_vault.test
+++ b/plugin/keyring_vault/tests/mtr/install_keyring_vault.test
@@ -3,6 +3,7 @@
 
 call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 
 --source generate_default_conf_files.inc
 

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_config.result
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_config.result
@@ -1,4 +1,5 @@
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '../../../../../bad_dir/bad_keyring_vault.conf' not found");
 # restart:--plugin_load=keyring_vault=keyring_vault.so --loose-keyring_vault_config=MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault1.conf KEYRING_VAULT_PLUGIN_OPT
 SELECT @@global.keyring_vault_config;
 @@global.keyring_vault_config

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_config.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_config.test
@@ -2,6 +2,7 @@
 --source include/not_embedded.inc
 
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '../../../../../bad_dir/bad_keyring_vault.conf' not found");
 
 --source generate_default_conf_files.inc
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR $KEYRING_PLUGIN keyring_vault.so $KEYRING_VAULT_PLUGIN_OPT KEYRING_VAULT_PLUGIN_OPT

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_config_qa.result
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_config_qa.result
@@ -5,7 +5,12 @@ call mtr.add_suppression("\\[Error\\] Couldn't load plugin named 'keyring_vault'
 call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault. Vault has returned the following error\\(s\\): \\[\"permission denied\"\\]'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '.*' not found");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not read file with credentials.'");
 INSTALL PLUGIN keyring_vault SONAME 'keyring_vault.so';
+Warnings:
+Warning	29	File '' not found (Errcode: 2 - No such file or directory)
+Warning	42000	keyring_vault initialization failure. Please check the server log.
 SELECT PLUGIN_NAME,PLUGIN_VERSION,PLUGIN_STATUS
 FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name='keyring_vault';
 PLUGIN_NAME	keyring_vault

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_config_qa.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_config_qa.test
@@ -12,6 +12,8 @@ call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_va
 
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault. Vault has returned the following error\\(s\\): \\[\"permission denied\"\\]'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '.*' not found");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not read file with credentials.'");
 
 --source generate_default_conf_files.inc
 

--- a/plugin/keyring_vault/tests/mtr/rpl_key_rotation.result
+++ b/plugin/keyring_vault/tests/mtr/rpl_key_rotation.result
@@ -11,6 +11,7 @@ call mtr.add_suppression("Error 'Can't find master key from keyring, please chec
 call mtr.add_suppression("\\[Warning\\] Slave: Can't find master key from keyring, please check keyring plugin is loaded.");
 call mtr.add_suppression("\\[Error\\] InnoDB: Can't generate new master key for tablespace encryption, please check the keyring plugin is loaded.");
 call mtr.add_suppression("The slave coordinator and worker threads are stopped");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 SET @@global.keyring_vault_config='MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault2.conf';
 [On Master]
 SET @@global.keyring_vault_config='MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault1.conf';
@@ -78,6 +79,9 @@ include/save_master_pos.inc
 START SLAVE SQL_THREAD;
 include/wait_for_slave_sql_error.inc [errno=3185]
 INSTALL PLUGIN keyring_vault SONAME 'keyring_vault.so';
+Warnings:
+Warning	29	File '' not found (Errcode: 2 - No such file or directory)
+Warning	42000	keyring_vault initialization failure. Please check the server log.
 SET @@global.keyring_vault_config='MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault2.conf';
 SELECT PLUGIN_NAME,PLUGIN_VERSION,PLUGIN_STATUS
 FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name='keyring_vault';
@@ -105,6 +109,9 @@ ALTER INSTANCE ROTATE INNODB MASTER KEY;
 ERROR HY000: Can't find master key from keyring, please check keyring plugin is loaded.
 # Installing keyring_vault plugin on master.
 INSTALL PLUGIN keyring_vault SONAME 'keyring_vault.so';
+Warnings:
+Warning	29	File '' not found (Errcode: 2 - No such file or directory)
+Warning	42000	keyring_vault initialization failure. Please check the server log.
 # Cleanup
 DROP TABLE t1,t2,t3,t4;
 include/sync_slave_sql_with_master.inc

--- a/plugin/keyring_vault/tests/mtr/rpl_key_rotation.test
+++ b/plugin/keyring_vault/tests/mtr/rpl_key_rotation.test
@@ -13,6 +13,7 @@ call mtr.add_suppression("Error 'Can't find master key from keyring, please chec
 call mtr.add_suppression("\\[Warning\\] Slave: Can't find master key from keyring, please check keyring plugin is loaded.");
 call mtr.add_suppression("\\[Error\\] InnoDB: Can't generate new master key for tablespace encryption, please check the keyring plugin is loaded.");
 call mtr.add_suppression("The slave coordinator and worker threads are stopped");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 
 --source generate_default_conf_files.inc
 

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_5.result
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_5.result
@@ -1,5 +1,6 @@
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Encryption can't find master key, please check the keyring plugin is loaded.");
 call mtr.add_suppression("ibd can't be decrypted , please confirm the keyfile is match and keyring plugin is loaded");
 call mtr.add_suppression("Can't generate new master key for tablespace encryption, please check the keyring plugin is loaded.");

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_5.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_5.test
@@ -1,5 +1,6 @@
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 
 --source include/have_keyring_vault_plugin.inc
 --source generate_default_conf_files.inc

--- a/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.result
+++ b/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.result
@@ -1,2 +1,3 @@
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
 call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '../bad_dir/../../bad_keyring' not found");

--- a/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.test
+++ b/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.test
@@ -7,3 +7,5 @@
 
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
 call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '../bad_dir/../../bad_keyring' not found");
+

--- a/plugin/keyring_vault/vault_credentials_parser.h
+++ b/plugin/keyring_vault/vault_credentials_parser.h
@@ -35,6 +35,7 @@ namespace keyring
     std::set<Secure_string> optional_value;
 
     ILogger *logger;
+    static const size_t max_file_size;
   };
 
 } // namespace keyring

--- a/plugin/keyring_vault/vault_keyring.cc
+++ b/plugin/keyring_vault/vault_keyring.cc
@@ -1,5 +1,6 @@
 #include <my_global.h>
 #include <mysql/plugin_keyring.h>
+#include <sql_class.h>
 #include "keyring.h"
 #include "vault_keys_container.h"
 #include "vault_parser.h"
@@ -148,6 +149,10 @@ static int keyring_vault_init(MYSQL_PLUGIN plugin_info)
         " file. Please also make sure Vault is running and accessible."
         " The keyring_vault will stay unusable until correct configuration file gets"
         " provided.");
+
+      if (current_thd != NULL)
+        push_warning(current_thd, Sql_condition::SL_WARNING, 42000,
+        	     "keyring_vault initialization failure. Please check the server log.");
       return 0;
     }
     is_keys_container_initialized = TRUE;

--- a/plugin/keyring_vault/vault_secure_string.h
+++ b/plugin/keyring_vault/vault_secure_string.h
@@ -7,6 +7,7 @@ namespace keyring
 {
   typedef std::basic_string<char, std::char_traits<char>, Secure_allocator<char> > Secure_string;
   typedef std::basic_ostringstream<char, std::char_traits<char>, Secure_allocator<char> > Secure_ostringstream;
+  typedef std::basic_istringstream<char, std::char_traits<char>, Secure_allocator<char> > Secure_istringstream;
 }
 
 #endif // MYSQL_VAULT_SECURE_STRING

--- a/unittest/gunit/keyring_vault/CMakeLists.txt
+++ b/unittest/gunit/keyring_vault/CMakeLists.txt
@@ -15,6 +15,7 @@ INCLUDE_DIRECTORIES(
         ${CMAKE_SOURCE_DIR}/include
         ${CMAKE_SOURCE_DIR}/sql
         ${CMAKE_SOURCE_DIR}/plugin/keyring/common
+        ${CMAKE_SOURCE_DIR}/plugin/keyring
         ${CMAKE_SOURCE_DIR}/plugin/keyring_vault
         ${CMAKE_SOURCE_DIR}/unittest/gunit
         ${CMAKE_SOURCE_DIR}/unittest/gunit/keyring
@@ -41,6 +42,7 @@ FOREACH(test ${TESTS})
             ${CMAKE_SOURCE_DIR}/plugin/keyring_vault/vault_credentials.cc
             ${CMAKE_SOURCE_DIR}/plugin/keyring_vault/vault_credentials_parser.cc
             ${CMAKE_SOURCE_DIR}/plugin/keyring_vault/vault_keys_container.cc
+            ${CMAKE_SOURCE_DIR}/plugin/keyring/file_io.cc
             ${CMAKE_SOURCE_DIR}/unittest/gunit/keyring_vault/vault_mount.cc
             )
     IF(WIN32)

--- a/unittest/gunit/keyring_vault/vault_credentials_parser-t.cc
+++ b/unittest/gunit/keyring_vault/vault_credentials_parser-t.cc
@@ -3,6 +3,7 @@
 #include "mock_logger.h"
 #include "vault_credentials_parser.h"
 #include <fstream>
+#include "test_utils.h"
 
 #if defined(HAVE_PSI_INTERFACE)
 namespace keyring
@@ -48,6 +49,9 @@ namespace keyring__vault_credentials_parser_unittest
 
     EXPECT_CALL(*(reinterpret_cast<Mock_logger*>(logger)),
       log(MY_ERROR_LEVEL, StrEq("Could not open file with credentials.")));
+    EXPECT_CALL(*(reinterpret_cast<Mock_logger*>(logger)),
+      log(MY_ERROR_LEVEL, StrEq("File '/.there_no_such_file' not found (Errcode: 2 - No such file or directory)")));
+
     std::string file_url = "/.there_no_such_file";
     Vault_credentials vault_credentials;
     EXPECT_TRUE(vault_credentials_parser.parse(file_url, &vault_credentials));
@@ -70,7 +74,7 @@ namespace keyring__vault_credentials_parser_unittest
     myfile.close();
 
     EXPECT_CALL(*(reinterpret_cast<Mock_logger*>(logger)),
-      log(MY_ERROR_LEVEL, StrEq("Could not read secret_mount_point from the configuration file.")));
+      log(MY_ERROR_LEVEL, StrEq("Empty file with credentials.")));
     std::string file_url = "./credentials";
 
     Vault_credentials vault_credentials;
@@ -282,5 +286,10 @@ namespace keyring__vault_credentials_parser_unittest
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  MY_INIT(argv[0]);
+  my_testing::setup_server_for_unit_tests();
+  int ret= RUN_ALL_TESTS();
+  my_testing::teardown_server_for_unit_tests();
+
+  return ret;
 }

--- a/unittest/gunit/keyring_vault/vault_io-t.cc
+++ b/unittest/gunit/keyring_vault/vault_io-t.cc
@@ -9,6 +9,7 @@
 #include "generate_credential_file.h"
 #include "uuid.h"
 #include "vault_mount.h"
+#include "test_utils.h"
 
 #if defined(HAVE_PSI_INTERFACE)
 namespace keyring
@@ -55,6 +56,8 @@ namespace keyring__vault_io_unittest
     std::string credential_file_name("./some_funny_name");
     Vault_io vault_io(logger, vault_curl, vault_parser);
     remove(credential_file_name.c_str());
+    EXPECT_CALL(*(reinterpret_cast<Mock_logger*>(logger)),
+      log(MY_ERROR_LEVEL, StrEq("File './some_funny_name' not found (Errcode: 2 - No such file or directory)")));
     EXPECT_CALL(*(reinterpret_cast<Mock_logger*>(logger)),
       log(MY_ERROR_LEVEL, StrEq("Could not open file with credentials.")));
     EXPECT_TRUE(vault_io.init(&credential_file_name));
@@ -605,6 +608,8 @@ namespace keyring__vault_io_unittest
 int main(int argc, char **argv) {
 
   ::testing::InitGoogleTest(&argc, argv);
+  MY_INIT(argv[0]);
+  my_testing::setup_server_for_unit_tests();
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
   //create unique secret mount point for this test suite
@@ -641,5 +646,7 @@ int main(int argc, char **argv) {
   curl_easy_cleanup(keyring__vault_io_unittest::curl);
   curl_global_cleanup();
   delete keyring__vault_io_unittest::logger;
+  my_testing::teardown_server_for_unit_tests();
+
   return ret;
 }

--- a/unittest/gunit/keyring_vault/vault_keys_container-t.cc
+++ b/unittest/gunit/keyring_vault/vault_keys_container-t.cc
@@ -101,9 +101,8 @@ namespace keyring__vault_keys_container_unittest
     myfile.close();
 
     IKeyring_io *vault_io = new Vault_io(logger, vault_curl, vault_parser);
-
     EXPECT_CALL(*(reinterpret_cast<Mock_logger*>(logger)),
-      log(MY_ERROR_LEVEL, StrEq("Could not read secret_mount_point from the configuration file.")));
+      log(MY_ERROR_LEVEL, StrEq("Empty file with credentials.")));
     EXPECT_TRUE(vault_keys_container->init(vault_io, "empty_credential.conf"));
     delete sample_key; // unused in this test
 


### PR DESCRIPTION
succedes, but keyring_vault is not operational

When keyring_vault is installed with use of install statement : INSTALL
PLUGIN (...) there is no feedback to the user
that keyring_vault_config_file may still need to be set. Currently when
user install the plugin he might gets the following response:

mysql> install plugin keyring_vault soname 'keyring_vault.so';
Query OK, 0 rows affected (0.02 sec)

And in server log there are these error messages:
[ERROR] Plugin keyring_vault reported: 'Could not open file with
credentials.'
[ERROR] Plugin keyring_vault reported: 'keyring_vault initialization
failure. Please check that the keyring_vault_config_file points to
readable keyring_vault configuration file. Please also make sure Vault
is running and accessible. The keyring_vault will stay unusable until
correct configuration file gets provided.'

The fix is to change this behavior so the user recieved warnings when
keyring_vault is not operational due to problem
with accessing configuration file (the path to configuration file is
stored in keyring_vault_config_file variable) - after
plugin has been installed with INSTALL PLUGIN SQL statement.