### PR TITLE
PS-3950 (5.7): gcc-8 compilation warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,17 +50,21 @@ matrix:
       compiler: clang
     # 5
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=Debug
+      env: VERSION=8    BUILD=Debug
       compiler: gcc
     # 6
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=Debug
+      env: VERSION=7    BUILD=Debug
       compiler: gcc
     # 7
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=Debug
+      env: VERSION=6    BUILD=Debug
       compiler: gcc
     # 8
+    - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=Debug
+      compiler: gcc
+    # 9
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=Debug
       compiler: gcc
@@ -87,17 +91,21 @@ matrix:
       compiler: clang
     # 5
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo
+      env: VERSION=8    BUILD=RelWithDebInfo
       compiler: gcc
     # 6
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo
+      env: VERSION=7    BUILD=RelWithDebInfo
       compiler: gcc
     # 7
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo
+      env: VERSION=6    BUILD=RelWithDebInfo
       compiler: gcc
     # 8
+    - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo
+      compiler: gcc
+    # 9
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo
       compiler: gcc
@@ -118,17 +126,21 @@ matrix:
       compiler: clang
     # 4
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 5
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 6
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 7
+    - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      compiler: gcc
+    #8
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
@@ -177,6 +189,8 @@ script:
     fi;
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
        sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test";
+       sudo -E apt-add-repository -y "ppa:jonathonf/binutils";
+       sudo -E apt-add-repository -y "ppa:jonathonf/gcc-8.0";
     fi;
 
   - echo --- Update list of packages and download dependencies;
@@ -218,12 +232,14 @@ script:
         -DMYSQL_MAINTAINER_MODE=ON
         -DWITH_MECAB=system
       ";
+      `# disable RocksDB for gcc-8 until MyRocks is warning-free`;
+      if [[ "$CC" == "gcc-8" ]]; then NOT_GCC_8=0; else NOT_GCC_8=1; fi;
       if [[ "$TRAVIS_REPO_SLUG" == "percona/percona-server" ]]; then
-        CMAKE_OPT+=" -DWITH_TOKUDB=ON -DWITH_ROCKSDB=ON";
+        CMAKE_OPT+=" -DWITH_TOKUDB=ON -DWITH_ROCKSDB=$NOT_GCC_8";
       else
         `# disable TokuDB or RocksDB as developers' forks must fit in the 50 min time limit`;
         if [[ "$BUILD" == "Debug" ]] && [[ "$CC" == "clang-$VERSION" ]]; then
-          CMAKE_OPT+=" -DWITH_TOKUDB=OFF -DWITH_ROCKSDB=ON";
+          CMAKE_OPT+=" -DWITH_TOKUDB=OFF -DWITH_ROCKSDB=$NOT_GCC_8";
         else
           CMAKE_OPT+=" -DWITH_TOKUDB=ON -DWITH_ROCKSDB=OFF";
         fi;

--- a/client/dump/program.cc
+++ b/client/dump/program.cc
@@ -150,7 +150,7 @@ int Program::execute(std::vector<std::string> positional_options)
       new Single_transaction_connection_provider(this, num_connections, message_handler)
       : new Thread_specific_connection_provider(this);
   }
-  catch (std::exception e)
+  catch (const std::exception &)
   {
     this->error(Mysql::Tools::Base::Message_data(
       0, "Error during creating connection.",

--- a/client/mysql_plugin.c
+++ b/client/mysql_plugin.c
@@ -325,9 +325,11 @@ static char *add_quotes(const char *path)
 
 static int get_default_values()
 {
+  static const char format_cmd[]= "%s mysqld > %s";
   char tool_path[FN_REFLEN];
-  char defaults_cmd[FN_REFLEN];
   char defaults_file[FN_REFLEN];
+  char defaults_cmd[sizeof(defaults_file) + sizeof(tool_path) +
+                    sizeof(format_cmd)];
   char line[FN_REFLEN];
   int error= 0;
   int ret= 0;
@@ -359,7 +361,7 @@ static int get_default_values()
     }
 #else
     my_snprintf(defaults_cmd, sizeof(defaults_cmd),
-                "%s mysqld > %s", tool_path, defaults_file);
+                format_cmd, tool_path, defaults_file);
 #endif
 
     /* Execute the command */
@@ -1234,7 +1236,9 @@ exit:
 
 static int bootstrap_server(char *server_path, char *bootstrap_file)
 {
-  char bootstrap_cmd[FN_REFLEN];
+  static const char format_cmd[]= "%s --no-defaults --bootstrap --datadir=%s "
+                           "--basedir=%s < %s";
+  char bootstrap_cmd[FN_REFLEN * 2 + sizeof(format_cmd)];
   int error= 0;
 
 #ifdef _WIN32
@@ -1257,9 +1261,8 @@ static int bootstrap_server(char *server_path, char *bootstrap_file)
               add_quotes(opt_datadir), add_quotes(opt_basedir),
               add_quotes(bootstrap_file));
 #else
-  my_snprintf(bootstrap_cmd, sizeof(bootstrap_cmd),
-              "%s --no-defaults --bootstrap --datadir=%s --basedir=%s"
-              " < %s", server_path, opt_datadir, opt_basedir, bootstrap_file);
+  my_snprintf(bootstrap_cmd, sizeof(bootstrap_cmd), format_cmd,
+              server_path, opt_datadir, opt_basedir, bootstrap_file);
 #endif
 
   /* Execute the command */

--- a/libbinlogevents/src/binlog_event.cpp
+++ b/libbinlogevents/src/binlog_event.cpp
@@ -92,7 +92,7 @@ Log_event_header(const char* buf, uint16_t binlog_version)
   memcpy(&tmp_sec, buf, sizeof(tmp_sec));
   when.tv_sec= le32toh(tmp_sec);
   when.tv_usec= 0;
-  type_code= static_cast<Log_event_type>(static_cast<const unsigned char>(buf[EVENT_TYPE_OFFSET]));
+  type_code= static_cast<Log_event_type>(static_cast<unsigned char>(buf[EVENT_TYPE_OFFSET]));
   memcpy(&unmasked_server_id,
          buf + SERVER_ID_OFFSET, sizeof(unmasked_server_id));
 

--- a/libbinlogevents/src/rows_event.cpp
+++ b/libbinlogevents/src/rows_event.cpp
@@ -91,14 +91,14 @@ Table_map_event::Table_map_event(const char *buf, unsigned int event_len,
   if (post_header_len == 6)
   {
     /* Master is of an intermediate source tree before 5.1.4. Id is 4 bytes */
-    memcpy(&m_table_id, post_start, 4);
+    memcpy(static_cast<void*>(&m_table_id), post_start, 4);
     m_table_id= le64toh(m_table_id);
     post_start+= 4;
   }
   else
   {
     BAPI_ASSERT(post_header_len == TABLE_MAP_HEADER_LEN);
-    memcpy(&m_table_id, post_start, 6);
+    memcpy(static_cast<void*>(&m_table_id), post_start, 6);
     m_table_id= le64toh(m_table_id);
     post_start+= TM_FLAGS_OFFSET;
   }
@@ -183,13 +183,13 @@ Rows_event::Rows_event(const char *buf, unsigned int event_len,
   if (post_header_len == 6)
   {
     /* Master is of an intermediate source tree before 5.1.4. Id is 4 bytes */
-    memcpy(&m_table_id, post_start, 4);
+    memcpy(static_cast<void*>(&m_table_id), post_start, 4);
     m_table_id= le64toh(m_table_id);
     post_start+= 4;
   }
   else
   {
-    memcpy(&m_table_id, post_start, 6);
+    memcpy(static_cast<void*>(&m_table_id), post_start, 6);
     m_table_id= le64toh(m_table_id);
     post_start+= ROWS_FLAGS_OFFSET;
   }

--- a/plugin/keyring/buffered_file_io.h
+++ b/plugin/keyring/buffered_file_io.h
@@ -40,7 +40,7 @@ public:
     , file_io(logger)
     , keyring_file(-1)
   {
-    memset(&saved_keyring_stat, 0, sizeof(MY_STAT));
+    memset(static_cast<void*>(&saved_keyring_stat), 0, sizeof(MY_STAT));
   }
 
   my_bool init(std::string *keyring_filename);

--- a/plugin/test_service_sql_api/test_session_detach.cc
+++ b/plugin/test_service_sql_api/test_session_detach.cc
@@ -246,7 +246,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_session_info.cc
+++ b/plugin/test_service_sql_api/test_session_info.cc
@@ -267,7 +267,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_2_sessions.cc
+++ b/plugin/test_service_sql_api/test_sql_2_sessions.cc
@@ -268,7 +268,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_all_col_types.cc
+++ b/plugin/test_service_sql_api/test_sql_all_col_types.cc
@@ -248,7 +248,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_commit.cc
+++ b/plugin/test_service_sql_api/test_sql_commit.cc
@@ -248,7 +248,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_complex.cc
+++ b/plugin/test_service_sql_api/test_sql_complex.cc
@@ -316,7 +316,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_errors.cc
+++ b/plugin/test_service_sql_api/test_sql_errors.cc
@@ -271,7 +271,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_lock.cc
+++ b/plugin/test_service_sql_api/test_sql_lock.cc
@@ -247,7 +247,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_processlist.cc
+++ b/plugin/test_service_sql_api/test_sql_processlist.cc
@@ -261,7 +261,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_replication.cc
+++ b/plugin/test_service_sql_api/test_sql_replication.cc
@@ -244,7 +244,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_shutdown.cc
+++ b/plugin/test_service_sql_api/test_sql_shutdown.cc
@@ -251,7 +251,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_sqlmode.cc
+++ b/plugin/test_service_sql_api/test_sql_sqlmode.cc
@@ -304,7 +304,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_stored_procedures_functions.cc
+++ b/plugin/test_service_sql_api/test_sql_stored_procedures_functions.cc
@@ -268,7 +268,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/plugin/test_service_sql_api/test_sql_views_triggers.cc
+++ b/plugin/test_service_sql_api/test_sql_views_triggers.cc
@@ -268,7 +268,8 @@ static int sql_get_null(void *ctx)
   uint col= pctx->current_col;
   pctx->current_col++;
 
-  strncpy(pctx->sql_str_value[row][col], "[NULL]", sizeof("[NULL]")-1);
+  strncpy(pctx->sql_str_value[row][col], "[NULL]",
+          sizeof(pctx->sql_str_value[0][0]));
   pctx->sql_str_len[row][col]=  sizeof("[NULL]")-1;
 
   DBUG_RETURN(false);

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -9518,8 +9518,9 @@ void MYSQL_BIN_LOG::handle_binlog_flush_or_sync_error(THD *thd,
           binlog_error_action == ABORT_SERVER ? "ABORT_SERVER" : "IGNORE_ERROR");
   if (binlog_error_action == ABORT_SERVER)
   {
-    char err_buff[MYSQL_ERRMSG_SIZE];
-    sprintf(err_buff, "%s Hence aborting the server.", errmsg);
+    static const char format_err[]= "%s Hence aborting the server.";
+    char err_buff[MYSQL_ERRMSG_SIZE + sizeof(format_err)];
+    snprintf(err_buff, sizeof(err_buff), format_err, errmsg);
     exec_binlog_error_action_abort(err_buff);
   }
   else

--- a/sql/datadict.cc
+++ b/sql/datadict.cc
@@ -182,7 +182,7 @@ bool dd_recreate_table(THD *thd, const char *db, const char *table_name)
                                                            db, table_name,
                                                            MDL_EXCLUSIVE));
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
 
   /* Create a path to the table, but without a extension. */
   build_table_filename(path, sizeof(path) - 1, db, table_name, "", 0);

--- a/sql/debug_sync.cc
+++ b/sql/debug_sync.cc
@@ -1015,7 +1015,7 @@ static void debug_sync_remove_action(st_debug_sync_control *ds_control,
     memmove(save_action, action, sizeof(st_debug_sync_action));
 
     /* Move actions down. */
-    memmove(ds_control->ds_action + dsp_idx,
+    memmove(static_cast<void*>(ds_control->ds_action + dsp_idx),
             ds_control->ds_action + dsp_idx + 1,
             (ds_control->ds_active - dsp_idx) *
             sizeof(st_debug_sync_action));
@@ -1026,8 +1026,8 @@ static void debug_sync_remove_action(st_debug_sync_control *ds_control,
       produced by the shift. Again do not use an assignment operator to
       avoid string allocation/copy.
     */
-    memmove(ds_control->ds_action + ds_control->ds_active, save_action,
-            sizeof(st_debug_sync_action));
+    memmove(static_cast<void*>(ds_control->ds_action + ds_control->ds_active),
+            save_action, sizeof(st_debug_sync_action));
   }
 
   DBUG_VOID_RETURN;
@@ -1099,7 +1099,7 @@ static st_debug_sync_action *debug_sync_get_action(THD *thd,
       ds_control->ds_action= (st_debug_sync_action*) new_action;
       ds_control->ds_allocated= new_alloc;
       /* Clear memory as we do not run string constructors here. */
-      memset((ds_control->ds_action + dsp_idx), 0,
+      memset(static_cast<void*>(ds_control->ds_action + dsp_idx), 0,
             (new_alloc - dsp_idx) * sizeof(st_debug_sync_action));
     }
     DBUG_PRINT("debug_sync", ("added action idx: %u", dsp_idx));

--- a/sql/field.h
+++ b/sql/field.h
@@ -3843,8 +3843,8 @@ public:
   }
   void reset_fields()
   { 
-    memset(&value, 0, sizeof(value)); 
-    memset(&old_value, 0, sizeof(old_value));
+    memset(static_cast<void*>(&value), 0, sizeof(value));
+    memset(static_cast<void*>(&old_value), 0, sizeof(old_value));
   }
   size_t get_field_buffer_size() { return value.alloced_length(); }
 #ifndef WORDS_BIGENDIAN
@@ -3926,7 +3926,9 @@ public:
     value.mem_free();
     old_value.mem_free();
   }
-  inline void clear_temporary() { memset(&value, 0, sizeof(value)); }
+  inline void clear_temporary() {
+    memset(static_cast<void*>(&value), 0, sizeof(value));
+  }
   friend type_conversion_status field_conv(Field *to,Field *from);
   bool has_charset(void) const
   { return charset() == &my_charset_bin ? FALSE : TRUE; }

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2742,8 +2742,8 @@ int ha_delete_table(THD *thd, handlerton *table_type, const char *path,
   TABLE_SHARE dummy_share;
   DBUG_ENTER("ha_delete_table");
 
-  memset(&dummy_table, 0, sizeof(dummy_table));
-  memset(&dummy_share, 0, sizeof(dummy_share));
+  memset(static_cast<void*>(&dummy_table), 0, sizeof(dummy_table));
+  memset(static_cast<void*>(&dummy_share), 0, sizeof(dummy_share));
   dummy_table.s= &dummy_share;
 
   /* DB_TYPE_UNKNOWN is used in ALTER TABLE when renaming only .frm files */
@@ -5583,7 +5583,7 @@ int ha_create_table_from_engine(THD* thd, const char *db, const char *name)
   DBUG_ENTER("ha_create_table_from_engine");
   DBUG_PRINT("enter", ("name '%s'.'%s'", db, name));
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
   if ((error= ha_discover(thd, db, name, &frmblob, &frmlen)))
   {
     /* Table could not be discovered and thus not created */

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1563,7 +1563,7 @@ Log_event* Log_event::read_log_event(const char* buf, uint event_len,
     DBUG_RETURN(NULL); // general sanity check - will fail on a partial read
   }
 
-  uint event_type= static_cast<const uchar>(buf[EVENT_TYPE_OFFSET]);
+  uint event_type= static_cast<uchar>(buf[EVENT_TYPE_OFFSET]);
   // all following START events in the current file are without checksum
   if (event_type == binary_log::START_EVENT_V3)
     (const_cast<Format_description_log_event*>(description_event))->

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3810,9 +3810,10 @@ static int generate_server_uuid()
 
   delete thd;
 
-  strncpy(server_uuid, uuid.c_ptr(), UUID_LENGTH);
+  strncpy(server_uuid, uuid.c_ptr(), sizeof(server_uuid));
   DBUG_EXECUTE_IF("server_uuid_deterministic",
-                  strncpy(server_uuid, "00000000-1111-0000-1111-000000000000", UUID_LENGTH););
+                  strncpy(server_uuid, "00000000-1111-0000-1111-000000000000",
+                          sizeof(server_uuid)););
   server_uuid[UUID_LENGTH]= '\0';
   return 0;
 }

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -1606,7 +1606,7 @@ QUICK_INDEX_MERGE_SELECT::QUICK_INDEX_MERGE_SELECT(THD *thd_param,
   DBUG_ENTER("QUICK_INDEX_MERGE_SELECT::QUICK_INDEX_MERGE_SELECT");
   index= MAX_KEY;
   head= table;
-  memset(&read_record, 0, sizeof(read_record));
+  memset(static_cast<void*>(&read_record), 0, sizeof(read_record));
   init_sql_alloc(key_memory_quick_index_merge_root,
                  &alloc, thd->variables.range_alloc_block_size, 0);
   DBUG_VOID_RETURN;

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -40,7 +40,7 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
     mem_alloc_error(sizeof(partition_info));
     DBUG_RETURN(NULL);
   }
-  memcpy(clone, this, sizeof(partition_info));
+  memcpy(static_cast<void*>(clone), this, sizeof(partition_info));
   memset(&(clone->read_partitions), 0, sizeof(clone->read_partitions));
   memset(&(clone->lock_partitions), 0, sizeof(clone->lock_partitions));
   clone->bitmaps_are_initialized= FALSE;
@@ -57,7 +57,7 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
       mem_alloc_error(sizeof(partition_element));
       DBUG_RETURN(NULL);
     }
-    memcpy(part_clone, part, sizeof(partition_element));
+    memcpy(static_cast<void*>(part_clone), part, sizeof(partition_element));
 
     /*
       Mark that RANGE and LIST values needs to be fixed so that we don't
@@ -87,7 +87,8 @@ partition_info *partition_info::get_clone(bool reset /* = false */)
         mem_alloc_error(sizeof(partition_element));
         DBUG_RETURN(NULL);
       }
-      memcpy(subpart_clone, subpart, sizeof(partition_element));
+      memcpy(static_cast<void*>(subpart_clone), subpart,
+             sizeof(partition_element));
       part_clone->subpartitions.push_back(subpart_clone);
     }
     clone->partitions.push_back(part_clone);
@@ -1921,7 +1922,7 @@ void partition_info::print_no_partition_found(TABLE *table_arg)
   char *buf_ptr= (char*)&buf;
   TABLE_LIST table_list;
 
-  memset(&table_list, 0, sizeof(table_list));
+  memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
   table_list.db= table_arg->s->db.str;
   table_list.table_name= table_arg->s->table_name.str;
 

--- a/sql/records.cc
+++ b/sql/records.cc
@@ -66,7 +66,7 @@ bool init_read_record_idx(READ_RECORD *info, THD *thd, TABLE *table,
 {
   int error;
   empty_record(table);
-  memset(info, 0, sizeof(*info));
+  memset(static_cast<void*>(info), 0, sizeof(*info));
   info->thd= thd;
   info->table= table;
   info->record= table->record[0];
@@ -191,7 +191,7 @@ bool init_read_record(READ_RECORD *info,THD *thd,
   if (!table)
     table= qep_tab->table();
 
-  memset(info, 0, sizeof(*info));
+  memset(static_cast<void*>(info), 0, sizeof(*info));
   info->thd=thd;
   info->table=table;
   info->forms= &info->table;		/* Only one table */

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -8167,7 +8167,7 @@ bool queue_event(Master_info* mi,const char* buf, ulong event_len)
   char *save_buf= NULL; // needed for checksumming the fake Rotate event
   char rot_buf[LOG_EVENT_HEADER_LEN + Binary_log_event::ROTATE_HEADER_LEN + FN_REFLEN];
   Gtid gtid= { 0, 0 };
-  Log_event_type event_type= (Log_event_type)static_cast<const uchar>(buf[EVENT_TYPE_OFFSET]);
+  Log_event_type event_type= (Log_event_type)static_cast<uchar>(buf[EVENT_TYPE_OFFSET]);
 
   DBUG_ASSERT(checksum_alg == binary_log::BINLOG_CHECKSUM_ALG_OFF || 
               checksum_alg == binary_log::BINLOG_CHECKSUM_ALG_UNDEF || 

--- a/sql/sp.cc
+++ b/sql/sp.cc
@@ -972,8 +972,8 @@ sp_returns_type(THD *thd, String &result, sp_head *sp)
   TABLE table;
   TABLE_SHARE share;
   Field *field;
-  memset(&table, 0, sizeof(table));
-  memset(&share, 0, sizeof(share));
+  memset(static_cast<void*>(&table), 0, sizeof(table));
+  memset(static_cast<void*>(&share), 0, sizeof(share));
   table.in_use= thd;
   table.s = &share;
   field= sp->create_result_field(0, 0, &table);

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -2174,7 +2174,7 @@ void sp_head::add_used_tables_to_table_list(THD *thd,
 bool sp_head::check_show_access(THD *thd, bool *full_access)
 {
   TABLE_LIST tables;
-  memset(&tables, 0, sizeof(tables));
+  memset(static_cast<void*>(&tables), 0, sizeof(tables));
   tables.db= (char*) "mysql";
   tables.table_name= tables.alias= (char*) "proc";
 

--- a/sql/sql_alter.cc
+++ b/sql/sql_alter.cc
@@ -307,7 +307,7 @@ bool Sql_cmd_alter_table::execute(THD *thd)
   {
     // Rename of table
     TABLE_LIST tmp_table;
-    memset(&tmp_table, 0, sizeof(tmp_table));
+    memset(static_cast<void*>(&tmp_table), 0, sizeof(tmp_table));
     tmp_table.table_name= lex->name.str;
     tmp_table.db= select_lex->db;
     tmp_table.grant.privilege= priv;

--- a/sql/sql_analyse.cc
+++ b/sql/sql_analyse.cc
@@ -237,12 +237,11 @@ bool get_ev_num_info(EV_NUM_INFO *ev_info, NUM_INFO *info, const char *num)
   return 1;
 } // get_ev_num_info
 
-
-void free_string(String *s)
+void free_string(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                 const void *param MY_ATTRIBUTE((unused)))
 {
-  s->mem_free();
+  reinterpret_cast<String*>(key)->mem_free();
 }
-
 
 void field_str::add()
 {
@@ -318,7 +317,7 @@ void field_str::add()
       }
       else
       {
-	memset(&s, 0, sizeof(s));  // Let tree handle free of this
+	memset(static_cast<void*>(&s), 0, sizeof(s));  // Let tree handle free of this
 	if ((treemem += length) > pc->max_treemem)
 	{
 	  room_in_tree = 0;	 // Remove tree, too big tree

--- a/sql/sql_analyse.h
+++ b/sql/sql_analyse.h
@@ -67,7 +67,8 @@ int compare_ulonglong(const ulonglong *s, const ulonglong *t);
 int compare_ulonglong2(void* cmp_arg MY_ATTRIBUTE((unused)),
 		       const ulonglong *s, const ulonglong *t);
 int compare_decimal2(int* len, const char *s, const char *t);
-void free_string(String*);
+void free_string(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                 const void *param MY_ATTRIBUTE((unused)));
 class Query_result_analyse;
 
 class field_info :public Sql_alloc
@@ -121,7 +122,7 @@ public:
     must_be_blob(0), was_zero_fill(0),
     was_maybe_zerofill(0), can_be_still_num(1)
     { init_tree(&tree, 0, 0, sizeof(String), (qsort_cmp2) sortcmp2,
-		0, (tree_element_free) free_string, NULL); };
+		0, free_string, NULL); };
 
   void	 add();
   void	 get_opt_type(String*, ha_rows);

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -1042,7 +1042,7 @@ OPEN_TABLE_LIST *list_open_tables(THD *thd, const char *db, const char *wild)
   TABLE_LIST table_list;
   DBUG_ENTER("list_open_tables");
 
-  memset(&table_list, 0, sizeof(table_list));
+  memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
   start_list= &open_list;
   open_list=0;
 

--- a/sql/sql_cache.cc
+++ b/sql/sql_cache.cc
@@ -2114,7 +2114,7 @@ def_week_frmt: %lu, in_trans: %d, autocommit: %d",
       }
     }
 
-    memset(&table_list, 0, sizeof(table_list));
+    memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
     table_list.db = table->db();
     table_list.alias= table_list.table_name= table->table();
 #ifndef NO_EMBEDDED_ACCESS_CHECKS

--- a/sql/sql_db.cc
+++ b/sql/sql_db.cc
@@ -378,7 +378,7 @@ bool load_db_opt(THD *thd, const char *path, HA_CREATE_INFO *create)
   bool error=1;
   uint nbytes;
 
-  memset(create, 0, sizeof(*create));
+  memset(static_cast<void*>(create), 0, sizeof(*create));
   create->default_table_charset= thd->variables.collation_server;
 
   /* Check if options for this database are already in the hash */

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -664,7 +664,7 @@ bool Sql_cmd_delete::mysql_prepare_delete(THD *thd)
     List<Item>   fields;
     List<Item>   all_fields;
 
-    memset(&tables, 0, sizeof(tables));
+    memset(static_cast<void*>(&tables), 0, sizeof(tables));
     tables.table = table_list->table;
     tables.alias = table_list->alias;
 

--- a/sql/sql_executor.h
+++ b/sql/sql_executor.h
@@ -381,7 +381,7 @@ public:
        All users do init_read_record(), which does memset(),
        rather than invoking a constructor.
     */
-    memset(&read_record, 0, sizeof(read_record));
+    memset(static_cast<void*>(&read_record), 0, sizeof(read_record));
   }
 
   /// Initializes the object from a JOIN_TAB

--- a/sql/sql_insert.cc
+++ b/sql/sql_insert.cc
@@ -2948,7 +2948,7 @@ int Query_result_create::binlog_show_create_table(TABLE **tables, uint count)
   int result;
   TABLE_LIST tmp_table_list;
 
-  memset(&tmp_table_list, 0, sizeof(tmp_table_list));
+  memset(static_cast<void*>(&tmp_table_list), 0, sizeof(tmp_table_list));
   tmp_table_list.table = *tables;
   query.length(0);      // Have to zero it since constructor doesn't
 

--- a/sql/sql_load.cc
+++ b/sql/sql_load.cc
@@ -447,8 +447,8 @@ int mysql_load(THD *thd,sql_exchange *ex,TABLE_LIST *table_list,
                        MY_RETURN_REAL_PATH);
     }
 
-    if (thd->slave_thread & ((SYSTEM_THREAD_SLAVE_SQL |
-                             (SYSTEM_THREAD_SLAVE_WORKER))!=0))
+    if ((thd->slave_thread & (SYSTEM_THREAD_SLAVE_SQL |
+                              SYSTEM_THREAD_SLAVE_WORKER))!=0)
     {
 #if defined(HAVE_REPLICATION) && !defined(MYSQL_CLIENT)
       Relay_log_info* rli= thd->rli_slave->get_c_rli();

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -2952,7 +2952,8 @@ bool JOIN::get_best_combination()
   List_iterator<TABLE_LIST> sj_list_it(select_lex->sj_nests);
   TABLE_LIST *sj_nest;
   while ((sj_nest= sj_list_it++))
-    TRASH(&sj_nest->nested_join->sjm, sizeof(sj_nest->nested_join->sjm));
+    TRASH(static_cast<void*>(&sj_nest->nested_join->sjm),
+          sizeof(sj_nest->nested_join->sjm));
 
   DBUG_RETURN(false);
 }
@@ -6377,7 +6378,7 @@ static bool optimize_semijoin_nests_for_materialization(JOIN *join)
       if (!(sj_nest->nested_join->sjm.positions=
             (st_position*)join->thd->alloc(sizeof(st_position)*n_tables)))
         DBUG_RETURN(true);
-      memcpy(sj_nest->nested_join->sjm.positions,
+      memcpy(static_cast<void*>(sj_nest->nested_join->sjm.positions),
              join->best_positions + join->const_tables,
              sizeof(st_position) * n_tables);
     }

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3474,7 +3474,7 @@ end_with_restore_list:
     */
     thd->set_slow_log_for_admin_command();
 
-    memset(&create_info, 0, sizeof(create_info));
+    memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
     create_info.db_type= 0;
     create_info.row_type= ROW_TYPE_NOT_USED;
     create_info.default_table_charset= thd->variables.collation_database;

--- a/sql/sql_partition_admin.cc
+++ b/sql/sql_partition_admin.cc
@@ -157,8 +157,8 @@ static bool compare_table_with_partition(THD *thd, TABLE *table,
   DBUG_ENTER("compare_table_with_partition");
 
   bool metadata_equal= false;
-  memset(&part_create_info, 0, sizeof(HA_CREATE_INFO));
-  memset(&table_create_info, 0, sizeof(HA_CREATE_INFO));
+  memset(static_cast<void*>(&part_create_info), 0, sizeof(HA_CREATE_INFO));
+  memset(static_cast<void*>(&table_create_info), 0, sizeof(HA_CREATE_INFO));
 
   update_create_info_from_table(&table_create_info, table);
   /* get the current auto_increment value */

--- a/sql/sql_planner.cc
+++ b/sql/sql_planner.cc
@@ -1833,7 +1833,7 @@ bool Optimize_table_order::choose_table_order()
   /* Are there any tables to optimize? */
   if (join->const_tables == join->tables)
   {
-    memcpy(join->best_positions, join->positions,
+    memcpy(static_cast<void*>(join->best_positions), join->positions,
 	   sizeof(POSITION) * join->const_tables);
     join->best_read= 1.0;
     join->best_rowcount= 1;
@@ -2041,7 +2041,8 @@ void Optimize_table_order::optimize_straight_join(table_map join_tables)
       join->sort_by_table != join->positions[join->const_tables].table->table())
     cost+= rowcount;  // We have to make a temp table
 
-  memcpy(join->best_positions, join->positions, sizeof(POSITION)*idx);
+  memcpy(static_cast<void*>(join->best_positions), join->positions,
+         sizeof(POSITION)*idx);
 
   /**
    * If many plans have identical cost, which one will be used
@@ -3285,7 +3286,8 @@ bool Optimize_table_order::fix_semijoin_strategies()
         setting it to SJ_OPT_NONE). But until then, pos->sj_strategy should
         not be read.
       */
-      memcpy(pos - table_count + 1, sjm_nest->nested_join->sjm.positions, 
+      memcpy(static_cast<void*>(pos - table_count + 1),
+             sjm_nest->nested_join->sjm.positions,
              sizeof(POSITION) * table_count);
       first= tableno - table_count + 1;
       join->best_positions[first].n_sj_tables= table_count;
@@ -3304,7 +3306,7 @@ bool Optimize_table_order::fix_semijoin_strategies()
       first= last_inner - table_count + 1;
       DBUG_ASSERT((join->best_positions + first)->table->emb_sj_nest ==
                   sjm_nest);
-      memcpy(join->best_positions + first, // stale semijoin strategy here too
+      memcpy(static_cast<void*>(join->best_positions + first), // stale semijoin strategy here too
              sjm_nest->nested_join->sjm.positions,
              sizeof(POSITION) * table_count);
       join->best_positions[first].sj_strategy= SJ_OPT_MATERIALIZE_SCAN;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -2374,7 +2374,7 @@ void JOIN_TAB::cleanup()
   else
     qs_cleanup();
 
-  TRASH(this, sizeof(*this));
+  TRASH(static_cast<void*>(this), sizeof(*this));
 }
 
 
@@ -2408,7 +2408,7 @@ void QEP_TAB::cleanup()
     op->mem_free();
   }
 
-  TRASH(this, sizeof(*this));
+  TRASH(static_cast<void*>(this), sizeof(*this));
 }
 
 

--- a/sql/sql_servers.cc
+++ b/sql/sql_servers.cc
@@ -366,7 +366,7 @@ static bool close_cached_connection_tables(THD *thd,
   DBUG_ENTER("close_cached_connection_tables");
   DBUG_ASSERT(thd);
 
-  memset(&tmp, 0, sizeof(TABLE_LIST));
+  memset(static_cast<void*>(&tmp), 0, sizeof(TABLE_LIST));
 
   mysql_mutex_lock(&LOCK_open);
 

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -628,7 +628,7 @@ find_files(THD *thd, List<LEX_STRING> *files, const char *db,
 
 
 
-  memset(&table_list, 0, sizeof(table_list));
+  memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
 
   if (!(dirp = my_dir(path,MYF(dir ? MY_WANT_STAT : 0))))
   {
@@ -1688,7 +1688,7 @@ int store_create_info(THD *thd, TABLE_LIST *table_list, String *packet,
   }
 
   key_info= table->key_info;
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
   /* Allow update_create_info to update row type */
   create_info.row_type= share->row_type;
   file->update_create_info(&create_info);
@@ -2661,7 +2661,7 @@ int add_status_vars(const SHOW_VAR *list)
     while (list->name)
       all_status_vars.push_back(*list++);
   }
-  catch (std::bad_alloc)
+  catch (const std::bad_alloc &)
   {
     my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR),
              static_cast<int>(sizeof(Status_var_array::value_type)));
@@ -4850,7 +4850,7 @@ static int fill_schema_table_from_frm(THD *thd, TABLE_LIST *tables,
   size_t key_length;
   char db_name_buff[NAME_LEN + 1], table_name_buff[NAME_LEN + 1];
 
-  memset(&table_list, 0, sizeof(TABLE_LIST));
+  memset(static_cast<void*>(&table_list), 0, sizeof(TABLE_LIST));
 
   DBUG_ASSERT(db_name->length <= NAME_LEN);
   DBUG_ASSERT(table_name->length <= NAME_LEN);
@@ -4917,7 +4917,7 @@ static int fill_schema_table_from_frm(THD *thd, TABLE_LIST *tables,
     {
       TABLE tbl;
 
-      memset(&tbl, 0, sizeof(TABLE));
+      memset(static_cast<void*>(&tbl), 0, sizeof(TABLE));
       init_sql_alloc(key_memory_table_triggers_list,
                      &tbl.mem_root, TABLE_ALLOC_BLOCK_SIZE, 0);
 
@@ -4998,7 +4998,7 @@ static int fill_schema_table_from_frm(THD *thd, TABLE_LIST *tables,
 
   {
     TABLE tbl;
-    memset(&tbl, 0, sizeof(TABLE));
+    memset(static_cast<void*>(&tbl), 0, sizeof(TABLE));
     init_sql_alloc(key_memory_table_triggers_list,
                    &tbl.mem_root, TABLE_ALLOC_BLOCK_SIZE, 0);
 
@@ -6306,7 +6306,7 @@ bool store_schema_params(THD *thd, TABLE *table, TABLE *proc_table,
   bool free_sp_head;
   DBUG_ENTER("store_schema_params");
 
-  memset(&tbl, 0, sizeof(TABLE));
+  memset(static_cast<void*>(&tbl), 0, sizeof(TABLE));
   (void) build_table_filename(path, sizeof(path), "", "", "", 0);
   init_tmp_table_share(thd, &share, "", 0, "", path);
 
@@ -6519,7 +6519,7 @@ bool store_schema_proc(THD *thd, TABLE *table, TABLE *proc_table,
           Field *field;
           Create_field *field_def= &sp->m_return_field_def;
 
-          memset(&tbl, 0, sizeof(TABLE));
+          memset(static_cast<void*>(&tbl), 0, sizeof(TABLE));
           (void) build_table_filename(path, sizeof(path), "", "", "", 0);
           init_tmp_table_share(thd, &share, "", 0, "", path);
           field= make_field(&share, (uchar*) 0, field_def->length,
@@ -6604,7 +6604,7 @@ int fill_schema_proc(THD *thd, TABLE_LIST *tables, Item *cond)
   strxmov(definer, thd->security_context()->priv_user().str, "@",
           thd->security_context()->priv_host().str, NullS);
   /* We use this TABLE_LIST instance only for checking of privileges. */
-  memset(&proc_tables, 0, sizeof(proc_tables));
+  memset(static_cast<void*>(&proc_tables), 0, sizeof(proc_tables));
   proc_tables.db= (char*) "mysql";
   proc_tables.db_length= 5;
   proc_tables.table_name= proc_tables.alias= (char*) "proc";
@@ -6792,7 +6792,7 @@ static int get_schema_views_record(THD *thd, TABLE_LIST *tables,
         {
           TABLE_LIST table_list;
           uint view_access;
-          memset(&table_list, 0, sizeof(table_list));
+          memset(static_cast<void*>(&table_list), 0, sizeof(table_list));
           table_list.db= tables->db;
           table_list.table_name= tables->table_name;
           table_list.grant.privilege= thd->col_access;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -6017,7 +6017,7 @@ bool mysql_create_like_table(THD* thd, TABLE_LIST* table, TABLE_LIST* src_table,
   }
 
   /* Fill HA_CREATE_INFO and Alter_info with description of source table. */
-  memset(&local_create_info, 0, sizeof(local_create_info));
+  memset(static_cast<void*>(&local_create_info), 0, sizeof(local_create_info));
   local_create_info.db_type= src_table->table->s->db_type();
   local_create_info.row_type= src_table->table->s->row_type;
   if (mysql_prepare_alter_table(thd, src_table->table, &local_create_info,
@@ -10771,7 +10771,7 @@ copy_data_between_tables(PSI_stage_progress *psi,
       from->sort.io_cache=(IO_CACHE*) my_malloc(key_memory_TABLE_sort_io_cache,
                                                 sizeof(IO_CACHE),
                                                 MYF(MY_FAE | MY_ZEROFILL));
-      memset(&tables, 0, sizeof(tables));
+      memset(static_cast<void*>(&tables), 0, sizeof(tables));
       tables.table= from;
       tables.alias= tables.table_name= from->s->table_name.str;
       tables.db= from->s->db.str;
@@ -10940,7 +10940,7 @@ bool mysql_recreate_table(THD *thd, TABLE_LIST *table_list, bool table_copy)
   /* Same applies to MDL request. */
   table_list->mdl_request.set_type(MDL_SHARED_NO_WRITE);
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
   create_info.row_type=ROW_TYPE_NOT_USED;
   create_info.default_table_charset=default_charset_info;
   /* Force alter table to recreate table */

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -804,7 +804,7 @@ create_tmp_table(THD *thd, Temp_table_param *param, List<Item> &fields,
   my_stpcpy(tmpname,path);
   /* make table according to fields */
 
-  memset(table, 0, sizeof(*table));
+  memset(static_cast<void*>(table), 0, sizeof(*table));
   memset(reg_field, 0, sizeof(Field*)*(field_count + 2));
   memset(default_field, 0, sizeof(Field*) * (field_count + 1));
   memset(from_field, 0, sizeof(Field*)*(field_count + 1));
@@ -1643,7 +1643,7 @@ TABLE *create_duplicate_weedout_tmp_table(THD *thd,
   my_stpcpy(tmpname,path);
 
   /* STEP 4: Create TABLE description */
-  memset(table, 0, sizeof(*table));
+  memset(static_cast<void*>(table), 0, sizeof(*table));
   memset(reg_field, 0, sizeof(Field*) * 3);
 
   table->mem_root= own_root;
@@ -1962,8 +1962,8 @@ TABLE *create_virtual_tmp_table(THD *thd, List<Create_field> &field_list)
                         NullS))
     return 0;
 
-  memset(table, 0, sizeof(*table));
-  memset(share, 0, sizeof(*share));
+  memset(static_cast<void*>(table), 0, sizeof(*table));
+  memset(static_cast<void*>(share), 0, sizeof(*share));
   table->field= field;
   table->s= share;
   table->temp_pool_slot= MY_BIT_NONE;
@@ -2243,7 +2243,7 @@ bool create_innodb_tmp_table(TABLE *table, KEY *keyinfo)
 
   HA_CREATE_INFO create_info;
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
 
   create_info.db_type= table->s->db_type();
   create_info.row_type= table->s->row_type;

--- a/sql/sql_truncate.cc
+++ b/sql/sql_truncate.cc
@@ -281,7 +281,7 @@ static bool recreate_temporary_table(THD *thd, TABLE *table)
   handlerton *table_type= table->s->db_type();
   DBUG_ENTER("recreate_temporary_table");
 
-  memset(&create_info, 0, sizeof(create_info));
+  memset(static_cast<void*>(&create_info), 0, sizeof(create_info));
 
   table->file->info(HA_STATUS_AUTO | HA_STATUS_NO_LOCK);
 

--- a/sql/sql_union.cc
+++ b/sql/sql_union.cc
@@ -631,7 +631,8 @@ bool st_select_lex_unit::prepare(THD *thd_arg, Query_result *sel_result,
                                           create_options, "", false,
                                           instantiate_tmp_table))
       goto err;
-    memset(&result_table_list, 0, sizeof(result_table_list));
+    memset(static_cast<void*>(&result_table_list), 0,
+           sizeof(result_table_list));
     result_table_list.db= (char*) "";
     result_table_list.table_name= result_table_list.alias= (char*) "union";
     result_table_list.table= table= union_result->table;

--- a/sql/sql_view.cc
+++ b/sql/sql_view.cc
@@ -212,7 +212,7 @@ fill_defined_view_parts (THD *thd, TABLE_LIST *view)
   LEX *lex= thd->lex;
   TABLE_LIST decoy;
 
-  memcpy (&decoy, view, sizeof (TABLE_LIST));
+  memcpy(static_cast<void*>(&decoy), view, sizeof (TABLE_LIST));
 
   key_length= get_table_def_key(view, &key);
 
@@ -2075,7 +2075,7 @@ mysql_rename_view(THD *thd,
       view definition parsing or use temporary 'view_def'
       object for it.
     */
-    memset(&view_def, 0, sizeof(view_def));
+    memset(static_cast<void*>(&view_def), 0, sizeof(view_def));
     view_def.timestamp.str= view_def.timestamp_buffer;
     view_def.view_suid= TRUE;
 

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -2290,7 +2290,8 @@ create:
             lex->alter_info.reset();
             lex->col_list.empty();
             lex->change=NullS;
-            memset(&lex->create_info, 0, sizeof(lex->create_info));
+            memset(static_cast<void*>(&lex->create_info), 0,
+                   sizeof(lex->create_info));
             lex->create_info.options=$2 | $4;
             lex->create_info.default_table_charset= NULL;
             lex->name.str= 0;
@@ -7648,7 +7649,8 @@ alter:
             lex->select_lex->init_order();
             lex->select_lex->db=
                     const_cast<char*>((lex->select_lex->table_list.first)->db);
-            memset(&lex->create_info, 0, sizeof(lex->create_info));
+            memset(static_cast<void*>(&lex->create_info), 0,
+                   sizeof(lex->create_info));
             lex->create_info.db_type= 0;
             lex->create_info.default_table_charset= NULL;
             lex->create_info.row_type= ROW_TYPE_NOT_USED;
@@ -11957,7 +11959,8 @@ show:
           SHOW
           {
             LEX *lex=Lex;
-            memset(&lex->create_info, 0, sizeof(lex->create_info));
+            memset(static_cast<void*>(&lex->create_info), 0,
+                   sizeof(lex->create_info));
           }
           show_param
         ;

--- a/sql/table.cc
+++ b/sql/table.cc
@@ -392,7 +392,7 @@ TABLE_SHARE *alloc_table_share(TABLE_LIST *table_list, const char *key,
                        table_cache_instances * sizeof(*cache_element_array),
                        NULL))
   {
-    memset(share, 0, sizeof(*share));
+    memset(static_cast<void*>(share), 0, sizeof(*share));
 
     share->set_table_cache_key(key_buff, key, key_length);
 
@@ -458,7 +458,7 @@ void init_tmp_table_share(THD *thd, TABLE_SHARE *share, const char *key,
   DBUG_ENTER("init_tmp_table_share");
   DBUG_PRINT("enter", ("table: '%s'.'%s'", key, table_name));
 
-  memset(share, 0, sizeof(*share));
+  memset(static_cast<void*>(share), 0, sizeof(*share));
   init_sql_alloc(key_memory_table_share,
                  &share->mem_root, TABLE_ALLOC_BLOCK_SIZE, 0);
   share->table_category=         TABLE_CATEGORY_TEMPORARY;
@@ -3168,7 +3168,7 @@ int open_table_from_share(THD *thd, TABLE_SHARE *share, const char *alias,
                       share->table_name.str, (long) outparam));
 
   error= 1;
-  memset(outparam, 0, sizeof(*outparam));
+  memset(static_cast<void*>(outparam), 0, sizeof(*outparam));
   outparam->in_use= thd;
   outparam->s= share;
   outparam->db_stat= db_stat;
@@ -4997,7 +4997,8 @@ TABLE_LIST *TABLE_LIST::new_nested_join(MEM_ROOT *allocator,
   if (join_nest == NULL)
     return NULL;
 
-  memset(join_nest, 0, ALIGN_SIZE(sizeof(TABLE_LIST)) + sizeof(NESTED_JOIN));
+  memset(static_cast<void*>(join_nest), 0,
+         ALIGN_SIZE(sizeof(TABLE_LIST)) + sizeof(NESTED_JOIN));
   join_nest->nested_join=
     (NESTED_JOIN *) ((uchar *)join_nest + ALIGN_SIZE(sizeof(TABLE_LIST)));
 

--- a/sql/table.h
+++ b/sql/table.h
@@ -1791,7 +1791,7 @@ struct TABLE_LIST
                              enum thr_lock_type lock_type_arg,
                              enum enum_mdl_type mdl_type_arg)
   {
-    memset(this, 0, sizeof(*this));
+    memset(static_cast<void*>(this), 0, sizeof(*this));
     m_map= 1;
     db= (char*) db_name_arg;
     db_length= db_length_arg;

--- a/sql/trigger.cc
+++ b/sql/trigger.cc
@@ -426,7 +426,8 @@ Trigger::Trigger(MEM_ROOT *mem_root,
   m_on_table_name= NULL_STR;
 
   m_parse_error_message[0]= 0;
-  memset(&m_subject_table_grant, 0, sizeof (m_subject_table_grant));
+  memset(static_cast<void*>(&m_subject_table_grant), 0,
+         sizeof(m_subject_table_grant));
 }
 
 

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -1537,7 +1537,8 @@ my_offset_tzs_get_key(Time_zone_offset *entry,
 static void
 tz_init_table_list(TABLE_LIST *tz_tabs)
 {
-  memset(tz_tabs, 0, sizeof(TABLE_LIST) * MY_TZ_TABLES_COUNT);
+  memset(static_cast<void*>(tz_tabs), 0,
+         sizeof(TABLE_LIST) * MY_TZ_TABLES_COUNT);
 
   for (int i= 0; i < MY_TZ_TABLES_COUNT; i++)
   {
@@ -1680,7 +1681,7 @@ my_tz_init(THD *org_thd, const char *default_tzname, my_bool bootstrap)
     leap seconds shared by all time zones.
   */
   thd->set_db(db);
-  memset(&tz_tables[0], 0, sizeof(TABLE_LIST));
+  memset(static_cast<void*>(&tz_tables[0]), 0, sizeof(TABLE_LIST));
   tz_tables[0].alias= tz_tables[0].table_name=
     (char*)"time_zone_leap_second";
   tz_tables[0].table_name_length= 21;

--- a/sql/unireg.cc
+++ b/sql/unireg.cc
@@ -1298,8 +1298,8 @@ static bool make_empty_rec(THD *thd, File file,
   DBUG_ENTER("make_empty_rec");
 
   /* We need a table to generate columns for default values */
-  memset(&table, 0, sizeof(table));
-  memset(&share, 0, sizeof(share));
+  memset(static_cast<void*>(&table), 0, sizeof(table));
+  memset(static_cast<void*>(&share), 0, sizeof(share));
   table.s= &share;
 
   if (!(buff=(uchar*) my_malloc(key_memory_frm,

--- a/storage/blackhole/ha_blackhole.cc
+++ b/storage/blackhole/ha_blackhole.cc
@@ -189,7 +189,7 @@ int ha_blackhole::info(uint flag)
 {
   DBUG_ENTER("ha_blackhole::info");
 
-  memset(&stats, 0, sizeof(stats));
+  memset(static_cast<void*>(&stats), 0, sizeof(stats));
   if (flag & HA_STATUS_AUTO)
     stats.auto_increment_value= 1;
   DBUG_RETURN(0);

--- a/storage/innobase/buf/buf0buddy.cc
+++ b/storage/innobase/buf/buf0buddy.cc
@@ -129,7 +129,8 @@ buf_buddy_stamp_free(
 	buf_buddy_free_t*	buf,	/*!< in/out: block to stamp */
 	ulint			i)	/*!< in: block size */
 {
-	ut_d(memset(buf, static_cast<int>(i), BUF_BUDDY_LOW << i));
+	ut_d(memset(static_cast<void*>(buf), static_cast<int>(i),
+		    BUF_BUDDY_LOW << i));
 	buf_buddy_mem_invalid(buf, i);
 	mach_write_to_4(buf->stamp.bytes + BUF_BUDDY_STAMP_OFFSET,
 			BUF_BUDDY_STAMP_FREE);

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2038,8 +2038,10 @@ buf_page_realloc(
 	if (buf_page_can_relocate(&block->page)) {
 		mutex_enter(&new_block->mutex);
 
-		memcpy(new_block->frame, block->frame, UNIV_PAGE_SIZE);
-		memcpy(&new_block->page, &block->page, sizeof block->page);
+		memcpy(static_cast<void*>(new_block->frame), block->frame,
+		       UNIV_PAGE_SIZE);
+		memcpy(static_cast<void*>(&new_block->page), &block->page,
+		       sizeof block->page);
 
 		/* relocate LRU list */
 		ut_ad(block->page.in_LRU_list);
@@ -3163,7 +3165,7 @@ buf_relocate(
 	}
 #endif /* UNIV_DEBUG */
 
-	memcpy(dpage, bpage, sizeof *dpage);
+	memcpy(static_cast<void*>(dpage), bpage, sizeof *dpage);
 
 	/* Important that we adjust the hazard pointer before
 	removing bpage from LRU list. */

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -346,7 +346,7 @@ buf_parallel_dblwr_make_path(void)
 	if (parallel_dblwr_buf.path)
 		return(DB_SUCCESS);
 
-	char path[FN_REFLEN];
+	char path[FN_REFLEN + 1 /* OS_PATH_SEPARATOR */];
 	const char *dir = NULL;
 
 	ut_ad(srv_parallel_doublewrite_path);

--- a/storage/innobase/buf/buf0dump.cc
+++ b/storage/innobase/buf/buf0dump.cc
@@ -265,8 +265,9 @@ buf_dump(
 {
 #define SHOULD_QUIT()	(SHUTTING_DOWN() && obey_shutdown)
 
+	static const char format_name[]= "%s.incomplete";
 	char	full_filename[OS_FILE_MAX_PATH];
-	char	tmp_filename[OS_FILE_MAX_PATH];
+	char	tmp_filename[OS_FILE_MAX_PATH + sizeof(format_name)];
 	char	now[32];
 	FILE*	f;
 	ulint	i;
@@ -275,7 +276,7 @@ buf_dump(
 	buf_dump_generate_path(full_filename, sizeof(full_filename));
 
 	ut_snprintf(tmp_filename, sizeof(tmp_filename),
-		    "%s.incomplete", full_filename);
+		    format_name, full_filename);
 
 	buf_dump_status(STATUS_INFO, "Dumping buffer pool(s) to %s",
 			full_filename);

--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -2152,7 +2152,7 @@ not_freed:
 	}
 
 	if (b) {
-		memcpy(b, bpage, sizeof *b);
+		memcpy(static_cast<void*>(b), bpage, sizeof *b);
 	}
 
 	if (!buf_LRU_block_remove_hashed(bpage, zip)) {

--- a/storage/innobase/fts/fts0pars.cc
+++ b/storage/innobase/fts/fts0pars.cc
@@ -107,8 +107,8 @@ typedef	int	(*fts_scanner_alt)(YYSTYPE* val, yyscan_t yyscanner);
 typedef	int	(*fts_scanner)();
 
 struct fts_lexer_t {
-	fts_scanner	scanner;
-	void*		yyscanner;
+	fts_scanner_alt		scanner;
+	void*			yyscanner;
 };
 
 
@@ -1948,7 +1948,7 @@ fts_lexer_create(
 			reinterpret_cast<const char*>(query),
 			static_cast<int>(query_len),
 			fts_lexer->yyscanner);
-		fts_lexer->scanner = reinterpret_cast<fts_scan>(fts_blexer);
+		fts_lexer->scanner = fts_blexer;
 		/* FIXME: Debugging */
 		/* fts0bset_debug(1 , fts_lexer->yyscanner); */
 	} else {
@@ -1957,7 +1957,7 @@ fts_lexer_create(
 			reinterpret_cast<const char*>(query),
 			static_cast<int>(query_len),
 			fts_lexer->yyscanner);
-		fts_lexer->scanner = reinterpret_cast<fts_scan>(fts_tlexer);
+		fts_lexer->scanner = fts_tlexer;
 	}
 
 	return(fts_lexer);
@@ -1971,7 +1971,7 @@ fts_lexer_free(
 /*===========*/
 	fts_lexer_t*	fts_lexer)
 {
-	if (fts_lexer->scanner == (fts_scan) fts_blexer) {
+	if (fts_lexer->scanner == fts_blexer) {
 		fts0blex_destroy(fts_lexer->yyscanner);
 	} else {
 		fts0tlex_destroy(fts_lexer->yyscanner);

--- a/storage/innobase/fts/fts0pars.y
+++ b/storage/innobase/fts/fts0pars.y
@@ -53,8 +53,8 @@ typedef	int	(*fts_scanner_alt)(YYSTYPE* val, yyscan_t yyscanner);
 typedef	int	(*fts_scanner)();
 
 struct fts_lexer_struct {
-	fts_scanner	scanner;
-	void*		yyscanner;
+	fts_scanner_alt		scanner;
+	void*			yyscanner;
 };
 
 %}
@@ -238,13 +238,13 @@ fts_lexer_create(
 	if (boolean_mode) {
 		fts0blex_init(&fts_lexer->yyscanner);
 		fts0b_scan_bytes((char*) query, (int) query_len, fts_lexer->yyscanner);
-		fts_lexer->scanner = (fts_scan) fts_blexer;
+		fts_lexer->scanner = fts_blexer;
 		/* FIXME: Debugging */
 		/* fts0bset_debug(1 , fts_lexer->yyscanner); */
 	} else {
 		fts0tlex_init(&fts_lexer->yyscanner);
 		fts0t_scan_bytes((char*) query, (int) query_len, fts_lexer->yyscanner);
-		fts_lexer->scanner = (fts_scan) fts_tlexer;
+		fts_lexer->scanner = fts_tlexer;
 	}
 
 	return(fts_lexer);
@@ -258,7 +258,7 @@ fts_lexer_free(
 /*===========*/
 	fts_lexer_t*	fts_lexer)
 {
-	if (fts_lexer->scanner == (fts_scan) fts_blexer) {
+	if (fts_lexer->scanner == fts_blexer) {
 		fts0blex_destroy(fts_lexer->yyscanner);
 	} else {
 		fts0tlex_destroy(fts_lexer->yyscanner);

--- a/storage/innobase/gis/gis0rtree.cc
+++ b/storage/innobase/gis/gis0rtree.cc
@@ -663,7 +663,7 @@ rtr_adjust_upper_level(
 
 	/* Create a memory heap where the data tuple is stored */
 	heap = mem_heap_create(1024);
-	memset(&cursor, 0, sizeof(cursor));
+	memset(static_cast<void*>(&cursor), 0, sizeof(cursor));
 
 	cursor.thr = sea_cur->thr;
 
@@ -1380,7 +1380,7 @@ rtr_ins_enlarge_mbr(
 		rtr_page_cal_mbr(index, block, &new_mbr, heap);
 
 		/* Get father block. */
-		memset(&cursor, 0, sizeof(cursor));
+		memset(static_cast<void*>(&cursor), 0, sizeof(cursor));
 		offsets = rtr_page_get_father_block(
 			NULL, heap, index, block, mtr, btr_cur, &cursor);
 

--- a/storage/innobase/gis/gis0sea.cc
+++ b/storage/innobase/gis/gis0sea.cc
@@ -1547,7 +1547,8 @@ rtr_copy_buf(
 	will be copied. It is also undefined what will happen with the
 	newly memcpy()ed mutex if the source mutex was acquired by
 	(another) thread while it was copied. */
-	memcpy(&matches->block.page, &block->page, sizeof(buf_page_t));
+	memcpy(static_cast<void*>(&matches->block.page), &block->page,
+	       sizeof(buf_page_t));
 	matches->block.frame = block->frame;
 #ifndef UNIV_HOTBACKUP
 	matches->block.unzip_LRU = block->unzip_LRU;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3217,7 +3217,7 @@ innobase_register_trx(
 	THD*		thd,	/* in: MySQL thd (connection) object */
 	trx_t*		trx)	/* in: transaction to register */
 {
-	const ulonglong	trx_id = static_cast<const ulonglong>(
+	const ulonglong	trx_id = static_cast<ulonglong>(
 		trx_get_id_for_print(trx));
 
 	trans_register_ha(thd, FALSE, hton, &trx_id);

--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -1467,7 +1467,7 @@ i_s_cmp_fill_low(
 		table->field[5]->store(zip_stat->decompressed_usec / 1000000, true);
 
 		if (reset) {
-			memset(zip_stat, 0, sizeof *zip_stat);
+			memset(static_cast<void*>(zip_stat), 0, sizeof *zip_stat);
 		}
 
 		if (schema_table_store_record(thd, table)) {

--- a/storage/innobase/include/data0type.ic
+++ b/storage/innobase/include/data0type.ic
@@ -506,6 +506,7 @@ dtype_get_fixed_size_low(
 			return(0);
 		}
 #endif /* UNIV_DEBUG */
+		// fallthrough
 	case DATA_CHAR:
 	case DATA_FIXBINARY:
 	case DATA_INT:
@@ -587,6 +588,7 @@ dtype_get_min_size_low(
 			return(0);
 		}
 #endif /* UNIV_DEBUG */
+		// fallthrough
 	case DATA_CHAR:
 	case DATA_FIXBINARY:
 	case DATA_INT:

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -6583,7 +6583,8 @@ AIO::AIO(
 	m_not_full = os_event_create("aio_not_full");
 	m_is_empty = os_event_create("aio_is_empty");
 
-	memset(&m_slots[0], 0x0, sizeof(m_slots[0]) * m_slots.size());
+	memset(static_cast<void*>(&m_slots[0]), 0x0,
+	       sizeof(m_slots[0]) * m_slots.size());
 #ifdef LINUX_NATIVE_AIO
 	memset(&m_events[0], 0x0, sizeof(m_events[0]) * m_events.size());
 #endif /* LINUX_NATIVE_AIO */

--- a/storage/innobase/row/row0ftsort.cc
+++ b/storage/innobase/row/row0ftsort.cc
@@ -789,7 +789,7 @@ fts_parallel_tokenization(
 	merge_file = psort_info->merge_file;
 	blob_heap = mem_heap_create(512);
 	memset(&doc, 0, sizeof(doc));
-	memset(&t_ctx, 0, sizeof(t_ctx));
+	memset(static_cast<void*>(&t_ctx), 0, sizeof(t_ctx));
 	memset(mycount, 0, FTS_NUM_AUX_INDEX * sizeof(int));
 
 	doc.charset = fts_index_get_charset(

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -2503,7 +2503,7 @@ row_import_cfg_read_index_fields(
 
 	dict_field_t*	field = index->m_fields;
 
-	memset(field, 0x0, sizeof(*field) * n_fields);
+	memset(static_cast<void*>(field), 0x0, sizeof(*field) * n_fields);
 
 	for (ulint i = 0; i < n_fields; ++i, ++field) {
 		byte*		ptr = row;
@@ -3623,7 +3623,7 @@ row_import_for_mysql(
 	row_import	cfg;
 	ulint		space_flags = 0;
 
-	memset(&cfg, 0x0, sizeof(cfg));
+	memset(static_cast<void*>(&cfg), 0x0, sizeof(cfg));
 
 	err = row_import_read_cfg(table, trx->mysql_thd, cfg);
 

--- a/storage/innobase/row/row0uins.cc
+++ b/storage/innobase/row/row0uins.cc
@@ -200,7 +200,7 @@ row_undo_ins_remove_sec_low(
 	ibool			modify_leaf = false;
 
 	log_free_check();
-	memset(&pcur, 0, sizeof(pcur));
+	memset(static_cast<void*>(&pcur), 0, sizeof(pcur));
 
 	mtr_start(&mtr);
 	mtr.set_named_space(index->space);

--- a/storage/myisam/mi_write.c
+++ b/storage/myisam/mi_write.c
@@ -926,7 +926,7 @@ static int keys_compare(bulk_insert_param *param, uchar *key1, uchar *key2)
 }
 
 
-static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
+static void keys_free(void* vkey, TREE_FREE mode, const void *vparam)
 {
   /*
     Probably I can use info->lastkey here, but I'm not sure,
@@ -935,6 +935,8 @@ static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
   uchar lastkey[MI_MAX_KEY_BUFF];
   uint keylen;
   MI_KEYDEF *keyinfo;
+  uchar *key= (uchar*)(vkey);
+  bulk_insert_param *param= (bulk_insert_param*)(vparam);
 
   switch (mode) {
   case free_init:
@@ -943,19 +945,20 @@ static int keys_free(uchar *key, TREE_FREE mode, bulk_insert_param *param)
       mysql_rwlock_wrlock(&param->info->s->key_root_lock[param->keynr]);
       param->info->s->keyinfo[param->keynr].version++;
     }
-    return 0;
+    return;
   case free_free:
     keyinfo=param->info->s->keyinfo+param->keynr;
     keylen=_mi_keylength(keyinfo, key);
     memcpy(lastkey, key, keylen);
-    return _mi_ck_write_btree(param->info,param->keynr,lastkey,
-			      keylen - param->info->s->rec_reflength);
+    _mi_ck_write_btree(param->info,param->keynr,lastkey,
+                       keylen - param->info->s->rec_reflength);
+    return;
   case free_end:
     if (param->info->s->concurrent_insert)
       mysql_rwlock_unlock(&param->info->s->key_root_lock[param->keynr]);
-    return 0;
+    return;
   }
-  return -1;
+  return;
 }
 
 
@@ -1013,7 +1016,7 @@ int mi_init_bulk_insert(MI_INFO *info, ulong cache_size, ha_rows rows)
                 cache_size * key[i].maxlength,
                 cache_size * key[i].maxlength, 0,
 		(qsort_cmp2)keys_compare, 0,
-		(tree_element_free) keys_free, (void *)params++);
+		keys_free, (void *)params++);
     }
     else
      info->bulk_insert[i].root=0;

--- a/storage/myisam/myisamlog.c
+++ b/storage/myisam/myisamlog.c
@@ -62,7 +62,8 @@ static int test_if_open(struct file_info *key,element_count count,
 static void fix_blob_pointers(MI_INFO *isam,uchar *record);
 static int test_when_accessed(struct file_info *key,element_count count,
 			      struct st_access_param *access_param);
-static void file_info_free(struct file_info *info);
+static void file_info_free(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                           const void *param MY_ATTRIBUTE((unused)));
 static int close_some_file(TREE *tree);
 static int reopen_closed_file(TREE *tree,struct file_info *file_info);
 static int find_record_with_key(struct file_info *file_info,uchar *record);
@@ -340,7 +341,7 @@ static int examine_log(char * file_name, char **table_names)
   init_io_cache(&cache,file,0,READ_CACHE,start_offset,0,MYF(0));
   memset(com_count, 0, sizeof(com_count));
   init_tree(&tree,0,0,sizeof(file_info),(qsort_cmp2) file_info_compare,1,
-	    (tree_element_free) file_info_free, NULL);
+            file_info_free, NULL);
   (void) init_key_cache(dflt_key_cache,KEY_CACHE_BLOCK_SIZE,KEY_CACHE_SIZE,
                       0, 0);
 
@@ -763,8 +764,10 @@ static int test_when_accessed (struct file_info *key,
 }
 
 
-static void file_info_free(struct file_info *fileinfo)
+static void file_info_free(void* key, TREE_FREE action MY_ATTRIBUTE((unused)),
+                           const void *param MY_ATTRIBUTE((unused)))
 {
+  struct file_info *fileinfo= (struct file_info*)key;
   DBUG_ENTER("file_info_free");
   if (update)
   {

--- a/storage/partition/ha_partition.cc
+++ b/storage/partition/ha_partition.cc
@@ -1455,7 +1455,7 @@ void ha_partition::update_create_info(HA_CREATE_INFO *create_info)
   uint num_parts = num_subparts ? m_file_tot_parts / num_subparts
                                 : m_file_tot_parts;
   HA_CREATE_INFO dummy_info;
-  memset(&dummy_info, 0, sizeof(dummy_info));
+  memset(static_cast<void*>(&dummy_info), 0, sizeof(dummy_info));
 
   /*
   Since update_create_info() can be called from mysql_prepare_alter_table()

--- a/unittest/gunit/decimal-t.cc
+++ b/unittest/gunit/decimal-t.cc
@@ -214,7 +214,7 @@ void do_test_d2f(const char *s, int ex)
 void do_test_d2b2d(const char *str, int p, int s, const char *orig, int ex)
 {
   char s1[100];
-  char s2[100];
+  char s2[164];
   uchar buf[100];
   char *end;
   int res, i, size=decimal_bin_size(p, s);
@@ -247,7 +247,7 @@ void do_test_f2d(double from, int ex)
 void do_test_ull2d(ulonglong from, const char *orig, int ex)
 {
   char s[100];
-  char s1[100];
+  char s1[123];
   int res;
 
   res=ulonglong2decimal(from, &a);
@@ -259,7 +259,7 @@ void do_test_ull2d(ulonglong from, const char *orig, int ex)
 void do_test_ll2d(longlong from, const char *orig, int ex)
 {
   char s[100];
-  char s1[100];
+  char s1[123];
   int res;
 
   res=longlong2decimal(from, &a);
@@ -271,7 +271,7 @@ void do_test_ll2d(longlong from, const char *orig, int ex)
 void do_test_d2ull(const char *s, const char *orig, int ex)
 {
   char s1[100], *end;
-  char s2[100];
+  char s2[154];
   ulonglong x;
   int res;
 
@@ -291,7 +291,7 @@ void do_test_d2ull(const char *s, const char *orig, int ex)
 void do_test_d2ll(const char *s, const char *orig, int ex)
 {
   char s1[100], *end;
-  char s2[100];
+  char s2[154];
   longlong x;
   int res;
 

--- a/unittest/gunit/fake_table.h
+++ b/unittest/gunit/fake_table.h
@@ -104,7 +104,7 @@ class Fake_TABLE: public TABLE
   void initialize()
   {
     TABLE *as_table= static_cast<TABLE*>(this);
-    memset(as_table, 0, sizeof(*as_table));
+    memset(static_cast<void*>(as_table), 0, sizeof(*as_table));
     s= &table_share;
     in_use= current_thd;
     null_row= '\0';

--- a/unittest/gunit/table_cache-t.cc
+++ b/unittest/gunit/table_cache-t.cc
@@ -133,7 +133,7 @@ class Mock_share : public TABLE_SHARE
 public:
   Mock_share(const char *key)
   {
-    memset((TABLE_SHARE *)this, 0, sizeof(TABLE_SHARE));
+    memset(static_cast<void*>(this), 0, sizeof(TABLE_SHARE));
     /*
       Both table_cache_key and cache_element array are used by
       Table_cache code.
@@ -162,7 +162,7 @@ public:
   {
     TABLE *result= (TABLE *)my_malloc(PSI_NOT_INSTRUMENTED, sizeof(TABLE), MYF(0));
 
-    memset(result, 0, sizeof(TABLE));
+    memset(static_cast<void*>(result), 0, sizeof(TABLE));
     result->s= this;
     // We create TABLE which is already marked as used
     result->in_use= thd;


### PR DESCRIPTION
1. Add gcc-8 to Travis config file
2. Fix the following gcc-8 warnings:
- cast between incompatible function types [-Werror=cast-function-type]
- clearing an object with no trivial copy-assignment [-Werror=class-memaccess]
- directive output may be truncated [-Werror=format-truncation=]
- type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
- catching polymorphic type 'class std::exception' by value [-Werror=catch-value=]

(cherry picked from commit 31b49ba6b4123dfab049357fc9a18d422dad741c)