### PR TITLE
PS-3950 (5.6): gcc-8 compilation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,17 +48,21 @@ matrix:
       compiler: clang
     # 5
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=Debug
+      env: VERSION=8    BUILD=Debug
       compiler: gcc
     # 6
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=Debug
+      env: VERSION=7    BUILD=Debug
       compiler: gcc
     # 7
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=Debug
+      env: VERSION=6    BUILD=Debug
       compiler: gcc
     # 8
+    - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=Debug
+      compiler: gcc
+    # 9
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=Debug
       compiler: gcc
@@ -85,17 +89,21 @@ matrix:
       compiler: clang
     # 5
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo
+      env: VERSION=8    BUILD=RelWithDebInfo
       compiler: gcc
     # 6
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo
+      env: VERSION=7    BUILD=RelWithDebInfo
       compiler: gcc
     # 7
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo
+      env: VERSION=6    BUILD=RelWithDebInfo
       compiler: gcc
     # 8
+    - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo
+      compiler: gcc
+    # 9
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo
       compiler: gcc
@@ -116,17 +124,21 @@ matrix:
       compiler: clang
     # 4
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 5
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 6
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 7
+    - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      compiler: gcc
+    #8
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
@@ -175,6 +187,8 @@ script:
     fi;
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
        sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test";
+       sudo -E apt-add-repository -y "ppa:jonathonf/binutils";
+       sudo -E apt-add-repository -y "ppa:jonathonf/gcc-8.0";
     fi;
 
   - echo --- Update list of packages and download dependencies;

--- a/client/mysql_plugin.c
+++ b/client/mysql_plugin.c
@@ -315,9 +315,11 @@ static char *add_quotes(const char *path)
 
 static int get_default_values()
 {
+  static const char format_cmd[]= "%s mysqld > %s";
   char tool_path[FN_REFLEN];
-  char defaults_cmd[FN_REFLEN];
   char defaults_file[FN_REFLEN];
+  char defaults_cmd[sizeof(defaults_file) + sizeof(tool_path) +
+                    sizeof(format_cmd)];
   char line[FN_REFLEN];
   int error= 0;
   int ret= 0;
@@ -349,7 +351,7 @@ static int get_default_values()
     }
 #else
     snprintf(defaults_cmd, sizeof(defaults_cmd),
-             "%s mysqld > %s", tool_path, defaults_file);
+             format_cmd, tool_path, defaults_file);
 #endif
 
     /* Execute the command */
@@ -1206,7 +1208,9 @@ exit:
 
 static int bootstrap_server(char *server_path, char *bootstrap_file)
 {
-  char bootstrap_cmd[FN_REFLEN];
+  static const char format_cmd[]= "%s --no-defaults --bootstrap --datadir=%s "
+                           "--basedir=%s < %s";
+  char bootstrap_cmd[FN_REFLEN * 2 + sizeof(format_cmd)];
   int error= 0;
 
 #ifdef __WIN__
@@ -1230,8 +1234,7 @@ static int bootstrap_server(char *server_path, char *bootstrap_file)
            add_quotes(bootstrap_file));
 #else
   snprintf(bootstrap_cmd, sizeof(bootstrap_cmd),
-           "%s --no-defaults --bootstrap --datadir=%s --basedir=%s"
-           " < %s", server_path, opt_datadir, opt_basedir, bootstrap_file);
+           format_cmd, server_path, opt_datadir, opt_basedir, bootstrap_file);
 #endif
 
   /* Execute the command */

--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -727,7 +727,7 @@ static int disable_binlog()
 
 static int handle_request_for_tables(char *tables, size_t length)
 {
-  char *query, *end, options[100], message[100];
+  char *query, *end, options[100];
   size_t query_length= 0, query_size= sizeof(char)*(length+110);
   const char *op = 0;
 
@@ -781,7 +781,10 @@ static int handle_request_for_tables(char *tables, size_t length)
   }
   if (mysql_real_query(sock, query, query_length))
   {
-    sprintf(message, "when executing '%s TABLE ... %s'", op, options);
+    static const char format_msg[]= "when executing '%s TABLE ... %s'";
+    char message[sizeof(options) + sizeof(format_msg) +
+                 32 /* to fit "OPTIMIZE NO_WRITE_TO_BINLOG" */];
+    snprintf(message, sizeof(message), format_msg, op, options);
     DBerror(sock, message);
     return 1;
   }

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -7361,8 +7361,9 @@ void MYSQL_BIN_LOG::handle_binlog_flush_or_sync_error(THD *thd,
           binlog_error_action == ABORT_SERVER ? "ABORT_SERVER" : "IGNORE_ERROR");
   if (binlog_error_action == ABORT_SERVER)
   {
-    char err_buff[MYSQL_ERRMSG_SIZE];
-    sprintf(err_buff, "%s Hence aborting the server.", errmsg);
+    static const char format_err[]= "%s Hence aborting the server.";
+    char err_buff[MYSQL_ERRMSG_SIZE + sizeof(format_err)];
+    snprintf(err_buff, sizeof(err_buff), format_err, errmsg);
     exec_binlog_error_action_abort(err_buff);
   }
   else

--- a/sql/datadict.cc
+++ b/sql/datadict.cc
@@ -175,7 +175,7 @@ bool dd_recreate_table(THD *thd, const char *db, const char *table_name)
   DBUG_ASSERT(thd->mdl_context.is_lock_owner(MDL_key::TABLE, db, table_name,
                                              MDL_EXCLUSIVE));
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
 
   /* Create a path to the table, but without a extension. */
   build_table_filename(path, sizeof(path) - 1, db, table_name, "", 0);

--- a/sql/debug_sync.cc
+++ b/sql/debug_sync.cc
@@ -947,7 +947,7 @@ static void debug_sync_remove_action(st_debug_sync_control *ds_control,
     memmove(save_action, action, sizeof(st_debug_sync_action));
 
     /* Move actions down. */
-    memmove(ds_control->ds_action + dsp_idx,
+    memmove(static_cast<void*>(ds_control->ds_action + dsp_idx),
             ds_control->ds_action + dsp_idx + 1,
             (ds_control->ds_active - dsp_idx) *
             sizeof(st_debug_sync_action));
@@ -958,8 +958,8 @@ static void debug_sync_remove_action(st_debug_sync_control *ds_control,
       produced by the shift. Again do not use an assignment operator to
       avoid string allocation/copy.
     */
-    memmove(ds_control->ds_action + ds_control->ds_active, save_action,
-            sizeof(st_debug_sync_action));
+    memmove(static_cast<void*>(ds_control->ds_action + ds_control->ds_active),
+            save_action, sizeof(st_debug_sync_action));
   }
 
   DBUG_VOID_RETURN;
@@ -1030,7 +1030,7 @@ static st_debug_sync_action *debug_sync_get_action(THD *thd,
       ds_control->ds_action= (st_debug_sync_action*) new_action;
       ds_control->ds_allocated= new_alloc;
       /* Clear memory as we do not run string constructors here. */
-      memset((ds_control->ds_action + dsp_idx), 0,
+      memset(static_cast<void*>(ds_control->ds_action + dsp_idx), 0,
             (new_alloc - dsp_idx) * sizeof(st_debug_sync_action));
     }
     DBUG_PRINT("debug_sync", ("added action idx: %u", dsp_idx));

--- a/sql/field.h
+++ b/sql/field.h
@@ -3444,7 +3444,10 @@ public:
     memset(ptr, 0, packlength+sizeof(uchar*));
     return TYPE_OK;
   }
-  void reset_fields() { memset(&value, 0, sizeof(value)); }
+  void reset_fields()
+  {
+    memset(static_cast<void*>(&value), 0, sizeof(value));
+  }
   uint32 get_field_buffer_size(void) { return value.alloced_length(); }
 #ifndef WORDS_BIGENDIAN
   static
@@ -3518,7 +3521,9 @@ public:
   uint packed_col_length(const uchar *col_ptr, uint length);
   uint max_packed_col_length(uint max_length);
   void free() { value.free(); }
-  inline void clear_temporary() { memset(&value, 0, sizeof(value)); }
+  inline void clear_temporary() {
+    memset(static_cast<void*>(&value), 0, sizeof(value));
+  }
   friend type_conversion_status field_conv(Field *to,Field *from);
   bool has_charset(void) const
   { return charset() == &my_charset_bin ? FALSE : TRUE; }

--- a/sql/ha_partition.cc
+++ b/sql/ha_partition.cc
@@ -2212,7 +2212,7 @@ void ha_partition::update_create_info(HA_CREATE_INFO *create_info)
   uint num_parts = num_subparts ? m_file_tot_parts / num_subparts
                                 : m_file_tot_parts;
   HA_CREATE_INFO dummy_info;
-  memset(&dummy_info, 0, sizeof(dummy_info));
+  memset(static_cast<void*>(&dummy_info), 0, sizeof(dummy_info));
 
   /*
   Since update_create_info() can be called from mysql_prepare_alter_table()

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2570,8 +2570,8 @@ int ha_delete_table(THD *thd, handlerton *table_type, const char *path,
   TABLE_SHARE dummy_share;
   DBUG_ENTER("ha_delete_table");
 
-  memset(&dummy_table, 0, sizeof(dummy_table));
-  memset(&dummy_share, 0, sizeof(dummy_share));
+  memset(static_cast<void*>(&dummy_table), 0, sizeof(dummy_table));
+  memset(static_cast<void*>(&dummy_share), 0, sizeof(dummy_share));
   dummy_table.s= &dummy_share;
 
   /* DB_TYPE_UNKNOWN is used in ALTER TABLE when renaming only .frm files */
@@ -5298,7 +5298,7 @@ int ha_create_table_from_engine(THD* thd, const char *db, const char *name)
   DBUG_ENTER("ha_create_table_from_engine");
   DBUG_PRINT("enter", ("name '%s'.'%s'", db, name));
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
   if ((error= ha_discover(thd, db, name, &frmblob, &frmlen)))
   {
     /* Table could not be discovered and thus not created */

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -1473,7 +1473,7 @@ QUICK_INDEX_MERGE_SELECT::QUICK_INDEX_MERGE_SELECT(THD *thd_param,
   DBUG_ENTER("QUICK_INDEX_MERGE_SELECT::QUICK_INDEX_MERGE_SELECT");
   index= MAX_KEY;
   head= table;
-  memset(&read_record, 0, sizeof(read_record));
+  memset(static_cast<void*>(&read_record), 0, sizeof(read_record));
   init_sql_alloc(&alloc, thd->variables.range_alloc_block_size, 0);
   DBUG_VOID_RETURN;
 }

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -42,7 +42,7 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
     mem_alloc_error(sizeof(partition_info));
     DBUG_RETURN(NULL);
   }
-  memcpy(clone, this, sizeof(partition_info));
+  memcpy(static_cast<void*>(clone), this, sizeof(partition_info));
   memset(&(clone->read_partitions), 0, sizeof(clone->read_partitions));
   memset(&(clone->lock_partitions), 0, sizeof(clone->lock_partitions));
   clone->bitmaps_are_initialized= FALSE;
@@ -59,7 +59,7 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
       mem_alloc_error(sizeof(partition_element));
       DBUG_RETURN(NULL);
     }
-    memcpy(part_clone, part, sizeof(partition_element));
+    memcpy(static_cast<void*>(part_clone), part, sizeof(partition_element));
 
     /*
       Mark that RANGE and LIST values needs to be fixed so that we don't
@@ -89,7 +89,8 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
         mem_alloc_error(sizeof(partition_element));
         DBUG_RETURN(NULL);
       }
-      memcpy(subpart_clone, subpart, sizeof(partition_element));
+      memcpy(static_cast<void*>(subpart_clone), subpart,
+             sizeof(partition_element));
       part_clone->subpartitions.push_back(subpart_clone);
     }
     clone->partitions.push_back(part_clone);
@@ -1874,7 +1875,7 @@ void partition_info::print_no_partition_found(TABLE *table_arg)
   char *buf_ptr= (char*)&buf;
   TABLE_LIST table_list;
 
-  memset(&table_list, 0, sizeof(table_list));
+  memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
   table_list.db= table_arg->s->db.str;
   table_list.table_name= table_arg->s->table_name.str;
 

--- a/sql/records.cc
+++ b/sql/records.cc
@@ -69,7 +69,7 @@ bool init_read_record_idx(READ_RECORD *info, THD *thd, TABLE *table,
 {
   int error;
   empty_record(table);
-  memset(info, 0, sizeof(*info));
+  memset(static_cast<void*>(info), 0, sizeof(*info));
   info->thd= thd;
   info->table= table;
   info->record= table->record[0];
@@ -188,7 +188,7 @@ bool init_read_record(READ_RECORD *info,THD *thd, TABLE *table,
   IO_CACHE *tempfile;
   DBUG_ENTER("init_read_record");
 
-  memset(info, 0, sizeof(*info));
+  memset(static_cast<void*>(info), 0, sizeof(*info));
   info->thd=thd;
   info->table=table;
   info->forms= &info->table;		/* Only one table */

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -955,8 +955,8 @@ sp_returns_type(THD *thd, String &result, sp_head *sp)
   TABLE table;
   TABLE_SHARE share;
   Field *field;
-  memset(&table, 0, sizeof(table));
-  memset(&share, 0, sizeof(share));
+  memset(static_cast<void*>(&table), 0, sizeof(table));
+  memset(static_cast<void*>(&share), 0, sizeof(share));
   table.in_use= thd;
   table.s = &share;
   field= sp->create_result_field(0, 0, &table);

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -1962,7 +1962,7 @@ bool sp_head::add_used_tables_to_table_list(THD *thd,
 bool sp_head::check_show_access(THD *thd, bool *full_access)
 {
   TABLE_LIST tables;
-  memset(&tables, 0, sizeof(tables));
+  memset(static_cast<void*>(&tables), 0, sizeof(tables));
   tables.db= (char*) "mysql";
   tables.table_name= tables.alias= (char*) "proc";
 

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -304,7 +304,7 @@ bool Sql_cmd_alter_table::execute(THD *thd)
   {
     // Rename of table
     TABLE_LIST tmp_table;
-    memset(&tmp_table, 0, sizeof(tmp_table));
+    memset(static_cast<void*>(&tmp_table), 0, sizeof(tmp_table));
     tmp_table.table_name= lex->name.str;
     tmp_table.db= select_lex->db;
     tmp_table.grant.privilege= priv;

--- a/sql/sql_analyse.cc
+++ b/sql/sql_analyse.cc
@@ -239,12 +239,11 @@ bool get_ev_num_info(EV_NUM_INFO *ev_info, NUM_INFO *info, const char *num)
   return 1;
 } // get_ev_num_info
 
-
-void free_string(String *s)
+void free_string(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                 const void *param MY_ATTRIBUTE((unused)))
 {
-  s->free();
+  reinterpret_cast<String*>(key)->free();
 }
-
 
 void field_str::add()
 {
@@ -320,7 +319,7 @@ void field_str::add()
       }
       else
       {
-	memset(&s, 0, sizeof(s));  // Let tree handle free of this
+	memset(static_cast<void*>(&s), 0, sizeof(s));  // Let tree handle free of this
 	if ((treemem += length) > pc->max_treemem)
 	{
 	  room_in_tree = 0;	 // Remove tree, too big tree

--- a/sql/sql_analyse.h
+++ b/sql/sql_analyse.h
@@ -62,7 +62,8 @@ int compare_ulonglong(const ulonglong *s, const ulonglong *t);
 int compare_ulonglong2(void* cmp_arg MY_ATTRIBUTE((unused)),
 		       const ulonglong *s, const ulonglong *t);
 int compare_decimal2(int* len, const char *s, const char *t);
-void free_string(String*);
+void free_string(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                 const void *param MY_ATTRIBUTE((unused)));
 class select_analyse;
 
 class field_info :public Sql_alloc
@@ -116,7 +117,7 @@ public:
     must_be_blob(0), was_zero_fill(0),
     was_maybe_zerofill(0), can_be_still_num(1)
     { init_tree(&tree, 0, 0, sizeof(String), (qsort_cmp2) sortcmp2,
-		0, (tree_element_free) free_string, NULL); };
+		0, free_string, NULL); };
 
   void	 add();
   void	 get_opt_type(String*, ha_rows);

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -753,7 +753,7 @@ OPEN_TABLE_LIST *list_open_tables(THD *thd, const char *db, const char *wild)
   TABLE_LIST table_list;
   DBUG_ENTER("list_open_tables");
 
-  memset(&table_list, 0, sizeof(table_list));
+  memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
   start_list= &open_list;
   open_list=0;
 
@@ -1079,7 +1079,7 @@ bool close_cached_connection_tables(THD *thd, LEX_STRING *connection)
   DBUG_ENTER("close_cached_connections");
   DBUG_ASSERT(thd);
 
-  memset(&tmp, 0, sizeof(TABLE_LIST));
+  memset(static_cast<void*>(&tmp), 0, sizeof(TABLE_LIST));
 
   mysql_mutex_lock(&LOCK_open);
 

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -2022,7 +2022,7 @@ def_week_frmt: %lu, in_trans: %d, autocommit: %d",
       }
     }
 
-    memset(&table_list, 0, sizeof(table_list));
+    memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
     table_list.db = table->db();
     table_list.alias= table_list.table_name= table->table();
 #ifndef NO_EMBEDDED_ACCESS_CHECKS

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -363,7 +363,7 @@ bool load_db_opt(THD *thd, const char *path, HA_CREATE_INFO *create)
   bool error=1;
   uint nbytes;
 
-  memset(create, 0, sizeof(*create));
+  memset(static_cast<void*>(create), 0, sizeof(*create));
   create->default_table_charset= thd->variables.collation_server;
 
   /* Check if options for this database are already in the hash */

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -91,7 +91,7 @@ bool mysql_delete(THD *thd, TABLE_LIST *table_list, Item *conds,
     List<Item>   fields;
     List<Item>   all_fields;
 
-    memset(&tables, 0, sizeof(tables));
+    memset(static_cast<void*>(&tables), 0, sizeof(tables));
     tables.table = table;
     tables.alias = table_list->alias;
 

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2266,7 +2266,7 @@ public:
     thd.variables.lock_wait_timeout= LONG_TIMEOUT;
 
     memset(&thd.net, 0, sizeof(thd.net));           // Safety
-    memset(&table_list, 0, sizeof(table_list));     // Safety
+    memset(static_cast<void*>(&table_list), 0, sizeof(table_list));   // Safety
     thd.system_thread= SYSTEM_THREAD_DELAYED_INSERT;
     thd.security_ctx->host_or_ip= "";
     mysql_mutex_init(key_delayed_insert_mutex, &mutex, MY_MUTEX_INIT_FAST);
@@ -4395,7 +4395,7 @@ select_create::binlog_show_create_table(TABLE **tables, uint count)
   int result;
   TABLE_LIST tmp_table_list;
 
-  memset(&tmp_table_list, 0, sizeof(tmp_table_list));
+  memset(static_cast<void*>(&tmp_table_list), 0, sizeof(tmp_table_list));
   tmp_table_list.table = *tables;
   query.length(0);      // Have to zero it since constructor doesn't
 

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -4393,7 +4393,7 @@ static bool optimize_semijoin_nests_for_materialization(JOIN *join)
       if (!(sj_nest->nested_join->sjm.positions=
             (st_position*)join->thd->alloc(sizeof(st_position)*n_tables)))
         DBUG_RETURN(true);
-      memcpy(sj_nest->nested_join->sjm.positions,
+      memcpy(static_cast<void*>(sj_nest->nested_join->sjm.positions),
              join->best_positions + join->const_tables,
              sizeof(st_position) * n_tables);
     }
@@ -8069,7 +8069,7 @@ static bool make_join_select(JOIN *join, Item *cond)
         */
         int idx= tab - join->join_tab;
         cond->walk(&Item::inform_item_in_cond_of_tab, false,
-                   reinterpret_cast<uchar * const>(&idx));
+                   reinterpret_cast<uchar*>(&idx));
       }
 
     }

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3618,7 +3618,7 @@ end_with_restore_list:
     */
     thd->set_slow_log_for_admin_command();
 
-    memset(&create_info, 0, sizeof(create_info));
+    memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
     create_info.db_type= 0;
     create_info.row_type= ROW_TYPE_NOT_USED;
     create_info.default_table_charset= thd->variables.collation_database;

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -179,8 +179,8 @@ static bool compare_table_with_partition(THD *thd, TABLE *table,
   DBUG_ENTER("compare_table_with_partition");
 
   bool metadata_equal= false;
-  memset(&part_create_info, 0, sizeof(HA_CREATE_INFO));
-  memset(&table_create_info, 0, sizeof(HA_CREATE_INFO));
+  memset(static_cast<void*>(&part_create_info), 0, sizeof(HA_CREATE_INFO));
+  memset(static_cast<void*>(&table_create_info), 0, sizeof(HA_CREATE_INFO));
 
   update_create_info_from_table(&table_create_info, table);
   /* get the current auto_increment value */

--- a/sql/sql_planner.cc
+++ b/sql/sql_planner.cc
@@ -427,7 +427,11 @@ void Optimize_table_order::best_access_path(
     idx == join->const_tables ||                                     // 1
     !thd->optimizer_switch_flag(OPTIMIZER_SWITCH_BNL);               // 2
 
+// See the comment at Loose_scan_opt::Loose_scan_opt for why this warning has
+// been left in the code intentionally
+MY_DISABLE_WARN_MAYBE_UNINITIALIZED
   Loose_scan_opt loose_scan_opt;
+MY_RESTORE_WARN_MAYBE_UNINITIALIZED
   DBUG_ENTER("Optimize_table_order::best_access_path");
 
   Opt_trace_object trace_wrapper(trace, "best_access_path");
@@ -1103,7 +1107,7 @@ bool Optimize_table_order::choose_table_order()
   /* Are there any tables to optimize? */
   if (join->const_tables == join->tables)
   {
-    memcpy(join->best_positions, join->positions,
+    memcpy(static_cast<void*>(join->best_positions), join->positions,
 	   sizeof(POSITION) * join->const_tables);
     join->best_read= 1.0;
     join->best_rowcount= 1;
@@ -1297,7 +1301,8 @@ void Optimize_table_order::optimize_straight_join(table_map join_tables)
       join->sort_by_table != join->positions[join->const_tables].table->table)
     read_time+= record_count;  // We have to make a temp table
 
-  memcpy(join->best_positions, join->positions, sizeof(POSITION)*idx);
+  memcpy(static_cast<void*>(join->best_positions), join->positions,
+         sizeof(POSITION)*idx);
 
   /**
    * If many plans have identical cost, which one will be used
@@ -2485,7 +2490,8 @@ bool Optimize_table_order::fix_semijoin_strategies()
         setting it to SJ_OPT_NONE). But until then, pos->sj_strategy should
         not be read.
       */
-      memcpy(pos - table_count + 1, sjm_nest->nested_join->sjm.positions, 
+      memcpy(static_cast<void*>(pos - table_count + 1),
+             sjm_nest->nested_join->sjm.positions,
              sizeof(POSITION) * table_count);
       first= tableno - table_count + 1;
       join->best_positions[first].n_sj_tables= table_count;
@@ -2504,7 +2510,7 @@ bool Optimize_table_order::fix_semijoin_strategies()
       first= last_inner - table_count + 1;
       DBUG_ASSERT((join->best_positions + first)->table->emb_sj_nest ==
                   sjm_nest);
-      memcpy(join->best_positions + first, // stale semijoin strategy here too
+      memcpy(static_cast<void*>(join->best_positions + first), // stale semijoin strategy here too
              sjm_nest->nested_join->sjm.positions,
              sizeof(POSITION) * table_count);
       join->best_positions[first].sj_strategy= SJ_OPT_MATERIALIZE_SCAN;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -1458,7 +1458,8 @@ bool JOIN::get_best_combination()
   List_iterator<TABLE_LIST> sj_list_it(select_lex->sj_nests);
   TABLE_LIST *sj_nest;
   while ((sj_nest= sj_list_it++))
-    TRASH(&sj_nest->nested_join->sjm, sizeof(sj_nest->nested_join->sjm));
+    TRASH(static_cast<void*>(&sj_nest->nested_join->sjm),
+          sizeof(sj_nest->nested_join->sjm));
 
   DBUG_RETURN(false);
 }

--- a/sql/sql_select.h
+++ b/sql/sql_select.h
@@ -982,7 +982,7 @@ st_join_table::st_join_table()
     All users do init_read_record(), which does memset(),
     rather than invoking a constructor.
   */
-  memset(&read_record, 0, sizeof(read_record));
+  memset(static_cast<void*>(&read_record), 0, sizeof(read_record));
 }
 
 /**

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -593,7 +593,7 @@ find_files(THD *thd, List<LEX_STRING> *files, const char *db,
 
 
 
-  memset(&table_list, 0, sizeof(table_list));
+  memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
 
   if (!(dirp = my_dir(path,MYF(dir ? MY_WANT_STAT : 0))))
   {
@@ -1591,7 +1591,7 @@ int store_create_info(THD *thd, TABLE_LIST *table_list, String *packet,
   }
 
   key_info= table->key_info;
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
   /* Allow update_create_info to update row type */
   create_info.row_type= share->row_type;
   file->update_create_info(&create_info);
@@ -4449,8 +4449,8 @@ static int fill_schema_table_from_frm(THD *thd, TABLE_LIST *tables,
   uint key_length;
   char db_name_buff[NAME_LEN + 1], table_name_buff[NAME_LEN + 1];
 
-  memset(&table_list, 0, sizeof(TABLE_LIST));
-  memset(&tbl, 0, sizeof(TABLE));
+  memset(static_cast<void*>(&table_list), 0, sizeof(TABLE_LIST));
+  memset(static_cast<void*>(&tbl), 0, sizeof(TABLE));
 
   DBUG_ASSERT(db_name->length <= NAME_LEN);
   DBUG_ASSERT(table_name->length <= NAME_LEN);
@@ -5792,7 +5792,7 @@ bool store_schema_params(THD *thd, TABLE *table, TABLE *proc_table,
   bool free_sp_head;
   DBUG_ENTER("store_schema_params");
 
-  memset(&tbl, 0, sizeof(TABLE));
+  memset(static_cast<void*>(&tbl), 0, sizeof(TABLE));
   (void) build_table_filename(path, sizeof(path), "", "", "", 0);
   init_tmp_table_share(thd, &share, "", 0, "", path);
 
@@ -6001,7 +6001,7 @@ bool store_schema_proc(THD *thd, TABLE *table, TABLE *proc_table,
           Field *field;
           Create_field *field_def= &sp->m_return_field_def;
 
-          memset(&tbl, 0, sizeof(TABLE));
+          memset(static_cast<void*>(&tbl), 0, sizeof(TABLE));
           (void) build_table_filename(path, sizeof(path), "", "", "", 0);
           init_tmp_table_share(thd, &share, "", 0, "", path);
           field= make_field(&share, (uchar*) 0, field_def->length,
@@ -6082,7 +6082,7 @@ int fill_schema_proc(THD *thd, TABLE_LIST *tables, Item *cond)
   strxmov(definer, thd->security_ctx->priv_user, "@",
           thd->security_ctx->priv_host, NullS);
   /* We use this TABLE_LIST instance only for checking of privileges. */
-  memset(&proc_tables, 0, sizeof(proc_tables));
+  memset(static_cast<void*>(&proc_tables), 0, sizeof(proc_tables));
   proc_tables.db= (char*) "mysql";
   proc_tables.db_length= 5;
   proc_tables.table_name= proc_tables.alias= (char*) "proc";
@@ -6265,7 +6265,7 @@ static int get_schema_views_record(THD *thd, TABLE_LIST *tables,
         {
           TABLE_LIST table_list;
           uint view_access;
-          memset(&table_list, 0, sizeof(table_list));
+          memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
           table_list.db= tables->db;
           table_list.table_name= tables->table_name;
           table_list.grant.privilege= thd->col_access;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -5688,7 +5688,7 @@ bool mysql_create_like_table(THD* thd, TABLE_LIST* table, TABLE_LIST* src_table,
   DEBUG_SYNC(thd, "create_table_like_after_open");
 
   /* Fill HA_CREATE_INFO and Alter_info with description of source table. */
-  memset(&local_create_info, 0, sizeof(local_create_info));
+  memset(static_cast<void*>(&local_create_info), 0, sizeof(local_create_info));
   local_create_info.db_type= src_table->table->s->db_type();
   local_create_info.row_type= src_table->table->s->row_type;
   if (mysql_prepare_alter_table(thd, src_table->table, &local_create_info,
@@ -9591,7 +9591,7 @@ copy_data_between_tables(TABLE *from,TABLE *to,
     {
       from->sort.io_cache=(IO_CACHE*) my_malloc(sizeof(IO_CACHE),
                                                 MYF(MY_FAE | MY_ZEROFILL));
-      memset(&tables, 0, sizeof(tables));
+      memset(static_cast<void*>(&tables), 0, sizeof(tables));
       tables.table= from;
       tables.alias= tables.table_name= from->s->table_name.str;
       tables.db= from->s->db.str;
@@ -9766,7 +9766,7 @@ bool mysql_recreate_table(THD *thd, TABLE_LIST *table_list, bool table_copy)
   /* Same applies to MDL request. */
   table_list->mdl_request.set_type(MDL_SHARED_NO_WRITE);
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
   create_info.row_type=ROW_TYPE_NOT_USED;
   create_info.default_table_charset=default_charset_info;
   /* Force alter table to recreate table */

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -588,7 +588,7 @@ create_tmp_table(THD *thd,TMP_TABLE_PARAM *param,List<Item> &fields,
   strmov(tmpname,path);
   /* make table according to fields */
 
-  memset(table, 0, sizeof(*table));
+  memset(static_cast<void*>(table), 0, sizeof(*table));
   memset(reg_field, 0, sizeof(Field*)*(field_count+1));
   memset(default_field, 0, sizeof(Field*) * (field_count));
   memset(from_field, 0, sizeof(Field*)*field_count);
@@ -1272,7 +1272,7 @@ TABLE *create_duplicate_weedout_tmp_table(THD *thd,
   
 
   /* STEP 4: Create TABLE description */
-  memset(table, 0, sizeof(*table));
+  memset(static_cast<void*>(table), 0, sizeof(*table));
   memset(reg_field, 0, sizeof(Field*)*2);
 
   table->mem_root= own_root;
@@ -1504,8 +1504,8 @@ TABLE *create_virtual_tmp_table(THD *thd, List<Create_field> &field_list)
                         NullS))
     return 0;
 
-  memset(table, 0, sizeof(*table));
-  memset(share, 0, sizeof(*share));
+  memset(static_cast<void*>(table), 0, sizeof(*table));
+  memset(static_cast<void*>(share), 0, sizeof(*share));
   table->field= field;
   table->s= share;
   table->temp_pool_slot= MY_BIT_NONE;

--- a/sql/sql_trigger.cc
+++ b/sql/sql_trigger.cc
@@ -1812,7 +1812,7 @@ bool Table_triggers_list::drop_all_triggers(THD *thd, char *db, char *name)
   bool result= 0;
   DBUG_ENTER("drop_all_triggers");
 
-  memset(&table, 0, sizeof(table));
+  memset(static_cast<void*>(&table), 0, sizeof(table));
   init_sql_alloc(&table.mem_root, 8192, 0);
 
   if (Table_triggers_list::check_n_load(thd, db, name, &table, 1))
@@ -2032,7 +2032,7 @@ bool Table_triggers_list::change_table_name(THD *thd, const char *db,
   LEX_STRING *err_trigname;
   DBUG_ENTER("change_table_name");
 
-  memset(&table, 0, sizeof(table));
+  memset(static_cast<void*>(&table), 0, sizeof(table));
   init_sql_alloc(&table.mem_root, 8192, 0);
 
   /*

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -279,7 +279,7 @@ static bool recreate_temporary_table(THD *thd, TABLE *table)
   handlerton *table_type= table->s->db_type();
   DBUG_ENTER("recreate_temporary_table");
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
 
   table->file->info(HA_STATUS_AUTO | HA_STATUS_NO_LOCK);
 

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -478,7 +478,8 @@ bool st_select_lex_unit::prepare(THD *thd_arg, select_result *sel_result,
     if (union_result->create_result_table(thd, &types, MY_TEST(union_distinct),
                                           create_options, "", FALSE, TRUE))
       goto err;
-    memset(&result_table_list, 0, sizeof(result_table_list));
+    memset(static_cast<void*>(&result_table_list), 0,
+           sizeof(result_table_list));
     result_table_list.db= (char*) "";
     result_table_list.table_name= result_table_list.alias= (char*) "union";
     result_table_list.table= table= union_result->table;

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -214,7 +214,7 @@ fill_defined_view_parts (THD *thd, TABLE_LIST *view)
   LEX *lex= thd->lex;
   TABLE_LIST decoy;
 
-  memcpy (&decoy, view, sizeof (TABLE_LIST));
+  memcpy(static_cast<void*>(&decoy), view, sizeof (TABLE_LIST));
 
   key_length= get_table_def_key(view, &key);
 
@@ -2157,7 +2157,7 @@ mysql_rename_view(THD *thd,
       view definition parsing or use temporary 'view_def'
       object for it.
     */
-    memset(&view_def, 0, sizeof(view_def));
+    memset(static_cast<void*>(&view_def), 0, sizeof(view_def));
     view_def.timestamp.str= view_def.timestamp_buffer;
     view_def.view_suid= TRUE;
 

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -2435,7 +2435,8 @@ create:
             lex->alter_info.reset();
             lex->col_list.empty();
             lex->change=NullS;
-            memset(&lex->create_info, 0, sizeof(lex->create_info));
+            memset(static_cast<void*>(&lex->create_info), 0,
+                   sizeof(lex->create_info));
             lex->create_info.options=$2 | $4;
             lex->create_info.default_table_charset= NULL;
             lex->name.str= 0;
@@ -7468,7 +7469,8 @@ alter:
             lex->col_list.empty();
             lex->select_lex.init_order();
             lex->select_lex.db= (lex->select_lex.table_list.first)->db;
-            memset(&lex->create_info, 0, sizeof(lex->create_info));
+            memset(static_cast<void*>(&lex->create_info), 0,
+                   sizeof(lex->create_info));
             lex->create_info.db_type= 0;
             lex->create_info.default_table_charset= NULL;
             lex->create_info.row_type= ROW_TYPE_NOT_USED;
@@ -12623,7 +12625,8 @@ show:
             lex->wild=0;
             mysql_init_select(lex);
             lex->current_select->parsing_place= SELECT_LIST;
-            memset(&lex->create_info, 0, sizeof(lex->create_info));
+            memset(static_cast<void*>(&lex->create_info), 0,
+                   sizeof(lex->create_info));
           }
           show_param
           {

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -342,7 +342,7 @@ TABLE_SHARE *alloc_table_share(TABLE_LIST *table_list, const char *key,
                        table_cache_instances * sizeof(*cache_element_array),
                        NULL))
   {
-    memset(share, 0, sizeof(*share));
+    memset(static_cast<void*>(share), 0, sizeof(*share));
 
     share->set_table_cache_key(key_buff, key, key_length);
 
@@ -408,7 +408,7 @@ void init_tmp_table_share(THD *thd, TABLE_SHARE *share, const char *key,
   DBUG_ENTER("init_tmp_table_share");
   DBUG_PRINT("enter", ("table: '%s'.'%s'", key, table_name));
 
-  memset(share, 0, sizeof(*share));
+  memset(static_cast<void*>(share), 0, sizeof(*share));
   init_sql_alloc(&share->mem_root, TABLE_ALLOC_BLOCK_SIZE, 0);
   share->table_category=         TABLE_CATEGORY_TEMPORARY;
   share->tmp_table=              INTERNAL_TMP_TABLE;
@@ -2215,7 +2215,7 @@ int open_table_from_share(THD *thd, TABLE_SHARE *share, const char *alias,
                       share->table_name.str, (long) outparam));
 
   error= 1;
-  memset(outparam, 0, sizeof(*outparam));
+  memset(static_cast<void*>(outparam), 0, sizeof(*outparam));
   outparam->in_use= thd;
   outparam->s= share;
   outparam->db_stat= db_stat;
@@ -3904,7 +3904,8 @@ TABLE_LIST *TABLE_LIST::new_nested_join(MEM_ROOT *allocator,
   if (join_nest == NULL)
     return NULL;
 
-  memset(join_nest, 0, ALIGN_SIZE(sizeof(TABLE_LIST)) + sizeof(NESTED_JOIN));
+  memset(static_cast<void*>(join_nest), 0,
+         ALIGN_SIZE(sizeof(TABLE_LIST)) + sizeof(NESTED_JOIN));
   join_nest->nested_join=
     (NESTED_JOIN *) ((uchar *)join_nest + ALIGN_SIZE(sizeof(TABLE_LIST)));
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -1575,7 +1575,7 @@ struct TABLE_LIST
                              const char *alias_arg,
                              enum thr_lock_type lock_type_arg)
   {
-    memset(this, 0, sizeof(*this));
+    memset(static_cast<void*>(this), 0, sizeof(*this));
     db= (char*) db_name_arg;
     db_length= db_length_arg;
     table_name= (char*) table_name_arg;

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -1522,7 +1522,8 @@ my_offset_tzs_get_key(Time_zone_offset *entry,
 static void
 tz_init_table_list(TABLE_LIST *tz_tabs)
 {
-  memset(tz_tabs, 0, sizeof(TABLE_LIST) * MY_TZ_TABLES_COUNT);
+  memset(static_cast<void*>(tz_tabs), 0,
+         sizeof(TABLE_LIST) * MY_TZ_TABLES_COUNT);
 
   for (int i= 0; i < MY_TZ_TABLES_COUNT; i++)
   {
@@ -1653,7 +1654,7 @@ my_tz_init(THD *org_thd, const char *default_tzname, my_bool bootstrap)
   */
 
   thd->set_db(db, sizeof(db)-1);
-  memset(&tz_tables[0], 0, sizeof(TABLE_LIST));
+  memset(static_cast<void*>(&tz_tables[0]), 0, sizeof(TABLE_LIST));
   tz_tables[0].alias= tz_tables[0].table_name=
     (char*)"time_zone_leap_second";
   tz_tables[0].table_name_length= 21;

--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -1094,8 +1094,8 @@ static bool make_empty_rec(THD *thd, File file,
   DBUG_ENTER("make_empty_rec");
 
   /* We need a table to generate columns for default values */
-  memset(&table, 0, sizeof(table));
-  memset(&share, 0, sizeof(share));
+  memset(static_cast<void*>(&table), 0, sizeof(table));
+  memset(static_cast<void*>(&share), 0, sizeof(share));
   table.s= &share;
 
   if (!(buff=(uchar*) my_malloc((size_t) reclength,MYF(MY_WME | MY_ZEROFILL))))

--- a/storage/blackhole/ha_blackhole.cc
+++ b/storage/blackhole/ha_blackhole.cc
@@ -188,7 +188,7 @@ int ha_blackhole::info(uint flag)
 {
   DBUG_ENTER("ha_blackhole::info");
 
-  memset(&stats, 0, sizeof(stats));
+  memset(static_cast<void*>(&stats), 0, sizeof(stats));
   if (flag & HA_STATUS_AUTO)
     stats.auto_increment_value= 1;
   DBUG_RETURN(0);

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -201,8 +201,9 @@ buf_dump(
 {
 #define SHOULD_QUIT()	(SHUTTING_DOWN() && obey_shutdown)
 
+	static const char format_name[]= "%s.incomplete";
 	char	full_filename[OS_FILE_MAX_PATH];
-	char	tmp_filename[OS_FILE_MAX_PATH];
+	char	tmp_filename[OS_FILE_MAX_PATH + sizeof(format_name)];
 	char	now[32];
 	FILE*	f;
 	ulint	i;
@@ -213,7 +214,7 @@ buf_dump(
 		    srv_buf_dump_filename);
 
 	ut_snprintf(tmp_filename, sizeof(tmp_filename),
-		    "%s.incomplete", full_filename);
+		    format_name, full_filename);
 
 	buf_dump_status(STATUS_NOTICE, "Dumping buffer pool(s) to %s",
 			full_filename);

--- a/storage/innobase/fts/fts0pars.cc
+++ b/storage/innobase/fts/fts0pars.cc
@@ -106,8 +106,8 @@ typedef	int	(*fts_scanner_alt)(YYSTYPE* val, yyscan_t yyscanner);
 typedef	int	(*fts_scanner)();
 
 struct fts_lexer_t {
-	fts_scanner	scanner;
-	void*		yyscanner;
+	fts_scanner_alt		scanner;
+	void*			yyscanner;
 };
 
 
@@ -1950,7 +1950,7 @@ fts_lexer_create(
 			reinterpret_cast<const char*>(query),
 			static_cast<int>(query_len),
 			fts_lexer->yyscanner);
-		fts_lexer->scanner = reinterpret_cast<fts_scan>(fts_blexer);
+		fts_lexer->scanner = fts_blexer;
 		/* FIXME: Debugging */
 		/* fts0bset_debug(1 , fts_lexer->yyscanner); */
 	} else {
@@ -1959,7 +1959,7 @@ fts_lexer_create(
 			reinterpret_cast<const char*>(query),
 			static_cast<int>(query_len),
 			fts_lexer->yyscanner);
-		fts_lexer->scanner = reinterpret_cast<fts_scan>(fts_tlexer);
+		fts_lexer->scanner = fts_tlexer;
 	}
 
 	return(fts_lexer);
@@ -1973,7 +1973,7 @@ fts_lexer_free(
 /*===========*/
 	fts_lexer_t*	fts_lexer)
 {
-	if (fts_lexer->scanner == (fts_scan) fts_blexer) {
+	if (fts_lexer->scanner == fts_blexer) {
 		fts0blex_destroy(fts_lexer->yyscanner);
 	} else {
 		fts0tlex_destroy(fts_lexer->yyscanner);

--- a/storage/innobase/fts/fts0pars.y
+++ b/storage/innobase/fts/fts0pars.y
@@ -52,8 +52,8 @@ typedef	int	(*fts_scanner_alt)(YYSTYPE* val, yyscan_t yyscanner);
 typedef	int	(*fts_scanner)();
 
 struct fts_lexer_struct {
-	fts_scanner	scanner;
-	void*		yyscanner;
+	fts_scanner_alt		scanner;
+	void*			yyscanner;
 };
 
 %}
@@ -238,13 +238,13 @@ fts_lexer_create(
 	if (boolean_mode) {
 		fts0blex_init(&fts_lexer->yyscanner);
 		fts0b_scan_bytes((char*) query, query_len, fts_lexer->yyscanner);
-		fts_lexer->scanner = (fts_scan) fts_blexer;
+		fts_lexer->scanner = fts_blexer;
 		/* FIXME: Debugging */
 		/* fts0bset_debug(1 , fts_lexer->yyscanner); */
 	} else {
 		fts0tlex_init(&fts_lexer->yyscanner);
 		fts0t_scan_bytes((char*) query, query_len, fts_lexer->yyscanner);
-		fts_lexer->scanner = (fts_scan) fts_tlexer;
+		fts_lexer->scanner = fts_tlexer;
 	}
 
 	return(fts_lexer);
@@ -258,7 +258,7 @@ fts_lexer_free(
 /*===========*/
 	fts_lexer_t*	fts_lexer)
 {
-	if (fts_lexer->scanner == (fts_scan) fts_blexer) {
+	if (fts_lexer->scanner == fts_blexer) {
 		fts0blex_destroy(fts_lexer->yyscanner);
 	} else {
 		fts0tlex_destroy(fts_lexer->yyscanner);

--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -1482,7 +1482,7 @@ i_s_cmp_fill_low(
 			static_cast<double>(zip_stat->decompressed_usec / 1000000));
 
 		if (reset) {
-			memset(zip_stat, 0, sizeof *zip_stat);
+			memset(static_cast<void*>(zip_stat), 0, sizeof *zip_stat);
 		}
 
 		if (schema_table_store_record(thd, table)) {

--- a/storage/innobase/include/data0type.ic
+++ b/storage/innobase/include/data0type.ic
@@ -544,6 +544,7 @@ dtype_get_fixed_size_low(
 			return(0);
 		}
 #endif /* UNIV_DEBUG */
+		// fallthrough
 	case DATA_CHAR:
 	case DATA_FIXBINARY:
 	case DATA_INT:
@@ -622,6 +623,7 @@ dtype_get_min_size_low(
 			return(0);
 		}
 #endif /* UNIV_DEBUG */
+		// fallthrough
 	case DATA_CHAR:
 	case DATA_FIXBINARY:
 	case DATA_INT:

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -3522,7 +3522,7 @@ row_import_for_mysql(
 
 	row_import	cfg;
 
-	memset(&cfg, 0x0, sizeof(cfg));
+	memset(static_cast<void*>(&cfg), 0x0, sizeof(cfg));
 
 	err = row_import_read_cfg(table, trx->mysql_thd, cfg);
 

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -2430,7 +2430,8 @@ trx_get_trx_by_xid_low(
 
 			/* Invalidate the XID, so that subsequent calls
 			will not find it. */
-			memset(&trx->xid, 0, sizeof(trx->xid));
+			memset(static_cast<void*>(&trx->xid), 0,
+			       sizeof(trx->xid));
 			trx->xid.formatID = -1;
 			break;
 		}

--- a/storage/innobase/trx/trx0undo.cc
+++ b/storage/innobase/trx/trx0undo.cc
@@ -1313,7 +1313,7 @@ trx_undo_mem_create_at_db_start(
 	/* Read X/Open XA transaction identification if it exists, or
 	set it to NULL. */
 
-	memset(&xid, 0, sizeof(xid));
+	memset(static_cast<void*>(&xid), 0, sizeof(xid));
 	xid.formatID = -1;
 
 	if (xid_exists == TRUE) {

--- a/storage/myisam/mi_write.c
+++ b/storage/myisam/mi_write.c
@@ -923,7 +923,7 @@ static int keys_compare(bulk_insert_param *param, uchar *key1, uchar *key2)
 }
 
 
-static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
+static void keys_free(void* vkey, TREE_FREE mode, const void *vparam)
 {
   /*
     Probably I can use info->lastkey here, but I'm not sure,
@@ -932,6 +932,8 @@ static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
   uchar lastkey[MI_MAX_KEY_BUFF];
   uint keylen;
   MI_KEYDEF *keyinfo;
+  uchar *key= (uchar*)(vkey);
+  bulk_insert_param *param= (bulk_insert_param*)(vparam);
 
   switch (mode) {
   case free_init:
@@ -940,19 +942,20 @@ static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
       mysql_rwlock_wrlock(&param->info->s->key_root_lock[param->keynr]);
       param->info->s->keyinfo[param->keynr].version++;
     }
-    return 0;
+    return;
   case free_free:
     keyinfo=param->info->s->keyinfo+param->keynr;
     keylen=_mi_keylength(keyinfo, key);
     memcpy(lastkey, key, keylen);
-    return _mi_ck_write_btree(param->info,param->keynr,lastkey,
-			      keylen - param->info->s->rec_reflength);
+    _mi_ck_write_btree(param->info,param->keynr,lastkey,
+                       keylen - param->info->s->rec_reflength);
+    return;
   case free_end:
     if (param->info->s->concurrent_insert)
       mysql_rwlock_unlock(&param->info->s->key_root_lock[param->keynr]);
-    return 0;
+    return;
   }
-  return -1;
+  return;
 }
 
 
@@ -1009,7 +1012,7 @@ int mi_init_bulk_insert(MI_INFO *info, ulong cache_size, ha_rows rows)
                 cache_size * key[i].maxlength,
                 cache_size * key[i].maxlength, 0,
 		(qsort_cmp2)keys_compare, 0,
-		(tree_element_free) keys_free, (void *)params++);
+		keys_free, (void *)params++);
     }
     else
      info->bulk_insert[i].root=0;

--- a/storage/myisam/myisamlog.c
+++ b/storage/myisam/myisamlog.c
@@ -62,7 +62,8 @@ static int test_if_open(struct file_info *key,element_count count,
 static void fix_blob_pointers(MI_INFO *isam,uchar *record);
 static int test_when_accessed(struct file_info *key,element_count count,
 			      struct st_access_param *access_param);
-static void file_info_free(struct file_info *info);
+static void file_info_free(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                           const void *param MY_ATTRIBUTE((unused)));
 static int close_some_file(TREE *tree);
 static int reopen_closed_file(TREE *tree,struct file_info *file_info);
 static int find_record_with_key(struct file_info *file_info,uchar *record);
@@ -329,7 +330,7 @@ static int examine_log(char * file_name, char **table_names)
   init_io_cache(&cache,file,0,READ_CACHE,start_offset,0,MYF(0));
   memset(com_count, 0, sizeof(com_count));
   init_tree(&tree,0,0,sizeof(file_info),(qsort_cmp2) file_info_compare,1,
-	    (tree_element_free) file_info_free, NULL);
+            file_info_free, NULL);
   (void) init_key_cache(dflt_key_cache,KEY_CACHE_BLOCK_SIZE,KEY_CACHE_SIZE,
                       0, 0);
 
@@ -749,8 +750,10 @@ static int test_when_accessed (struct file_info *key,
 }
 
 
-static void file_info_free(struct file_info *fileinfo)
+static void file_info_free(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                           const void *param MY_ATTRIBUTE((unused)))
 {
+  struct file_info *fileinfo= (struct file_info*)key;
   DBUG_ENTER("file_info_free");
   if (update)
   {

--- a/unittest/gunit/decimal-t.cc
+++ b/unittest/gunit/decimal-t.cc
@@ -214,7 +214,7 @@ void do_test_d2f(const char *s, int ex)
 void do_test_d2b2d(const char *str, int p, int s, const char *orig, int ex)
 {
   char s1[100];
-  char s2[100];
+  char s2[164];
   uchar buf[100];
   char *end;
   int res, i, size=decimal_bin_size(p, s);
@@ -247,7 +247,7 @@ void do_test_f2d(double from, int ex)
 void do_test_ull2d(ulonglong from, const char *orig, int ex)
 {
   char s[100];
-  char s1[100];
+  char s1[123];
   int res;
 
   res=ulonglong2decimal(from, &a);
@@ -259,7 +259,7 @@ void do_test_ull2d(ulonglong from, const char *orig, int ex)
 void do_test_ll2d(longlong from, const char *orig, int ex)
 {
   char s[100];
-  char s1[100];
+  char s1[123];
   int res;
 
   res=longlong2decimal(from, &a);
@@ -271,7 +271,7 @@ void do_test_ll2d(longlong from, const char *orig, int ex)
 void do_test_d2ull(const char *s, const char *orig, int ex)
 {
   char s1[100], *end;
-  char s2[100];
+  char s2[154];
   ulonglong x;
   int res;
 
@@ -291,7 +291,7 @@ void do_test_d2ull(const char *s, const char *orig, int ex)
 void do_test_d2ll(const char *s, const char *orig, int ex)
 {
   char s1[100], *end;
-  char s2[100];
+  char s2[154];
   longlong x;
   int res;
 

--- a/unittest/gunit/opt_range-t.cc
+++ b/unittest/gunit/opt_range-t.cc
@@ -105,7 +105,7 @@ public:
                  false)                         // unsigned_arg
   {
     m_table_name= "mock_table";
-    memset(&m_share, 0, sizeof(m_share));
+    memset(static_cast<void*>(&m_share), 0, sizeof(m_share));
     const char *foo= "mock_db";
     m_share.db.str= const_cast<char*>(foo);
     m_share.db.length= strlen(m_share.db.str);
@@ -114,7 +114,7 @@ public:
     bitmap_set_above(&share_allset, 0, 1); //all bits 1
     m_share.all_set= share_allset;
 
-    memset(&m_table, 0, sizeof(m_table));
+    memset(static_cast<void*>(&m_table), 0, sizeof(m_table));
     m_table.s= &m_share;
 
     bitmap_init(&tbl_readset, 0, sizeof(my_bitmap_map), 0);

--- a/unittest/gunit/table_cache-t.cc
+++ b/unittest/gunit/table_cache-t.cc
@@ -125,7 +125,7 @@ class Mock_share : public TABLE_SHARE
 public:
   Mock_share(const char *key)
   {
-    memset((TABLE_SHARE *)this, 0, sizeof(TABLE_SHARE));
+    memset(static_cast<void*>(this), 0, sizeof(TABLE_SHARE));
     /*
       Both table_cache_key and cache_element array are used by
       Table_cache code.
@@ -154,7 +154,7 @@ public:
   {
     TABLE *result= (TABLE *)my_malloc(sizeof(TABLE), MYF(0));
 
-    memset(result, 0, sizeof(TABLE));
+    memset(static_cast<void*>(result), 0, sizeof(TABLE));
     result->s= this;
     // We create TABLE which is already marked as used
     result->in_use= thd;


### PR DESCRIPTION
1. Add gcc-8 to Travis config file
2. Fix the following gcc-8 warnings:
- cast between incompatible function types [-Werror=cast-function-type]
- clearing an object with no trivial copy-assignment [-Werror=class-memaccess]
- directive output may be truncated [-Werror=format-truncation=]

(the commit will be cherry-picked forward to 5.7)