### PR TITLE
Ps 5.6 tdb 104 105

### DIFF
--- a/storage/tokudb/.clang-format
+++ b/storage/tokudb/.clang-format
@@ -1,0 +1,40 @@
+# .clang-format file for Percona TokuDB
+# Minimum required version of clang-format is 5.0.1. Earlier versions will work
+# but may need removal of some parameters.
+Language:        Cpp
+BasedOnStyle:  Google
+
+# The following parameters are default for Google style,
+# but as they are important for our project they
+# are set explicitly here
+AlignAfterOpenBracket: Align
+BreakBeforeBinaryOperators: None
+ColumnLimit:     80
+PointerAlignment: Left
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+UseTab:          Never
+
+# Non-default parameters
+NamespaceIndentation: All
+IndentWidth:     4
+TabWidth:        4
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackParameters: false
+BinPackArguments: false
+ExperimentalAutoDetectBinPacking: false
+AllowAllParametersOfDeclarationOnNextLine: false
+# not supported in 5.0.1
+#AlignConsecutiveAssignments: yes
+#AlignConsecutiveDeclarations: yes
+BreakStringLiterals: false
+ReflowComments: true


### PR DESCRIPTION
Pick up changes merged to FT :
https://github.com/percona/PerconaFT/pull/391 : https://github.com/percona/PerconaFT/pull/397 : fix issues found with gcc 7
https://github.com/percona/PerconaFT/pull/392 : TDB-98 : pfs leaks memory on shutdown
https://github.com/percona/PerconaFT/pull/394 : TDB-99 : Directory_lock test fails with valgrind due to uninitialized variable
https://github.com/percona/PerconaFT/pull/398 : TDB-93 : Unaligned pointers in perconaFT
https://github.com/percona/PerconaFT/pull/389 :  test-max-data: ppc64 behaves like x86_64 and aarch64
https://github.com/percona/PerconaFT/pull/386 : tests: compile error on arches where char is unsigned
https://github.com/percona/PerconaFT/pull/388 : Add POWER implementation for toku_time_now
TDB-104 : add .clang-format file to PerconaFT and TDB