### PR TITLE
TDB-193 : Handlerton. trx->tokudb_lock_count > 0

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/TDB-193.result
+++ b/mysql-test/suite/tokudb.bugs/r/TDB-193.result
@@ -1,0 +1,11 @@
+CREATE TABLE t(a INT, b INT, c CHAR(1), d CHAR (1), e VARCHAR(1), f VARCHAR(1), g BLOB, h BLOB, id INT, KEY(b), CLUSTERING KEY(e)) ENGINE=TokuDB;
+ALTER TABLE t CHANGE COLUMN a a CHAR(1);
+ERROR HY000: Error on rename of './test/t' to './test/#sql-temporary' (errno: -100000 - Unknown error -100000)
+CREATE TABLE t(k INT, uq INT, UNIQUE KEY ix1 (uq)) ENGINE=InnoDB;
+ERROR 42S01: Table 't' already exists
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20,t21,t22,t23,t24,t25,t26,t27,t28,t29,t30,t31,t32,t33,t34,t35,t36,t37,t38,t39,t40,t41,t42,t43,t44,t45,t46,t47,t48,t49,t50,t51,t52,t53,t54,t55,t56,t57,t58,t59,t60,t61,t62,t63,t64,t65,t66,t67,t68,t69,t70,t71,t72,t73,t74,t75,t76,t77,t78,t79,t80,t81,t82,t83,t84,t85,t86,t87,t88,t89,t90,t91,t92,t93,t94,t95,t96,t97,t98,t99,t100,t101,t102,t103,t104,t105,t106,t107,t108,t109,t110,t111,t112,t113,t114,t115,t116,t117,t118,t119,t120,t121,t122,t123,t124,t125,t126,t127,t128,t129,t130,t131,t132,t133,t134,t135,t136,t137,t138,t139,t140,t141,t142,t143,t144,t145,t146,t147,t148,t149,t150,t151,t152,t153,t154,t155,t156,t157,t158,t159,t160,t161,t162,t163,t164,t165,t166,t167,t168,t169,t170,t171,t172,t173,t174,t175,t176,t177,t178,t179,t180,t181,t182,t183,t184,t185,t186,t187,t188,t189,t190,t191,t192,t193,t194,t195,t196,t197,t198,t199,t200,t201,t202,t203,t204,t205,t206,t207,t208,t209,t210,t211,t212,t213,t214,t215,t216,t217,t218,t219,t220,t221,t222,t223,t224,t225,t226,t227,t228,t229,t230,t231,t232,t233,t234,t235,t236,t237,t238,t239,t240,t241,t242,t243,t244,t245,t246,t247,t248,t249,t250,t251,t252,t253,t254,t255,t256,t257,t00;
+ERROR 42S02: Unknown table 'test.t1,test.t2,test.t3,test.t4,test.t5,test.t6,test.t7,test.t8,test.t9,test.t10,test.t11,test.t12,t'
+ALTER TABLE t ADD KEY bk(b);
+Warnings:
+Warning	1831	Duplicate index 'bk' defined on the table 'test.t'. This is deprecated and will be disallowed in a future release.
+DROP TABLE t;

--- a/mysql-test/suite/tokudb.bugs/t/TDB-193-master.opt
+++ b/mysql-test/suite/tokudb.bugs/t/TDB-193-master.opt
@@ -1,0 +1,1 @@
+--loose-tokudb-max-lock-memory=1023

--- a/mysql-test/suite/tokudb.bugs/t/TDB-193.test
+++ b/mysql-test/suite/tokudb.bugs/t/TDB-193.test
@@ -1,0 +1,20 @@
+--source include/have_tokudb.inc
+
+CREATE TABLE t(a INT, b INT, c CHAR(1), d CHAR (1), e VARCHAR(1), f VARCHAR(1), g BLOB, h BLOB, id INT, KEY(b), CLUSTERING KEY(e)) ENGINE=TokuDB;
+
+# this will return error -10000 from PerconaFT which is TOKUDB_OUT_OF_LOCKS but
+# mtr does not allow a negative value to be passed to --error, so, disable error
+# handling for now
+--disable_abort_on_error
+--replace_regex /#sql[0-9a-f_-]*/#sql-temporary/
+ALTER TABLE t CHANGE COLUMN a a CHAR(1);
+--enable_abort_on_error
+--error ER_TABLE_EXISTS_ERROR
+CREATE TABLE t(k INT, uq INT, UNIQUE KEY ix1 (uq)) ENGINE=InnoDB;
+--error ER_BAD_TABLE_ERROR
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8,t9,t10,t11,t12,t13,t14,t15,t16,t17,t18,t19,t20,t21,t22,t23,t24,t25,t26,t27,t28,t29,t30,t31,t32,t33,t34,t35,t36,t37,t38,t39,t40,t41,t42,t43,t44,t45,t46,t47,t48,t49,t50,t51,t52,t53,t54,t55,t56,t57,t58,t59,t60,t61,t62,t63,t64,t65,t66,t67,t68,t69,t70,t71,t72,t73,t74,t75,t76,t77,t78,t79,t80,t81,t82,t83,t84,t85,t86,t87,t88,t89,t90,t91,t92,t93,t94,t95,t96,t97,t98,t99,t100,t101,t102,t103,t104,t105,t106,t107,t108,t109,t110,t111,t112,t113,t114,t115,t116,t117,t118,t119,t120,t121,t122,t123,t124,t125,t126,t127,t128,t129,t130,t131,t132,t133,t134,t135,t136,t137,t138,t139,t140,t141,t142,t143,t144,t145,t146,t147,t148,t149,t150,t151,t152,t153,t154,t155,t156,t157,t158,t159,t160,t161,t162,t163,t164,t165,t166,t167,t168,t169,t170,t171,t172,t173,t174,t175,t176,t177,t178,t179,t180,t181,t182,t183,t184,t185,t186,t187,t188,t189,t190,t191,t192,t193,t194,t195,t196,t197,t198,t199,t200,t201,t202,t203,t204,t205,t206,t207,t208,t209,t210,t211,t212,t213,t214,t215,t216,t217,t218,t219,t220,t221,t222,t223,t224,t225,t226,t227,t228,t229,t230,t231,t232,t233,t234,t235,t236,t237,t238,t239,t240,t241,t242,t243,t244,t245,t246,t247,t248,t249,t250,t251,t252,t253,t254,t255,t256,t257,t00;
+
+# TokuDB commit_inplace_alter would assert here with trx->tokudb_lock_count > 0
+ALTER TABLE t ADD KEY bk(b);
+
+DROP TABLE t;

--- a/storage/tokudb/ha_tokudb_alter.cc
+++ b/storage/tokudb/ha_tokudb_alter.cc
@@ -1503,15 +1503,6 @@ bool ha_tokudb::commit_inplace_alter_table(
         if (ha_alter_info->group_commit_ctx) {
             ha_alter_info->group_commit_ctx = NULL;
         }
-        int error = write_frm_data(
-            share->status_block,
-            ctx->alter_txn,
-            altered_table->s->path.str);
-        if (error) {
-            commit = false;
-            result = true;
-            print_error(error, MYF(0));
-        }
     }
 
     if (!commit) {


### PR DESCRIPTION
- Commit https://github.com/percona/percona-server/commit/530b938570593d661c496978bd4d59c8695a5e83
  for TDB-129 incorrectly removed 5.5 and MariaDB specific compile out guards
  for code that should not exist within Percona Server 5.7. This eventually
  leads to the assertion in the issue report when an the FT layer returns an
  error during an alter table.