### PR TITLE
Fix PS-3937 (Some file operations in mf_iocache2.c are not instrumented) (5.5)

### DIFF
--- a/mysql-test/suite/perfschema/r/relaylog.result
+++ b/mysql-test/suite/perfschema/r/relaylog.result
@@ -20,7 +20,7 @@ from performance_schema.file_summary_by_instance
 where file_name like "%master-%" order by file_name;
 FILE_NAME	EVENT_NAME	COUNT_READ	COUNT_WRITE	SUM_NUMBER_OF_BYTES_READ	SUM_NUMBER_OF_BYTES_WRITE
 master-bin.000001	wait/io/file/sql/binlog	MANY	MANY	MANY	MANY
-master-bin.index	wait/io/file/sql/binlog_index	NONE	MANY	NONE	MANY
+master-bin.index	wait/io/file/sql/binlog_index	MANY	MANY	MANY	MANY
 select * from performance_schema.file_summary_by_instance
 where file_name like "%slave-%" order by file_name;
 FILE_NAME	EVENT_NAME	COUNT_READ	COUNT_WRITE	SUM_NUMBER_OF_BYTES_READ	SUM_NUMBER_OF_BYTES_WRITE
@@ -36,7 +36,7 @@ from performance_schema.file_summary_by_instance
 where event_name like "%binlog%" order by file_name;
 FILE_NAME	EVENT_NAME	COUNT_READ	COUNT_WRITE	SUM_NUMBER_OF_BYTES_READ	SUM_NUMBER_OF_BYTES_WRITE
 master-bin.000001	wait/io/file/sql/binlog	MANY	MANY	MANY	MANY
-master-bin.index	wait/io/file/sql/binlog_index	NONE	MANY	NONE	MANY
+master-bin.index	wait/io/file/sql/binlog_index	MANY	MANY	MANY	MANY
 select
 EVENT_NAME,
 if (count_read > 0, "MANY", "NONE") as COUNT_READ,
@@ -47,7 +47,7 @@ from performance_schema.file_summary_by_event_name
 where event_name like "%binlog%" order by event_name;
 EVENT_NAME	COUNT_READ	COUNT_WRITE	SUM_NUMBER_OF_BYTES_READ	SUM_NUMBER_OF_BYTES_WRITE
 wait/io/file/sql/binlog	MANY	MANY	MANY	MANY
-wait/io/file/sql/binlog_index	NONE	MANY	NONE	MANY
+wait/io/file/sql/binlog_index	MANY	MANY	MANY	MANY
 select
 EVENT_NAME,
 if (count_star > 0, "MANY", "NONE") as COUNT_STAR
@@ -93,7 +93,7 @@ where file_name like "%slave-%"
 order by file_name;
 FILE_NAME	EVENT_NAME	COUNT_READ	COUNT_WRITE	SUM_NUMBER_OF_BYTES_READ	SUM_NUMBER_OF_BYTES_WRITE
 slave-bin.000001	wait/io/file/sql/binlog	MANY	MANY	MANY	MANY
-slave-bin.index	wait/io/file/sql/binlog_index	NONE	MANY	NONE	MANY
+slave-bin.index	wait/io/file/sql/binlog_index	MANY	MANY	MANY	MANY
 slave-relay-bin.000001	wait/io/file/sql/relaylog	MANY	MANY	MANY	MANY
 slave-relay-bin.000002	wait/io/file/sql/relaylog	MANY	MANY	MANY	MANY
 slave-relay-bin.index	wait/io/file/sql/relaylog_index	MANY	MANY	MANY	MANY
@@ -109,7 +109,7 @@ from performance_schema.file_summary_by_instance
 where event_name like "%binlog%" order by file_name;
 FILE_NAME	EVENT_NAME	COUNT_READ	COUNT_WRITE	SUM_NUMBER_OF_BYTES_READ	SUM_NUMBER_OF_BYTES_WRITE
 slave-bin.000001	wait/io/file/sql/binlog	MANY	MANY	MANY	MANY
-slave-bin.index	wait/io/file/sql/binlog_index	NONE	MANY	NONE	MANY
+slave-bin.index	wait/io/file/sql/binlog_index	MANY	MANY	MANY	MANY
 select
 EVENT_NAME,
 if (count_read > 0, "MANY", "NONE") as COUNT_READ,
@@ -120,7 +120,7 @@ from performance_schema.file_summary_by_event_name
 where event_name like "%binlog%" order by event_name;
 EVENT_NAME	COUNT_READ	COUNT_WRITE	SUM_NUMBER_OF_BYTES_READ	SUM_NUMBER_OF_BYTES_WRITE
 wait/io/file/sql/binlog	MANY	MANY	MANY	MANY
-wait/io/file/sql/binlog_index	NONE	MANY	NONE	MANY
+wait/io/file/sql/binlog_index	MANY	MANY	MANY	MANY
 select
 EVENT_NAME,
 if (count_star > 0, "MANY", "NONE") as COUNT_STAR

--- a/mysys/mf_iocache2.c
+++ b/mysys/mf_iocache2.c
@@ -102,14 +102,14 @@ my_off_t my_b_append_tell(IO_CACHE* info)
   */
   {
     volatile my_off_t save_pos;
-    save_pos = my_tell(info->file,MYF(0));
-    my_seek(info->file,(my_off_t)0,MY_SEEK_END,MYF(0));
+    save_pos= mysql_file_tell(info->file, MYF(0));
+    mysql_file_seek(info->file, (my_off_t)0, MY_SEEK_END,MYF(0));
     /*
       Save the value of my_tell in res so we can see it when studying coredump
     */
     DBUG_ASSERT(info->end_of_file - (info->append_read_pos-info->write_buffer)
-		== (res=my_tell(info->file,MYF(0))));
-    my_seek(info->file,save_pos,MY_SEEK_SET,MYF(0));
+		== (res= mysql_file_tell(info->file, MYF(0))));
+    mysql_file_seek(info->file, save_pos, MY_SEEK_SET,MYF(0));
   }
 #endif  
   res = info->end_of_file + (info->write_pos-info->append_read_pos);
@@ -203,7 +203,7 @@ size_t my_b_fill(IO_CACHE *info)
 
   if (info->seek_not_done)
   {					/* File touched, do seek */
-    if (my_seek(info->file,pos_in_file,MY_SEEK_SET,MYF(0)) ==
+    if (mysql_file_seek(info->file, pos_in_file, MY_SEEK_SET,MYF(0)) ==
 	MY_FILEPOS_ERROR)
     {
       info->error= 0;
@@ -223,7 +223,7 @@ size_t my_b_fill(IO_CACHE *info)
   }
   DBUG_EXECUTE_IF ("simulate_my_b_fill_error",
                    {DBUG_SET("+d,simulate_file_read_error");});
-  if ((length= my_read(info->file,info->buffer,max_length,
+  if ((length= mysql_file_read(info->file, info->buffer, max_length,
                        info->myflags)) == (size_t) -1)
   {
     info->error= -1;
@@ -287,7 +287,7 @@ my_off_t my_b_filelength(IO_CACHE *info)
     return my_b_tell(info);
 
   info->seek_not_done= 1;
-  return my_seek(info->file, 0L, MY_SEEK_END, MYF(0));
+  return mysql_file_seek(info->file, 0L, MY_SEEK_END, MYF(0));
 }
 
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-3937

In 'mf_iocache2.c' my_tell() / my_seek() / my_read() changed to
mysql_file_tell() / mysql_file_seek() / mysql_file_read() correspondingly.

Re-recorded 'perfschema.relaylog' MTR test case as proper values are now
reported in 'count_read' / 'sum_number_of_bytes_read' fields in
'performance_schema.file_summary_by_instance' table.