### PR TITLE
PS-3926 (5.5): gcc 7.2 warns of potentially truncated file name in log_online_open_bitmap_file_read_only()

### DIFF
--- a/storage/innobase/log/log0online.c
+++ b/storage/innobase/log/log0online.c
@@ -1561,10 +1561,10 @@ log_online_open_bitmap_file_read_only(
 	if (srv_data_home_len
 			&& srv_data_home[srv_data_home_len-1]
 			!= SRV_PATH_SEPARATOR) {
-		ut_snprintf(bitmap_file->name, FN_REFLEN, "%s%c%s",
+		ut_snprintf(bitmap_file->name, sizeof(bitmap_file->name), "%s%c%s",
 				srv_data_home, SRV_PATH_SEPARATOR, name);
 	} else {
-		ut_snprintf(bitmap_file->name, FN_REFLEN, "%s%s",
+		ut_snprintf(bitmap_file->name, sizeof(bitmap_file->name), "%s%s",
 				srv_data_home, name);
 	}
 	bitmap_file->file


### PR DESCRIPTION
Provide real buffer size for snprintf() what fixes a warning from `__builtin___snprintf_chk`.