### PR TITLE
TDB-115 : Fix -Wunused-parameter

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -214,7 +214,6 @@ void TOKUDB_SHARE::destroy() {
     TOKUDB_SHARE_DBUG_VOID_RETURN();
 }
 TOKUDB_SHARE* TOKUDB_SHARE::get_share(const char* table_name,
-                                      TABLE_SHARE* table_share,
                                       THR_LOCK_DATA* data,
                                       bool create_new) {
     mutex_t_lock(_open_tables_mutex);
@@ -426,7 +425,7 @@ const char *ha_tokudb::table_type() const {
     return tokudb_hton_name;
 } 
 
-const char *ha_tokudb::index_type(uint inx) {
+const char *ha_tokudb::index_type(TOKUDB_UNUSED(uint inx)) {
     return "BTREE";
 }
 
@@ -487,7 +486,9 @@ ulonglong ha_tokudb::table_flags() const {
 // Returns a bit mask of capabilities of the key or its part specified by 
 // the arguments. The capabilities are defined in sql/handler.h.
 //
-ulong ha_tokudb::index_flags(uint idx, uint part, bool all_parts) const {
+ulong ha_tokudb::index_flags(uint idx,
+                             TOKUDB_UNUSED(uint part),
+                             TOKUDB_UNUSED(bool all_parts)) const {
     TOKUDB_HANDLER_DBUG_ENTER("");
     assert_always(table_share);
     ulong flags = (HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER |
@@ -531,8 +532,10 @@ typedef struct index_read_info {
 // want to actually do anything with the data, hence
 // callback does nothing
 //
-static int smart_dbt_do_nothing (DBT const *key, DBT  const *row, void *context) {
-  return 0;
+static int smart_dbt_do_nothing(TOKUDB_UNUSED(DBT const* key),
+                                TOKUDB_UNUSED(DBT const* row),
+                                TOKUDB_UNUSED(void* context)) {
+    return 0;
 }
 
 static int
@@ -545,8 +548,9 @@ smart_dbt_callback_rowread_ptquery (DBT const *key, DBT  const *row, void *conte
 //
 // Smart DBT callback function in case where we have a covering index
 //
-static int
-smart_dbt_callback_keyread(DBT const *key, DBT  const *row, void *context) {
+static int smart_dbt_callback_keyread(DBT const* key,
+                                      DBT TOKUDB_UNUSED(const* row),
+                                      void* context) {
     SMART_DBT_INFO info = (SMART_DBT_INFO)context;
     info->ha->extract_hidden_primary_key(info->keynr, key);
     info->ha->read_key_only(info->buf,info->keynr,key);
@@ -568,20 +572,24 @@ smart_dbt_callback_rowread(DBT const *key, DBT  const *row, void *context) {
 //
 // Smart DBT callback function in case where we have a covering index
 //
-static int
-smart_dbt_callback_ir_keyread(DBT const *key, DBT  const *row, void *context) {
+static int smart_dbt_callback_ir_keyread(DBT const* key,
+                                         TOKUDB_UNUSED(DBT const* row),
+                                         void* context) {
     INDEX_READ_INFO ir_info = (INDEX_READ_INFO)context;
-    ir_info->cmp = ir_info->smart_dbt_info.ha->prefix_cmp_dbts(ir_info->smart_dbt_info.keynr, ir_info->orig_key, key);
+    ir_info->cmp = ir_info->smart_dbt_info.ha->prefix_cmp_dbts(
+        ir_info->smart_dbt_info.keynr, ir_info->orig_key, key);
     if (ir_info->cmp) {
         return 0;
     }
     return smart_dbt_callback_keyread(key, row, &ir_info->smart_dbt_info);
 }
 
-static int
-smart_dbt_callback_lookup(DBT const *key, DBT  const *row, void *context) {
+static int smart_dbt_callback_lookup(DBT const* key,
+                                     TOKUDB_UNUSED(DBT const* row),
+                                     void* context) {
     INDEX_READ_INFO ir_info = (INDEX_READ_INFO)context;
-    ir_info->cmp = ir_info->smart_dbt_info.ha->prefix_cmp_dbts(ir_info->smart_dbt_info.keynr, ir_info->orig_key, key);
+    ir_info->cmp = ir_info->smart_dbt_info.ha->prefix_cmp_dbts(
+        ir_info->smart_dbt_info.keynr, ir_info->orig_key, key);
     return 0;
 }
 
@@ -1020,16 +1028,12 @@ cleanup:
     return error;
 }
 
-
-static inline int tokudb_generate_row(
-    DB *dest_db, 
-    DB *src_db,
-    DBT *dest_key, 
-    DBT *dest_val,
-    const DBT *src_key, 
-    const DBT *src_val
-    ) 
-{
+static inline int tokudb_generate_row(DB* dest_db,
+                                      TOKUDB_UNUSED(DB* src_db),
+                                      DBT* dest_key,
+                                      DBT* dest_val,
+                                      const DBT* src_key,
+                                      const DBT* src_val) {
     int error;
 
     DB* curr_db = dest_db;
@@ -1043,7 +1047,7 @@ static inline int tokudb_generate_row(
     desc_size = (*(uint32_t *)row_desc) - 4;
     row_desc += 4;
     
-    if (is_key_pk(row_desc, desc_size)) {
+    if (is_key_pk(row_desc)) {
         if (dest_key->flags == DB_DBT_REALLOC && dest_key->data != NULL) {
             free(dest_key->data);
         }
@@ -1106,7 +1110,7 @@ static inline int tokudb_generate_row(
     desc_size = (*(uint32_t *)row_desc) - 4;
     row_desc += 4;
     if (dest_val != NULL) {
-        if (!is_key_clustering(row_desc, desc_size) || src_val->size == 0) {
+        if (!is_key_clustering(desc_size) || src_val->size == 0) {
             dest_val->size = 0;
         } else {
             uchar* buff = NULL;
@@ -1884,7 +1888,7 @@ int ha_tokudb::open(const char *name, int mode, uint test_if_locked) {
     }
 
     // lookup or create share
-    share = TOKUDB_SHARE::get_share(name, table_share, &lock, true);
+    share = TOKUDB_SHARE::get_share(name, &lock, true);
     assert_always(share);
 
     if (share->state() != TOKUDB_SHARE::OPENED) {
@@ -2110,7 +2114,9 @@ int ha_tokudb::remove_frm_data(DB *db, DB_TXN *txn) {
     return remove_from_status(db, hatoku_frm_data, txn);
 }
 
-static int smart_dbt_callback_verify_frm (DBT const *key, DBT  const *row, void *context) {
+static int smart_dbt_callback_verify_frm(TOKUDB_UNUSED(DBT const* key),
+                                         DBT const* row,
+                                         void* context) {
     DBT* stored_frm = (DBT *)context;
     stored_frm->size = row->size;
     stored_frm->data = (uchar *)tokudb::memory::malloc(row->size, MYF(MY_WME));
@@ -3382,21 +3388,21 @@ int ha_tokudb::bulk_insert_poll(void* extra, float progress) {
 #endif
     return 0;
 }
-void ha_tokudb::loader_add_index_err(DB* db,
-                                     int i,
-                                     int err,
-                                     DBT* key,
-                                     DBT* val,
+void ha_tokudb::loader_add_index_err(TOKUDB_UNUSED(DB* db),
+                                     TOKUDB_UNUSED(int i),
+                                     TOKUDB_UNUSED(int err),
+                                     TOKUDB_UNUSED(DBT* key),
+                                     TOKUDB_UNUSED(DBT* val),
                                      void* error_extra) {
     LOADER_CONTEXT context = (LOADER_CONTEXT)error_extra;
     assert_always(context->ha);
     context->ha->set_loader_error(err);
 }
-void ha_tokudb::loader_dup(DB* db,
-                           int i,
+void ha_tokudb::loader_dup(TOKUDB_UNUSED(DB* db),
+                           TOKUDB_UNUSED(int i),
                            int err,
                            DBT* key,
-                           DBT* val,
+                           TOKUDB_UNUSED(DBT* val),
                            void* error_extra) {
     LOADER_CONTEXT context = (LOADER_CONTEXT)error_extra;
     assert_always(context->ha);
@@ -3411,7 +3417,7 @@ void ha_tokudb::loader_dup(DB* db,
 // (ha_tokudb::write_row). If start_bulk_insert is called, then
 // this is guaranteed to be called.
 //
-int ha_tokudb::end_bulk_insert(bool abort) {
+int ha_tokudb::end_bulk_insert(TOKUDB_UNUSED(bool abort)) {
     TOKUDB_HANDLER_DBUG_ENTER("");
     int error = 0;
     THD* thd = ha_thd();
@@ -3866,7 +3872,11 @@ void ha_tokudb::set_main_dict_put_flags(THD* thd, bool opt_eligible, uint32_t* p
     }
 }
 
-int ha_tokudb::insert_row_to_main_dictionary(uchar* record, DBT* pk_key, DBT* pk_val, DB_TXN* txn) {
+int ha_tokudb::insert_row_to_main_dictionary(
+    DBT* pk_key,
+    DBT* pk_val,
+    DB_TXN* txn) {
+
     int error = 0;
     uint curr_num_DBs = table->s->keys + tokudb_test(hidden_primary_key);
     assert_always(curr_num_DBs == 1);
@@ -4090,7 +4100,7 @@ int ha_tokudb::write_row(uchar * record) {
             goto cleanup; 
         }
         if (curr_num_DBs == 1) {
-            error = insert_row_to_main_dictionary(record, &prim_key, &row, txn);
+            error = insert_row_to_main_dictionary(&prim_key, &row, txn);
             if (error) { goto cleanup; }
         } else {
             error = insert_rows_to_dictionaries_mult(&prim_key, &row, txn, thd);
@@ -4708,8 +4718,7 @@ int ha_tokudb::index_end() {
     TOKUDB_HANDLER_DBUG_RETURN(0);
 }
 
-
-int ha_tokudb::handle_cursor_error(int error, int err_to_return, uint keynr) {
+int ha_tokudb::handle_cursor_error(int error, int err_to_return) {
     TOKUDB_HANDLER_DBUG_ENTER("");
     if (error) {
         error = map_to_handler_error(error);
@@ -4911,7 +4920,7 @@ int ha_tokudb::index_next_same(uchar* buf, const uchar* key, uint keylen) {
     }
 
 cleanup:
-    error = handle_cursor_error(error, HA_ERR_END_OF_FILE, tokudb_active_index);
+    error = handle_cursor_error(error, HA_ERR_END_OF_FILE);
     TOKUDB_HANDLER_DBUG_RETURN(error);
 } 
 
@@ -5038,7 +5047,7 @@ int ha_tokudb::index_read(
         error = HA_ERR_UNSUPPORTED;
         break;
     }
-    error = handle_cursor_error(error,HA_ERR_KEY_NOT_FOUND,tokudb_active_index);
+    error = handle_cursor_error(error, HA_ERR_KEY_NOT_FOUND);
     if (!error && !key_read && tokudb_active_index != primary_key && !key_is_clustering(&table->key_info[tokudb_active_index])) {
         error = read_full_row(buf);
     }
@@ -5545,11 +5554,7 @@ int ha_tokudb::get_next(
                     bulk_fetch_iteration++;
                 }
 
-                error =
-                    handle_cursor_error(
-                        error,
-                        HA_ERR_END_OF_FILE,
-                        tokudb_active_index);
+                error = handle_cursor_error(error, HA_ERR_END_OF_FILE);
                 if (error) {
                     goto cleanup;
                 }
@@ -5580,11 +5585,7 @@ int ha_tokudb::get_next(
                             SMART_DBT_CALLBACK(do_key_read),
                             &info);
                 }
-                error =
-                    handle_cursor_error(
-                        error,
-                        HA_ERR_END_OF_FILE,
-                        tokudb_active_index);
+                error = handle_cursor_error(error, HA_ERR_END_OF_FILE);
             }
         }
     }
@@ -5682,7 +5683,7 @@ int ha_tokudb::index_first(uchar * buf) {
     info.keynr = tokudb_active_index;
 
     error = cursor->c_getf_first(cursor, flags, SMART_DBT_CALLBACK(key_read), &info);
-    error = handle_cursor_error(error,HA_ERR_END_OF_FILE,tokudb_active_index);
+    error = handle_cursor_error(error, HA_ERR_END_OF_FILE);
 
     //
     // still need to get entire contents of the row if operation done on
@@ -5726,7 +5727,7 @@ int ha_tokudb::index_last(uchar * buf) {
     info.keynr = tokudb_active_index;
 
     error = cursor->c_getf_last(cursor, flags, SMART_DBT_CALLBACK(key_read), &info);
-    error = handle_cursor_error(error,HA_ERR_END_OF_FILE,tokudb_active_index);
+    error = handle_cursor_error(error, HA_ERR_END_OF_FILE);
     //
     // still need to get entire contents of the row if operation done on
     // secondary DB and it was NOT a covering index
@@ -6887,7 +6888,7 @@ int ha_tokudb::write_key_name_to_status(DB* status_block, char* key_name, DB_TXN
 // some tracing moved out of ha_tokudb::create, because ::create was
 // getting cluttered
 //
-void ha_tokudb::trace_create_table_info(const char *name, TABLE * form) {
+void ha_tokudb::trace_create_table_info(TABLE* form) {
     uint i;
     //
     // tracing information about what type of table we are creating
@@ -7301,7 +7302,7 @@ int ha_tokudb::create(
     }
 
     /* do some tracing */
-    trace_create_table_info(name,form);
+    trace_create_table_info(form);
 
     /* Create status.tokudb and save relevant metadata */
     make_name(newname, newname_len, name, "status");
@@ -7422,7 +7423,7 @@ cleanup:
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
 
-int ha_tokudb::discard_or_import_tablespace(my_bool discard) {
+int ha_tokudb::discard_or_import_tablespace(TOKUDB_UNUSED(my_bool discard)) {
     /*
     if (discard) {
         my_errno=HA_ERR_WRONG_COMMAND;
@@ -7621,7 +7622,7 @@ cleanup:
 //
 int ha_tokudb::delete_table(const char *name) {
     TOKUDB_HANDLER_DBUG_ENTER("%s", name);
-    TOKUDB_SHARE* share = TOKUDB_SHARE::get_share(name, NULL, NULL, false);
+    TOKUDB_SHARE* share = TOKUDB_SHARE::get_share(name, NULL, false);
     if (share) {
         share->unlock();
         share->release();
@@ -7683,7 +7684,7 @@ static bool tokudb_check_db_dir_exist_from_table_name(const char *table_name) {
 //
 int ha_tokudb::rename_table(const char *from, const char *to) {
     TOKUDB_HANDLER_DBUG_ENTER("%s %s", from, to);
-    TOKUDB_SHARE* share = TOKUDB_SHARE::get_share(from, NULL, NULL, false);
+    TOKUDB_SHARE* share = TOKUDB_SHARE::get_share(from, NULL, false);
     if (share) {
         share->unlock();
         share->release();
@@ -8541,13 +8542,10 @@ void ha_tokudb::restore_add_index(
 // Internal function called by ha_tokudb::prepare_drop_index and ha_tokudb::alter_table_phase2
 // With a transaction, drops dictionaries associated with indexes in key_num
 //
-int ha_tokudb::drop_indexes(
-    TABLE* table_arg,
-    uint* key_num,
-    uint num_of_keys,
-    KEY* key_info,
-    DB_TXN* txn) {
-
+int ha_tokudb::drop_indexes(uint* key_num,
+                            uint num_of_keys,
+                            KEY* key_info,
+                            DB_TXN* txn) {
     TOKUDB_HANDLER_DBUG_ENTER("");
     assert_always(txn);
 
@@ -8605,11 +8603,7 @@ cleanup:
 // Restores dropped indexes in case of error in error path of
 // prepare_drop_index and alter_table_phase2
 //
-void ha_tokudb::restore_drop_indexes(
-    TABLE* table_arg,
-    uint* key_num,
-    uint num_of_keys) {
-
+void ha_tokudb::restore_drop_indexes(uint* key_num, uint num_of_keys) {
     //
     // reopen closed dictionaries
     //

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -79,7 +79,6 @@ public:
     // doesn't exist, otherwise will return NULL if an existing is not found.
     static TOKUDB_SHARE* get_share(
         const char* table_name,
-        TABLE_SHARE* table_share,
         THR_LOCK_DATA* data,
         bool create_new);
 
@@ -661,7 +660,7 @@ private:
     DBT *pack_ext_key(DBT * key, uint keynr, uchar * buff, const uchar * key_ptr, uint key_length, int8_t inf_byte);
 #endif
     bool key_changed(uint keynr, const uchar * old_row, const uchar * new_row);
-    int handle_cursor_error(int error, int err_to_return, uint keynr);
+    int handle_cursor_error(int error, int err_to_return);
     DBT *get_pos(DBT * to, uchar * pos);
  
     int open_main_dictionary(const char* name, bool is_read_only, DB_TXN* txn);
@@ -706,12 +705,12 @@ private:
         toku_compression_method compression_method
         );
     int create_main_dictionary(const char* name, TABLE* form, DB_TXN* txn, KEY_AND_COL_INFO* kc_info, toku_compression_method compression_method);
-    void trace_create_table_info(const char *name, TABLE * form);
+    void trace_create_table_info(TABLE* form);
     int is_index_unique(bool* is_unique, DB_TXN* txn, DB* db, KEY* key_info, int lock_flags);
     int is_val_unique(bool* is_unique, uchar* record, KEY* key_info, uint dict_index, DB_TXN* txn);
     int do_uniqueness_checks(uchar* record, DB_TXN* txn, THD* thd);
     void set_main_dict_put_flags(THD* thd, bool opt_eligible, uint32_t* put_flags);
-    int insert_row_to_main_dictionary(uchar* record, DBT* pk_key, DBT* pk_val, DB_TXN* txn);
+    int insert_row_to_main_dictionary(DBT* pk_key, DBT* pk_val, DB_TXN* txn);
     int insert_rows_to_dictionaries_mult(DBT* pk_key, DBT* pk_val, DB_TXN* txn, THD* thd);
     void test_row_packing(uchar* record, DBT* pk_key, DBT* pk_val);
     uint32_t fill_row_mutator(
@@ -928,8 +927,8 @@ public:
     bool inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
     bool commit_inplace_alter_table(TABLE *altered_table, Alter_inplace_info *ha_alter_info, bool commit);
  private:
-    int alter_table_add_index(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
-    int alter_table_drop_index(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
+    int alter_table_add_index(Alter_inplace_info* ha_alter_info);
+    int alter_table_drop_index(Alter_inplace_info* ha_alter_info);
     int alter_table_add_or_drop_column(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
     int alter_table_expand_varchar_offsets(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
     int alter_table_expand_columns(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
@@ -937,7 +936,10 @@ public:
     int alter_table_expand_blobs(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
     void print_alter_info(TABLE *altered_table, Alter_inplace_info *ha_alter_info);
     int setup_kc_info(TABLE *altered_table, KEY_AND_COL_INFO *kc_info);
-    int new_row_descriptor(TABLE *table, TABLE *altered_table, Alter_inplace_info *ha_alter_info, uint32_t idx, DBT *row_descriptor);
+    int new_row_descriptor(TABLE* altered_table,
+                           Alter_inplace_info* ha_alter_info,
+                           uint32_t idx,
+                           DBT* row_descriptor);
 
  public:
 #endif
@@ -962,12 +964,8 @@ public:
                          uint num_of_keys,
                          bool incremented_numDBs,
                          bool modified_DBs);
-  int drop_indexes(TABLE* table_arg,
-                   uint* key_num,
-                   uint num_of_keys,
-                   KEY* key_info,
-                   DB_TXN* txn);
-  void restore_drop_indexes(TABLE* table_arg, uint* key_num, uint num_of_keys);
+  int drop_indexes(uint* key_num, uint num_of_keys, KEY* key_info, DB_TXN* txn);
+  void restore_drop_indexes(uint* key_num, uint num_of_keys);
 
  public:
     // delete all rows from the table
@@ -1044,7 +1042,9 @@ private:
     int send_update_message(List<Item> &update_fields, List<Item> &update_values, Item *conds, DB_TXN *txn);
     int upsert(THD *thd, List<Item> &update_fields, List<Item> &update_values);
     bool check_upsert(THD *thd, List<Item> &update_fields, List<Item> &update_values);
-    int send_upsert_message(THD *thd, List<Item> &update_fields, List<Item> &update_values, DB_TXN *txn);
+    int send_upsert_message(List<Item>& update_fields,
+                            List<Item>& update_values,
+                            DB_TXN* txn);
 #endif
 public:
     // mysql sometimes retires a txn before a cursor that references the txn is closed.

--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -760,7 +760,7 @@ done:
 } // namespace tokudb
 
 
-int ha_tokudb::analyze(THD *thd, HA_CHECK_OPT *check_opt) {
+int ha_tokudb::analyze(THD *thd, TOKUDB_UNUSED(HA_CHECK_OPT *check_opt)) {
     TOKUDB_HANDLER_DBUG_ENTER("%s", share->table_name());
     int result = HA_ADMIN_OK;
     tokudb::sysvars::analyze_mode_t mode = tokudb::sysvars::analyze_mode(thd);
@@ -985,7 +985,8 @@ cleanup:
     TOKUDB_HANDLER_DBUG_RETURN(error);
 }
 
-int ha_tokudb::optimize(THD* thd, HA_CHECK_OPT* check_opt) {
+int ha_tokudb::optimize(TOKUDB_UNUSED(THD* thd),
+                        TOKUDB_UNUSED(HA_CHECK_OPT* check_opt)) {
     TOKUDB_HANDLER_DBUG_ENTER("%s", share->table_name());
     int error;
 #if TOKU_OPTIMIZE_WITH_RECREATE
@@ -1000,7 +1001,8 @@ struct check_context {
     THD* thd;
 };
 
-static int ha_tokudb_check_progress(void* extra, float progress) {
+static int ha_tokudb_check_progress(void* extra,
+                                    TOKUDB_UNUSED(float progress)) {
     struct check_context* context = (struct check_context*)extra;
     int result = 0;
     if (thd_killed(context->thd))

--- a/storage/tokudb/ha_tokudb_alter_56.cc
+++ b/storage/tokudb/ha_tokudb_alter_56.cc
@@ -163,17 +163,13 @@ static int find_changed_fields(
     return changed_fields.elements();
 }
 
-static bool change_length_is_supported(
-    TABLE* table,
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    tokudb_alter_ctx* ctx);
+static bool change_length_is_supported(TABLE* table,
+                                       TABLE* altered_table,
+                                       tokudb_alter_ctx* ctx);
 
-static bool change_type_is_supported(
-    TABLE* table,
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    tokudb_alter_ctx* ctx);
+static bool change_type_is_supported(TABLE* table,
+                                     TABLE* altered_table,
+                                     tokudb_alter_ctx* ctx);
 
 // The ha_alter_info->handler_flags can not be trusted.
 // This function maps the bogus handler flags to something we like.
@@ -446,10 +442,7 @@ enum_alter_inplace_result ha_tokudb::check_if_supported_inplace_alter(
                 setup_kc_info(altered_table, ctx->altered_table_kc_info) == 0) {
 
         // change column length
-        if (change_length_is_supported(
-                table,
-                altered_table,
-                ha_alter_info, ctx)) {
+        if (change_length_is_supported(table, altered_table, ctx)) {
             result = HA_ALTER_INPLACE_EXCLUSIVE_LOCK;
         }
     } else if ((ctx->handler_flags & Alter_inplace_info::ALTER_COLUMN_TYPE) &&
@@ -465,10 +458,7 @@ enum_alter_inplace_result ha_tokudb::check_if_supported_inplace_alter(
                 setup_kc_info(altered_table, ctx->altered_table_kc_info) == 0) {
 
         // change column type
-        if (change_type_is_supported(
-                table,
-                altered_table,
-                ha_alter_info, ctx)) {
+        if (change_type_is_supported(table, altered_table, ctx)) {
             result = HA_ALTER_INPLACE_EXCLUSIVE_LOCK;
         }
     } else if (only_flags(
@@ -538,10 +528,8 @@ enum_alter_inplace_result ha_tokudb::check_if_supported_inplace_alter(
 }
 
 // Prepare for the alter operations
-bool ha_tokudb::prepare_inplace_alter_table(
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info) {
-
+bool ha_tokudb::prepare_inplace_alter_table(TOKUDB_UNUSED(TABLE* altered_table),
+                                            Alter_inplace_info* ha_alter_info) {
     TOKUDB_HANDLER_DBUG_ENTER("");
     tokudb_alter_ctx* ctx =
         static_cast<tokudb_alter_ctx*>(ha_alter_info->handler_ctx);
@@ -571,13 +559,13 @@ bool ha_tokudb::inplace_alter_table(
         (ctx->handler_flags &
             (Alter_inplace_info::DROP_INDEX +
              Alter_inplace_info::DROP_UNIQUE_INDEX))) {
-        error = alter_table_drop_index(altered_table, ha_alter_info);
+        error = alter_table_drop_index(ha_alter_info);
     }
     if (error == 0 &&
         (ctx->handler_flags &
             (Alter_inplace_info::ADD_INDEX +
              Alter_inplace_info::ADD_UNIQUE_INDEX))) {
-        error = alter_table_add_index(altered_table, ha_alter_info);
+        error = alter_table_add_index(ha_alter_info);
     }
     if (error == 0 &&
         (ctx->handler_flags &
@@ -668,9 +656,7 @@ bool ha_tokudb::inplace_alter_table(
     DBUG_RETURN(result);
 }
 
-int ha_tokudb::alter_table_add_index(
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info) {
+int ha_tokudb::alter_table_add_index(Alter_inplace_info* ha_alter_info) {
 
     // sort keys in add index order
     KEY* key_info = (KEY*)tokudb::memory::malloc(
@@ -741,9 +727,7 @@ static bool find_index_of_key(
     return false;
 }
 
-int ha_tokudb::alter_table_drop_index(
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info) {
+int ha_tokudb::alter_table_drop_index(Alter_inplace_info* ha_alter_info) {
 
     KEY *key_info = table->key_info;
     // translate key names to indexes into the key_info array
@@ -771,12 +755,10 @@ int ha_tokudb::alter_table_drop_index(
         static_cast<tokudb_alter_ctx*>(ha_alter_info->handler_ctx);
     ctx->drop_index_changed = true;
 
-    int error = drop_indexes(
-        table,
-        index_drop_offsets,
-        ha_alter_info->index_drop_count,
-        key_info,
-        ctx->alter_txn);
+    int error = drop_indexes(index_drop_offsets,
+                             ha_alter_info->index_drop_count,
+                             key_info,
+                             ctx->alter_txn);
 
     if (error == 0)
         ctx->reset_card = true;
@@ -837,11 +819,7 @@ int ha_tokudb::alter_table_add_or_drop_column(
         // change to a new descriptor
         DBT row_descriptor; memset(&row_descriptor, 0, sizeof row_descriptor);
         error = new_row_descriptor(
-            table,
-            altered_table,
-            ha_alter_info,
-            i,
-            &row_descriptor);
+            altered_table, ha_alter_info, i, &row_descriptor);
         if (error)
             goto cleanup;
         error = share->key_file[i]->change_descriptor(
@@ -891,11 +869,9 @@ int ha_tokudb::alter_table_add_or_drop_column(
 //    transaction.
 // If abort then abort the alter transaction and try to rollback the
 //    non-transactional changes.
-bool ha_tokudb::commit_inplace_alter_table(
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    bool commit) {
-
+bool ha_tokudb::commit_inplace_alter_table(TOKUDB_UNUSED(TABLE* altered_table),
+                                           Alter_inplace_info* ha_alter_info,
+                                           bool commit) {
     TOKUDB_HANDLER_DBUG_ENTER("");
     
     tokudb_alter_ctx* ctx =
@@ -1010,10 +986,8 @@ bool ha_tokudb::commit_inplace_alter_table(
                     &index_drop_offsets[i]);
                 assert_always(found);
             }
-            restore_drop_indexes(
-                table,
-                index_drop_offsets,
-                ha_alter_info->index_drop_count);
+            restore_drop_indexes(index_drop_offsets,
+                                 ha_alter_info->index_drop_count);
         }
         if (ctx->compression_changed) {
             uint32_t curr_num_DBs =
@@ -1060,11 +1034,7 @@ int ha_tokudb::alter_table_expand_varchar_offsets(
         // change to a new descriptor
         DBT row_descriptor; memset(&row_descriptor, 0, sizeof row_descriptor);
         error = new_row_descriptor(
-            table,
-            altered_table,
-            ha_alter_info,
-            i,
-            &row_descriptor);
+            altered_table, ha_alter_info, i, &row_descriptor);
         if (error)
             break;
         error = share->key_file[i]->change_descriptor(
@@ -1142,14 +1112,9 @@ static bool field_in_key_of_table(TABLE *table, Field *field) {
 
 // Return true if all changed varchar/varbinary field lengths can be changed
 // inplace, otherwise return false
-static bool change_varchar_length_is_supported(
-    Field* old_field,
-    Field* new_field,
-    TABLE* table,
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    tokudb_alter_ctx* ctx) {
-
+static bool change_varchar_length_is_supported(Field* old_field,
+                                               Field* new_field,
+                                               tokudb_alter_ctx* ctx) {
     if (old_field->real_type() != MYSQL_TYPE_VARCHAR || 
         new_field->real_type() != MYSQL_TYPE_VARCHAR || 
         old_field->binary() != new_field->binary() || 
@@ -1168,12 +1133,9 @@ static bool change_varchar_length_is_supported(
 
 // Return true if all changed field lengths can be changed inplace, otherwise
 // return false
-static bool change_length_is_supported(
-    TABLE* table,
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    tokudb_alter_ctx* ctx) {
-
+static bool change_length_is_supported(TABLE* table,
+                                       TABLE* altered_table,
+                                       tokudb_alter_ctx* ctx) {
     if (table->s->fields != altered_table->s->fields)
         return false;
     if (table->s->null_bytes != altered_table->s->null_bytes)
@@ -1193,13 +1155,7 @@ static bool change_length_is_supported(
         if (field_in_key_of_table(table, old_field) ||
             field_in_key_of_table(altered_table, new_field))
             return false; // not in any key
-        if (!change_varchar_length_is_supported(
-                old_field,
-                new_field,
-                table,
-                altered_table,
-                ha_alter_info,
-                ctx))
+        if (!change_varchar_length_is_supported(old_field, new_field, ctx))
             return false;
     }
 
@@ -1307,11 +1263,7 @@ int ha_tokudb::alter_table_expand_one_column(
         // change to a new descriptor
         DBT row_descriptor; memset(&row_descriptor, 0, sizeof row_descriptor);
         error = new_row_descriptor(
-            table,
-            altered_table,
-            ha_alter_info,
-            i,
-            &row_descriptor);
+            altered_table, ha_alter_info, i, &row_descriptor);
         if (error)
             break;
         error = share->key_file[i]->change_descriptor(
@@ -1426,11 +1378,7 @@ int ha_tokudb::alter_table_expand_blobs(
         // change to a new descriptor
         DBT row_descriptor; memset(&row_descriptor, 0, sizeof row_descriptor);
         error = new_row_descriptor(
-            table,
-            altered_table,
-            ha_alter_info,
-            i,
-            &row_descriptor);
+            altered_table, ha_alter_info, i, &row_descriptor);
         if (error)
             break;
         error = share->key_file[i]->change_descriptor(
@@ -1486,13 +1434,9 @@ int ha_tokudb::alter_table_expand_blobs(
 }
 
 // Return true if two fixed length fields can be changed inplace
-static bool change_fixed_length_is_supported(
-    TABLE* table,
-    TABLE* altered_table,
-    Field* old_field,
-    Field* new_field,
-    tokudb_alter_ctx* ctx) {
-
+static bool change_fixed_length_is_supported(Field* old_field,
+                                             Field* new_field,
+                                             tokudb_alter_ctx* ctx) {
     // no change in size is supported
     if (old_field->pack_length() == new_field->pack_length())
         return true;
@@ -1503,13 +1447,9 @@ static bool change_fixed_length_is_supported(
     return true;
 }
 
-static bool change_blob_length_is_supported(
-    TABLE* table,
-    TABLE* altered_table,
-    Field* old_field,
-    Field* new_field,
-    tokudb_alter_ctx* ctx) {
-
+static bool change_blob_length_is_supported(Field* old_field,
+                                            Field* new_field,
+                                            tokudb_alter_ctx* ctx) {
     // blob -> longer or equal length blob
     if (old_field->binary() && new_field->binary() &&
         old_field->pack_length() <= new_field->pack_length()) {
@@ -1541,26 +1481,16 @@ static bool is_int_type(enum_field_types t) {
 }
 
 // Return true if two field types can be changed inplace
-static bool change_field_type_is_supported(
-    Field* old_field,
-    Field* new_field,
-    TABLE* table,
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    tokudb_alter_ctx* ctx) {
-
+static bool change_field_type_is_supported(Field* old_field,
+                                           Field* new_field,
+                                           tokudb_alter_ctx* ctx) {
     enum_field_types old_type = old_field->real_type();
     enum_field_types new_type = new_field->real_type();
     if (is_int_type(old_type)) {
         // int and unsigned int expansion
         if (is_int_type(new_type) &&
             is_unsigned(old_field) == is_unsigned(new_field))
-            return change_fixed_length_is_supported(
-                table,
-                altered_table,
-                old_field,
-                new_field,
-                ctx);
+            return change_fixed_length_is_supported(old_field, new_field, ctx);
         else
             return false;
     } else if (old_type == MYSQL_TYPE_STRING) {
@@ -1568,43 +1498,24 @@ static bool change_field_type_is_supported(
         if (new_type == MYSQL_TYPE_STRING && 
             old_field->binary() == new_field->binary() && 
             old_field->charset()->number == new_field->charset()->number)
-            return change_fixed_length_is_supported(
-                table,
-                altered_table,
-                old_field,
-                new_field,
-                ctx);
+            return change_fixed_length_is_supported(old_field, new_field, ctx);
         else
             return false;
     } else if (old_type == MYSQL_TYPE_VARCHAR) {
         // varchar(X) -> varchar(Y) and varbinary(X) -> varbinary(Y) expansion
         // where X < 256 <= Y the ALTER_COLUMN_TYPE handler flag is set for
         // these cases
-        return change_varchar_length_is_supported(
-            old_field,
-            new_field,
-            table,
-            altered_table,
-            ha_alter_info,
-            ctx);
+        return change_varchar_length_is_supported(old_field, new_field, ctx);
     } else if (old_type == MYSQL_TYPE_BLOB && new_type == MYSQL_TYPE_BLOB) {
-        return change_blob_length_is_supported(
-            table,
-            altered_table,
-            old_field,
-            new_field,
-            ctx);
+        return change_blob_length_is_supported(old_field, new_field, ctx);
     } else
         return false;
 }
 
 // Return true if all changed field types can be changed inplace
-static bool change_type_is_supported(
-    TABLE* table,
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    tokudb_alter_ctx* ctx) {
-
+static bool change_type_is_supported(TABLE* table,
+                                     TABLE* altered_table,
+                                     tokudb_alter_ctx* ctx) {
     if (table->s->null_bytes != altered_table->s->null_bytes)
         return false;
     if (table->s->fields != altered_table->s->fields)
@@ -1620,13 +1531,7 @@ static bool change_type_is_supported(
         if (field_in_key_of_table(table, old_field) ||
             field_in_key_of_table(altered_table, new_field))
             return false;
-        if (!change_field_type_is_supported(
-                old_field,
-                new_field,
-                table,
-                altered_table,
-                ha_alter_info,
-                ctx))
+        if (!change_field_type_is_supported(old_field, new_field, ctx))
             return false;            
     }
     return true;
@@ -1636,13 +1541,10 @@ static bool change_type_is_supported(
 // table identified with idx.
 // Return the new descriptor in the row_descriptor DBT.
 // Return non-zero on error.
-int ha_tokudb::new_row_descriptor(
-    TABLE* table,
-    TABLE* altered_table,
-    Alter_inplace_info* ha_alter_info,
-    uint32_t idx,
-    DBT* row_descriptor) {
-
+int ha_tokudb::new_row_descriptor(TABLE* altered_table,
+                                  Alter_inplace_info* ha_alter_info,
+                                  uint32_t idx,
+                                  DBT* row_descriptor) {
     int error = 0;
     tokudb_alter_ctx* ctx =
         static_cast<tokudb_alter_ctx*>(ha_alter_info->handler_ctx);

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -1865,15 +1865,10 @@ static uint32_t pack_desc_pk_info(uchar* buf, KEY_AND_COL_INFO* kc_info, TABLE_S
     return pos - buf;
 }
 
-static uint32_t pack_desc_pk_offset_info(
-    uchar* buf, 
-    KEY_AND_COL_INFO* kc_info, 
-    TABLE_SHARE* table_share, 
-    KEY_PART_INFO* key_part, 
-    KEY* prim_key,
-    uchar* pk_info
-    ) 
-{
+static uint32_t pack_desc_pk_offset_info(uchar* buf,
+                                         KEY_PART_INFO* key_part,
+                                         KEY* prim_key,
+                                         uchar* pk_info) {
     uchar* pos = buf;
     uint16 field_index = key_part->field->field_index;
     bool found_col_in_pk = false;
@@ -1999,7 +1994,9 @@ static uint32_t pack_desc_key_length_info(uchar* buf, KEY_AND_COL_INFO* kc_info,
     return pos - buf;
 }
 
-static uint32_t pack_desc_char_info(uchar* buf, KEY_AND_COL_INFO* kc_info, TABLE_SHARE* table_share, KEY_PART_INFO* key_part) {
+static uint32_t pack_desc_char_info(uchar* buf,
+                                    TABLE_SHARE* table_share,
+                                    KEY_PART_INFO* key_part) {
     uchar* pos = buf;
     uint16 field_index = key_part->field->field_index;
     Field* field = table_share->field[field_index];
@@ -2561,14 +2558,7 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
             pos += sizeof(uint32_t);
         }
         if (is_col_in_pk) {
-            pos += pack_desc_pk_offset_info(
-                pos,
-                kc_info,
-                table_share,
-                &curr_kpi,
-                prim_key,
-                pk_info
-                );
+            pos += pack_desc_pk_offset_info(pos, &curr_kpi, prim_key, pk_info);
         }
         else {
             pos += pack_desc_offset_info(
@@ -2585,12 +2575,7 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
             table_share,
             &curr_kpi
             );
-        pos += pack_desc_char_info(
-            pos,
-            kc_info,
-            table_share,
-            &curr_kpi
-            );
+        pos += pack_desc_char_info(pos, table_share, &curr_kpi);
     }
 
     offset = pos - buf;

--- a/storage/tokudb/hatoku_cmp.h
+++ b/storage/tokudb/hatoku_cmp.h
@@ -354,11 +354,7 @@ static uint32_t create_toku_clustering_val_pack_descriptor (
     bool is_clustering
     );
 
-static inline bool is_key_clustering(
-    void* row_desc,
-    uint32_t row_desc_size
-    ) 
-{
+static inline bool is_key_clustering(uint32_t row_desc_size) {
     return (row_desc_size > 0);
 }
 
@@ -384,12 +380,8 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
     KEY* prim_key
     );
 
-static inline bool is_key_pk(
-    void* row_desc,
-    uint32_t row_desc_size
-    ) 
-{
-    uchar* buf = (uchar *)row_desc;
+static inline bool is_key_pk(void* row_desc) {
+    uchar* buf = (uchar*)row_desc;
     return buf[0];
 }
 

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -143,7 +143,7 @@ struct tokudb_map_pair {
 static int tokudb_map_pair_cmp(void *custom_arg, const void *a, const void *b) {
 #else
 static int tokudb_map_pair_cmp(
-    const void* custom_arg,
+    TOKUDB_UNUSED(const void* custom_arg),
     const void* a,
     const void* b) {
 #endif
@@ -678,7 +678,7 @@ error:
     DBUG_RETURN(true);
 }
 
-static int tokudb_done_func(void* p) {
+static int tokudb_done_func(TOKUDB_UNUSED(void* p)) {
     TOKUDB_DBUG_ENTER("");
     tokudb::memory::free(toku_global_status_variables);
     toku_global_status_variables = NULL;
@@ -694,7 +694,8 @@ static handler* tokudb_create_handler(
     return new(mem_root) ha_tokudb(hton, table);
 }
 
-int tokudb_end(handlerton* hton, ha_panic_function type) {
+int tokudb_end(TOKUDB_UNUSED(handlerton* hton),
+               TOKUDB_UNUSED(ha_panic_function type)) {
     TOKUDB_DBUG_ENTER("");
     int error = 0;
     
@@ -774,7 +775,7 @@ int tokudb_end(handlerton* hton, ha_panic_function type) {
     TOKUDB_DBUG_RETURN(error);
 }
 
-static int tokudb_close_connection(handlerton* hton, THD* thd) {
+static int tokudb_close_connection(TOKUDB_UNUSED(handlerton* hton), THD* thd) {
     int error = 0;
     tokudb_trx_data* trx = (tokudb_trx_data*)thd_get_ha_data(thd, tokudb_hton);
     if (trx && trx->checkpoint_lock_taken) {
@@ -796,13 +797,13 @@ static int tokudb_close_connection(handlerton* hton, THD* thd) {
     return error;
 }
 
-void tokudb_kill_connection(handlerton *hton, THD *thd) {
+void tokudb_kill_connection(TOKUDB_UNUSED(handlerton* hton), THD* thd) {
     TOKUDB_DBUG_ENTER("");
     db_env->kill_waiter(db_env, thd);
     DBUG_VOID_RETURN;
 }
 
-bool tokudb_flush_logs(handlerton * hton) {
+bool tokudb_flush_logs(TOKUDB_UNUSED(handlerton* hton)) {
     TOKUDB_DBUG_ENTER("");
     int error;
     bool result = 0;
@@ -894,7 +895,7 @@ extern "C" enum durability_properties thd_get_durability_property(
 #endif
 
 // Determine if an fsync is used when a transaction is committed.  
-static bool tokudb_sync_on_commit(THD* thd, tokudb_trx_data* trx, DB_TXN* txn) {
+static bool tokudb_sync_on_commit(THD* thd) {
 #if MYSQL_VERSION_ID >= 50600
     // Check the client durability property which is set during 2PC
     if (thd_get_durability_property(thd) == HA_IGNORE_DURABILITY)
@@ -917,8 +918,7 @@ static int tokudb_commit(handlerton * hton, THD * thd, bool all) {
     DB_TXN **txn = all ? &trx->all : &trx->stmt;
     DB_TXN *this_txn = *txn;
     if (this_txn) {
-        uint32_t syncflag =
-            tokudb_sync_on_commit(thd, trx, this_txn) ? 0 : DB_TXN_NOSYNC;
+        uint32_t syncflag = tokudb_sync_on_commit(thd) ? 0 : DB_TXN_NOSYNC;
         TOKUDB_TRACE_FOR_FLAGS(
             TOKUDB_DEBUG_TXN,
             "commit trx %u txn %p syncflag %u",
@@ -1034,7 +1034,9 @@ static int tokudb_xa_prepare(handlerton* hton, THD* thd, bool all) {
     TOKUDB_DBUG_RETURN(r);
 }
 
-static int tokudb_xa_recover(handlerton* hton, XID* xid_list, uint len) {
+static int tokudb_xa_recover(TOKUDB_UNUSED(handlerton* hton),
+                             XID* xid_list,
+                             uint len) {
     TOKUDB_DBUG_ENTER("");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
     int r = 0;
@@ -1054,7 +1056,7 @@ static int tokudb_xa_recover(handlerton* hton, XID* xid_list, uint len) {
     TOKUDB_DBUG_RETURN((int)num_returned);
 }
 
-static int tokudb_commit_by_xid(handlerton* hton, XID* xid) {
+static int tokudb_commit_by_xid(TOKUDB_UNUSED(handlerton* hton), XID* xid) {
     TOKUDB_DBUG_ENTER("");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "xid %p", xid);
@@ -1074,7 +1076,7 @@ cleanup:
     TOKUDB_DBUG_RETURN(r);
 }
 
-static int tokudb_rollback_by_xid(handlerton* hton, XID*  xid) {
+static int tokudb_rollback_by_xid(TOKUDB_UNUSED(handlerton* hton), XID* xid) {
     TOKUDB_DBUG_ENTER("");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "enter");
     TOKUDB_TRACE_FOR_FLAGS(TOKUDB_DEBUG_XA, "xid %p", xid);
@@ -1254,15 +1256,13 @@ static int tokudb_discover2(
     return tokudb_discover3(hton, thd, db, name, path, frmblob, frmlen);
 }
 
-static int tokudb_discover3(
-    handlerton* hton,
-    THD* thd,
-    const char* db,
-    const char* name,
-    char* path,
-    uchar** frmblob,
-    size_t* frmlen) {
-
+static int tokudb_discover3(TOKUDB_UNUSED(handlerton* hton),
+                            THD* thd,
+                            const char* db,
+                            const char* name,
+                            char* path,
+                            uchar** frmblob,
+                            size_t* frmlen) {
     TOKUDB_DBUG_ENTER("%s %s %s", db, name, path);
     int error;
     DB* status_db = NULL;
@@ -1525,7 +1525,7 @@ cleanup:
 }
 
 static bool tokudb_show_status(
-    handlerton* hton,
+    TOKUDB_UNUSED(handlerton* hton),
     THD* thd,
     stat_print_fn* stat_print,
     enum ha_stat_type stat_type) {
@@ -1552,10 +1552,9 @@ static void tokudb_handle_fatal_signal(
 }
 #endif
 
-static void tokudb_print_error(
-    const DB_ENV* db_env,
-    const char* db_errpfx,
-    const char* buffer) {
+static void tokudb_print_error(TOKUDB_UNUSED(const DB_ENV* db_env),
+                               const char* db_errpfx,
+                               const char* buffer) {
     sql_print_error("%s: %s", db_errpfx, buffer);
 }
 
@@ -1666,7 +1665,6 @@ static bool tokudb_txn_id_to_client_id(
 #endif
 
 static void tokudb_pretty_key(
-    const DB* db,
     const DBT* key,
     const char* default_key,
     String* out) {
@@ -1688,12 +1686,12 @@ static void tokudb_pretty_key(
     }
 }
 
-void tokudb_pretty_left_key(const DB* db, const DBT* key, String* out) {
-    tokudb_pretty_key(db, key, "-infinity", out);
+void tokudb_pretty_left_key(const DBT* key, String* out) {
+    tokudb_pretty_key(key, "-infinity", out);
 }
 
-void tokudb_pretty_right_key(const DB* db, const DBT* key, String* out) {
-    tokudb_pretty_key(db, key, "+infinity", out);
+void tokudb_pretty_right_key(const DBT* key, String* out) {
+    tokudb_pretty_key(key, "+infinity", out);
 }
 
 const char* tokudb_get_index_name(DB* db) {
@@ -1740,20 +1738,20 @@ static void tokudb_lock_timeout_callback(
         log_str.append_ulonglong(blocking_txnid);
         if (tokudb_equal_key(left_key, right_key)) {
             String key_str;
-            tokudb_pretty_key(db, left_key, "?", &key_str);
+            tokudb_pretty_key(left_key, "?", &key_str);
             log_str.append(", \"key\":");
             log_str.append("\"");
             log_str.append(key_str);
             log_str.append("\"");
         } else {
             String left_str;
-            tokudb_pretty_left_key(db, left_key, &left_str);
+            tokudb_pretty_left_key(left_key, &left_str);
             log_str.append(", \"key_left\":");
             log_str.append("\"");
             log_str.append(left_str);
             log_str.append("\"");
             String right_str;
-            tokudb_pretty_right_key(db, right_key, &right_str);
+            tokudb_pretty_right_key(right_key, &right_str);
             log_str.append(", \"key_right\":");
             log_str.append("\"");
             log_str.append(right_str);
@@ -1817,7 +1815,9 @@ static void tokudb_lock_timeout_callback(
 // Retrieves variables for information_schema.global_status.
 // Names (columnname) are automatically converted to upper case,
 // and prefixed with "TOKUDB_"
-static int show_tokudb_vars(THD *thd, SHOW_VAR *var, char *buff) {
+static int show_tokudb_vars(TOKUDB_UNUSED(THD* thd),
+                            SHOW_VAR* var,
+                            TOKUDB_UNUSED(char* buff)) {
     TOKUDB_DBUG_ENTER("");
 
     int error;

--- a/storage/tokudb/hatoku_hton.h
+++ b/storage/tokudb/hatoku_hton.h
@@ -158,7 +158,8 @@ inline toku_compression_method row_type_to_toku_compression_method(
 void tokudb_checkpoint_lock(THD * thd);
 void tokudb_checkpoint_unlock(THD * thd);
 
-inline uint64_t tokudb_get_lock_wait_time_callback(uint64_t default_wait_time) {
+inline uint64_t tokudb_get_lock_wait_time_callback(
+    TOKUDB_UNUSED(uint64_t default_wait_time)) {
     THD *thd = current_thd;
     return tokudb::sysvars::lock_timeout(thd);
 }
@@ -168,7 +169,8 @@ inline uint64_t tokudb_get_loader_memory_size_callback(void) {
     return tokudb::sysvars::loader_memory_size(thd);
 }
 
-inline uint64_t tokudb_get_killed_time_callback(uint64_t default_killed_time) {
+inline uint64_t tokudb_get_killed_time_callback(
+    TOKUDB_UNUSED(uint64_t default_killed_time)) {
     THD *thd = current_thd;
     return tokudb::sysvars::killed_time(thd);
 }
@@ -178,7 +180,8 @@ inline int tokudb_killed_callback(void) {
     return thd_killed(thd);
 }
 
-inline bool tokudb_killed_thd_callback(void *extra, uint64_t deleted_rows) {
+inline bool tokudb_killed_thd_callback(void* extra,
+                                       TOKUDB_UNUSED(uint64_t deleted_rows)) {
     THD *thd = static_cast<THD *>(extra);
     return thd_killed(thd) != 0;
 }
@@ -196,8 +199,8 @@ void tokudb_split_dname(
     String& table_name,
     String& dictionary_name);
 
-void tokudb_pretty_left_key(const DB* db, const DBT* key, String* out);
-void tokudb_pretty_right_key(const DB* db, const DBT* key, String* out);
+void tokudb_pretty_left_key(const DBT* key, String* out);
+void tokudb_pretty_right_key(const DBT* key, String* out);
 const char *tokudb_get_index_name(DB* db);
 
 #endif //#ifdef _HATOKU_HTON

--- a/storage/tokudb/tokudb_information_schema.cc
+++ b/storage/tokudb/tokudb_information_schema.cc
@@ -66,12 +66,10 @@ struct trx_extra_t {
     TABLE *table;
 };
 
-int trx_callback(
-    DB_TXN* txn,
-    iterate_row_locks_callback iterate_locks,
-    void* locks_extra,
-    void *extra) {
-
+int trx_callback(DB_TXN* txn,
+                 TOKUDB_UNUSED(iterate_row_locks_callback iterate_locks),
+                 TOKUDB_UNUSED(void* locks_extra),
+                 void* extra) {
     uint64_t txn_id = txn->id64(txn);
     uint64_t client_id;
     txn->get_client_id(txn, &client_id, NULL);
@@ -90,9 +88,9 @@ int trx_callback(
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int trx_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int trx_fill_table(THD* thd, TABLE_LIST* tables, TOKUDB_UNUSED(Item* cond)) {
 #else
-int trx_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
+int trx_fill_table(THD* thd, TABLE_LIST* tables, TOKUDB_UNUSED(COND* cond)) {
 #endif
     TOKUDB_DBUG_ENTER("");
     int error;
@@ -120,7 +118,7 @@ int trx_init(void* p) {
     return 0;
 }
 
-int trx_done(void* p) {
+int trx_done(TOKUDB_UNUSED(void* p)) {
     return 0;
 }
 
@@ -188,13 +186,13 @@ int lock_waits_callback(
     size_t dname_length = strlen(dname);
     table->field[2]->store(dname, dname_length, system_charset_info);
     String left_str;
-    tokudb_pretty_left_key(db, left_key, &left_str);
+    tokudb_pretty_left_key(left_key, &left_str);
     table->field[3]->store(
         left_str.ptr(),
         left_str.length(),
         system_charset_info);
     String right_str;
-    tokudb_pretty_right_key(db, right_key, &right_str);
+    tokudb_pretty_right_key(right_key, &right_str);
     table->field[4]->store(
         right_str.ptr(),
         right_str.length(),
@@ -225,9 +223,13 @@ int lock_waits_callback(
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int lock_waits_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int lock_waits_fill_table(THD* thd,
+                          TABLE_LIST* tables,
+                          TOKUDB_UNUSED(Item* cond)) {
 #else
-int lock_waits_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
+int lock_waits_fill_table(THD* thd,
+                          TABLE_LIST* tables,
+                          TOKUDB_UNUSED(COND* cond)) {
 #endif
     TOKUDB_DBUG_ENTER("");
     int error;
@@ -258,7 +260,7 @@ int lock_waits_init(void* p) {
     return 0;
 }
 
-int lock_waits_done(void *p) {
+int lock_waits_done(TOKUDB_UNUSED(void *p)) {
     return 0;
 }
 
@@ -331,14 +333,14 @@ int locks_callback(
         table->field[2]->store(dname, dname_length, system_charset_info);
 
         String left_str;
-        tokudb_pretty_left_key(db, &left_key, &left_str);
+        tokudb_pretty_left_key(&left_key, &left_str);
         table->field[3]->store(
             left_str.ptr(),
             left_str.length(),
             system_charset_info);
 
         String right_str;
-        tokudb_pretty_right_key(db, &right_key, &right_str);
+        tokudb_pretty_right_key(&right_key, &right_str);
         table->field[4]->store(
             right_str.ptr(),
             right_str.length(),
@@ -368,9 +370,9 @@ int locks_callback(
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int locks_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int locks_fill_table(THD* thd, TABLE_LIST* tables, TOKUDB_UNUSED(Item* cond)) {
 #else
-int locks_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
+int locks_fill_table(THD* thd, TABLE_LIST* tables, TOKUDB_UNUSED(COND* cond)) {
 #endif
     TOKUDB_DBUG_ENTER("");
     int error;
@@ -398,7 +400,7 @@ int locks_init(void* p) {
     return 0;
 }
 
-int locks_done(void* p) {
+int locks_done(TOKUDB_UNUSED(void* p)) {
     return 0;
 }
 
@@ -511,9 +513,13 @@ cleanup:
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int file_map_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int file_map_fill_table(THD* thd,
+                        TABLE_LIST* tables,
+                        TOKUDB_UNUSED(Item* cond)) {
 #else
-int file_map_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
+int file_map_fill_table(THD* thd,
+                        TABLE_LIST* tables,
+                        TOKUDB_UNUSED(COND* cond)) {
 #endif
     TOKUDB_DBUG_ENTER("");
     int error;
@@ -541,7 +547,7 @@ int file_map_init(void* p) {
     return 0;
 }
 
-int file_map_done(void* p) {
+int file_map_done(TOKUDB_UNUSED(void* p)) {
     return 0;
 }
 
@@ -716,9 +722,13 @@ cleanup:
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int fractal_tree_info_fill_table(THD* thd, TABLE_LIST* tables, Item* cond) {
+int fractal_tree_info_fill_table(THD* thd,
+                                 TABLE_LIST* tables,
+                                 TOKUDB_UNUSED(Item* cond)) {
 #else
-int fractal_tree_info_fill_table(THD* thd, TABLE_LIST* tables, COND* cond) {
+int fractal_tree_info_fill_table(THD* thd,
+                                 TABLE_LIST* tables,
+                                 TOKUDB_UNUSED(COND* cond)) {
 #endif
     TOKUDB_DBUG_ENTER("");
     int error;
@@ -749,7 +759,7 @@ int fractal_tree_info_init(void* p) {
     return 0;
 }
 
-int fractal_tree_info_done(void* p) {
+int fractal_tree_info_done(TOKUDB_UNUSED(void* p)) {
     return 0;
 }
 
@@ -1010,12 +1020,12 @@ cleanup:
 int fractal_tree_block_map_fill_table(
     THD* thd,
     TABLE_LIST* tables,
-    Item* cond) {
+    TOKUDB_UNUSED(Item* cond)) {
 #else
 int fractal_tree_block_map_fill_table(
     THD* thd,
     TABLE_LIST* tables,
-    COND* cond) {
+    TOKUDB_UNUSED(COND* cond)) {
 #endif
     TOKUDB_DBUG_ENTER("");
     int error;
@@ -1046,7 +1056,7 @@ int fractal_tree_block_map_init(void* p) {
     return 0;
 }
 
-int fractal_tree_block_map_done(void *p) {
+int fractal_tree_block_map_done(TOKUDB_UNUSED(void *p)) {
     return 0;
 }
 
@@ -1152,9 +1162,9 @@ int report_background_job_status(TABLE *table, THD *thd) {
 }
 
 #if MYSQL_VERSION_ID >= 50600
-int background_job_status_fill_table(THD *thd, TABLE_LIST *tables, Item *cond) {
+int background_job_status_fill_table(THD *thd, TABLE_LIST *tables, TOKUDB_UNUSED(Item *cond)) {
 #else
-int background_job_status_fill_table(THD *thd, TABLE_LIST *tables, COND *cond) {
+int background_job_status_fill_table(THD *thd, TABLE_LIST *tables, TOKUDB_UNUSED(COND *cond)) {
 #endif
     TOKUDB_DBUG_ENTER("");
     int error;
@@ -1182,7 +1192,7 @@ int background_job_status_init(void* p) {
     return 0;
 }
 
-int background_job_status_done(void* p) {
+int background_job_status_done(TOKUDB_UNUSED(void* p)) {
     return 0;
 }
 

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -140,11 +140,10 @@ static MYSQL_SYSVAR_UINT(
     0);
 
 static void checkpointing_period_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
+    TOKUDB_UNUSED(THD* thd),
+    TOKUDB_UNUSED(st_mysql_sys_var* sys_var),
     void* var,
     const void* save) {
-
     uint* cp = (uint*)var;
     *cp = *(const uint*)save;
     int r = db_env->checkpointing_set_period(db_env, *cp);
@@ -163,12 +162,10 @@ static MYSQL_SYSVAR_UINT(
     ~0U,
     0);
 
-static void cleaner_iterations_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
-    void* var,
-    const void* save) {
-
+static void cleaner_iterations_update(TOKUDB_UNUSED(THD* thd),
+                                      TOKUDB_UNUSED(st_mysql_sys_var* sys_var),
+                                      void* var,
+                                      const void* save) {
     ulong* ci = (ulong*)var;
     *ci = *(const ulong*)save;
     int r = db_env->cleaner_set_iterations(db_env, *ci);
@@ -187,12 +184,10 @@ static MYSQL_SYSVAR_ULONG(
     ~0UL,
     0);
 
-static void cleaner_period_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
-    void* var,
-    const void * save) {
-
+static void cleaner_period_update(TOKUDB_UNUSED(THD* thd),
+                                  TOKUDB_UNUSED(st_mysql_sys_var* sys_var),
+                                  void* var,
+                                  const void* save) {
     ulong* cp = (ulong*)var;
     *cp = *(const ulong*)save;
     int r = db_env->cleaner_set_period(db_env, *cp);
@@ -273,11 +268,10 @@ static MYSQL_SYSVAR_BOOL(
     FALSE);
 
 static void enable_partial_eviction_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
+    TOKUDB_UNUSED(THD* thd),
+    TOKUDB_UNUSED(st_mysql_sys_var* sys_var),
     void* var,
     const void* save) {
-
     my_bool* epe = (my_bool*)var;
     *epe = *(const my_bool*)save;
     int r = db_env->evictor_set_enable_partial_eviction(db_env, *epe);
@@ -305,12 +299,10 @@ static MYSQL_SYSVAR_INT(
     100,
     0);
 
-static void fsync_log_period_update(
-    THD* thd,
-    st_mysql_sys_var* sys_var,
-    void* var,
-    const void* save) {
-
+static void fsync_log_period_update(TOKUDB_UNUSED(THD* thd),
+                                    TOKUDB_UNUSED(st_mysql_sys_var* sys_var),
+                                    void* var,
+                                    const void* save) {
     uint* flp = (uint*)var;
     *flp = *(const uint*)save;
     db_env->change_fsync_log_period(db_env, *flp);
@@ -400,9 +392,11 @@ static MYSQL_SYSVAR_UINT(
     ~0U,
     0);
 
-static void tokudb_dir_per_db_update(THD* thd,
-                                     struct st_mysql_sys_var* sys_var,
-                                     void* var, const void* save) {
+static void tokudb_dir_per_db_update(
+    TOKUDB_UNUSED(THD* thd),
+    TOKUDB_UNUSED(struct st_mysql_sys_var* sys_var),
+    void* var,
+    const void* save) {
     my_bool *value = (my_bool *) var;
     *value = *(const my_bool *) save;
     db_env->set_dir_per_db(db_env, *value);
@@ -550,12 +544,10 @@ static MYSQL_THDVAR_BOOL(
     NULL,
     true);
 
-static void checkpoint_lock_update(
-    THD* thd,
-    st_mysql_sys_var* var,
-    void* var_ptr,
-    const void* save) {
-
+static void checkpoint_lock_update(TOKUDB_UNUSED(THD* thd),
+                                   TOKUDB_UNUSED(st_mysql_sys_var* var),
+                                   void* var_ptr,
+                                   const void* save) {
     my_bool* val = (my_bool*)var_ptr;
     *val= *(my_bool*)save ? true : false;
     if (*val) {
@@ -959,8 +951,10 @@ static void dir_cmd_set_error(THD *thd,
     THDVAR_SET(thd, dir_cmd_last_error_string, buff);
 }
 
-static int dir_cmd_check(THD* thd, struct st_mysql_sys_var* var,
-                         void* save, struct st_mysql_value* value) {
+static int dir_cmd_check(THD* thd,
+                         TOKUDB_UNUSED(struct st_mysql_sys_var* var),
+                         void* save,
+                         struct st_mysql_value* value) {
     int error = 0;
     dir_cmd_set_error(thd, error, "");
 

--- a/storage/tokudb/tokudb_update_fun.cc
+++ b/storage/tokudb/tokudb_update_fun.cc
@@ -343,14 +343,11 @@ static inline uint32_t copy_toku_blob(
     return (length + len_bytes);
 }
 
-static int tokudb_hcad_update_fun(
-    DB* db,
-    const DBT* key,
-    const DBT* old_val,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_hcad_update_fun(const DBT* old_val,
+                                  const DBT* extra,
+                                  void (*set_val)(const DBT* new_val,
+                                                  void* set_extra),
+                                  void* set_extra) {
     uint32_t max_num_bytes;
     uint32_t num_columns;
     DBT new_val;
@@ -761,14 +758,11 @@ cleanup:
 
 // Expand the variable offset array in the old row given the update mesage
 // in the extra.
-static int tokudb_expand_variable_offsets(
-    DB* db,
-    const DBT* key,
-    const DBT* old_val,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_expand_variable_offsets(const DBT* old_val,
+                                          const DBT* extra,
+                                          void (*set_val)(const DBT* new_val,
+                                                          void* set_extra),
+                                          void* set_extra) {
     int error = 0;
     tokudb::buffer extra_val(extra->data, 0, extra->size);
 
@@ -840,14 +834,11 @@ cleanup:
 }
 
 // Expand an int field in a old row given the expand message in the extra.
-static int tokudb_expand_int_field(
-    DB* db,
-    const DBT* key,
-    const DBT* old_val,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_expand_int_field(const DBT* old_val,
+                                   const DBT* extra,
+                                   void (*set_val)(const DBT* new_val,
+                                                   void* set_extra),
+                                   void* set_extra) {
     int error = 0;
     tokudb::buffer extra_val(extra->data, 0, extra->size);
 
@@ -937,14 +928,11 @@ cleanup:
 }
 
 // Expand a char field in a old row given the expand message in the extra.
-static int tokudb_expand_char_field(
-    DB* db,
-    const DBT* key,
-    const DBT* old_val,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_expand_char_field(const DBT* old_val,
+                                    const DBT* extra,
+                                    void (*set_val)(const DBT* new_val,
+                                                    void* set_extra),
+                                    void* set_extra) {
     int error = 0;
     tokudb::buffer extra_val(extra->data, 0, extra->size);
 
@@ -1497,14 +1485,11 @@ static uint8_t *consume_uint8_array(tokudb::buffer &b, uint32_t array_size) {
     return p;
 }
 
-static int tokudb_expand_blobs(
-    DB* db,
-    const DBT* key_dbt,
-    const DBT* old_val_dbt,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val_dbt, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_expand_blobs(const DBT* old_val_dbt,
+                               const DBT* extra,
+                               void (*set_val)(const DBT* new_val_dbt,
+                                               void* set_extra),
+                               void* set_extra) {
     tokudb::buffer extra_val(extra->data, 0, extra->size);
     
     uint8_t operation;
@@ -1549,12 +1534,9 @@ static int tokudb_expand_blobs(
 
 // Decode and apply a sequence of update operations defined in the extra to
 // the old value and put the result in the new value.
-static void apply_1_updates(
-    tokudb::value_map& vd,
-    tokudb::buffer& new_val,
-    tokudb::buffer& old_val,
-    tokudb::buffer& extra_val) {
-
+static void apply_1_updates(tokudb::value_map& vd,
+                            tokudb::buffer& old_val,
+                            tokudb::buffer& extra_val) {
     uint32_t num_updates;
     extra_val.consume(&num_updates, sizeof num_updates);
     for ( ; num_updates > 0; num_updates--) {
@@ -1628,14 +1610,11 @@ static void apply_1_updates(
 
 // Simple update handler. Decode the update message, apply the update operations
 // to the old value, and set the new value.
-static int tokudb_update_1_fun(
-    DB* db,
-    const DBT* key_dbt,
-    const DBT* old_val_dbt,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val_dbt, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_update_1_fun(const DBT* old_val_dbt,
+                               const DBT* extra,
+                               void (*set_val)(const DBT* new_val_dbt,
+                                               void* set_extra),
+                               void* set_extra) {
     tokudb::buffer extra_val(extra->data, 0, extra->size);
     
     uint8_t operation;
@@ -1669,7 +1648,7 @@ static int tokudb_update_1_fun(
             m_bytes_per_offset);
 
         // apply updates to new val
-        apply_1_updates(vd, new_val, old_val, extra_val);
+        apply_1_updates(vd, old_val, extra_val);
 
         // set the new val
         DBT new_val_dbt; memset(&new_val_dbt, 0, sizeof new_val_dbt);
@@ -1685,14 +1664,11 @@ static int tokudb_update_1_fun(
 // then insert a new value from the extra.
 // Otherwise, apply the update operations to the old value, and then set the
 // new value.
-static int tokudb_upsert_1_fun(
-    DB* db,
-    const DBT* key_dbt,
-    const DBT* old_val_dbt,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val_dbt, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_upsert_1_fun(const DBT* old_val_dbt,
+                               const DBT* extra,
+                               void (*set_val)(const DBT* new_val_dbt,
+                                               void* set_extra),
+                               void* set_extra) {
     tokudb::buffer extra_val(extra->data, 0, extra->size);
 
     uint8_t operation;
@@ -1736,7 +1712,7 @@ static int tokudb_upsert_1_fun(
             m_bytes_per_offset);
 
         // apply updates to new val
-        apply_1_updates(vd, new_val, old_val, extra_val);
+        apply_1_updates(vd, old_val, extra_val);
 
         // set the new val
         DBT new_val_dbt; memset(&new_val_dbt, 0, sizeof new_val_dbt);
@@ -1750,12 +1726,9 @@ static int tokudb_upsert_1_fun(
 
 // Decode and apply a sequence of update operations defined in the extra to the
 // old value and put the result in the new value.
-static void apply_2_updates(
-    tokudb::value_map& vd,
-    tokudb::buffer& new_val,
-    tokudb::buffer& old_val,
-    tokudb::buffer& extra_val) {
-
+static void apply_2_updates(tokudb::value_map& vd,
+                            tokudb::buffer& old_val,
+                            tokudb::buffer& extra_val) {
     uint32_t num_updates = consume_uint32(extra_val);
     for (uint32_t i = 0; i < num_updates; i++) {
         uint32_t update_operation = consume_uint32(extra_val);
@@ -1856,14 +1829,11 @@ static void apply_2_updates(
 
 // Simple update handler. Decode the update message, apply the update
 // operations to the old value, and set the new value.
-static int tokudb_update_2_fun(
-    DB* db,
-    const DBT* key_dbt,
-    const DBT* old_val_dbt,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val_dbt, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_update_2_fun(const DBT* old_val_dbt,
+                               const DBT* extra,
+                               void (*set_val)(const DBT* new_val_dbt,
+                                               void* set_extra),
+                               void* set_extra) {
     tokudb::buffer extra_val(extra->data, 0, extra->size);
     
     uint8_t op;
@@ -1883,7 +1853,7 @@ static int tokudb_update_2_fun(
         tokudb::value_map vd(&new_val);
 
         // apply updates to new val
-        apply_2_updates(vd, new_val, old_val, extra_val);
+        apply_2_updates(vd, old_val, extra_val);
 
         // set the new val
         DBT new_val_dbt; memset(&new_val_dbt, 0, sizeof new_val_dbt);
@@ -1899,14 +1869,11 @@ static int tokudb_update_2_fun(
 // then insert a new value from the extra.
 // Otherwise, apply the update operations to the old value, and then set the
 // new value.
-static int tokudb_upsert_2_fun(
-    DB* db,
-    const DBT* key_dbt,
-    const DBT* old_val_dbt,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val_dbt, void* set_extra),
-    void* set_extra) {
-
+static int tokudb_upsert_2_fun(const DBT* old_val_dbt,
+                               const DBT* extra,
+                               void (*set_val)(const DBT* new_val_dbt,
+                                               void* set_extra),
+                               void* set_extra) {
     tokudb::buffer extra_val(extra->data, 0, extra->size);
 
     uint8_t op;
@@ -1937,7 +1904,7 @@ static int tokudb_upsert_2_fun(
         tokudb::value_map vd(&new_val);
 
         // apply updates to new val
-        apply_2_updates(vd, new_val, old_val, extra_val);
+        apply_2_updates(vd, old_val, extra_val);
 
         // set the new val
         DBT new_val_dbt; memset(&new_val_dbt, 0, sizeof new_val_dbt);
@@ -1952,101 +1919,46 @@ static int tokudb_upsert_2_fun(
 // This function is the update callback function that is registered with the
 // YDB environment. It uses the first byte in the update message to identify
 // the update message type and call the handler for that message.
-int tokudb_update_fun(
-    DB* db,
-    const DBT* key,
-    const DBT* old_val,
-    const DBT* extra,
-    void (*set_val)(const DBT* new_val, void* set_extra),
-    void* set_extra) {
-
+int tokudb_update_fun(TOKUDB_UNUSED(DB* db),
+                      TOKUDB_UNUSED(const DBT* key),
+                      const DBT* old_val,
+                      const DBT* extra,
+                      void (*set_val)(const DBT* new_val, void* set_extra),
+                      void* set_extra) {
     assert_always(extra->size > 0);
     uint8_t* extra_pos = (uchar*)extra->data;
     uint8_t operation = extra_pos[0];
     int error;
     switch (operation) {
     case UPDATE_OP_COL_ADD_OR_DROP:
-        error = tokudb_hcad_update_fun(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_hcad_update_fun(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_EXPAND_VARIABLE_OFFSETS:
-        error = tokudb_expand_variable_offsets(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error =
+            tokudb_expand_variable_offsets(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_EXPAND_INT:
     case UPDATE_OP_EXPAND_UINT:
-        error = tokudb_expand_int_field(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_expand_int_field(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_EXPAND_CHAR:
     case UPDATE_OP_EXPAND_BINARY:
-        error = tokudb_expand_char_field(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_expand_char_field(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_EXPAND_BLOB:
-        error = tokudb_expand_blobs(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_expand_blobs(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_UPDATE_1:
-        error = tokudb_update_1_fun(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_update_1_fun(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_UPSERT_1:
-        error = tokudb_upsert_1_fun(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_upsert_1_fun(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_UPDATE_2:
-        error = tokudb_update_2_fun(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_update_2_fun(old_val, extra, set_val, set_extra);
         break;
     case UPDATE_OP_UPSERT_2:
-        error = tokudb_upsert_2_fun(
-            db,
-            key,
-            old_val,
-            extra,
-            set_val,
-            set_extra);
+        error = tokudb_upsert_2_fun(old_val, extra, set_val, set_extra);
         break;
     default:
         assert_unreachable();


### PR DESCRIPTION
- Many places where API is pre-defined either by FT or by server and parameters
  are unused needed annotation with TOKUDB_UNUSED.
- Many internally used functions had extra, unused parameters added and were
  cleaned up to remove the parameters rather than proliferating TOKUDB_UNUSED.