### PR TITLE
PS-3925: Use strncmp instead of memcmp in log_in_use (5.7)

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2800,7 +2800,7 @@ public:
     mysql_mutex_lock(&thd->LOCK_thd_data);
     if ((linfo = thd->current_linfo))
     {
-      if(!memcmp(m_log_name, linfo->log_file_name, m_log_name_len))
+      if(!strncmp(m_log_name, linfo->log_file_name, m_log_name_len))
       {
         sql_print_warning("file %s was not purged because it was being read"
                           "by thread number %u", m_log_name, thd->thread_id());


### PR DESCRIPTION
(cherry picked from commit 2c950c3ca2bf890549825417c10dd3065b78befc)
(cherry picked from commit 2fb17005e0d4b5d3c3c53d817e2be1c899a94e59)