### PR TITLE
PS-3325: Prevent changes with gtid_deployment_step set

### DIFF
--- a/mysql-test/r/percona_bug_ps3325.result
+++ b/mysql-test/r/percona_bug_ps3325.result
@@ -1,0 +1,32 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE TABLE test_table(id INT) ENGINE=innodb;
+include/sync_slave_sql_with_master.inc
+INSERT INTO test_table VALUES (1);
+include/sync_slave_sql_with_master.inc
+SET GLOBAL gtid_deployment_step = ON;
+SET GLOBAL super_read_only=1;
+ERROR HY000: super_read_only cannot be changed when gtid_deployment_step is ON
+SET GLOBAL super_read_only=0;
+ERROR HY000: super_read_only cannot be changed when gtid_deployment_step is ON
+INSERT INTO test_table VALUES (2);
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+SET GLOBAL gtid_deployment_step = OFF;
+SET GLOBAL super_read_only = ON;
+SET GLOBAL gtid_deployment_step = ON;
+SET GLOBAL gtid_deployment_step = OFF;
+INSERT INTO test_table VALUES (2);
+ERROR HY000: The MySQL server is running with the --read-only (super) option so it cannot execute this statement
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+INSERT INTO test_table VALUES (2);
+include/sync_slave_sql_with_master.inc
+SELECT * FROM test_table;
+id
+1
+2
+DROP TABLE test_table;
+include/rpl_end.inc

--- a/mysql-test/t/percona_bug_ps3325-master.opt
+++ b/mysql-test/t/percona_bug_ps3325-master.opt
@@ -1,0 +1,3 @@
+--gtid_mode=ON
+--log-slave-updates=ON
+--enforce_gtid_consistency

--- a/mysql-test/t/percona_bug_ps3325-slave.opt
+++ b/mysql-test/t/percona_bug_ps3325-slave.opt
@@ -1,0 +1,3 @@
+--gtid_mode=ON
+--log_slave_updates=ON
+--enforce_gtid_consistency

--- a/mysql-test/t/percona_bug_ps3325.test
+++ b/mysql-test/t/percona_bug_ps3325.test
@@ -1,0 +1,48 @@
+#
+# PS-3325: Queries while/after setting gtid_deployment_step cause binlog corruption and assertions
+#
+--source include/have_innodb.inc
+--source include/master-slave.inc
+
+connect (mm,localhost,root,,);
+
+connection master;
+CREATE TABLE test_table(id INT) ENGINE=innodb;
+--source include/sync_slave_sql_with_master.inc
+
+connection master;
+INSERT INTO test_table VALUES (1);
+--source include/sync_slave_sql_with_master.inc
+
+connection master;
+SET GLOBAL gtid_deployment_step = ON;
+--error ER_GTID_DEPLOYMENT_STEP_ACTIVE
+SET GLOBAL super_read_only=1;
+--error ER_GTID_DEPLOYMENT_STEP_ACTIVE
+SET GLOBAL super_read_only=0;
+
+connection master;
+--error ER_OPTION_PREVENTS_STATEMENT
+INSERT INTO test_table VALUES (2);
+
+SET GLOBAL gtid_deployment_step = OFF;
+
+SET GLOBAL super_read_only = ON;
+SET GLOBAL gtid_deployment_step = ON;
+SET GLOBAL gtid_deployment_step = OFF;
+--error ER_OPTION_PREVENTS_STATEMENT
+INSERT INTO test_table VALUES (2);
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+
+INSERT INTO test_table VALUES (2);
+--source include/sync_slave_sql_with_master.inc
+
+
+connection slave;
+SELECT * FROM test_table;
+
+connection master;
+DROP TABLE test_table;
+
+--source include/rpl_end.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -962,14 +962,14 @@ static bool should_write_gtids(const THD *thd) {
     return false;
   /*
     Return true (allow gtids to be generated) in the scenario where
-    gtid_deployment_step is false (Normal run after deployment procedure
+    opt_gtid_deployment_step is false (Normal run after deployment procedure
     is done).
 
     Return true in the scenario where slave sql_thread uses gtid received from
     master. This is necessary in the situation where deployment is done on
-    master, but slave still in deployment mode (gtid_deployment_step is true).
+    master, but slave still in deployment mode (opt_gtid_deployment_step is true).
   */
-  return (!gtid_deployment_step || (thd->rli_slave &&
+  return (!opt_gtid_deployment_step || (thd->rli_slave &&
           thd->variables.gtid_next.type != AUTOMATIC_GROUP));
 
 }

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5781,6 +5781,8 @@ int mysqld_main(int argc, char **argv)
   if (init_common_variables())
     unireg_abort(1);        // Will do exit
 
+  opt_gtid_deployment_step= gtid_deployment_step;
+
   my_init_signals();
 
   size_t guardize= 0;

--- a/sql/rpl_master.cc
+++ b/sql/rpl_master.cc
@@ -1425,9 +1425,9 @@ void mysql_binlog_send(THD* thd, char* log_ident, my_off_t pos,
         {
           /*
              Skip groups in the binlogs which don't have any gtid event
-             logged before them. When gtid_deployment_step is ON, the server
+             logged before them. When opt_gtid_deployment_step is ON, the server
              doesn't generate GTID and so no gtid_event is logged before binlog
-             events. But when gtid_deployment_step is OFF, the server starts
+             events. But when opt_gtid_deployment_step is OFF, the server starts
              writing gtid_events in the middle of active binlog. When slave
              connects with gtid_protocol, master needs to skip binlog events
              which don't have corresponding gtid_event.

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -2745,7 +2745,7 @@ when it try to get the value of TIME_ZONE global variable from master.";
     }
     if ((mi->master_gtid_mode > gtid_mode + 1 ||
         gtid_mode > mi->master_gtid_mode + 1) &&
-        !gtid_deployment_step)
+        !opt_gtid_deployment_step)
     {
       mi->report(ERROR_LEVEL, ER_SLAVE_FATAL_ERROR,
                  "The slave IO thread stops because the master has "

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7138,6 +7138,9 @@ ER_COMPRESSION_DICTIONARY_DATA_TOO_LONG
 ER_COMPRESSION_DICTIONARY_IS_REFERENCED
   eng "Compression dictionary '%-.192s' is in use"
 
+ER_GTID_DEPLOYMENT_STEP_ACTIVE
+  eng "super_read_only cannot be changed when gtid_deployment_step is ON"
+
 #
 #  End of 5.6 error messages.
 #

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2404,6 +2404,11 @@ static bool check_read_only(sys_var *self, THD *thd, set_var *var)
     my_error(ER_LOCK_OR_ACTIVE_TRANSACTION, MYF(0));
     return true;
   }
+  if (opt_gtid_deployment_step)
+  {
+    my_error(ER_GTID_DEPLOYMENT_STEP_ACTIVE, MYF(0));
+    return true;
+  }
   return false;
 }
 static bool fix_read_only(sys_var *self, THD *thd, enum_var_type type)
@@ -5208,10 +5213,8 @@ static bool fix_gtid_deployment_step(sys_var *self, THD *thd, enum_var_type type
   bool new_gtid_deployment_step= gtid_deployment_step;
   bool result= true;
 
-  if (gtid_deployment_step == FALSE ||
-      gtid_deployment_step == opt_gtid_deployment_step)
+  if (gtid_deployment_step == opt_gtid_deployment_step)
   {
-    opt_gtid_deployment_step= gtid_deployment_step;
     DBUG_RETURN(false);
   }
 
@@ -5227,12 +5230,19 @@ static bool fix_gtid_deployment_step(sys_var *self, THD *thd, enum_var_type type
   if ((result= thd->global_read_lock.make_global_read_lock_block_commit(thd)))
     goto end_with_read_lock;
 
-  /*
-   Change the opt_deployment_step system variable,
-   safe because the lock is held
-  */
   opt_gtid_deployment_step= new_gtid_deployment_step;
   result= false;
+
+  if (opt_gtid_deployment_step)
+  {
+    opt_super_readonly= opt_gtid_deployment_step;
+    opt_readonly= opt_gtid_deployment_step;
+  }
+  else
+  {
+    opt_super_readonly= super_read_only;
+    opt_readonly= read_only;
+  }
 
  end_with_read_lock:
   /* Release the lock */


### PR DESCRIPTION
Changes executed after gtid_deployment_step was set resulted in binlog damage, or assertions/crashes of the server.

This commit ensures that checks are based on the correct, lock protected variable, and also enforces super_read_only while gtid_deployment_step is set.

It incorporates PR#1554 by keyurdg, which implements the first part of the above changes.