### PR TITLE
PS-3899: silence an uninitialized read in zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,7 +332,7 @@ ENDIF()
 
 OPTION(WITH_MSAN "Enable memory sanitizer" OFF)
 IF(WITH_MSAN)
-  MY_SANITIZER_CHECK("-fsanitize=memory -fsanitize-memory-track-origins"
+  MY_SANITIZER_CHECK("-fsanitize=memory -fsanitize-memory-track-origins -fsanitize-blacklist=${CMAKE_CURRENT_SOURCE_DIR}/cmake/msan-blacklist.txt"
                      WITH_MSAN_OK)
   IF(NOT WITH_MSAN_OK)
     MESSAGE(FATAL_ERROR "Do not know how to enable memory sanitizer")

--- a/cmake/msan-blacklist.txt
+++ b/cmake/msan-blacklist.txt
@@ -1,0 +1,1 @@
+fun:longest_match


### PR DESCRIPTION
According to the library developers, this is an optimization which while reads these bytes, doesn't use them for anything, and should be ignored.

(cherry picked from commit 2096be4b643e2047fa33c2dbd12c73d820fdae18)
(cherry picked from commit 43f99a0eacd2a6e0271482d79e544c9d518268d6)