### PR TITLE
Fix attempt for DOC-444: note on dbl-quotes and semicolon in early-plugin-load

### DIFF
--- a/doc/source/management/data_at_rest_encryption.rst
+++ b/doc/source/management/data_at_rest_encryption.rst
@@ -145,6 +145,13 @@ option:
 It should be loaded this way to be able to facilitate recovery for encrypted
 tables.
 
+.. warning::
+
+  If server should be started with several plugins loaded early,
+  ``--early-plugin-load`` should contain their list separated by semicolons. Also
+  it's a good practice to put this list in double quotes so that semicolons
+  do not create problems when executed in a script.
+
 Apart from installing plugin you also need to set the
 :variable:`keyring_vault_config` variable. This variable should point to the
 keyring_vault configuration file, whose contents are discussed below.


### PR DESCRIPTION
...the only variable of this family which appears in percona-server documentation. Discussion in comments for this issue had settled down with the following statements: "loading plugins is described in the upstream docs" (i), "the problem of semicolon with or without quotes is related to bash scripting and not percona-server" (ii), and "MyRocks and TokuDB installation instructions propose using ps-admin, not command line options" (iii).  So perhaps this is the only place such comment is reasonable to reside.