### PR TITLE
PS-4482: item_geofunc_internal.h:163:60: error: 'box' may be used uninitialized

### DIFF
--- a/sql/geometry_rtree.cc
+++ b/sql/geometry_rtree.cc
@@ -66,9 +66,7 @@ struct Rtree_value_maker_bggeom
   template<typename  T>
   result_type operator()(T const &v) const
   {
-    BG_box box;
-    boost::geometry::envelope(v.value(), box);
-
+    BG_box box = boost::geometry::return_envelope<BG_box>(v.value());
     return result_type(box, v.index());
   }
 };


### PR DESCRIPTION
Replace envelope() with return_envelope() what quiets gcc-4.7.2 on debian:wheezy