### PR TITLE
PS-4511: Limit clang-format checkings to given extensions (5.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
       script:
         - wget https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py
         - chmod a+x clang-format-diff.py
-        - git diff -U0 --no-color HEAD^1 | ./clang-format-diff.py -style=file -p1 >_GIT_DIFF
+        - git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | ./clang-format-diff.py -style=file -p1 >_GIT_DIFF
         - '[ ! -s _GIT_DIFF ] && { echo The last git commit is clang-formatted; travis_terminate 0; } || { cat _GIT_DIFF; travis_terminate 1; }'
 
 
@@ -220,29 +220,29 @@ script:
       -DENABLE_DTRACE=OFF
       -DWITH_PAM=ON
     ";
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      CMAKE_OPT+="
-        -DMYSQL_MAINTAINER_MODE=ON
-      ";
-    else
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       CMAKE_OPT+="
         -DMYSQL_MAINTAINER_MODE=OFF
       ";
-    fi;
-    if [[ "$INVERTED" == "ON" ]]; then
+    else
       CMAKE_OPT+="
-        -DWITH_EMBEDDED_SERVER=OFF
-        -DWITH_READLINE=OFF
-        -DWITH_SSL=system
-        -DWITH_ZLIB=bundled
-        -DWITH_ARCHIVE_STORAGE_ENGINE=OFF
-        -DWITH_BLACKHOLE_STORAGE_ENGINE=OFF
-        -DWITH_EXAMPLE_STORAGE_ENGINE=ON
-        -DWITH_FEDERATED_STORAGE_ENGINE=OFF
-        -DWITH_INNOBASE_STORAGE_ENGINE=OFF
-        -DWITHOUT_PARTITION_STORAGE_ENGINE=ON
-        -DWITH_SCALABILITY_METRICS=ON
+        -DMYSQL_MAINTAINER_MODE=ON
       ";
+      if [[ "$INVERTED" == "ON" ]]; then
+        CMAKE_OPT+="
+          -DWITH_EMBEDDED_SERVER=OFF
+          -DWITH_READLINE=OFF
+          -DWITH_SSL=system
+          -DWITH_ZLIB=bundled
+          -DWITH_ARCHIVE_STORAGE_ENGINE=OFF
+          -DWITH_BLACKHOLE_STORAGE_ENGINE=OFF
+          -DWITH_EXAMPLE_STORAGE_ENGINE=ON
+          -DWITH_FEDERATED_STORAGE_ENGINE=OFF
+          -DWITH_INNOBASE_STORAGE_ENGINE=OFF
+          -DWITHOUT_PARTITION_STORAGE_ENGINE=ON
+          -DWITH_SCALABILITY_METRICS=ON
+        ";
+      fi;
     fi;
 
   - echo --- Perform Debug or RelWithDebInfo compilation;


### PR DESCRIPTION
Travis CI:
1. Limit clang-format checkings to the follwing extensions: *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih
2. Refactor CMAKE_OPT