### PR TITLE
Bug: PS-264 handle_fatal_signal (sig=11) in

### DIFF
--- a/plugin/keyring/CMakeLists.txt
+++ b/plugin/keyring/CMakeLists.txt
@@ -50,6 +50,9 @@ IF(HAVE_DLOPEN)
       PROPERTIES LINK_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}")
 ENDIF()
 
+get_property(keyring_file_link_flags TARGET keyring_file PROPERTY LINK_FLAGS)
+set_property(TARGET keyring_file PROPERTY LINK_FLAGS "${keyring_file_link_flags} -Wl,--version-script=${CMAKE_SOURCE_DIR}/plugin/keyring/keyring_file.version")
+
 # Boost source has unused local typedefs.
 MY_CHECK_CXX_COMPILER_FLAG("-Wunused-local-typedefs" HAVE_UNUSED_TYPEDEFS)
 IF(HAVE_UNUSED_TYPEDEFS)

--- a/plugin/keyring/keyring_file.version
+++ b/plugin/keyring/keyring_file.version
@@ -1,0 +1,8 @@
+KEYRING_FILE_VERSION_1.0 {
+  global:
+     _mysql_*;
+     mysql_malloc_service;
+     my_plugin_log_service;
+     security_context_service;
+  local: *;
+};

--- a/plugin/keyring_vault/CMakeLists.txt
+++ b/plugin/keyring_vault/CMakeLists.txt
@@ -49,6 +49,9 @@ MYSQL_ADD_PLUGIN(keyring_vault
                  MODULE_ONLY
                  MODULE_OUTPUT_NAME "keyring_vault")
 
+get_property(keyring_vault_link_flags TARGET keyring_vault PROPERTY LINK_FLAGS)
+set_property(TARGET keyring_vault PROPERTY LINK_FLAGS "${keyring_vault_link_flags} -Wl,--version-script=${CMAKE_SOURCE_DIR}/plugin/keyring_vault/keyring_vault.version")
+
 IF(WITH_KEYRING_VAULT_TEST)
   ADD_SUBDIRECTORY(keyring_vault-test)
 ENDIF()

--- a/plugin/keyring_vault/keyring_vault.version
+++ b/plugin/keyring_vault/keyring_vault.version
@@ -1,0 +1,8 @@
+KEYRING_VAULT_VERSION_1.0 {
+  global:
+     _mysql_*;
+     mysql_malloc_service;
+     my_plugin_log_service;
+     security_context_service;
+  local: *;
+};

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_3.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_3.test
@@ -1,3 +1,4 @@
+--source include/big_test.inc
 --source include/have_keyring_vault_plugin.inc
 --source generate_default_conf_files.inc
 

--- a/plugin/keyring_vault/vault_curl.h
+++ b/plugin/keyring_vault/vault_curl.h
@@ -18,9 +18,8 @@ namespace keyring
 class Vault_curl : public IVault_curl, private boost::noncopyable
 {
 public:
-  Vault_curl(ILogger *logger, CURL *curl)
+  Vault_curl(ILogger *logger)
     : logger(logger)
-    , curl(curl)
     , list(NULL)
   {}
 
@@ -38,7 +37,7 @@ public:
 
 private:
 
-  bool reset_curl_session();
+  bool setup_curl_session(CURL *curl);
   std::string get_error_from_curl(CURLcode curl_code);
   bool encode_key_signature(const Vault_key &key, Secure_string *encoded_key_signature);
   bool get_key_url(const Vault_key &key, Secure_string *key_url);
@@ -46,7 +45,6 @@ private:
   ILogger *logger;
   Secure_string token_header;
   Secure_string vault_url;
-  CURL *curl;
   char curl_errbuf[CURL_ERROR_SIZE]; //error from CURL
   Secure_ostringstream read_data_ss;
   struct curl_slist *list;


### PR DESCRIPTION
keyring::Vault_curl::write_key | plugin/keyring_vault/vault_curl.cc:256

The problem itself was in CURL library, sometimes it fails to
re-initialize CURL session properly. The CURL documentation is vague in
describing the issue. The fix was to reinitialize curl session per
every operation and do not try to reuse the existing curl session.

Also both keyrings (keyring_file and keyring_vault) export a lot of
variables. Scope of those variables were limited to library scope. This
should guard against any dynamic linking problems when both keyrings
get installed on PS.