### PR TITLE
PS-4845 : MyRocks tests leave files behind in $MYSQL_TMP_DIR

### DIFF
--- a/mysql-test/suite/rocksdb/include/bloomfilter_load_select.inc
+++ b/mysql-test/suite/rocksdb/include/bloomfilter_load_select.inc
@@ -1,9 +1,11 @@
 # loading some data (larger than write buf size) to cause compaction
---exec perl suite/rocksdb/t/gen_insert.pl t1 >  $MYSQL_TMP_DIR/insert_t1.sql
---exec perl suite/rocksdb/t/gen_insert.pl t2 >  $MYSQL_TMP_DIR/insert_t2.sql
+--exec perl suite/rocksdb/t/gen_insert.pl t1 >  $MYSQLTEST_VARDIR/tmp/insert_t1.sql
+--exec perl suite/rocksdb/t/gen_insert.pl t2 >  $MYSQLTEST_VARDIR/tmp/insert_t2.sql
 --disable_query_log
---source $MYSQL_TMP_DIR/insert_t1.sql
---source $MYSQL_TMP_DIR/insert_t2.sql
+--source $MYSQLTEST_VARDIR/tmp/insert_t1.sql
+--source $MYSQLTEST_VARDIR/tmp/insert_t2.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/insert_t1.sql
+--remove_file $MYSQLTEST_VARDIR/tmp/insert_t2.sql
 --enable_query_log
 
 # BF conditions (prefix short(4B)|medium(20B)|long(240B))

--- a/mysql-test/suite/rocksdb/t/unique_sec_rev_cf.test
+++ b/mysql-test/suite/rocksdb/t/unique_sec_rev_cf.test
@@ -1,6 +1,6 @@
 --source include/have_rocksdb.inc
 
-let ddl= $MYSQL_TMP_DIR/unique_sec_rev_cf.sql;
+let ddl= $MYSQLTEST_VARDIR/tmp/unique_sec_rev_cf.sql;
 --exec sed s/##CF##/" COMMENT 'rev:cf'"/g suite/rocksdb/include/unique_sec.inc > $ddl
 
 # MyRocks does not support gap locks in REPEATABLE-READ mode, so run through
@@ -9,3 +9,4 @@ let $trx_isolation = READ COMMITTED;
 --source $ddl
 let $trx_isolation = REPEATABLE READ;
 --source $ddl
+--remove_file $ddl


### PR DESCRIPTION
- Fixed up tests to use $MYSQLTEST_VARDIR/tmp and cleanup after themselves.