### PR TITLE
PS-269: Fix MTR --suite=keyring_vault (8.0)

### DIFF
--- a/plugin/keyring_vault/keyring_vault.version
+++ b/plugin/keyring_vault/keyring_vault.version
@@ -4,5 +4,6 @@ KEYRING_VAULT_VERSION_1.0 {
      mysql_malloc_service;
      my_plugin_log_service;
      security_context_service;
+     plugin_registry_service;
   local: *;
 };

--- a/plugin/keyring_vault/tests/mtr/generate_default_conf_files.inc
+++ b/plugin/keyring_vault/tests/mtr/generate_default_conf_files.inc
@@ -1,6 +1,6 @@
 --let $KEYRING_CONF_FILE_1=$MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault1.conf
 --let $KEYRING_CONF_FILE_2=$MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault2.conf
---let $KEYRING_INVALID_TOKEN_CONF_FILE=$MYSQLTEST_VARDIR/keyring_vault_invalid_token.conf
+--let $KEYRING_INVALID_TOKEN_CONF_FILE=$MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault_invalid_token.conf
 
 --let $KEYRING_CONF_TEMPLATE_FILE=$MYSQL_TEST_DIR/std_data/keyring_vault_confs/keyring_vault_mtr_template1.conf
 --let $KEYRING_CONF_FILE_TO_GENERATE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/is_vault_server_up.inc
+++ b/plugin/keyring_vault/tests/mtr/is_vault_server_up.inc
@@ -81,15 +81,21 @@ if (!$CURL_TIMEOUT)
   {
     if ($curl_response)
     {
-      print $F "--skip Cannot connect to Hashicorp Vault due to : $curl_response";
+      print $F "--let VAULT_ERROR= Cannot connect to Hashicorp Vault due to : $curl_response\n";
     }
     else
     {
-      print $F "--skip Seems that Hashicorp Vault testing server is down";
+      print $F "--let VAULT_ERROR= Seems that Hashicorp Vault testing server is down\n";
     }
   }
   $F->close();
 EOF
 
+--let VAULT_ERROR= 
 --source $MYSQLTEST_VARDIR/tmp/mount_list_result.inc
 --remove_file $MYSQLTEST_VARDIR/tmp/mount_list_result.inc
+
+if ($VAULT_ERROR)
+{
+  --skip $VAULT_ERROR
+}

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.result
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.result
@@ -1,13 +1,13 @@
-call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : Connection timed out after");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault.'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : connect\\(\\) timed out!'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
+call mtr.add_suppression("Plugin keyring_vault reported: 'keyring_vault initialization failure.");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : Connection timed out after");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault.'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : connect\\(\\) timed out!'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'File '' not found");
 INSTALL PLUGIN keyring_vault SONAME 'keyring_vault.so';
 Warnings:
-Warning	29	File '' not found (Errcode: 2 - No such file or directory)
+Warning	29	File '' not found (OS errno 2 - No such file or directory)
 Warning	42000	keyring_vault initialization failure. Please check the server log.
 include/assert.inc [Default vaule of keyring_vault_timeout should be 15]
 SET @@GLOBAL.keyring_vault_timeout=15;

--- a/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.test
@@ -2,13 +2,13 @@
 
 # PS-298: keyring_vault's timeout should be configurable
 
-call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : Connection timed out after");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault.'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : connect\\(\\) timed out!'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
+call mtr.add_suppression("Plugin keyring_vault reported: 'keyring_vault initialization failure.");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : Connection timed out after");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not retrieve list of keys from Vault.'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Error while loading keyring content. The keyring might be malformed'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : connect\\(\\) timed out!'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'File '' not found");
 
 --let $KEYRING_CONF_FILE_1=$MYSQLTEST_VARDIR/std_data/keyring_vault_confs/keyring_vault_incorrect_server.conf
 --let $KEYRING_CONF_TEMPLATE_FILE=$MYSQL_TEST_DIR/std_data/keyring_vault_confs/keyring_vault_incorrect_server.conf

--- a/plugin/keyring_vault/tests/mtr/plugin.defs
+++ b/plugin/keyring_vault/tests/mtr/plugin.defs
@@ -32,4 +32,4 @@
 # with name1, name2 etc from the comma separated list of plugin names
 # in the optional 4th argument.
 
-keyring_vault      plugin/keyring_vault      KEYRING_VAULT_PLUGIN keyring_vault
+keyring_vault      plugin_output_directory      KEYRING_VAULT_PLUGIN keyring_vault

--- a/plugin/keyring_vault/tests/mtr/timeout_basic.result
+++ b/plugin/keyring_vault/tests/mtr/timeout_basic.result
@@ -1,6 +1,6 @@
-call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
+call mtr.add_suppression("keyring_vault initialization failure.");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'File '' not found");
 SET @start_global_value = @@GLOBAL.keyring_vault_timeout;
 SET @@GLOBAL.keyring_vault_timeout = 100;
 SET @@GLOBAL.keyring_vault_timeout = DEFAULT;

--- a/plugin/keyring_vault/tests/mtr/timeout_basic.test
+++ b/plugin/keyring_vault/tests/mtr/timeout_basic.test
@@ -10,9 +10,9 @@
 ###############################################################################
 
 --source include/have_keyring_vault_plugin.inc
-call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' not found");
+call mtr.add_suppression("keyring_vault initialization failure.");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("Plugin keyring_vault reported: 'File '' not found");
 
 #############################################################
 #                 Save initial value                        #

--- a/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.result
+++ b/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.result
@@ -1,3 +1,3 @@
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
-call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '../bad_dir/../../bad_keyring' not found");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("keyring_vault initialization failure.");
+call mtr.add_suppression("Plugin keyring_vault reported: 'File '../bad_dir/../../bad_keyring' not found");

--- a/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.test
+++ b/plugin/keyring_vault/tests/mtr/wrong_keyring_vault_config.test
@@ -4,7 +4,7 @@
 # incorrect path to configuration file is assigned to keyring_vault_config variable. The path is
 # set in master.opt file.
 
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Could not open file with credentials.'");
-call mtr.add_suppression("\\[Error\\] Plugin keyring_vault reported: 'keyring_vault initialization failure.");
-call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '../bad_dir/../../bad_keyring' not found");
+call mtr.add_suppression("Plugin keyring_vault reported: 'Could not open file with credentials.'");
+call mtr.add_suppression("keyring_vault initialization failure.");
+call mtr.add_suppression("Plugin keyring_vault reported: 'File '../bad_dir/../../bad_keyring' not found");
 

--- a/plugin/keyring_vault/vault_keyring.cc
+++ b/plugin/keyring_vault/vault_keyring.cc
@@ -175,6 +175,7 @@ int keyring_vault_deinit(void *arg MY_ATTRIBUTE((unused))) noexcept {
   logger.reset();
   keyring_file_data.reset();
   mysql_rwlock_destroy(&LOCK_keyring);
+  deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
 
   curl_global_cleanup();
   return 0;


### PR DESCRIPTION
Warning: Tests that return `Seems that Hashicorp Vault testing server is down` are not fixed.

1. Change `plugin/keyring_vault/tests/mtr/plugin.defs` to 8.0 format
2. Fix `is_vault_server_up.inc` to work with fail-check-testcases
3. Add missing `plugin_registry_service` symbol to `plugin/keyring_vault/keyring_vault.version`
4. Adapt add_suppression to 8.0 error log format and record again MTR tests
5. Add missing deinit_logging_service_for_plugin to `keyring_vault_deinit`