### PR TITLE
Fixed PS-4581 (stack-use-after-scope in _db_enter_() / mysql_select_db() detected by ASan) (5.5)

### DIFF
--- a/client/mysqlcheck.c
+++ b/client/mysqlcheck.c
@@ -914,10 +914,10 @@ static int dbConnect(char *host, char *user, char *passwd)
                                        opt_ssl_mode == SSL_MODE_REQUIRED)))
   {
     DBerror(&mysql_connection, "when trying to connect");
-    return 1;
+    DBUG_RETURN(1);
   }
   mysql_connection.reconnect= 1;
-  return 0;
+  DBUG_RETURN(0);
 } /* dbConnect */
 
 

--- a/mysys/default.c
+++ b/mysys/default.c
@@ -646,7 +646,7 @@ int my_load_defaults(const char *conf_file, const char **groups,
  err:
   fprintf(stderr,"Fatal error in defaults handling. Program aborted\n");
   exit(1);
-  return 0;					/* Keep compiler happy */
+  DBUG_RETURN(0); /* Keep compiler happy */
 }
 
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4581

Function 'dbConnect()' in 'client/mysqlcheck.c' has 'DBUG_ENTER("dbConnect")'
at the beginning but ends with plain 'return' which causes stack corruption
in Debug mode.

Fixed by changing plain 'return's to 'DBUG_RETURN()'s.