### PR TITLE
PS-4514: rpl.bug68490 is unstable in 5.7

### DIFF
--- a/mysql-test/suite/rpl/r/bug68490.result
+++ b/mysql-test/suite/rpl/r/bug68490.result
@@ -5,6 +5,7 @@ Note	####	Storing MySQL user name or password information in the master info rep
 [connection master]
 CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, payload MEDIUMBLOB NOT NULL);
 include/rpl_restart_server.inc [server_number=1]
+include/sync_slave_sql_with_master.inc
 include/stop_slave.inc
 include/start_slave.inc
 INSERT INTO t1(payload) VALUES(REPEAT('a',1468872));

--- a/mysql-test/suite/rpl/t/bug68490.test
+++ b/mysql-test/suite/rpl/t/bug68490.test
@@ -6,7 +6,7 @@ CREATE TABLE t1(id INT AUTO_INCREMENT PRIMARY KEY, payload MEDIUMBLOB NOT NULL);
 
 --let $rpl_server_number= 1
 --source include/rpl_restart_server.inc
---connection slave
+--source include/sync_slave_sql_with_master.inc
 --source include/stop_slave.inc
 --source include/start_slave.inc
 --connection master


### PR DESCRIPTION
The issues here was related to restart of master replication server while slave was still connected to master.
Under heavy load `stop_slave.inc` can return Last_IO_Errno=2003 that is `error reconnecting to master 'root@127.0.0.1:13001'`.
To solve this `sync_slave_sql_with_master.inc` should be run before `stop_slave.inc`.
