### PR TITLE
PS-4728: ASan: heap-buffer-overflow in

### DIFF
--- a/unittest/gunit/keyring/keyring-api-t.cc
+++ b/unittest/gunit/keyring/keyring-api-t.cc
@@ -314,7 +314,8 @@ namespace keyring__api_unittest
     key_type= NULL;
 
     // make sure that rotated key is different than the original one
-    ASSERT_TRUE(memcmp(reinterpret_cast<char*>(key_ver0) + 2, reinterpret_cast<char*>(key_ver1) + 2, 16) != 0);
+    // + 2 to skip key version of retrieved latest percona_binlog key
+    ASSERT_TRUE(memcmp(reinterpret_cast<char*>(key_ver0), reinterpret_cast<char*>(key_ver1) + 2, 16) != 0);
 
     my_free(key_ver0);
     my_free(key_ver1);


### PR DESCRIPTION
Keyring_api_test.GeneratePBRotatePBFetchFirstVersionFetchLatestPB unit
test

In test GeneratePBRotatePBFetchFirstVersionFetchLatestPB there is a
comparison of keys' data retrieved first by specifying key with version
percona_binlog:0 and next by specifying just percona_binlog (latest
key). Since there was a key rotation those operations should retrieve different keys.
The second key apart from key's data should also contain key's
version. The first one should not - before the fix the key version was
also skipped in the first key and thus there was ill memory access.