### PR TITLE
Fix bug PS-2415 (Test main.innodb_mysql_lock is unstable)

### DIFF
--- a/mysql-test/r/innodb_mysql_lock.result
+++ b/mysql-test/r/innodb_mysql_lock.result
@@ -14,6 +14,7 @@ INSERT INTO t1 VALUES (1);
 set @@autocommit=0;
 DROP TABLE t1;
 # Connection 1
+# Waiting for until transaction will be locked inside innodb subsystem
 # Connection 1 is now holding the lock.
 # Issuing insert from connection 1 while connection 2&3 
 # is waiting for the lock should give a deadlock error.

--- a/mysql-test/t/innodb_mysql_lock.test
+++ b/mysql-test/t/innodb_mysql_lock.test
@@ -34,10 +34,12 @@ set @@autocommit=0;
 
 --echo # Connection 1
 connection con1;
+--echo # Waiting for until transaction will be locked inside innodb subsystem
 let $wait_condition=
-  SELECT COUNT(*) = 1 FROM information_schema.processlist
-  WHERE info = "INSERT INTO t1 VALUES (1)" and 
-  state = "update";
+  SELECT COUNT(*) = 1 FROM information_schema.innodb_trx
+  WHERE trx_query = 'INSERT INTO t1 VALUES (1)' AND
+  trx_operation_state = 'inserting' AND
+  trx_state = 'LOCK WAIT';
 --source include/wait_condition.inc
 let $wait_condition=
   SELECT COUNT(*) = 1 FROM information_schema.processlist


### PR DESCRIPTION
Fix by cherry-picking the fix from upstream 5.6.

Fixed bug#13625834 - main.innodb_mysql_lock test fails on debian5.0-x86_64
                     sporadically.

The reason for this bug is that there was a race condition in checking for
'update' state in wait_condition loop and acquiring real transaction lock
during execution of statement 'INSERT'. Such race condition arised since
there was a time window between the step when server sets a transaction state
in 'update' value and when the real lock for transation is acquired. Such
race condition could result in successful execution of the following statement
'INSERT INTO t1 VALUES (2)' that else should failed with error
ER_LOCK_DEADLOCK.

To eliminate this race condition we replaced the conditon of waiting for
lock by polling the table information_schema.innodb_trx until transaction will
be locked.

(cherry picked from commit 0454f5aba958117a777bab005ed36815a073d3c7)

https://jenkins.percona.com/job/percona-server-5.5-param/1625/