### PR TITLE
PS-269: Fix member access within null pointer in item.cc (8.0)

### DIFF
--- a/sql/item.cc
+++ b/sql/item.cc
@@ -2302,7 +2302,8 @@ Item_field::Item_field(Field *f)
       no_const_subst(false),
       have_privileges(0),
       any_privileges(false) {
-  if (f->table->pos_in_table_list != NULL)
+  if (f->table->pos_in_table_list != nullptr &&
+      f->table->pos_in_table_list->select_lex != nullptr)
     context = &(f->table->pos_in_table_list->select_lex->context);
 
   set_field(f);


### PR DESCRIPTION
Fix ASAN/UBSAN runtime error: member access within null pointer of type 'struct SELECT_LEX' in item.cc