### PR TITLE
Fix PS-3906 (handle_fatal_signal (sig=11) in dict_index_is_auto_gen_clust | sql/signal_handler.cc:223)

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -13100,9 +13100,9 @@ create_table_info_t::create_table_update_dict()
 		dict_table_autoinc_unlock(innobase_table);
 	}
 
-	dict_table_close(innobase_table, FALSE, FALSE);
-
 	innobase_parse_hint_from_comment(m_thd, innobase_table, m_form->s);
+
+	dict_table_close(innobase_table, FALSE, FALSE);
 
 	DBUG_RETURN(0);
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-3906

Problem:
Inside 'create_table_info_t::create_table_update_dict()' which is called from
"CREATE TABLE" / "ALTER TABLE" handlers we invoke
'innobase_parse_hint_from_comment()', which is supposed to parse the hint for
the table and its indexes and update the information in dictionary, after the
table is closed by 'dict_table_close()'.
This can lead to a race condition in which the first thread calls
'dict_table_close()' and therefore the table is no longer locked.
Meanwhile the second thread ('srv_master_thread') triggers
'srv_master_evict_from_table_cache()' for this table and frees its resources.
After that, the first thread (the one which executes "CREATE TABLE" /
"ALTER TABLE") is activated again and calls
'innobase_parse_hint_from_comment()' which in turn tries to access freed
memory.

Fix:
Making sure that 'innobase_parse_hint_from_comment()' is called before
'dict_table_close()'.