### PR TITLE
TDB-139 : Make read free rpl optional at compile time

### DIFF
--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -1060,6 +1060,7 @@ private:
     int do_optimize(THD *thd);
     int map_to_handler_error(int error);
 
+#if defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 public:
     void rpl_before_write_rows();
     void rpl_after_write_rows();
@@ -1072,6 +1073,7 @@ private:
     bool in_rpl_write_rows;
     bool in_rpl_delete_rows;
     bool in_rpl_update_rows;
+#endif // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 };
 
 #if TOKU_INCLUDE_OPTION_STRUCTS

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -91,6 +91,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_INCLUDE_ALTER_56 1
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 0
 #define TOKU_PARTITION_WRITE_FRM_DATA 0
+#define TOKU_INCLUDE_RFR 1
 #else
 #error
 #endif
@@ -117,6 +118,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #endif
 #endif
 #define TOKU_OPTIMIZE_WITH_RECREATE 1
+#define TOKU_INCLUDE_RFR 1
 
 #elif 50500 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50599
 // mysql 5.5 and mariadb 5.5

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -849,6 +849,7 @@ static MYSQL_THDVAR_ENUM(
     SRV_ROW_FORMAT_ZLIB,
     &tokudb_row_format_typelib);
 
+#if defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 static MYSQL_THDVAR_BOOL(
     rpl_check_readonly,
     PLUGIN_VAR_THDLOCAL,
@@ -894,6 +895,7 @@ static MYSQL_THDVAR_ULONGLONG(
     0,
     ~0ULL,
     1);
+#endif // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 
 #if TOKU_INCLUDE_UPSERT
 static MYSQL_THDVAR_BOOL(
@@ -1057,11 +1059,13 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(read_block_size),
     MYSQL_SYSVAR(read_buf_size),
     MYSQL_SYSVAR(row_format),
+#if defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
     MYSQL_SYSVAR(rpl_check_readonly),
     MYSQL_SYSVAR(rpl_lookup_rows),
     MYSQL_SYSVAR(rpl_lookup_rows_delay),
     MYSQL_SYSVAR(rpl_unique_checks),
     MYSQL_SYSVAR(rpl_unique_checks_delay),
+#endif // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 
 #if TOKU_INCLUDE_UPSERT
     MYSQL_SYSVAR(disable_slow_update),
@@ -1187,6 +1191,7 @@ uint read_buf_size(THD* thd) {
 row_format_t row_format(THD *thd) {
     return (row_format_t) THDVAR(thd, row_format);
 }
+#if defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 my_bool rpl_check_readonly(THD* thd) {
     return (THDVAR(thd, rpl_check_readonly) != 0);
 }
@@ -1202,6 +1207,7 @@ my_bool rpl_unique_checks(THD* thd) {
 ulonglong rpl_unique_checks_delay(THD* thd) {
     return THDVAR(thd, rpl_unique_checks_delay);
 }
+#endif // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 my_bool support_xa(THD* thd) {
     return (THDVAR(thd, support_xa) != 0);
 }

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -132,11 +132,13 @@ my_bool     prelock_empty(THD* thd);
 uint        read_block_size(THD* thd);
 uint        read_buf_size(THD* thd);
 row_format_t row_format(THD *thd);
+#if defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 my_bool     rpl_check_readonly(THD* thd);
 my_bool     rpl_lookup_rows(THD* thd);
 ulonglong   rpl_lookup_rows_delay(THD* thd);
 my_bool     rpl_unique_checks(THD* thd);
 ulonglong   rpl_unique_checks_delay(THD* thd);
+#endif // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 my_bool     support_xa(THD* thd);
 
 extern st_mysql_sys_var* system_variables[];


### PR DESCRIPTION
- Based on idea from "rik prohaska <prohaska7@gmail.com>", make RFR
  functionality a compile time option to allow easier initial porting to 8.0
- Introduced new macro flag TOKU_INCLUDE_RFR that when defined, causes
  all RFR functionality and variables to be compiled in, otherwise it is
  compiled out.

Copyright (c) 2018, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.