### PR TITLE
PS-4727 - intrinsic temp table behaviour shouldn't depend on innodb_e…

### DIFF
--- a/mysql-test/suite/innodb/r/temp_table_encrypt.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt.result
@@ -1,5 +1,16 @@
 call mtr.add_suppression("\\[Error\\] InnoDB: keyring error: please check that a keyring plugin is loaded");
 call mtr.add_suppression("\\[Error\\] InnoDB: Can't set temporary tablespace to be encrypted because keyring plugin is not available");
+#
+# PS-4727: instrinsic temp table behaviour shouldn't depend on innodb_encrypt_tables
+#
+CREATE TABLE t1 (a INT, b BLOB);
+INSERT INTO t1 VALUES (1, 'hello'), (2, 'hi'), (3, 'satya');
+SET GLOBAL innodb_encrypt_tables=ON;
+SET big_tables=ON;
+INSERT INTO t1 SELECT * FROM t1;
+DROP TABLE t1;
+SET big_tables=default;
+SET GLOBAL innodb_encrypt_tables=default;
 # without keyring plugin, try to enable encryption of temporary
 # tablespace
 SELECT @@innodb_temp_tablespace_encrypt;

--- a/mysql-test/suite/innodb/t/temp_table_encrypt.test
+++ b/mysql-test/suite/innodb/t/temp_table_encrypt.test
@@ -4,6 +4,18 @@
 call mtr.add_suppression("\\[Error\\] InnoDB: keyring error: please check that a keyring plugin is loaded");
 call mtr.add_suppression("\\[Error\\] InnoDB: Can't set temporary tablespace to be encrypted because keyring plugin is not available");
 
+--echo #
+--echo # PS-4727: instrinsic temp table behaviour shouldn't depend on innodb_encrypt_tables
+--echo #
+CREATE TABLE t1 (a INT, b BLOB);
+INSERT INTO t1 VALUES (1, 'hello'), (2, 'hi'), (3, 'satya');
+SET GLOBAL innodb_encrypt_tables=ON;
+SET big_tables=ON;
+INSERT INTO t1 SELECT * FROM t1;
+DROP TABLE t1;
+SET big_tables=default;
+SET GLOBAL innodb_encrypt_tables=default;
+
 --echo # without keyring plugin, try to enable encryption of temporary
 --echo # tablespace
 SELECT @@innodb_temp_tablespace_encrypt;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12045,10 +12045,15 @@ ha_innobase::adjust_create_info_for_frm(
 	bool	is_intrinsic =
 		(create_info->options & HA_LEX_CREATE_INTERNAL_TMP_TABLE) != 0;
 
+	/* If table is intrinsic, it will use encryption for table based on
+	temporary tablespace encryption property. For non-intrinsic tables
+	without explicit encryption attribute, table will be forced to be
+	encrypted if innodb_encrypt_tables=ON/FORCE */
 	if (create_info->encrypt_type.length == 0
 	    && create_info->encrypt_type.str == NULL
-	    && (srv_encrypt_tables != SRV_ENCRYPT_TABLES_OFF
-		|| (srv_tmp_space.is_encrypted() && is_intrinsic))) {
+	    && ((is_intrinsic && srv_tmp_space.is_encrypted())
+		|| (!is_intrinsic
+		    && srv_encrypt_tables != SRV_ENCRYPT_TABLES_OFF))) {
 		create_info->encrypt_type = yes_string;
 	}
 }


### PR DESCRIPTION
…ncrypt_tables

Problem:
--------
Optimizer temporary tables (aka Intrinsic temp table) encryption attribute is based on innodb_encrypt_tables. So when innodb_encrypt_tables is ON and innodb_temp_tablespace_encrypt is OFF,  queries that use disk temp storage engine will fail. For example  statements that use GROUP BY, ORDER BY INSERT SELECT,  etc will fail.

Fix:
----
Intrinsic temp tables should derive encryption attribute from
temporary tablespace property and not rely on innodb_encrypt_tables