### PR TITLE
PS-3780: Fixing release errors with GCC7

### DIFF
--- a/client/dump/sql_formatter.cc
+++ b/client/dump/sql_formatter.cc
@@ -302,7 +302,7 @@ void Sql_formatter::format_dump_start(
     << this->get_charset()->csname
     << ";\n";
   if (dump_start_dump_task->m_gtid_mode == "OFF" &&
-      *((ulong*)&m_options->m_gtid_purged) == ((ulong)GTID_PURGED_ON))
+      m_options->m_gtid_purged == GTID_PURGED_ON)
   {
     m_options->m_mysql_chain_element_options->get_program()->error(
       Mysql::Tools::Base::Message_data(1, "Server has GTIDs disabled.\n",
@@ -311,14 +311,8 @@ void Sql_formatter::format_dump_start(
   }
   if (dump_start_dump_task->m_gtid_mode != "OFF")
   {
-    /*
-     value for m_gtid_purged is set by typecasting its address to ulong*
-     however below conditions fails if we do direct comparison without
-     typecasting on solaris sparc. Guessing that this is due to differnt
-     endianess.
-    */
-    if (*((ulong*)&m_options->m_gtid_purged) == ((ulong)GTID_PURGED_ON) ||
-        *((ulong*)&m_options->m_gtid_purged) == ((ulong)GTID_PURGED_AUTO))
+    if (m_options->m_gtid_purged == GTID_PURGED_ON ||
+        m_options->m_gtid_purged == GTID_PURGED_AUTO)
     {
       if (!m_mysqldump_tool_options->m_dump_all_databases)
       {

--- a/client/dump/sql_formatter_options.h
+++ b/client/dump/sql_formatter_options.h
@@ -56,7 +56,12 @@ public:
   bool m_suppress_create_database;
   bool m_timezone_consistent;
   bool m_skip_definer;
-  enum enum_gtid_purged_mode m_gtid_purged;
+  // Storing m_gtid_purged as an ulong, because its setter code treats it as a
+  // long variable.
+  // Storing it as an enum causes issues on some systems beacuse of endianness,
+  // and only works because of the alignment of the next pointer on 64 bit
+  // systems.
+  ulong m_gtid_purged;
   const Mysql_chain_element_options* m_mysql_chain_element_options;
 
   const TYPELIB* get_gtid_purged_mode_typelib()

--- a/cmake/build_configurations/compiler_options.cmake
+++ b/cmake/build_configurations/compiler_options.cmake
@@ -24,9 +24,12 @@ ENDIF()
 IF(SIZEOF_VOIDP EQUAL 8)
   SET(64BIT 1)
 ENDIF()
+
+SET(CMAKE_CXX_STANDARD 98)
  
 # Compiler options
 IF(UNIX)  
+  SET(CMAKE_CXX98_EXTENSION_COMPILE_OPTION -std=gnu++03)
 
   # Default GCC flags
   IF(CMAKE_COMPILER_IS_GNUCC)
@@ -58,9 +61,6 @@ IF(UNIX)
     # GCC 6 has C++14 as default, set it explicitly to the old default.
     EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GXX_VERSION)
-    IF(GXX_VERSION VERSION_EQUAL 6.0 OR GXX_VERSION VERSION_GREATER 6.0)
-      SET(COMMON_CXX_FLAGS             "${COMMON_CXX_FLAGS} -std=gnu++03")
-    ENDIF()
     # Disable inline optimizations for valgrind testing to avoid false positives
     IF(WITH_VALGRIND)
       SET(COMMON_CXX_FLAGS             "-fno-inline ${COMMON_CXX_FLAGS}")

--- a/cmake/check_stdcxx11.cmake
+++ b/cmake/check_stdcxx11.cmake
@@ -22,8 +22,15 @@ INCLUDE (CheckCXXCompilerFlag)
 check_cxx_compiler_flag (-std=c++11 HAVE_STDCXX11)
 
 IF (HAVE_STDCXX11)
-  STRING (REPLACE "-std=gnu++03" "" COMMON_CXX_FLAGS ${COMMON_CXX_FLAGS})
-  STRING (REPLACE "-std=gnu++03" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
-  STRING (REPLACE "-std=gnu++03" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
-  SET (CMAKE_CXX_FLAGS "-std=c++11 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
+  IF ("${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION}" VERSION_GREATER "3.1")
+    SET (CMAKE_CXX_FLAGS "-Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
+  ELSE ()
+    # CMAKE_CXX_STANDARD was introduced in CMake 3.1, it will be ignored by older CMake
+    SET (CMAKE_CXX_FLAGS "--std=c++11 -Wno-deprecated-declarations ${CMAKE_CXX_FLAGS}")
+  ENDIF()
 ENDIF ()
+
+
+SET(CMAKE_CXX_STANDARD 11)
+SET(CMAKE_CXX_EXTENSIONS OFF)
+SET(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/sql/rpl_reporting.cc
+++ b/sql/rpl_reporting.cc
@@ -115,6 +115,28 @@ Slave_reporting_capability::report(loglevel level, int err_code,
 }
 
 void
+Slave_reporting_capability::Error::update_timestamp()
+{
+  struct tm tm_tmp;
+  struct tm *start;
+
+  skr= my_time(0);
+  localtime_r(&skr, &tm_tmp);
+  start=&tm_tmp;
+
+  my_snprintf(timestamp,
+              sizeof(timestamp),
+              "%02d%02d%02d %02d:%02d:%02d",
+              start->tm_year % 100,
+              start->tm_mon+1,
+              start->tm_mday,
+              start->tm_hour,
+              start->tm_min,
+              start->tm_sec);
+  timestamp[15]= '\0';
+}
+
+void
 Slave_reporting_capability::va_report(loglevel level, int err_code,
                                       const char *prefix_msg,
                                       const char *msg, va_list args) const
@@ -154,7 +176,9 @@ Slave_reporting_capability::va_report(loglevel level, int err_code,
     break;
   default:
     DBUG_ASSERT(0);                            // should not come here
-    return;          // don't crash production builds, just do nothing
+    // don't crash production builds, just do nothing
+    mysql_mutex_unlock(&err_lock);
+    return;
   }
   curr_buff= pbuff;
   if (prefix_msg)

--- a/sql/rpl_reporting.h
+++ b/sql/rpl_reporting.h
@@ -101,24 +101,7 @@ public:
 
     }
 
-    void update_timestamp()
-    {
-      struct tm tm_tmp;
-      struct tm *start;
-
-      skr= my_time(0);
-      localtime_r(&skr, &tm_tmp);
-      start=&tm_tmp;
-
-      sprintf(timestamp, "%02d%02d%02d %02d:%02d:%02d",
-              start->tm_year % 100,
-              start->tm_mon+1,
-              start->tm_mday,
-              start->tm_hour,
-              start->tm_min,
-              start->tm_sec);
-      timestamp[15]= '\0';
-    }
+    void update_timestamp();
 
     /** Error code */
     uint32 number;

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -1,4 +1,5 @@
 # TODO: Copyrights
+SET(CMAKE_CXX_STANDARD 11)
 
 # by default MyRocks is not built
 IF (NOT DEFINED WITH_ROCKSDB)
@@ -34,6 +35,13 @@ IF ((CMAKE_CXX_COMPILER_ID STREQUAL GNU) AND
   RETURN ()
 ENDIF ()
 
+# Relax unused variable warnings for release modes
+MY_CHECK_CXX_COMPILER_FLAG("-Wunused-variable" HAVE_UNUSED_VARIABLE)
+IF(HAVE_UNUSED_VARIABLE)
+  SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-unused-variable")
+  SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -Wno-unused-variable")
+ENDIF()
+
 # Relax fallthrough warnings we have no control over, as it's in zstd
 IF(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   MY_CHECK_CXX_COMPILER_FLAG("-Wimplicit-fallthrough=0" HAVE_IMPLICIT_FALLTHROUGH)
@@ -60,7 +68,7 @@ IF(HAVE_SCHED_GETCPU)
 ENDIF()
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
-SET(CMAKE_REQUIRED_FLAGS ${CMAKE_CXX_FLAGS})
+SET(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
 INCLUDE(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("
 #include <cstdint>

--- a/testclients/bug25714.c
+++ b/testclients/bug25714.c
@@ -71,6 +71,6 @@ int main (int argc, char **argv)
   mysql_close(&conn);
   my_end(0);
 
-  return 0;
+  return OK;
 }
 


### PR DESCRIPTION
* Changed the type of m_gtid_purged from an enum to an ulong, as it's used with TYPELIB.
* Removed basically broken c style casts of m_gtid_purged to ulong*
* Changed C++ standard handling in the CMake files from hand written CXXFLAGS to the standard variables
  This is required because modern compilers default to C++14,which results in a long list of deprecation
  warnings for MySQL code, and the previous solution only set it explicitly to C++03 for debug builds -
  release builds compiled with C++14 mode, which could even cause semantic differences.
* Fixed an snprintf call in update_timestamp
* Moved update_timestamp to the cpp file from the header, as my_snprintf isn't available in the header
* Added a missing mutex unlock in an execution path which should never happen
* Fixed an unused variable in the release buld of a test, and made the tests's return code the result