### PR TITLE
PS-2414: keyring_vault timeout MTR tests always producing warnings

### DIFF
--- a/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.result
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.result
@@ -4,7 +4,11 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL retur
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault.'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : connect\\(\\) timed out!'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 INSTALL PLUGIN keyring_vault SONAME 'keyring_vault.so';
+Warnings:
+Warning	29	File '' not found (Errcode: 2 - No such file or directory)
+Warning	42000	keyring_vault initialization failure. Please check the server log.
 include/assert.inc [Default vaule of keyring_vault_timeout should be 15]
 SET @@GLOBAL.keyring_vault_timeout=15;
 SET @@GLOBAL.keyring_vault_config='MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault_incorrect_server.conf';

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.test
@@ -8,6 +8,7 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL retur
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault.'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : connect\\(\\) timed out!'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
 
 --let $KEYRING_CONF_FILE_1=$MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault_incorrect_server.conf
 --let $KEYRING_CONF_TEMPLATE_FILE=$MYSQL_TEST_DIR/std_data/keyring_vault_confs/keyring_vault_incorrect_server.conf


### PR DESCRIPTION
Suppressed warning "File '' not found". This is a correct warning
generated when keyring_vault is loaded without correct path to
configuration file. In this case the path is null, i.e. ''.

(fix for keyring_vault_timeout)