### PR TITLE
Fix PS-3959 (Installing QRT plugins causes server crash) (5.6)

### DIFF
--- a/plugin/query_response_time/plugin.cc
+++ b/plugin/query_response_time/plugin.cc
@@ -29,6 +29,46 @@ ulong opt_query_response_time_range_base= QRT_DEFAULT_BASE;
 static my_bool opt_query_response_time_stats= FALSE;
 static my_bool opt_query_response_time_flush= FALSE;
 
+class qrt_atomic_flag
+{
+  public:
+    explicit qrt_atomic_flag(bool initial_value):
+      value_(initial_value ? 1 : 0)
+    {
+      my_atomic_rwlock_init(&lock_);
+    }
+    ~qrt_atomic_flag()
+    {
+      my_atomic_rwlock_destroy(&lock_);
+    }
+    void set()
+    {
+      my_atomic_rwlock_wrlock(&lock_);
+      my_atomic_store32(&value_, 1);
+      my_atomic_rwlock_wrunlock(&lock_);
+    }
+    void clear()
+    {
+      my_atomic_rwlock_wrlock(&lock_);
+      my_atomic_store32(&value_, 0);
+      my_atomic_rwlock_wrunlock(&lock_);
+    }
+    bool is_set() const
+    {
+      my_atomic_rwlock_rdlock(&lock_);
+      int32 res= my_atomic_load32(const_cast<volatile int32*>(&value_));
+      my_atomic_rwlock_rdunlock(&lock_);
+      return res != 0;
+    }
+
+  private:
+    qrt_atomic_flag(const qrt_atomic_flag&);
+    qrt_atomic_flag& operator = (const qrt_atomic_flag&);
+
+    mutable my_atomic_rwlock_t lock_;
+    volatile int32 value_;
+};
+static qrt_atomic_flag qrt_vars_initialized(false);
 
 static void query_response_time_flush_update(
               MYSQL_THD thd __attribute__((unused)),
@@ -69,7 +109,7 @@ enum session_stat
   session_stat_off
 };
 
-static const char *session_stat_names[]= {"GLOBAL", "ON", "OFF"};
+static const char *session_stat_names[]= {"GLOBAL", "ON", "OFF", NullS};
 static TYPELIB session_stat_typelib= { array_elements(session_stat_names) - 1,
                                        "", session_stat_names, NULL};
 
@@ -140,6 +180,12 @@ static int query_response_time_info_init(void *p)
   return 0;
 }
 
+static int query_response_time_info_init_main(void *p)
+{
+  int res= query_response_time_info_init(p);
+  qrt_vars_initialized.set();
+  return res;
+}
 
 static int query_response_time_info_deinit(void *arg __attribute__((unused)))
 {
@@ -148,14 +194,20 @@ static int query_response_time_info_deinit(void *arg __attribute__((unused)))
   return 0;
 }
 
+static int query_response_time_info_deinit_main(void *arg)
+{
+  qrt_vars_initialized.clear();
+  return query_response_time_info_deinit(arg);
+}
 
 static struct st_mysql_information_schema query_response_time_info_descriptor=
 { MYSQL_INFORMATION_SCHEMA_INTERFACE_VERSION };
 
 static bool query_response_time_should_log(MYSQL_THD thd)
 {
-  const enum session_stat session_stat_val
-    = static_cast<session_stat>(THDVAR(thd, session_stats));
+  const enum session_stat session_stat_val= qrt_vars_initialized.is_set() ?
+    static_cast<session_stat>(THDVAR(thd, session_stats)) :
+    session_stat_off;
   return (session_stat_val == session_stat_on)
     || (session_stat_val == session_stat_global
         && opt_query_response_time_stats);
@@ -243,8 +295,8 @@ mysql_declare_plugin(query_response_time)
   "Percona and Sergey Vojtovich",
   "Query Response Time Distribution INFORMATION_SCHEMA Plugin",
   PLUGIN_LICENSE_GPL,
-  query_response_time_info_init,
-  query_response_time_info_deinit,
+  query_response_time_info_init_main,
+  query_response_time_info_deinit_main,
   0x0100,
   NULL,
   query_response_time_info_vars,

--- a/plugin/query_response_time/tests/mtr/install_query_response_time-master.opt
+++ b/plugin/query_response_time/tests/mtr/install_query_response_time-master.opt
@@ -1,0 +1,1 @@
+--plugin_load=

--- a/plugin/query_response_time/tests/mtr/install_query_response_time.result
+++ b/plugin/query_response_time/tests/mtr/install_query_response_time.result
@@ -1,0 +1,11 @@
+#
+# Bug PS-3959 "Installing QRT plugins causes server crash"
+# https://jira.percona.com/browse/PS-3959
+#
+include/assert.inc [QUERY_RESPONSE_TIME_AUDIT must not be present on startup]
+INSTALL PLUGIN QUERY_RESPONSE_TIME_AUDIT SONAME 'query_response_time.so';
+include/assert.inc [QUERY_RESPONSE_TIME_AUDIT must be active]
+UNINSTALL PLUGIN QUERY_RESPONSE_TIME_AUDIT;
+Warnings:
+Warning	1620	Plugin is busy and will be uninstalled on shutdown
+include/assert.inc [QUERY_RESPONSE_TIME_AUDIT must not be present after uninstall]

--- a/plugin/query_response_time/tests/mtr/install_query_response_time.test
+++ b/plugin/query_response_time/tests/mtr/install_query_response_time.test
@@ -1,0 +1,22 @@
+--echo #
+--echo # Bug PS-3959 "Installing QRT plugins causes server crash"
+--echo # https://jira.percona.com/browse/PS-3959
+--echo #
+
+--source include/have_query_response_time_plugin.inc
+
+--let $assert_text= QUERY_RESPONSE_TIME_AUDIT must not be present on startup
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = \'QUERY_RESPONSE_TIME_AUDIT\']" = 0
+--source include/assert.inc
+
+--replace_regex /\.dll/.so/
+eval INSTALL PLUGIN QUERY_RESPONSE_TIME_AUDIT SONAME '$PLUGIN_QUERY_RESPONSE_TIME';
+--let $assert_text= QUERY_RESPONSE_TIME_AUDIT must be active
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = \'QUERY_RESPONSE_TIME_AUDIT\' AND PLUGIN_STATUS = \'ACTIVE\']" = 1
+--source include/assert.inc
+
+UNINSTALL PLUGIN QUERY_RESPONSE_TIME_AUDIT;
+
+--let $assert_text= QUERY_RESPONSE_TIME_AUDIT must not be present after uninstall
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME = \'QUERY_RESPONSE_TIME_AUDIT\']" = 0
+--source include/assert.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PS-3959

When only the audit part of the QRT plugin ('QUERY_RESPONSE_TIME_AUDIT') was
installed
"INSTALL PLUGIN QUERY_RESPONSE_TIME_AUDIT SONAME 'query_response_time.so'",
server used to crash in 'query_response_time_audit_notify()' as
'session_stats' plugin session variable used in this function
was not registered by MySQL plugin loading system in THD. This used to happen
because this variable was declared in another part of the same plugin -
'QUERY_RESPONSE_TIME'.

Fixed by introducing a new global flag 'query_response_time_vars_initialized'
indicating whether all the plugin variables from 'QUERY_RESPONSE_TIME' were
registered and initialized and it is safe to access them.

'query_response_time_should_log()' now attempts to access 'session_stats'
variable only if this flag is set. If it is not set, its value considered to
be 'OFF'.

In addition, fixed problem with declaring 'session_stat_names' array
without terminating 'NullS'.

Added new MTR test case 'query_response_time.install_query_response_time'
which simulates the scenario reported in the original bug description.