### PR TITLE
PS-4818: audit_null.audit_plugin_bugs test always failing (8.0)

### DIFF
--- a/components/mysql_server/log_builtins.cc
+++ b/components/mysql_server/log_builtins.cc
@@ -1547,7 +1547,8 @@ int log_line_submit(log_line *ll) {
       int n = log_line_index_by_type(ll, LOG_ITEM_SQL_ERRCODE);
       if (n >= 0) {
         int ec = (int)ll->item[n].data.data_integer;
-        DBUG_ASSERT((ec < 1) || (ec >= ER_SERVER_RANGE_START));
+        DBUG_ASSERT((ec < 1) || (ec == ER_AUDIT_API_ABORT) ||
+                    (ec >= ER_SERVER_RANGE_START));
       }
     }
 #endif

--- a/sql/auto_thd.cc
+++ b/sql/auto_thd.cc
@@ -68,12 +68,20 @@ bool Auto_THD::handle_condition(
   else if (*level == Sql_condition::SL_NOTE)
     log_err_level = INFORMATION_LEVEL;
 
-  LogEvent()
-      .type(LOG_TYPE_ERROR)
-      .prio(log_err_level)
-      .sqlstate(sqlstate)
-      .errcode(ER_SERVER_NO_SESSION_TO_SEND_TO)  // override if exists
-      .lookup(ER_SERVER_NO_SESSION_TO_SEND_TO, sql_errno, msg);
+  if (sql_errno == ER_AUDIT_API_ABORT)
+    LogEvent()
+        .type(LOG_TYPE_ERROR)
+        .prio(log_err_level)
+        .sqlstate(sqlstate)
+        .errcode(sql_errno)
+        .verbatim(msg);
+  else
+    LogEvent()
+        .type(LOG_TYPE_ERROR)
+        .prio(log_err_level)
+        .sqlstate(sqlstate)
+        .errcode(ER_SERVER_NO_SESSION_TO_SEND_TO)  // override if exists
+        .lookup(ER_SERVER_NO_SESSION_TO_SEND_TO, sql_errno, msg);
 
   return false;
 }


### PR DESCRIPTION
`audit_null.audit_plugin_bugs` doesn't work because
```
[ERROR] [MY-013129] [Server] A message intended for a client cannot be sent there as no client-session is attached. Therefore, we're sending the information to the error-log instead: MY-003164 - Abort message custom
```
doesn't match
```
let SEARCH_PATTERN= \[ERROR\] \[[^]]*\] \[[^]]*\] Abort message custom;
```
The real cause of wrong-formatting are changes in `auto_thd.cc` at mysql/mysql-server@c7154cf

After fixes:
```
[ERROR] [MY-003164] [Server] Abort message custom
```