### PR TITLE
PS-3925: Use strncmp instead of memcmp in log_in_use (5.6)

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2022,7 +2022,7 @@ static int log_in_use(const char* log_name)
     if ((linfo = (*it)->current_linfo))
     {
       mysql_mutex_lock(&linfo->lock);
-      if(!memcmp(log_name, linfo->log_file_name, log_name_len))
+      if(!strncmp(log_name, linfo->log_file_name, log_name_len))
       {
         thread_count++;
         sql_print_warning("file %s was not purged because it was being read"


### PR DESCRIPTION
(cherry picked from commit 2c950c3ca2bf890549825417c10dd3065b78befc)