### PR TITLE
Fix lp:1690011 (pfs unit test ASan error in 5.6.36) (5.6)

### DIFF
--- a/storage/perfschema/unittest/pfs-t.cc
+++ b/storage/perfschema/unittest/pfs-t.cc
@@ -899,6 +899,7 @@ void test_init_disabled()
   psi->create_file(file_key_A, "foo-instrumented", (File) 12);
   file_A1= lookup_file_by_name("foo-instrumented");
   ok(file_A1 != NULL, "file_A1 instrumented");
+  destroy_file(reinterpret_cast<PFS_thread*>(psi->get_thread()), file_A1);
 
   /* broken key + enabled T-1: no instrumentation */
 
@@ -1150,6 +1151,8 @@ void test_locker_disabled()
   psi->create_file(file_key_A, "foo", (File) 12);
   file_A1= (PSI_file*) lookup_file_by_name("foo");
   ok(file_A1 != NULL, "instrumented");
+  destroy_file(reinterpret_cast<PFS_thread*>(psi->get_thread()),
+               reinterpret_cast<PFS_file*>(file_A1));
 
   socket_class_A->m_enabled= true;
   socket_A1= psi->init_socket(socket_key_A, NULL, NULL, 0);


### PR DESCRIPTION
https://bugs.launchpad.net/percona-server/+bug/1690011

Fixed problem with memory leak in 'pfs-t' unit test caused by
'test_locker_disabled()' not freeing resources after calling
'psi->create_file().'