### PR TITLE
PS-4565 Inconsistent behaviour of innodb_temp_tablespace_encrypt=ON a…

### DIFF
--- a/mysql-test/suite/innodb/include/temp_table_encrypt.inc
+++ b/mysql-test/suite/innodb/include/temp_table_encrypt.inc
@@ -52,10 +52,9 @@ SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 --let $wait_condition= SELECT SUM(VARIABLE_VALUE) > $innodb_master_loops + 2 FROM performance_schema.global_status WHERE VARIABLE_NAME LIKE 'innodb_master%loops'
 --source include/wait_condition.inc
 
---error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t02 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 
-CREATE TEMPORARY TABLE t03 (a TEXT) ENGINE=InnoDB ENCRYPTION='N';
+CREATE TEMPORARY TABLE t03 (a TEXT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t03 VALUES ('Curabitur laoreet, velit non interdum venenatis');
 
 # wait until pages flushed
@@ -71,7 +70,9 @@ INSERT INTO t03 VALUES ('Curabitur laoreet, velit non interdum venenatis');
 
 # this table created in separate file per table tablespace, make sure it is
 # encrypted as well
+SET GLOBAL innodb_encrypt_tables=ON;
 CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 
 # wait until pages flushed
@@ -87,17 +88,19 @@ INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 --let $grep_output= boolean
 --source include/grep_pattern.inc
 
---error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+INSERT INTO t05 VALUES (1), (2), (3);
 
+--error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
-INSERT INTO t06 VALUES (1), (2), (3);
 
 # test that we can turn encryption OFF and ON
 
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
 
-CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
+# Setting OFF after encryption doesn't make it decrypted. So temp tablespace
+# is still encrypted.
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t07 VALUES (1), (2), (3);
 
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
@@ -131,7 +134,7 @@ let $restart_hide_args = 1;
 let $restart_parameters = $KEYRING_RESTART_PARAM --innodb-temp-tablespace-encrypt --innodb_max_dirty_pages_pct=0;
 --source include/restart_mysqld.inc
 
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 
 # test crashing
@@ -139,7 +142,7 @@ let $restart_hide_args = 1;
 let $restart_parameters = $KEYRING_RESTART_PARAM --innodb-temp-tablespace-encrypt --innodb_max_dirty_pages_pct=0;
 --source include/kill_and_restart_mysqld.inc
 
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 
 # and able to startup without keyring plugin
@@ -154,7 +157,7 @@ let $restart_hide_args = 1;
 let $restart_parameters = $KEYRING_RESTART_PARAM --innodb-temp-tablespace-encrypt --innodb_max_dirty_pages_pct=0;
 --source include/restart_mysqld.inc
 
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 
 DROP TABLE t10;

--- a/mysql-test/suite/innodb/r/table_encrypt_1.result
+++ b/mysql-test/suite/innodb/r/table_encrypt_1.result
@@ -28,7 +28,7 @@ ERROR HY000: InnoDB: Tablespace `innodb_system` cannot contain an ENCRYPTED tabl
 CREATE TABLE t1(c int) ENCRYPTION="N" tablespace innodb_system;
 DROP TABLE t1;
 CREATE TEMPORARY TABLE t1(c int) ENCRYPTION="Y";
-ERROR HY000: InnoDB: Unsupported encryption option for temporary tables.
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
 CREATE TEMPORARY TABLE t1(c int) ENCRYPTION="N";
 DROP TABLE t1;
 CREATE TABLE t1(c int) ENCRYPTION="R" ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/table_encrypt_3.result
+++ b/mysql-test/suite/innodb/r/table_encrypt_3.result
@@ -207,7 +207,7 @@ CREATE TABLE tde_db.t_encrypt (a int, b text) ENCRYPTION="Y" TABLESPACE=`s_alt1`
 ERROR HY000: InnoDB: Tablespace `s_alt1` cannot contain an ENCRYPTED table.
 DROP TABLESPACE s_alt1;
 CREATE TEMPORARY TABLE tde_db.t_encrypt (a int, b text) ENCRYPTION="Y" ENGINE=InnoDB;
-ERROR HY000: InnoDB: Unsupported encryption option for temporary tables.
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
 CREATE TABLE tde_db.t_encrypt_myisam (a int, b text) ENCRYPTION="Y" ENGINE=MyISAM;
 ERROR HY000: Table storage engine for 't_encrypt_myisam' doesn't have this option
 CREATE PROCEDURE tde_db.row_format_t_encrypt(row_form VARCHAR(1000))

--- a/mysql-test/suite/innodb/r/temp_table_encrypt_debug.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt_debug.result
@@ -3,10 +3,14 @@ INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_master_encrypt_debug = 1;
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
+SET GLOBAL innodb_encrypt_tables=ON;
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_master_encrypt_debug = 0;
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;

--- a/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
@@ -9,19 +9,20 @@ Pattern found.
 DROP TABLE t04;
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TEMPORARY TABLE t02 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
-ERROR HY000: InnoDB: Unsupported encryption option for temporary tables.
-CREATE TEMPORARY TABLE t03 (a TEXT) ENGINE=InnoDB ENCRYPTION='N';
+CREATE TEMPORARY TABLE t03 (a TEXT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t03 VALUES ('Curabitur laoreet, velit non interdum venenatis');
 Pattern not found.
+SET GLOBAL innodb_encrypt_tables=ON;
 CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
+SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 Pattern not found.
 CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
-ERROR HY000: InnoDB: Unsupported encryption option for temporary tables.
+INSERT INTO t05 VALUES (1), (2), (3);
 CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
-INSERT INTO t06 VALUES (1), (2), (3);
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
-CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t07 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TABLE t10 (a INT AUTO_INCREMENT PRIMARY KEY, b INT);
@@ -44,16 +45,16 @@ DROP INDEX t10_b ON t10;
 CREATE INDEX t10_b ON t10 (b) ALGORITHM=COPY;
 DROP INDEX t10_b ON t10 ALGORITHM=COPY;
 # restart:<hidden args>
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 # Kill and restart:<hidden args>
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 # restart:<hidden args>
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 # restart:<hidden args>
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 DROP TABLE t10;
 # restart: --innodb-temp-tablespace-encrypt

--- a/mysql-test/suite/innodb/t/temp_table_encrypt_debug.test
+++ b/mysql-test/suite/innodb/t/temp_table_encrypt_debug.test
@@ -22,7 +22,10 @@ SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 connect (other2,localhost,root,,test);
 connection other2;
 
+--error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 
 disconnect other2;
@@ -30,7 +33,9 @@ disconnect other2;
 connect (other2,localhost,root,,test);
 connection other2;
 
+SET GLOBAL innodb_encrypt_tables=ON;
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t01 VALUES (1), (2), (3);
 
 connection default;
@@ -42,7 +47,7 @@ disconnect other2;
 
 disconnect other1;
 
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t01 VALUES (1), (2), (3);
 
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -2256,6 +2256,9 @@ bool create_innodb_tmp_table(TABLE *table, KEY *keyinfo)
   create_info.row_type= table->s->row_type;
   create_info.options|= HA_LEX_CREATE_TMP_TABLE |
                         HA_LEX_CREATE_INTERNAL_TMP_TABLE;
+
+  table->file->adjust_create_info_for_frm(&create_info);
+
   /*
     INNODB's fixed length column size is restricted to 1024. Exceeding this can
     result in incorrect behavior.

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -814,6 +814,13 @@ public:
 		const char*     name,
 		ibool           set_lower_case);
 
+	/** If encryption is requested, check for master key availability
+	and set the encryption flag in table flags
+	@param[in,out]	table	table object
+	@return on success DB_SUCCESS else DB_UNSPPORTED on failure */
+
+	dberr_t	enable_encryption(dict_table_t*	table);
+
 private:
 	/** Parses the table name into normal name and either temp path or
 	remote path if needed.*/

--- a/storage/innobase/include/fsp0space.h
+++ b/storage/innobase/include/fsp0space.h
@@ -206,6 +206,12 @@ public:
 	/** Check if undo tablespace.
 	@return true if undo tablespace */
 	static bool is_undo_tablespace(ulint id);
+
+	/** @return true if tablespace is encrypted */
+	bool is_encrypted() const {
+		return(FSP_FLAGS_GET_ENCRYPTION(m_flags));
+	}
+
 private:
 	/**
 	@param[in]	filename	Name to lookup in the data files.

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2757,6 +2757,8 @@ srv_enable_temp_encryption_if_set()
 			ib::error() << "Can't set temporary tablespace "
 				    << "to be encrypted.";
 			return;
+		} else {
+			srv_tmp_space.set_flags(space->flags);
 		}
 	}
 }

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1241,6 +1241,8 @@ srv_open_tmp_tablespace(
 							 Encryption::AES,
 							 NULL,
 							 NULL);
+
+				tmp_space->set_flags(space->flags);
 				ut_a(err == DB_SUCCESS);
 			}
 


### PR DESCRIPTION
…nd CREATE TABLE with ENCRYPTION option

Problem:
-------
Encryption behaviour of temporary tables is inconsistent. When a
temp tablespace is encrypted, CREATE TEMPORARY TABLE t1() ENCRYPTION='Y'
fails.

Also temporary table do not adhere to the behaviour of innodb_encrypt_tables;

Fix:
----
When innodb_temp_tablespace_encrypt is ON

CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='Y' :- table created and encrypted
CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='N' :- error
innodb_encrypt_tables=OFF && CREATE TEMPORARY TABLE t1 (a INT) :- error
innodb_encrypt_tables=ON && CREATE TEMPORARY TABLE t1 (a INT) :- table created and encrypted

When innodb_temp_tablespace_encrypt is OFF
CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='Y' :- error
CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='N' :- table created and unencrypted
innodb_encrypt_tables=OFF && CREATE TEMPORARY TABLE t1 (a INT) :- table created and unencrypted
innodb_encrypt_tables=ON && CREATE TEMPORARY TABLE t1 (a INT) :- error

Instrinsic temp tables go by the temp tablespace property.