### PR TITLE
Implement PS-3804 (Add MeCab testing to TravisCI)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
     fi 
 
   # Download dependencies
-  - PACKAGES="$PACKAGES cmake cmake-curses-gui libaio-dev libssl-dev libncurses5-dev libevent-dev bison"
+  - PACKAGES="$PACKAGES cmake cmake-curses-gui libaio-dev libssl-dev libncurses5-dev libevent-dev bison libmecab-dev"
   - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install $PACKAGES
   - mkdir bin; cd bin
   - $CC -v
@@ -61,6 +61,7 @@ script:
     -DWITH_SSL=$LIBTYPE
     -DWITH_ZLIB=$LIBTYPE
     -DWITH_LIBEVENT=$LIBTYPE
+    -DWITH_MECAB=system
     -DENABLE_DOWNLOADS=1
     -DDOWNLOAD_BOOST=1
     -DWITH_BOOST=../deps
@@ -79,6 +80,7 @@ script:
     -DENABLE_DTRACE=OFF
     -DWITH_SSL=$LIBTYPE
     -DWITH_ZLIB=$LIBTYPE
+    -DWITH_MECAB=system
     -DWITH_LIBEVENT=$LIBTYPE
     -DENABLE_DOWNLOADS=1
     -DDOWNLOAD_BOOST=1

--- a/plugin/fulltext/mecab_parser/plugin_mecab.cc
+++ b/plugin/fulltext/mecab_parser/plugin_mecab.cc
@@ -35,12 +35,6 @@ static char*	mecab_rc_file;
 static const char*	mecab_min_supported_version = "0.993";
 static const char*	mecab_max_supported_version = "0.996";
 
-#if defined(BUNDLE_MECAB)
-static const bool bundle_mecab= true;
-#else
-static const bool bundle_mecab= false;
-#endif
-
 /** Set MeCab parser charset.
 @param[in]	charset charset string
 @retval	true	on success


### PR DESCRIPTION
Install mecab dev library on Travis-CI builder and pass
-DWITH_MECAB=system to CMake.

At the same time remove unused variable bundle_mecab from the plugin
to fix a compilation warning.

https://travis-ci.org/laurynas-biveinis/percona-server/builds/339009799 shows no regressions - only pre-existing errors and timeouts.