### PR TITLE
Fix PS-3812 (Revert PS-3360 (Busy server prefers LRU flushing over fl…

### DIFF
--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3273,15 +3273,7 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 			n_flushed_last = 0;
 		}
 
-		if (ut_time_ms() > next_loop_time
-		    && ret_sleep != OS_SYNC_TIME_EXCEEDED)
-
-			/* If our LRU flush took too long, skip the rest only
-			if the last iteration completed in time, otherwise we'd
-			be LRU flushing all the time, even if e.g. a sync flush
-			is waiting. */
-			ret_sleep = OS_SYNC_TIME_EXCEEDED;
-		else if (ret_sleep != OS_SYNC_TIME_EXCEEDED
+		if (ret_sleep != OS_SYNC_TIME_EXCEEDED
 		    && srv_flush_sync
 		    && buf_flush_sync_lsn > 0) {
 			/* woke up for flush_sync */


### PR DESCRIPTION
…ush list flushing too strongly))

Once the main cleaner loop was performing both LRU and flush list
flushing, it used to skip the flush list part if the LRU part took too
long. This broke sync flushes and PS-3360 fixed this by not skipping
the rest of iteration. This became meaningless with MT LRU flusher -
which removed LRU flushing from the cleaner loop - and left no-op code
and outdated comment. Removed.

https://jenkins.percona.com/job/mysql-5.7-param/1614/