### PR TITLE
PS-4745: Travis CI jobs timeout for 5.7 and 8.0 (8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ matrix:
       env:              BUILD=Debug
       compiler: clang
       os: osx
-      osx_image: xcode9.4
     # 2
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=6.0  BUILD=RelWithDebInfo
@@ -80,7 +79,6 @@ matrix:
       env:              BUILD=RelWithDebInfo
       compiler: clang
       os: osx
-      osx_image: xcode9.3
     # 2
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=6.0  BUILD=Debug
@@ -151,11 +149,13 @@ matrix:
 
 
 script:
-  - JOB_NUMBER=$(echo $TRAVIS_JOB_NUMBER | sed -e 's:[0-9][0-9]*\.\(.*\):\1:');
+  - INIT_TIME=$SECONDS;
+    JOB_NUMBER=$(echo $TRAVIS_JOB_NUMBER | sed -e 's:[0-9][0-9]*\.\(.*\):\1:');
+    echo --- Initialization time $INIT_TIME seconds;
     echo --- JOB_NUMBER=$JOB_NUMBER TRAVIS_COMMIT=$TRAVIS_COMMIT TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
 
   - echo --- Perform all Travis jobs or only jobs that are included in ENV_VAR_JOB_NUMBERS list if it is defined;
-    JOB_NUMBERS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24";
+    JOB_NUMBERS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27";
     if [[ "$ENV_VAR_JOB_NUMBERS" != "" ]]; then
        JOB_NUMBERS=$ENV_VAR_JOB_NUMBERS;
     fi;
@@ -201,6 +201,7 @@ script:
 
   - echo --- Update list of packages and download dependencies;
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+       TIMEOUT_CMD=timeout;
        CC=$CC-$VERSION;
        CXX=$CXX-$VERSION;
        sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
@@ -208,10 +209,13 @@ script:
        sudo ln -s $(which ccache) /usr/lib/ccache/$CC;
        sudo ln -s $(which ccache) /usr/lib/ccache/$CXX || echo;
     else
+       TIMEOUT_CMD=gtimeout;
        brew update;
        brew install ccache protobuf lz4 re2;
        export PATH="/usr/local/opt/ccache/libexec:$PATH";
-    fi
+    fi;
+    UPDATE_TIME=$(($SECONDS - $INIT_TIME));
+    echo --- Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.
 
   - mkdir bin; cd bin;
   - $CC -v
@@ -246,35 +250,44 @@ script:
         -DWITH_MECAB=system
         -DWITH_ICU=bundled
       ";
-      if [[ "$INVERTED" == "ON" ]]; then
-        CMAKE_OPT+=" -DWITH_NUMA=OFF";
+      if [[ "$INVERTED" != "ON" ]]; then
+        CMAKE_OPT+="
+          -DWITH_NUMA=ON
+        ";
       else
-        CMAKE_OPT+=" -DWITH_NUMA=ON";
+        CMAKE_OPT+="
+          -DWITH_NUMA=OFF
+          -DWITH_EDITLINE=bundled
+          -DWITH_LIBEVENT=system
+          -DWITH_LZ4=system
+          -DWITH_PROTOBUF=system
+          -DWITH_SSL=system
+          -DWITH_ZLIB=bundled
+          -DWITH_ARCHIVE_STORAGE_ENGINE=OFF
+          -DWITH_BLACKHOLE_STORAGE_ENGINE=OFF
+          -DWITH_EXAMPLE_STORAGE_ENGINE=ON
+          -DWITH_FEDERATED_STORAGE_ENGINE=OFF
+          -DWITHOUT_PARTITION_STORAGE_ENGINE=ON
+          -DWITHOUT_PERFSCHEMA_STORAGE_ENGINE=ON
+          -DWITH_INNODB_MEMCACHED=ON
+        ";
       fi;
-    fi;
-    if [[ "$INVERTED" == "ON" ]]; then
-      CMAKE_OPT+="
-        -DWITH_EDITLINE=bundled
-        -DWITH_LIBEVENT=system
-        -DWITH_LZ4=system
-        -DWITH_PROTOBUF=system
-        -DWITH_SSL=system
-        -DWITH_ZLIB=bundled
-        -DWITH_ARCHIVE_STORAGE_ENGINE=OFF
-        -DWITH_BLACKHOLE_STORAGE_ENGINE=OFF
-        -DWITH_EXAMPLE_STORAGE_ENGINE=ON
-        -DWITH_FEDERATED_STORAGE_ENGINE=OFF
-        -DWITHOUT_PARTITION_STORAGE_ENGINE=ON
-        -DWITHOUT_PERFSCHEMA_STORAGE_ENGINE=ON
-      ";
     fi;
 
   - echo --- Perform Debug or RelWithDebInfo compilation;
     echo --- CMAKE_OPT=\"$CMAKE_OPT\";
     echo --- ENV_VAR_CMAKE_OPT=\"$ENV_VAR_CMAKE_OPT\";
-    cmake ..
-      $CMAKE_OPT
-      $ENV_VAR_CMAKE_OPT
-  - make -j2 || travis_terminate 1
-  - ccache --show-stats
+    cmake .. $CMAKE_OPT $ENV_VAR_CMAKE_OPT;
 
+  - CMAKE_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME));
+    if [[ "$TRAVIS_REPO_SLUG" == "percona/percona-server" ]]; then
+      TIMEOUT_TIME=$((116 * 60 - $SECONDS));
+    else
+      TIMEOUT_TIME=$((46 * 60 - $SECONDS));
+    fi;
+    echo --- Timeout $TIMEOUT_TIME seconds. CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.;
+    $TIMEOUT_CMD $TIMEOUT_TIME make -j2
+
+  - ccache --show-stats;
+    BUILD_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME - $CMAKE_TIME));
+    echo --- Total time $SECONDS seconds. Build time $BUILD_TIME/$TIMEOUT_TIME seconds. CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.


### PR DESCRIPTION
1. Remove `osx_image: xcode9.3` to use default version of XCode (which is 9.4 now for Travis, and 10.0 is in beta).
2. Use `timeout` command to stop Travis build at 46/116 min (developers/percona) to allow to write `ccached` files.
3. Reorder `CMAKE_OPT` to match changes in 5.7 in PS-4511.