### PR TITLE
PS-3885: Revert "Merge branch 'bug1689489-5.6' into bug1689489-5.7"

### DIFF
--- a/mysql-test/suite/rpl/r/percona_bug_ps3885.result
+++ b/mysql-test/suite/rpl/r/percona_bug_ps3885.result
@@ -1,0 +1,19 @@
+include/rpl_init.inc [topology=1->2->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+include/stop_slave_io.inc
+CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=SERVER_MYPORT_1, MASTER_LOG_FILE='mysqld-1.000001';;
+Warnings:
+Warning	3023	CHANGE MASTER TO with a MASTER_LOG_FILE clause but no MASTER_LOG_POS clause may not be safe. The old position value may not be valid for the new binary log file.
+include/start_slave_io.inc
+SHOW SLAVE STATUS;
+include/stop_slave_io.inc
+CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=SERVER_MYPORT_2, MASTER_LOG_FILE='mysqld-two.000001';;
+Warnings:
+Warning	3023	CHANGE MASTER TO with a MASTER_LOG_FILE clause but no MASTER_LOG_POS clause may not be safe. The old position value may not be valid for the new binary log file.
+include/start_slave_io.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/percona_bug_ps3885.cnf
+++ b/mysql-test/suite/rpl/t/percona_bug_ps3885.cnf
@@ -1,0 +1,15 @@
+!include ../my.cnf
+
+[mysqld.1]
+log_bin=mysqld-1.log
+
+[mysqld.2]
+log_bin=mysqld-two.log
+
+[mysqld.3]
+
+[ENV]
+SERVER_MYPORT_1=		@mysqld.1.port
+SERVER_MYPORT_2=		@mysqld.2.port
+SERVER_MYPORT_3=		@mysqld.3.port
+

--- a/mysql-test/suite/rpl/t/percona_bug_ps3885.test
+++ b/mysql-test/suite/rpl/t/percona_bug_ps3885.test
@@ -1,0 +1,24 @@
+#
+# PS-3885: Assertion when switching slaves without stopping the slave thread
+#
+
+--let $rpl_topology= 1->2->3
+--source include/rpl_init.inc
+
+--connection server_3
+--source include/stop_slave_io.inc
+--replace_result $SERVER_MYPORT_1 SERVER_MYPORT_1
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$SERVER_MYPORT_1, MASTER_LOG_FILE='mysqld-1.000001';
+--source include/start_slave_io.inc
+--disable_result_log
+SHOW SLAVE STATUS;
+--enable_result_log
+
+# cleanup
+--connection server_3
+--source include/stop_slave_io.inc
+--replace_result $SERVER_MYPORT_2 SERVER_MYPORT_2
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$SERVER_MYPORT_2, MASTER_LOG_FILE='mysqld-two.000001';
+--source include/start_slave_io.inc
+
+--source include/rpl_end.inc

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -3696,23 +3696,13 @@ bool show_slave_status_send_data(THD *thd, Master_info *mi,
   protocol->store(mi->get_user(), &my_charset_bin);
   protocol->store((uint32) mi->port);
   protocol->store((uint32) mi->connect_retry);
-  const char * const master_log_file=
-    mi->get_master_log_name();
-  protocol->store(master_log_file, &my_charset_bin);
+  protocol->store(mi->get_master_log_name(), &my_charset_bin);
   protocol->store((ulonglong) mi->get_master_log_pos());
   protocol->store(mi->rli->get_group_relay_log_name() +
                   dirname_length(mi->rli->get_group_relay_log_name()),
                   &my_charset_bin);
   protocol->store((ulonglong) mi->rli->get_group_relay_log_pos());
-  const char * const relay_master_log_file=
-    mi->rli->get_group_master_log_name();
-#ifndef DBUG_OFF
-  const size_t master_log_file_len= strlen(master_log_file);
-  const size_t relay_master_log_file_len= strlen(relay_master_log_file);
-#endif
-  DBUG_ASSERT((relay_master_log_file_len == master_log_file_len)
-              || !relay_master_log_file_len || !master_log_file_len);
-  protocol->store(relay_master_log_file, &my_charset_bin);
+  protocol->store(mi->rli->get_group_master_log_name(), &my_charset_bin);
   protocol->store(mi->slave_running == MYSQL_SLAVE_RUN_CONNECT ?
                   "Yes" : (mi->slave_running == MYSQL_SLAVE_RUN_NOT_CONNECT ?
                            "Connecting" : "No"), &my_charset_bin);


### PR DESCRIPTION
This reverts commit f7df43021e7d979790d4936ed7d824899ba615c4, reversing
changes made to 2d7a1dd02ee0a72bd8c164e5c88678b96ee74731.

5.7 added the option to change masters with only the IO thread stopped, and keeping the slave thread running.
In this case, relay_master_log_name and master_log_name could be different, which isn't an error.
This assertion was originally added to catch an RPL bug failure.

More details:

* WL#6120: https://dev.mysql.com/worklog/task/?id=6120
* Original Percona issue: https://jira.percona.com/browse/PS-3696