### PR TITLE
Implement PS-4746 (Revert our fix for PS-3851 (Percona Ver 5.6.39-83.1 Failing assertion: sym_node->table != NULL))

### DIFF
--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -5500,18 +5500,6 @@ row_rename_table_for_mysql(
 		goto funct_exit;
 	}
 
-	/* Wait for background fts sync to finish */
-	for (retry = 1; dict_fts_index_syncing(table); ++retry) {
-		DICT_BG_YIELD(trx);
-		if (retry % 100 == 0) {
-			ib_logf(IB_LOG_LEVEL_INFO,
-				"Unable to rename table %s to new name"
-				" %s because FTS sync is running on table."
-				" Retrying\n",
-				old_name, new_name);
-		}
-	}
-
 	/* We use the private SQL parser of Innobase to generate the query
 	graphs needed in updating the dictionary data from system tables. */
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4746

Reverted our fix for PS-3851
"Percona Ver 5.6.39-83.1 Failing assertion: sym_node->table != NULL"
(https://jira.percona.com/browse/PS-3851)
(commit 43cb07f)
in favor of Oracle's fix for the bug Bug #27326796
"MYSQL CRASH WITH INNODB ASSERTION FAILURE IN FILE PARS0PARS.CC"
(commit mysql/mysql-server@a4ea462)

Percona's extensions to 'innodb_fts.sync' MTR test case left intact.