### PR TITLE
Bug: PS-3877 User experience improvement for Percona keyring use

### DIFF
--- a/mysql-test/suite/binlog_encryption/r/encryption_init_error.result
+++ b/mysql-test/suite/binlog_encryption/r/encryption_init_error.result
@@ -1,4 +1,4 @@
-call mtr.add_suppression("Failed to fetch percona_binlog key from keyring and thus failed to initialize binlog encryption.");
+call mtr.add_suppression("Failed to fetch or create percona_binlog key from/in keyring and thus failed to initialize binlog encryption. Have you enabled keyring plugin?");
 call mtr.add_suppression("Could not use ./master-bin.000002 for logging");
 call mtr.add_suppression("Could not open ./master-bin.000002 for logging");
 SET debug="+d,binlog_encryption_error_on_key_fetch";

--- a/mysql-test/suite/binlog_encryption/t/binlog_encryption_without_keyring.test
+++ b/mysql-test/suite/binlog_encryption/t/binlog_encryption_without_keyring.test
@@ -35,7 +35,7 @@ RESET MASTER;
 --let SEARCH_FILE= $MYSQLTEST_VARDIR/tmp/binlog_encryption_without_keyring.err
 --let SEARCH_PATTERN= Binary logging not possible. Message: Either disk is full or file system is read only or encryption failed while opening the binlog. Aborting the server.
 --source include/search_pattern_in_file.inc
---let SEARCH_PATTERN= Failed to fetch percona_binlog key from keyring and thus failed to initialize binlog encryption. Have you enabled keyring plugin?
+--let SEARCH_PATTERN= Failed to fetch or create percona_binlog key from/in keyring and thus failed to initialize binlog encryption. Have you enabled keyring plugin?
 --source include/search_pattern_in_file.inc
 
 --let $restart_parameters=

--- a/mysql-test/suite/binlog_encryption/t/encryption_init_error.test
+++ b/mysql-test/suite/binlog_encryption/t/encryption_init_error.test
@@ -1,7 +1,7 @@
 source include/have_log_bin.inc;
 source include/have_debug.inc;
 
-call mtr.add_suppression("Failed to fetch percona_binlog key from keyring and thus failed to initialize binlog encryption.");
+call mtr.add_suppression("Failed to fetch or create percona_binlog key from/in keyring and thus failed to initialize binlog encryption. Have you enabled keyring plugin?");
 call mtr.add_suppression("Could not use ./master-bin.000002 for logging");
 call mtr.add_suppression("Could not open ./master-bin.000002 for logging");
 

--- a/mysql-test/suite/rpl_encryption/r/encrypted_slave_without_keyring_and_bin_off_relay_on.result
+++ b/mysql-test/suite/rpl_encryption/r/encrypted_slave_without_keyring_and_bin_off_relay_on.result
@@ -1,0 +1,21 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+include/rpl_restart_server.inc [server_number=2]
+UNINSTALL PLUGIN keyring_file;
+include/assert.inc [No keyring plugin should be installed]
+include/assert.inc [Binlog should be OFF]
+include/assert.inc [Binlog encryption should be ON]
+SELECT @@log_slave_updates;
+@@log_slave_updates
+0
+SET GLOBAL binlog_error_action= ABORT_SERVER;
+FLUSH LOGS;
+ERROR HY000: Binary logging not possible. Message: Either disk is full or file system is read only or encryption failed while opening the relay_log. Aborting the server.
+# Check that error messages related to encryption are present in error log
+include/rpl_start_server.inc [server_number=2]
+include/start_slave.inc
+include/sync_slave_sql_with_master.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_encryption/t/encrypted_slave_without_keyring_and_bin_off_relay_on.cnf
+++ b/mysql-test/suite/rpl_encryption/t/encrypted_slave_without_keyring_and_bin_off_relay_on.cnf
@@ -1,0 +1,12 @@
+!include ../my.cnf
+
+[mysqld.1]
+encrypt-binlog=0
+
+[mysqld.2]
+encrypt-binlog
+log-slave-updates=0
+master-verify-checksum=1
+plugin_dir=@env.KEYRING_PLUGIN_DIR
+early-plugin-load=@env.KEYRING_PLUGIN
+keyring_file_data=../../tmp/keyring2

--- a/mysql-test/suite/rpl_encryption/t/encrypted_slave_without_keyring_and_bin_off_relay_on.test
+++ b/mysql-test/suite/rpl_encryption/t/encrypted_slave_without_keyring_and_bin_off_relay_on.test
@@ -1,0 +1,54 @@
+# Bug: PS-3877 User experience improvement for Percona keyring use
+#
+# When it is not possible to encrypt relay log - due to lack of keyring plugin installed
+# an appropriate error message - mentioning relay log is generated. Also an error messages
+# were improvement and now provide more information
+
+--source include/not_embedded.inc
+--source include/master-slave.inc
+
+--let $rpl_server_number= 2
+--let $rpl_omit_print_server_parameters= 1
+--let $rpl_server_parameters=--log-error=$MYSQLTEST_VARDIR/tmp/encrypted_slave_without_keyring_and_bin_off_relay_on.err --skip-log-bin
+--source include/rpl_restart_server.inc
+
+--connection server_2
+UNINSTALL PLUGIN keyring_file;
+
+--let $assert_text= No keyring plugin should be installed
+--let $assert_cond= "[SELECT COUNT(PLUGIN_NAME) = 0 FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name LIKE \\'keyring%\\']" = 1
+--source include/assert.inc
+
+--let $assert_text= Binlog should be OFF
+--let $assert_cond= "[SELECT @@GLOBAL.log_bin = 0]" = 1
+--source include/assert.inc
+
+--let $assert_text= Binlog encryption should be ON
+--let $assert_cond= "[SELECT @@GLOBAL.encrypt_binlog = 1]" = 1
+--source include/assert.inc
+
+SELECT @@log_slave_updates;
+
+SET GLOBAL binlog_error_action= ABORT_SERVER;
+--disable_reconnect
+--source include/expect_crash.inc
+--error ER_BINLOG_LOGGING_IMPOSSIBLE
+FLUSH LOGS;
+--echo # Check that error messages related to encryption are present in error log
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/tmp/encrypted_slave_without_keyring_and_bin_off_relay_on.err
+--let SEARCH_PATTERN= Binary logging not possible. Message: Either disk is full or file system is read only or encryption failed while opening the relay_log. Aborting the server.
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=Failed to fetch or create percona_binlog key from/in keyring and thus failed to initialize relay_log encryption. Have you enabled keyring plugin?
+--source include/search_pattern_in_file.inc
+
+--let $rpl_server_number= 2
+--let $rpl_omit_print_server_parameters= 1
+--let $rpl_server_parameters=
+--source include/rpl_start_server.inc
+--source include/start_slave.inc
+
+--remove_file $MYSQLTEST_VARDIR/tmp/encrypted_slave_without_keyring_and_bin_off_relay_on.err
+
+--connection server_1
+--source include/sync_slave_sql_with_master.inc
+--source include/rpl_end.inc


### PR DESCRIPTION
When it is not possible to encrypt relay log - due to lack of keyring plugin installed -
an appropriate error message - mentioning relay log - is generated. Also an error messages
were improved and now provide more information.