### PR TITLE
PS-269: Fix service_sys_var_registration.sys_var_service_cr (8.0)

### DIFF
--- a/sql/persisted_variable.cc
+++ b/sql/persisted_variable.cc
@@ -693,7 +693,9 @@ bool Persisted_variables_cache::set_persist_options(bool plugin_options) {
         res = new (thd->mem_root)
             Item_uint(iter->value.c_str(), (uint)iter->value.length());
         break;
+      case SHOW_SIGNED_INT:
       case SHOW_SIGNED_LONG:
+      case SHOW_SIGNED_LONGLONG:
         res = new (thd->mem_root)
             Item_int(iter->value.c_str(), (uint)iter->value.length());
         break;

--- a/storage/perfschema/pfs_variable.cc
+++ b/storage/perfschema/pfs_variable.cc
@@ -941,7 +941,9 @@ bool PFS_status_variable_cache::can_aggregate(
     case SHOW_DOUBLE_STATUS:
     case SHOW_HA_ROWS:
     case SHOW_LONG_NOFLUSH:
+    case SHOW_SIGNED_INT:
     case SHOW_SIGNED_LONG:
+    case SHOW_SIGNED_LONGLONG:
     default:
       return false;
       break;


### PR DESCRIPTION
Fix bugs that appeared after changes in https://github.com/percona/percona-server/commit/4ad1d0ccd476ae4990dac354b382d0e2d7220be8
```
--- a/sql/sql_plugin_var.cc
+++ b/sql/sql_plugin_var.cc
@@ -151,15 +151,16 @@ bool plugin_var_memalloc_session_update(THD *thd, SYS_VAR *var, char **dest,
 }
 
 SHOW_TYPE pluginvar_show_type(SYS_VAR *plugin_var) {
+  const bool is_unsigned = plugin_var->flags & PLUGIN_VAR_UNSIGNED;
   switch (plugin_var->flags & PLUGIN_VAR_TYPEMASK) {
     case PLUGIN_VAR_BOOL:
       return SHOW_MY_BOOL;
     case PLUGIN_VAR_INT:
-      return SHOW_INT;
+      return is_unsigned ? SHOW_INT : SHOW_SIGNED_INT;
     case PLUGIN_VAR_LONG:
-      return SHOW_LONG;
+      return is_unsigned ? SHOW_LONG : SHOW_SIGNED_LONG;
     case PLUGIN_VAR_LONGLONG:
-      return SHOW_LONGLONG;
+      return is_unsigned ? SHOW_LONGLONG : SHOW_SIGNED_LONGLONG;
     case PLUGIN_VAR_STR:
       return SHOW_CHAR_PTR;
     case PLUGIN_VAR_ENUM:
```
