### PR TITLE
Prepare tokudb for mysql 8

### DIFF
--- a/storage/tokudb/CMakeLists.txt
+++ b/storage/tokudb/CMakeLists.txt
@@ -101,8 +101,11 @@ IF(DEFINED TOKUDB_NOPATCH_CONFIG)
     ADD_DEFINITIONS("-DTOKUDB_NOPATCH_CONFIG=${TOKUDB_NOPATCH_CONFIG}")
 ENDIF()
 
+message(STATUS "tokudb ${CMAKE_CXX_FLAGS}")
 prepend_cflags_if_supported(-Wno-missing-field-initializers)
+# append_cflags_if_supported(-Werror=unused-parameter)
 append_cflags_if_supported(-Wno-vla)
+message(STATUS "tokudb ${CMAKE_CXX_FLAGS}")
 
 IF (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/PerconaFT/")
     IF (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ft-index/")

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -435,7 +435,7 @@ const char *ha_tokudb::table_type() const {
     return tokudb_hton_name;
 } 
 
-const char *ha_tokudb::index_type(uint inx MY_ATTRIBUTE((unused))) {
+const char *ha_tokudb::index_type(uint TOKUDB_UNUSED(inx)) {
     return "BTREE";
 }
 
@@ -496,7 +496,7 @@ ulonglong ha_tokudb::table_flags() const {
 // Returns a bit mask of capabilities of the key or its part specified by 
 // the arguments. The capabilities are defined in sql/handler.h.
 //
-ulong ha_tokudb::index_flags(uint idx, uint part MY_ATTRIBUTE((unused)), bool all_parts MY_ATTRIBUTE((unused))) const {
+ulong ha_tokudb::index_flags(uint idx, uint TOKUDB_UNUSED(part), bool TOKUDB_UNUSED(all_parts)) const {
     TOKUDB_HANDLER_DBUG_ENTER("");
     assert_always(table_share);
     ulong flags = (HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER |
@@ -540,7 +540,7 @@ typedef struct index_read_info {
 // want to actually do anything with the data, hence
 // callback does nothing
 //
-static int smart_dbt_do_nothing (DBT const *key MY_ATTRIBUTE((unused)), DBT const *row MY_ATTRIBUTE((unused)), void *context MY_ATTRIBUTE((unused))) {
+static int smart_dbt_do_nothing (DBT const *TOKUDB_UNUSED(key), DBT const *TOKUDB_UNUSED(row), void *TOKUDB_UNUSED(context)) {
   return 0;
 }
 
@@ -553,7 +553,7 @@ static int smart_dbt_callback_rowread_ptquery (DBT const *key, DBT  const *row, 
 //
 // Smart DBT callback function in case where we have a covering index
 //
-static int smart_dbt_callback_keyread(DBT const *key, DBT  const *row MY_ATTRIBUTE((unused)), void *context) {
+static int smart_dbt_callback_keyread(DBT const *key, DBT  const *TOKUDB_UNUSED(row), void *context) {
     SMART_DBT_INFO info = (SMART_DBT_INFO)context;
     info->ha->extract_hidden_primary_key(info->keynr, key);
     info->ha->read_key_only(info->buf,info->keynr,key);
@@ -586,7 +586,7 @@ smart_dbt_callback_ir_keyread(DBT const *key, DBT  const *row, void *context) {
 }
 
 static int
-smart_dbt_callback_lookup(DBT const *key, DBT  const *row MY_ATTRIBUTE((unused)), void *context) {
+smart_dbt_callback_lookup(DBT const *key, DBT  const *TOKUDB_UNUSED(row), void *context) {
     INDEX_READ_INFO ir_info = (INDEX_READ_INFO)context;
     ir_info->cmp = ir_info->smart_dbt_info.ha->prefix_cmp_dbts(ir_info->smart_dbt_info.keynr, ir_info->orig_key, key);
     return 0;
@@ -1030,7 +1030,7 @@ cleanup:
 
 static inline int tokudb_generate_row(
     DB *dest_db, 
-    DB *src_db MY_ATTRIBUTE((unused)),
+    DB *TOKUDB_UNUSED(src_db),
     DBT *dest_key, 
     DBT *dest_val,
     const DBT *src_key, 
@@ -2123,7 +2123,7 @@ int ha_tokudb::remove_frm_data(DB *db, DB_TXN *txn) {
     return remove_from_status(db, hatoku_frm_data, txn);
 }
 
-static int smart_dbt_callback_verify_frm (DBT const *key MY_ATTRIBUTE((unused)), DBT  const *row, void *context) {
+static int smart_dbt_callback_verify_frm (DBT const *TOKUDB_UNUSED(key), DBT  const *row, void *context) {
     DBT* stored_frm = (DBT *)context;
     stored_frm->size = row->size;
     stored_frm->data = (uchar *)tokudb::memory::malloc(row->size, MYF(MY_WME));
@@ -3402,22 +3402,22 @@ int ha_tokudb::bulk_insert_poll(void* extra, float progress) {
     return 0;
 }
 
-void ha_tokudb::loader_add_index_err(DB* db MY_ATTRIBUTE((unused)),
-                                     int i MY_ATTRIBUTE((unused)),
+void ha_tokudb::loader_add_index_err(DB* TOKUDB_UNUSED(db),
+                                     int TOKUDB_UNUSED(i),
                                      int err,
-                                     DBT* key MY_ATTRIBUTE((unused)),
-                                     DBT* val MY_ATTRIBUTE((unused)),
+                                     DBT* TOKUDB_UNUSED(key),
+                                     DBT* TOKUDB_UNUSED(val),
                                      void* error_extra) {
     LOADER_CONTEXT context = (LOADER_CONTEXT)error_extra;
     assert_always(context->ha);
     context->ha->set_loader_error(err);
 }
 
-void ha_tokudb::loader_dup(DB* db MY_ATTRIBUTE((unused)),
-                           int i MY_ATTRIBUTE((unused)),
+void ha_tokudb::loader_dup(DB* TOKUDB_UNUSED(db),
+                           int TOKUDB_UNUSED(i),
                            int err,
                            DBT* key,
-                           DBT* val MY_ATTRIBUTE((unused)),
+                           DBT* TOKUDB_UNUSED(val),
                            void* error_extra) {
     LOADER_CONTEXT context = (LOADER_CONTEXT)error_extra;
     assert_always(context->ha);
@@ -3906,7 +3906,7 @@ void ha_tokudb::set_main_dict_put_flags(
 }
 
 int ha_tokudb::insert_row_to_main_dictionary(
-    uchar* record MY_ATTRIBUTE((unused)),
+    uchar* TOKUDB_UNUSED(record),
     DBT* pk_key,
     DBT* pk_val,
     DB_TXN* txn) {
@@ -7520,7 +7520,7 @@ cleanup:
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
 
-int ha_tokudb::discard_or_import_tablespace(my_bool discard MY_ATTRIBUTE((unused))) {
+int ha_tokudb::discard_or_import_tablespace(my_bool TOKUDB_UNUSED(discard)) {
     /*
     if (discard) {
         my_errno=HA_ERR_WRONG_COMMAND;
@@ -8640,7 +8640,7 @@ void ha_tokudb::restore_add_index(
 // With a transaction, drops dictionaries associated with indexes in key_num
 //
 int ha_tokudb::drop_indexes(
-    TABLE* table_arg MY_ATTRIBUTE((unused)),
+    TABLE* TOKUDB_UNUSED(table_arg),
     uint* key_num,
     uint num_of_keys,
     KEY* key_info,
@@ -8704,7 +8704,7 @@ cleanup:
 // prepare_drop_index and alter_table_phase2
 //
 void ha_tokudb::restore_drop_indexes(
-    TABLE* table_arg MY_ATTRIBUTE((unused)),
+    TABLE* TOKUDB_UNUSED(table_arg),
     uint* key_num,
     uint num_of_keys) {
 

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -34,7 +34,11 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 pfs_key_t ha_tokudb_mutex_key;
 pfs_key_t num_DBs_lock_key;
 
+#if TOKU_USE_OPEN_TABLES_MAP
+std::unordered_map<std::string,TOKUDB_SHARE*> TOKUDB_SHARE::_open_tables;
+#else
 HASH TOKUDB_SHARE::_open_tables;
+#endif
 tokudb::thread::mutex_t TOKUDB_SHARE::_open_tables_mutex;
 
 static const char* ha_tokudb_exts[] = {
@@ -152,6 +156,9 @@ void TOKUDB_SHARE::hash_free_element(TOKUDB_SHARE* share) {
     delete share;
 }
 void TOKUDB_SHARE::static_init() {
+#if TOKU_USE_OPEN_TABLES_MAP
+    assert_always(_open_tables.size() == 0);
+#else
     my_hash_init(
         &_open_tables,
         table_alias_charset,
@@ -161,9 +168,19 @@ void TOKUDB_SHARE::static_init() {
         (my_hash_get_key)hash_get_key,
         (my_hash_free_key)hash_free_element, 0,
         0); // TODO: instrument for PFS
+#endif
 }
 void TOKUDB_SHARE::static_destroy() {
+#if TOKU_USE_OPEN_TABLES_MAP
+    for (auto it = _open_tables.cbegin(); it != _open_tables.cend(); ) {
+        TOKUDB_TRACE("_open_tables %s %p", it->first.c_str(), it->second);
+        hash_free_element(it->second);
+        it = _open_tables.erase(it);
+    }
+    assert_always(_open_tables.size() == 0);
+#else
     my_hash_free(&_open_tables);
+#endif
 }
 const char* TOKUDB_SHARE::get_state_string(share_state_t state) {
     static const char* state_string[] = {
@@ -218,11 +235,19 @@ TOKUDB_SHARE* TOKUDB_SHARE::get_share(const char* table_name,
                                       THR_LOCK_DATA* data,
                                       bool create_new) {
     mutex_t_lock(_open_tables_mutex);
+#if TOKU_USE_OPEN_TABLES_MAP
+    auto it = _open_tables.find({std::string(table_name)});
+    TOKUDB_SHARE *share = nullptr;
+    if (it != _open_tables.end()) {
+        share = it->second;
+        assert_always(strcmp(table_name, share->full_table_name()) == 0);
+    }
+#else
     int error = 0;
     uint length = (uint)strlen(table_name);
     TOKUDB_SHARE* share = (TOKUDB_SHARE*)my_hash_search(
         &_open_tables, (uchar*)table_name, length);
-
+#endif
     TOKUDB_TRACE_FOR_FLAGS(
         TOKUDB_DEBUG_SHARE,
         "existing share[%s] %s:share[%p]",
@@ -240,6 +265,9 @@ TOKUDB_SHARE* TOKUDB_SHARE::get_share(const char* table_name,
 
         share->init(table_name);
 
+#if TOKU_USE_OPEN_TABLES_MAP
+        _open_tables.insert({std::string(table_name), share});
+#else
         error = my_hash_insert(&_open_tables, (uchar*)share);
         if (error) {
             free_key_and_col_info(&share->kc_info);
@@ -248,6 +276,7 @@ TOKUDB_SHARE* TOKUDB_SHARE::get_share(const char* table_name,
             share = NULL;
             goto exit;
         }
+#endif
     }
 
     share->addref();
@@ -268,7 +297,12 @@ void TOKUDB_SHARE::drop_share(TOKUDB_SHARE* share) {
                            share->_use_count);
 
     mutex_t_lock(_open_tables_mutex);
+#if TOKU_USE_OPEN_TABLES_MAP
+    size_t n = _open_tables.erase(std::string(share->full_table_name()));
+    assert_always(n == 1);
+#else
     my_hash_delete(&_open_tables, (uchar*)share);
+#endif
     mutex_t_unlock(_open_tables_mutex);
 }
 TOKUDB_SHARE::share_state_t TOKUDB_SHARE::addref() {

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -79,7 +79,6 @@ public:
     // doesn't exist, otherwise will return NULL if an existing is not found.
     static TOKUDB_SHARE* get_share(
         const char* table_name,
-        TABLE_SHARE* table_share,
         THR_LOCK_DATA* data,
         bool create_new);
 
@@ -706,7 +705,7 @@ private:
         toku_compression_method compression_method
         );
     int create_main_dictionary(const char* name, TABLE* form, DB_TXN* txn, KEY_AND_COL_INFO* kc_info, toku_compression_method compression_method);
-    void trace_create_table_info(const char *name, TABLE * form);
+    void trace_create_table_info(TABLE * form);
     int is_index_unique(bool* is_unique, DB_TXN* txn, DB* db, KEY* key_info, int lock_flags);
     int is_val_unique(bool* is_unique, uchar* record, KEY* key_info, uint dict_index, DB_TXN* txn);
     int do_uniqueness_checks(uchar* record, DB_TXN* txn, THD* thd);

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -26,6 +26,10 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #ifndef _HA_TOKUDB_H
 #define _HA_TOKUDB_H
 
+#if TOKU_USE_OPEN_TABLES_MAP
+#include <string>
+#include <unordered_map>
+#endif
 #include "hatoku_hton.h"
 #include "hatoku_cmp.h"
 #include "tokudb_background.h"
@@ -273,7 +277,11 @@ public:
     uint32_t num_DBs;
 
 private:
+#if TOKU_USE_OPEN_TABLES_MAP
+    static std::unordered_map<std::string,TOKUDB_SHARE*> _open_tables;
+#else
     static HASH _open_tables;
+#endif
     static tokudb::thread::mutex_t _open_tables_mutex;
 
     static uchar* hash_get_key(

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -1058,7 +1058,7 @@ private:
 private:
     int do_optimize(THD *thd);
     int map_to_handler_error(int error);
-
+#if TOKU_INCLUDE_RFR
 public:
     void rpl_before_write_rows();
     void rpl_after_write_rows();
@@ -1071,6 +1071,7 @@ private:
     bool in_rpl_write_rows;
     bool in_rpl_delete_rows;
     bool in_rpl_update_rows;
+#endif
 };
 
 #if TOKU_INCLUDE_OPTION_STRUCTS

--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -763,7 +763,7 @@ done:
 } // namespace tokudb
 
 
-int ha_tokudb::analyze(THD *thd MY_ATTRIBUTE((unused)), HA_CHECK_OPT *check_opt MY_ATTRIBUTE((unused))) {
+int ha_tokudb::analyze(THD *TOKUDB_UNUSED(thd), HA_CHECK_OPT *TOKUDB_UNUSED(check_opt)) {
     TOKUDB_HANDLER_DBUG_ENTER("%s", share->table_name());
     int result = HA_ADMIN_OK;
     tokudb::sysvars::analyze_mode_t mode = tokudb::sysvars::analyze_mode(thd);
@@ -988,7 +988,7 @@ cleanup:
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
 
-int ha_tokudb::optimize(THD* thd MY_ATTRIBUTE((unused)), HA_CHECK_OPT* check_opt MY_ATTRIBUTE((unused))) {
+int ha_tokudb::optimize(THD* TOKUDB_UNUSED(thd), HA_CHECK_OPT* TOKUDB_UNUSED(check_opt)) {
     TOKUDB_HANDLER_DBUG_ENTER("%s", share->table_name());
     int error;
 #if TOKU_OPTIMIZE_WITH_RECREATE
@@ -1003,7 +1003,7 @@ struct check_context {
     THD* thd;
 };
 
-static int ha_tokudb_check_progress(void* extra, float progress MY_ATTRIBUTE((unused))) {
+static int ha_tokudb_check_progress(void* extra, float TOKUDB_UNUSED(progress)) {
     struct check_context* context = (struct check_context*)extra;
     int result = 0;
     if (thd_killed(context->thd))

--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -763,7 +763,7 @@ done:
 } // namespace tokudb
 
 
-int ha_tokudb::analyze(THD *thd, HA_CHECK_OPT *check_opt) {
+int ha_tokudb::analyze(THD *thd MY_ATTRIBUTE((unused)), HA_CHECK_OPT *check_opt MY_ATTRIBUTE((unused))) {
     TOKUDB_HANDLER_DBUG_ENTER("%s", share->table_name());
     int result = HA_ADMIN_OK;
     tokudb::sysvars::analyze_mode_t mode = tokudb::sysvars::analyze_mode(thd);
@@ -988,7 +988,7 @@ cleanup:
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
 
-int ha_tokudb::optimize(THD* thd, HA_CHECK_OPT* check_opt) {
+int ha_tokudb::optimize(THD* thd MY_ATTRIBUTE((unused)), HA_CHECK_OPT* check_opt MY_ATTRIBUTE((unused))) {
     TOKUDB_HANDLER_DBUG_ENTER("%s", share->table_name());
     int error;
 #if TOKU_OPTIMIZE_WITH_RECREATE
@@ -1003,7 +1003,7 @@ struct check_context {
     THD* thd;
 };
 
-static int ha_tokudb_check_progress(void* extra, float progress) {
+static int ha_tokudb_check_progress(void* extra, float progress MY_ATTRIBUTE((unused))) {
     struct check_context* context = (struct check_context*)extra;
     int result = 0;
     if (thd_killed(context->thd))

--- a/storage/tokudb/ha_tokudb_alter_56.cc
+++ b/storage/tokudb/ha_tokudb_alter_56.cc
@@ -537,7 +537,7 @@ enum_alter_inplace_result ha_tokudb::check_if_supported_inplace_alter(
 
 // Prepare for the alter operations
 bool ha_tokudb::prepare_inplace_alter_table(
-    TABLE* altered_table MY_ATTRIBUTE((unused)),
+    TABLE* TOKUDB_UNUSED(altered_table),
     Alter_inplace_info* ha_alter_info) {
 
     TOKUDB_HANDLER_DBUG_ENTER("");
@@ -667,7 +667,7 @@ bool ha_tokudb::inplace_alter_table(
 }
 
 int ha_tokudb::alter_table_add_index(
-    TABLE* altered_table MY_ATTRIBUTE((unused)),
+    TABLE* TOKUDB_UNUSED(altered_table),
     Alter_inplace_info* ha_alter_info) {
 
     // sort keys in add index order
@@ -741,7 +741,7 @@ static bool find_index_of_key(
 }
 
 int ha_tokudb::alter_table_drop_index(
-    TABLE* altered_table MY_ATTRIBUTE((unused)),
+    TABLE* TOKUDB_UNUSED(altered_table),
     Alter_inplace_info* ha_alter_info) {
 
     KEY *key_info = table->key_info;
@@ -891,7 +891,7 @@ int ha_tokudb::alter_table_add_or_drop_column(
 // If abort then abort the alter transaction and try to rollback the
 //    non-transactional changes.
 bool ha_tokudb::commit_inplace_alter_table(
-    TABLE* altered_table MY_ATTRIBUTE((unused)),
+    TABLE* TOKUDB_UNUSED(altered_table),
     Alter_inplace_info* ha_alter_info,
     bool commit) {
 
@@ -1602,7 +1602,7 @@ static bool change_type_is_supported(
 // Return the new descriptor in the row_descriptor DBT.
 // Return non-zero on error.
 int ha_tokudb::new_row_descriptor(
-    TABLE* table MY_ATTRIBUTE((unused)),
+    TABLE* TOKUDB_UNUSED(table),
     TABLE* altered_table,
     Alter_inplace_info* ha_alter_info,
     uint32_t idx,

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1869,8 +1869,8 @@ static uint32_t pack_desc_pk_info(uchar* buf, KEY_AND_COL_INFO* kc_info, TABLE_S
 
 static uint32_t pack_desc_pk_offset_info(
     uchar* buf, 
-    KEY_AND_COL_INFO* kc_info MY_ATTRIBUTE((unused)),
-    TABLE_SHARE* table_share MY_ATTRIBUTE((unused)),
+    KEY_AND_COL_INFO* TOKUDB_UNUSED(kc_info),
+    TABLE_SHARE* TOKUDB_UNUSED(table_share),
     KEY_PART_INFO* key_part, 
     KEY* prim_key,
     uchar* pk_info
@@ -2001,7 +2001,7 @@ static uint32_t pack_desc_key_length_info(uchar* buf, KEY_AND_COL_INFO* kc_info,
     return pos - buf;
 }
 
-static uint32_t pack_desc_char_info(uchar* buf, KEY_AND_COL_INFO* kc_info MY_ATTRIBUTE((unused)), TABLE_SHARE* table_share, KEY_PART_INFO* key_part) {
+static uint32_t pack_desc_char_info(uchar* buf, KEY_AND_COL_INFO* TOKUDB_UNUSED(kc_info), TABLE_SHARE* table_share, KEY_PART_INFO* key_part) {
     uchar* pos = buf;
     uint16 field_index = key_part->field->field_index;
     Field* field = table_share->field[field_index];

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1869,8 +1869,8 @@ static uint32_t pack_desc_pk_info(uchar* buf, KEY_AND_COL_INFO* kc_info, TABLE_S
 
 static uint32_t pack_desc_pk_offset_info(
     uchar* buf, 
-    KEY_AND_COL_INFO* kc_info, 
-    TABLE_SHARE* table_share, 
+    KEY_AND_COL_INFO* kc_info MY_ATTRIBUTE((unused)),
+    TABLE_SHARE* table_share MY_ATTRIBUTE((unused)),
     KEY_PART_INFO* key_part, 
     KEY* prim_key,
     uchar* pk_info
@@ -2001,7 +2001,7 @@ static uint32_t pack_desc_key_length_info(uchar* buf, KEY_AND_COL_INFO* kc_info,
     return pos - buf;
 }
 
-static uint32_t pack_desc_char_info(uchar* buf, KEY_AND_COL_INFO* kc_info, TABLE_SHARE* table_share, KEY_PART_INFO* key_part) {
+static uint32_t pack_desc_char_info(uchar* buf, KEY_AND_COL_INFO* kc_info MY_ATTRIBUTE((unused)), TABLE_SHARE* table_share, KEY_PART_INFO* key_part) {
     uchar* pos = buf;
     uint16 field_index = key_part->field->field_index;
     Field* field = table_share->field[field_index];

--- a/storage/tokudb/hatoku_cmp.h
+++ b/storage/tokudb/hatoku_cmp.h
@@ -355,7 +355,7 @@ static uint32_t create_toku_clustering_val_pack_descriptor (
     );
 
 static inline bool is_key_clustering(
-    void* row_desc,
+    void* row_desc MY_ATTRIBUTE((unused)),
     uint32_t row_desc_size
     ) 
 {
@@ -386,7 +386,7 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
 
 static inline bool is_key_pk(
     void* row_desc,
-    uint32_t row_desc_size
+    uint32_t row_desc_size MY_ATTRIBUTE((unused))
     ) 
 {
     uchar* buf = (uchar *)row_desc;

--- a/storage/tokudb/hatoku_cmp.h
+++ b/storage/tokudb/hatoku_cmp.h
@@ -355,7 +355,7 @@ static uint32_t create_toku_clustering_val_pack_descriptor (
     );
 
 static inline bool is_key_clustering(
-    void* row_desc MY_ATTRIBUTE((unused)),
+    void* TOKUDB_UNUSED(row_desc),
     uint32_t row_desc_size
     ) 
 {
@@ -386,7 +386,7 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
 
 static inline bool is_key_pk(
     void* row_desc,
-    uint32_t row_desc_size MY_ATTRIBUTE((unused))
+    uint32_t TOKUDB_UNUSED(row_desc_size)
     ) 
 {
     uchar* buf = (uchar *)row_desc;

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -78,6 +78,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_INCLUDE_EXTENDED_KEYS 1
 #endif
 #define TOKU_INCLUDE_RFR 1
+#define TOKU_USE_OPEN_TABLES_MAP 0
 #define TOKU_OPTIMIZE_WITH_RECREATE 1
 
 #ifdef MARIADB_BASE_VERSION

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -77,6 +77,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #if defined(HTON_SUPPORTS_EXTENDED_KEYS)
 #define TOKU_INCLUDE_EXTENDED_KEYS 1
 #endif
+#define TOKU_INCLUDE_RFR 1
 #define TOKU_OPTIMIZE_WITH_RECREATE 1
 
 #ifdef MARIADB_BASE_VERSION

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -144,7 +144,7 @@ struct tokudb_map_pair {
 static int tokudb_map_pair_cmp(void *custom_arg, const void *a, const void *b) {
 #else
 static int tokudb_map_pair_cmp(
-    const void* custom_arg MY_ATTRIBUTE((unused)),
+    const void* TOKUDB_UNUSED(custom_arg),
     const void* a,
     const void* b) {
 #endif
@@ -1235,7 +1235,7 @@ static int tokudb_discover2(
 }
 
 static int tokudb_discover3(
-    handlerton* hton MY_ATTRIBUTE((unused)),
+    handlerton* TOKUDB_UNUSED(hton),
     THD* thd,
     const char* db,
     const char* name,
@@ -1505,7 +1505,7 @@ cleanup:
 }
 
 static bool tokudb_show_status(
-    handlerton* hton MY_ATTRIBUTE((unused)),
+    handlerton* TOKUDB_UNUSED(hton),
     THD* thd,
     stat_print_fn* stat_print,
     enum ha_stat_type stat_type) {
@@ -1533,7 +1533,7 @@ static void tokudb_handle_fatal_signal(
 #endif
 
 static void tokudb_print_error(
-    const DB_ENV* db_env MY_ATTRIBUTE((unused)),
+    const DB_ENV* TOKUDB_UNUSED(db_env),
     const char* db_errpfx,
     const char* buffer) {
     sql_print_error("%s: %s", db_errpfx, buffer);
@@ -1646,7 +1646,7 @@ static bool tokudb_txn_id_to_client_id(
 #endif
 
 static void tokudb_pretty_key(
-    const DB* db MY_ATTRIBUTE((unused)),
+    const DB* TOKUDB_UNUSED(db),
     const DBT* key,
     const char* default_key,
     String* out) {
@@ -1797,7 +1797,7 @@ static void tokudb_lock_timeout_callback(
 // Retrieves variables for information_schema.global_status.
 // Names (columnname) are automatically converted to upper case,
 // and prefixed with "TOKUDB_"
-static int show_tokudb_vars(THD *thd MY_ATTRIBUTE((unused)), SHOW_VAR *var, char *buff MY_ATTRIBUTE((unused))) {
+static int show_tokudb_vars(THD *TOKUDB_UNUSED(thd), SHOW_VAR *var, char *TOKUDB_UNUSED(buff)) {
     TOKUDB_DBUG_ENTER("");
 
     int error;

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -144,7 +144,7 @@ struct tokudb_map_pair {
 static int tokudb_map_pair_cmp(void *custom_arg, const void *a, const void *b) {
 #else
 static int tokudb_map_pair_cmp(
-    const void* custom_arg MY_ATTRIBUTE((unused)),
+    const void* TOKUDB_UNUSED(custom_arg),
     const void* a,
     const void* b) {
 #endif
@@ -1253,7 +1253,7 @@ static int tokudb_discover2(
 }
 
 static int tokudb_discover3(
-    handlerton* hton MY_ATTRIBUTE((unused)),
+    handlerton* TOKUDB_UNUSED(hton),
     THD* thd,
     const char* db,
     const char* name,
@@ -1523,7 +1523,7 @@ cleanup:
 }
 
 static bool tokudb_show_status(
-    handlerton* hton MY_ATTRIBUTE((unused)),
+    handlerton* TOKUDB_UNUSED(hton),
     THD* thd,
     stat_print_fn* stat_print,
     enum ha_stat_type stat_type) {
@@ -1551,7 +1551,7 @@ static void tokudb_handle_fatal_signal(
 #endif
 
 static void tokudb_print_error(
-    const DB_ENV* db_env MY_ATTRIBUTE((unused)),
+    const DB_ENV* TOKUDB_UNUSED(db_env),
     const char* db_errpfx,
     const char* buffer) {
     sql_print_error("%s: %s", db_errpfx, buffer);
@@ -1664,7 +1664,7 @@ static bool tokudb_txn_id_to_client_id(
 #endif
 
 static void tokudb_pretty_key(
-    const DB* db MY_ATTRIBUTE((unused)),
+    const DB* TOKUDB_UNUSED(db),
     const DBT* key,
     const char* default_key,
     String* out) {
@@ -1815,7 +1815,7 @@ static void tokudb_lock_timeout_callback(
 // Retrieves variables for information_schema.global_status.
 // Names (columnname) are automatically converted to upper case,
 // and prefixed with "TOKUDB_"
-static int show_tokudb_vars(THD *thd MY_ATTRIBUTE((unused)), SHOW_VAR *var, char *buff MY_ATTRIBUTE((unused))) {
+static int show_tokudb_vars(THD *TOKUDB_UNUSED(thd), SHOW_VAR *var, char *TOKUDB_UNUSED(buff)) {
     TOKUDB_DBUG_ENTER("");
 
     int error;

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -144,7 +144,7 @@ struct tokudb_map_pair {
 static int tokudb_map_pair_cmp(void *custom_arg, const void *a, const void *b) {
 #else
 static int tokudb_map_pair_cmp(
-    const void* custom_arg,
+    const void* custom_arg MY_ATTRIBUTE((unused)),
     const void* a,
     const void* b) {
 #endif
@@ -676,7 +676,7 @@ error:
 }
 
 static int tokudb_done_func(void* p) {
-    TOKUDB_DBUG_ENTER("");
+    TOKUDB_DBUG_ENTER("%p", p);
     tokudb::memory::free(toku_global_status_variables);
     toku_global_status_variables = NULL;
     tokudb::memory::free(toku_global_status_rows);
@@ -692,7 +692,7 @@ static handler* tokudb_create_handler(
 }
 
 int tokudb_end(handlerton* hton, ha_panic_function type) {
-    TOKUDB_DBUG_ENTER("");
+    TOKUDB_DBUG_ENTER("%p %u", hton, type);
     int error = 0;
     
     // 3938: if we finalize the storage engine plugin, it is no longer
@@ -768,6 +768,7 @@ int tokudb_end(handlerton* hton, ha_panic_function type) {
 }
 
 static int tokudb_close_connection(handlerton* hton, THD* thd) {
+    TOKUDB_DBUG_ENTER("%p", hton);
     int error = 0;
     tokudb_trx_data* trx = (tokudb_trx_data*)thd_get_ha_data(thd, tokudb_hton);
     if (trx && trx->checkpoint_lock_taken) {
@@ -786,17 +787,17 @@ static int tokudb_close_connection(handlerton* hton, THD* thd) {
     }
     mutex_t_unlock(tokudb_map_mutex);
 #endif
-    return error;
+    TOKUDB_DBUG_RETURN(error);
 }
 
 void tokudb_kill_connection(handlerton *hton, THD *thd) {
-    TOKUDB_DBUG_ENTER("");
+    TOKUDB_DBUG_ENTER("%p", hton);
     db_env->kill_waiter(db_env, thd);
     DBUG_VOID_RETURN;
 }
 
-bool tokudb_flush_logs(handlerton * hton, bool binlog_group_commit) {
-    TOKUDB_DBUG_ENTER("");
+bool tokudb_flush_logs(handlerton *hton, bool binlog_group_commit) {
+    TOKUDB_DBUG_ENTER("%p", hton);
     int error;
     bool result = 0;
 
@@ -889,8 +890,9 @@ extern "C" enum durability_properties thd_get_durability_property(
 #endif
 
 // Determine if an fsync is used when a transaction is committed.  
-static bool tokudb_sync_on_commit(THD* thd, tokudb_trx_data* trx, DB_TXN* txn) {
+static bool tokudb_sync_on_commit(THD* thd, DB_TXN* txn) {
 #if MYSQL_VERSION_ID >= 50600
+    std::ignore = txn;
     // Check the client durability property which is set during 2PC
     if (thd_get_durability_property(thd) == HA_IGNORE_DURABILITY)
         return false;
@@ -913,7 +915,7 @@ static int tokudb_commit(handlerton * hton, THD * thd, bool all) {
     DB_TXN *this_txn = *txn;
     if (this_txn) {
         uint32_t syncflag =
-            tokudb_sync_on_commit(thd, trx, this_txn) ? 0 : DB_TXN_NOSYNC;
+            tokudb_sync_on_commit(thd, this_txn) ? 0 : DB_TXN_NOSYNC;
         TOKUDB_TRACE_FOR_FLAGS(
             TOKUDB_DEBUG_TXN,
             "commit trx %u txn %p syncflag %u",
@@ -1017,7 +1019,7 @@ static int tokudb_xa_prepare(handlerton* hton, THD* thd, bool all) {
 }
 
 static int tokudb_xa_recover(handlerton* hton, XID* xid_list, uint len) {
-    TOKUDB_DBUG_ENTER("");
+    TOKUDB_DBUG_ENTER("%p", hton);
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
     int r = 0;
     if (len == 0 || xid_list == NULL) {
@@ -1037,7 +1039,7 @@ static int tokudb_xa_recover(handlerton* hton, XID* xid_list, uint len) {
 }
 
 static int tokudb_commit_by_xid(handlerton* hton, XID* xid) {
-    TOKUDB_DBUG_ENTER("");
+    TOKUDB_DBUG_ENTER("%p", hton);
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
     int r = 0;
     DB_TXN* txn = NULL;
@@ -1056,7 +1058,7 @@ cleanup:
 }
 
 static int tokudb_rollback_by_xid(handlerton* hton, XID*  xid) {
-    TOKUDB_DBUG_ENTER("");
+    TOKUDB_DBUG_ENTER("%p", hton);
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
     int r = 0;
     DB_TXN* txn = NULL;
@@ -1233,7 +1235,7 @@ static int tokudb_discover2(
 }
 
 static int tokudb_discover3(
-    handlerton* hton,
+    handlerton* hton MY_ATTRIBUTE((unused)),
     THD* thd,
     const char* db,
     const char* name,
@@ -1503,7 +1505,7 @@ cleanup:
 }
 
 static bool tokudb_show_status(
-    handlerton* hton,
+    handlerton* hton MY_ATTRIBUTE((unused)),
     THD* thd,
     stat_print_fn* stat_print,
     enum ha_stat_type stat_type) {
@@ -1531,7 +1533,7 @@ static void tokudb_handle_fatal_signal(
 #endif
 
 static void tokudb_print_error(
-    const DB_ENV* db_env,
+    const DB_ENV* db_env MY_ATTRIBUTE((unused)),
     const char* db_errpfx,
     const char* buffer) {
     sql_print_error("%s: %s", db_errpfx, buffer);
@@ -1644,7 +1646,7 @@ static bool tokudb_txn_id_to_client_id(
 #endif
 
 static void tokudb_pretty_key(
-    const DB* db,
+    const DB* db MY_ATTRIBUTE((unused)),
     const DBT* key,
     const char* default_key,
     String* out) {
@@ -1795,7 +1797,7 @@ static void tokudb_lock_timeout_callback(
 // Retrieves variables for information_schema.global_status.
 // Names (columnname) are automatically converted to upper case,
 // and prefixed with "TOKUDB_"
-static int show_tokudb_vars(THD *thd, SHOW_VAR *var, char *buff) {
+static int show_tokudb_vars(THD *thd MY_ATTRIBUTE((unused)), SHOW_VAR *var, char *buff MY_ATTRIBUTE((unused))) {
     TOKUDB_DBUG_ENTER("");
 
     int error;

--- a/storage/tokudb/hatoku_hton.h
+++ b/storage/tokudb/hatoku_hton.h
@@ -158,7 +158,7 @@ inline toku_compression_method row_type_to_toku_compression_method(
 void tokudb_checkpoint_lock(THD * thd);
 void tokudb_checkpoint_unlock(THD * thd);
 
-inline uint64_t tokudb_get_lock_wait_time_callback(uint64_t default_wait_time) {
+inline uint64_t tokudb_get_lock_wait_time_callback(uint64_t default_wait_time MY_ATTRIBUTE((unused))) {
     THD *thd = current_thd;
     return tokudb::sysvars::lock_timeout(thd);
 }
@@ -168,7 +168,7 @@ inline uint64_t tokudb_get_loader_memory_size_callback(void) {
     return tokudb::sysvars::loader_memory_size(thd);
 }
 
-inline uint64_t tokudb_get_killed_time_callback(uint64_t default_killed_time) {
+inline uint64_t tokudb_get_killed_time_callback(uint64_t default_killed_time MY_ATTRIBUTE((unused))) {
     THD *thd = current_thd;
     return tokudb::sysvars::killed_time(thd);
 }
@@ -178,7 +178,7 @@ inline int tokudb_killed_callback(void) {
     return thd_killed(thd);
 }
 
-inline bool tokudb_killed_thd_callback(void *extra, uint64_t deleted_rows) {
+inline bool tokudb_killed_thd_callback(void *extra, uint64_t deleted_rows MY_ATTRIBUTE((unused))) {
     THD *thd = static_cast<THD *>(extra);
     return thd_killed(thd) != 0;
 }

--- a/storage/tokudb/hatoku_hton.h
+++ b/storage/tokudb/hatoku_hton.h
@@ -90,9 +90,9 @@ inline toku_compression_method row_format_to_toku_compression_method(
     }
 }
 
+#if TOKU_INCLUDE_ROW_TYPE_COMPRESSION
 inline enum row_type row_format_to_row_type(
     tokudb::sysvars::row_format_t row_format) {
-#if TOKU_INCLUDE_ROW_TYPE_COMPRESSION
     switch (row_format) {
     case tokudb::sysvars::SRV_ROW_FORMAT_UNCOMPRESSED:
         return ROW_TYPE_TOKU_UNCOMPRESSED;
@@ -111,13 +111,18 @@ inline enum row_type row_format_to_row_type(
     case tokudb::sysvars::SRV_ROW_FORMAT_DEFAULT:
         return ROW_TYPE_DEFAULT;
     }
-#endif
     return ROW_TYPE_DEFAULT;
 }
+#else
+inline enum row_type row_format_to_row_type(
+    tokudb::sysvars::row_format_t TOKUDB_UNUSED(row_format)) {
+    return ROW_TYPE_DEFAULT;
+}
+#endif
 
+#if TOKU_INCLUDE_ROW_TYPE_COMPRESSION
 inline tokudb::sysvars::row_format_t row_type_to_row_format(
     enum row_type type) {
-#if TOKU_INCLUDE_ROW_TYPE_COMPRESSION
     switch (type) {
     case ROW_TYPE_TOKU_UNCOMPRESSED:
         return tokudb::sysvars::SRV_ROW_FORMAT_UNCOMPRESSED;
@@ -138,9 +143,14 @@ inline tokudb::sysvars::row_format_t row_type_to_row_format(
     default:
         return tokudb::sysvars::SRV_ROW_FORMAT_DEFAULT;
     }
-#endif
     return tokudb::sysvars::SRV_ROW_FORMAT_DEFAULT;
 }
+#else
+inline tokudb::sysvars::row_format_t row_type_to_row_format(
+    enum row_type TOKUDB_UNUSED(type)) {
+    return tokudb::sysvars::SRV_ROW_FORMAT_DEFAULT;
+}
+#endif
 
 inline enum row_type toku_compression_method_to_row_type(
     toku_compression_method method) {

--- a/storage/tokudb/hatoku_hton.h
+++ b/storage/tokudb/hatoku_hton.h
@@ -193,7 +193,6 @@ inline bool tokudb_killed_thd_callback(void *extra, uint64_t deleted_rows MY_ATT
     return thd_killed(thd) != 0;
 }
 
-extern HASH tokudb_open_tables;
 extern const char* tokudb_hton_name;
 extern int tokudb_hton_initialized;
 extern tokudb::thread::rwlock_t tokudb_hton_initialized_lock;

--- a/storage/tokudb/hatoku_hton.h
+++ b/storage/tokudb/hatoku_hton.h
@@ -168,7 +168,7 @@ inline toku_compression_method row_type_to_toku_compression_method(
 void tokudb_checkpoint_lock(THD * thd);
 void tokudb_checkpoint_unlock(THD * thd);
 
-inline uint64_t tokudb_get_lock_wait_time_callback(uint64_t default_wait_time MY_ATTRIBUTE((unused))) {
+inline uint64_t tokudb_get_lock_wait_time_callback(uint64_t TOKUDB_UNUSED(default_wait_time)) {
     THD *thd = current_thd;
     return tokudb::sysvars::lock_timeout(thd);
 }
@@ -178,7 +178,7 @@ inline uint64_t tokudb_get_loader_memory_size_callback(void) {
     return tokudb::sysvars::loader_memory_size(thd);
 }
 
-inline uint64_t tokudb_get_killed_time_callback(uint64_t default_killed_time MY_ATTRIBUTE((unused))) {
+inline uint64_t tokudb_get_killed_time_callback(uint64_t TOKUDB_UNUSED(default_killed_time)) {
     THD *thd = current_thd;
     return tokudb::sysvars::killed_time(thd);
 }
@@ -188,7 +188,7 @@ inline int tokudb_killed_callback(void) {
     return thd_killed(thd);
 }
 
-inline bool tokudb_killed_thd_callback(void *extra, uint64_t deleted_rows MY_ATTRIBUTE((unused))) {
+inline bool tokudb_killed_thd_callback(void *extra, uint64_t TOKUDB_UNUSED(deleted_rows)) {
     THD *thd = static_cast<THD *>(extra);
     return thd_killed(thd) != 0;
 }

--- a/storage/tokudb/tokudb_information_schema.cc
+++ b/storage/tokudb/tokudb_information_schema.cc
@@ -68,8 +68,8 @@ struct trx_extra_t {
 
 int trx_callback(
     DB_TXN* txn,
-    iterate_row_locks_callback iterate_locks,
-    void* locks_extra,
+    iterate_row_locks_callback TOKUDB_UNUSED(iterate_locks),
+    void* TOKUDB_UNUSED(locks_extra),
     void *extra) {
 
     uint64_t txn_id = txn->id64(txn);
@@ -90,7 +90,7 @@ int trx_callback(
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int trx_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int trx_fill_table(THD* thd, TABLE_LIST* tables, Item* TOKUDB_UNUSED(cond)) {
 #else
 int trx_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
 #endif
@@ -120,7 +120,7 @@ int trx_init(void* p) {
     return 0;
 }
 
-int trx_done(void* p) {
+int trx_done(void* TOKUDB_UNUSED(p)) {
     return 0;
 }
 
@@ -225,7 +225,7 @@ int lock_waits_callback(
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int lock_waits_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int lock_waits_fill_table(THD* thd, TABLE_LIST* tables, Item* TOKUDB_UNUSED(cond)) {
 #else
 int lock_waits_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
 #endif
@@ -258,7 +258,7 @@ int lock_waits_init(void* p) {
     return 0;
 }
 
-int lock_waits_done(void *p) {
+int lock_waits_done(void *TOKUDB_UNUSED(p)) {
     return 0;
 }
 
@@ -368,7 +368,7 @@ int locks_callback(
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int locks_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int locks_fill_table(THD* thd, TABLE_LIST* tables, Item* TOKUDB_UNUSED(cond)) {
 #else
 int locks_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
 #endif
@@ -398,7 +398,7 @@ int locks_init(void* p) {
     return 0;
 }
 
-int locks_done(void* p) {
+int locks_done(void* TOKUDB_UNUSED(p)) {
     return 0;
 }
 
@@ -511,7 +511,7 @@ cleanup:
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int file_map_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int file_map_fill_table(THD* thd, TABLE_LIST* tables, Item* TOKUDB_UNUSED(cond)) {
 #else
 int file_map_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
 #endif
@@ -541,7 +541,7 @@ int file_map_init(void* p) {
     return 0;
 }
 
-int file_map_done(void* p) {
+int file_map_done(void* TOKUDB_UNUSED(p)) {
     return 0;
 }
 
@@ -716,7 +716,7 @@ cleanup:
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int fractal_tree_info_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+ int fractal_tree_info_fill_table(THD* thd, TABLE_LIST* tables, Item* TOKUDB_UNUSED(cond)) {
 #else
 int fractal_tree_info_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
 #endif
@@ -749,7 +749,7 @@ int fractal_tree_info_init(void* p) {
     return 0;
 }
 
-int fractal_tree_info_done(void* p) {
+int fractal_tree_info_done(void* TOKUDB_UNUSED(p)) {
     return 0;
 }
 
@@ -1010,7 +1010,7 @@ cleanup:
 int fractal_tree_block_map_fill_table(
     THD* thd,
     TABLE_LIST* tables,
-    Item* cond) {
+    Item* TOKUDB_UNUSED(cond)) {
 #else
 int fractal_tree_block_map_fill_table(
     THD* thd,
@@ -1046,7 +1046,7 @@ int fractal_tree_block_map_init(void* p) {
     return 0;
 }
 
-int fractal_tree_block_map_done(void *p) {
+int fractal_tree_block_map_done(void *TOKUDB_UNUSED(p)) {
     return 0;
 }
 
@@ -1152,7 +1152,7 @@ int report_background_job_status(TABLE *table, THD *thd) {
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int background_job_status_fill_table(THD *thd, TABLE_LIST *tables, Item *cond) {
+int background_job_status_fill_table(THD *thd, TABLE_LIST *tables, Item *TOKUDB_UNUSED(cond)) {
 #else
 int background_job_status_fill_table(THD *thd, TABLE_LIST *tables, COND *cond) {
 #endif
@@ -1182,7 +1182,7 @@ int background_job_status_init(void* p) {
     return 0;
 }
 
-int background_job_status_done(void* p) {
+int background_job_status_done(void* TOKUDB_UNUSED(p)) {
     return 0;
 }
 

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -806,6 +806,7 @@ static MYSQL_THDVAR_ENUM(
     SRV_ROW_FORMAT_ZLIB,
     &tokudb_row_format_typelib);
 
+#if TOKU_INCLUDE_RFR
 static MYSQL_THDVAR_BOOL(
     rpl_check_readonly,
     PLUGIN_VAR_THDLOCAL,
@@ -851,6 +852,7 @@ static MYSQL_THDVAR_ULONGLONG(
     0,
     ~0ULL,
     1);
+#endif
 
 #if TOKU_INCLUDE_UPSERT
 static MYSQL_THDVAR_BOOL(
@@ -1032,12 +1034,13 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(read_block_size),
     MYSQL_SYSVAR(read_buf_size),
     MYSQL_SYSVAR(row_format),
+#if TOKU_INCLUDE_RFR
     MYSQL_SYSVAR(rpl_check_readonly),
     MYSQL_SYSVAR(rpl_lookup_rows),
     MYSQL_SYSVAR(rpl_lookup_rows_delay),
     MYSQL_SYSVAR(rpl_unique_checks),
     MYSQL_SYSVAR(rpl_unique_checks_delay),
-
+#endif
 #if TOKU_INCLUDE_UPSERT
     MYSQL_SYSVAR(disable_slow_update),
     MYSQL_SYSVAR(disable_slow_upsert),
@@ -1156,6 +1159,7 @@ uint read_buf_size(THD* thd) {
 row_format_t row_format(THD *thd) {
     return (row_format_t) THDVAR(thd, row_format);
 }
+#if TOKU_INCLUDE_RFR
 my_bool rpl_check_readonly(THD* thd) {
     return (THDVAR(thd, rpl_check_readonly) != 0);
 }
@@ -1171,6 +1175,7 @@ my_bool rpl_unique_checks(THD* thd) {
 ulonglong rpl_unique_checks_delay(THD* thd) {
     return THDVAR(thd, rpl_unique_checks_delay);
 }
+#endif
 my_bool support_xa(THD* thd) {
     return (THDVAR(thd, support_xa) != 0);
 }

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -141,8 +141,8 @@ static MYSQL_SYSVAR_UINT(
     0);
 
 static void checkpointing_period_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
+    THD* TOKUDB_UNUSED(thd),
+    st_mysql_sys_var* TOKUDB_UNUSED(sys_var),
     void* var,
     const void* save) {
 
@@ -165,8 +165,8 @@ static MYSQL_SYSVAR_UINT(
     0);
 
 static void cleaner_iterations_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
+    THD* TOKUDB_UNUSED(thd),
+    st_mysql_sys_var* TOKUDB_UNUSED(sys_var),
     void* var,
     const void* save) {
 
@@ -189,8 +189,8 @@ static MYSQL_SYSVAR_ULONG(
     0);
 
 static void cleaner_period_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
+    THD* TOKUDB_UNUSED(thd),
+    st_mysql_sys_var* TOKUDB_UNUSED(sys_var),
     void* var,
     const void * save) {
 
@@ -274,8 +274,8 @@ static MYSQL_SYSVAR_BOOL(
     FALSE);
 
 static void enable_partial_eviction_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
+    THD* TOKUDB_UNUSED(thd),
+    st_mysql_sys_var* TOKUDB_UNUSED(sys_var),
     void* var,
     const void* save) {
 
@@ -307,8 +307,8 @@ static MYSQL_SYSVAR_INT(
     0);
 
 static void fsync_log_period_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
+    THD* TOKUDB_UNUSED(thd),
+    st_mysql_sys_var* TOKUDB_UNUSED(sys_var),
     void* var,
     const void* save) {
 
@@ -401,8 +401,8 @@ static MYSQL_SYSVAR_UINT(
     ~0U,
     0);
 
-static void tokudb_dir_per_db_update(THD* thd,
-                                     struct st_mysql_sys_var* sys_var,
+static void tokudb_dir_per_db_update(THD* TOKUDB_UNUSED(thd),
+                                     struct st_mysql_sys_var* TOKUDB_UNUSED(sys_var),
                                      void* var, const void* save) {
     my_bool *value = (my_bool *) var;
     *value = *(const my_bool *) save;
@@ -553,7 +553,7 @@ static MYSQL_THDVAR_BOOL(
 
 static void checkpoint_lock_update(
     THD* thd,
-    st_mysql_sys_var* var,
+    st_mysql_sys_var* TOKUDB_UNUSED(var),
     void* var_ptr,
     const void* save) {
 
@@ -880,8 +880,8 @@ static const char* deprecated_tokudb_support_xa_off =
 
 static void support_xa_update(
     THD* thd,
-    st_mysql_sys_var* var,
-    void* var_ptr,
+    st_mysql_sys_var* TOKUDB_UNUSED(var),
+    void* TOKUDB_UNUSED(var_ptr),
     const void* save) {
     my_bool tokudb_support_xa = *static_cast<const my_bool*>(save);
     push_warning(thd,
@@ -935,7 +935,7 @@ static void dir_cmd_set_error(THD *thd,
     THDVAR_SET(thd, dir_cmd_last_error_string, buff);
 }
 
-static int dir_cmd_check(THD* thd, struct st_mysql_sys_var* var,
+static int dir_cmd_check(THD* thd, struct st_mysql_sys_var* TOKUDB_UNUSED(var),
                          void* save, struct st_mysql_value* value) {
     int error = 0;
     dir_cmd_set_error(thd, error, "");

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -133,11 +133,13 @@ my_bool     prelock_empty(THD* thd);
 uint        read_block_size(THD* thd);
 uint        read_buf_size(THD* thd);
 row_format_t row_format(THD *thd);
+#if TOKU_INCLUDE_RFR
 my_bool     rpl_check_readonly(THD* thd);
 my_bool     rpl_lookup_rows(THD* thd);
 ulonglong   rpl_lookup_rows_delay(THD* thd);
 my_bool     rpl_unique_checks(THD* thd);
 ulonglong   rpl_unique_checks_delay(THD* thd);
+#endif
 my_bool     support_xa(THD* thd);
 void        set_support_xa(THD* thd, my_bool xa);
 

--- a/storage/tokudb/tokudb_thread.h
+++ b/storage/tokudb/tokudb_thread.h
@@ -204,21 +204,21 @@ inline mutex_t::mutex_t(pfs_key_t key) {
     _owners = 0;
     _owner = _null_owner;
 #endif
-    int  r MY_ATTRIBUTE((unused)) = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
+    int  TOKUDB_UNUSED(r) = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
     assert_debug(r == 0);
 }
 inline mutex_t::~mutex_t(void) {
 #ifdef TOKUDB_DEBUG
     assert_debug(_owners == 0);
 #endif
-    int  r MY_ATTRIBUTE((unused)) = mysql_mutex_destroy(&_mutex);
+    int  TOKUDB_UNUSED(r) = mysql_mutex_destroy(&_mutex);
     assert_debug(r == 0);
 }
 inline void mutex_t::reinit(pfs_key_t key) {
 #ifdef TOKUDB_DEBUG
     assert_debug(_owners == 0);
 #endif
-    int  r MY_ATTRIBUTE((unused));
+    int  TOKUDB_UNUSED(r);
     r = mysql_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = mysql_mutex_init(key, &_mutex, MY_MUTEX_INIT_FAST);
@@ -231,7 +231,7 @@ inline void mutex_t::lock(
 #endif  // HAVE_PSI_MUTEX_INTERFACE
     ) {
     assert_debug(is_owned_by_me() == false);
-    int r MY_ATTRIBUTE((unused)) = inline_mysql_mutex_lock(&_mutex
+    int TOKUDB_UNUSED(r) = inline_mysql_mutex_lock(&_mutex
 #ifdef HAVE_PSI_MUTEX_INTERFACE
                                     ,
                                     src_file,
@@ -260,7 +260,7 @@ inline void mutex_t::unlock(
     _owners--;
     _owner = _null_owner;
 #endif
-    int r MY_ATTRIBUTE((unused)) = inline_mysql_mutex_unlock(&_mutex
+    int TOKUDB_UNUSED(r) = inline_mysql_mutex_unlock(&_mutex
 #ifdef SAFE_MUTEX
                                       ,
                                       src_file,
@@ -276,11 +276,11 @@ inline bool mutex_t::is_owned_by_me(void) const {
 #endif
 
 inline rwlock_t::rwlock_t(pfs_key_t key) {
-    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_init(key, &_rwlock);
+    int TOKUDB_UNUSED(r) = mysql_rwlock_init(key, &_rwlock);
     assert_debug(r == 0);
 }
 inline rwlock_t::~rwlock_t(void) {
-    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_destroy(&_rwlock);
+    int TOKUDB_UNUSED(r) = mysql_rwlock_destroy(&_rwlock);
     assert_debug(r == 0);
 }
 inline void rwlock_t::lock_read(
@@ -328,7 +328,7 @@ inline void rwlock_t::lock_write(
     assert_debug(r == 0);
 }
 inline void rwlock_t::unlock(void) {
-    int r MY_ATTRIBUTE((unused)) = mysql_rwlock_unlock(&_rwlock);
+    int TOKUDB_UNUSED(r) = mysql_rwlock_unlock(&_rwlock);
     assert_debug(r == 0);
 }
 inline rwlock_t::rwlock_t(const rwlock_t&) {}
@@ -340,7 +340,7 @@ inline rwlock_t& rwlock_t::operator=(const rwlock_t&) {
 inline event_t::event_t(bool create_signalled, bool manual_reset) :
     _manual_reset(manual_reset) {
 
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_init(&_mutex, NULL);
+    int TOKUDB_UNUSED(r) = pthread_mutex_init(&_mutex, NULL);
     assert_debug(r == 0);
     r = pthread_cond_init(&_cond, NULL);
     assert_debug(r == 0);
@@ -352,13 +352,13 @@ inline event_t::event_t(bool create_signalled, bool manual_reset) :
     _pulsed = false;
 }
 inline event_t::~event_t(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_destroy(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = pthread_cond_destroy(&_cond);
     assert_debug(r == 0);
 }
 inline void event_t::wait(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     while (_signalled == false && _pulsed == false) {
         r = pthread_cond_wait(&_cond, &_mutex);
@@ -395,7 +395,7 @@ inline int event_t::wait(ulonglong microseconds) {
     return 0;
 }
 inline void event_t::signal(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = true;
     if (_manual_reset) {
@@ -409,7 +409,7 @@ inline void event_t::signal(void) {
     assert_debug(r == 0);
 }
 inline void event_t::pulse(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _pulsed = true;
     r = pthread_cond_signal(&_cond);
@@ -419,7 +419,7 @@ inline void event_t::pulse(void) {
 }
 inline bool event_t::signalled(void) {
     bool ret = false;
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     ret = _signalled;
     r = pthread_mutex_unlock(&_mutex);
@@ -427,7 +427,7 @@ inline bool event_t::signalled(void) {
     return ret;
 }
 inline void event_t::reset(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = false;
     _pulsed = false;
@@ -449,21 +449,21 @@ inline semaphore_t::semaphore_t(
     _initial_count(initial_count),
     _max_count(max_count) {
 
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_init(&_mutex, NULL);
+    int TOKUDB_UNUSED(r) = pthread_mutex_init(&_mutex, NULL);
     assert_debug(r == 0);
     r = pthread_cond_init(&_cond, NULL);
     assert_debug(r == 0);
     _signalled = _initial_count;
 }
 inline semaphore_t::~semaphore_t(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_destroy(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_destroy(&_mutex);
     assert_debug(r == 0);
     r = pthread_cond_destroy(&_cond);
     assert_debug(r == 0);
 }
 inline semaphore_t::E_WAIT semaphore_t::wait(void) {
     E_WAIT ret;
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     while (_signalled == 0 && _interrupted == false) {
         r = pthread_cond_wait(&_cond, &_mutex);
@@ -506,7 +506,7 @@ inline semaphore_t::E_WAIT semaphore_t::wait(ulonglong microseconds) {
 }
 inline bool semaphore_t::signal(void) {
     bool ret = false;
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     if (_signalled < _max_count) {
         _signalled++;
@@ -520,7 +520,7 @@ inline bool semaphore_t::signal(void) {
 }
 inline int semaphore_t::signalled(void) {
     int ret = 0;
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     ret = _signalled;
     r = pthread_mutex_unlock(&_mutex);
@@ -528,7 +528,7 @@ inline int semaphore_t::signalled(void) {
     return ret;
 }
 inline void semaphore_t::reset(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _signalled = 0;
     r = pthread_mutex_unlock(&_mutex);
@@ -536,7 +536,7 @@ inline void semaphore_t::reset(void) {
     return;
 }
 inline void semaphore_t::set_interrupt(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _interrupted = true;
     r = pthread_cond_broadcast(&_cond);
@@ -545,7 +545,7 @@ inline void semaphore_t::set_interrupt(void) {
     assert_debug(r == 0);
 }
 inline void semaphore_t::clear_interrupt(void) {
-    int r MY_ATTRIBUTE((unused)) = pthread_mutex_lock(&_mutex);
+    int TOKUDB_UNUSED(r) = pthread_mutex_lock(&_mutex);
     assert_debug(r == 0);
     _interrupted = false;
     r = pthread_mutex_unlock(&_mutex);

--- a/storage/tokudb/tokudb_update_fun.cc
+++ b/storage/tokudb/tokudb_update_fun.cc
@@ -344,8 +344,8 @@ static inline uint32_t copy_toku_blob(
 }
 
 static int tokudb_hcad_update_fun(
-    DB* db,
-    const DBT* key,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key MY_ATTRIBUTE((unused)),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -762,8 +762,8 @@ cleanup:
 // Expand the variable offset array in the old row given the update mesage
 // in the extra.
 static int tokudb_expand_variable_offsets(
-    DB* db,
-    const DBT* key,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key MY_ATTRIBUTE((unused)),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -841,8 +841,8 @@ cleanup:
 
 // Expand an int field in a old row given the expand message in the extra.
 static int tokudb_expand_int_field(
-    DB* db,
-    const DBT* key,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key MY_ATTRIBUTE((unused)),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -938,8 +938,8 @@ cleanup:
 
 // Expand a char field in a old row given the expand message in the extra.
 static int tokudb_expand_char_field(
-    DB* db,
-    const DBT* key,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key MY_ATTRIBUTE((unused)),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -1498,8 +1498,8 @@ static uint8_t *consume_uint8_array(tokudb::buffer &b, uint32_t array_size) {
 }
 
 static int tokudb_expand_blobs(
-    DB* db,
-    const DBT* key_dbt,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key_dbt MY_ATTRIBUTE((unused)),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1551,7 +1551,7 @@ static int tokudb_expand_blobs(
 // the old value and put the result in the new value.
 static void apply_1_updates(
     tokudb::value_map& vd,
-    tokudb::buffer& new_val,
+    tokudb::buffer& new_val MY_ATTRIBUTE((unused)),
     tokudb::buffer& old_val,
     tokudb::buffer& extra_val) {
 
@@ -1629,8 +1629,8 @@ static void apply_1_updates(
 // Simple update handler. Decode the update message, apply the update operations
 // to the old value, and set the new value.
 static int tokudb_update_1_fun(
-    DB* db,
-    const DBT* key_dbt,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key_dbt MY_ATTRIBUTE((unused)),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1686,8 +1686,8 @@ static int tokudb_update_1_fun(
 // Otherwise, apply the update operations to the old value, and then set the
 // new value.
 static int tokudb_upsert_1_fun(
-    DB* db,
-    const DBT* key_dbt,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key_dbt MY_ATTRIBUTE((unused)),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1752,7 +1752,7 @@ static int tokudb_upsert_1_fun(
 // old value and put the result in the new value.
 static void apply_2_updates(
     tokudb::value_map& vd,
-    tokudb::buffer& new_val,
+    tokudb::buffer& new_val MY_ATTRIBUTE((unused)),
     tokudb::buffer& old_val,
     tokudb::buffer& extra_val) {
 
@@ -1857,8 +1857,8 @@ static void apply_2_updates(
 // Simple update handler. Decode the update message, apply the update
 // operations to the old value, and set the new value.
 static int tokudb_update_2_fun(
-    DB* db,
-    const DBT* key_dbt,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key_dbt MY_ATTRIBUTE((unused)),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1900,8 +1900,8 @@ static int tokudb_update_2_fun(
 // Otherwise, apply the update operations to the old value, and then set the
 // new value.
 static int tokudb_upsert_2_fun(
-    DB* db,
-    const DBT* key_dbt,
+    DB* db MY_ATTRIBUTE((unused)),
+    const DBT* key_dbt MY_ATTRIBUTE((unused)),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),

--- a/storage/tokudb/tokudb_update_fun.cc
+++ b/storage/tokudb/tokudb_update_fun.cc
@@ -344,8 +344,8 @@ static inline uint32_t copy_toku_blob(
 }
 
 static int tokudb_hcad_update_fun(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -762,8 +762,8 @@ cleanup:
 // Expand the variable offset array in the old row given the update mesage
 // in the extra.
 static int tokudb_expand_variable_offsets(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -841,8 +841,8 @@ cleanup:
 
 // Expand an int field in a old row given the expand message in the extra.
 static int tokudb_expand_int_field(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -938,8 +938,8 @@ cleanup:
 
 // Expand a char field in a old row given the expand message in the extra.
 static int tokudb_expand_char_field(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key),
     const DBT* old_val,
     const DBT* extra,
     void (*set_val)(const DBT* new_val, void* set_extra),
@@ -1498,8 +1498,8 @@ static uint8_t *consume_uint8_array(tokudb::buffer &b, uint32_t array_size) {
 }
 
 static int tokudb_expand_blobs(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key_dbt MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key_dbt),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1551,7 +1551,7 @@ static int tokudb_expand_blobs(
 // the old value and put the result in the new value.
 static void apply_1_updates(
     tokudb::value_map& vd,
-    tokudb::buffer& new_val MY_ATTRIBUTE((unused)),
+    tokudb::buffer& TOKUDB_UNUSED(new_val),
     tokudb::buffer& old_val,
     tokudb::buffer& extra_val) {
 
@@ -1629,8 +1629,8 @@ static void apply_1_updates(
 // Simple update handler. Decode the update message, apply the update operations
 // to the old value, and set the new value.
 static int tokudb_update_1_fun(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key_dbt MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key_dbt),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1686,8 +1686,8 @@ static int tokudb_update_1_fun(
 // Otherwise, apply the update operations to the old value, and then set the
 // new value.
 static int tokudb_upsert_1_fun(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key_dbt MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key_dbt),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1752,7 +1752,7 @@ static int tokudb_upsert_1_fun(
 // old value and put the result in the new value.
 static void apply_2_updates(
     tokudb::value_map& vd,
-    tokudb::buffer& new_val MY_ATTRIBUTE((unused)),
+    tokudb::buffer& TOKUDB_UNUSED(new_val),
     tokudb::buffer& old_val,
     tokudb::buffer& extra_val) {
 
@@ -1857,8 +1857,8 @@ static void apply_2_updates(
 // Simple update handler. Decode the update message, apply the update
 // operations to the old value, and set the new value.
 static int tokudb_update_2_fun(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key_dbt MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key_dbt),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),
@@ -1900,8 +1900,8 @@ static int tokudb_update_2_fun(
 // Otherwise, apply the update operations to the old value, and then set the
 // new value.
 static int tokudb_upsert_2_fun(
-    DB* db MY_ATTRIBUTE((unused)),
-    const DBT* key_dbt MY_ATTRIBUTE((unused)),
+    DB* TOKUDB_UNUSED(db),
+    const DBT* TOKUDB_UNUSED(key_dbt),
     const DBT* old_val_dbt,
     const DBT* extra,
     void (*set_val)(const DBT* new_val_dbt, void* set_extra),


### PR DESCRIPTION
How to bootstrap tokudb on Mysql 8?  This pull request is 1 of 4 needed to run tokudb on Mysql 8, and it compiles and runs on Percona server 5.7.  A follow on branch compiles a stripped down tokudb on Mysql 8 and runs some tests.  See https://github.com/prohaska7/tokudb-tools/tree/master/mysql-8.0 for details.  Most of the interesting tokudb features still need patches to the Mysql code.

Mysql 8 changed the compiler options and now includes -Wunused-parameter.  Tokudb has lots of functions with unused parameters so tokudb does not compile with this compiler option.  We could remove this compiler option from the CFLAGS used to compile tokudb, or we could investigate all of the warnings.  Rather than just removing this compiler option, this pull request annotates the unused parameters. In addition, many internal functions have been simplified by removing unused parameters.

This pull request implements the set of open tables as a std c++ unordered map since Mysql 8 renamed the API to its hash table and I did not want to deal with this ugly API change.  The choice of data structure is a compile time option.

Copyright (c) 2018, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.