### PR TITLE
PS-4745: Travis CI refactoring (5.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - CCACHE_CPP2=1
 
 matrix:
+  allow_failures:
+    - env: COMMAND=clang-test
   include:
     # Common
     - env: COMMAND=clang-test
@@ -37,7 +39,6 @@ matrix:
       env:              BUILD=Debug
       compiler: clang
       os: osx
-      osx_image: xcode9.3
     # 2
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=6.0  BUILD=RelWithDebInfo
@@ -78,7 +79,6 @@ matrix:
       env:              BUILD=RelWithDebInfo
       compiler: clang
       os: osx
-      osx_image: xcode9.3
     # 2
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=6.0  BUILD=Debug
@@ -149,7 +149,9 @@ matrix:
 
 
 script:
-  - JOB_NUMBER=$(echo $TRAVIS_JOB_NUMBER | sed -e 's:[0-9][0-9]*\.\(.*\):\1:');
+  - INIT_TIME=$SECONDS;
+    JOB_NUMBER=$(echo $TRAVIS_JOB_NUMBER | sed -e 's:[0-9][0-9]*\.\(.*\):\1:');
+    echo --- Initialization time $INIT_TIME seconds;
     echo --- JOB_NUMBER=$JOB_NUMBER TRAVIS_COMMIT=$TRAVIS_COMMIT TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
 
   - echo --- Perform all Travis jobs or only jobs that are included in ENV_VAR_JOB_NUMBERS list if it is defined;
@@ -207,7 +209,9 @@ script:
        brew install ccache;
        brew link ccache;
        export PATH="/usr/local/opt/ccache/libexec:$PATH";
-    fi
+    fi;
+    UPDATE_TIME=$(($SECONDS - $INIT_TIME));
+    echo --- Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.
 
   - mkdir bin; cd bin;
   - $CC -v
@@ -252,9 +256,10 @@ script:
   - echo --- Perform Debug or RelWithDebInfo compilation;
     echo --- CMAKE_OPT=\"$CMAKE_OPT\";
     echo --- ENV_VAR_CMAKE_OPT=\"$ENV_VAR_CMAKE_OPT\";
-    cmake ..
-      $CMAKE_OPT
-      $ENV_VAR_CMAKE_OPT
-  - make -j2 || travis_terminate 1
-  - ccache --show-stats
-
+    cmake .. $CMAKE_OPT $ENV_VAR_CMAKE_OPT;
+    CMAKE_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME));
+    echo --- CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.
+  - make -j2
+  - ccache --show-stats;
+    BUILD_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME - $CMAKE_TIME));
+    echo --- Total time $SECONDS seconds. Build time $BUILD_TIME seconds. CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.


### PR DESCRIPTION
1. Remove `osx_image: xcode9.3` to use default version of XCode (which is 9.4 now for Travis, and 10.0 is in beta).
2. Add `allow_failures:` for the `clang-format` job. When only `clang-format` will fail the whole build still will be green.