### PR TITLE
TDB-148 : Make UPSERT/NOAR optional at compile time

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -8972,7 +8972,9 @@ bool ha_tokudb::rpl_lookup_rows() {
 #include "tokudb_update_fun.cc"
 
 // fast updates
+#if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 #include "ha_tokudb_update.cc"
+#endif  // defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 
 // alter table
 #include "ha_tokudb_alter.cc"

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -984,6 +984,7 @@ private:
     int write_frm_data(const uchar *frm_data, size_t frm_len);
 #endif
 private:
+#if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
     MY_NODISCARD int fast_update(THD *thd,
                                  List<Item> &update_fields,
                                  List<Item> &update_values,
@@ -1005,6 +1006,7 @@ private:
     MY_NODISCARD int send_upsert_message(List<Item> &update_fields,
                                          List<Item> &update_values,
                                          DB_TXN *txn);
+#endif  // defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 public:
     // mysql sometimes retires a txn before a cursor that references the txn is closed.
     // for example, commit is sometimes called before index_end.  the following methods

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -80,6 +80,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_OPTIMIZE_WITH_RECREATE 1
 #define TOKU_INCLUDE_DISCOVER_FRM 1
 #define TOKU_INCLUDE_RFR 1
+#define TOKU_INCLUDE_UPSERT 1
 
 #if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
 #include "discover.h"

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -854,6 +854,7 @@ static MYSQL_THDVAR_ULONGLONG(
     1);
 #endif // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 
+#if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 static MYSQL_THDVAR_BOOL(
     enable_fast_update,
     PLUGIN_VAR_THDLOCAL,
@@ -869,6 +870,7 @@ static MYSQL_THDVAR_BOOL(
     NULL,
     NULL,
     false);
+#endif  // defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 
 static const char* deprecated_tokudb_support_xa =
     "Using tokudb_support_xa is deprecated and the "
@@ -1038,9 +1040,11 @@ st_mysql_sys_var* system_variables[] = {
     MYSQL_SYSVAR(rpl_lookup_rows_delay),
     MYSQL_SYSVAR(rpl_unique_checks),
     MYSQL_SYSVAR(rpl_unique_checks_delay),
-#endif // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
+#endif  // defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
+#if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
     MYSQL_SYSVAR(enable_fast_update),
     MYSQL_SYSVAR(enable_fast_upsert),
+#endif  // defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
     MYSQL_SYSVAR(support_xa),
 
 #if TOKUDB_DEBUG
@@ -1095,13 +1099,14 @@ my_bool disable_prefetching(THD* thd) {
 my_bool disable_slow_alter(THD* thd) {
     return (THDVAR(thd, disable_slow_alter) != 0);
 }
+#if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 my_bool enable_fast_update(THD* thd) {
     return (THDVAR(thd, enable_fast_update) != 0);
 }
 my_bool enable_fast_upsert(THD* thd) {
     return (THDVAR(thd, enable_fast_upsert) != 0);
 }
-
+#endif  // defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 empty_scan_mode_t empty_scan(THD* thd) {
     return (empty_scan_mode_t)THDVAR(thd, empty_scan);
 }

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -111,8 +111,10 @@ my_bool     create_index_online(THD* thd);
 my_bool     disable_hot_alter(THD* thd);
 my_bool     disable_prefetching(THD* thd);
 my_bool     disable_slow_alter(THD* thd);
+#if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 my_bool     enable_fast_update(THD* thd);
 my_bool     enable_fast_upsert(THD* thd);
+#endif  // defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
 empty_scan_mode_t empty_scan(THD* thd);
 uint        fanout(THD* thd);
 my_bool     hide_default_row_format(THD* thd);


### PR DESCRIPTION
- UPSERT/NOAR functionality requires server side patches to funvtion correctly.
  For 8.0, these initially will not be present, and thus we will have a bunch
  of dead-code present, and get compiler warning/errors from -Wunused-function.
- Added in proper #if defined(TOKU_INCLUDE_UPSERT && TOKU_INCLUDE_UPSERT around
  all new functionality.