### PR TITLE
Ps 3903 build dep issue 5.7 gca

### DIFF
--- a/libmysqld/CMakeLists.txt
+++ b/libmysqld/CMakeLists.txt
@@ -84,7 +84,10 @@ ENDIF()
 
 ADD_CONVENIENCE_LIBRARY(sql_embedded ${SQL_EMBEDDED_SOURCES})
 DTRACE_INSTRUMENT(sql_embedded)
-ADD_DEPENDENCIES(sql_embedded GenError GenServerSource)
+# sql_yacc.cc includes lex_token.h, that is why both
+# GenServerSource and GenDigestServerSource must be generated before
+# sql_embedded target build
+ADD_DEPENDENCIES(sql_embedded GenError GenServerSource GenDigestServerSource)
 
 # On Windows, static embedded server library is called mysqlserver.lib
 # On Unix, it is libmysqld.a


### PR DESCRIPTION
sql_yacc.cc includes lex_token.h, that is why both
GenServerSource and GenDigestServerSource must be generated before
sql_embedded target build.

See also https://docs.google.com/presentation/d/1n_T-nC9ig0wGbLxsCUkvPvaW7lkfqP87VgHETkaULPE/edit?usp=sharing.

Testing: https://jenkins.percona.com/job/percona-server-5.6-param/2115/

5.6 PR: https://github.com/percona/percona-server/pull/2243