### PR TITLE
Fixed PS-4600 (stack-use-after-scope in _db_enter_() / get_upgrade_ifo_file_name() detected by ASan) (5.5)

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -831,7 +831,7 @@ static int run_sql_fix_privilege_tables(void)
   }
 
   dynstr_free(&ds_result);
-  return found_real_errors;
+  DBUG_RETURN(found_real_errors);
 }
 
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4600

Function 'run_sql_fix_privilege_tables()' in 'client/mysql_upgrade.c' has
'DBUG_ENTER("run_sql_fix_privilege_tables")' at the beginning but ends with
plain 'return' which causes stack corruption in Debug mode.

Fixed by changing plain 'return' to 'DBUG_RETURN()'.