### PR TITLE
TDB-48 : mtr Valgrind errors on LZMA

### DIFF
--- a/mysql-test/valgrind.supp
+++ b/mysql-test/valgrind.supp
@@ -915,6 +915,13 @@
    fun:tls_get_addr_tail
 }
 
+{
+   lzma encoder prepare bug
+   Memcheck:Cond
+   fun:lz_encoder_prepare
+   fun:lzma_lz_encoder_init
+}
+
 #supress warnings from openssl
 
 {


### PR DESCRIPTION
- Added mtr Valgrind suppression for PerconaFT LZMA lz_encoder_prepare