### PR TITLE
PS-4506 (5.6): Backport fixes from 8.0 for InnoDB memcached Plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,7 +394,7 @@ ENDIF()
 
 # Add safemutex for debug configurations, except on Windows
 # (safemutex has never worked on Windows)
-IF(WITH_DEBUG AND NOT WIN32 AND NOT WITH_INNODB_MEMCACHED)
+IF(WITH_DEBUG AND NOT WIN32)
   FOREACH(LANG C CXX)
       SET(CMAKE_${LANG}_FLAGS_DEBUG
           "${CMAKE_${LANG}_FLAGS_DEBUG} -DSAFE_MUTEX")

--- a/plugin/innodb_memcached/daemon_memcached/include/memcached/engine.h
+++ b/plugin/innodb_memcached/daemon_memcached/include/memcached/engine.h
@@ -204,7 +204,7 @@ extern "C" {
         /**
          * An array containing all of the features the engine supports
          */
-        feature_info features[1];
+        feature_info features[3];
     } engine_info;
 
     /**

--- a/plugin/innodb_memcached/daemon_memcached/utilities/config_parser.c
+++ b/plugin/innodb_memcached/daemon_memcached/utilities/config_parser.c
@@ -120,10 +120,10 @@ int parse_config(const char *str, struct config_item *items, FILE *error) {
             switch (items[ii].datatype) {
             case DT_SIZE:
                {
-                  char *sfx = "kmgt";
-                  int multiplier = 1;
-                  int m = 1;
-                  for (char *p = sfx; *p != '\0'; ++p) {
+                  const char *sfx = "kmgt";
+                  long int multiplier = 1;
+                  long int m = 1;
+                  for (const char *p = sfx; *p != '\0'; ++p) {
                      m *= 1024;
                      char *ptr = strchr(value, *p);
                      if (ptr == NULL) {

--- a/plugin/innodb_memcached/innodb_memcache/src/handler_api.cc
+++ b/plugin/innodb_memcached/innodb_memcache/src/handler_api.cc
@@ -80,7 +80,7 @@ handler_create_thd(
 	}
 
 	my_thread_init();
-	thd = new THD;
+	thd = new (std::nothrow) THD;
 
 	if (!thd) {
 		return(NULL);

--- a/plugin/innodb_memcached/innodb_memcache/src/innodb_engine.c
+++ b/plugin/innodb_memcached/innodb_memcache/src/innodb_engine.c
@@ -205,7 +205,7 @@ create_instance(
 	innodb_eng->info.info.features[0].feature = ENGINE_FEATURE_CAS;
 	innodb_eng->info.info.features[1].feature =
 		ENGINE_FEATURE_PERSISTENT_STORAGE;
-	innodb_eng->info.info.features[0].feature = ENGINE_FEATURE_LRU;
+	innodb_eng->info.info.features[2].feature = ENGINE_FEATURE_LRU;
 
 	/* Now call create_instace() for the default engine */
 	err_ret = create_my_default_instance(interface, get_server_api,
@@ -1979,7 +1979,8 @@ search_done:
 			conn_data->mul_col_buf_len = int_len;
 		}
 
-		memcpy(conn_data->mul_col_buf, int_buf, int_len);
+		if (int_len > 0)
+			memcpy(conn_data->mul_col_buf, int_buf, int_len);
 		result->col_value[MCI_COL_VALUE].value_str =
 			 conn_data->mul_col_buf;
 

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -1725,10 +1725,12 @@ void memcached_shutdown(void)
       {
 	plugin_deinitialize(plugin, true);
 
+        mysql_mutex_lock(&LOCK_plugin_delete);
         mysql_mutex_lock(&LOCK_plugin);
 	plugin->state= PLUGIN_IS_DYING;
 	plugin_del(plugin);
         mysql_mutex_unlock(&LOCK_plugin);
+        mysql_mutex_unlock(&LOCK_plugin_delete);
       }
     }
 


### PR DESCRIPTION
The original commit is available at:
https://github.com/mysql/mysql-server/commit/fb8d67315d2cb956976d838559ae3bdc88d43d60

Bug#26442367 ALWAYS ENABLE SAFE_MUTEX IN DEBUG BUILDS, MAKE MEMCACHED UBSAN CLEAN

CMakeLists.txt contains this snippet:

IF(NOT WITH_INNODB_MEMCACHED)
  FOREACH(LANG C CXX)
      SET(CMAKE_${LANG}_FLAGS_DEBUG
          "${CMAKE_${LANG}_FLAGS_DEBUG} -DSAFE_MUTEX")
  ENDFOREACH()
ENDIF()

There  should be  no  reason to  disable safe_mutex  if  we build  the
memcached  plugin  (it  actually   hides  real  problems,  since  most
pushbuild trees are built with  the memcached plugin) Enabling it, and
running with  UBSAN shows a  few issues,  with wrong mutex  usage, and
undefined behaviour.

engine.h
src/innodb_engine.c:312:32:
runtime error: index 1 out of bounds for type 'feature_info [1]'

config_parser.c
config_parser.c:127:24:
runtime error: signed integer overflow: 1073741824 * 1024 cannot be represented in type 'int'

innodb_engine.c
the double assignment to innodb_eng->info.info.features[0].feature *must* be wrong
innodb_engine.c:2341:3: runtime error:
null pointer passed as argument 1, which is declared to never be null

sql/sql_plugin.cc
==9557== Process terminating with default action of signal 6 (SIGABRT)
==9557==    at 0x78DD91F: raise (in /usr/lib64/libc-2.24.so)
==9557==    by 0x78DF519: abort (in /usr/lib64/libc-2.24.so)
==9557==    by 0x78D5DA6: __assert_fail_base (in /usr/lib64/libc-2.24.so)
==9557==    by 0x78D5E51: __assert_fail (in /usr/lib64/libc-2.24.so)
==9557==    by 0x23272A2: safe_mutex_assert_owner (thr_mutex.h:151)
==9557==    by 0x2329884: plugin_del(st_plugin_int*) (sql_plugin.cc:1097)
==9557==    by 0x232C1FB: memcached_shutdown() (sql_plugin.cc:1889)
==9557==    by 0x21BC38F: clean_up(bool) (mysqld.cc:1925)
==9557==    by 0x21C7A72: mysqld_main(int, char**) (mysqld.cc:5970)
==9557==    by 0x21B9795: main (main.cc:25)

Change-Id: I88bb6751ae8401d4c461a6f03dd098f016e0adf8