### PR TITLE
PS-3950 (5.5): gcc-8 compilation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,17 +48,21 @@ matrix:
       compiler: clang
     # 5
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=Debug
+      env: VERSION=8    BUILD=Debug
       compiler: gcc
     # 6
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=Debug
+      env: VERSION=7    BUILD=Debug
       compiler: gcc
     # 7
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=Debug
+      env: VERSION=6    BUILD=Debug
       compiler: gcc
     # 8
+    - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=Debug
+      compiler: gcc
+    # 9
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=Debug
       compiler: gcc
@@ -85,17 +89,21 @@ matrix:
       compiler: clang
     # 5
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo
+      env: VERSION=8    BUILD=RelWithDebInfo
       compiler: gcc
     # 6
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo
+      env: VERSION=7    BUILD=RelWithDebInfo
       compiler: gcc
     # 7
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo
+      env: VERSION=6    BUILD=RelWithDebInfo
       compiler: gcc
     # 8
+    - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo
+      compiler: gcc
+    # 9
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo
       compiler: gcc
@@ -116,17 +124,21 @@ matrix:
       compiler: clang
     # 4
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 5
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 6
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 7
+    - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      compiler: gcc
+    #8
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
@@ -175,6 +187,8 @@ script:
     fi;
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
        sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test";
+       sudo -E apt-add-repository -y "ppa:jonathonf/binutils";
+       sudo -E apt-add-repository -y "ppa:jonathonf/gcc-8.0";
     fi;
 
   - echo --- Update list of packages and download dependencies;

--- a/client/mysql_plugin.c
+++ b/client/mysql_plugin.c
@@ -315,9 +315,11 @@ static char *add_quotes(const char *path)
 
 static int get_default_values()
 {
+  static const char format_cmd[]= "%s mysqld > %s";
   char tool_path[FN_REFLEN];
-  char defaults_cmd[FN_REFLEN];
   char defaults_file[FN_REFLEN];
+  char defaults_cmd[sizeof(defaults_file) + sizeof(tool_path) +
+                    sizeof(format_cmd)];
   char line[FN_REFLEN];
   int error= 0;
   int ret= 0;
@@ -349,7 +351,7 @@ static int get_default_values()
     }
 #else
     snprintf(defaults_cmd, sizeof(defaults_cmd),
-             "%s mysqld > %s", tool_path, defaults_file);
+             format_cmd, tool_path, defaults_file);
 #endif
 
     /* Execute the command */
@@ -1168,7 +1170,9 @@ exit:
 
 static int bootstrap_server(char *server_path, char *bootstrap_file)
 {
-  char bootstrap_cmd[FN_REFLEN];
+  static const char format_cmd[]= "%s --no-defaults --bootstrap --datadir=%s "
+                           "--basedir=%s < %s";
+  char bootstrap_cmd[FN_REFLEN * 2 + sizeof(format_cmd)];
   int error= 0;
 
 #ifdef __WIN__
@@ -1192,8 +1196,7 @@ static int bootstrap_server(char *server_path, char *bootstrap_file)
            add_quotes(bootstrap_file));
 #else
   snprintf(bootstrap_cmd, sizeof(bootstrap_cmd),
-           "%s --no-defaults --bootstrap --datadir=%s --basedir=%s"
-           " < %s", server_path, opt_datadir, opt_basedir, bootstrap_file);
+           format_cmd, server_path, opt_datadir, opt_basedir, bootstrap_file);
 #endif
 
   /* Execute the command */

--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -708,7 +708,7 @@ static int disable_binlog()
 
 static int handle_request_for_tables(char *tables, size_t length)
 {
-  char *query, *end, options[100], message[100];
+  char *query, *end, options[100];
   size_t query_length= 0, query_size= sizeof(char)*(length+110);
   const char *op = 0;
 
@@ -762,7 +762,10 @@ static int handle_request_for_tables(char *tables, size_t length)
   }
   if (mysql_real_query(sock, query, query_length))
   {
-    sprintf(message, "when executing '%s TABLE ... %s'", op, options);
+    static const char format_msg[]= "when executing '%s TABLE ... %s'";
+    char message[sizeof(options) + sizeof(format_msg) +
+                 32 /* to fit "OPTIMIZE NO_WRITE_TO_BINLOG" */];
+    snprintf(message, sizeof(message), format_msg, op, options);
     DBerror(sock, message);
     return 1;
   }

--- a/sql/datadict.cc
+++ b/sql/datadict.cc
@@ -171,7 +171,7 @@ bool dd_recreate_table(THD *thd, const char *db, const char *table_name)
   DBUG_ASSERT(thd->mdl_context.is_lock_owner(MDL_key::TABLE, db, table_name,
                                              MDL_EXCLUSIVE));
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
 
   /* Create a path to the table, but without a extension. */
   build_table_filename(path, sizeof(path) - 1, db, table_name, "", 0);

--- a/sql/debug_sync.cc
+++ b/sql/debug_sync.cc
@@ -928,7 +928,7 @@ static void debug_sync_remove_action(st_debug_sync_control *ds_control,
     memmove(save_action, action, sizeof(st_debug_sync_action));
 
     /* Move actions down. */
-    memmove(ds_control->ds_action + dsp_idx,
+    memmove(static_cast<void*>(ds_control->ds_action + dsp_idx),
             ds_control->ds_action + dsp_idx + 1,
             (ds_control->ds_active - dsp_idx) *
             sizeof(st_debug_sync_action));
@@ -939,8 +939,8 @@ static void debug_sync_remove_action(st_debug_sync_control *ds_control,
       produced by the shift. Again do not use an assignment operator to
       avoid string allocation/copy.
     */
-    memmove(ds_control->ds_action + ds_control->ds_active, save_action,
-            sizeof(st_debug_sync_action));
+    memmove(static_cast<void*>(ds_control->ds_action + ds_control->ds_active),
+            save_action, sizeof(st_debug_sync_action));
   }
 
   DBUG_VOID_RETURN;

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -4810,7 +4810,7 @@ bool MYSQL_BIN_LOG::appendv(const char* buf, uint len,...)
 {
   bool error= 0;
   DBUG_ENTER("MYSQL_BIN_LOG::appendv");
-  va_list(args);
+  va_list args;
   va_start(args,len);
 
   DBUG_ASSERT(log_file.type == SEQ_READ_APPEND);

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -1279,7 +1279,7 @@ QUICK_INDEX_MERGE_SELECT::QUICK_INDEX_MERGE_SELECT(THD *thd_param,
   DBUG_ENTER("QUICK_INDEX_MERGE_SELECT::QUICK_INDEX_MERGE_SELECT");
   index= MAX_KEY;
   head= table;
-  bzero(&read_record, sizeof(read_record));
+  bzero(static_cast<void*>(&read_record), sizeof(read_record));
   init_sql_alloc(&alloc, thd->variables.range_alloc_block_size, 0);
   DBUG_VOID_RETURN;
 }

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -41,7 +41,7 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
     mem_alloc_error(sizeof(partition_info));
     return NULL;
   }
-  memcpy(clone, this, sizeof(partition_info));
+  memcpy(static_cast<void*>(clone), this, sizeof(partition_info));
   clone->partitions.empty();
 
   while ((part= (part_it++)))
@@ -54,7 +54,7 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
       mem_alloc_error(sizeof(partition_element));
       return NULL;
     }
-    memcpy(part_clone, part, sizeof(partition_element));
+    memcpy(static_cast<void*>(part_clone), part, sizeof(partition_element));
 
     /*
       Mark that RANGE and LIST values needs to be fixed so that we don't
@@ -84,7 +84,7 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
         mem_alloc_error(sizeof(partition_element));
         return NULL;
       }
-      memcpy(subpart_clone, subpart, sizeof(partition_element));
+      memcpy(static_cast<void*>(subpart_clone), subpart, sizeof(partition_element));
       part_clone->subpartitions.push_back(subpart_clone);
     }
     clone->partitions.push_back(part_clone);
@@ -1361,7 +1361,7 @@ void partition_info::print_no_partition_found(TABLE *table_arg)
   char *buf_ptr= (char*)&buf;
   TABLE_LIST table_list;
 
-  bzero(&table_list, sizeof(table_list));
+  bzero(static_cast<void*>(&table_list), sizeof(table_list));
   table_list.db= table_arg->s->db.str;
   table_list.table_name= table_arg->s->table_name.str;
 

--- a/sql/sql_analyse.cc
+++ b/sql/sql_analyse.cc
@@ -295,12 +295,11 @@ bool get_ev_num_info(EV_NUM_INFO *ev_info, NUM_INFO *info, const char *num)
   return 1;
 } // get_ev_num_info
 
-
-void free_string(String *s)
+void free_string(void* key, TREE_FREE action __attribute__((unused)),
+                 void *param __attribute__((unused)))
 {
-  s->free();
+  reinterpret_cast<String*>(key)->free();
 }
-
 
 void field_str::add()
 {

--- a/sql/sql_analyse.h
+++ b/sql/sql_analyse.h
@@ -68,7 +68,8 @@ int compare_ulonglong2(void* cmp_arg __attribute__((unused)),
 int compare_decimal2(int* len, const char *s, const char *t);
 Procedure *proc_analyse_init(THD *thd, ORDER *param, select_result *result,
 			     List<Item> &field_list);
-void free_string(String*);
+void free_string(void* key, TREE_FREE action __attribute__((unused)),
+                 void *param __attribute__((unused)));
 class analyse;
 
 class field_info :public Sql_alloc
@@ -121,7 +122,7 @@ public:
     must_be_blob(0), was_zero_fill(0),
     was_maybe_zerofill(0), can_be_still_num(1)
     { init_tree(&tree, 0, 0, sizeof(String), (qsort_cmp2) sortcmp2,
-		0, (tree_element_free) free_string, NULL); };
+		0, free_string, NULL); };
 
   void	 add();
   void	 get_opt_type(String*, ha_rows);

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -1193,7 +1193,7 @@ bool close_cached_connection_tables(THD *thd, LEX_STRING *connection)
   DBUG_ENTER("close_cached_connections");
   DBUG_ASSERT(thd);
 
-  bzero(&tmp, sizeof(TABLE_LIST));
+  bzero(static_cast<void*>(&tmp), sizeof(TABLE_LIST));
 
   mysql_mutex_lock(&LOCK_open);
 

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -4078,7 +4078,7 @@ select_create::binlog_show_create_table(TABLE **tables, uint count)
   int result;
   TABLE_LIST tmp_table_list;
 
-  memset(&tmp_table_list, 0, sizeof(tmp_table_list));
+  memset(static_cast<void*>(&tmp_table_list), 0, sizeof(tmp_table_list));
   tmp_table_list.table = *tables;
   query.length(0);      // Have to zero it since constructor doesn't
 

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -1779,7 +1779,7 @@ void JOIN::restore_tmp()
 {
   DBUG_PRINT("info", ("restore_tmp this %p tmp_join %p", this, tmp_join));
   DBUG_ASSERT(tmp_join != this);
-  memcpy(tmp_join, this, (size_t) sizeof(JOIN));
+  memcpy(static_cast<void*>(tmp_join), this, (size_t) sizeof(JOIN));
 }
 
 
@@ -11106,8 +11106,8 @@ TABLE *create_virtual_tmp_table(THD *thd, List<Create_field> &field_list)
                         NullS))
     return 0;
 
-  bzero(table, sizeof(*table));
-  bzero(share, sizeof(*share));
+  bzero(static_cast<void*>(table), sizeof(*table));
+  bzero(static_cast<void*>(share), sizeof(*share));
   table->field= field;
   table->s= share;
   table->temp_pool_slot= MY_BIT_NONE;

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -5882,7 +5882,7 @@ static int get_schema_views_record(THD *thd, TABLE_LIST *tables,
         {
           TABLE_LIST table_list;
           uint view_access;
-          memset(&table_list, 0, sizeof(table_list));
+          memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
           table_list.db= tables->db;
           table_list.table_name= tables->table_name;
           table_list.grant.privilege= thd->col_access;

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -1786,7 +1786,7 @@ bool Table_triggers_list::drop_all_triggers(THD *thd, char *db, char *name)
   bool result= 0;
   DBUG_ENTER("drop_all_triggers");
 
-  bzero(&table, sizeof(table));
+  bzero(static_cast<void*>(&table), sizeof(table));
   init_sql_alloc(&table.mem_root, 8192, 0);
 
   if (Table_triggers_list::check_n_load(thd, db, name, &table, 1))
@@ -2006,7 +2006,7 @@ bool Table_triggers_list::change_table_name(THD *thd, const char *db,
   LEX_STRING *err_trigname;
   DBUG_ENTER("change_table_name");
 
-  bzero(&table, sizeof(table));
+  bzero(static_cast<void*>(&table), sizeof(table));
   init_sql_alloc(&table.mem_root, 8192, 0);
 
   /*

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -283,7 +283,7 @@ static bool recreate_temporary_table(THD *thd, TABLE *table)
   handlerton *table_type= table->s->db_type();
   DBUG_ENTER("recreate_temporary_table");
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
 
   table->file->info(HA_STATUS_AUTO | HA_STATUS_NO_LOCK);
 

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -215,7 +215,7 @@ fill_defined_view_parts (THD *thd, TABLE_LIST *view)
   LEX *lex= thd->lex;
   TABLE_LIST decoy;
 
-  memcpy (&decoy, view, sizeof (TABLE_LIST));
+  memcpy(static_cast<void*>(&decoy), view, sizeof (TABLE_LIST));
   key_length= create_table_def_key(thd, key, view, 0);
 
   if (tdc_open_view(thd, &decoy, decoy.alias, key, key_length,
@@ -2025,7 +2025,7 @@ mysql_rename_view(THD *thd,
       view definition parsing or use temporary 'view_def'
       object for it.
     */
-    bzero(&view_def, sizeof(view_def));
+    bzero(static_cast<void*>(&view_def), sizeof(view_def));
     view_def.timestamp.str= view_def.timestamp_buffer;
     view_def.view_suid= TRUE;
 

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -1523,7 +1523,7 @@ my_offset_tzs_get_key(Time_zone_offset *entry,
 static void
 tz_init_table_list(TABLE_LIST *tz_tabs)
 {
-  bzero(tz_tabs, sizeof(TABLE_LIST) * MY_TZ_TABLES_COUNT);
+  bzero(static_cast<void*>(tz_tabs), sizeof(TABLE_LIST) * MY_TZ_TABLES_COUNT);
 
   for (int i= 0; i < MY_TZ_TABLES_COUNT; i++)
   {

--- a/storage/innobase/include/data0type.ic
+++ b/storage/innobase/include/data0type.ic
@@ -446,6 +446,7 @@ dtype_get_fixed_size_low(
 			return(0);
 		}
 #endif /* UNIV_DEBUG */
+		// fallthrough
 	case DATA_CHAR:
 	case DATA_FIXBINARY:
 	case DATA_INT:
@@ -524,6 +525,7 @@ dtype_get_min_size_low(
 			return(0);
 		}
 #endif /* UNIV_DEBUG */
+		// fallthrough
 	case DATA_CHAR:
 	case DATA_FIXBINARY:
 	case DATA_INT:

--- a/storage/myisam/mi_write.c
+++ b/storage/myisam/mi_write.c
@@ -926,7 +926,7 @@ static int keys_compare(bulk_insert_param *param, uchar *key1, uchar *key2)
 }
 
 
-static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
+static void keys_free(void* vkey, TREE_FREE mode, void *vparam)
 {
   /*
     Probably I can use info->lastkey here, but I'm not sure,
@@ -935,6 +935,8 @@ static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
   uchar lastkey[MI_MAX_KEY_BUFF];
   uint keylen;
   MI_KEYDEF *keyinfo;
+  uchar *key= (uchar*)(vkey);
+  bulk_insert_param *param= (bulk_insert_param*)(vparam);
 
   switch (mode) {
   case free_init:
@@ -943,19 +945,20 @@ static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
       mysql_rwlock_wrlock(&param->info->s->key_root_lock[param->keynr]);
       param->info->s->keyinfo[param->keynr].version++;
     }
-    return 0;
+    return;
   case free_free:
     keyinfo=param->info->s->keyinfo+param->keynr;
     keylen=_mi_keylength(keyinfo, key);
     memcpy(lastkey, key, keylen);
-    return _mi_ck_write_btree(param->info,param->keynr,lastkey,
-			      keylen - param->info->s->rec_reflength);
+    _mi_ck_write_btree(param->info,param->keynr,lastkey,
+                       keylen - param->info->s->rec_reflength);
+    return;
   case free_end:
     if (param->info->s->concurrent_insert)
       mysql_rwlock_unlock(&param->info->s->key_root_lock[param->keynr]);
-    return 0;
+    return;
   }
-  return -1;
+  return;
 }
 
 
@@ -1012,7 +1015,7 @@ int mi_init_bulk_insert(MI_INFO *info, ulong cache_size, ha_rows rows)
                 cache_size * key[i].maxlength,
                 cache_size * key[i].maxlength, 0,
 		(qsort_cmp2)keys_compare, 0,
-		(tree_element_free) keys_free, (void *)params++);
+		keys_free, (void *)params++);
     }
     else
      info->bulk_insert[i].root=0;

--- a/storage/myisam/myisamlog.c
+++ b/storage/myisam/myisamlog.c
@@ -62,7 +62,8 @@ static int test_if_open(struct file_info *key,element_count count,
 static void fix_blob_pointers(MI_INFO *isam,uchar *record);
 static int test_when_accessed(struct file_info *key,element_count count,
 			      struct st_access_param *access_param);
-static void file_info_free(struct file_info *info);
+static void file_info_free(void* key, TREE_FREE action __attribute__((unused)),
+                           void *param __attribute__((unused)));
 static int close_some_file(TREE *tree);
 static int reopen_closed_file(TREE *tree,struct file_info *file_info);
 static int find_record_with_key(struct file_info *file_info,uchar *record);
@@ -329,7 +330,7 @@ static int examine_log(char * file_name, char **table_names)
   init_io_cache(&cache,file,0,READ_CACHE,start_offset,0,MYF(0));
   bzero((uchar*) com_count,sizeof(com_count));
   init_tree(&tree,0,0,sizeof(file_info),(qsort_cmp2) file_info_compare,1,
-	    (tree_element_free) file_info_free, NULL);
+            file_info_free, NULL);
   (void) init_key_cache(dflt_key_cache,KEY_CACHE_BLOCK_SIZE,KEY_CACHE_SIZE,
                       0, 0);
 
@@ -749,8 +750,10 @@ static int test_when_accessed (struct file_info *key,
 }
 
 
-static void file_info_free(struct file_info *fileinfo)
+static void file_info_free(void* key, TREE_FREE action __attribute__((unused)),
+                           void *param __attribute__((unused)))
 {
+  struct file_info *fileinfo= (struct file_info*)key;
   DBUG_ENTER("file_info_free");
   if (update)
   {


### PR DESCRIPTION
1. Add gcc-8 to Travis config file
2. Fix the following gcc-8 warnings:
- cast between incompatible function types [-Werror=cast-function-type]
- clearing an object with no trivial copy-assignment [-Werror=class-memaccess]
- directive output may be truncated [-Werror=format-truncation=]