### PR TITLE
[*] PS-4533 fixed hardcoded paths in audit log tests

### DIFF
--- a/plugin/audit_log/tests/mtr/audit_log_csv.test
+++ b/plugin/audit_log/tests/mtr/audit_log_csv.test
@@ -7,7 +7,7 @@ SET GLOBAL audit_log_flush=ON;
 --remove_file $MYSQLD_DATADIR/test_audit.log
 SET GLOBAL audit_log_flush=ON;
 
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
+--source audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_csv.log
 set global audit_log_flush= ON;

--- a/plugin/audit_log/tests/mtr/audit_log_json.test
+++ b/plugin/audit_log/tests/mtr/audit_log_json.test
@@ -8,7 +8,7 @@ SET GLOBAL audit_log_flush=ON;
 SET GLOBAL audit_log_flush=ON;
 
 --let $test_control_chars=1;
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
+--source audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_json.log
 set global audit_log_flush= ON;

--- a/plugin/audit_log/tests/mtr/audit_log_new.test
+++ b/plugin/audit_log/tests/mtr/audit_log_new.test
@@ -7,7 +7,7 @@ SET GLOBAL audit_log_flush=ON;
 --remove_file $MYSQLD_DATADIR/test_audit.log
 SET GLOBAL audit_log_flush=ON;
 
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
+--source audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_new.log
 set global audit_log_flush= ON;

--- a/plugin/audit_log/tests/mtr/audit_log_old.test
+++ b/plugin/audit_log/tests/mtr/audit_log_old.test
@@ -7,7 +7,7 @@ SET GLOBAL audit_log_flush=ON;
 --remove_file $MYSQLD_DATADIR/test_audit.log
 SET GLOBAL audit_log_flush=ON;
 
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
+--source audit_log_events.inc
 
 --move_file $MYSQLD_DATADIR/test_audit.log $MYSQLD_DATADIR/test_audit_old.log
 set global audit_log_flush= ON;

--- a/plugin/audit_log/tests/mtr/audit_log_rotate.test
+++ b/plugin/audit_log/tests/mtr/audit_log_rotate.test
@@ -5,10 +5,10 @@ let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
 --disable_result_log
 --disable_query_log
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
+--source audit_log_events.inc
+--source audit_log_events.inc
+--source audit_log_events.inc
+--source audit_log_events.inc
 --enable_query_log
 --enable_result_log
 

--- a/plugin/audit_log/tests/mtr/audit_log_syslog.test
+++ b/plugin/audit_log/tests/mtr/audit_log_syslog.test
@@ -1,3 +1,3 @@
 --source include/not_embedded.inc
 
---source ../plugin/audit_log/tests/mtr/audit_log_events.inc
+--source audit_log_events.inc


### PR DESCRIPTION
change allows both in-tree mtr and audit log tests from installed directory to run without include errors