### PR TITLE
PS-2414: keyring_vault timeout MTR tests always producing warnings

### DIFF
--- a/plugin/keyring_vault/tests/mtr/timeout_basic.result
+++ b/plugin/keyring_vault/tests/mtr/timeout_basic.result
@@ -1,5 +1,6 @@
 call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 SET @start_global_value = @@GLOBAL.keyring_vault_timeout;
 SET @@GLOBAL.keyring_vault_timeout = 100;
 SET @@GLOBAL.keyring_vault_timeout = DEFAULT;

--- a/plugin/keyring_vault/tests/mtr/timeout_basic.test
+++ b/plugin/keyring_vault/tests/mtr/timeout_basic.test
@@ -12,6 +12,7 @@
 --source include/have_keyring_vault_plugin.inc
 call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 
 #############################################################
 #                 Save initial value                        #


### PR DESCRIPTION
Suppressed warning "File '' not found". This is a correct warning
generated when keyring_vault is loaded without correct path to
configuration file. In this case the path is null, i.e. ''.