### PR TITLE
TDB-128 : Make .frm discovery optional at compile time

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -1631,7 +1631,7 @@ int ha_tokudb::initialize_share(const char* name, int mode) {
         goto exit;
     }
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 #if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
     // verify frm data for non-partitioned tables
     if (TOKU_PARTITION_WRITE_FRM_DATA || table->part_info == NULL) {
@@ -1648,8 +1648,8 @@ int ha_tokudb::initialize_share(const char* name, int mode) {
     error = verify_frm_data(table->s->path.str, txn);
     if (error)
         goto exit;
-#endif // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
     error =
         initialize_key_and_col_info(
@@ -2070,7 +2070,7 @@ cleanup:
     return error;
 }
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 int ha_tokudb::write_frm_data(DB* db, DB_TXN* txn, const char* frm_name) {
     TOKUDB_HANDLER_DBUG_ENTER("%p %p %s", db, txn, frm_name);
 
@@ -2159,7 +2159,7 @@ cleanup:
     tokudb::memory::free(stored_frm.data);
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
 //
 // Updates status.tokudb with a new max value used for the auto increment column
@@ -7358,7 +7358,7 @@ int ha_tokudb::create(
         goto cleanup;
     }
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 #if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
     if (TOKU_PARTITION_WRITE_FRM_DATA || form->part_info == NULL) {
         error = write_frm_data(status_block, txn, form->s->path.str);
@@ -7371,8 +7371,8 @@ int ha_tokudb::create(
     if (error) {
         goto cleanup;
     }
-#endif // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
     error = allocate_key_and_col_info(form->s, &kc_info);
     if (error) {

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -663,11 +663,11 @@ private:
     int estimate_num_rows(DB* db, uint64_t* num_rows, DB_TXN* txn);
     bool has_auto_increment_flag(uint* index);
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
     int write_frm_data(DB* db, DB_TXN* txn, const char* frm_name);
     int verify_frm_data(const char* frm_name, DB_TXN* trans);
     int remove_frm_data(DB *db, DB_TXN *txn);
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
     int write_to_status(DB* db, HA_METADATA_KEY curr_key_data, void* data, uint size, DB_TXN* txn);
     int remove_from_status(DB* db, HA_METADATA_KEY curr_key_data, DB_TXN* txn);
@@ -1029,9 +1029,9 @@ private:
     void close_dsmrr();
     void reset_dsmrr();
     
-#if TOKU_INCLUDE_WRITE_FRM_DATA
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
     int write_frm_data(const uchar *frm_data, size_t frm_len);
-#endif
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 private:
     MY_NODISCARD int fast_update(THD *thd,
                                  List<Item> &update_fields,

--- a/storage/tokudb/ha_tokudb_alter_55.cc
+++ b/storage/tokudb/ha_tokudb_alter_55.cc
@@ -35,7 +35,11 @@ bool ha_tokudb::try_hot_alter_table() {
 }
 
 int ha_tokudb::new_alter_table_frm_data(const uchar *frm_data, size_t frm_len) {
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
     return write_frm_data(frm_data, frm_len);
+#else
+    return 0;
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 }
 
 #endif

--- a/storage/tokudb/ha_tokudb_alter_56.cc
+++ b/storage/tokudb/ha_tokudb_alter_56.cc
@@ -644,20 +644,24 @@ bool ha_tokudb::inplace_alter_table(
         error = do_optimize(ha_thd());
     }
 
+
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 #if (50600 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50699) || \
     (50700 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50799)
-#if WITH_PARTITION_STORAGE_ENGINE
+#if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
     if (error == 0 &&
         (TOKU_PARTITION_WRITE_FRM_DATA || altered_table->part_info == NULL)) {
 #else
     if (error == 0) {
-#endif
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
         error = write_frm_data(
             share->status_block,
             ctx->alter_txn,
             altered_table->s->path.str);
     }
-#endif
+#endif  // (50600 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50699) ||
+        // (50700 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50799)
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
     bool result = false; // success
     if (error) {
@@ -911,13 +915,14 @@ bool ha_tokudb::commit_inplace_alter_table(
             ha_alter_info->group_commit_ctx = NULL;
         }
 #endif
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 #if (50500 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50599) || \
     (100000 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100099)
-#if WITH_PARTITION_STORAGE_ENGINE
+#if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
         if (TOKU_PARTITION_WRITE_FRM_DATA || altered_table->part_info == NULL) {
 #else
         if (true) {
-#endif
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
             int error = write_frm_data(
                 share->status_block,
                 ctx->alter_txn,
@@ -928,7 +933,9 @@ bool ha_tokudb::commit_inplace_alter_table(
                 print_error(error, MYF(0));
             }
         }
-#endif
+#endif  // (50500 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50599) ||
+        // (100000 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100099)
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
     }
 
     if (!commit) {

--- a/storage/tokudb/ha_tokudb_alter_common.cc
+++ b/storage/tokudb/ha_tokudb_alter_common.cc
@@ -764,13 +764,14 @@ exit:
     return retval;
 }
 
-#if TOKU_INCLUDE_WRITE_FRM_DATA
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 // write the new frm data to the status dictionary using the alter table
 // transaction
 int ha_tokudb::write_frm_data(const uchar* frm_data, size_t frm_len) {
     TOKUDB_DBUG_ENTER("write_frm_data");
 
     int error = 0;
+#if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
     if (TOKU_PARTITION_WRITE_FRM_DATA || table->part_info == NULL) {
         // write frmdata to status
         THD* thd = ha_thd();
@@ -787,9 +788,10 @@ int ha_tokudb::write_frm_data(const uchar* frm_data, size_t frm_len) {
                 (uint)frm_len,
                 txn);
     }
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
 
     TOKUDB_DBUG_RETURN(error);
 }
-#endif
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
 #endif

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -72,21 +72,34 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #pragma interface               /* gcc class implementation */
 #endif
 
+// TOKU_INCLUDE_WRITE_FRM_DATA, TOKU_PARTITION_WRITE_FRM_DATA, and
+// TOKU_INCLUDE_DISCOVER_FRM all work together as two opposing sides
+// of the same functionality. The 'WRITE' includes functionality to
+// write a copy of every tables .frm data into the tables status dictionary on
+// CREATE or ALTER. When WRITE is in, the .frm data is also verified whenever a
+// table is opened.
+//
+// The 'DISCOVER' then implements the MySQL table discovery API which reads
+// this same data and returns it back to MySQL.
+// In most cases, they should all be in or out without mixing. There may be
+// extreme cases though where one side (WRITE) is supported but perhaps
+// 'DISCOVERY' may not be, thus the need for individual indicators.
+
 #if 100000 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100099
 // mariadb 10.0
 #define TOKU_USE_DB_TYPE_TOKUDB 1
 #define TOKU_INCLUDE_ALTER_56 1
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 0
 #define TOKU_INCLUDE_XA 1
-#define TOKU_INCLUDE_WRITE_FRM_DATA 0
+#define TOKU_INCLUDE_WRITE_FRM_DATA 1
 #define TOKU_PARTITION_WRITE_FRM_DATA 0
+#define TOKU_INCLUDE_DISCOVER_FRM 1
 #if defined(MARIADB_BASE_VERSION)
 #define TOKU_INCLUDE_EXTENDED_KEYS 1
 #endif
 #define TOKU_INCLUDE_OPTION_STRUCTS 1
 #define TOKU_OPTIMIZE_WITH_RECREATE 1
 #define TOKU_CLUSTERING_IS_COVERING 1
-#define TOKU_INCLUDE_DISCOVER_FRM 1
 
 #elif 50700 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50799
 // mysql 5.7 with no patches
@@ -94,6 +107,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_USE_DB_TYPE_UNKNOWN 1
 #define TOKU_INCLUDE_ALTER_56 1
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 0
+#define TOKU_INCLUDE_WRITE_FRM_DATA 1
 #define TOKU_PARTITION_WRITE_FRM_DATA 0
 #define TOKU_INCLUDE_DISCOVER_FRM 1
 #define TOKU_INCLUDE_RFR 1
@@ -108,22 +122,24 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_INCLUDE_ALTER_56 1    
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 0
 #define TOKU_INCLUDE_XA 0
+#define TOKU_INCLUDE_WRITE_FRM_DATA 1
 #define TOKU_PARTITION_WRITE_FRM_DATA 0
+#define TOKU_INCLUDE_DISCOVER_FRM 1
 #else
 // mysql 5.6 with tokutek patches
 #define TOKU_USE_DB_TYPE_TOKUDB 1           // has DB_TYPE_TOKUDB patch
 #define TOKU_INCLUDE_ALTER_56 1
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 1 // has tokudb row format compression patch
 #define TOKU_INCLUDE_XA 1                   // has patch that fixes TC_LOG_MMAP code
+#define TOKU_INCLUDE_WRITE_FRM_DATA 1
 #define TOKU_PARTITION_WRITE_FRM_DATA 0
-#define TOKU_INCLUDE_WRITE_FRM_DATA 0
+#define TOKU_INCLUDE_DISCOVER_FRM 1
 #define TOKU_INCLUDE_UPSERT 1               // has tokudb upsert patch
 #if defined(HTON_SUPPORTS_EXTENDED_KEYS)
 #define TOKU_INCLUDE_EXTENDED_KEYS 1
 #endif
 #endif
 #define TOKU_OPTIMIZE_WITH_RECREATE 1
-#define TOKU_INCLUDE_DISCOVER_FRM 1
 #define TOKU_INCLUDE_RFR 1
 
 #elif 50500 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 50599
@@ -133,8 +149,9 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_INCLUDE_ALTER_55 1
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 1
 #define TOKU_INCLUDE_XA 1
-#define TOKU_PARTITION_WRITE_FRM_DATA 1
 #define TOKU_INCLUDE_WRITE_FRM_DATA 1
+#define TOKU_PARTITION_WRITE_FRM_DATA 1
+#define TOKU_INCLUDE_DISCOVER_FRM 1
 #define TOKU_INCLUDE_UPSERT 1
 #if defined(MARIADB_BASE_VERSION)
 #define TOKU_INCLUDE_EXTENDED_KEYS 1
@@ -143,7 +160,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #define TOKU_INCLUDE_LOCK_TIMEOUT_QUERY_STRING 1
 #endif
 #define TOKU_INCLUDE_HANDLERTON_HANDLE_FATAL_SIGNAL 0
-#define TOKU_INCLUDE_DISCOVER_FRM 1
 
 #else
 #error
@@ -152,7 +168,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
 #include "discover.h"
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
 
 
 #ifdef MARIADB_BASE_VERSION

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -128,7 +128,7 @@ static int tokudb_discover3(
     char* path,
     uchar** frmblob,
     size_t* frmlen);
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
 handlerton* tokudb_hton;
 
 const char* ha_tokudb_ext = ".tokudb";
@@ -389,9 +389,9 @@ static int tokudb_init_func(void *p) {
     tokudb_hton->discover = tokudb_discover;
 #if defined(MYSQL_HANDLERTON_INCLUDE_DISCOVER2)
     tokudb_hton->discover2 = tokudb_discover2;
-#endif // MYSQL_HANDLERTON_INCLUDE_DISCOVER2
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
-#endif // 100000 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100099
+#endif  // MYSQL_HANDLERTON_INCLUDE_DISCOVER2
+#endif  // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // 100000 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100099
     tokudb_hton->commit = tokudb_commit;
     tokudb_hton->rollback = tokudb_rollback;
 #if TOKU_INCLUDE_XA
@@ -1325,7 +1325,7 @@ cleanup:
     }
     TOKUDB_DBUG_RETURN(error);
 }
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
 
 
 #define STATPRINT(legend, val) if (legend != NULL && val != NULL) \


### PR DESCRIPTION
- The original patch that introduced TOKU_INCLUDE_WRITE_FRM_DATA was incorrect
  and incomplete. It failed to properly isolate all instances of storing .frm
  data within TokuDB status (metadata) files and so in all cases, TokuDB would
  perform this regardless of the definition of the macro.
- The second patch which introduced TOKU_INCLUDE_DISCOVER_FRM was also incorrect
  in that it extended beyond just guarding the functionality of using the stored
  .frm data to provide MySQL table discovery functionality and guarded some, but
  not all, of the 'WRITE' functionaloty.
- This patch corrects all of these incorrect behaviors and properly isolated the
  two different, but related areas of 'WRITE' and 'DISCOVER'.
- Due to the timing and logistics of merging this within the GCA workflow, it is
  not GCA but will be a cherry-pick to 5.7