### PR TITLE
PS-4471 (5.6): gcc-4.4 error: #pragma GCC diagnostic not allowed inside functions

### DIFF
--- a/include/my_compiler.h
+++ b/include/my_compiler.h
@@ -164,16 +164,12 @@ struct my_aligned_storage
       MY_DO_PRAGMA(STRINGIFY_ARG(GCC diagnostic ignored WMAYBE_UNINITIALIZED_OPTION))
 #  define MY_RESTORE_WARN_MAYBE_UNINITIALIZED     \
       _Pragma("GCC diagnostic pop")
+#  define GCC45_DISABLE_WARN_UNINITIALIZED
 #else
-#  define MY_DISABLE_WARN_MAYBE_UNINITIALIZED     \
+#  define MY_DISABLE_WARN_MAYBE_UNINITIALIZED
+#  define MY_RESTORE_WARN_MAYBE_UNINITIALIZED
+#  define GCC45_DISABLE_WARN_UNINITIALIZED        \
       MY_DO_PRAGMA(STRINGIFY_ARG(GCC diagnostic ignored WMAYBE_UNINITIALIZED_OPTION))
-   /* true for gcc 4.6+ and all other compilers */
-#  if defined(__clang__) || !defined(__GNUC__) || MY_GNUC_PREREQ(4,6)
-#    define MY_RESTORE_WARN_MAYBE_UNINITIALIZED     \
-        MY_DO_PRAGMA(STRINGIFY_ARG(GCC diagnostic warning WMAYBE_UNINITIALIZED_OPTION))
-#  else
-#    define MY_RESTORE_WARN_MAYBE_UNINITIALIZED
-#  endif
 #endif
 
 #endif /* MY_COMPILER_INCLUDED */

--- a/sql/sql_planner.cc
+++ b/sql/sql_planner.cc
@@ -36,6 +36,9 @@
 using std::max;
 using std::min;
 
+/* disable "-Wuninitialized" for whole file for gcc-4.5 or older */
+GCC45_DISABLE_WARN_UNINITIALIZED
+
 static double prev_record_reads(JOIN *join, uint idx, table_map found_ref);
 static void trace_plan_prefix(JOIN *join, uint idx,
                               table_map excluded_tables);


### PR DESCRIPTION
Use separate macros for gcc-4.5 and older to disable "-Wuninitialized" warning.