### PR TITLE
PS-3702: Unnecessary flush list iteration during ALTER TABLE ADD INDEX

### DIFF
--- a/storage/innobase/include/buf0flu.h
+++ b/storage/innobase/include/buf0flu.h
@@ -314,6 +314,7 @@ buf_flush_ready_for_flush(
 	buf_flush_t	flush_type)/*!< in: type of flush */
 	MY_ATTRIBUTE((warn_unused_result));
 
+#ifdef UNIV_DEBUG
 /******************************************************************//**
 Check if there are any dirty pages that belong to a space id in the flush
 list in a particular buffer pool.
@@ -332,6 +333,7 @@ buf_flush_get_dirty_pages_count(
 /*============================*/
 	ulint		id,		/*!< in: space id to check */
 	FlushObserver*	observer);	/*!< in: flush observer to check */
+#endif /* UNIV_DEBUG */
 
 /*******************************************************************//**
 Signal the page cleaner to flush and wait until it and the LRU manager clean
@@ -400,6 +402,17 @@ public:
 	void notify_remove(
 		buf_pool_t*	buf_pool,
 		buf_page_t*	bpage);
+
+	/** Increase the estimate of dirty pages by this observer
+	@param[in]	block		buffer pool block */
+	void inc_estimate(const buf_block_t*	block);
+
+	/** @return estimate of dirty pages to be flushed */
+	ulint get_estimate() const {
+		os_rmb;
+		return(m_estimate);
+	}
+
 private:
 	/** Table space id */
 	ulint			m_space_id;
@@ -422,6 +435,13 @@ private:
 
 	/* True if the operation was interrupted. */
 	bool			m_interrupted;
+
+	/* Estimate of pages to be flushed */
+	ulint			m_estimate;
+
+	/** LSN at which observer started observing. This is
+	used to find the dirty blocks that are dirtied before Observer */
+	const lsn_t		m_lsn;
 };
 
 #endif /* !UNIV_HOTBACKUP */

--- a/storage/innobase/include/buf0flu.ic
+++ b/storage/innobase/include/buf0flu.ic
@@ -82,6 +82,10 @@ buf_flush_note_modification(
 	mutex_enter(&block->mutex);
 
 	ut_ad(block->page.newest_modification <= end_lsn);
+	if (observer != NULL) {
+		observer->inc_estimate(block);
+	}
+
 	block->page.newest_modification = end_lsn;
 
 	/* Don't allow to set flush observer from non-null to null,


### PR DESCRIPTION

    Problem:
    --------
    ALTER TABLE ADD INDEX in 5.7 uses bottom-up index build(BulkInsert).
    It skips redo logging and flushes all dirty pages dirtied by ALTER.
    FlushObserver is used which flushes and waits until dirty pages
    are flushed and written to disk.
    
    There are two iterations of flush list as part of ALTER:
    1. For PFS monitoring, an estimate of dirty pages is required.
       (buf_flush_get_dirty_pages_count())
    2. To do the actual flushing of dirty pages of ALTER
    
    When there are lot of dirty pages, this iteration takes significant
    amount of time.
    
    Fix:
    ----
    1. Remove one iteration of flush list of all buffer pool instances.
       i.e the iteration used for estimate.
    
    2. Note the LSN at which Observer is created. When mtr commits
       with an Observer, as part of commit, dirty pages
       are added to flush list. Count the dirty pages that are dirted
       before Observer (newest_modification < observer_lsn) and also
       the new blocks that are dirtied. This count serves
       as a very good estimate
    
    3. Make buf_flush_get_dirty_pages_count() debug only function.
       This is no longer required in release builds.

```
Performance results with 200GB buffer pool
-----------------------------------------------------------
bp     ps        ps            ps
dirty  5.7.21    5.7.21+fix    5.6.40
pct
---------------------------------------
0      0.03       0.02          0.01
5      0.42       0.29          0.48
10     1.21       0.66          0.05
15     1.70       0.85          0.04
20     2.23       1.16          0.12
25     2.75       1.50          0.04
30     3.17       1.42          0.16
35     4.13       2.07          0.02
40     3.51       1.77          0.04
45     5.36       2.11          0.20
50     4.61       2.23          0.18
55     6.13       2.93          0.29
60     6.19       3.34          0.30
65     6.37       2.91          0.03
70     7.86       4.39          0.05

```
jenkins: https://jenkins.percona.com/view/5.7/job/mysql-5.7-param/1863/