### PR TITLE
PS-4738: Fix Travis-CI configuration for Trusty and 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -220,6 +220,7 @@ script:
     CMAKE_OPT="
       -DCMAKE_BUILD_TYPE=$BUILD
       -DBUILD_CONFIG=mysql_release
+      -DREPRODUCIBLE_BUILD=OFF
       -DFEATURE_SET=community
       -DENABLE_DOWNLOADS=1
       -DDOWNLOAD_BOOST=1
@@ -227,25 +228,25 @@ script:
       -DWITH_KEYRING_VAULT=ON
       -DWITHOUT_TOKUDB=ON
       -DWITH_ROCKSDB=OFF
-      -DWITH_ICU=system
     ";
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      CMAKE_OPT+="
-        -DMYSQL_MAINTAINER_MODE=ON
-        -DWITH_MECAB=system
-      ";
-      if [[ "$INVERTED" == "ON" ]]; then
-        CMAKE_OPT+=" -DWITH_NUMA=OFF";
-      else
-        CMAKE_OPT+=" -DWITH_NUMA=ON";
-      fi;
-    else
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       CMAKE_OPT+="
         -DMYSQL_MAINTAINER_MODE=OFF
         -DWITH_PROTOBUF=system
         -DWITH_SYSTEM_LIBS=ON
         -DWITH_ICU=/usr/local/opt/icu4c
       ";
+    else
+      CMAKE_OPT+="
+        -DMYSQL_MAINTAINER_MODE=ON
+        -DWITH_MECAB=system
+        -DWITH_ICU=bundled
+      ";
+      if [[ "$INVERTED" == "ON" ]]; then
+        CMAKE_OPT+=" -DWITH_NUMA=OFF";
+      else
+        CMAKE_OPT+=" -DWITH_NUMA=ON";
+      fi;
     fi;
     if [[ "$INVERTED" == "ON" ]]; then
       CMAKE_OPT+="
@@ -261,7 +262,6 @@ script:
         -DWITH_FEDERATED_STORAGE_ENGINE=OFF
         -DWITHOUT_PARTITION_STORAGE_ENGINE=ON
         -DWITHOUT_PERFSCHEMA_STORAGE_ENGINE=ON
-        -DWITH_ICU=bundled
       ";
     fi;
 


### PR DESCRIPTION
Changes:
1. Set `-DREPRODUCIBLE_BUILD=OFF` for all builds as `-DREPRODUCIBLE_BUILD=ON` resolves symlinks with invoke-with-relative-paths.pl and breaks ccache
2. Set `-DWITH_ICU=bundled` for Trusty builds as ICU_MAJOR_VERSION = 52 on Trusty is too old