### PR TITLE
PS-3940: key_block_size shouldn't be set automatically for the heap engine (5.5)

### DIFF
--- a/mysql-test/r/percona_heap_var.result
+++ b/mysql-test/r/percona_heap_var.result
@@ -1,11 +1,11 @@
-drop table if exists t1;
+DROP TABLE IF EXISTS t1;
 set @@session.max_heap_table_size=16*1024*1024;
-create table t1 (a int not null, b varchar(400), c int, primary key (a), key (c)) engine=heap comment="testing heaps" key_block_size=128;
+CREATE TABLE t1 (a INT NOT NULL, b VARCHAR(400), c INT, PRIMARY KEY (a), KEY (c)) ENGINE=HEAP COMMENT="testing heaps" KEY_BLOCK_SIZE=128;
 ERROR 42000: Incorrect usage/placement of 'key_block_size'
-create table t1 (a int not null, b int, c varchar(400), primary key (a), key (b)) engine=heap comment="testing heaps" key_block_size=4;
+CREATE TABLE t1 (a INT NOT NULL, b INT, c VARCHAR(400), PRIMARY KEY (a), KEY (b)) ENGINE=HEAP COMMENT="testing heaps" KEY_BLOCK_SIZE=4;
 ERROR 42000: Incorrect usage/placement of 'key_block_size'
-create table t1 (a int not null, b int, c varchar(400), d varchar(400), primary key (a), key (b)) engine=heap comment="testing heaps" key_block_size=24;
-show table status like "t1";
+CREATE TABLE t1 (a INT NOT NULL, b INT, c VARCHAR(400), d VARCHAR(400), PRIMARY KEY (a), KEY (b)) ENGINE=HEAP COMMENT="testing heaps" KEY_BLOCK_SIZE=24;
+SHOW TABLE STATUS LIKE "t1";
 Name	t1
 Engine	MEMORY
 Version	10
@@ -24,45 +24,45 @@ Collation	latin1_swedish_ci
 Checksum	NULL
 Create_options	KEY_BLOCK_SIZE=24
 Comment	testing heaps
-insert into t1 values (1,1,'012',NULL), (2,2,'0123456789',NULL), (3,3,'012345678901234567890123456789',NULL), (4,4,NULL,'0123456789012345678901234567890123456789012345678901234567890123456789');
-select * from t1;
+INSERT INTO t1 VALUES (1,1,'012',NULL), (2,2,'0123456789',NULL), (3,3,'012345678901234567890123456789',NULL), (4,4,NULL,'0123456789012345678901234567890123456789012345678901234567890123456789');
+SELECT * FROM t1;
 a	b	c	d
 1	1	012	NULL
 2	2	0123456789	NULL
 3	3	012345678901234567890123456789	NULL
 4	4	NULL	0123456789012345678901234567890123456789012345678901234567890123456789
-delete from t1 where a = 3;
-select * from t1;
+DELETE FROM t1 WHERE a = 3;
+SELECT * FROM t1;
 a	b	c	d
 1	1	012	NULL
 2	2	0123456789	NULL
 4	4	NULL	0123456789012345678901234567890123456789012345678901234567890123456789
-insert into t1 values (5,5,NULL,'0123'), (6,6,NULL,'0123');
-select * from t1;
+INSERT INTO t1 VALUES (5,5,NULL,'0123'), (6,6,NULL,'0123');
+SELECT * FROM t1;
 a	b	c	d
 1	1	012	NULL
 2	2	0123456789	NULL
 6	6	NULL	0123
 5	5	NULL	0123
 4	4	NULL	0123456789012345678901234567890123456789012345678901234567890123456789
-update t1 set c = '012345678901234567890123456789' where a = 2;
-select * from t1;
+UPDATE t1 SET c = '012345678901234567890123456789' WHERE a = 2;
+SELECT * FROM t1;
 a	b	c	d
 1	1	012	NULL
 2	2	012345678901234567890123456789	NULL
 6	6	NULL	0123
 5	5	NULL	0123
 4	4	NULL	0123456789012345678901234567890123456789012345678901234567890123456789
-update t1 set c = '0123456789' where a = 2;
-select * from t1;
+UPDATE t1 SET c = '0123456789' WHERE a = 2;
+SELECT * FROM t1;
 a	b	c	d
 1	1	012	NULL
 2	2	0123456789	NULL
 6	6	NULL	0123
 5	5	NULL	0123
 4	4	NULL	0123456789012345678901234567890123456789012345678901234567890123456789
-insert into t1 values (7,7,'0123',NULL), (8,8,'0123',NULL);
-select * from t1;
+INSERT INTO t1 VALUES (7,7,'0123',NULL), (8,8,'0123',NULL);
+SELECT * FROM t1;
 a	b	c	d
 1	1	012	NULL
 2	2	0123456789	NULL
@@ -71,7 +71,7 @@ a	b	c	d
 4	4	NULL	0123456789012345678901234567890123456789012345678901234567890123456789
 7	7	0123	NULL
 8	8	0123	NULL
-show table status like "t1";
+SHOW TABLE STATUS LIKE "t1";
 Name	t1
 Engine	MEMORY
 Version	10
@@ -90,8 +90,8 @@ Collation	latin1_swedish_ci
 Checksum	NULL
 Create_options	KEY_BLOCK_SIZE=24
 Comment	testing heaps
-alter table t1 key_block_size = 0;
-show table status like "t1";
+ALTER TABLE t1 KEY_BLOCK_SIZE = 0;
+SHOW TABLE STATUS LIKE "t1";
 Name	t1
 Engine	MEMORY
 Version	10
@@ -110,8 +110,8 @@ Collation	latin1_swedish_ci
 Checksum	NULL
 Create_options	
 Comment	testing heaps
-alter table t1 row_format = dynamic;
-show table status like "t1";
+ALTER TABLE t1 ROW_FORMAT = DYNAMIC;
+SHOW TABLE STATUS LIKE "t1";
 Name	t1
 Engine	MEMORY
 Version	10
@@ -128,10 +128,10 @@ Update_time	X
 Check_time	X
 Collation	latin1_swedish_ci
 Checksum	NULL
-Create_options	row_format=DYNAMIC KEY_BLOCK_SIZE=X
+Create_options	row_format=DYNAMIC
 Comment	testing heaps
-alter table t1 key_block_size = 128, max_rows = 10001;
-show table status like "t1";
+ALTER TABLE t1 KEY_BLOCK_SIZE = 128, MAX_ROWS = 10001;
+SHOW TABLE STATUS LIKE "t1";
 Name	t1
 Engine	MEMORY
 Version	10
@@ -150,7 +150,7 @@ Collation	latin1_swedish_ci
 Checksum	NULL
 Create_options	max_rows=10001 row_format=DYNAMIC KEY_BLOCK_SIZE=128
 Comment	testing heaps
-select * from t1;
+SELECT * FROM t1;
 a	b	c	d
 1	1	012	NULL
 2	2	0123456789	NULL
@@ -159,16 +159,16 @@ a	b	c	d
 4	4	NULL	0123456789012345678901234567890123456789012345678901234567890123456789
 7	7	0123	NULL
 8	8	0123	NULL
-delete from t1;
-select * from t1;
+DELETE FROM t1;
+SELECT * FROM t1;
 a	b	c	d
 call mtr.add_suppression("The table 't1' is full");
-select count(*) from t1;
-count(*)
+SELECT COUNT(*) FROM t1;
+COUNT(*)
 10001
-insert into t1 values (100000,100000,NULL,'0123'), (100000,100000,NULL,'0123');
+INSERT INTO t1 VALUES (100000,100000,NULL,'0123'), (100000,100000,NULL,'0123');
 ERROR HY000: The table 't1' is full
-show table status like "t1";
+SHOW TABLE STATUS LIKE "t1";
 Name	t1
 Engine	MEMORY
 Version	10
@@ -187,11 +187,11 @@ Collation	latin1_swedish_ci
 Checksum	NULL
 Create_options	max_rows=10001 row_format=DYNAMIC KEY_BLOCK_SIZE=128
 Comment	testing heaps
-select count(*) from t1;
-count(*)
+SELECT COUNT(*) FROM t1;
+COUNT(*)
 10001
-set @@session.max_heap_table_size=default;
-drop table t1;
+SET @@session.max_heap_table_size=default;
+DROP TABLE t1;
 #
 # Bug 1731483: MEMORY storage engine incorrectly allows BLOB columns before indexed columns
 #
@@ -254,4 +254,84 @@ ALTER TABLE t1 ADD PRIMARY KEY (a, c);
 ERROR 42000: The used table type doesn't support BLOB/TEXT columns
 ALTER TABLE t1 ADD INDEX idx (c, a);
 ERROR 42000: The used table type doesn't support BLOB/TEXT columns
+DROP TABLE t1;
+#
+# PS-3940: Engine can be changed to innodb and back
+#
+CREATE TABLE `t1` (
+`id` INT(11) NOT NULL AUTO_INCREMENT,
+`json_column` TEXT,
+PRIMARY KEY (`id`)
+) ENGINE=MEMORY;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `json_column` text,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1
+ALTER TABLE  t1 ENGINE=INNODB;
+ALTER TABLE  t1 ENGINE=MEMORY;
+#
+# PS-3943: Adding additional columns won't change the key_block size
+#
+ALTER TABLE t1 MODIFY json_column BLOB;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `json_column` blob,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1
+ALTER TABLE t1 MODIFY json_column TEXT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `json_column` text,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1
+ALTER TABLE t1 MODIFY json_column BLOB;
+ALTER TABLE t1 MODIFY json_column TEXT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `json_column` text,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1
+DROP TABLE t1;
+#
+# PS-3943: Explicit key_block_size is kept and doesn't change
+#
+CREATE TABLE `t1` (
+`id` INT(11) NOT NULL AUTO_INCREMENT,
+`json_column` TEXT,
+PRIMARY KEY (`id`)
+) ENGINE=MEMORY KEY_BLOCK_SIZE=200;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `json_column` text,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1 KEY_BLOCK_SIZE=200
+ALTER TABLE  t1 ENGINE=INNODB KEY_BLOCK_SIZE=0;
+ALTER TABLE  t1 ENGINE=MEMORY;
+ALTER TABLE t1 MODIFY json_column BLOB;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `json_column` blob,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1
+ALTER TABLE t1 MODIFY json_column TEXT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `json_column` text,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY DEFAULT CHARSET=latin1
 DROP TABLE t1;

--- a/mysql-test/t/percona_heap_var.test
+++ b/mysql-test/t/percona_heap_var.test
@@ -4,57 +4,56 @@
 --source include/have_innodb.inc
 
 --disable_warnings
-drop table if exists t1;
+DROP TABLE IF EXISTS t1;
 --enable_warnings
 
 set @@session.max_heap_table_size=16*1024*1024;
 
 --error 1234
-create table t1 (a int not null, b varchar(400), c int, primary key (a), key (c)) engine=heap comment="testing heaps" key_block_size=128;
+CREATE TABLE t1 (a INT NOT NULL, b VARCHAR(400), c INT, PRIMARY KEY (a), KEY (c)) ENGINE=HEAP COMMENT="testing heaps" KEY_BLOCK_SIZE=128;
 
 --error 1234
-create table t1 (a int not null, b int, c varchar(400), primary key (a), key (b)) engine=heap comment="testing heaps" key_block_size=4;
+CREATE TABLE t1 (a INT NOT NULL, b INT, c VARCHAR(400), PRIMARY KEY (a), KEY (b)) ENGINE=HEAP COMMENT="testing heaps" KEY_BLOCK_SIZE=4;
 
-create table t1 (a int not null, b int, c varchar(400), d varchar(400), primary key (a), key (b)) engine=heap comment="testing heaps" key_block_size=24;
-
---replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
---query_vertical show table status like "t1"
-
-insert into t1 values (1,1,'012',NULL), (2,2,'0123456789',NULL), (3,3,'012345678901234567890123456789',NULL), (4,4,NULL,'0123456789012345678901234567890123456789012345678901234567890123456789');
-select * from t1;
-
-delete from t1 where a = 3;
-select * from t1;
-
-insert into t1 values (5,5,NULL,'0123'), (6,6,NULL,'0123');
-select * from t1;
-
-update t1 set c = '012345678901234567890123456789' where a = 2;
-select * from t1;
-
-update t1 set c = '0123456789' where a = 2;
-select * from t1;
-
-insert into t1 values (7,7,'0123',NULL), (8,8,'0123',NULL);
-select * from t1;
+CREATE TABLE t1 (a INT NOT NULL, b INT, c VARCHAR(400), d VARCHAR(400), PRIMARY KEY (a), KEY (b)) ENGINE=HEAP COMMENT="testing heaps" KEY_BLOCK_SIZE=24;
 
 --replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
---query_vertical show table status like "t1"
-alter table t1 key_block_size = 0;
---replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
---query_vertical show table status like "t1"
-alter table t1 row_format = dynamic;
---replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
---replace_regex /KEY_BLOCK_SIZE=[[:digit:]]+/KEY_BLOCK_SIZE=X/
---query_vertical show table status like "t1"
-alter table t1 key_block_size = 128, max_rows = 10001;
---replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
---query_vertical show table status like "t1"
+--query_vertical SHOW TABLE STATUS LIKE "t1"
 
-select * from t1;
+INSERT INTO t1 VALUES (1,1,'012',NULL), (2,2,'0123456789',NULL), (3,3,'012345678901234567890123456789',NULL), (4,4,NULL,'0123456789012345678901234567890123456789012345678901234567890123456789');
+SELECT * FROM t1;
 
-delete from t1;
-select * from t1;
+DELETE FROM t1 WHERE a = 3;
+SELECT * FROM t1;
+
+INSERT INTO t1 VALUES (5,5,NULL,'0123'), (6,6,NULL,'0123');
+SELECT * FROM t1;
+
+UPDATE t1 SET c = '012345678901234567890123456789' WHERE a = 2;
+SELECT * FROM t1;
+
+UPDATE t1 SET c = '0123456789' WHERE a = 2;
+SELECT * FROM t1;
+
+INSERT INTO t1 VALUES (7,7,'0123',NULL), (8,8,'0123',NULL);
+SELECT * FROM t1;
+
+--replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
+--query_vertical SHOW TABLE STATUS LIKE "t1"
+ALTER TABLE t1 KEY_BLOCK_SIZE = 0;
+--replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
+--query_vertical SHOW TABLE STATUS LIKE "t1"
+ALTER TABLE t1 ROW_FORMAT = DYNAMIC;
+--replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
+--query_vertical SHOW TABLE STATUS LIKE "t1"
+ALTER TABLE t1 KEY_BLOCK_SIZE = 128, MAX_ROWS = 10001;
+--replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
+--query_vertical SHOW TABLE STATUS LIKE "t1"
+
+SELECT * FROM t1;
+
+DELETE FROM t1;
+SELECT * FROM t1;
 
 let $1=10001;
 
@@ -65,25 +64,25 @@ disable_query_log;
 while ($1) 
 {
 
-  eval insert into t1 values ($1,$1,$1,$1);
+  eval INSERT INTO t1 VALUES ($1,$1,$1,$1);
 
   dec $1;
 
 }
 enable_query_log;
 
-select count(*) from t1;
+SELECT COUNT(*) FROM t1;
 
 --error 1114
-insert into t1 values (100000,100000,NULL,'0123'), (100000,100000,NULL,'0123');
+INSERT INTO t1 VALUES (100000,100000,NULL,'0123'), (100000,100000,NULL,'0123');
 
 --replace_column 6 X 7 X 8 X 9 X 10 X 11 X 12 X 13 X 14 X
---query_vertical show table status like "t1"
-select count(*) from t1;
+--query_vertical SHOW TABLE STATUS LIKE "t1"
+SELECT COUNT(*) FROM t1;
 
-set @@session.max_heap_table_size=default;
+SET @@session.max_heap_table_size=default;
 
-drop table t1;
+DROP TABLE t1;
 
 --echo #
 --echo # Bug 1731483: MEMORY storage engine incorrectly allows BLOB columns before indexed columns
@@ -164,4 +163,58 @@ CREATE TABLE t1 (a INT, b TEXT, c INT) ENGINE=MEMORY;
 ALTER TABLE t1 ADD PRIMARY KEY (a, c);
 --error ER_TABLE_CANT_HANDLE_BLOB
 ALTER TABLE t1 ADD INDEX idx (c, a);
+DROP TABLE t1;
+
+--echo #
+--echo # PS-3940: Engine can be changed to innodb and back
+--echo #
+
+CREATE TABLE `t1` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `json_column` TEXT,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY;
+# no key_block_size displayed even before the bugfix
+SHOW CREATE TABLE t1;
+
+ALTER TABLE  t1 ENGINE=INNODB;
+ALTER TABLE  t1 ENGINE=MEMORY;
+
+--echo #
+--echo # PS-3943: Adding additional columns won't change the key_block size
+--echo #
+
+ALTER TABLE t1 MODIFY json_column BLOB;
+# a key_block_size of 256 appeared without the bugfix
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 MODIFY json_column TEXT;
+# a key_block_size of 256+16 appeared without the bugfix
+SHOW CREATE TABLE t1;
+
+ALTER TABLE t1 MODIFY json_column BLOB;
+ALTER TABLE t1 MODIFY json_column TEXT;
+# a key_block_size of 256+3*16 appeared without the bugfix
+SHOW CREATE TABLE t1;
+
+DROP TABLE t1;
+
+--echo #
+--echo # PS-3943: Explicit key_block_size is kept and doesn't change
+--echo #
+CREATE TABLE `t1` (
+  `id` INT(11) NOT NULL AUTO_INCREMENT,
+  `json_column` TEXT,
+  PRIMARY KEY (`id`)
+) ENGINE=MEMORY KEY_BLOCK_SIZE=200;
+SHOW CREATE TABLE t1;
+ALTER TABLE  t1 ENGINE=INNODB KEY_BLOCK_SIZE=0;
+ALTER TABLE  t1 ENGINE=MEMORY;
+
+ALTER TABLE t1 MODIFY json_column BLOB;
+# a key_block_size changed to 200+16 without the bugfix
+SHOW CREATE TABLE t1;
+ALTER TABLE t1 MODIFY json_column TEXT;
+# a key_block_size changed to 200+2*16 without the bugfix
+SHOW CREATE TABLE t1;
+
 DROP TABLE t1;

--- a/storage/heap/ha_heap.cc
+++ b/storage/heap/ha_heap.cc
@@ -925,13 +925,6 @@ void ha_heap::update_create_info(HA_CREATE_INFO *create_info)
   table->file->info(HA_STATUS_AUTO);
   if (!(create_info->used_fields & HA_CREATE_USED_AUTO))
     create_info->auto_increment_value= stats.auto_increment_value;
-  if (!(create_info->used_fields & HA_CREATE_USED_KEY_BLOCK_SIZE))
-  {
-    if (file->s->recordspace.is_variable_size)
-      create_info->key_block_size= file->s->recordspace.chunk_length;
-    else
-      create_info->key_block_size= 0;
-  }
 }
 
 void ha_heap::get_auto_increment(ulonglong offset, ulonglong increment,


### PR DESCRIPTION
Key_block_size was set automatically by the improved heap storage engine, which caused:
* warnings (5.5/5.6) or errors (5.7) when changing the engine type to innodb
* constantly growing key_block_size during alter operations

With this change, key_block_size won't be set unless the user specifies a custom value.
* switching to innodb will only result in an error if the user manually specified a key_block_size before, which is expected.
* key_block_size was growing because max_chuck_size is set based on the specified key_block_size, and then key_block_size was set to max_chunk_size plus an overhead value, increasing it every time.
  by leaving out the second step, it remains stable.

Note that key_block_size was set so the chunk size is visible even when calculated automatically.
As it is always set to 256 unless the user specifies something else, this didn't provide too much information.
