### PR TITLE
Fix for DOC-640 - don't mention MariaDB as having XtraDB as a part

### DIFF
--- a/doc/source/percona_xtradb.rst
+++ b/doc/source/percona_xtradb.rst
@@ -10,4 +10,4 @@
 
 |Percona| |XtraDB| includes all of |InnoDB| 's robust, reliable ``ACID``-compliant design and advanced ``MVCC`` architecture, and builds on that solid foundation with more features, more tunability, more metrics, and more scalability. In particular, it is designed to scale better on many cores, to use memory more efficiently, and to be more convenient and useful. The new features are especially designed to alleviate some of |InnoDB| 's limitations. We choose features and fixes based on customer requests and on our best judgment of real-world needs as a high-performance consulting company.
 
-|Percona| |XtraDB| engine will not have further binary releases, it is distributed as part of |Percona Server| and *MariaDB*.
+|Percona| |XtraDB| engine will not have further binary releases, it is distributed as part of |Percona Server|.


### PR DESCRIPTION
(it doesn't, starting from version 10.2)