### PR TITLE
Fix header guard to match filename.

### DIFF
--- a/sql/events.h
+++ b/sql/events.h
@@ -1,5 +1,5 @@
-#ifndef _EVENT_H_
-#define _EVENT_H_
+#ifndef _EVENTS_H_
+#define _EVENTS_H_
 /* Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
 
    This program is free software; you can redistribute it and/or modify
@@ -159,4 +159,4 @@ private:
   @} (end of group Event Scheduler)
 */
 
-#endif /* _EVENT_H_ */
+#endif /* _EVENTS_H_ */


### PR DESCRIPTION
I was looking at 

  https://lgtm.com/projects/g/mysql/mysql-server/alerts/?mode=list&lang=cpp&severity=error

and the report of a duplicate include guard  `_EVENT_H_` used in 2 different header files.
https://github.com/mysql/mysql-server/commit/1d1e9d10b6fa27c433e71c5270818ea81e8f72ea in 2006 renamed `sql/event.h` to `sql/events.h` but kept the same header guard `_EVENT_H_`.

`extra/libevent/event.h` (previously `libevent/event.h`, previously `plugin/innodb_memcached/libevent/event.h`) also uses `_EVENT_H_`.

I think `sql/events.h` could use `_EVENTS_H_` to be consistent with convention to match the filename, and to avoid any confusion or potential clashes when building with the bundled `libevent`.