### PR TITLE
PS-3793: added osx travis config (5.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 dist: trusty
 sudo: required
 language: c
+env:
+  global:
+    - MAINTAINER_MODE=ON
+    - WITHOUT_TOKUDB=OFF
 matrix:
   include:
     - env: COMMAND=clang-test
@@ -20,11 +24,14 @@ matrix:
     - env: GCC=gcc-6     CXX=g++-6       LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES=g++-6     PPA=ubuntu-toolchain-r/test
     - env: GCC=clang-4.0 CXX=clang++-4.0 LIBTYPE=system  CMAKE_OPT="-DWITH_READLINE=system" PACKAGES="clang-4.0 llvm-4.0-dev" PPA=ubuntu-toolchain-r/test LLVM=llvm-toolchain-trusty-4.0
     - env: GCC=clang-5.0 CXX=clang++-5.0 LIBTYPE=bundled CMAKE_OPT="-DWITH_PAM=1"           PACKAGES="clang-5.0 llvm-5.0-dev" LLVM=llvm-toolchain-trusty-5.0
+    - os: osx
+      osx_image: xcode9.2
+      env: LIBTYPE=bundled GCC=clang CXX=clang++ MAINTAINER_MODE=OFF WITHOUT_TOKUDB=ON
 
 script:
   - export CC=$GCC
   - JOB_NUMBER=$(echo $TRAVIS_JOB_NUMBER | sed -e 's:[0-9][0-9]*\.\(.*\):\1:')
-  - echo PACKAGES=$PACKAGES PPA=$PPA LLVM=$LLVM JOB_NUMBER=$JOB_NUMBER TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST
+  - echo PACKAGES=$PACKAGES PPA=$PPA LLVM=$LLVM JOB_NUMBER=$JOB_NUMBER TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST MAINTAINER_MODE=$MAINTAINER_MODE WITHOUT_TOKUDB=$WITHOUT_TOKUDB
 
   # Jobs with a number >= 6 are done only for a pull request
   - if [ $JOB_NUMBER -ge 6 ] && [ "$TRAVIS_EVENT_TYPE" != "pull_request" ]; then 
@@ -33,20 +40,22 @@ script:
     fi
 
   # Update required LLVM and Ubuntu Toolchain repositories
-  - if [ "$LLVM" != "" ]; then
+  - if [[ "$LLVM" != "" ]]; then
        curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -;
        echo "deb http://apt.llvm.org/trusty/ $LLVM main" | sudo tee -a /etc/apt/sources.list > /dev/null;
     fi
-  - if [ "$PPA" != "" ]; then
+  - if [[ "$PPA" != "" ]]; then
        sudo -E apt-add-repository -y "ppa:$PPA";
     fi
-  - if [ "$LLVM" != "" ] || [ "$PPA" != "" ]; then
-       sudo -E apt-get -yq update &>> ~/apt-get-update.log;
+  - if [[ "$LLVM" != "" ]] || [[ "$PPA" != "" ]]; then
+       sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
     fi 
 
   # Download dependencies
-  - PACKAGES="$PACKAGES cmake cmake-curses-gui libaio-dev libssl-dev libncurses5-dev libevent-dev bison"
-  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES
+  - if [[ "$TRAVIS_OS_NAME" != "osx" ]]; then
+       export PACKAGES="$PACKAGES cmake cmake-curses-gui libaio-dev libssl-dev libncurses5-dev libevent-dev bison";
+       sudo -E apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES;
+    fi
   - mkdir bin; cd bin
   - $CC -v
   - $CXX -v
@@ -54,13 +63,14 @@ script:
   # Test "RelWithDebInfo" compilation
   - cmake ..
     -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    -DMYSQL_MAINTAINER_MODE=ON
+    -DMYSQL_MAINTAINER_MODE=$MAINTAINER_MODE
     -DBUILD_CONFIG=mysql_release
     -DFEATURE_SET=community
     -DENABLE_DTRACE=OFF
     -DWITH_SSL=$LIBTYPE
     -DWITH_ZLIB=$LIBTYPE
     -DWITH_LIBEVENT=$LIBTYPE
+    -DWITHOUT_TOKUDB=$WITHOUT_TOKUDB
     -DENABLE_DOWNLOADS=1
      $CMAKE_OPT
   - make -j2
@@ -69,13 +79,14 @@ script:
   - rm -rf *
   - cmake ..
     -DCMAKE_BUILD_TYPE=Debug
-    -DMYSQL_MAINTAINER_MODE=ON
+    -DMYSQL_MAINTAINER_MODE=$MAINTAINER_MODE
     -DBUILD_CONFIG=mysql_release
     -DFEATURE_SET=community
     -DENABLE_DTRACE=OFF
     -DWITH_SSL=$LIBTYPE
     -DWITH_ZLIB=$LIBTYPE
     -DWITH_LIBEVENT=$LIBTYPE
+    -DWITHOUT_TOKUDB=$WITHOUT_TOKUDB
     -DENABLE_DOWNLOADS=1
      $CMAKE_OPT
   - make -j2


### PR DESCRIPTION
* Added OSX to the build matrix.
* Fixed issues with older bash versions on OSX.
* Made maintainer_mode optional, as the OSX build results in some warnings, and fixing them would take time.
  As it's not an officially supported platform, warnings are ok for now.
* Made tokudb optional, as the OSX build doesn't support it

(cherry picked from commit 568ab7d75834ea909dacd94a1134226827d5de7b)

(I created this pull request because some tests are only ran for PRs. I will update it with a comment if everyting is OK)