### PR TITLE
Fix PS-3798 (MTR test innodb.percona_extended_innodb_status fails if …

### DIFF
--- a/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
+++ b/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
@@ -78,6 +78,5 @@ DROP TABLE innodb_lock_monitor, t;
 #
 # Bug 1586262: "Buffer pool size, bytes" always 0 in InnoDB status
 #
-CREATE TEMPORARY TABLE t(a TEXT);
-include/assert.inc [Buffer pool size must be reported as 32M]
-DROP TEMPORARY TABLE t;
+mysql -e "SHOW ENGINE INNODB STATUS"
+Grepping InnoDB status for Buffer pool size, bytes 33538048

--- a/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
+++ b/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
@@ -54,16 +54,14 @@ DROP TABLE innodb_lock_monitor, t;
 --echo # Bug 1586262: "Buffer pool size, bytes" always 0 in InnoDB status
 --echo #
 
-CREATE TEMPORARY TABLE t(a TEXT);
+--let innodb_status= $MYSQL_TMP_DIR/innodb.status
 
---let $status = query_get_value(SHOW ENGINE INNODB STATUS, Status, 1)
+--echo mysql -e "SHOW ENGINE INNODB STATUS"
+--exec $MYSQL -e "SHOW ENGINE INNODB STATUS" > $innodb_status;
 
---disable_query_log
-eval INSERT INTO t VALUES("$status");
---enable_query_log
+--let SEARCH_FILE=$innodb_status
+--let SEARCH_PATTERN=Buffer pool size, bytes 33538048
+--echo Grepping InnoDB status for $SEARCH_PATTERN
+--source include/search_pattern_in_file.inc
 
---let $assert_text= Buffer pool size must be reported as 32M
---let $assert_cond= COUNT(*) = 1 FROM t WHERE a LIKE "%Buffer pool size, bytes 33538048%"
---source include/assert.inc
-
-DROP TEMPORARY TABLE t;
+--remove_file $innodb_status


### PR DESCRIPTION
…InnoDB status contains unquoted special characters)

The testcase performed

--let $status = query_get_value(SHOW ENGINE INNODB STATUS, Status, 1)
eval INSERT INTO t VALUES("$status");

which does not perform any SQL quoting on $status, breaking the INSERT
statement in case it contains quote characters. Fix by redirecting
status output to a temporary file and searching for a pattern there
instead.

https://jenkins.percona.com/job/percona-server-5.5-param/1631/