### PR TITLE
TDB-130: alter TokuDB table comment rebuild whole engine data

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/alter_table_comment_rebuild_data.result
+++ b/mysql-test/suite/tokudb.bugs/r/alter_table_comment_rebuild_data.result
@@ -1,0 +1,186 @@
+create table t1(id int auto_increment, name varchar(30), primary key(id)) engine=TokuDB;
+alter table t1 min_rows = 8;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1 MIN_ROWS=8
+include/assert.inc [underlying ft file name not changed after alter min_rows]
+alter table t1 max_rows = 100;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1 MIN_ROWS=8 MAX_ROWS=100
+include/assert.inc [underlying ft file name not changed after alter max_rows]
+alter table t1 avg_row_length = 100;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100
+include/assert.inc [underlying ft file name not changed after alter avg_row_length]
+alter table t1 pack_keys = 1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=latin1 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1
+include/assert.inc [underlying ft file name not changed after alter pack_keys]
+alter table t1 character set = utf8;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1
+include/assert.inc [underlying ft file name not changed after alter character set]
+alter table t1 data directory = '/tmp';
+Warnings:
+Warning	1618	<DATA DIRECTORY> option ignored
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1
+include/assert.inc [underlying ft file name not changed after alter data directory]
+alter table t1 index directory = '/tmp';
+Warnings:
+Warning	1618	<INDEX DIRECTORY> option ignored
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1
+include/assert.inc [underlying ft file name not changed after alter index directory]
+alter table t1 checksum = 1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 CHECKSUM=1
+include/assert.inc [underlying ft file name not changed after alter checksum]
+alter table t1 delay_key_write=1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 CHECKSUM=1 DELAY_KEY_WRITE=1
+include/assert.inc [underlying ft file name not changed after alter delay_key_write]
+alter table t1 comment = 'test table';
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 CHECKSUM=1 DELAY_KEY_WRITE=1 COMMENT='test table'
+include/assert.inc [underlying ft file name not changed after alter comment]
+alter table t1 password = '123456';
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 CHECKSUM=1 DELAY_KEY_WRITE=1 COMMENT='test table'
+include/assert.inc [underlying ft file name not changed after alter password]
+alter table t1 connection = '127.0.0.1:3306';
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 CHECKSUM=1 DELAY_KEY_WRITE=1 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name not changed after alter connection]
+alter table t1 key_block_size=32;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 CHECKSUM=1 DELAY_KEY_WRITE=1 KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name not changed after alter key_block_size]
+alter table t1 stats_persistent = 1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 STATS_PERSISTENT=1 CHECKSUM=1 DELAY_KEY_WRITE=1 KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name not changed after alter stats_persistent]
+alter table t1 stats_auto_recalc = 1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 STATS_PERSISTENT=1 STATS_AUTO_RECALC=1 CHECKSUM=1 DELAY_KEY_WRITE=1 KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name not changed after alter stats_auto_recalc]
+alter table t1 stats_sample_pages = 1;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 STATS_PERSISTENT=1 STATS_AUTO_RECALC=1 STATS_SAMPLE_PAGES=1 CHECKSUM=1 DELAY_KEY_WRITE=1 KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name not changed after alter stats_sample_pages]
+alter table t1 auto_increment = 1000;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 STATS_PERSISTENT=1 STATS_AUTO_RECALC=1 STATS_SAMPLE_PAGES=1 CHECKSUM=1 DELAY_KEY_WRITE=1 KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name not changed after alter auto_increment]
+alter table t1 row_format=tokudb_lzma;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 STATS_PERSISTENT=1 STATS_AUTO_RECALC=1 STATS_SAMPLE_PAGES=1 CHECKSUM=1 DELAY_KEY_WRITE=1 ROW_FORMAT=TOKUDB_LZMA KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name not changed after alter compression method]
+alter table t1 engine=TokuDB;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) CHARACTER SET latin1 DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 STATS_PERSISTENT=1 STATS_AUTO_RECALC=1 STATS_SAMPLE_PAGES=1 CHECKSUM=1 DELAY_KEY_WRITE=1 ROW_FORMAT=TOKUDB_LZMA KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name changed after alter engine type]
+alter table t1 convert to character set utf8;
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(30) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=TokuDB AUTO_INCREMENT=1000 DEFAULT CHARSET=utf8 MIN_ROWS=8 MAX_ROWS=100 AVG_ROW_LENGTH=100 PACK_KEYS=1 STATS_PERSISTENT=1 STATS_AUTO_RECALC=1 STATS_SAMPLE_PAGES=1 CHECKSUM=1 DELAY_KEY_WRITE=1 ROW_FORMAT=TOKUDB_LZMA KEY_BLOCK_SIZE=32 COMMENT='test table' CONNECTION='127.0.0.1:3306'
+include/assert.inc [underlying ft file name changed after alter convert character]
+drop table t1;

--- a/mysql-test/suite/tokudb.bugs/t/alter_table_comment_rebuild_data.test
+++ b/mysql-test/suite/tokudb.bugs/t/alter_table_comment_rebuild_data.test
@@ -1,0 +1,184 @@
+--source include/have_tokudb.inc
+
+#
+# Create a table and get the underlying main ft file name
+#
+create table t1(id int auto_increment, name varchar(30), primary key(id)) engine=TokuDB;
+--let $ori_file= `select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+
+#
+# Case 1: alter create options that are ignored by TokuDB
+#
+
+# Alter table with min_rows
+alter table t1 min_rows = 8;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter min_rows
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with max_rows
+alter table t1 max_rows = 100;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter max_rows
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with avg_row_length
+alter table t1 avg_row_length = 100;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter avg_row_length
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with pack_keys
+alter table t1 pack_keys = 1;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter pack_keys
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with default character set
+alter table t1 character set = utf8;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter character set
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with data directory
+alter table t1 data directory = '/tmp';
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter data directory
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with index directory
+alter table t1 index directory = '/tmp';
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter index directory
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with checksum
+alter table t1 checksum = 1;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter checksum
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with delay_key_write
+alter table t1 delay_key_write=1;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter delay_key_write
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with comment
+alter table t1 comment = 'test table';
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter comment
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with password
+alter table t1 password = '123456';
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter password
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with connection
+alter table t1 connection = '127.0.0.1:3306';
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter connection
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with key_block_size
+alter table t1 key_block_size=32;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter key_block_size
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with stats_persistent
+alter table t1 stats_persistent = 1;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter stats_persistent
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with stats_auto_recalc
+alter table t1 stats_auto_recalc = 1;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter stats_auto_recalc
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with stats_sample_pages
+alter table t1 stats_sample_pages = 1;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter stats_sample_pages
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+#
+# Case 2: alter create options that only update meta info, i.e inplace
+#
+
+# Alter table with auto_increment
+alter table t1 auto_increment = 1000;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter auto_increment
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+# Alter table with compression method
+alter table t1 row_format=tokudb_lzma;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name not changed after alter compression method
+--let $assert_cond= "$ori_file" = "$new_file"
+--source include/assert.inc
+
+#
+# Case 3: alter create options that rebuild table using copy algorithm
+#
+
+# Alter table with engine type
+alter table t1 engine=TokuDB;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name changed after alter engine type
+--let $assert_cond= "$ori_file" != "$new_file"
+--source include/assert.inc
+
+# Alter table with convert character
+alter table t1 convert to character set utf8;
+show create table t1;
+--let $new_file=`select internal_file_name from information_schema.tokudb_file_map where table_schema='test' and table_name='t1' and table_dictionary_name='main'`
+--let $assert_text= underlying ft file name changed after alter convert character
+--let $assert_cond= "$ori_file" != "$new_file"
+--source include/assert.inc
+
+#
+# clean up
+#
+drop table t1;

--- a/storage/tokudb/ha_tokudb_alter_56.cc
+++ b/storage/tokudb/ha_tokudb_alter_56.cc
@@ -248,6 +248,40 @@ static bool only_flags(ulong bits, ulong mask) {
     return (bits & mask) != 0 && (bits & ~mask) == 0;
 }
 
+// Table create options that should be ignored by TokuDB
+// There are 25 total create options defined by mysql server (see handler.h),
+// and only 4 options will touch engine data, either rebuild engine data or
+// just update meta info:
+//   1. HA_CREATE_USED_AUTO        update auto_inc info
+//   2. HA_CREATE_USED_CHARSET     rebuild table if contains character columns
+//   3. HA_CREATE_USED_ENGINE      rebuild table
+//   4. HA_CREATE_USED_ROW_FORMAT  update compression method info
+//
+// All the others are either not supported by TokuDB or no need to
+// touch engine data.
+static constexpr uint32_t TOKUDB_IGNORED_ALTER_CREATE_OPTION_FIELDS =
+    HA_CREATE_USED_RAID |              // deprecated field
+    HA_CREATE_USED_UNION |             // for MERGE table
+    HA_CREATE_USED_INSERT_METHOD |     // for MERGE table
+    HA_CREATE_USED_MIN_ROWS |          // for MEMORY table
+    HA_CREATE_USED_MAX_ROWS |          // for NDB table
+    HA_CREATE_USED_AVG_ROW_LENGTH |    // for MyISAM table
+    HA_CREATE_USED_PACK_KEYS |         // for MyISAM table
+    HA_CREATE_USED_DEFAULT_CHARSET |   // no need to rebuild
+    HA_CREATE_USED_DATADIR |           // ignored by alter
+    HA_CREATE_USED_INDEXDIR |          // ignored by alter
+    HA_CREATE_USED_CHECKSUM |          // for MyISAM table
+    HA_CREATE_USED_DELAY_KEY_WRITE |   // for MyISAM table
+    HA_CREATE_USED_COMMENT |           // no need to rebuild
+    HA_CREATE_USED_PASSWORD |          // not supported by community version
+    HA_CREATE_USED_CONNECTION |        // for FEDERATED table
+    HA_CREATE_USED_KEY_BLOCK_SIZE |    // not supported by TokuDB
+    HA_CREATE_USED_TRANSACTIONAL |     // unused
+    HA_CREATE_USED_PAGE_CHECKSUM |     // unsued
+    HA_CREATE_USED_STATS_PERSISTENT |  // not supported by TokuDB
+    HA_CREATE_USED_STATS_AUTO_RECALC | // not supported by TokuDB
+    HA_CREATE_USED_STATS_SAMPLE_PAGES; // not supported by TokuDB
+
 // Check if an alter table operation on this table and described by the alter
 // table parameters is supported inplace and if so, what type of locking is
 // needed to execute it. return values:
@@ -503,6 +537,10 @@ enum_alter_inplace_result ha_tokudb::check_if_supported_inplace_alter(
                     tokudb::sysvars::alter_print_error(thd) != 0)) {
                 result = HA_ALTER_INPLACE_EXCLUSIVE_LOCK;
             }
+        } else if (only_flags(
+                        create_info->used_fields,
+                        TOKUDB_IGNORED_ALTER_CREATE_OPTION_FIELDS)) {
+            result = HA_ALTER_INPLACE_NO_LOCK_AFTER_PREPARE;
         }
     }
 #if TOKU_OPTIMIZE_WITH_RECREATE


### PR DESCRIPTION
Alter TokuDB table comment should not using copying algorithm and
rebuild whole engine data, only FRM definition should be changed.

Make `ha_tokudb::check_if_supported_inplace_alter()` return
`HA_ALTER_INPLACE_EXCLUSIVE_LOCK` while altering comment, and mysql
server will invoke `ha_tokudb::inplace_alter_table` which will do
nothing for altering comment.

Besides table comment, there are many other create options that
should be ignored by TokuDB, and they are all handled in this patch.