### PR TITLE
MYR-234 : lower default value of rocksdb_max_row_locks to 1 million

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_row_locks_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_row_locks_basic.result
@@ -6,11 +6,11 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 SET @start_global_value = @@global.ROCKSDB_MAX_ROW_LOCKS;
 SELECT @start_global_value;
 @start_global_value
-1073741824
+1048576
 SET @start_session_value = @@session.ROCKSDB_MAX_ROW_LOCKS;
 SELECT @start_session_value;
 @start_session_value
-1073741824
+1048576
 '# Setting to valid values in global scope#'
 "Trying to set variable @@global.ROCKSDB_MAX_ROW_LOCKS to 1"
 SET @@global.ROCKSDB_MAX_ROW_LOCKS   = 1;
@@ -21,7 +21,7 @@ SELECT @@global.ROCKSDB_MAX_ROW_LOCKS;
 SET @@global.ROCKSDB_MAX_ROW_LOCKS = DEFAULT;
 SELECT @@global.ROCKSDB_MAX_ROW_LOCKS;
 @@global.ROCKSDB_MAX_ROW_LOCKS
-1073741824
+1048576
 "Trying to set variable @@global.ROCKSDB_MAX_ROW_LOCKS to 1024"
 SET @@global.ROCKSDB_MAX_ROW_LOCKS   = 1024;
 SELECT @@global.ROCKSDB_MAX_ROW_LOCKS;
@@ -31,7 +31,7 @@ SELECT @@global.ROCKSDB_MAX_ROW_LOCKS;
 SET @@global.ROCKSDB_MAX_ROW_LOCKS = DEFAULT;
 SELECT @@global.ROCKSDB_MAX_ROW_LOCKS;
 @@global.ROCKSDB_MAX_ROW_LOCKS
-1073741824
+1048576
 '# Setting to valid values in session scope#'
 "Trying to set variable @@session.ROCKSDB_MAX_ROW_LOCKS to 1"
 SET @@session.ROCKSDB_MAX_ROW_LOCKS   = 1;
@@ -42,7 +42,7 @@ SELECT @@session.ROCKSDB_MAX_ROW_LOCKS;
 SET @@session.ROCKSDB_MAX_ROW_LOCKS = DEFAULT;
 SELECT @@session.ROCKSDB_MAX_ROW_LOCKS;
 @@session.ROCKSDB_MAX_ROW_LOCKS
-1073741824
+1048576
 "Trying to set variable @@session.ROCKSDB_MAX_ROW_LOCKS to 1024"
 SET @@session.ROCKSDB_MAX_ROW_LOCKS   = 1024;
 SELECT @@session.ROCKSDB_MAX_ROW_LOCKS;
@@ -52,21 +52,21 @@ SELECT @@session.ROCKSDB_MAX_ROW_LOCKS;
 SET @@session.ROCKSDB_MAX_ROW_LOCKS = DEFAULT;
 SELECT @@session.ROCKSDB_MAX_ROW_LOCKS;
 @@session.ROCKSDB_MAX_ROW_LOCKS
-1073741824
+1048576
 '# Testing with invalid values in global scope #'
 "Trying to set variable @@global.ROCKSDB_MAX_ROW_LOCKS to 'aaa'"
 SET @@global.ROCKSDB_MAX_ROW_LOCKS   = 'aaa';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_MAX_ROW_LOCKS;
 @@global.ROCKSDB_MAX_ROW_LOCKS
-1073741824
+1048576
 SET @@global.ROCKSDB_MAX_ROW_LOCKS = @start_global_value;
 SELECT @@global.ROCKSDB_MAX_ROW_LOCKS;
 @@global.ROCKSDB_MAX_ROW_LOCKS
-1073741824
+1048576
 SET @@session.ROCKSDB_MAX_ROW_LOCKS = @start_session_value;
 SELECT @@session.ROCKSDB_MAX_ROW_LOCKS;
 @@session.ROCKSDB_MAX_ROW_LOCKS
-1073741824
+1048576
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -956,7 +956,7 @@ rocksdb_max_background_jobs	2
 rocksdb_max_latest_deadlocks	5
 rocksdb_max_log_file_size	0
 rocksdb_max_manifest_file_size	18446744073709551615
-rocksdb_max_row_locks	1073741824
+rocksdb_max_row_locks	1048576
 rocksdb_max_subcompactions	1
 rocksdb_max_total_wal_size	0
 rocksdb_merge_buf_size	67108864

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -433,7 +433,7 @@ static void rocksdb_set_wal_bytes_per_sync(THD *thd,
 // Options definitions
 //////////////////////////////////////////////////////////////////////////////
 static constexpr ulong RDB_MAX_LOCK_WAIT_SECONDS = 1024 * 1024 * 1024;
-static constexpr ulong RDB_MAX_ROW_LOCKS = 1024 * 1024 * 1024;
+static constexpr ulong RDB_MAX_ROW_LOCKS = 1024 * 1024;
 static constexpr ulong RDB_DEFAULT_BULK_LOAD_SIZE = 1000;
 static constexpr ulong RDB_MAX_BULK_LOAD_SIZE = 1024 * 1024 * 1024;
 static constexpr size_t RDB_DEFAULT_MERGE_BUF_SIZE = 64 * 1024 * 1024;


### PR DESCRIPTION
- To help prevent OOM on bulk/large operations and return an error to client
  before server is killed as RocksDB keep all uncommitted changes in memory
  until commit. This is only a temporary fix to try to prevent server kills.
  Longer term fix is in the works upstream.
- Reduced rocksdb_max_row_locks from 1024 * 1024 * 1024 (~ 1 billion) to
  1024 * 1024 (1 million) and re-recorded tests that need to be adjusted.