### PR TITLE
MYR-126 : rocksdb.concurrent_alter unstable

### DIFF
--- a/mysql-test/suite/rocksdb/r/concurrent_alter.result
+++ b/mysql-test/suite/rocksdb/r/concurrent_alter.result
@@ -1,3 +1,6 @@
+set @orig_max_connections=@@global.max_connections;
+set @@global.max_connections=500;
+call mtr.add_suppression("Too many connections");
 CREATE DATABASE mysqlslap;
 use mysqlslap;
 CREATE TABLE a1 (a int, b int) ENGINE=ROCKSDB;
@@ -9,3 +12,4 @@ a1	CREATE TABLE `a1` (
   `b` int(11) DEFAULT NULL
 ) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
 DROP DATABASE mysqlslap;
+set @@global.max_connections=@orig_max_connections;

--- a/mysql-test/suite/rocksdb/t/concurrent_alter.test
+++ b/mysql-test/suite/rocksdb/t/concurrent_alter.test
@@ -1,8 +1,11 @@
 --source include/have_rocksdb.inc
+--source include/big_test.inc
 
 #
 # Generate concurrent requests to alter a table using mysqlslap
 #
+set @orig_max_connections=@@global.max_connections;
+set @@global.max_connections=500;
 
 CREATE DATABASE mysqlslap;
 
@@ -30,3 +33,5 @@ SHOW CREATE TABLE a1;
 --remove_file $MYSQL_TMP_DIR/concurrent_alter.sh
 
 DROP DATABASE mysqlslap;
+
+set @@global.max_connections=@orig_max_connections;


### PR DESCRIPTION
- Test uses multiple instances of mysqlslap with multiple threads each, which
  occasionally causes mysqld to emit "[Warning] Too many connections" to the
  error log.
- Fixed this in two ways, one was to raise the servers max_connections to 500.
  The other was to suppress the warning as it means nothing to the test.
- Also added big_test as a single instance of this test can overtake an entire
  system for the duration of the test.