### PR TITLE
PS-296: mysqld crashing with subselects and long keys

### DIFF
--- a/include/heap.h
+++ b/include/heap.h
@@ -42,7 +42,7 @@ extern "C" {
 #define HP_MAX_KEY                  MAX_INDEXES         /* Max allowed keys */
 #endif
 
-#define HP_MAX_KEY_LENGTH           1000            /* Max length in bytes */
+#define HP_MAX_KEY_LENGTH           MAX_KEY_LENGTH      /* Max length in bytes */
 
 /* defines used by heap-funktions */
 

--- a/mysql-test/r/ctype_utf8mb4_heap.result
+++ b/mysql-test/r/ctype_utf8mb4_heap.result
@@ -1195,8 +1195,6 @@ CREATE TABLE t1 (
 a varchar(255) NOT NULL default '',
 KEY a (a)
 ) ENGINE=heap DEFAULT CHARSET=utf8mb4 COLLATE utf8mb4_general_ci;
-Warnings:
-Warning	1071	Specified key was too long; max key length is 1000 bytes
 insert into t1 values (_utf8mb4 0xe880bd);
 insert into t1 values (_utf8mb4 0x5b);
 select hex(a) from t1;
@@ -1239,8 +1237,6 @@ DROP TABLE IF EXISTS t1;
 Warnings:
 Note	1051	Unknown table 'test.t1'
 CREATE TABLE t1(a VARCHAR(255), KEY(a)) ENGINE=heap DEFAULT CHARSET=utf8mb4;
-Warnings:
-Warning	1071	Specified key was too long; max key length is 1000 bytes
 INSERT INTO t1 VALUES('uuABCDEFGHIGKLMNOPRSTUVWXYZ̈bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb');
 INSERT INTO t1 VALUES('uu');
 check table t1;

--- a/mysql-test/r/percona_heap_bug_ps296.result
+++ b/mysql-test/r/percona_heap_bug_ps296.result
@@ -1,0 +1,76 @@
+PS-296: inconsistent maximum key lenghts caused a crash in the query optimizer
+CREATE TABLE big_ok (id VARBINARY(3072) NOT NULL, PRIMARY KEY (id)) ENGINE=MEMORY;
+CREATE TABLE big_ok2 (id VARBINARY(1072) NOT NULL, id2 VARBINARY(2000), PRIMARY KEY (id, id2)) ENGINE=MEMORY;
+CREATE TABLE big_fails (id VARBINARY(3073) NOT NULL, PRIMARY KEY (id)) ENGINE=MEMORY;
+ERROR 42000: Specified key was too long; max key length is 3072 bytes
+CREATE TABLE big_fails (id VARBINARY(1073) NOT NULL, id2 VARBINARY(2000), PRIMARY KEY (id, id2)) ENGINE=MEMORY;
+ERROR 42000: Specified key was too long; max key length is 3072 bytes
+SET @@session.max_sort_length = 4000;
+INSERT INTO big_ok VALUES (CONCAT(REPEAT('a', 3071), 'c'));
+INSERT INTO big_ok VALUES (CONCAT(REPEAT('a', 3071), 'b'));
+INSERT INTO big_ok VALUES (CONCAT(REPEAT('a', 3071), 'a'));
+SELECT RIGHT(id, 5) FROM big_ok FORCE INDEX (PRIMARY) ORDER BY id ASC LIMIT 10;
+RIGHT(id, 5)
+aaaaa
+aaaab
+aaaac
+SELECT RIGHT(id, 5) FROM big_ok IGNORE INDEX (PRIMARY) ORDER BY id ASC LIMIT 10;
+RIGHT(id, 5)
+aaaaa
+aaaab
+aaaac
+INSERT INTO big_ok2 VALUES (REPEAT('a', 1072), CONCAT(REPEAT('a', 1999), 'c'));
+INSERT INTO big_ok2 VALUES (REPEAT('a', 1072), CONCAT(REPEAT('a', 1999), 'b'));
+INSERT INTO big_ok2 VALUES (REPEAT('a', 1072), CONCAT(REPEAT('a', 1999), 'a'));
+SELECT RIGHT(id2, 5) FROM big_ok2 FORCE INDEX (PRIMARY) ORDER BY id ASC, id2 ASC LIMIT 10;
+RIGHT(id2, 5)
+aaaaa
+aaaab
+aaaac
+SELECT RIGHT(id2, 5) FROM big_ok2 IGNORE INDEX (PRIMARY) ORDER BY id ASC, id2 ASC LIMIT 10;
+RIGHT(id2, 5)
+aaaaa
+aaaab
+aaaac
+CREATE TABLE a (id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY);
+INSERT INTO a () VALUES ();
+CREATE PROCEDURE dowhile()
+BEGIN
+DECLARE v1 INT DEFAULT 1;
+WHILE v1 < 15 DO 
+INSERT INTO a SELECT NULL FROM a;
+SET v1 = v1 + 1;
+END WHILE;
+END;
+|
+CREATE TABLE big1 (id VARBINARY(3070) NOT NULL, PRIMARY KEY (id)) ENGINE=InnoDB;
+CREATE TABLE big2 (id VARBINARY(3070) NOT NULL, PRIMARY KEY (id)) ENGINE=InnoDB;
+CALL dowhile();
+INSERT INTO big1 SELECT * FROM a;
+INSERT INTO big2 SELECT * FROM a;
+SET session optimizer_switch='duplicateweedout=off,materialization=on';
+EXPLAIN SELECT * FROM big1 WHERE id IN (SELECT id FROM big2 IGNORE INDEX (PRIMARY)) ORDER BY id ASC LIMIT 10;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	<subquery2>	NULL	ALL	NULL	NULL	NULL	NULL	NULL	100.00	Using temporary; Using filesort
+1	SIMPLE	big1	NULL	eq_ref	PRIMARY	PRIMARY	3072	<subquery2>.id	1	100.00	Using index
+2	MATERIALIZED	big2	NULL	ALL	NULL	NULL	NULL	NULL	16384	100.00	NULL
+Warnings:
+Note	1003	/* select#1 */ select `test`.`big1`.`id` AS `id` from `test`.`big1` semi join (`test`.`big2` IGNORE INDEX (PRIMARY)) where (`test`.`big1`.`id` = `<subquery2>`.`id`) order by `test`.`big1`.`id` limit 10
+SELECT * FROM big1 WHERE id IN (SELECT id FROM big2 IGNORE INDEX (PRIMARY)) ORDER BY id ASC LIMIT 10;
+id
+1
+10000
+10001
+10002
+10003
+10004
+10005
+10006
+10007
+10008
+DROP TABLE big_ok;
+DROP TABLE big_ok2;
+DROP TABLE big1;
+DROP TABLE big2;
+DROP TABLE a;
+DROP PROCEDURE dowhile;

--- a/mysql-test/r/subquery_mat.result
+++ b/mysql-test/r/subquery_mat.result
@@ -2132,7 +2132,7 @@ id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered
 1	PRIMARY	t1	NULL	ALL	NULL	NULL	NULL	NULL	32	100.00	Using where
 2	SUBQUERY	t2	NULL	ALL	NULL	NULL	NULL	NULL	32	100.00	NULL
 Warnings:
-Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (not(<in_optimizer>(`test`.`t1`.`a`,`test`.`t1`.`a` in ( <materialize> (/* select#2 */ select `test`.`t2`.`a` from `test`.`t1` `t2` where 1 having 1 ), <index_lookup>(`test`.`t1`.`a` in <temporary table> on <hash_distinct_key> where ((`test`.`t1`.`a` = `materialized-subquery`.`a`)))))))
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (not(<in_optimizer>(`test`.`t1`.`a`,`test`.`t1`.`a` in ( <materialize> (/* select#2 */ select `test`.`t2`.`a` from `test`.`t1` `t2` where 1 having 1 ), <primary_index_lookup>(`test`.`t1`.`a` in <temporary table> on <auto_key> where ((`test`.`t1`.`a` = `materialized-subquery`.`a`)))))))
 SELECT COUNT(*)
 FROM t1
 WHERE t1.a NOT IN (

--- a/mysql-test/r/subquery_mat_all.result
+++ b/mysql-test/r/subquery_mat_all.result
@@ -2133,7 +2133,7 @@ id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered
 1	PRIMARY	t1	NULL	ALL	NULL	NULL	NULL	NULL	32	100.00	Using where
 2	SUBQUERY	t2	NULL	ALL	NULL	NULL	NULL	NULL	32	100.00	NULL
 Warnings:
-Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (not(<in_optimizer>(`test`.`t1`.`a`,`test`.`t1`.`a` in ( <materialize> (/* select#2 */ select `test`.`t2`.`a` from `test`.`t1` `t2` where 1 having 1 ), <index_lookup>(`test`.`t1`.`a` in <temporary table> on <hash_distinct_key> where ((`test`.`t1`.`a` = `materialized-subquery`.`a`)))))))
+Note	1003	/* select#1 */ select count(0) AS `COUNT(*)` from `test`.`t1` where (not(<in_optimizer>(`test`.`t1`.`a`,`test`.`t1`.`a` in ( <materialize> (/* select#2 */ select `test`.`t2`.`a` from `test`.`t1` `t2` where 1 having 1 ), <primary_index_lookup>(`test`.`t1`.`a` in <temporary table> on <auto_key> where ((`test`.`t1`.`a` = `materialized-subquery`.`a`)))))))
 SELECT COUNT(*)
 FROM t1
 WHERE t1.a NOT IN (

--- a/mysql-test/t/percona_heap_bug_ps296.test
+++ b/mysql-test/t/percona_heap_bug_ps296.test
@@ -1,0 +1,59 @@
+--echo PS-296: inconsistent maximum key lenghts caused a crash in the query optimizer
+--source include/have_innodb.inc
+
+# Test that we can use long strings in memory tables
+CREATE TABLE big_ok (id VARBINARY(3072) NOT NULL, PRIMARY KEY (id)) ENGINE=MEMORY;
+CREATE TABLE big_ok2 (id VARBINARY(1072) NOT NULL, id2 VARBINARY(2000), PRIMARY KEY (id, id2)) ENGINE=MEMORY;
+--error ER_TOO_LONG_KEY
+CREATE TABLE big_fails (id VARBINARY(3073) NOT NULL, PRIMARY KEY (id)) ENGINE=MEMORY;
+--error ER_TOO_LONG_KEY
+CREATE TABLE big_fails (id VARBINARY(1073) NOT NULL, id2 VARBINARY(2000), PRIMARY KEY (id, id2)) ENGINE=MEMORY;
+
+SET @@session.max_sort_length = 4000;
+INSERT INTO big_ok VALUES (CONCAT(REPEAT('a', 3071), 'c'));
+INSERT INTO big_ok VALUES (CONCAT(REPEAT('a', 3071), 'b'));
+INSERT INTO big_ok VALUES (CONCAT(REPEAT('a', 3071), 'a'));
+
+SELECT RIGHT(id, 5) FROM big_ok FORCE INDEX (PRIMARY) ORDER BY id ASC LIMIT 10;
+SELECT RIGHT(id, 5) FROM big_ok IGNORE INDEX (PRIMARY) ORDER BY id ASC LIMIT 10;
+
+INSERT INTO big_ok2 VALUES (REPEAT('a', 1072), CONCAT(REPEAT('a', 1999), 'c'));
+INSERT INTO big_ok2 VALUES (REPEAT('a', 1072), CONCAT(REPEAT('a', 1999), 'b'));
+INSERT INTO big_ok2 VALUES (REPEAT('a', 1072), CONCAT(REPEAT('a', 1999), 'a'));
+
+SELECT RIGHT(id2, 5) FROM big_ok2 FORCE INDEX (PRIMARY) ORDER BY id ASC, id2 ASC LIMIT 10;
+SELECT RIGHT(id2, 5) FROM big_ok2 IGNORE INDEX (PRIMARY) ORDER BY id ASC, id2 ASC LIMIT 10;
+
+# Test that materialized queries do not crash
+
+CREATE TABLE a (id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY);
+INSERT INTO a () VALUES ();
+delimiter |;
+CREATE PROCEDURE dowhile()
+BEGIN
+  DECLARE v1 INT DEFAULT 1;
+  WHILE v1 < 15 DO 
+    INSERT INTO a SELECT NULL FROM a;
+    SET v1 = v1 + 1;
+  END WHILE;
+END;
+|
+delimiter ;|
+CREATE TABLE big1 (id VARBINARY(3070) NOT NULL, PRIMARY KEY (id)) ENGINE=InnoDB;
+CREATE TABLE big2 (id VARBINARY(3070) NOT NULL, PRIMARY KEY (id)) ENGINE=InnoDB;
+--disable_result_log
+CALL dowhile();
+INSERT INTO big1 SELECT * FROM a;
+INSERT INTO big2 SELECT * FROM a;
+--enable_result_log
+
+SET session optimizer_switch='duplicateweedout=off,materialization=on';
+EXPLAIN SELECT * FROM big1 WHERE id IN (SELECT id FROM big2 IGNORE INDEX (PRIMARY)) ORDER BY id ASC LIMIT 10;
+SELECT * FROM big1 WHERE id IN (SELECT id FROM big2 IGNORE INDEX (PRIMARY)) ORDER BY id ASC LIMIT 10;
+
+DROP TABLE big_ok;
+DROP TABLE big_ok2;
+DROP TABLE big1;
+DROP TABLE big2;
+DROP TABLE a;
+DROP PROCEDURE dowhile;


### PR DESCRIPTION
The heap-dynamic-rows patch limited the maximum key size of strings to 1000.
This worked fine in earlier versions, where the maximum key length was below 1000.
In 5.7, this was increased to 3072, which resulted in keys with 999 or more characters crashing in some operations.
The latest dynamic rows patch doesn't contain this limitation anymore, looks like it can be safely removed.

Note that this change doesn't fix the issue completely:
varchar/varbinary keys at least 3071 character long will still crash - in practice, this means a maximum length of 3071 or 3072 chararcters, as that's the current maximum.
This same bug is also present in mysql server.