### PR TITLE
PS-4587: ROCKSDB_INCLUDE_RFR macros in wrong file

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -19,7 +19,6 @@
 #endif
 
 #define MYSQL_SERVER 1
-#define ROCKSDB_INCLUDE_RFR 1
 
 /* The C++ file's header */
 #include "./ha_rocksdb.h"

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -19,6 +19,8 @@
 #pragma interface /* gcc class implementation */
 #endif
 
+#define ROCKSDB_INCLUDE_RFR 1
+
 /* C++ standard header files */
 #include <cinttypes>
 #include <set>


### PR DESCRIPTION
ROCKSDB_INCLUDE_RFR is defined in ha_rocksdb.cc file. There is conditional
compilation in both .h and .cc files where the condition is the macro
definition. If ha_rocksdb.h is included somewhere outside from ha_rocksdb.cc
where ROCKSDB_INCLUDE_RFR is not defined then the objects of ha_rocksdb class
will have not the same content as expected in the class member-functions in
ha_rocksdb.cc, what can cause memory corruption. Move ROCKSDB_INCLUDE_RFR macro
definition from .cc to .h file.

Testing: https://jenkins.percona.com/view/5.7/job/mysql-5.7-param/1869/