### PR TITLE
5.6: PS-3840: With FIPS enabled and performance_schema=off, instance crash…

### DIFF
--- a/mysql-test/include/have_fips.inc
+++ b/mysql-test/include/have_fips.inc
@@ -1,0 +1,31 @@
+# This inc file detects FIPS only on centOS/RHEL
+
+--source include/not_windows.inc
+--source include/have_openssl.inc
+
+--let OUTFILE= $MYSQLTEST_VARDIR/tmp/fips.out
+
+perl;
+use strict;
+# This file contents should only be either 0 or 1
+my $fips_file = "/proc/sys/crypto/fips_enabled";
+my $fips = 0;
+if ((-e $fips_file) && (-r $fips_file))
+{
+  local $/=undef;
+  open FILE, $fips_file or die "Couldn't open file: $!";
+  $fips = <FILE>;
+  close FILE;
+}
+
+open(FILE, ">$ENV{OUTFILE}") or die;
+print FILE "let \$fips= $fips;\n";
+close(FILE);
+EOF
+
+--source $OUTFILE
+--remove_file $OUTFILE
+
+if (!$fips) {
+  --skip Test requires FIPS enabled environment like centOS/RHEL
+}

--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -99,6 +99,7 @@ INSERT INTO global_suppressions VALUES
  ("Forcing shutdown of [0-9]* plugins"),
  ("Forcing close of thread"),
 
+ ("Percona Server cannot operate under OpenSSL FIPS mode"),
  /*
    Due to timing issues, it might be that this warning
    is printed when the server shuts down and the

--- a/mysql-test/r/fips.result
+++ b/mysql-test/r/fips.result
@@ -1,0 +1,4 @@
+# Check for warnings in the error log
+SELECT MD5('mysql running under fips');
+MD5('mysql running under fips')
+c9ae6499f03db3c8d8fe0ace851d87cd

--- a/mysql-test/t/fips.test
+++ b/mysql-test/t/fips.test
@@ -1,0 +1,17 @@
+--source include/have_fips.inc
+--source include/have_openssl.inc
+
+--echo # Check for warnings in the error log
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/log/fips.err
+
+--replace_result $SEARCH_FILE SEARCH_FILE
+--let $restart_parameters=restart: --log-error=$SEARCH_FILE --no-console
+--source include/restart_mysqld.inc
+
+--let SEARCH_PATTERN = Percona Server cannot operate under OpenSSL FIPS mode. Disabling FIPS
+--source include/search_pattern_in_file.inc
+SELECT MD5('mysql running under fips');
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+--remove_file $SEARCH_FILE


### PR DESCRIPTION
…es on CREATE VIEW

Description:
-----------
MySQL Server compiled with OpenSSL (not YaSSL) and running the
server under FIPS enabled environment, leads to crash.

This is because MD5 algorithm is not FIPS compliant.

Fix:
----
Disable FIPS mode for MySQL which allows mysqld to be run under
FIPS environment.
(cherry picked from commit 86e2187f88214703568643817374832a534a342a)