### PR TITLE
PS-4524: innodb-optimize-keys fails when variable name is a prefix (5.6)

### DIFF
--- a/mysql-test/r/percona_mysqldump_innodb_optimize_keys.result
+++ b/mysql-test/r/percona_mysqldump_innodb_optimize_keys.result
@@ -738,3 +738,75 @@ UNLOCK TABLES;
 
 ######################################
 DROP TABLE t1;
+CREATE TABLE `t1` (
+`prefix` int(5) NOT NULL,
+`prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
+UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`),
+PRIMARY KEY (`prefix`)
+) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3);
+INSERT INTO t1(`prefix`) VALUES (4);
+CREATE TABLE `t2` (
+`prefix` int(5) NOT NULL,
+`prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
+PRIMARY KEY (`prefix`),
+UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`)
+) ENGINE=InnoDB;
+INSERT INTO t2 VALUES (1,10), (2,11), (3,12);
+INSERT INTO t2(`prefix`) VALUES (13);
+######################################
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `t1`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `t1` (
+  `prefix` int(5) NOT NULL,
+  `prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`prefix`),
+  UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`)
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+LOCK TABLES `t1` WRITE;
+/*!40000 ALTER TABLE `t1` DISABLE KEYS */;
+INSERT INTO `t1` VALUES (1,1),(2,2),(3,3),(4,4);
+/*!40000 ALTER TABLE `t1` ENABLE KEYS */;
+UNLOCK TABLES;
+DROP TABLE IF EXISTS `t2`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `t2` (
+  `prefix` int(5) NOT NULL,
+  `prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`prefix`),
+  UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`)
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=latin1;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+LOCK TABLES `t2` WRITE;
+/*!40000 ALTER TABLE `t2` DISABLE KEYS */;
+INSERT INTO `t2` VALUES (1,10),(2,11),(3,12),(13,13);
+/*!40000 ALTER TABLE `t2` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+######################################
+DROP TABLE t1, t2;

--- a/mysql-test/t/percona_mysqldump_innodb_optimize_keys.test
+++ b/mysql-test/t/percona_mysqldump_innodb_optimize_keys.test
@@ -392,6 +392,46 @@ INSERT INTO t1(`id`) VALUES (4);
 
 DROP TABLE t1;
 
+#############################################################################
+# Bug PS-4524: Error occurs only if a variable name is a prefix of the
+#              name of the second variable with AUTO_INCREMENT
+#############################################################################
+
+CREATE TABLE `t1` (
+  `prefix` int(5) NOT NULL,
+  `prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
+  UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`),
+  PRIMARY KEY (`prefix`)
+) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES (1,1), (2,2), (3,3);
+INSERT INTO t1(`prefix`) VALUES (4);
+
+CREATE TABLE `t2` (
+  `prefix` int(5) NOT NULL,
+  `prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`prefix`),
+  UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`)
+) ENGINE=InnoDB;
+
+INSERT INTO t2 VALUES (1,10), (2,11), (3,12);
+INSERT INTO t2(`prefix`) VALUES (13);
+
+
+--exec $MYSQL_DUMP --skip-comments --innodb-optimize-keys test t1 t2 >$file
+
+--echo ######################################
+--cat_file $file
+--echo ######################################
+
+# Check that the resulting dump can be imported back
+
+--exec $MYSQL test < $file
+
+--remove_file $file
+
+DROP TABLE t1, t2;
+
 
 # Wait till we reached the initial number of concurrent sessions
 --source include/wait_until_count_sessions.inc


### PR DESCRIPTION
https://ps.cd.percona.com/view/5.6/job/percona-server-5.6-param/5/