### PR TITLE
PS-3788: partially dynamic @version variable using support of @version_suffix

### DIFF
--- a/mysql-test/suite/sys_vars/r/version_comment_basic.result
+++ b/mysql-test/suite/sys_vars/r/version_comment_basic.result
@@ -5,8 +5,23 @@ COUNT(@@GLOBAL.version_comment)
 1 Expected
 '#---------------------BS_STVARS_054_02----------------------#'
 SET @@GLOBAL.version_comment=1;
-ERROR HY000: Variable 'version_comment' is a read only variable
-Expected error 'Read only variable'
+ERROR 42000: Incorrect argument type to variable 'version_comment'
+Expected error 'Incorrect argument type to variable'
+SET @saved_version_comment = @@global.version_comment;
+SET GLOBAL version_comment = DEFAULT;
+SET GLOBAL version_comment = '';
+SELECT @@global.version_comment;
+@@global.version_comment
+
+SET GLOBAL version_comment = 'my_comment';
+SELECT @@global.version_comment;
+@@global.version_comment
+my_comment
+SET GLOBAL version_comment = 'my_comment2';
+SELECT @@global.version_comment;
+@@global.version_comment
+my_comment2
+SET GLOBAL version_comment = @saved_version_comment;
 SELECT COUNT(@@GLOBAL.version_comment);
 COUNT(@@GLOBAL.version_comment)
 1

--- a/mysql-test/suite/sys_vars/r/version_suffix_basic.result
+++ b/mysql-test/suite/sys_vars/r/version_suffix_basic.result
@@ -1,0 +1,66 @@
+SELECT COUNT(@@GLOBAL.version_suffix);
+COUNT(@@GLOBAL.version_suffix)
+1
+1 Expected
+SET @@GLOBAL.version_suffix=1;
+ERROR 42000: Incorrect argument type to variable 'version_suffix'
+Expected error 'Incorrect argument type to variable'
+SET @saved_version_suffix = @@global.version_suffix;
+SET GLOBAL version_suffix = DEFAULT;
+SET GLOBAL version_suffix = '';
+SET @version_base = @@global.version;
+SELECT @@global.version_suffix;
+@@global.version_suffix
+
+SET GLOBAL version_suffix = '-my_version';
+SELECT @@global.version_suffix;
+@@global.version_suffix
+-my_version
+include/assert.inc [Strings should be equal]
+SET GLOBAL version_suffix = '-my_version2';
+SELECT @@global.version_suffix;
+@@global.version_suffix
+-my_version2
+include/assert.inc [Strings should be equal]
+SET GLOBAL version_suffix = @saved_version_suffix;
+SELECT COUNT(@@GLOBAL.version_suffix);
+COUNT(@@GLOBAL.version_suffix)
+1
+1 Expected
+SELECT @@GLOBAL.version_suffix = VARIABLE_VALUE
+FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES
+WHERE VARIABLE_NAME='version_suffix';
+@@GLOBAL.version_suffix = VARIABLE_VALUE
+1
+1 Expected
+SELECT COUNT(@@GLOBAL.version_suffix);
+COUNT(@@GLOBAL.version_suffix)
+1
+1 Expected
+SELECT COUNT(VARIABLE_VALUE)
+FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES 
+WHERE VARIABLE_NAME='version_suffix';
+COUNT(VARIABLE_VALUE)
+1
+1 Expected
+SELECT @@version_suffix = @@GLOBAL.version_suffix;
+@@version_suffix = @@GLOBAL.version_suffix
+1
+1 Expected
+SELECT COUNT(@@version_suffix);
+COUNT(@@version_suffix)
+1
+1 Expected
+SELECT COUNT(@@local.version_suffix);
+ERROR HY000: Variable 'version_suffix' is a GLOBAL variable
+Expected error 'Variable is a GLOBAL variable'
+SELECT COUNT(@@SESSION.version_suffix);
+ERROR HY000: Variable 'version_suffix' is a GLOBAL variable
+Expected error 'Variable is a GLOBAL variable'
+SELECT COUNT(@@GLOBAL.version_suffix);
+COUNT(@@GLOBAL.version_suffix)
+1
+1 Expected
+SELECT version_suffix = @@SESSION.version_suffix;
+ERROR 42S22: Unknown column 'version_suffix' in 'field list'
+Expected error 'Readonly variable'

--- a/mysql-test/suite/sys_vars/t/version_comment_basic.test
+++ b/mysql-test/suite/sys_vars/t/version_comment_basic.test
@@ -35,9 +35,26 @@ SELECT COUNT(@@GLOBAL.version_comment);
 #   Check if Value can set                                         #
 ####################################################################
 
---error ER_INCORRECT_GLOBAL_LOCAL_VAR
+--error ER_WRONG_TYPE_FOR_VAR
 SET @@GLOBAL.version_comment=1;
---echo Expected error 'Read only variable'
+--echo Expected error 'Incorrect argument type to variable'
+
+# save the start value
+SET @saved_version_comment = @@global.version_comment;
+
+SET GLOBAL version_comment = DEFAULT;
+
+SET GLOBAL version_comment = '';
+SELECT @@global.version_comment;
+
+SET GLOBAL version_comment = 'my_comment';
+SELECT @@global.version_comment;
+
+SET GLOBAL version_comment = 'my_comment2';
+SELECT @@global.version_comment;
+
+# restore the start value
+SET GLOBAL version_comment = @saved_version_comment;
 
 SELECT COUNT(@@GLOBAL.version_comment);
 --echo 1 Expected

--- a/mysql-test/suite/sys_vars/t/version_suffix_basic.test
+++ b/mysql-test/suite/sys_vars/t/version_suffix_basic.test
@@ -1,0 +1,96 @@
+####################################################################
+#   Displaying default value                                       #
+####################################################################
+SELECT COUNT(@@GLOBAL.version_suffix);
+--echo 1 Expected
+
+
+####################################################################
+#   Check if Value can set and if @@version is set according to    #
+#   @@version_suffix                                               #
+####################################################################
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET @@GLOBAL.version_suffix=1;
+--echo Expected error 'Incorrect argument type to variable'
+
+# save the start value
+SET @saved_version_suffix = @@global.version_suffix;
+
+SET GLOBAL version_suffix = DEFAULT;
+
+SET GLOBAL version_suffix = '';
+SET @version_base = @@global.version;
+SELECT @@global.version_suffix;
+
+SET GLOBAL version_suffix = '-my_version';
+SELECT @@global.version_suffix;
+--let $assert_text= Strings should be equal
+--let $assert_cond= STRCMP(@@global.version, CONCAT(@version_base, @@global.version_suffix)) = 0
+--source include/assert.inc
+
+SET GLOBAL version_suffix = '-my_version2';
+SELECT @@global.version_suffix;
+--let $assert_text= Strings should be equal
+--let $assert_cond= STRCMP(@@global.version, CONCAT(@version_base, @@global.version_suffix)) = 0
+--source include/assert.inc
+
+# restore the start value
+SET GLOBAL version_suffix = @saved_version_suffix;
+
+SELECT COUNT(@@GLOBAL.version_suffix);
+--echo 1 Expected
+
+
+
+
+#################################################################
+# Check if the value in GLOBAL Table matches value in variable  #
+#################################################################
+
+SELECT @@GLOBAL.version_suffix = VARIABLE_VALUE
+FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES
+WHERE VARIABLE_NAME='version_suffix';
+--echo 1 Expected
+
+SELECT COUNT(@@GLOBAL.version_suffix);
+--echo 1 Expected
+
+SELECT COUNT(VARIABLE_VALUE)
+FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES 
+WHERE VARIABLE_NAME='version_suffix';
+--echo 1 Expected
+
+
+
+################################################################################
+#  Check if accessing variable with and without GLOBAL point to same variable  #
+################################################################################
+SELECT @@version_suffix = @@GLOBAL.version_suffix;
+--echo 1 Expected
+
+
+
+################################################################################
+#   Check if version_suffix can be accessed with and without @@ sign          #
+################################################################################
+
+SELECT COUNT(@@version_suffix);
+--echo 1 Expected
+
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT COUNT(@@local.version_suffix);
+--echo Expected error 'Variable is a GLOBAL variable'
+
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT COUNT(@@SESSION.version_suffix);
+--echo Expected error 'Variable is a GLOBAL variable'
+
+SELECT COUNT(@@GLOBAL.version_suffix);
+--echo 1 Expected
+
+--Error ER_BAD_FIELD_ERROR
+SELECT version_suffix = @@SESSION.version_suffix;
+--echo Expected error 'Readonly variable'
+
+

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -674,6 +674,7 @@ Time_zone *default_tz;
 char *mysql_data_home= const_cast<char*>(".");
 const char *mysql_real_data_home_ptr= mysql_real_data_home;
 char server_version[SERVER_VERSION_LENGTH];
+char server_version_suffix[SERVER_VERSION_LENGTH];
 char *mysqld_unix_port, *opt_mysql_tmpdir;
 ulong thread_handling;
 
@@ -9597,7 +9598,10 @@ static void set_server_version(void)
     end= strmov(end, "-debug");
 #endif
   if (opt_log || opt_slow_log || opt_bin_log)
-    strmov(end, "-log");                        // This may slow down system
+    end= strmov(end, "-log");                        // This may slow down system
+
+  DBUG_ASSERT(end < server_version + SERVER_VERSION_LENGTH);
+  strmov(server_version_suffix, server_version + strlen(MYSQL_SERVER_VERSION));
 }
 
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -609,6 +609,7 @@ extern const char *mysql_real_data_home_ptr;
 extern ulong thread_handling;
 extern MYSQL_PLUGIN_IMPORT char  *mysql_data_home;
 extern "C" MYSQL_PLUGIN_IMPORT char server_version[SERVER_VERSION_LENGTH];
+extern "C" MYSQL_PLUGIN_IMPORT char server_version_suffix[SERVER_VERSION_LENGTH];
 extern MYSQL_PLUGIN_IMPORT char mysql_real_data_home[];
 extern char mysql_unpacked_real_data_home[];
 extern MYSQL_PLUGIN_IMPORT struct system_variables global_system_variables;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3463,15 +3463,21 @@ static Sys_var_mybool Sys_timed_mutexes(
        DEPRECATED(""));
 
 static char *server_version_ptr;
-static Sys_var_charptr Sys_version(
+static Sys_var_version Sys_version(
        "version", "Server version",
        READ_ONLY GLOBAL_VAR(server_version_ptr), NO_CMD_LINE,
-       IN_SYSTEM_CHARSET, DEFAULT(server_version));
+       IN_SYSTEM_CHARSET, DEFAULT(MYSQL_SERVER_VERSION));
+
+static char *server_version_suffix_ptr;
+static Sys_var_charptr Sys_version_suffix(
+       "version_suffix", "version_suffix",
+       GLOBAL_VAR(server_version_suffix_ptr), NO_CMD_LINE,
+       IN_SYSTEM_CHARSET, DEFAULT(server_version_suffix));
 
 static char *server_version_comment_ptr;
 static Sys_var_charptr Sys_version_comment(
        "version_comment", "version_comment",
-       READ_ONLY GLOBAL_VAR(server_version_comment_ptr), NO_CMD_LINE,
+       GLOBAL_VAR(server_version_comment_ptr), NO_CMD_LINE,
        IN_SYSTEM_CHARSET, DEFAULT(MYSQL_COMPILATION_COMMENT));
 
 static char *server_version_compile_machine_ptr;


### PR DESCRIPTION
…nd @version_comment variables.

@version_comment: convert this variable from a global read-only to a global read-write variable.

@version: introduce new global read-write string variable @version_suffix. If @version_suffix is set to a string, for example, "-foo", then @version variable is truncated after the version number and @version_suffix is appended, resulting in e.g. "5.7.13-foo". Note that an empty string provides a way to leave only the version number in @version.