### PR TITLE
lp-1738171: Build error on FreeBSD with 5.6.38-83.0

### DIFF
--- a/cmake/do_abi_check.cmake
+++ b/cmake/do_abi_check.cmake
@@ -55,6 +55,7 @@ SET(abi_check_out ${BINARY_DIR}/abi_check.out)
 FOREACH(file ${ABI_HEADERS})
   GET_FILENAME_COMPONENT(header_basename ${file} NAME)
   SET(tmpfile ${BINARY_DIR}/${header_basename}.pp.tmp)
+  SET(errorfile ${BINARY_DIR}/${header_basename}.pp.err)
 
   EXECUTE_PROCESS(
     COMMAND ${COMPILER} 
@@ -62,7 +63,7 @@ FOREACH(file ${ABI_HEADERS})
       -I${BINARY_DIR}/include -I${SOURCE_DIR}/include/mysql -I${SOURCE_DIR}/sql
       -I${SOURCE_DIR}/libbinlogevents/export
       ${file} 
-      ERROR_QUIET OUTPUT_FILE ${tmpfile})
+      ERROR_FILE ${errorfile} OUTPUT_FILE ${tmpfile})
   EXECUTE_PROCESS(
     COMMAND sed -e "/^# /d"
                 -e "/^[	]*$/d"
@@ -77,8 +78,10 @@ FOREACH(file ${ABI_HEADERS})
     COMMAND diff -w ${file}.pp ${abi_check_out} RESULT_VARIABLE result)
   IF(NOT ${result} EQUAL 0)
     MESSAGE(FATAL_ERROR 
-      "ABI check found difference between ${file}.pp and ${abi_check_out}")
+      "ABI check found difference between ${file}.pp and ${abi_check_out}, "
+      "compilation error file can be found here: ${errorfile}")
   ENDIF()
+  FILE(REMOVE ${errorfile})
   FILE(REMOVE ${abi_check_out})
 ENDFOREACH()
 

--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -57,7 +57,13 @@ typedef void * MYSQL_PLUGIN;
 
 #ifndef MYSQL_ABI_CHECK
 #include <mysql/services.h>
-#endif
+#ifndef __WIN__
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS    /* Enable C99 printf format macros */
+#endif /* !__STDC_FORMAT_MACROS */
+#include <inttypes.h>
+#endif /* !__WIN__ */
+#endif /* !MYSQL_ABI_CHECK */
 
 #define MYSQL_XIDDATASIZE 128
 /**


### PR DESCRIPTION
Added <inttypes.h> include in plugin.h. FreeBSD maintainer suggested to include
<my_global.h> instead of <inttypes.h>. This increases code coherence.

Also changes in do_abi_check.cmake were made to have the ability to see
compilator output on compilation error.

(cherry picked from commit cf8bfa4ef1fcd90596cdcfda1146231cd2e8a124)

https://jenkins.percona.com/view/5.7/job/mysql-5.7-param/1485/

See also: https://github.com/percona/percona-server/pull/2074