### PR TITLE
PS-1096: destroy PSI objects when removing thread from pool

### DIFF
--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -208,6 +208,10 @@ void threadpool_remove_connection(THD *thd)
 
   thd->release_resources();
 
+#ifdef HAVE_PSI_THREAD_INTERFACE
+  PSI_THREAD_CALL(delete_thread)(thd->get_psi());
+#endif
+
   Global_THD_manager::get_instance()->remove_thd(thd);
   Connection_handler_manager::dec_connection_count(false);
   delete thd;


### PR DESCRIPTION
Previous versions used my_thread_end, which was changed to some other code in 5.7. The call to free up the psi resources was missing from it.