### PR TITLE
Fix PS-3794 (MTR test main.percona_show_temp_tables_stress does not w…

### DIFF
--- a/mysql-test/t/percona_show_temp_tables_stress.test
+++ b/mysql-test/t/percona_show_temp_tables_stress.test
@@ -27,6 +27,12 @@ DO
 
 delimiter ;|
 
+--let $wait_condition= SELECT COUNT(*)= 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER='event_runner1'
+--source include/wait_condition.inc
+
+--let $wait_condition= SELECT COUNT(*)= 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE USER='event_runner2'
+--source include/wait_condition.inc
+
 --let $i=400
 --echo # Creating 400 temp tables with each of MyISAM, InnoDB, MEMORY
 --disable_query_log
@@ -74,3 +80,5 @@ DROP EVENT query_tables;
 
 DROP USER event_runner1@localhost;
 DROP USER event_runner2@localhost;
+
+--source include/no_running_event_scheduler.inc


### PR DESCRIPTION
…ait for events to start)

Synchronize the event scheduler-spawned worker threads with the main
connection thread by waiting for them to start up. At the same time
wait at the end of the testcase for the event scheduler to finish
stopping.

https://jenkins.percona.com/job/percona-server-5.5-param/1630/