### PR TITLE
Fixed PS-4574 (stack-use-after-scope in innobase_convert_identifier() detected by ASan) (5.6)

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3162,10 +3162,10 @@ innobase_convert_identifier(
 	const char*	s	= id;
 	int		q;
 
-	if (file_id) {
+	char nz[MAX_TABLE_NAME_LEN + 1];
+	char nz2[MAX_TABLE_NAME_LEN + 1];
 
-		char nz[MAX_TABLE_NAME_LEN + 1];
-		char nz2[MAX_TABLE_NAME_LEN + 1];
+	if (file_id) {
 
 		/* Decode the table name.  The MySQL function expects
 		a NUL-terminated string.  The input and output strings


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4574

Fixed problem with 'nz' and 'nz2' buffers inside
'innobase_convert_identifier()' used after they run out of scope.