### PR TITLE
Implement PS-3947 (Refactor IO_CACHE layer to allow custom read/write function)

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -1,4 +1,6 @@
 /* Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+   Copyright (c) 2010, 2017, MariaDB Corporation.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -273,7 +275,7 @@ enum cache_type
 {
   TYPE_NOT_SET= 0, READ_CACHE, WRITE_CACHE,
   SEQ_READ_APPEND		/* sequential read or append */,
-  READ_FIFO, READ_NET,WRITE_NET};
+  READ_FIFO, READ_NET};
 
 enum flush_type
 {
@@ -487,46 +489,101 @@ typedef void (*my_error_reporter)(enum loglevel level, const char *format, ...)
 
 extern my_error_reporter my_charset_error_reporter;
 
-/* defines for mf_iocache */
 extern PSI_file_key key_file_io_cache;
 
+MY_NODISCARD
+extern int _my_b_get(IO_CACHE *info);
+MY_NODISCARD
+extern int _my_b_read(IO_CACHE *info, uchar *Buffer, size_t Count);
+MY_NODISCARD
+extern int _my_b_write(IO_CACHE *info, const uchar *Buffer, size_t Count);
+
+/* inline functions for mf_iocache */
+static inline void my_b_clear(IO_CACHE *info)
+{ 
+  info->buffer= 0;
+}
+
 /* Test if buffer is inited */
-#define my_b_clear(info) (info)->buffer=0
-#define my_b_inited(info) (info)->buffer
+MY_NODISCARD
+static inline int my_b_inited(const IO_CACHE *info)
+{
+  return MY_TEST(info->buffer);
+}
 #define my_b_EOF INT_MIN
 
-#define my_b_read(info,Buffer,Count) \
-  ((info)->read_pos + (Count) <= (info)->read_end ?\
-   (memcpy(Buffer,(info)->read_pos,(size_t) (Count)), \
-    ((info)->read_pos+=(Count)),0) :\
-   (*(info)->read_function)((info),Buffer,Count))
+MY_NODISCARD
+static inline int my_b_read(IO_CACHE *info, uchar *Buffer, size_t Count)
+{
+  if (info->read_pos + Count <= info->read_end)
+  {
+    memcpy(Buffer, info->read_pos, Count);
+    info->read_pos+= Count;
+    return 0;
+  }
+  return _my_b_read(info, Buffer, Count);
+}
 
-#define my_b_write(info,Buffer,Count) \
- ((info)->write_pos + (Count) <=(info)->write_end ?\
-  (memcpy((info)->write_pos, (Buffer), (size_t)(Count)),\
-   ((info)->write_pos+=(Count)),0) : \
-   (*(info)->write_function)((info),(uchar *)(Buffer),(Count)))
+MY_NODISCARD
+static inline int my_b_write(IO_CACHE *info, const uchar *Buffer,
+                             size_t Count)
+{
+  if (info->write_pos + Count <= info->write_end)
+  {
+    memcpy(info->write_pos, Buffer, Count);
+    info->write_pos+= Count;
+    return 0;
+  }
+  return _my_b_write(info, Buffer, Count);
+}
 
-#define my_b_get(info) \
-  ((info)->read_pos != (info)->read_end ?\
-   ((info)->read_pos++, (int) (uchar) (info)->read_pos[-1]) :\
-   _my_b_get(info))
+MY_NODISCARD
+static inline int my_b_get(IO_CACHE *info)
+{
+  if (info->read_pos != info->read_end)
+  {
+    info->read_pos++;
+    return info->read_pos[-1];
+  }
+  return _my_b_get(info);
+}
 
-#define my_b_tell(info) ((info)->pos_in_file + \
-			 (size_t) (*(info)->current_pos - (info)->request_pos))
+MY_NODISCARD
+static inline my_off_t my_b_tell(const IO_CACHE *info)
+{
+  return info->pos_in_file + (*info->current_pos - info->request_pos);
+}
 
-#define my_b_get_buffer_start(info) (info)->request_pos 
-#define my_b_get_bytes_in_buffer(info) (char*) (info)->read_end -   \
-  (char*) my_b_get_buffer_start(info)
-#define my_b_get_pos_in_file(info) (info)->pos_in_file
+MY_NODISCARD
+static inline uchar* my_b_get_buffer_start(const IO_CACHE *info)
+{
+  return info->request_pos;
+}
+
+MY_NODISCARD
+static inline size_t my_b_get_bytes_in_buffer(const IO_CACHE *info)
+{
+  return info->read_end - info->request_pos;
+}
+
+MY_NODISCARD
+static inline my_off_t my_b_get_pos_in_file(const IO_CACHE *info)
+{
+  return info->pos_in_file;
+}
+
+MY_NODISCARD
+static inline size_t my_b_bytes_in_cache(const IO_CACHE *info)
+{
+  return *info->current_end - *info->current_pos;
+}
 
 /* tell write offset in the SEQ_APPEND cache */
 int      my_b_copy_to_file(IO_CACHE *cache, FILE *file);
 my_off_t my_b_append_tell(IO_CACHE* info);
 my_off_t my_b_safe_tell(IO_CACHE* info); /* picks the correct tell() */
-
-#define my_b_bytes_in_cache(info) (size_t) (*(info)->current_end - \
-					  *(info)->current_pos)
+MY_NODISCARD
+int my_b_pread(IO_CACHE *info, uchar *Buffer, size_t Count, my_off_t pos);
 
 typedef uint32 ha_checksum;
 
@@ -723,26 +780,24 @@ extern void my_qsort2(void *base_ptr, size_t total_elems, size_t size,
                       qsort2_cmp cmp, const void *cmp_argument);
 void my_store_ptr(uchar *buff, size_t pack_length, my_off_t pos);
 my_off_t my_get_ptr(uchar *ptr, size_t pack_length);
+MY_NODISCARD
 extern int init_io_cache_ext(IO_CACHE *info,File file,size_t cachesize,
                              enum cache_type type,my_off_t seek_offset,
-                             pbool use_async_io, myf cache_myflags,
+                             my_bool use_async_io, myf cache_myflags,
                              PSI_file_key file_key);
+MY_NODISCARD
 extern int init_io_cache(IO_CACHE *info,File file,size_t cachesize,
                          enum cache_type type,my_off_t seek_offset,
-                         pbool use_async_io, myf cache_myflags);
+                         my_bool use_async_io, myf cache_myflags);
+MY_NODISCARD
 extern my_bool reinit_io_cache(IO_CACHE *info,enum cache_type type,
-                               my_off_t seek_offset,pbool use_async_io,
-                               pbool clear_cache);
+                               my_off_t seek_offset, my_bool use_async_io,
+                               my_bool clear_cache);
 extern void setup_io_cache(IO_CACHE* info);
-extern int _my_b_read(IO_CACHE *info,uchar *Buffer,size_t Count);
-extern int _my_b_read_r(IO_CACHE *info,uchar *Buffer,size_t Count);
 extern void init_io_cache_share(IO_CACHE *read_cache, IO_CACHE_SHARE *cshare,
                                 IO_CACHE *write_cache, uint num_threads);
 extern void remove_io_thread(IO_CACHE *info);
-extern int _my_b_seq_read(IO_CACHE *info,uchar *Buffer,size_t Count);
 extern int _my_b_net_read(IO_CACHE *info,uchar *Buffer,size_t Count);
-extern int _my_b_get(IO_CACHE *info);
-extern int _my_b_write(IO_CACHE *info,const uchar *Buffer,size_t Count);
 extern int my_b_append(IO_CACHE *info,const uchar *Buffer,size_t Count);
 extern int my_b_safe_write(IO_CACHE *info,const uchar *Buffer,size_t Count);
 

--- a/mysys/mf_iocache2.c
+++ b/mysys/mf_iocache2.c
@@ -1,4 +1,6 @@
 /* Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+   Copyright (c) 2010, 2017, MariaDB
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -236,6 +238,13 @@ size_t my_b_fill(IO_CACHE *info)
   return length;
 }
 
+int my_b_pread(IO_CACHE *info, uchar *Buffer, size_t Count, my_off_t pos)
+{
+  if (mysql_file_pread(info->file, Buffer, Count, pos,
+                       info->myflags | MY_NABP))
+    return info->error= -1;
+  return 0;
+}
 
 /*
   Read a string ended by '\n' into a buffer of 'max_length' size.
@@ -460,7 +469,7 @@ process_flags:
           memset(buffz, '0', minimum_width - length2);
         else
           memset(buffz, ' ', minimum_width - length2);
-        if (my_b_write(info, buffz, minimum_width - length2))
+        if (my_b_write(info, (uchar*)buffz, minimum_width - length2))
         {
           goto err;
         }

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -491,7 +491,11 @@ public:
     my_off_t oldpos= get_byte_position();
 
     if (use_reinit)
-      reinit_io_cache(&cache_log, WRITE_CACHE, pos, 0, 0);
+    {
+      MY_ATTRIBUTE((unused)) int reinit_res=
+        reinit_io_cache(&cache_log, WRITE_CACHE, pos, 0, 0);
+      DBUG_ASSERT(reinit_res == 0);
+    }
     else
       my_b_seek(&cache_log, pos);
 
@@ -602,7 +606,9 @@ protected:
   {
     DBUG_PRINT("info", ("truncating to position %lu", (ulong) pos));
     remove_pending_event();
-    reinit_io_cache(&cache_log, WRITE_CACHE, pos, 0, 0);
+    MY_ATTRIBUTE((unused)) int reinit_res=
+      reinit_io_cache(&cache_log, WRITE_CACHE, pos, 0, 0);
+    DBUG_ASSERT(reinit_res == 0);
     cache_log.end_of_file= saved_max_binlog_cache_size;
   }
 

--- a/sql/filesort.cc
+++ b/sql/filesort.cc
@@ -1,5 +1,7 @@
 /*
    Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+   Copyright (c) 2009, 2015, MariaDB
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1160,7 +1162,8 @@ write_keys(Sort_param *param, Filesort_info *fs_info, uint count,
       DBUG_RETURN(1);                           /* purecov: inspected */
   }
 
-  if (my_b_write(chunk_file, &merge_chunk, sizeof(merge_chunk)))
+  if (my_b_write(chunk_file, reinterpret_cast<uchar*>(&merge_chunk),
+                 sizeof(merge_chunk)))
     DBUG_RETURN(1);                             /* purecov: inspected */
 
   DBUG_RETURN(0);
@@ -1941,10 +1944,8 @@ uint read_to_buffer(IO_CACHE *fromfile,
                         merge_chunk,
                         static_cast<ulonglong>(merge_chunk->file_position()),
                         static_cast<ulonglong>(bytes_to_read)));
-    if (mysql_file_pread(fromfile->file,
-                         merge_chunk->buffer_start(),
-                         bytes_to_read,
-                         merge_chunk->file_position(), MYF_RW))
+    if (my_b_pread(fromfile, merge_chunk->buffer_start(), bytes_to_read,
+                   merge_chunk->file_position()))
       DBUG_RETURN((uint) -1);			/* purecov: inspected */
 
     size_t num_bytes_read;

--- a/sql/records.cc
+++ b/sql/records.cc
@@ -245,7 +245,8 @@ bool init_read_record(READ_RECORD *info,THD *thd,
     }
 
     info->io_cache=tempfile;
-    reinit_io_cache(info->io_cache,READ_CACHE,0L,0,0);
+    if (reinit_io_cache(info->io_cache, READ_CACHE, 0L, 0, 0))
+      goto err;
     info->ref_pos=table->file->ref;
     if (!table->file->inited &&
         (error= table->file->ha_rnd_init(0)))

--- a/sql/rpl_info_file.cc
+++ b/sql/rpl_info_file.cc
@@ -109,7 +109,14 @@ file '%s')", info_fname);
   else if (ret_check == REPOSITORY_EXISTS)
   {
     if (info_fd >= 0)
-      reinit_io_cache(&info_file, READ_CACHE, 0L,0,0);
+    {
+      if (reinit_io_cache(&info_file, READ_CACHE, 0L, 0, 0))
+      {
+        sql_print_error("Failed to recreate a cache on info file (\
+file '%s')", info_fname);
+        error= 1;
+      }
+    }  
     else
     {
       if ((info_fd = my_open(info_fname, O_RDWR|O_BINARY, MYF(MY_WME))) < 0 )
@@ -125,12 +132,12 @@ file '%s', errno %d)", info_fname, my_errno());
 file '%s')", info_fname);
         error= 1;
       }
-      if (error)
-      {
-        if (info_fd >= 0)
-          my_close(info_fd, MYF(0));
-        info_fd= -1;
-      }
+    }
+    if (error)
+    {
+      if (info_fd >= 0)
+        my_close(info_fd, MYF(0));
+      info_fd= -1;
     }
   }
   else

--- a/sql/rpl_master.cc
+++ b/sql/rpl_master.cc
@@ -723,7 +723,8 @@ bool show_binlogs(THD* thd)
   
   cur_dir_len= dirname_length(cur.log_file_name);
 
-  reinit_io_cache(index_file, READ_CACHE, (my_off_t) 0, 0, 0);
+  if (reinit_io_cache(index_file, READ_CACHE, (my_off_t)0, 0, 0))
+    goto err;
 
   /* The file ends with EOF or empty line */
   while ((length=my_b_gets(index_file, fname, sizeof(fname))) > 1)

--- a/sql/uniques.cc
+++ b/sql/uniques.cc
@@ -1,4 +1,6 @@
 /* Copyright (c) 2001, 2016, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+   Copyright (c) 2010, 2015, MariaDB
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -391,7 +393,9 @@ Unique::reset()
   if (elements)
   {
     file_ptrs.clear();
-    reinit_io_cache(&file, WRITE_CACHE, 0L, 0, 1);
+    MY_ATTRIBUTE((unused)) int reinit_res=
+      reinit_io_cache(&file, WRITE_CACHE, 0L, 0, 1);
+    DBUG_ASSERT(reinit_res == 0);
   }
   elements= 0;
 }
@@ -680,7 +684,6 @@ bool Unique::get(TABLE *table)
       open_cached_file(outfile,mysql_tmpdir,TEMP_PREFIX,READ_RECORD_BUFFER,
 		       MYF(MY_WME))))
     return 1;
-  reinit_io_cache(outfile,WRITE_CACHE,0L,0,0);
 
   Sort_param sort_param;
   sort_param.max_rows= elements;

--- a/storage/myisam/mi_cache.c
+++ b/storage/myisam/mi_cache.c
@@ -1,4 +1,6 @@
 /* Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+   Copyright (c) 2009, 2016, MariaDB
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -81,7 +83,7 @@ int _mi_read_cache(IO_CACHE *info, uchar *buff, my_off_t pos, uint length,
     }
     else
       info->read_pos=info->read_end;			/* All block used */
-    if (!(*info->read_function)(info,buff,length))
+    if (!_my_b_read(info, buff, length))
       DBUG_RETURN(0);
     read_length=info->error;
   }

--- a/storage/myisam/mi_check.c
+++ b/storage/myisam/mi_check.c
@@ -1,5 +1,7 @@
 /*
    Copyright (c) 2000, 2016, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+   Copyright (c) 2009, 2016, MariaDB
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -1561,11 +1563,6 @@ int mi_repair(MI_CHECK *param, MI_INFO *info,
     memset(&info->rec_cache, 0, sizeof(info->rec_cache));
     goto err;
   }
-  if (!rep_quick)
-    if (init_io_cache(&info->rec_cache,-1,(uint) param->write_buffer_length,
-		      WRITE_CACHE, new_header_length, 1,
-		      MYF(MY_WME | MY_WAIT_IF_FULL)))
-      goto err;
   info->opt_flag|=WRITE_CACHE_USED;
   if (!mi_alloc_rec_buff(info, -1, &sort_param.record) ||
       !mi_alloc_rec_buff(info, -1, &sort_param.rec_buff))
@@ -1593,12 +1590,16 @@ int mi_repair(MI_CHECK *param, MI_INFO *info,
 		 "datafile-header"))
       goto err;
     info->s->state.dellink= HA_OFFSET_ERROR;
-    info->rec_cache.file=new_file;
     if (param->testflag & T_UNPACK)
     {
       share->options&= ~HA_OPTION_COMPRESS_RECORD;
       mi_int2store(share->state.header.options,share->options);
     }
+    if (init_io_cache(&info->rec_cache, new_file,
+                      (uint)param->write_buffer_length,
+                      WRITE_CACHE, new_header_length, 1,
+                      MYF(MY_WME | MY_WAIT_IF_FULL)))
+      goto err;
   }
   sort_info.info=info;
   sort_info.param = param;
@@ -2268,21 +2269,18 @@ int mi_repair_by_sort(MI_CHECK *param, MI_INFO *info,
   memset(&sort_info, 0, sizeof(sort_info));
   memset(&sort_param, 0, sizeof(sort_param));
   if (!(sort_info.key_block=
-	alloc_key_blocks(param,
-			 (uint) param->sort_key_blocks,
-			 share->base.max_key_block_length))
-      || init_io_cache(&param->read_cache,info->dfile,
-		       (uint) param->read_buffer_length,
-		       READ_CACHE,share->pack.header_length,1,MYF(MY_WME)) ||
-      (! rep_quick &&
-       init_io_cache(&info->rec_cache,info->dfile,
-		     (uint) param->write_buffer_length,
-		     WRITE_CACHE,new_header_length,1,
-		     MYF(MY_WME | MY_WAIT_IF_FULL) & param->myf_rw)))
+          alloc_key_blocks(param,
+                           (uint) param->sort_key_blocks,
+                           share->base.max_key_block_length)))
     goto err;
+
+  if (init_io_cache(&param->read_cache, info->dfile,
+                    (uint)param->read_buffer_length,
+                    READ_CACHE, share->pack.header_length, 1, MYF(MY_WME)))
+    goto err;
+
   sort_info.key_block_end=sort_info.key_block+param->sort_key_blocks;
   info->opt_flag|=WRITE_CACHE_USED;
-  info->rec_cache.file=info->dfile;		/* for sort_delete_record */
 
   if (!mi_alloc_rec_buff(info, -1, &sort_param.record) ||
       !mi_alloc_rec_buff(info, -1, &sort_param.rec_buff))
@@ -2314,7 +2312,11 @@ int mi_repair_by_sort(MI_CHECK *param, MI_INFO *info,
       mi_int2store(share->state.header.options,share->options);
     }
     share->state.dellink= HA_OFFSET_ERROR;
-    info->rec_cache.file=new_file;
+    if (init_io_cache(&info->rec_cache, new_file,
+                      (uint)param->write_buffer_length,
+                      WRITE_CACHE, new_header_length, 1,
+                      MYF((param->myf_rw & MY_WAIT_IF_FULL) | MY_WME)))
+      goto err;
   }
 
   info->update= (short) (HA_STATE_CHANGED | HA_STATE_ROW_CHANGED);
@@ -2496,8 +2498,9 @@ int mi_repair_by_sort(MI_CHECK *param, MI_INFO *info,
       info->state->data_file_length=sort_param.max_pos;
 
     param->read_cache.file=info->dfile;		/* re-init read cache */
-    reinit_io_cache(&param->read_cache,READ_CACHE,share->pack.header_length,
-                    1,1);
+    if (reinit_io_cache(&param->read_cache, READ_CACHE,
+                        share->pack.header_length, 1, 1))
+      goto err;
   }
 
   if (param->testflag & T_WRITE_LOOP)
@@ -2725,24 +2728,17 @@ int mi_repair_parallel(MI_CHECK *param, MI_INFO *info,
   param->need_print_msg_lock= 1;
 
   if (!(sort_info.key_block=
-	alloc_key_blocks(param, (uint) param->sort_key_blocks,
-			 share->base.max_key_block_length)) ||
-      init_io_cache(&param->read_cache, info->dfile,
-                    (uint) param->read_buffer_length,
-                    READ_CACHE, share->pack.header_length, 1, MYF(MY_WME)) ||
-      (!rep_quick &&
-       (init_io_cache(&info->rec_cache, info->dfile,
-                      (uint) param->write_buffer_length,
-                      WRITE_CACHE, new_header_length, 1,
-                      MYF(MY_WME | MY_WAIT_IF_FULL) & param->myf_rw) ||
-        init_io_cache(&new_data_cache, -1,
-                      (uint) param->write_buffer_length,
-                      READ_CACHE, new_header_length, 1,
-                      MYF(MY_WME | MY_DONT_CHECK_FILESIZE)))))
+          alloc_key_blocks(param, (uint) param->sort_key_blocks,
+                           share->base.max_key_block_length)))
     goto err;
+
+  if (init_io_cache(&param->read_cache, info->dfile,
+                    (uint)param->read_buffer_length,
+                    READ_CACHE, share->pack.header_length, 1, MYF(MY_WME)))
+    goto err;
+
   sort_info.key_block_end=sort_info.key_block+param->sort_key_blocks;
   info->opt_flag|=WRITE_CACHE_USED;
-  info->rec_cache.file=info->dfile;         /* for sort_delete_record */
 
   if (!rep_quick)
   {
@@ -2768,7 +2764,18 @@ int mi_repair_parallel(MI_CHECK *param, MI_INFO *info,
       mi_int2store(share->state.header.options,share->options);
     }
     share->state.dellink= HA_OFFSET_ERROR;
-    info->rec_cache.file=new_file;
+
+    if (init_io_cache(&info->rec_cache, new_file,
+                      (uint)param->write_buffer_length,
+                      WRITE_CACHE, new_header_length, 1,
+                      MYF(MY_WME | MY_WAIT_IF_FULL) & param->myf_rw))
+      goto err;
+
+    if (init_io_cache(&new_data_cache, -1,
+                      (uint)param->write_buffer_length,
+                      READ_CACHE, new_header_length, 1,
+                      MYF(MY_WME | MY_DONT_CHECK_FILESIZE)))
+      goto err;
   }
 
   info->update= (short) (HA_STATE_CHANGED | HA_STATE_ROW_CHANGED);

--- a/storage/myisam/mi_extra.c
+++ b/storage/myisam/mi_extra.c
@@ -53,10 +53,10 @@ int mi_extra(MI_INFO *info, enum ha_extra_function function, void *extra_arg)
 					/* Next/prev gives first/last */
     if (info->opt_flag & READ_CACHE_USED)
     {
-      reinit_io_cache(&info->rec_cache,READ_CACHE,0,
-		      (pbool) (info->lock_type != F_UNLCK),
-		      (pbool) MY_TEST(info->update & HA_STATE_ROW_CHANGED)
-		      );
+      if ((error= reinit_io_cache(&info->rec_cache,READ_CACHE, 0,
+                    (info->lock_type != F_UNLCK),
+                    MY_TEST(info->update & HA_STATE_ROW_CHANGED))))
+        break;
     }
     info->update= ((info->update & HA_STATE_CHANGED) | HA_STATE_NEXT_FOUND |
 		   HA_STATE_PREV_FOUND);
@@ -114,9 +114,10 @@ int mi_extra(MI_INFO *info, enum ha_extra_function function, void *extra_arg)
   case HA_EXTRA_REINIT_CACHE:
     if (info->opt_flag & READ_CACHE_USED)
     {
-      reinit_io_cache(&info->rec_cache,READ_CACHE,info->nextpos,
-		      (pbool) (info->lock_type != F_UNLCK),
-		      (pbool) MY_TEST(info->update & HA_STATE_ROW_CHANGED));
+      if ((error= reinit_io_cache(&info->rec_cache, READ_CACHE,
+                    info->nextpos, (info->lock_type != F_UNLCK),
+                    MY_TEST(info->update & HA_STATE_ROW_CHANGED))))
+        break;
       info->update&= ~HA_STATE_ROW_CHANGED;
       if (share->concurrent_insert)
 	info->rec_cache.end_of_file=info->state->data_file_length;

--- a/storage/myisam/mi_panic.c
+++ b/storage/myisam/mi_panic.c
@@ -53,8 +53,9 @@ int mi_panic(enum ha_panic_function flag)
       {
 	if (flush_io_cache(&info->rec_cache))
 	  error=my_errno();
-	reinit_io_cache(&info->rec_cache,READ_CACHE,0,
-		       (pbool) (info->lock_type != F_UNLCK),1);
+        if (reinit_io_cache(&info->rec_cache, READ_CACHE, 0,
+              (info->lock_type != F_UNLCK), 1))
+          error= my_errno();
       }
       if (info->lock_type != F_UNLCK && ! info->was_locked)
       {

--- a/storage/myisam/myisamchk.c
+++ b/storage/myisam/myisamchk.c
@@ -1098,17 +1098,19 @@ static int myisamchk(MI_CHECK *param, char * filename)
       if ((!rep_quick && !error) ||
 	  !(param->testflag & (T_FAST | T_FORCE_CREATE)))
       {
+        MY_ATTRIBUTE((unused)) int init_res;
 	if (param->testflag & (T_EXTEND | T_MEDIUM))
 	  (void) init_key_cache(dflt_key_cache,opt_key_cache_block_size,
                                 (size_t)param->use_buffers, 0, 0);
-	(void) init_io_cache(&param->read_cache,datafile,
-			   (uint) param->read_buffer_length,
-			   READ_CACHE,
-			   (param->start_check_pos ?
-			    param->start_check_pos :
-			    share->pack.header_length),
-			   1,
-			   MYF(MY_WME));
+        init_res= init_io_cache(&param->read_cache, datafile,
+                                (uint) param->read_buffer_length,
+                                READ_CACHE,
+                                (param->start_check_pos ?
+                                 param->start_check_pos :
+                                 share->pack.header_length),
+                                1,
+                                MYF(MY_WME));
+        DBUG_ASSERT(init_res == 0);
 	lock_memory(param);
 	if ((info->s->options & (HA_OPTION_PACK_RECORD |
 				 HA_OPTION_COMPRESS_RECORD)) ||

--- a/storage/myisam/myisamlog.c
+++ b/storage/myisam/myisamlog.c
@@ -338,7 +338,13 @@ static int examine_log(char * file_name, char **table_names)
     }
   }
 
-  init_io_cache(&cache,file,0,READ_CACHE,start_offset,0,MYF(0));
+  if (init_io_cache(&cache, file, 0, READ_CACHE, start_offset, 0, MYF(0)))
+  {
+    if (write_file != NULL)
+      my_fclose(write_file, MYF(MY_WME));
+    my_close(file, MYF(0));
+    DBUG_RETURN(1);
+  }
   memset(com_count, 0, sizeof(com_count));
   init_tree(&tree,0,0,sizeof(file_info),(qsort_cmp2) file_info_compare,1,
             file_info_free, NULL);

--- a/storage/myisam/sort.cc
+++ b/storage/myisam/sort.cc
@@ -1,4 +1,6 @@
 /* Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+   Copyright (c) 2009, 2016, MariaDB
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -801,8 +803,10 @@ static int merge_many_buff(MI_SORT_PARAM *info, uint keys,
   from_file= t_file ; to_file= &t_file2;
   while (*maxbuffer >= MERGEBUFF2)
   {
-    reinit_io_cache(from_file,READ_CACHE,0L,0,0);
-    reinit_io_cache(to_file,WRITE_CACHE,0L,0,0);
+    if (reinit_io_cache(from_file, READ_CACHE, 0L, 0, 0))
+      goto cleanup;
+    if (reinit_io_cache(to_file, WRITE_CACHE, 0L, 0, 0))
+      goto cleanup;
     lastbuff=buffpek;
     for (i=0 ; i <= *maxbuffer-MERGEBUFF*3/2 ; i+=MERGEBUFF)
     {
@@ -853,9 +857,8 @@ static uint read_to_buffer(IO_CACHE *fromfile, BUFFPEK *buffpek,
 
   if ((count=(uint) MY_MIN((ha_rows) buffpek->max_keys,buffpek->count)))
   {
-    if (mysql_file_pread(fromfile->file, (uchar*) buffpek->base,
-                         (length= sort_length*count),
-                         buffpek->file_pos, MYF_RW))
+    if (my_b_pread(fromfile, buffpek->base,
+                   (length= sort_length * count), buffpek->file_pos))
       return((uint) -1);                        /* purecov: inspected */
     buffpek->key=buffpek->base;
     buffpek->file_pos+= length;                 /* New filepos */
@@ -879,12 +882,12 @@ static uint read_to_buffer_varlen(IO_CACHE *fromfile, BUFFPEK *buffpek,
 
     for (idx=1;idx<=count;idx++)
     {
-      if (mysql_file_pread(fromfile->file, (uchar*)&length_of_key,
-                           sizeof(length_of_key), buffpek->file_pos, MYF_RW))
+      if (my_b_pread(fromfile, (uchar*)&length_of_key,
+                     sizeof(length_of_key), buffpek->file_pos))
         return((uint) -1);
       buffpek->file_pos+=sizeof(length_of_key);
-      if (mysql_file_pread(fromfile->file, (uchar*) buffp,
-                           length_of_key, buffpek->file_pos, MYF_RW))
+      if (my_b_pread(fromfile, buffp, length_of_key,
+                     buffpek->file_pos))
         return((uint) -1);
       buffpek->file_pos+=length_of_key;
       buffp = buffp + sort_length;

--- a/unittest/gunit/mysys_my_b_vprintf-t.cc
+++ b/unittest/gunit/mysys_my_b_vprintf-t.cc
@@ -26,7 +26,8 @@ void test1(const char *res, const char *fmt, ...)
   IO_CACHE info;
   va_list args;
   size_t len;
-  init_io_cache(&info, -1, 0, WRITE_CACHE, 0 , 1 , MYF(0));
+  int init_res= init_io_cache(&info, -1, 0, WRITE_CACHE, 0 , 1 , MYF(0));
+  EXPECT_EQ(init_res, 0);
   memset(info.write_buffer, 0, 64);             /* RECORD_CACHE_SIZE is 64K */
   va_start(args, fmt);
   len= my_b_vprintf(&info, fmt, args);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-3947

This is a prerequisite for temporary file encryption.
https://jira.percona.com/browse/PS-3879

Cherry-picked commit MariaDB/server@318c826
"always use my_b_pread() instead of mysql_file_pread()".

Partially cherry-picked commit MariaDB/server@6309a30
"my_b_fill, inline my_b_* functions instead of hairy macros".
'my_b_fill()' function left as is.

Cherry-picked commit MariaDB/server@196e852
"misc IO_CACHE cleanups"

Cherry-picked commit MariaDB/server@1d21b22
"MDEV-10001 my_b_seek() may not work correctly after my_b_read() hits EOF"

Cherry-picked commit MariaDB/server@58b54b7
"MDEV-9044 : Binlog corruption in Galera"

Cherry-picked commit MariaDB/server@735a4a1
"MDEV-10508 Mariadb crash on out of disk space during dump import"

Cherry-picked commit MariaDB/server@1841557
"myisam/aria: don't mess with IO_CACHE::file"

Various formatting and spelling fixes.