### PR TITLE
TDB-188 : TDB-114 (Change use of MySQL HASH to unordered_map) introdu…

### DIFF
--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -252,6 +252,8 @@ void TOKUDB_SHARE::drop_share(TOKUDB_SHARE* share) {
     mutex_t_lock(_open_tables_mutex);
     size_t n = _open_tables.erase(std::string(share->full_table_name()));
     assert_always(n == 1);
+    share->destroy();
+    delete share;
     mutex_t_unlock(_open_tables_mutex);
 }
 TOKUDB_SHARE::share_state_t TOKUDB_SHARE::addref() {


### PR DESCRIPTION
…ces memory leak

- TDB-188 eliminated the HASH callback that releases a TOKUDB_SHARE without
  adding that logic back into the drop_share method. Added destruction logic
  back.
- Since this commit is fixing an issue that has not yet been released, the GCA
  position is behind the place where the issue was introduced, therefore, this
  commit is being made on the HEAD and will be cherry picked forward to 5.7.

(cherry picked from commit ef33a418371017cbe745ceafa0dfe7f2ff99c175)