### PR TITLE
PS-314: issue with 65536+ threads and mdl locks

### DIFF
--- a/include/lf.h
+++ b/include/lf.h
@@ -59,19 +59,19 @@ typedef struct {
   lf_pinbox_free_func *free_func;
   void *free_func_arg;
   uint free_ptr_offset;
-  uint32 volatile pinstack_top_ver;         /* this is a versioned pointer */
-  uint32 volatile pins_in_array;            /* number of elements in array */
+  uint64 volatile pinstack_top_ver;         /* this is a versioned pointer */
+  uint64 volatile pins_in_array;            /* number of elements in array */
 } LF_PINBOX;
 
 typedef struct st_lf_pins {
   void * volatile pin[LF_PINBOX_PINS];
   LF_PINBOX *pinbox;
   void  *purgatory;
-  uint32 purgatory_count;
-  uint32 volatile link;
+  uint64 purgatory_count;
+  uint64 volatile link;
 /* we want sizeof(LF_PINS) to be 64 to avoid false sharing */
-#if SIZEOF_INT*2+SIZEOF_CHARP*(LF_PINBOX_PINS+2) != 64
-  char pad[64-sizeof(uint32)*2-sizeof(void*)*(LF_PINBOX_PINS+2)];
+#if 2*8+SIZEOF_CHARP*(LF_PINBOX_PINS+2) != 64
+  char pad[64-sizeof(uint64)*2-sizeof(void*)*(LF_PINBOX_PINS+2)];
 #endif
 } LF_PINS;
 


### PR DESCRIPTION
MDL uses the LF_PINS structure for maintaining a global map, which had a 16 bit limitations.
After reaching 65535 threads, new threads couldn't access the MDL structures until older threads disconnected.
This limitation also caused assertions in the debug builds, stopping the server.

This patch changes the 16 bit limitation of the LF_PINS structure to 32 bit.
While this solves the problem, it does so with a high memory cost:
as the LF_PINS structure uses the LF_DYNARRAY for storing its data, a 1GB array will be allocated when reaching 65536+256+1 threads.
99% of that memory will never be used, as MySQL has a connection limit of 100000, and this array would be enough for 4 billion.
As servers with 65k+ connections will use more than 40GB of address space anyway, this shouldn't be an issue, especially as most of it will never be accessed..