### PR TITLE
TDB-128 : Make .frm discovery optional at compile time

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -1627,7 +1627,7 @@ int ha_tokudb::initialize_share(const char* name, int mode) {
         goto exit;
     }
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 #if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
     // verify frm data for non-partitioned tables
     if (table->part_info == NULL) {
@@ -1644,8 +1644,8 @@ int ha_tokudb::initialize_share(const char* name, int mode) {
     error = verify_frm_data(table->s->path.str, txn);
     if (error)
         goto exit;
-#endif // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
     error =
         initialize_key_and_col_info(
@@ -2070,7 +2070,7 @@ cleanup:
     return error;
 }
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 int ha_tokudb::write_frm_data(DB* db, DB_TXN* txn, const char* frm_name) {
     TOKUDB_HANDLER_DBUG_ENTER("%p %p %s", db, txn, frm_name);
 
@@ -2147,7 +2147,7 @@ cleanup:
     tokudb::memory::free(stored_frm.data);
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
 //
 // Updates status.tokudb with a new max value used for the auto increment column
@@ -7364,7 +7364,7 @@ int ha_tokudb::create(
         goto cleanup;
     }
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 #if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
     if (form->part_info == NULL) {
         error = write_frm_data(status_block, txn, form->s->path.str);
@@ -7377,8 +7377,8 @@ int ha_tokudb::create(
     if (error) {
         goto cleanup;
     }
-#endif // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
     error = allocate_key_and_col_info(form->s, &kc_info);
     if (error) {

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -658,11 +658,11 @@ private:
     int estimate_num_rows(DB* db, uint64_t* num_rows, DB_TXN* txn);
     bool has_auto_increment_flag(uint* index);
 
-#if defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#if defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
     int write_frm_data(DB* db, DB_TXN* txn, const char* frm_name);
     int verify_frm_data(const char* frm_name, DB_TXN* trans);
     int remove_frm_data(DB *db, DB_TXN *txn);
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_WRITE_FRM_DATA) && TOKU_INCLUDE_WRITE_FRM_DATA
 
     int write_to_status(DB* db, HA_METADATA_KEY curr_key_data, void* data, uint size, DB_TXN* txn);
     int remove_from_status(DB* db, HA_METADATA_KEY curr_key_data, DB_TXN* txn);
@@ -980,9 +980,6 @@ private:
     void invalidate_icp();
     int delete_all_rows_internal();
     
-#if TOKU_INCLUDE_WRITE_FRM_DATA
-    int write_frm_data(const uchar *frm_data, size_t frm_len);
-#endif
 private:
 #if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
     MY_NODISCARD int fast_update(THD *thd,

--- a/storage/tokudb/ha_tokudb_alter.cc
+++ b/storage/tokudb/ha_tokudb_alter.cc
@@ -1240,11 +1240,11 @@ bool ha_tokudb::inplace_alter_table(
         error = do_optimize(ha_thd());
     }
 
-#if WITH_PARTITION_STORAGE_ENGINE
+#if defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
     if (error == 0 && (altered_table->part_info == NULL)) {
 #else
     if (error == 0) {
-#endif
+#endif  // defined(WITH_PARTITION_STORAGE_ENGINE) && WITH_PARTITION_STORAGE_ENGINE
         error = write_frm_data(
             share->status_block,
             ctx->alter_txn,

--- a/storage/tokudb/hatoku_defines.h
+++ b/storage/tokudb/hatoku_defines.h
@@ -72,12 +72,24 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #pragma interface               /* gcc class implementation */
 #endif
 
+// TOKU_INCLUDE_WRITE_FRM_DATA and TOKU_INCLUDE_DISCOVER_FRM work together as
+// two opposing sides of the same functionality. The 'WRITE' includes
+// functionality to write a copy of every tables .frm data into the tables
+// status dictionary on CREATE or ALTER. When WRITE is in, the .frm data is
+// also verified whenever a table is opened.
+//
+// The 'DISCOVER' then implements the MySQL table discovery API which reads
+// this same data and returns it back to MySQL.
+// In most cases, they should all be in or out without mixing. There may be
+// extreme cases though where one side (WRITE) is supported but perhaps
+// 'DISCOVERY' may not be, thus the need for individual indicators.
 #define TOKU_USE_DB_TYPE_TOKUDB 1           // has DB_TYPE_TOKUDB patch
 #define TOKU_INCLUDE_ROW_TYPE_COMPRESSION 1 // has tokudb row format compression patch
 #if defined(HTON_SUPPORTS_EXTENDED_KEYS)
 #define TOKU_INCLUDE_EXTENDED_KEYS 1
 #endif
 #define TOKU_OPTIMIZE_WITH_RECREATE 1
+#define TOKU_INCLUDE_WRITE_FRM_DATA 1
 #define TOKU_INCLUDE_DISCOVER_FRM 1
 #define TOKU_INCLUDE_RFR 1
 #define TOKU_INCLUDE_UPSERT 1

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -122,7 +122,7 @@ static int tokudb_discover3(
     char* path,
     uchar** frmblob,
     size_t* frmlen);
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
 handlerton* tokudb_hton;
 
 const char* ha_tokudb_ext = ".tokudb";
@@ -375,8 +375,8 @@ static int tokudb_init_func(void *p) {
     tokudb_hton->discover = tokudb_discover;
 #if defined(MYSQL_HANDLERTON_INCLUDE_DISCOVER2)
     tokudb_hton->discover2 = tokudb_discover2;
-#endif // MYSQL_HANDLERTON_INCLUDE_DISCOVER2
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // MYSQL_HANDLERTON_INCLUDE_DISCOVER2
+#endif  // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
     tokudb_hton->commit = tokudb_commit;
     tokudb_hton->rollback = tokudb_rollback;
     tokudb_hton->prepare = tokudb_xa_prepare;
@@ -1249,7 +1249,7 @@ cleanup:
     }
     TOKUDB_DBUG_RETURN(error);
 }
-#endif // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
+#endif  // defined(TOKU_INCLUDE_DISCOVER_FRM) && TOKU_INCLUDE_DISCOVER_FRM
 
 
 #define STATPRINT(legend, val) if (legend != NULL && val != NULL) \


### PR DESCRIPTION
- The original patch that introduced TOKU_INCLUDE_WRITE_FRM_DATA was incorrect
  and incomplete. It failed to properly isolate all instances of storing .frm
  data within TokuDB status (metadata) files and so in all cases, TokuDB would
  perform this regardless of the definition of the macro.
- The second patch which introduced TOKU_INCLUDE_DISCOVER_FRM was also incorrect
  in that it extended beyond just guarding the functionality of using the stored
  .frm data to provide MySQL table discovery functionality and guarded some, but
  not all, of the 'WRITE' functionaloty.
- This patch corrects all of these incorrect behaviors and properly isolated the
  two different, but related areas of 'WRITE' and 'DISCOVER'.
- Due to the timing and logistics of merging this within the GCA workflow, it is
  not GCA but will be a cherry-pick to 5.7

(cherry picked from commit e1ca073a5b7034a6b37c07eaee29552054018b18)

Conflicts:
	storage/tokudb/ha_tokudb_alter_55.cc
	storage/tokudb/ha_tokudb_alter_56.cc
	storage/tokudb/ha_tokudb_alter_common.cc
	storage/tokudb/hatoku_defines.h
	storage/tokudb/hatoku_hton.cc