### PR TITLE
TDB-114 : pre-8.0 : Change use of MySQL HASH to unordered_map

### DIFF
--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -274,15 +274,8 @@ public:
     uint32_t num_DBs;
 
 private:
-    static HASH _open_tables;
+    static std::unordered_map<std::string, TOKUDB_SHARE*> _open_tables;
     static tokudb::thread::mutex_t _open_tables_mutex;
-
-    static uchar* hash_get_key(
-        TOKUDB_SHARE* share,
-        size_t* length,
-        TOKUDB_UNUSED(my_bool not_used));
-
-    static void hash_free_element(TOKUDB_SHARE* share);
 
     //*********************************
     // Spans open-close-open

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -60,6 +60,9 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "misc.h"
 #endif
 
+#include <string>
+#include <unordered_map>
+
 #include "db.h"
 #include "toku_os.h"
 #include "toku_time.h"


### PR DESCRIPTION
- Harmless change that changes the container of currently opened TOKUDB_SHARE
  instances from themysql HASH to std::unordered_map to prep for the coming 8.0
  change that alters the API to the HASH in ways we just don't want to deal
  with.