### PR TITLE
PS-4711: crash on TokuDB PFS-instrumented mutexes deinitialization

### DIFF
--- a/mysql-test/suite/tokudb.perfschema/r/bug-ps-4711.result
+++ b/mysql-test/suite/tokudb.perfschema/r/bug-ps-4711.result
@@ -1,0 +1,1 @@
+# restart

--- a/mysql-test/suite/tokudb.perfschema/t/bug-ps-4711.test
+++ b/mysql-test/suite/tokudb.perfschema/t/bug-ps-4711.test
@@ -1,0 +1,9 @@
+# PS-4711 test
+# All PFS objects deinitialization must be before PFS shutdown, otherwise
+# there will be crash on server shutdown
+
+--source include/not_embedded.inc
+--source include/have_perfschema.inc
+--source include/have_tokudb.inc
+
+--source include/restart_mysqld.inc

--- a/storage/tokudb/hatoku_hton.cc
+++ b/storage/tokudb/hatoku_hton.cc
@@ -22,9 +22,11 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 ======= */
 
-#ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
+#ident \
+    "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
 
 #include "hatoku_hton.h"
+#include "src/ydb.h"
 
 #include <dlfcn.h>
 
@@ -648,6 +650,8 @@ static int tokudb_done_func(TOKUDB_UNUSED(void* p)) {
     toku_global_status_variables = NULL;
     tokudb::memory::free(toku_global_status_rows);
     toku_global_status_rows = NULL;
+    tokudb_map_mutex.deinit();
+    toku_ydb_destroy();
     TOKUDB_DBUG_RETURN(0);
 }
 


### PR DESCRIPTION
If we look at mysqld_exit(), we will see that shutdown_performance_schema()
is always invoked before exit(), what means global mutexes like tokudb_map_mutex
are always destroyed after perfomance schema shutdown, what causes SIGFAULT
on some platforms(debian wheeze in particular).

There are two cases:

1) global mutexes in TokuDB storage engine

The fix is in deinitialization of global mutexes explicitly from storage engine
shutdown function, which is always invoked before PFS shutdown.

2) global mutexes in PerconaFT

There also must be separate patch for PerconaFT to fix it. The fix is in
invoking ydb-layer deinitialization function explicitly from storage engine
shutdown function.

Testing:
https://jenkins.percona.com/view/5.7/job/mysql-5.7-param/1891/

See also: https://github.com/percona/PerconaFT/pull/414