### PR TITLE
PS-3898: Include array in rdb_datadic

### DIFF
--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -17,6 +17,7 @@
 
 /* C++ standard header files */
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <map>
 #include <mutex>


### PR DESCRIPTION
It is used in this file, but never included. With libstdc++, the header works beacuse array is included internally by one of the other headers.