### PR TITLE
PS-3899: silence an uninitialized read in zlib

### DIFF
--- a/cmake/msan-blacklist.txt
+++ b/cmake/msan-blacklist.txt
@@ -1,0 +1,1 @@
+fun:longest_match


### PR DESCRIPTION
According to the library developers, this is an optimization which while reads these bytes, doesn't use them for anything, and should be ignored.

(cherry picked from commit 2096be4b643e2047fa33c2dbd12c73d820fdae18)