### PR TITLE
PS-259 : Issue during valgrind-yassl binary build

### DIFF
--- a/storage/tokudb/CMakeLists.txt
+++ b/storage/tokudb/CMakeLists.txt
@@ -92,7 +92,11 @@ ELSEIF (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ft-index/")
     MESSAGE(WARNING "Found ft-index sources, ft-index is deprecated and replaced with PerconaFT.")
     SET(TOKU_FT_DIR_NAME "ft-index")
 ELSE ()
-        MESSAGE(FATAL_ERROR "Could not find PerconaFT sources.")
+    MESSAGE(FATAL_ERROR "Could not find PerconaFT sources.")
+ENDIF ()
+
+IF (WITH_VALGRIND)
+    SET(USE_VALGRIND "ON")
 ENDIF ()
 
 ADD_SUBDIRECTORY(${TOKU_FT_DIR_NAME})


### PR DESCRIPTION
PS-1121 : LP #1729321: Tokudb does not build when WITH_VALGRIND=1
- PerconaFT recognizes USE_VALGRIND and not WITH_VALGRIND. Added minor check in
  TokuDB CMakeLists.txt that setc USE_VALGRIND if WITH_VALGRIND is set.