### PR TITLE
PS-3958: handle_fatal_signal (sig=11) in subselect_hash_sj_engine::cl…

### DIFF
--- a/mysql-test/include/wait_until_connected_again.inc
+++ b/mysql-test/include/wait_until_connected_again.inc
@@ -14,12 +14,15 @@ while ($mysql_errno)
   # Strangely enough, the server might return "Too many connections"
   # while being shutdown, thus 1040 is an "allowed" error
   # See BUG#36228
-  --error 0,1040,1053,2002,2003,2006,2013,1045,ER_SECURE_TRANSPORT_REQUIRED
+  --error 0,1040,1053,2002,2003,2006,2013,1045,ER_CANNOT_FIND_KEY_IN_KEYRING,ER_SECURE_TRANSPORT_REQUIRED
   show session status;
   if ($mysql_errno == 1045){
     let mysql_errno=0;
   }
   if ($mysql_errname == ER_SECURE_TRANSPORT_REQUIRED){
+    let mysql_errno=0;
+  }
+  if ($mysql_errname == ER_CANNOT_FIND_KEY_IN_KEYRING){
     let mysql_errno=0;
   }
   dec $counter;

--- a/mysql-test/suite/innodb/include/temp_table_encrypt.inc
+++ b/mysql-test/suite/innodb/include/temp_table_encrypt.inc
@@ -1,5 +1,7 @@
 # test temporary tables encryption
 
+call mtr.add_suppression("\\[Error\\] InnoDB: Encryption can't find master key, please check the keyring plugin is loaded.");
+
 --let $MYSQL_DATA_DIR= `select @@datadir`
 
 # we need restart to make sure keyring settings are picked up
@@ -156,3 +158,23 @@ CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 
 DROP TABLE t10;
+
+
+
+#
+# PS-3958: handle_fatal_signal (sig=11) in subselect_hash_sj_engine::cleanup
+#
+# Make sure MySQL doesn't crash in subselect_hash_sj_engine::cleanup
+# when innodb_temp_tablespace_encrypt=ON but keyring isn't set up
+#
+
+let $restart_hide_args = 0;
+let $restart_parameters = restart: --innodb-temp-tablespace-encrypt;
+--source include/restart_mysqld.inc
+
+CREATE TABLE t1(a INT key) ENGINE = MEMORY;
+INSERT INTO t1 VALUES (11061);
+INSERT INTO t1 VALUES (3);
+SET big_tables=1;
+--error ER_CANNOT_FIND_KEY_IN_KEYRING
+SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);

--- a/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("\\[Error\\] InnoDB: Encryption can't find master key, please check the keyring plugin is loaded.");
 # restart:<hidden args>
 CREATE TEMPORARY TABLE t01 (a TEXT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES ('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
@@ -55,3 +56,10 @@ INSERT INTO t01 VALUES (1), (2), (3);
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 DROP TABLE t10;
+# restart: --innodb-temp-tablespace-encrypt
+CREATE TABLE t1(a INT key) ENGINE = MEMORY;
+INSERT INTO t1 VALUES (11061);
+INSERT INTO t1 VALUES (3);
+SET big_tables=1;
+SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
+ERROR HY000: Can't find master key from keyring, please check keyring plugin is loaded.

--- a/mysql-test/suite/innodb/t/temp_table_encrypt_keyring_file-master.opt
+++ b/mysql-test/suite/innodb/t/temp_table_encrypt_keyring_file-master.opt
@@ -1,3 +1,0 @@
---early-plugin-load="keyring_file=$KEYRING_PLUGIN"
---loose-keyring_file_data=$MYSQL_TMP_DIR/ts_encrypt_keyring
-$KEYRING_PLUGIN_OPT

--- a/plugin/keyring_vault/tests/mtr/temp_table_encrypt_keyring_vault.result
+++ b/plugin/keyring_vault/tests/mtr/temp_table_encrypt_keyring_vault.result
@@ -1,6 +1,7 @@
 call mtr.add_suppression("\\[ERROR\\] Function 'keyring_vault' already exists");
 call mtr.add_suppression("\\[ERROR\\] Couldn't load plugin named 'keyring_vault' with soname 'keyring_vault.*'.");
 call mtr.add_suppression("Plugin keyring_vault reported");
+call mtr.add_suppression("\\[Error\\] InnoDB: Encryption can't find master key, please check the keyring plugin is loaded.");
 # restart:<hidden args>
 CREATE TEMPORARY TABLE t01 (a TEXT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES ('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
@@ -58,3 +59,10 @@ INSERT INTO t01 VALUES (1), (2), (3);
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 DROP TABLE t10;
+# restart: --innodb-temp-tablespace-encrypt
+CREATE TABLE t1(a INT key) ENGINE = MEMORY;
+INSERT INTO t1 VALUES (11061);
+INSERT INTO t1 VALUES (3);
+SET big_tables=1;
+SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
+ERROR HY000: Can't find master key from keyring, please check keyring plugin is loaded.

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -4013,15 +4013,19 @@ void subselect_hash_sj_engine::cleanup()
 {
   DBUG_ENTER("subselect_hash_sj_engine::cleanup");
   is_materialized= false;
-  result->cleanup(); /* Resets the temp table as well. */
+  if (result != NULL)
+    result->cleanup(); /* Resets the temp table as well. */
   THD * const thd= item->unit->thd;
   DEBUG_SYNC(thd, "before_index_end_in_subselect");
-  TABLE *const table= tab->table();
-  if (table->file->inited)
-    table->file->ha_index_end();  // Close the scan over the index
-  free_tmp_table(thd, table);
-  // Note that tab->qep_cleanup() is not called
-  tab= NULL;
+  if (tab != NULL)
+  {
+    TABLE *const table= tab->table();
+    if (table->file->inited)
+      table->file->ha_index_end();  // Close the scan over the index
+    free_tmp_table(thd, table);
+    // Note that tab->qep_cleanup() is not called
+    tab= NULL;
+  }
   materialize_engine->cleanup();
   DBUG_VOID_RETURN;
 }


### PR DESCRIPTION
…eanup

subselect_hash_sj_engine::cleanup crashed when temporary table was not
created.

Fix is to avoid crash.

Changes in MTR required to allow it to start server with "Encryption
can't find master key" error.