### PR TITLE
Fix PS-3781 ('main.mysqld--help-notwin' MTR test case fails after introducing 'ft-query-extra-word-chars')

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -299,6 +299,9 @@ The following options may be given as the first argument:
  after changing this variable
  --ft-query-expansion-limit=# 
  Number of best matches to use for query expansion
+ --ft-query-extra-word-chars 
+ If enabled, all non-whitespace characters are considered
+ word symbols for full text search queries
  --ft-stopword-file=name 
  Use stopwords from this file instead of built-in list
  --gdb               Set up signals usable for debugging.
@@ -1410,6 +1413,7 @@ ft-boolean-syntax + -><()~*:""&|
 ft-max-word-len 84
 ft-min-word-len 4
 ft-query-expansion-limit 20
+ft-query-extra-word-chars FALSE
 ft-stopword-file (No default value)
 gdb FALSE
 general-log FALSE


### PR DESCRIPTION
https://jira.percona.com/projects/PS/issues/PS-3781

Re-recorded 'main.mysqld--help-notwin' MTR test case because of the new
'ft-query-extra-word-chars' system variable introduces in the fix for
PS-2501
"LP #1689268: Fulltext search can not find word which contains punctuation marks"
(https://jira.percona.com/browse/PS-2501).