### PR TITLE
TDB-137 : TokuDB 5.6 missing MRR tests

### DIFF
--- a/mysql-test/suite/tokudb/r/tokudb_mrr.result
+++ b/mysql-test/suite/tokudb/r/tokudb_mrr.result
@@ -1,0 +1,706 @@
+set optimizer_switch='mrr=on,mrr_cost_based=off';
+set default_storage_engine=TokuDB;
+create table t1(a int);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) DEFAULT NULL
+) ENGINE=TokuDB DEFAULT CHARSET=latin1
+insert into t1 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t2(a int);
+insert into t2 select A.a + 10*(B.a + 10*C.a) from t1 A, t1 B, t1 C;
+create table t3 (
+a char(8) not null, b char(8) not null, filler char(200),
+key(a)
+);
+insert into t3 select @a:=concat('c-', 1000+ A.a, '=w'), @a, 'filler' from t2 A;
+insert into t3 select concat('c-', 1000+A.a, '=w'), concat('c-', 2000+A.a, '=w'), 
+'filler-1' from t2 A;
+insert into t3 select concat('c-', 1000+A.a, '=w'), concat('c-', 3000+A.a, '=w'), 
+'filler-2' from t2 A;
+select a,filler from t3 where a >= 'c-9011=w';
+a	filler
+select a,filler from t3 where a >= 'c-1011=w' and a <= 'c-1015=w';
+a	filler
+c-1011=w	filler
+c-1011=w	filler-1
+c-1011=w	filler-2
+c-1012=w	filler
+c-1012=w	filler-1
+c-1012=w	filler-2
+c-1013=w	filler
+c-1013=w	filler-1
+c-1013=w	filler-2
+c-1014=w	filler
+c-1014=w	filler-1
+c-1014=w	filler-2
+c-1015=w	filler
+c-1015=w	filler-1
+c-1015=w	filler-2
+select a,filler from t3 where (a>='c-1011=w' and a <= 'c-1013=w') or
+(a>='c-1014=w' and a <= 'c-1015=w');
+a	filler
+c-1011=w	filler
+c-1011=w	filler-1
+c-1011=w	filler-2
+c-1012=w	filler
+c-1012=w	filler-1
+c-1012=w	filler-2
+c-1013=w	filler
+c-1013=w	filler-1
+c-1013=w	filler-2
+c-1014=w	filler
+c-1014=w	filler-1
+c-1014=w	filler-2
+c-1015=w	filler
+c-1015=w	filler-1
+c-1015=w	filler-2
+insert into t3 values ('c-1013=z', 'c-1013=z', 'err');
+insert into t3 values ('a-1014=w', 'a-1014=w', 'err');
+select a,filler from t3 where (a>='c-1011=w' and a <= 'c-1013=w') or
+(a>='c-1014=w' and a <= 'c-1015=w');
+a	filler
+c-1011=w	filler
+c-1011=w	filler-1
+c-1011=w	filler-2
+c-1012=w	filler
+c-1012=w	filler-1
+c-1012=w	filler-2
+c-1013=w	filler
+c-1013=w	filler-1
+c-1013=w	filler-2
+c-1014=w	filler
+c-1014=w	filler-1
+c-1014=w	filler-2
+c-1015=w	filler
+c-1015=w	filler-1
+c-1015=w	filler-2
+delete from t3 where b in ('c-1013=z', 'a-1014=w');
+select a,filler from t3 where a='c-1011=w' or a='c-1012=w' or a='c-1013=w' or
+a='c-1014=w' or a='c-1015=w';
+a	filler
+c-1011=w	filler
+c-1011=w	filler-1
+c-1011=w	filler-2
+c-1012=w	filler
+c-1012=w	filler-1
+c-1012=w	filler-2
+c-1013=w	filler
+c-1013=w	filler-1
+c-1013=w	filler-2
+c-1014=w	filler
+c-1014=w	filler-1
+c-1014=w	filler-2
+c-1015=w	filler
+c-1015=w	filler-1
+c-1015=w	filler-2
+insert into t3 values ('c-1013=w', 'del-me', 'inserted');
+select a,filler from t3 where a='c-1011=w' or a='c-1012=w' or a='c-1013=w' or
+a='c-1014=w' or a='c-1015=w';
+a	filler
+c-1011=w	filler
+c-1011=w	filler-1
+c-1011=w	filler-2
+c-1012=w	filler
+c-1012=w	filler-1
+c-1012=w	filler-2
+c-1013=w	filler
+c-1013=w	filler-1
+c-1013=w	filler-2
+c-1013=w	inserted
+c-1014=w	filler
+c-1014=w	filler-1
+c-1014=w	filler-2
+c-1015=w	filler
+c-1015=w	filler-1
+c-1015=w	filler-2
+delete from t3 where b='del-me';
+alter table t3 add primary key(b);
+select b,filler from t3 where (b>='c-1011=w' and b<= 'c-1018=w') or 
+b IN ('c-1019=w', 'c-1020=w', 'c-1021=w', 
+'c-1022=w', 'c-1023=w', 'c-1024=w');
+b	filler
+c-1011=w	filler
+c-1012=w	filler
+c-1013=w	filler
+c-1014=w	filler
+c-1015=w	filler
+c-1016=w	filler
+c-1017=w	filler
+c-1018=w	filler
+c-1019=w	filler
+c-1020=w	filler
+c-1021=w	filler
+c-1022=w	filler
+c-1023=w	filler
+c-1024=w	filler
+select b,filler from t3 where (b>='c-1011=w' and b<= 'c-1020=w') or 
+b IN ('c-1021=w', 'c-1022=w', 'c-1023=w');
+b	filler
+c-1011=w	filler
+c-1012=w	filler
+c-1013=w	filler
+c-1014=w	filler
+c-1015=w	filler
+c-1016=w	filler
+c-1017=w	filler
+c-1018=w	filler
+c-1019=w	filler
+c-1020=w	filler
+c-1021=w	filler
+c-1022=w	filler
+c-1023=w	filler
+select b,filler from t3 where (b>='c-1011=w' and b<= 'c-1018=w') or 
+b IN ('c-1019=w', 'c-1020=w') or 
+(b>='c-1021=w' and b<= 'c-1023=w');
+b	filler
+c-1011=w	filler
+c-1012=w	filler
+c-1013=w	filler
+c-1014=w	filler
+c-1015=w	filler
+c-1016=w	filler
+c-1017=w	filler
+c-1018=w	filler
+c-1019=w	filler
+c-1020=w	filler
+c-1021=w	filler
+c-1022=w	filler
+c-1023=w	filler
+create table t4 (a varchar(10), b int, c char(10), filler char(200),
+key idx1 (a, b, c));
+insert into t4 (filler) select concat('NULL-', 15-a) from t2 order by a limit 15;
+insert into t4 (a,b,c,filler) 
+select 'b-1',NULL,'c-1', concat('NULL-', 15-a) from t2 order by a limit 15;
+insert into t4 (a,b,c,filler) 
+select 'b-1',NULL,'c-222', concat('NULL-', 15-a) from t2 order by a limit 15;
+insert into t4 (a,b,c,filler) 
+select 'bb-1',NULL,'cc-2', concat('NULL-', 15-a) from t2 order by a limit 15;
+insert into t4 (a,b,c,filler) 
+select 'zz-1',NULL,'cc-2', 'filler-data' from t2 order by a limit 500;
+explain 
+select * from t4 where a IS NULL and b IS NULL and (c IS NULL or c='no-such-row1'
+                                                      or c='no-such-row2');
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t4	range	idx1	idx1	29	NULL	16	Using where; Using MRR
+select * from t4 where a IS NULL and b IS NULL and (c IS NULL or c='no-such-row1'
+                                                    or c='no-such-row2');
+a	b	c	filler
+NULL	NULL	NULL	NULL-15
+NULL	NULL	NULL	NULL-14
+NULL	NULL	NULL	NULL-13
+NULL	NULL	NULL	NULL-12
+NULL	NULL	NULL	NULL-11
+NULL	NULL	NULL	NULL-10
+NULL	NULL	NULL	NULL-9
+NULL	NULL	NULL	NULL-8
+NULL	NULL	NULL	NULL-7
+NULL	NULL	NULL	NULL-6
+NULL	NULL	NULL	NULL-5
+NULL	NULL	NULL	NULL-4
+NULL	NULL	NULL	NULL-3
+NULL	NULL	NULL	NULL-2
+NULL	NULL	NULL	NULL-1
+explain 
+select * from t4 where (a ='b-1' or a='bb-1') and b IS NULL and (c='c-1' or c='cc-2');
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t4	range	idx1	idx1	29	NULL	32	Using where; Using MRR
+select * from t4 where (a ='b-1' or a='bb-1') and b IS NULL and (c='c-1' or c='cc-2');
+a	b	c	filler
+b-1	NULL	c-1	NULL-15
+b-1	NULL	c-1	NULL-14
+b-1	NULL	c-1	NULL-13
+b-1	NULL	c-1	NULL-12
+b-1	NULL	c-1	NULL-11
+b-1	NULL	c-1	NULL-10
+b-1	NULL	c-1	NULL-9
+b-1	NULL	c-1	NULL-8
+b-1	NULL	c-1	NULL-7
+b-1	NULL	c-1	NULL-6
+b-1	NULL	c-1	NULL-5
+b-1	NULL	c-1	NULL-4
+b-1	NULL	c-1	NULL-3
+b-1	NULL	c-1	NULL-2
+b-1	NULL	c-1	NULL-1
+bb-1	NULL	cc-2	NULL-15
+bb-1	NULL	cc-2	NULL-14
+bb-1	NULL	cc-2	NULL-13
+bb-1	NULL	cc-2	NULL-12
+bb-1	NULL	cc-2	NULL-11
+bb-1	NULL	cc-2	NULL-10
+bb-1	NULL	cc-2	NULL-9
+bb-1	NULL	cc-2	NULL-8
+bb-1	NULL	cc-2	NULL-7
+bb-1	NULL	cc-2	NULL-6
+bb-1	NULL	cc-2	NULL-5
+bb-1	NULL	cc-2	NULL-4
+bb-1	NULL	cc-2	NULL-3
+bb-1	NULL	cc-2	NULL-2
+bb-1	NULL	cc-2	NULL-1
+select * from t4 ignore index(idx1) where (a ='b-1' or a='bb-1') and b IS NULL and (c='c-1' or c='cc-2');
+a	b	c	filler
+b-1	NULL	c-1	NULL-15
+b-1	NULL	c-1	NULL-14
+b-1	NULL	c-1	NULL-13
+b-1	NULL	c-1	NULL-12
+b-1	NULL	c-1	NULL-11
+b-1	NULL	c-1	NULL-10
+b-1	NULL	c-1	NULL-9
+b-1	NULL	c-1	NULL-8
+b-1	NULL	c-1	NULL-7
+b-1	NULL	c-1	NULL-6
+b-1	NULL	c-1	NULL-5
+b-1	NULL	c-1	NULL-4
+b-1	NULL	c-1	NULL-3
+b-1	NULL	c-1	NULL-2
+b-1	NULL	c-1	NULL-1
+bb-1	NULL	cc-2	NULL-15
+bb-1	NULL	cc-2	NULL-14
+bb-1	NULL	cc-2	NULL-13
+bb-1	NULL	cc-2	NULL-12
+bb-1	NULL	cc-2	NULL-11
+bb-1	NULL	cc-2	NULL-10
+bb-1	NULL	cc-2	NULL-9
+bb-1	NULL	cc-2	NULL-8
+bb-1	NULL	cc-2	NULL-7
+bb-1	NULL	cc-2	NULL-6
+bb-1	NULL	cc-2	NULL-5
+bb-1	NULL	cc-2	NULL-4
+bb-1	NULL	cc-2	NULL-3
+bb-1	NULL	cc-2	NULL-2
+bb-1	NULL	cc-2	NULL-1
+drop table t1, t2, t3, t4;
+create table t1 (a int, b int not null,unique key (a,b),index(b));
+insert ignore into t1 values (1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(null,7),(9,9),(8,8),(7,7),(null,9),(null,9),(6,6);
+create table t2 like t1;
+insert into t2 select * from t1;
+alter table t1 modify b blob not null, add c int not null, drop key a, add unique key (a,b(20),c), drop key b, add key (b(10));
+select * from t1 where a is null;
+a	b	c
+NULL	7	0
+NULL	9	0
+NULL	9	0
+select * from t1 where (a is null or a > 0 and a < 3) and b > 7 limit 3;
+a	b	c
+NULL	9	0
+NULL	9	0
+select * from t1 where a is null and b=9 or a is null and b=7 limit 3;
+a	b	c
+NULL	7	0
+NULL	9	0
+NULL	9	0
+drop table t1, t2;
+CREATE TABLE t1 (
+ID int(10) unsigned NOT NULL AUTO_INCREMENT,
+col1 int(10) unsigned DEFAULT NULL,
+key1 int(10) unsigned NOT NULL DEFAULT '0',
+key2 int(10) unsigned DEFAULT NULL,
+text1 text,
+text2 text,
+col2 smallint(6) DEFAULT '100',
+col3 enum('headers','bodyandsubject') NOT NULL DEFAULT 'bodyandsubject',
+col4 tinyint(3) unsigned NOT NULL DEFAULT '0',
+PRIMARY KEY (ID),
+KEY (key1),
+KEY (key2)
+) AUTO_INCREMENT=6 DEFAULT CHARSET=utf8;
+INSERT INTO t1 VALUES
+(1,NULL,1130,NULL,'Hello',NULL,100,'bodyandsubject',0),
+(2,NULL,1130,NULL,'bye',NULL,100,'bodyandsubject',0),
+(3,NULL,1130,NULL,'red',NULL,100,'bodyandsubject',0),
+(4,NULL,1130,NULL,'yellow',NULL,100,'bodyandsubject',0),
+(5,NULL,1130,NULL,'blue',NULL,100,'bodyandsubject',0);
+select * FROM t1 WHERE key1=1130 AND col1 IS NULL ORDER BY text1;
+ID	col1	key1	key2	text1	text2	col2	col3	col4
+5	NULL	1130	NULL	blue	NULL	100	bodyandsubject	0
+2	NULL	1130	NULL	bye	NULL	100	bodyandsubject	0
+1	NULL	1130	NULL	Hello	NULL	100	bodyandsubject	0
+3	NULL	1130	NULL	red	NULL	100	bodyandsubject	0
+4	NULL	1130	NULL	yellow	NULL	100	bodyandsubject	0
+drop table t1;
+
+BUG#37851: Crash in test_if_skip_sort_order tab->select is zero
+
+CREATE TABLE t1 (
+pk int(11) NOT NULL AUTO_INCREMENT,
+PRIMARY KEY (pk)
+);
+INSERT INTO t1 VALUES (1);
+CREATE TABLE t2 (
+pk int(11) NOT NULL AUTO_INCREMENT,
+int_key int(11) DEFAULT NULL,
+PRIMARY KEY (pk),
+KEY int_key (int_key)
+);
+INSERT INTO t2 VALUES (1,1),(2,6),(3,0);
+EXPLAIN EXTENDED
+SELECT MIN(t1.pk)
+FROM t1 WHERE EXISTS (
+SELECT t2.pk
+FROM t2
+WHERE t2.int_key IS NULL
+GROUP BY t2.pk
+);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	Impossible WHERE
+2	SUBQUERY	t2	ref	int_key	int_key	5	const	1	100.00	Using where; Using index
+Warnings:
+Note	1003	/* select#1 */ select min(`test`.`t1`.`pk`) AS `MIN(t1.pk)` from `test`.`t1` where 0
+DROP TABLE t1, t2;
+#
+# BUG#42048 Discrepancy between MyISAM and Maria's ICP implementation
+#
+create table t0 (a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1 (a int, b char(20), filler char(200), key(a,b(10)));
+insert into t1 select A.a + 10*(B.a + 10*C.a), 'bbb','filler' from t0 A, t0 B, t0 C;
+update t1 set b=repeat(char(65+a), 20) where a < 25;
+This must show range + using index condition:
+explain select * from t1 where a < 10 and b = repeat(char(65+a), 20);
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	a	a	5	NULL	x	Using where
+select * from t1 where a < 10 and b = repeat(char(65+a), 20);
+a	b	filler
+0	AAAAAAAAAAAAAAAAAAAA	filler
+1	BBBBBBBBBBBBBBBBBBBB	filler
+2	CCCCCCCCCCCCCCCCCCCC	filler
+3	DDDDDDDDDDDDDDDDDDDD	filler
+4	EEEEEEEEEEEEEEEEEEEE	filler
+5	FFFFFFFFFFFFFFFFFFFF	filler
+6	GGGGGGGGGGGGGGGGGGGG	filler
+7	HHHHHHHHHHHHHHHHHHHH	filler
+8	IIIIIIIIIIIIIIIIIIII	filler
+9	JJJJJJJJJJJJJJJJJJJJ	filler
+drop table t0,t1;
+#
+# BUG#41136: ORDER BY + range access: EXPLAIN shows "Using MRR" while MRR is actually not used
+#
+create table t0 (a int);
+insert into t0 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t1 (a int, b int, key(a));
+insert into t1 select A.a + 10 *(B.a + 10*C.a), A.a + 10 *(B.a + 10*C.a) from t0 A, t0 B, t0 C;
+This mustn't show "Using MRR":
+explain select * from t1 where a < 20  order by a;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	a	a	5	NULL	20	Using where
+drop table t0, t1;
+set @read_rnd_buffer_size_save= @@read_rnd_buffer_size;
+set read_rnd_buffer_size=64;
+create table t1(a int);
+insert into t1 values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+create table t2(a char(8), b char(8), c char(8), filler char(100), key k1(a,b,c) );
+insert into t2 select 
+concat('a-', 1000 + A.a, '-a'),
+concat('b-', 1000 + B.a, '-b'),
+concat('c-', 1000 + C.a, '-c'),
+'filler'
+from t1 A, t1 B, t1 C;
+EXPLAIN select count(length(a) + length(filler))
+from t2 force index (k1)
+where a>='a-1000-a' and a <'a-1001-a';
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	k1	k1	9	NULL	100	Using where; Using MRR
+select count(length(a) + length(filler))
+from t2 force index (k1)
+where a>='a-1000-a' and a <'a-1001-a';
+count(length(a) + length(filler))
+100
+drop table t2;
+create table t2 (a char(100), b char(100), c char(100), d int, 
+filler char(10), key(d), primary key (a,b,c));
+insert into t2 select A.a, B.a, B.a, A.a, 'filler' from t1 A, t1 B;
+explain select * from t2 force index (d) where d < 10;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	range	d	d	5	NULL	#	Using where
+drop table t2;
+drop table t1;
+set @@read_rnd_buffer_size= @read_rnd_buffer_size_save;
+create table t1 (f1 int not null, f2 int not null,f3 int not null, f4 char(1), primary key (f1,f2), key ix(f3));
+select * from t1 where (f3>=5 and f3<=10) or (f3>=1 and f3<=4);
+f1	f2	f3	f4
+1	1	1	A
+10	10	10	A
+2	2	2	A
+3	3	3	A
+4	4	4	A
+5	5	5	A
+6	6	6	A
+7	7	7	A
+8	8	8	A
+9	9	9	A
+drop table t1;
+
+BUG#37977: Wrong result returned on GROUP BY + OR + Innodb
+
+CREATE TABLE t1 (
+`pk` int(11) NOT NULL AUTO_INCREMENT,
+`int_nokey` int(11) NOT NULL,
+`int_key` int(11) NOT NULL,
+`date_key` date NOT NULL,
+`date_nokey` date NOT NULL,
+`time_key` time NOT NULL,
+`time_nokey` time NOT NULL,
+`datetime_key` datetime NOT NULL,
+`datetime_nokey` datetime NOT NULL,
+`varchar_key` varchar(5) DEFAULT NULL,
+`varchar_nokey` varchar(5) DEFAULT NULL,
+PRIMARY KEY (`pk`),
+KEY `int_key` (`int_key`),
+KEY `date_key` (`date_key`),
+KEY `time_key` (`time_key`),
+KEY `datetime_key` (`datetime_key`),
+KEY `varchar_key` (`varchar_key`)
+);
+INSERT INTO t1 VALUES 
+(1,5,5,'2009-10-16','2009-10-16','09:28:15','09:28:15','2007-09-14 05:34:08','2007-09-14 05:34:08','qk','qk'),
+(2,6,6,'0000-00-00','0000-00-00','23:06:39','23:06:39','0000-00-00 00:00:00','0000-00-00 00:00:00','j','j'),
+(3,10,10,'2000-12-18','2000-12-18','22:16:19','22:16:19','2006-11-04 15:42:50','2006-11-04 15:42:50','aew','aew'),
+(4,0,0,'2001-09-18','2001-09-18','00:00:00','00:00:00','2004-03-23 13:23:35','2004-03-23 13:23:35',NULL,NULL),
+(5,6,6,'2007-08-16','2007-08-16','22:13:38','22:13:38','2004-08-19 11:01:28','2004-08-19 11:01:28','qu','qu');
+select pk from t1 WHERE `varchar_key` > 'kr' group by pk;
+pk
+1
+5
+select pk from t1 WHERE `int_nokey` IS NULL OR  `varchar_key` > 'kr' group by pk;
+pk
+1
+5
+drop table t1;
+#
+# BUG#39447: Error with NOT NULL condition and LIMIT 1
+#
+CREATE TABLE t1 (                 
+id int(11) NOT NULL,                
+parent_id int(11) DEFAULT NULL,     
+name varchar(10) DEFAULT NULL,      
+PRIMARY KEY (id),                   
+KEY ind_parent_id (parent_id)     
+);
+insert into t1 (id, parent_id, name) values
+(10,NULL,'A'),
+(20,10,'B'),
+(30,10,'C'),
+(40,NULL,'D'),
+(50,40,'E'),
+(60,40,'F'),
+(70,NULL,'J');
+SELECT id FROM t1 WHERE parent_id IS NOT NULL ORDER BY id DESC LIMIT 1;
+id
+60
+This must show type=index, extra=Using where
+explain SELECT * FROM t1 WHERE parent_id IS NOT NULL ORDER BY id DESC LIMIT 1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	index	ind_parent_id	PRIMARY	4	NULL	1	Using where
+SELECT * FROM t1 WHERE parent_id IS NOT NULL ORDER BY id DESC LIMIT 1;
+id	parent_id	name
+60	40	F
+drop table t1;
+#
+# Bug#50381 "Assertion failing in handler.h:1283: 
+#            void COST_VECT::add_io(double, double)"
+#
+CREATE TABLE t1 (
+c1 INT NOT NULL,
+c2 VARCHAR(1) DEFAULT NULL,
+PRIMARY KEY (c1)
+);
+CREATE TABLE t2 (
+c1 INT NOT NULL,
+c2 VARCHAR(1) DEFAULT NULL,
+PRIMARY KEY (c1)
+);
+INSERT INTO t2 VALUES (10,'v');
+INSERT INTO t2 VALUES (11,'r');
+SELECT t1.c2  
+FROM t2 STRAIGHT_JOIN t1 ON t1.c1 < t2.c1;
+c2
+DROP TABLE t1, t2;
+#
+# Bug#58463: Error Can't find record on SELECT with JOIN and ORDER BY
+#
+CREATE TABLE t1 (
+pk INT NOT NULL,
+PRIMARY KEY (pk)
+) ENGINE=MyISAM;
+INSERT INTO t1 VALUES (2);
+CREATE TABLE t2 (
+pk INT NOT NULL,
+i1 INT NOT NULL,
+i2 INT NOT NULL,
+c1 VARCHAR(1024) CHARACTER SET utf8,
+PRIMARY KEY (pk),
+KEY k1 (i1)
+);
+INSERT INTO t2 VALUES (3, 9, 1, NULL);
+EXPLAIN SELECT i1
+FROM t1 LEFT JOIN t2 ON t1.pk = t2.i2
+WHERE t2.i1 > 5
+AND t2.pk IS  NULL
+ORDER BY i1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	system	PRIMARY	NULL	NULL	NULL	1	NULL
+1	SIMPLE	t2	const	PRIMARY,k1	PRIMARY	4	const	1	Using where
+SELECT i1
+FROM t1 LEFT JOIN t2 ON t1.pk = t2.i2
+WHERE t2.i1 > 5
+AND t2.pk IS  NULL
+ORDER BY i1;
+i1
+DROP TABLE t1, t2;
+#
+# Bug#12321461: CRASH IN DSMRR_IMPL::DSMRR_INIT ON SELECT STRAIGHT_JOIN
+#
+set @save_optimizer_switch = @@optimizer_switch;
+set optimizer_switch='block_nested_loop=off,batched_key_access=off';
+CREATE TABLE t1 (
+pk INTEGER,
+c1 VARCHAR(1) NOT NULL,
+PRIMARY KEY (pk)
+);
+CREATE TABLE t2 (
+c1 VARCHAR(1) NOT NULL
+);
+INSERT INTO t2 VALUES ('v'), ('c');
+EXPLAIN SELECT STRAIGHT_JOIN t1.c1
+FROM t1 RIGHT OUTER JOIN t2 ON t1.c1 = t2.c1
+WHERE t1.pk > 176;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	2	NULL
+1	SIMPLE	t1	range	PRIMARY	PRIMARY	4	NULL	1	Using where
+SELECT STRAIGHT_JOIN t1.c1
+FROM t1 RIGHT OUTER JOIN t2 ON t1.c1 = t2.c1
+WHERE t1.pk > 176;
+c1
+DROP TABLE t1,t2;
+set optimizer_switch= @save_optimizer_switch;
+#
+# Bug#13249966 MRR: RANDOM ERROR DUE TO UNINITIALIZED RES WITH 
+#              SMALL READ_RND_BUFFER_SIZE
+#
+set @read_rnd_buffer_size_save= @@read_rnd_buffer_size;
+set read_rnd_buffer_size=1;
+select @@read_rnd_buffer_size;
+@@read_rnd_buffer_size
+1
+CREATE TABLE t1 (
+i1 INTEGER NOT NULL,
+i2 INTEGER NOT NULL,
+KEY (i2)
+);
+INSERT INTO t1 VALUES (0,1),(1,2),(2,3);
+EXPLAIN SELECT i1
+FROM t1
+WHERE i2 > 2;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	i2	i2	4	NULL	1	Using where
+SELECT i1
+FROM t1
+WHERE i2 > 2;
+i1
+2
+DROP TABLE t1;
+set @@read_rnd_buffer_size= @read_rnd_buffer_size_save;
+select @@read_rnd_buffer_size;
+@@read_rnd_buffer_size
+262144
+#
+# Bug 12365385 STRAIGHT_JOIN QUERY QUICKLY EXHAUSTS SYSTEM+VIRT. 
+#              MEMORY LEADING TO SYSTEM CRASH
+#
+CREATE TABLE ten (a INTEGER);
+INSERT INTO ten VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9);
+CREATE TABLE t1 (
+pk INTEGER NOT NULL,
+i1 INTEGER NOT NULL,
+c1 VARCHAR(10) NOT NULL,
+PRIMARY KEY (pk)
+);
+INSERT INTO t1
+SELECT a, 1, 'MySQL' FROM ten;
+CREATE TABLE t2 (
+pk INTEGER NOT NULL,
+c1 VARCHAR(10) NOT NULL,
+c2 varchar(10) NOT NULL,
+PRIMARY KEY (pk)
+);
+INSERT INTO t2
+SELECT a, 'MySQL', 'MySQL' FROM ten;
+CREATE TABLE t3 (
+pk INTEGER NOT NULL,
+c1 VARCHAR(10) NOT NULL,
+PRIMARY KEY (pk)
+);
+INSERT INTO t3
+SELECT a, 'MySQL' FROM ten;
+CREATE TABLE t4 (
+pk int(11) NOT NULL,
+c1_key varchar(10) CHARACTER SET utf8 NOT NULL,
+c2 varchar(10) NOT NULL,
+c3 varchar(10) NOT NULL,
+PRIMARY KEY (pk),
+KEY k1 (c1_key)
+);
+CREATE TABLE t5 (
+pk INTEGER NOT NULL,
+c1 VARCHAR(10) NOT NULL,
+PRIMARY KEY (pk)
+);
+INSERT INTO t5
+SELECT a, 'MySQL' FROM ten;
+EXPLAIN SELECT STRAIGHT_JOIN *
+FROM 
+(t1 LEFT JOIN 
+(t2 LEFT JOIN
+(t3 LEFT OUTER JOIN t4 ON t3.c1 <= t4.c1_key)
+ON t2.c1 = t4.c3) 
+ON t1.c1 = t4.c2)
+RIGHT OUTER JOIN t5 ON t2.c2 <= t5.c1
+WHERE t1.i1 = 1;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t5	ALL	NULL	NULL	NULL	NULL	10	NULL
+1	SIMPLE	t1	ALL	NULL	NULL	NULL	NULL	10	Using where; Using join buffer (Block Nested Loop)
+1	SIMPLE	t2	ALL	NULL	NULL	NULL	NULL	10	Using where; Using join buffer (Block Nested Loop)
+1	SIMPLE	t3	ALL	NULL	NULL	NULL	NULL	10	Using join buffer (Block Nested Loop)
+1	SIMPLE	t4	ALL	k1	NULL	NULL	NULL	1	Range checked for each record (index map: 0x2)
+SELECT STRAIGHT_JOIN *
+FROM 
+(t1 LEFT JOIN 
+(t2 LEFT JOIN
+(t3 LEFT OUTER JOIN t4 ON t3.c1 <= t4.c1_key)
+ON t2.c1 = t4.c3) 
+ON t1.c1 = t4.c2)
+RIGHT OUTER JOIN t5 ON t2.c2 <= t5.c1
+WHERE t1.i1 = 1;
+pk	i1	c1	pk	c1	c2	pk	c1	pk	c1_key	c2	c3	pk	c1
+DROP TABLE ten, t1, t2, t3, t4, t5;
+#
+# Bug#41029 "MRR: SELECT FOR UPDATE fails to lock gaps (InnoDB table)"
+#
+SET AUTOCOMMIT=0;
+CREATE TABLE t1 (
+dummy INT PRIMARY KEY,
+a INT UNIQUE,
+b INT
+) ENGINE=TokuDB;
+INSERT INTO t1 VALUES (1,1,1),(3,3,3),(5,5,5);
+COMMIT;
+SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT @@tx_isolation;
+@@tx_isolation
+REPEATABLE-READ
+START TRANSACTION;
+EXPLAIN SELECT * FROM t1 WHERE a >= 2 FOR UPDATE;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	range	a	a	5	NULL	2	Using where
+SELECT * FROM t1 WHERE a >= 2 FOR UPDATE;
+dummy	a	b
+3	3	3
+5	5	5
+SET AUTOCOMMIT=0;
+SET TOKUDB_LOCK_TIMEOUT=2;
+START TRANSACTION;
+INSERT INTO t1 VALUES (2,2,2);
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ROLLBACK;
+ROLLBACK;
+DROP TABLE t1;

--- a/mysql-test/suite/tokudb/t/tokudb_mrr.test
+++ b/mysql-test/suite/tokudb/t/tokudb_mrr.test
@@ -1,0 +1,89 @@
+#
+# MRR/Tokudb tests, taken from mysqltest/t/innodb_mrr.test
+# (Turns off all other 6.0 optimizer switches than MRR)
+#
+
+--source include/have_tokudb.inc
+--source include/have_mrr.inc
+
+set optimizer_switch='mrr=on,mrr_cost_based=off';
+
+--disable_query_log
+if (`select locate('semijoin', @@optimizer_switch) > 0`)
+{
+  set optimizer_switch='semijoin=off';
+}
+if (`select locate('materialization', @@optimizer_switch) > 0`)
+{
+  set optimizer_switch='materialization=off';
+}
+if (`select locate('index_condition_pushdown', @@optimizer_switch) > 0`)
+{
+  set optimizer_switch='index_condition_pushdown=off';
+}
+--enable_query_log
+
+set default_storage_engine=TokuDB;
+
+--source include/mrr_tests.inc
+
+
+# taken from include/mrr_innodb_tests.inc
+
+--source include/count_sessions.inc
+
+# MRR tests that are special for InnoDB (and copied for TokuDB)
+
+--echo #
+--echo # Bug#41029 "MRR: SELECT FOR UPDATE fails to lock gaps (InnoDB table)"
+--echo #
+
+# This test verifies that a SELECT FOR UPDATE statement executed in
+# REPEATABLE READ isolation will lock the entire read interval by verifying
+# that a second transaction trying to update data within this interval will
+# be blocked.
+
+connect (con1,localhost,root,,);
+connect (con2,localhost,root,,);
+
+connection con1;
+
+SET AUTOCOMMIT=0;
+
+CREATE TABLE t1 (
+  dummy INT PRIMARY KEY,
+  a INT UNIQUE,
+  b INT
+) ENGINE=TokuDB;
+
+INSERT INTO t1 VALUES (1,1,1),(3,3,3),(5,5,5);
+COMMIT;
+
+SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT @@tx_isolation;
+START TRANSACTION;
+
+EXPLAIN SELECT * FROM t1 WHERE a >= 2 FOR UPDATE;
+
+SELECT * FROM t1 WHERE a >= 2 FOR UPDATE;
+
+connection con2;
+
+SET AUTOCOMMIT=0;
+SET TOKUDB_LOCK_TIMEOUT=2;
+START TRANSACTION;
+
+--error ER_LOCK_WAIT_TIMEOUT
+INSERT INTO t1 VALUES (2,2,2);
+ROLLBACK;
+
+connection con1;
+
+ROLLBACK;
+DROP TABLE t1;
+
+connection default;
+disconnect con1;
+disconnect con2;
+
+--source include/wait_until_count_sessions.inc


### PR DESCRIPTION
- TokuDB 5.6 supports the Multi-Range Read optimization but has no tests to
  verify it. This adds the basic MRR test taken from mysql-test/t/inodb_mrr.test
  with some minor modifications.