### PR TITLE
PS-3848: macOS build broken, undefined symbol __db_keyword_, referenced

### DIFF
--- a/client/mysqlbinlog.cc
+++ b/client/mysqlbinlog.cc
@@ -3196,6 +3196,9 @@ static Exit_status dump_local_log_entries(PRINT_EVENT_INFO *print_event_info,
     char llbuff[21];
     my_off_t old_off = my_b_tell(file);
 
+    binary_log_debug::debug_expect_unknown_event=
+      DBUG_EVALUATE_IF("expect_Unknown_event", true, false);
+
     Log_event* ev = Log_event::read_log_event(file, glob_description_event,
                                               opt_verify_binlog_checksum,
                                               rewrite_db_filter);

--- a/libbinlogevents/include/debug_vars.h
+++ b/libbinlogevents/include/debug_vars.h
@@ -30,6 +30,7 @@ namespace binary_log_debug
   extern bool debug_query_mts_corrupt_db_names;
   extern bool debug_simulate_invalid_address;
   extern bool debug_pretend_version_50034_in_binlog;
+  extern bool debug_expect_unknown_event;
   // TODO(WL#7546):Add variables here as we move methods into libbinlogevent
   // from the server while implementing the WL#7546(Moving binlog event
   // encoding into a separate package)

--- a/libbinlogevents/src/binlog_event.cpp
+++ b/libbinlogevents/src/binlog_event.cpp
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <stdint.h>
-#include "my_dbug.h"
 
 const unsigned char checksum_version_split[3]= {5, 6, 1};
 const unsigned long checksum_version_product=
@@ -33,6 +32,7 @@ namespace binary_log_debug
   bool debug_checksum_test= false;
   bool debug_simulate_invalid_address= false;
   bool debug_pretend_version_50034_in_binlog= false;
+  bool debug_expect_unknown_event= false;
 }
 
 namespace binary_log
@@ -199,7 +199,10 @@ Log_event_header(const char* buf, uint16_t binlog_version)
   // The below type_code assert is correct and needed in 99% of time. In normal testing we do not
   // anticipate type_code to be of unknown value. This is why we only skip this assert when
   // debug variable expect_Unknown_event is set.
-  DBUG_EXECUTE_IF("expect_Unknown_event", return;);
+#ifndef DBUG_OFF
+  if (binary_log_debug::debug_expect_unknown_event)
+    return;
+#endif
   BAPI_ASSERT(type_code < ENUM_END_EVENT || flags & LOG_EVENT_IGNORABLE_F);
 }
 


### PR DESCRIPTION
from binary_log::Log_event_header::Log_event_header

binlog_event.cpp as a part of libbinlogevent should not depend on
mtr debug variables and thus on my_dbug.h. Created
binary_log_debug::debug_expect_unknown_event variable which value
depends on the value of mtr debug variable expect_Unknown_event.
This is the correct way to make binlog_event.cpp not depend on
my_dbug.h