### PR TITLE
TDB-102: support xa interleaving on slave thread

### DIFF
--- a/mysql-test/suite/tokudb.rpl/r/rpl_xa_interleave.result
+++ b/mysql-test/suite/tokudb.rpl/r/rpl_xa_interleave.result
@@ -1,0 +1,62 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE t1(`a` INT) ENGINE=TokuDB;
+XA START 'x1';
+INSERT INTO t1 VALUES (1);
+XA END 'x1';
+XA PREPARE 'x1';
+BEGIN;
+INSERT INTO t1 VALUES (10);
+COMMIT;
+XA START 'y1';
+INSERT INTO t1 VALUES (2);
+XA END 'y1';
+XA PREPARE 'y1';
+XA COMMIT 'x1';
+XA COMMIT 'y1';
+BEGIN;
+INSERT INTO t1 VALUES (11);
+COMMIT;
+XA START 'x2';
+INSERT INTO t1 VALUES (3);
+XA END 'x2';
+XA PREPARE 'x2';
+XA START 'y2';
+INSERT INTO t1 VALUES (4);
+XA END 'y2';
+XA PREPARE 'y2';
+XA COMMIT 'x2';
+XA COMMIT 'y2';
+XA START 'x1';
+INSERT INTO t1 VALUES (1);
+XA END 'x1';
+XA PREPARE 'x1';
+BEGIN;
+INSERT INTO t1 VALUES (10);
+COMMIT;
+XA START 'y1';
+INSERT INTO t1 VALUES (2);
+XA END 'y1';
+XA PREPARE 'y1';
+XA ROLLBACK 'x1';
+XA ROLLBACK 'y1';
+BEGIN;
+INSERT INTO t1 VALUES (11);
+COMMIT;
+XA START 'x2';
+INSERT INTO t1 VALUES (3);
+XA END 'x2';
+XA PREPARE 'x2';
+XA START 'y2';
+INSERT INTO t1 VALUES (4);
+XA END 'y2';
+XA PREPARE 'y2';
+XA ROLLBACK 'x2';
+XA ROLLBACK 'y2';
+TABLES t1 and t2 must be equal otherwise an error will be thrown.
+include/diff_tables.inc [master:test.t1, slave:test.t1]
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/tokudb.rpl/t/rpl_xa_interleave.test
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_xa_interleave.test
@@ -1,0 +1,103 @@
+--source include/have_tokudb.inc
+--source include/have_binlog_format_mixed_or_row.inc
+--source include/master-slave.inc
+
+CREATE TABLE t1(`a` INT) ENGINE=TokuDB;
+
+## XA interleave commit
+--connection master
+XA START 'x1';
+INSERT INTO t1 VALUES (1);
+XA END 'x1';
+XA PREPARE 'x1';
+
+--connection master1
+BEGIN;
+INSERT INTO t1 VALUES (10);
+COMMIT;
+XA START 'y1';
+INSERT INTO t1 VALUES (2);
+XA END 'y1';
+XA PREPARE 'y1';
+
+--connection master
+XA COMMIT 'x1';
+
+--connection master1
+XA COMMIT 'y1';
+
+--connection master
+BEGIN;
+INSERT INTO t1 VALUES (11);
+COMMIT;
+XA START 'x2';
+INSERT INTO t1 VALUES (3);
+XA END 'x2';
+XA PREPARE 'x2';
+
+--connection master1
+XA START 'y2';
+INSERT INTO t1 VALUES (4);
+XA END 'y2';
+XA PREPARE 'y2';
+
+--connection master
+XA COMMIT 'x2';
+
+--connection master1
+XA COMMIT 'y2';
+
+## XA interleave rollback
+--connection master
+XA START 'x1';
+INSERT INTO t1 VALUES (1);
+XA END 'x1';
+XA PREPARE 'x1';
+
+--connection master1
+BEGIN;
+INSERT INTO t1 VALUES (10);
+COMMIT;
+XA START 'y1';
+INSERT INTO t1 VALUES (2);
+XA END 'y1';
+XA PREPARE 'y1';
+
+--connection master
+XA ROLLBACK 'x1';
+
+--connection master1
+XA ROLLBACK 'y1';
+
+--connection master
+BEGIN;
+INSERT INTO t1 VALUES (11);
+COMMIT;
+XA START 'x2';
+INSERT INTO t1 VALUES (3);
+XA END 'x2';
+XA PREPARE 'x2';
+
+--connection master1
+XA START 'y2';
+INSERT INTO t1 VALUES (4);
+XA END 'y2';
+XA PREPARE 'y2';
+
+--connection master
+XA ROLLBACK 'x2';
+
+--connection master1
+XA ROLLBACK 'y2';
+
+--connection master
+
+--sync_slave_with_master
+
+--echo TABLES t1 and t2 must be equal otherwise an error will be thrown.
+--let $diff_tables= master:test.t1, slave:test.t1
+--source include/diff_tables.inc
+
+--connection master
+DROP TABLE t1;
+--source include/rpl_end.inc

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -983,7 +983,7 @@ static bool tokudb_sync_on_prepare(void) {
 }   
 
 static int tokudb_xa_prepare(handlerton* hton, THD* thd, bool all) {
-    TOKUDB_DBUG_ENTER("");
+    TOKUDB_DBUG_ENTER("%u", all);
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
     int r = 0;
 
@@ -1011,6 +1011,22 @@ static int tokudb_xa_prepare(handlerton* hton, THD* thd, bool all) {
         r = txn->xa_prepare(txn, &thd_xid, syncflag);
         // test hook to induce a crash on a debug build
         DBUG_EXECUTE_IF("tokudb_crash_prepare_after", DBUG_SUICIDE(););
+
+        // XA log entries can be interleaved in the binlog since XA prepare on the master
+        // flushes to the binlog.  There can be log entries from different clients pushed
+        // into the binlog before XA commit is executed on the master.  Therefore, the slave
+        // thread must be able to juggle multiple XA transactions.  Tokudb does this by
+        // zapping the client transaction context on the slave when executing the XA prepare
+        // and expecting to process XA commit with commit_by_xid (which supplies the XID so
+        // that the transaction can be looked up and committed).
+        if (r == 0 && all && thd->slave_thread) {
+            TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "zap txn context %u", thd_sql_command(thd));
+            if (thd_sql_command(thd) == SQLCOM_XA_PREPARE) {
+                trx->all = NULL;
+                trx->sub_sp_level = NULL;
+                trx->sp_level = NULL;
+            }
+        }
     } else {
         TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "nothing to prepare %d", all);
     }
@@ -1041,6 +1057,7 @@ static int tokudb_xa_recover(handlerton* hton, XID* xid_list, uint len) {
 static int tokudb_commit_by_xid(handlerton* hton, XID* xid) {
     TOKUDB_DBUG_ENTER("");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
+    TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "xid %p", xid);
     int r = 0;
     DB_TXN* txn = NULL;
     TOKU_XA_XID* toku_xid = (TOKU_XA_XID*)xid;
@@ -1060,6 +1077,7 @@ cleanup:
 static int tokudb_rollback_by_xid(handlerton* hton, XID*  xid) {
     TOKUDB_DBUG_ENTER("");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
+    TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "xid %p", xid);
     int r = 0;
     DB_TXN* txn = NULL;
     TOKU_XA_XID* toku_xid = (TOKU_XA_XID*)xid;


### PR DESCRIPTION
The initial code can be found here:
https://github.com/XeLabs/tokudb/tree/tokudb_xa_interleave

XA log entries can be interleaved in the binlog since XA prepare on the master
flushes to the binlog. There can be log entries from different clients pushed
into the binlog before XA commit is executed on the master. Therefore, the slave
thread must be able to juggle multiple XA transactions. Tokudb does this by
zapping the client transaction context on the slave when executing the XA
prepare and expecting to process XA commit with commit_by_xid (which supplies
the XID so that the transaction can be looked up and committed).

For 5.6 the test does not fail even without code changes because there is no separate binlog event for "XA PREPARE", as a result, there is no XA interleaving.

(cherry picked from commit 1033c6ae36db712713aa7b8f4256267dba1446ed)
5.7 PR: https://github.com/percona/percona-server/pull/2082,
See also https://github.com/percona/percona-server/pull/2057,
Testing: https://jenkins.percona.com/job/percona-server-5.6-param/2051/.