### PR TITLE
PS-310: Added support for building PS 5.6 with clang and MSAN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,28 @@ IF (WITH_ASAN)
   ENDIF()
 ENDIF()
 
+OPTION(WITH_MSAN "Enable memory sanitizer" OFF)
+IF(WITH_MSAN)
+  # TLS model is required because otherwise MSAN has issues with thread local
+  # variable initialization in dynamic libraries
+  SET(MSAN_FLAGS "-fsanitize=memory -fsanitize-memory-track-origins=2 -ftls-model=initial-exec -fPIC -fno-omit-frame-pointer -fsanitize-blacklist=${CMAKE_CURRENT_SOURCE_DIR}/cmake/msan-blacklist.txt")
+  MY_CHECK_C_COMPILER_FLAG("-fsanitize=memory" HAVE_C_MSANITIZE)
+  MY_CHECK_CXX_COMPILER_FLAG("-fsanitize=memory" HAVE_CXX_MSANITIZE)
+  IF(HAVE_C_MSANITIZE AND HAVE_CXX_MSANITIZE)
+    SET(CMAKE_C_FLAGS_DEBUG
+      "${CMAKE_C_FLAGS_DEBUG} ${MSAN_FLAGS} -O1")
+    SET(CMAKE_C_FLAGS_RELWITHDEBINFO
+      "${CMAKE_C_FLAGS_RELWITHDEBINFO} ${MSAN_FLAGS}")
+    SET(CMAKE_CXX_FLAGS_DEBUG
+      "${CMAKE_CXX_FLAGS_DEBUG} ${MSAN_FLAGS} -O1")
+    SET(CMAKE_CXX_FLAGS_RELWITHDEBINFO
+      "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${MSAN_FLAGS}")
+    SET(WITH_MSAN_OK 1)
+  ELSE()
+    MESSAGE(FATAL_ERROR "Do not know how to enable memory sanitizer.")
+  ENDIF()
+ENDIF()	
+
 # Always enable debug sync for debug builds.
 SET(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DENABLED_DEBUG_SYNC")
 SET(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DENABLED_DEBUG_SYNC")

--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -10541,10 +10541,10 @@ int insert_pointer_name(reg1 POINTER_ARRAY *pa,char * name)
     if (!(pa->typelib.type_names=(const char **)
 	  my_malloc(((PC_MALLOC-MALLOC_OVERHEAD)/
 		     (sizeof(char *)+sizeof(*pa->flag))*
-		     (sizeof(char *)+sizeof(*pa->flag))),MYF(MY_WME))))
+		     (sizeof(char *)+sizeof(*pa->flag))),MYF(MY_WME | MY_ZEROFILL))))
       DBUG_RETURN(-1);
     if (!(pa->str= (uchar*) my_malloc((uint) (PS_MALLOC-MALLOC_OVERHEAD),
-				     MYF(MY_WME))))
+				     MYF(MY_WME | MY_ZEROFILL))))
     {
       my_free(pa->typelib.type_names);
       DBUG_RETURN (-1);

--- a/cmake/os/Linux.cmake
+++ b/cmake/os/Linux.cmake
@@ -33,7 +33,7 @@ ENDFOREACH()
 # Ensure we have clean build for shared libraries
 # without unresolved symbols
 # Not supported with AddressSanitizer
-IF(NOT WITH_ASAN)
+IF(NOT WITH_ASAN AND NOT WITH_MSAN)
   SET(LINK_FLAG_NO_UNDEFINED "-Wl,--no-undefined")
 ENDIF()
 


### PR DESCRIPTION
This change adds the option to build PS 5.6 with MSAN, but doesn't try to fix any actual issues in the main MySQL code.

The only issue fixed is an uninitailized read in the mysqltest binary - without that, the test suite can't be started.

After these changes, running the MTR tests is possible, but there are still some remaining errors.
To build with MSAN:

* use an instrumented libcxx (with msan)
* use the bundled zlib and libssl

And set the following environment variables before running CMake:

* CFLAGS: -fsanitize=memory
* CXXFLAGS: -fsanitize=memory -Wno-unused-command-line-argument -nostdinc++ -stdlib=libc++
* CC, CXX to clang
* CPLUS_INCLUDE_PATH, C_INCLUDE_PATH, LIBRARY_PATH, LD_LIBRARY_PATH to use the instrumented libcxx

the LD_LIBRARY_PATH setting is also required for running any of the binaries, otherwise MSAN will report false positives.

(cherry picked from commit efb02379116a56af2c91933cd36c0cd79a6e7cf0)