### PR TITLE
PS-287: It is possible to enable encrypt_binlog with no binary logging

### DIFF
--- a/mysql-test/suite/binlog_encryption/r/binlog_encryption_on_while_binlog_off.result
+++ b/mysql-test/suite/binlog_encryption/r/binlog_encryption_on_while_binlog_off.result
@@ -1,0 +1,4 @@
+# restart:<hidden args>
+include/assert.inc [Binlog should be OFF]
+include/assert.inc [Binlog encryption should be ON]
+# restart

--- a/mysql-test/suite/binlog_encryption/t/binlog_encryption_on_while_binlog_off.test
+++ b/mysql-test/suite/binlog_encryption/t/binlog_encryption_on_while_binlog_off.test
@@ -1,0 +1,28 @@
+# PS-287: It is possible to enable encrypt_binlog with no binary logging
+#
+# It is possible to enable encrypt_binlog without binary logging. In this setup
+# server will only encrypt relay logs - if used. We print an information in server's log
+# file to notify user that although encrypt_binlog in on, there is no binlog file to
+# encrypt and only relay logs will get encrypted.
+
+--let $restart_hide_args=1
+--let $restart_parameters=restart:--log-error=$MYSQLTEST_VARDIR/tmp/binlog_encryption_on_while_binlog_off.err --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --encrypt-binlog=1 --master-verify-checksum=1
+--source include/restart_mysqld.inc
+
+--let $assert_text= Binlog should be OFF
+--let $assert_cond= "[SELECT @@GLOBAL.log_bin = 0]" = 1
+--source include/assert.inc
+
+--let $assert_text= Binlog encryption should be ON
+--let $assert_cond= "[SELECT @@GLOBAL.encrypt_binlog = 1]" = 1
+--source include/assert.inc
+
+# Find a note in server's log
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/tmp/binlog_encryption_on_while_binlog_off.err
+--let SEARCH_PATTERN= binlog and relay log encryption enabled without binary logging being enabled. If relay logs are in use, they will be encrypted.
+--source include/search_pattern_in_file.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--remove_file $MYSQLTEST_VARDIR/tmp/binlog_encryption_on_while_binlog_off.err

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4500,13 +4500,19 @@ a file name for --log-bin-index option", opt_binlog_index_name);
     unireg_abort(MYSQLD_ABORT_EXIT);
   }
 
-  if (encrypt_binlog && (!opt_master_verify_checksum ||
-      binlog_checksum_options == binary_log::BINLOG_CHECKSUM_ALG_OFF ||
-      binlog_checksum_options == binary_log::BINLOG_CHECKSUM_ALG_UNDEF))
-  {
-    sql_print_error("BINLOG_ENCRYPTION requires MASTER_VERIFY_CHECKSUM = ON and "
-                    "BINLOG_CHECKSUM to be turned ON.");
-    unireg_abort(MYSQLD_ABORT_EXIT);
+  if (encrypt_binlog)
+  { 
+    if (!opt_master_verify_checksum ||
+        binlog_checksum_options == binary_log::BINLOG_CHECKSUM_ALG_OFF ||
+        binlog_checksum_options == binary_log::BINLOG_CHECKSUM_ALG_UNDEF)
+    {
+      sql_print_error("BINLOG_ENCRYPTION requires MASTER_VERIFY_CHECKSUM = ON and "
+                      "BINLOG_CHECKSUM to be turned ON.");
+      unireg_abort(MYSQLD_ABORT_EXIT);
+    }
+    if (!opt_bin_log)
+      sql_print_information("binlog and relay log encryption enabled without binary logging being enabled. "
+                            "If relay logs are in use, they will be encrypted.");
   }
 
   /// @todo: this looks suspicious, revisit this /sven


### PR DESCRIPTION
It is possible to enable encrypt_binlog without binary logging. In
this setup server will only encrypt relay logs - if used.
We print an information in server's log file to notify user that
although encrypt_binlog in on, there is no binlog file to
encrypt and only relay logs will get encrypted.