### PR TITLE
BLD-933: CMake option to force build and fail it if the library is not

### DIFF
--- a/plugin/keyring_vault/CMakeLists.txt
+++ b/plugin/keyring_vault/CMakeLists.txt
@@ -1,29 +1,27 @@
+IF (NOT DEFINED WITH_KEYRING_VAULT)
+  SET (WITH_KEYRING_VAULT 1)
+ENDIF()
+IF (NOT WITH_KEYRING_VAULT)
+  MESSAGE (STATUS "Not building keyring_vault plugin")
+  RETURN()
+ENDIF()
+
 INCLUDE(CheckFunctionExists)
 INCLUDE(curl)
 
 SET(CMAKE_EXTRA_INCLUDE_FILES string.h)
 SET(CMAKE_EXTRA_INCLUDE_FILES)
 
-MACRO (CHECK_IF_LIB_FOUND lib_name project_name)
+MACRO (CHECK_IF_LIB_FOUND lib_name project_name status_mode)
   SET (lib_found_variable_name "${lib_name}_FOUND")
   IF (NOT DEFINED ${lib_found_variable_name} OR NOT ${${lib_found_variable_name}})
-    message("Not building ${project_name}, could not find library: ${lib_name}")
+    message(${status_mode} "Not building ${project_name}, could not find library: ${lib_name}")
     RETURN()
   ENDIF()
 ENDMACRO()
 
-MACRO (CHECK_IF_CURL_DEPENDS_ON_RTMP project_name)
-  EXECUTE_PROCESS(COMMAND ldd ${CURL_LIBRARY}
-                  COMMAND grep rtmp
-                  OUTPUT_VARIABLE CURL_DEPENDS_ON_RTMP)
-  IF (NOT CURL_DEPENDS_ON_RTMP STREQUAL "")
-    message("Not building ${project_name}. The supplied CURL library depends on rtmp library.
-Please provide CURL library that does not depend on rtmp library to build keyring_vault unittests.")
-    RETURN()
-  ENDIF()
-ENDMACRO()
-
-CHECK_IF_LIB_FOUND(CURL "keyring_vault")
+CHECK_IF_LIB_FOUND(CURL "keyring_vault" FATAL_ERROR)
+MESSAGE (STATUS "Building keyring_vault plugin")
 
 INCLUDE_DIRECTORIES(${BOOST_PATCHES_DIR})
 INCLUDE_DIRECTORIES(SYSTEM ${BOOST_INCLUDE_DIR} ${CURL_INCLUDE_DIRS})

--- a/unittest/gunit/keyring_vault/CMakeLists.txt
+++ b/unittest/gunit/keyring_vault/CMakeLists.txt
@@ -1,11 +1,28 @@
 INCLUDE(curl)
 
-IF(NOT GMOCK_FOUND)
+IF (NOT DEFINED WITH_KEYRING_VAULT)
+  SET (WITH_KEYRING_VAULT 1)
+ENDIF()
+IF(NOT GMOCK_FOUND OR NOT WITH_KEYRING_VAULT)
+    MESSAGE (STATUS "Not building keyring_vault unit tests")
     RETURN()
 ENDIF()
 
-CHECK_IF_LIB_FOUND(CURL "keyring_vault unit tests")
+MACRO (CHECK_IF_CURL_DEPENDS_ON_RTMP project_name)
+  EXECUTE_PROCESS(COMMAND ldd ${CURL_LIBRARY}
+                  COMMAND grep rtmp
+                  OUTPUT_VARIABLE CURL_DEPENDS_ON_RTMP)
+  IF (NOT CURL_DEPENDS_ON_RTMP STREQUAL "")
+    message(WARNING "Not building ${project_name}. The supplied CURL library depends on rtmp library.
+Please provide CURL library that does not depend on rtmp library to build keyring_vault unittests.")
+    RETURN()
+  ENDIF()
+ENDMACRO()
+
+CHECK_IF_LIB_FOUND(CURL "keyring_vault unit tests" FATAL_ERROR)
 CHECK_IF_CURL_DEPENDS_ON_RTMP("keyring_vault unit tests")
+
+message(STATUS "Building keyring_vault unittests")
 
 INCLUDE_DIRECTORIES(
         SYSTEM ${GMOCK_INCLUDE_DIRS}


### PR DESCRIPTION
found

Adds a new cmake variable WITH_KEYRING_VAULT. Allowed values are:
FORCE,ON,1,OFF,0

When cmake is run with -DWITH_KEYRING_VAULT=FORCE and compilation of
keyring_vault plugin is not possible, cmake aborts. Setting
WITH_KEYRING_VAULT to FORCE and providing CURL library which depends on
RTMP library will cause keyring vault unitest to not be build, but
overall cmake configuration will not be aborted. A warning message will
be generated.

When cmake is run with -DWITH_KEYRING_VAULT=ON and compilation of
keyring_vault plugin is not possible, a warning message is generated,
but the cmake configuration is not aborted.