### PR TITLE
PS-3967: Use MAP_POPULATE when NUMA interleave is turned on. (5.7)

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -1129,7 +1129,8 @@ buf_chunk_init(
 /*===========*/
 	buf_pool_t*	buf_pool,	/*!< in: buffer pool instance */
 	buf_chunk_t*	chunk,		/*!< out: chunk of buffers */
-	ulint		mem_size)	/*!< in: requested size in bytes */
+	ulint		mem_size,	/*!< in: requested size in bytes */
+	bool            populate)	/*!< in: virtual page preallocation */
 {
 	buf_block_t*	block;
 	byte*		frame;
@@ -1145,7 +1146,7 @@ buf_chunk_init(
 				  + (UNIV_PAGE_SIZE - 1), UNIV_PAGE_SIZE);
 
 	chunk->mem_size = mem_size;
-	chunk->mem = os_mem_alloc_large(&chunk->mem_size);
+	chunk->mem = os_mem_alloc_large(&chunk->mem_size, populate);
 
 	if (UNIV_UNLIKELY(chunk->mem == NULL)) {
 
@@ -1364,6 +1365,7 @@ buf_pool_init_instance(
 /*===================*/
 	buf_pool_t*	buf_pool,	/*!< in: buffer pool instance */
 	ulint		buf_pool_size,	/*!< in: size in bytes */
+	bool		populate,	/*!< in: virtual page preallocation */
 	ulint		instance_no)	/*!< in: id of the instance */
 {
 	ulint		i;
@@ -1392,7 +1394,7 @@ buf_pool_init_instance(
 
 		UT_LIST_INIT(buf_pool->free);
 
-		if (!buf_chunk_init(buf_pool, chunk, buf_pool_size)) {
+		if (!buf_chunk_init(buf_pool, chunk, buf_pool_size, populate)) {
 			mem_free(chunk);
 			mem_free(buf_pool);
 
@@ -1518,6 +1520,7 @@ dberr_t
 buf_pool_init(
 /*==========*/
 	ulint	total_size,	/*!< in: size of the total pool in bytes */
+	bool	populate,	/*!< in: virtual page preallocation */
 	ulint	n_instances)	/*!< in: number of instances */
 {
 	ulint		i;
@@ -1548,7 +1551,7 @@ buf_pool_init(
 	for (i = 0; i < n_instances; i++) {
 		buf_pool_t*	ptr	= &buf_pool_ptr[i];
 
-		if (buf_pool_init_instance(ptr, size, i) != DB_SUCCESS) {
+		if (buf_pool_init_instance(ptr, size, populate, i) != DB_SUCCESS) {
 
 			/* Free all the instances created so far. */
 			buf_pool_free(i);

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -349,6 +349,7 @@ dberr_t
 buf_pool_init(
 /*=========*/
 	ulint	size,		/*!< in: Size of the total pool in bytes */
+	bool	populate,	/*!< in: Force virtual page preallocation */
 	ulint	n_instances);	/*!< in: Number of instances */
 /********************************************************************//**
 Frees the buffer pool at shutdown.  This must not be invoked before

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -214,6 +214,7 @@ dberr_t
 buf_pool_init(
 /*=========*/
 	ulint	size,		/*!< in: Size of the total pool in bytes */
+	bool	populate,	/*!< in: Force virtual page preallocation */
 	ulint	n_instances);	/*!< in: Number of instances */
 /********************************************************************//**
 Frees the buffer pool at shutdown.  This must not be invoked before

--- a/storage/innobase/include/os0proc.h
+++ b/storage/innobase/include/os0proc.h
@@ -54,10 +54,12 @@ os_proc_get_number(void);
 
 /** Allocates large pages memory.
 @param[in,out]	n	Number of bytes to allocate
+@param[in] populate virtual page preallocation
 @return allocated memory */
 void*
 os_mem_alloc_large(
-	ulint*	n);
+	ulint*	n,
+	bool	populate);
 
 /** Frees large pages memory.
 @param[in]	ptr	pointer returned by os_mem_alloc_large()

--- a/storage/innobase/include/os0proc.h
+++ b/storage/innobase/include/os0proc.h
@@ -58,7 +58,8 @@ UNIV_INTERN
 void*
 os_mem_alloc_large(
 /*===============*/
-	ulint*	n);			/*!< in/out: number of bytes */
+	ulint*	n,			/*!< in/out: number of bytes */
+	bool	populate);		/*!< in: virtual page preallocation */
 /****************************************************************//**
 Frees large pages memory. */
 UNIV_INTERN

--- a/storage/innobase/include/ut0new.h
+++ b/storage/innobase/include/ut0new.h
@@ -605,7 +605,8 @@ public:
 	pointer
 	allocate_large(
 		size_type	n_elements,
-		ut_new_pfx_t*	pfx)
+		ut_new_pfx_t*	pfx,
+		bool            populate)
 	{
 		if (n_elements == 0 || n_elements > max_size()) {
 			return(NULL);
@@ -614,7 +615,7 @@ public:
 		ulint	n_bytes = n_elements * sizeof(T);
 
 		pointer	ptr = reinterpret_cast<pointer>(
-			os_mem_alloc_large(&n_bytes));
+			os_mem_alloc_large(&n_bytes, populate));
 
 #ifdef UNIV_PFS_MEMORY
 		if (ptr != NULL) {

--- a/storage/innobase/os/os0proc.cc
+++ b/storage/innobase/os/os0proc.cc
@@ -32,6 +32,14 @@ Created 9/30/1995 Heikki Tuuri
 #include "ut0mem.h"
 #include "ut0byte.h"
 
+/* Linux release version */
+#if defined(UNIV_LINUX) && defined(_GNU_SOURCE)
+#include <string.h>		/* strverscmp() */
+#include <sys/utsname.h>	/* uname() */
+#endif
+
+#include "ha_prototypes.h"
+
 /* FreeBSD for example has only MAP_ANON, Linux has MAP_ANONYMOUS and
 MAP_ANON but MAP_ANON is marked as deprecated */
 #if defined(MAP_ANONYMOUS)
@@ -40,9 +48,35 @@ MAP_ANON but MAP_ANON is marked as deprecated */
 #define OS_MAP_ANON	MAP_ANON
 #endif
 
+/* Linux's MAP_POPULATE */
+#if defined(MAP_POPULATE)
+#define OS_MAP_POPULATE	MAP_POPULATE
+#else
+#define OS_MAP_POPULATE	0
+#endif
+
 UNIV_INTERN ibool os_use_large_pages;
 /* Large page size. This may be a boot-time option on some platforms */
 UNIV_INTERN ulint os_large_page_size;
+
+
+/****************************************************************//**
+Retrieve and compare operating system release.
+@return	TRUE if the OS release is equal to, or later than release. */
+UNIV_INTERN
+bool
+os_compare_release(
+/*===============*/
+	const char*	release		/*!< in: OS release */
+	MY_ATTRIBUTE((unused)))
+{
+#if defined(UNIV_LINUX) && defined(_GNU_SOURCE)
+	struct utsname name;
+	return uname(&name) == 0 && strverscmp(name.release, release) >= 0;
+#else
+	return false;
+#endif
+}
 
 /****************************************************************//**
 Converts the current process id to a number. It is not guaranteed that the
@@ -69,7 +103,8 @@ UNIV_INTERN
 void*
 os_mem_alloc_large(
 /*===============*/
-	ulint*	n)			/*!< in/out: number of bytes */
+	ulint*	n,			/*!< in/out: number of bytes */
+	bool	populate)		/*!< in: virtual page preallocation */
 {
 	void*	ptr;
 	ulint	size;
@@ -155,12 +190,13 @@ skip:
 	ut_ad(ut_is_2pow(size));
 	size = *n = ut_2pow_round(*n + (size - 1), size);
 	ptr = mmap(NULL, size, PROT_READ | PROT_WRITE,
-		   MAP_PRIVATE | OS_MAP_ANON, -1, 0);
-	if (UNIV_UNLIKELY(ptr == (void*) -1)) {
+		   MAP_PRIVATE | OS_MAP_ANON |
+		   (populate ? OS_MAP_POPULATE : 0), -1, 0);
+	if (UNIV_UNLIKELY(ptr == MAP_FAILED)) {
 		fprintf(stderr, "InnoDB: mmap(%lu bytes) failed;"
 			" errno %lu\n",
 			(ulong) size, (ulong) errno);
-		ptr = NULL;
+		return NULL;
 	} else {
 		os_fast_mutex_lock(&ut_list_mutex);
 		ut_total_allocated_memory += size;
@@ -168,6 +204,25 @@ skip:
 		UNIV_MEM_ALLOC(ptr, size);
 	}
 #endif
+
+#if OS_MAP_ANON && OS_MAP_POPULATE
+	/* MAP_POPULATE is only supported for private mappings
+	since Linux 2.6.23. */
+	populate = populate && !os_compare_release("2.6.23");
+
+	if (populate) {
+		ib_logf(IB_LOG_LEVEL_WARN, "InnoDB: Warning: mmap(MAP_POPULATE) "
+			"is not supported for private mappings. "
+			"Forcing preallocation by faulting in pages.\n");
+	}
+#endif
+
+	/* Initialize the entire buffer to force the allocation
+	of physical memory page frames. */
+	if (populate) {
+		memset(ptr, '\0', size);
+	}
+
 	return(ptr);
 }
 

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -407,7 +407,7 @@ row_log_block_allocate(
 		);
 
 		log_buf.block = ut_allocator<byte>(mem_key_row_log_buf)
-			.allocate_large(srv_sort_buf_size, &log_buf.block_pfx);
+			.allocate_large(srv_sort_buf_size, &log_buf.block_pfx, false);
 
 		if (log_buf.block == NULL) {
 			DBUG_RETURN(false);
@@ -3425,8 +3425,8 @@ row_log_allocate(
 
 	if (log_tmp_is_encrypted()) {
 		ulint size = srv_sort_buf_size;
-		log->crypt_head = static_cast<byte *>(os_mem_alloc_large(&size));
-		log->crypt_tail = static_cast<byte *>(os_mem_alloc_large(&size));
+		log->crypt_head = static_cast<byte *>(os_mem_alloc_large(&size, false));
+		log->crypt_tail = static_cast<byte *>(os_mem_alloc_large(&size, false));
 
 		if (!log->crypt_head || !log->crypt_tail) {
 			row_log_free(log);

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -225,7 +225,7 @@ row_log_block_allocate(
 	DBUG_ENTER("row_log_block_allocate");
 	if (log_buf.block == NULL) {
 		log_buf.size = srv_sort_buf_size;
-		log_buf.block = (byte*) os_mem_alloc_large(&log_buf.size);
+		log_buf.block = (byte*) os_mem_alloc_large(&log_buf.size, false);
 		DBUG_EXECUTE_IF("simulate_row_log_allocation_failure",
 			if (log_buf.block)
 				os_mem_free_large(log_buf.block, log_buf.size);

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -4468,7 +4468,7 @@ row_merge_build_indexes(
 
 	/* This will allocate "3 * srv_sort_buf_size" elements of type
 	row_merge_block_t. The latter is defined as byte. */
-	block = alloc.allocate_large(3 * srv_sort_buf_size, &block_pfx);
+	block = alloc.allocate_large(3 * srv_sort_buf_size, &block_pfx, false);
 
 	if (block == NULL) {
 		DBUG_RETURN(DB_OUT_OF_MEMORY);
@@ -4481,7 +4481,7 @@ row_merge_build_indexes(
 	if (log_tmp_is_encrypted()) {
 		crypt_block = static_cast<row_merge_block_t*>(
 			alloc.allocate_large(
-				3 * srv_sort_buf_size, &crypt_pfx));
+				3 * srv_sort_buf_size, &crypt_pfx, false));
 
 		if (crypt_block == NULL) {
 			DBUG_RETURN(DB_OUT_OF_MEMORY);

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -3672,7 +3672,7 @@ row_merge_build_indexes(
 
 	block_size = 3 * srv_sort_buf_size;
 	block = static_cast<row_merge_block_t*>(
-		os_mem_alloc_large(&block_size));
+		os_mem_alloc_large(&block_size, false));
 
 	if (block == NULL) {
 		DBUG_RETURN(DB_OUT_OF_MEMORY);

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2059,7 +2059,8 @@ innobase_start_or_create_for_mysql(void)
 	ib_logf(IB_LOG_LEVEL_INFO,
 		"Initializing buffer pool, size = %.1f%c", size, unit);
 
-	err = buf_pool_init(srv_buf_pool_size, srv_buf_pool_instances);
+	err = buf_pool_init(srv_buf_pool_size, static_cast<bool>(srv_numa_interleave),
+			    srv_buf_pool_instances);
 
 	if (err != DB_SUCCESS) {
 		ib_logf(IB_LOG_LEVEL_ERROR,

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1880,7 +1880,8 @@ innobase_start_or_create_for_mysql(void)
 		<< size << unit << ", instances = " << srv_buf_pool_instances
 		<< ", chunk size = " << chunk_size << chunk_unit;
 
-	err = buf_pool_init(srv_buf_pool_size, srv_buf_pool_instances);
+	err = buf_pool_init(srv_buf_pool_size, static_cast<bool>(srv_numa_interleave),
+	                    srv_buf_pool_instances);
 
 	if (err != DB_SUCCESS) {
 		ib::error() << "Cannot allocate memory for the buffer pool";

--- a/unittest/gunit/innodb/ut0new-t.cc
+++ b/unittest/gunit/innodb/ut0new-t.cc
@@ -173,7 +173,7 @@ TEST(ut0new, edgecases)
 	void*			ret;
 	const void*		null_ptr= NULL;
 
-	ret = alloc1.allocate_large(0, &pfx);
+	ret = alloc1.allocate_large(0, &pfx, false);
 	EXPECT_EQ(null_ptr, ret);
 
 #ifdef UNIV_PFS_MEMORY


### PR DESCRIPTION
Compared to the NUMA implementation in MySQL, this version forces allocation using MAP_POPULATE.

(cherry picked from commit 1170aef6fa012e44398e8dfa3096b440a3a77fda)