### PR TITLE
Fixed PS-1107 (LP #1703346: Binlog corruption when tmpdir gets full) (5.5)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_bug72457.result
+++ b/mysql-test/suite/rpl/r/rpl_bug72457.result
@@ -1,0 +1,38 @@
+#
+# Bug #72457 "Replication with no tmpdir space can break replication"
+# (https://bugs.mysql.com/bug.php?id=72457)
+# Bug #86991 "binlog corruption when tmpdir gets full"
+# (https://bugs.mysql.com/bug.php?id=86991)
+# Bug #88223 "Replication with no tmpdir space and InnoDB as tmp_storage_engine can break"
+# (https://bugs.mysql.com/bug.php?id=88223)
+#
+include/master-slave.inc
+[connection master]
+call mtr.add_suppression("Slave SQL: The incident LOST_EVENTS occured on the master\\. Message: error writing to the binary log");
+CREATE TABLE t1(f1 TEXT) ENGINE=MyISAM;
+INSERT INTO t1 VALUES(MD5(1));
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+include/rpl_sync.inc
+[connection master]
+SET SESSION debug = "+d,simulate_disk_full_at_flush_pending";
+INSERT INTO t1 SELECT * FROM t1;
+ERROR HY000: Error writing file <tmp_file_name> (Errcode: ##)
+SET SESSION debug = "-d,simulate_disk_full_at_flush_pending";
+[connection slave]
+include/wait_for_slave_sql_error.inc [errno=1590]
+Last_SQL_Error = 'The incident LOST_EVENTS occured on the master. Message: error writing to the binary log'
+include/stop_slave_io.inc
+RESET SLAVE;
+DROP TABLE t1;
+[connection master]
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_bug72457.test
+++ b/mysql-test/suite/rpl/t/rpl_bug72457.test
@@ -1,0 +1,49 @@
+--source include/have_debug.inc
+--source include/have_binlog_format_row.inc
+--source include/have_log_bin.inc
+
+--echo #
+--echo # Bug #72457 "Replication with no tmpdir space can break replication"
+--echo # (https://bugs.mysql.com/bug.php?id=72457)
+--echo # Bug #86991 "binlog corruption when tmpdir gets full"
+--echo # (https://bugs.mysql.com/bug.php?id=86991)
+--echo # Bug #88223 "Replication with no tmpdir space and InnoDB as tmp_storage_engine can break"
+--echo # (https://bugs.mysql.com/bug.php?id=88223)
+--echo #
+
+--source include/master-slave.inc
+
+call mtr.add_suppression("Slave SQL: The incident LOST_EVENTS occured on the master\\. Message: error writing to the binary log");
+
+CREATE TABLE t1(f1 TEXT) ENGINE=MyISAM;
+INSERT INTO t1 VALUES(MD5(1));
+
+--let $i = 10
+while($i)
+{
+  INSERT INTO t1 SELECT * FROM t1;
+  --dec $i
+}
+--source include/rpl_sync.inc
+
+--source include/rpl_connection_master.inc
+SET SESSION debug = "+d,simulate_disk_full_at_flush_pending";
+--replace_regex /Error writing file .*/Error writing file <tmp_file_name> (Errcode: ##)/
+--error 3
+INSERT INTO t1 SELECT * FROM t1;
+SET SESSION debug = "-d,simulate_disk_full_at_flush_pending";
+
+--source include/rpl_connection_slave.inc
+# 1590 == ER_SLAVE_INCIDENT
+--let $slave_sql_errno = 1590
+--let $show_slave_sql_error = 1
+--source include/wait_for_slave_sql_error.inc
+--source include/stop_slave_io.inc
+RESET SLAVE;
+DROP TABLE t1;
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+
+--let $rpl_only_running_threads = 1
+--source include/rpl_end.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PS-1107

Problem:
The binlog cache file code has support for handling errors and not writing
corrupt entries to the binlog, but it has an oversight that causes this code
to not get executed correctly.  Inside 'sql/binlog.cc' you can find places
where it calls 'set_write_error()' and then checks 'check_write_error()' as
well as some other conditions and if it passes it calls 'set_incident()' to
flag the file as containing corrupt data.  The 'set_write_error()' sets the
error to one of 'ER_TRANS_CACHE_FULL', 'ER_STMT_CACHE_FULL', or
'ER_ERROR_ON_WRITE' and the 'check_write_error()' checks for those three as
well as 'ER_BINLOG_LOGGING_IMPOSSIBLE'.

The problem is that 'check_write_error()' only checks the first error.  In
the case where we run out of disk space, there is a low level error that is
being set first.  Then, when 'set_write_error()' is called, there is already
an existing error so the new error does not overwrite the existing one and
then 'check_write_error()' does not see the expected value.

Fix:
'MYSQL_BIN_LOG::check_write_error()' made to not only check
'thd->stmt_da->sql_errno()' for expected error codes but traverse through
'thd->warning_info->warn_list()' and check SQL errno there as well.

Tesing:
Added 'rpl.rpl_bug72457' MTR test case which simulates the scenario described
in the original bug description using 'simulate_disk_full_at_flush_pending'
DEBUG directive.

Thanks to Jay Edgar for original patch.