### PR TITLE
PS-311: On server shutdown threadpool is crashing in debug mode due to

### DIFF
--- a/mysys/my_thr_init.c
+++ b/mysys/my_thr_init.c
@@ -354,7 +354,7 @@ void my_thread_end()
       tmp->dbug= NULL;
     }
     free(tmp);
-
+    set_mysys_thread_var(NULL);
     /*
       Decrement counter for number of running threads. We are using this
       in my_thread_global_end() to wait until all threads have called
@@ -367,7 +367,6 @@ void my_thread_end()
       mysql_cond_signal(&THR_COND_threads);
     mysql_mutex_unlock(&THR_LOCK_threads);
   }
-  set_mysys_thread_var(NULL);
 #endif
 }
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -4781,6 +4781,7 @@ int mysqld_main(int argc, char **argv)
   sys_var_init();
   ulong requested_open_files;
   adjust_related_options(&requested_open_files);
+  my_init_signals();
 
 #ifdef WITH_PERFSCHEMA_STORAGE_ENGINE
   if (ho_error == 0)
@@ -4883,8 +4884,6 @@ int mysqld_main(int argc, char **argv)
 
   if (init_common_variables())
     unireg_abort(MYSQLD_ABORT_EXIT);        // Will do exit
-
-  my_init_signals();
 
 #ifndef EMBEDDED_LIBRARY
   // Move connection handler initialization after the signal handling has been


### PR DESCRIPTION
race condition

Moved calling set_my_sys_thread_var before signaling conditional variable
THR_COND_threads. This is variable on which my_thread_global_end is waiting.
After it is signalled THR_KEY_mysys_initialized is set to FALSE in my_thread_global_end.
There is a debug assertion that THE_KEY_mysys_initialized == TRUE in
set_my_sys_thread_var.

Moved my_init_singals, which sets signal mask to block all handleable kill signals
- which are later serviced by singal_hand thread. my_init_singals was
moved before PFS initialization. As threadpool initialization can take
long time PFS thread created before the threadpool initialization starts
can be affected by "handlable kill" signals unless they have singal mask set.