### PR TITLE
PS-3773 : LP #1744430: "Incorrect key file for table" frequently for …

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/PS-3773.result
+++ b/mysql-test/suite/tokudb.bugs/r/PS-3773.result
@@ -1,0 +1,7 @@
+CREATE TABLE t1(a INT, b INT, c INT, PRIMARY KEY(a), KEY(b)) ENGINE=TokuDB;
+SET tokudb_auto_analyze=0;
+INSERT INTO t1 VALUES(0,0,0), (1,1,1), (2,2,2), (3,3,3), (4,4,4), (5,5,5);
+SET GLOBAL debug = "+d,tokudb_fake_db_notfound_error_in_read_full_row";
+SELECT * FROM t1 WHERE b = 2;
+ERROR HY000: Incorrect key file for table 't1'; try to repair it
+DROP TABLE t1;

--- a/mysql-test/suite/tokudb.bugs/t/PS-3773.test
+++ b/mysql-test/suite/tokudb.bugs/t/PS-3773.test
@@ -1,0 +1,26 @@
+--source include/have_tokudb.inc
+--source include/have_debug.inc
+
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/tokudb.bugs.PS-3773.log
+--let $restart_parameters="restart: --log-error=$SEARCH_FILE"
+--source include/restart_mysqld.inc
+
+CREATE TABLE t1(a INT, b INT, c INT, PRIMARY KEY(a), KEY(b)) ENGINE=TokuDB;
+SET tokudb_auto_analyze=0;
+INSERT INTO t1 VALUES(0,0,0), (1,1,1), (2,2,2), (3,3,3), (4,4,4), (5,5,5);
+
+SET GLOBAL debug = "+d,tokudb_fake_db_notfound_error_in_read_full_row";
+--error ER_NOT_KEYFILE
+SELECT * FROM t1 WHERE b = 2;
+
+DROP TABLE t1;
+
+--let SEARCH_PATTERN=ha_tokudb::read_full_row on table
+--source include/search_pattern_in_file.inc
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--remove_file $SEARCH_FILE
+--let SEARCH_PATTERN=
+--let SEARCH_FILE=


### PR DESCRIPTION
…tokudb

- Added new logging when an index inconsistency is discovered between any SK
  and the PK, specifically when a key in an SK can not find the corresponding
  record in the PK.
- Added DBUG_EXECUTE_IF point to fake return a HA_ERR_CRASHED/ER_NOT_KEYFILE from
  various index lookup calls and implemented basic test to ensure new logging
  actualy occurs.