### PR TITLE
PS-4834 - encrypted system tablespace has empty uuid

### DIFF
--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1061,6 +1061,17 @@ struct handlerton
   */
   bool (*rotate_encryption_master_key)(void);
 
+ /**
+    @brief
+    Fix empty UUID of tablespaces of an engine. This is used when engine encrypts
+    tablespaces as part of initialization. These tablespaces will have empty UUID
+    because UUID is generated after all plugins are initialized. This API will be
+    called by server only after UUID is available.
+    @returns false on success,
+             true on failure
+  */
+  bool (*fix_tablespaces_empty_uuid)(void);
+
   /**
     Creates a new compression dictionary with the specified data for this SE.
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5144,6 +5144,20 @@ int mysqld_main(int argc, char **argv)
     unireg_abort(MYSQLD_ABORT_EXIT);
   }
 
+  /* Server generates uuid after innodb is initialized. But during
+  initialization, if tablespaces like system, redo, temporary are encrypted,
+  they are initialized with "empty" UUID. Now UUID is available, fix the
+  empty UUID of such tablespaces now */
+  if (innodb_hton != NULL && innodb_hton->fix_tablespaces_empty_uuid)
+  {
+    if (innodb_hton->fix_tablespaces_empty_uuid())
+    {
+      sql_print_error("Fixing empty UUID with InnoDB Engine failed. Please"
+		      " check if keyring plugin is loaded and execute"
+		      " \"ALTER INSTANCE ROTATE INNODB MASTER KEY\"");
+    }
+  }
+
   /*
     Add server_uuid to the sid_map.  This must be done after
     server_uuid has been initialized in init_server_auto_options and

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -930,6 +930,11 @@ fsp_header_fill_encryption_info(
 	if (version == Encryption::ENCRYPTION_VERSION_2) {
 		memcpy(ptr, Encryption::uuid, ENCRYPTION_SERVER_UUID_LEN);
 		ptr += ENCRYPTION_SERVER_UUID_LEN;
+		/* We should never write empty UUID. Only exemption is for
+		tablespaces when InnoDB is initializing (like system, temp, etc).
+		These tablespaces UUID will be fixed by handlerton API after server
+		generates uuid */
+		ut_ad(!innodb_inited || strlen(Encryption::uuid) != 0);
 	}
 
 	/* Write tablespace key to temp space. */
@@ -1287,6 +1292,7 @@ fsp_header_decode_encryption_info(
 		memset(srv_uuid, 0, ENCRYPTION_SERVER_UUID_LEN + 1);
 		memcpy(srv_uuid, ptr, ENCRYPTION_SERVER_UUID_LEN);
 		ptr += ENCRYPTION_SERVER_UUID_LEN;
+		ut_ad(strlen(srv_uuid) != 0);
 	}
 
 	/* Get master key by key id. */

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1706,4 +1706,12 @@ fil_space_set_corrupt(
 /*==================*/
 	ulint	space_id);
 
+typedef std::vector<ulint> space_id_vec;
+
+/** Rotate tablespace keys of global tablespaces like system, temporary, etc.
+This is used only at startup to fix the empty UUIDs.
+@param[in]	space_ids	vector of space_ids
+@return true on success, false on failure */
+bool
+fil_encryption_rotate_global(const space_id_vec& space_ids);
 #endif /* fil0fil_h */

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -576,6 +576,7 @@ MY_NODISCARD
 trx_t*
 innobase_get_trx_for_slow_log(void);
 
+extern bool innodb_inited;
 #endif /* !UNIV_HOTBACKUP && !UNIV_INNOCHECKSUM */
 
 #endif /* HA_INNODB_PROTOTYPES_H */


### PR DESCRIPTION
Problem:
    --------
    This is happening because when master key is created at innodb
    initialization time, it gets server uuid. But server generates
    server_uuid() only after innodb intialization is done.
    So an empty uuid is given to InnoDB by server.
    
    Since master key is created with empty uuid and all tables will
    continue this.
    
    Whats the fix then?:
    
    Can't we not make server generate UUID before innodb is intialized.
    Well, not that simple. the UUID generation code needs THD, which
    inturn needs all plugins to be initialized. So it is kind of
    chicken and egg problem. (InnoDB needs server_uuid() to be ready
    and server_uuid() needs InnoDB to ready)
    
    Ideally server uuid generation shouldn't have any dependencies with InnoDB
    (the best fix but hard)
    
    How upstream avoids empty UUID with tablespaces like redo(in 8.0):
    
    1. Like system, redo is also created with empty uuid, default masterkey
    2. Background threads keep checking for the default master key id and then
       tries to rotate the encryption info of a tablespace
    
    Fix:
    ----
    Unlike upstream, we will use a new handlerton method. This is a better
    way because
    
    1. It doesn't rely on background threads to fix empty UUID
    2. Allows redo and undo encryption to be enabled from foreground threads.
        As part of variable update function
    3. Fixes empty UUID for tablespaces not only at bootstrap but also for
        tablespaces that are encrypted at startup.
    4. Fixes empty UUID not only innodb global tablespaces(system, temp etc),
        but also for all mysql.* ibds. They can be chosen to encrypted if
        --innodb-encrypt-tables is ON during bootstrap
    
    Added debug asserts that crash when empty UUID is written to
    tablespace header and also crash if empty UUID is read from tablespace
    header.