### PR TITLE
Fixed PS-4566 (stack-use-after-scope in reinit_io_cache() detected by ASan) (5.5)

### DIFF
--- a/sql/sql_update.cc
+++ b/sql/sql_update.cc
@@ -605,6 +605,7 @@ int mysql_update(THD *thd,
       if (reinit_io_cache(&tempfile,READ_CACHE,0L,0,0))
 	error=1; /* purecov: inspected */
       select->file=tempfile;			// Read row ptrs from this file
+      setup_io_cache(&select->file);
       if (error >= 0)
 	goto err;
     }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4566

Although 'tempfile' variable of type 'IO_CACHE' declared inside an inner
block in 'mysql_update()' function is copied by value to 'select->file'
"select->file=tempfile;", this operation is not safe as some of the members
inside 'IO_CACHE' struct were initialized with addresses of other data
members.

In particular, in 'setup_io_cache()', called from 'init_functions()',
called from 'init_io_cache()', called from 'open_cached_file()'
'current_pos' and 'current_end' are initialized with such addresses.

/* Ensure that my_b_tell() and my_b_bytes_in_cache works */
if (info->type == WRITE_CACHE)
{
  info->current_pos= &info->write_pos;
  info->current_end= &info->write_end;
}
else
{
  info->current_pos= &info->read_pos;
  info->current_end= &info->read_end;
}

Fixed by adding "setup_io_cache(&select->file);" call after assignment, which
reassigns those pointers to the new addresses.