### PR TITLE
PS-3957 : TokuDB tests skipped because they expect non-default binlog…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/rpl_mixed_replace_into.result
+++ b/mysql-test/suite/tokudb.bugs/r/rpl_mixed_replace_into.result
@@ -1,4 +1,7 @@
 include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
 set default_storage_engine='tokudb';
 drop table if exists testr;

--- a/mysql-test/suite/tokudb.bugs/t/rpl_mixed_replace_into-master.opt
+++ b/mysql-test/suite/tokudb.bugs/t/rpl_mixed_replace_into-master.opt
@@ -1,0 +1,1 @@
+--binlog-format=mixed

--- a/mysql-test/suite/tokudb.bugs/t/rpl_stmt_replace_into-master.opt
+++ b/mysql-test/suite/tokudb.bugs/t/rpl_stmt_replace_into-master.opt
@@ -1,0 +1,1 @@
+--binlog-format=statement


### PR DESCRIPTION
… format

- Added specific .opt files to force explicit setting binlog-format for rpl
  tests that are not under a suite with binlog-format in combinations.
- Re-recorded rpl_mixed_replace_into test to pick up Warning that is new to 5.7