### PR TITLE
lp-1738171: Build error on FreeBSD with 5.6.38-83.0

### DIFF
--- a/cmake/do_abi_check.cmake
+++ b/cmake/do_abi_check.cmake
@@ -55,13 +55,14 @@ SET(abi_check_out ${BINARY_DIR}/abi_check.out)
 FOREACH(file ${ABI_HEADERS})
   GET_FILENAME_COMPONENT(header_basename ${file} NAME)
   SET(tmpfile ${BINARY_DIR}/${header_basename}.pp.tmp)
+  SET(errorfile ${BINARY_DIR}/${header_basename}.pp.err)
 
   EXECUTE_PROCESS(
     COMMAND ${COMPILER} 
       -E -nostdinc -dI -DMYSQL_ABI_CHECK -I${SOURCE_DIR}/include
       -I${BINARY_DIR}/include -I${SOURCE_DIR}/include/mysql -I${SOURCE_DIR}/sql
       ${file} 
-      ERROR_QUIET OUTPUT_FILE ${tmpfile})
+      ERROR_FILE ${errorfile} OUTPUT_FILE ${tmpfile})
   EXECUTE_PROCESS(
     COMMAND sed -e "/^# /d"
                 -e "/^[	]*$/d"
@@ -76,8 +77,10 @@ FOREACH(file ${ABI_HEADERS})
     COMMAND diff -w ${file}.pp ${abi_check_out} RESULT_VARIABLE result)
   IF(NOT ${result} EQUAL 0)
     MESSAGE(FATAL_ERROR 
-      "ABI check found difference between ${file}.pp and ${abi_check_out}")
+      "ABI check found difference between ${file}.pp and ${abi_check_out}, "
+      "compilation error file can be found here: ${errorfile}")
   ENDIF()
+  FILE(REMOVE ${errorfile})
   FILE(REMOVE ${abi_check_out})
 ENDFOREACH()
 

--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -51,6 +51,14 @@ class Item;
 typedef void * MYSQL_PLUGIN;
 
 #include <mysql/services.h>
+#ifndef MYSQL_ABI_CHECK
+#ifndef __WIN__
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS    /* Enable C99 printf format macros */
+#endif /* !__STDC_FORMAT_MACROS */
+#include <inttypes.h>
+#endif /* !__WIN__ */
+#endif /* !MYSQL_ABI_CHECK */
 
 #define MYSQL_XIDDATASIZE 128
 /**


### PR DESCRIPTION
Added <inttypes.h> include in plugin.h. FreeBSD maintainer suggested to include
<my_global.h> instead of <inttypes.h>. This increases code coherence.

Also changes in do_abi_check.cmake were made to have the ability to see
compilator output on compilation error.

https://jenkins.percona.com/job/percona-server-5.6-param/2049/

See also: https://github.com/percona/percona-server/pull/2075