### PR TITLE
Fix PS-4723 (PURGE CHANGED_PAGE_BITMAPS doesn't work when innodb_data_home_dir used) (5.5)

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests_debug.result
@@ -7,3 +7,70 @@ INSERT INTO t1 VALUES (20);
 SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 DROP TABLE t1;
+#
+# PS-4723 "PURGE CHANGED_PAGE_BITMAPS doesn't work when innodb_data_home_dir used"
+# https://jira.percona.com/browse/PS-4723
+#
+
+# Creating a custom data directory.
+
+# Restarting with custom InnoDB data directories.
+include/assert.inc [InnoDB redo log tracking must be enabled]
+include/assert.inc [InnoDB file per table must be disabled]
+
+# Creating a simple table and filling it with some records.
+CREATE TABLE t1(id INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+# Flushing the table and changed page bitmaps.
+FLUSH TABLES t1;
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Listing .xdb files after the flush.
+# The output must show three .xdb files: ib_modified_log_1_0.xdb, ib_modified_log_2_nnn.xdb and ib_modified_log_3_nnn.xdb.
+ib_modified_log_1_<nnn>.xdb
+ib_modified_log_2_<nnn>.xdb
+ib_modified_log_3_<nnn>.xdb
+
+# Purging changed page bitmaps (tracking enabled).
+# The first two .xdb files (ib_modified_log_1_0.xdb and ib_modified_log_2_nnn.xdb) must be deleted.
+PURGE CHANGED_PAGE_BITMAPS BEFORE PREVIOUS_LSN;
+
+# Listing .xdb files after the purge (tracking enabled).
+# The output must show only one .xdb file - ib_modified_log_3_nnn.xdb.
+ib_modified_log_3_<nnn>.xdb
+
+# Inserting a few more records into the table.
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+# Flushing the table and changed page bitmaps again.
+FLUSH TABLES t1;
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+# Listing .xdb files after the second flush.
+# The output must show two .xdb files: ib_modified_log_3_nnn.xdb and ib_modified_log_4_nnn.xdb.
+ib_modified_log_3_<nnn>.xdb
+ib_modified_log_4_<nnn>.xdb
+
+# Restarting with redo log tracking disabled.
+include/assert.inc [InnoDB redo log tracking must be disabled]
+
+# Listing .xdb files after the restart with tracking disabled.
+# The output must show the same two .xdb files: ib_modified_log_3_nnn.xdb and ib_modified_log_4_nnn.xdb.
+ib_modified_log_3_<nnn>.xdb
+ib_modified_log_4_<nnn>.xdb
+
+# Purging changed page bitmaps (tracking disabled).
+# The third .xdb file (ib_modified_log_3_nnn.xdb) must be deleted.
+PURGE CHANGED_PAGE_BITMAPS BEFORE PREVIOUS_LSN;
+
+# Listing .xdb files after the purge (tracking disabled).
+# The output must show only one .xdb file - ib_modified_log_4_nnn.xdb.
+ib_modified_log_4_<nnn>.xdb
+
+# Dropping the table.
+DROP TABLE t1;
+# Restarting with initial parameters.
+# Cleaning up

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests_debug.test
@@ -3,6 +3,7 @@
 #
 --source include/have_innodb.inc
 --source include/have_debug.inc
+--source include/not_embedded.inc
 
 #
 # Bug 1382336: Purging bitmaps exactly up to the last tracked LSN aborts change tracking
@@ -25,3 +26,116 @@ SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 
 DROP TABLE t1;
+
+--echo #
+--echo # PS-4723 "PURGE CHANGED_PAGE_BITMAPS doesn't work when innodb_data_home_dir used"
+--echo # https://jira.percona.com/browse/PS-4723
+--echo #
+
+--let $MYSQLD_DATADIR = `SELECT @@datadir`
+--let $CUSTOM_SUFFIX = custom
+--let $select_lsn_query = SELECT MIN(start_lsn) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE space_id = 0 AND end_lsn = (SELECT MAX(end_lsn) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE space_id = 0)
+
+--echo
+--echo # Creating a custom data directory.
+--let $CUSTOM_INNODB_DATA_HOME_DIR = $MYSQLD_DATADIR$CUSTOM_SUFFIX
+--mkdir $CUSTOM_INNODB_DATA_HOME_DIR
+
+--echo
+--echo # Restarting with custom InnoDB data directories.
+--let $restart_parameters = restart:--innodb-track-changed-pages=1 --innodb-max-bitmap-file-size=4096 --innodb-data-home-dir=$CUSTOM_INNODB_DATA_HOME_DIR --innodb-log-group-home-dir=$CUSTOM_INNODB_DATA_HOME_DIR --innodb-file-per-table=0
+--source include/restart_mysqld.inc
+
+--let $assert_text = InnoDB redo log tracking must be enabled
+--let $assert_cond = @@innodb_track_changed_pages = 1
+--source include/assert.inc
+
+--let $assert_text = InnoDB file per table must be disabled
+--let $assert_cond = @@innodb_file_per_table = 0
+--source include/assert.inc
+
+--echo
+--echo # Creating a simple table and filling it with some records.
+CREATE TABLE t1(id INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+--echo
+--echo # Flushing the table and changed page bitmaps.
+FLUSH TABLES t1;
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+--echo
+--echo # Listing .xdb files after the flush.
+--echo # The output must show three .xdb files: ib_modified_log_1_0.xdb, ib_modified_log_2_nnn.xdb and ib_modified_log_3_nnn.xdb.
+--replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
+--list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+
+--echo
+--echo # Purging changed page bitmaps (tracking enabled).
+--echo # The first two .xdb files (ib_modified_log_1_0.xdb and ib_modified_log_2_nnn.xdb) must be deleted.
+--let $previous_lsn = `$select_lsn_query`
+--replace_regex /[[:digit:]]+/PREVIOUS_LSN/
+eval PURGE CHANGED_PAGE_BITMAPS BEFORE $previous_lsn;
+
+--echo
+--echo # Listing .xdb files after the purge (tracking enabled).
+--echo # The output must show only one .xdb file - ib_modified_log_3_nnn.xdb.
+--replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
+--list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+
+--echo
+--echo # Inserting a few more records into the table.
+INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+--echo
+--echo # Flushing the table and changed page bitmaps again.
+FLUSH TABLES t1;
+SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
+SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
+
+--echo
+--echo # Listing .xdb files after the second flush.
+--echo # The output must show two .xdb files: ib_modified_log_3_nnn.xdb and ib_modified_log_4_nnn.xdb.
+--replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
+--list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+
+--echo
+--echo # Restarting with redo log tracking disabled.
+--let $restart_parameters = restart:--innodb-track-changed-pages=0 --innodb-max-bitmap-file-size=4096 --innodb-data-home-dir=$CUSTOM_INNODB_DATA_HOME_DIR --innodb-log-group-home-dir=$CUSTOM_INNODB_DATA_HOME_DIR
+--source include/restart_mysqld.inc
+
+--let $assert_text = InnoDB redo log tracking must be disabled
+--let $assert_cond = @@innodb_track_changed_pages = 0
+--source include/assert.inc
+
+--echo
+--echo # Listing .xdb files after the restart with tracking disabled.
+--echo # The output must show the same two .xdb files: ib_modified_log_3_nnn.xdb and ib_modified_log_4_nnn.xdb.
+--replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
+--list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+
+--echo
+--echo # Purging changed page bitmaps (tracking disabled).
+--echo # The third .xdb file (ib_modified_log_3_nnn.xdb) must be deleted.
+--let $previous_lsn = `$select_lsn_query`
+--replace_regex /[[:digit:]]+/PREVIOUS_LSN/
+eval PURGE CHANGED_PAGE_BITMAPS BEFORE $previous_lsn;
+
+--echo
+--echo # Listing .xdb files after the purge (tracking disabled).
+--echo # The output must show only one .xdb file - ib_modified_log_4_nnn.xdb.
+--replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
+--list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+
+--echo
+--echo # Dropping the table.
+DROP TABLE t1;
+
+--echo # Restarting with initial parameters.
+--let $restart_parameters =
+--source include/restart_mysqld.inc
+
+--echo # Cleaning up
+--remove_files_wildcard $CUSTOM_INNODB_DATA_HOME_DIR
+--rmdir $CUSTOM_INNODB_DATA_HOME_DIR

--- a/storage/innobase/log/log0online.c
+++ b/storage/innobase/log/log0online.c
@@ -1906,6 +1906,8 @@ log_online_purge_changed_page_bitmaps(
 
 	for (i = 0; i < bitmap_files.count; i++) {
 
+		char	full_bmp_file_name[2 * FN_REFLEN + 2];
+
 		/* We consider the end LSN of the current bitmap, derived from
 		the start LSN of the subsequent bitmap file, to determine
 		whether to remove the current bitmap.  Note that bitmap_files
@@ -1921,7 +1923,44 @@ log_online_purge_changed_page_bitmaps(
 
 			break;
 		}
-		if (!os_file_delete_if_exists(bitmap_files.files[i].name)) {
+
+		/* In some non-trivial cases the sequence of .xdb files may
+		have gaps. For instance:
+			ib_modified_log_1_0.xdb
+			ib_modified_log_2_<mmm>.xdb
+			ib_modified_log_4_<nnn>.xdb
+		Adding this check as a safety precaution. */
+		if (bitmap_files.files[i].name[0] == '\0')
+			continue;
+
+		/* If redo log tracking is enabled, reuse 'bmp_file_home'
+		from 'log_bmp_sys'. Otherwise, compose the full '.xdb' file
+		path from 'srv_data_home', adding a path separator if
+		necessary. */
+		if (log_bmp_sys != NULL) {
+			ut_snprintf(full_bmp_file_name,
+				sizeof(full_bmp_file_name),
+				"%s%s", log_bmp_sys->bmp_file_home,
+				bitmap_files.files[i].name);
+		}
+		else {
+			char		separator[2] = {0, 0};
+			const size_t	srv_data_home_len =
+				strlen(srv_data_home);
+
+			ut_a(srv_data_home_len < FN_REFLEN);
+			if (srv_data_home_len != 0 &&
+				srv_data_home[srv_data_home_len - 1] !=
+				SRV_PATH_SEPARATOR) {
+				separator[0] = SRV_PATH_SEPARATOR;
+			}
+			ut_snprintf(full_bmp_file_name,
+				sizeof(full_bmp_file_name), "%s%s%s",
+				srv_data_home, separator,
+				bitmap_files.files[i].name);
+		}
+
+		if (!os_file_delete_if_exists(full_bmp_file_name)) {
 			os_file_get_last_error(TRUE);
 			result = TRUE;
 			break;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4723

'PURGE CHANGED_PAGE_BITMAPS' InnoDB handler
('log_online_purge_changed_page_bitmaps()') used to call
'os_file_delete_if_exists()' for deleting old '.xdb' files using relative
paths. Therefore, when '--innodb-data-home-dir' was different from
'--datadir'(which is by default the current working directory), it tried to
delete these file from the wrong location.

Fixed by prepending '.xdb' file name with 'log_bmp_sys->bmp_file_home'.

Added 'innidb.percona_bug_ps4723' MTR test case which simulates the reported
scenario.