### PR TITLE
PS-4834 - encrypted system tablespace has empty uuid

### DIFF
--- a/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
+++ b/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
@@ -104,7 +104,7 @@ SHOW CREATE TABLE t6;
 Table	Create Table
 t6	CREATE TABLE `t6` (
   `a` text
-) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
 CREATE TABLE t7(a TEXT) TABLESPACE = innodb_system, ENCRYPTION='Y';
 INSERT INTO t7 (a) VALUES ('Abracadabra is of unknown origin, and its first occurrence is');
 ALTER TABLE t7 ALGORITHM=COPY;
@@ -112,7 +112,7 @@ SHOW CREATE TABLE t7;
 Table	Create Table
 t7	CREATE TABLE `t7` (
   `a` text
-) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
 # rebuild to a table unencrypted and in system should be disalowed
 ALTER TABLE t7 ALGORITHM=COPY, ENCRYPTION='N';
 ERROR HY000: InnoDB: Tablespace `innodb_system` can contain only an ENCRYPTED tables.
@@ -120,14 +120,14 @@ SHOW CREATE TABLE t7;
 Table	Create Table
 t7	CREATE TABLE `t7` (
   `a` text
-) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
 ALTER TABLE t7 ENCRYPTION='N';
 ERROR HY000: InnoDB: Tablespace `innodb_system` can contain only an ENCRYPTED tables.
 SHOW CREATE TABLE t7;
 Table	Create Table
 t7	CREATE TABLE `t7` (
   `a` text
-) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
 # Move encrypted table in system tablespace to file_per_table tablespace
 # t7 should be encrypted table. Verify the ibd later
 ALTER TABLE t7 TABLESPACE=`innodb_file_per_table`;
@@ -135,14 +135,14 @@ SHOW CREATE TABLE t7;
 Table	Create Table
 t7	CREATE TABLE `t7` (
   `a` text
-) /*!50100 TABLESPACE `innodb_file_per_table` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) /*!50100 TABLESPACE `innodb_file_per_table` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
 # Move encrypted table in sytem tablespace as an unencrypted table
 ALTER TABLE t6 TABLESPACE=`innodb_file_per_table`, ENCRYPTION='N';
 SHOW CREATE TABLE t6;
 Table	Create Table
 t6	CREATE TABLE `t6` (
   `a` text
-) /*!50100 TABLESPACE `innodb_file_per_table` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='N'
+) /*!50100 TABLESPACE `innodb_file_per_table` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='N'
 # Move unencrypted file_per_table to a table in encrypted system tablespace
 CREATE TABLE t8(a TEXT);
 INSERT INTO t8 (a) VALUES ('Abracadabra is of unknown origin, and its first occurrence is');

--- a/mysql-test/suite/innodb/t/disabled.def
+++ b/mysql-test/suite/innodb/t/disabled.def
@@ -41,7 +41,6 @@ xtradb_compressed_columns_debug : percona disabled until zip dict 8.0 reimplemen
 xtradb_compressed_columns_ibd_sizes : percona disabled until zip dict 8.0 reimplementation
 xtradb_compressed_columns_ibd_sizes_partitioning : percona disabled until zip dict 8.0 reimplementation
 xtradb_compressed_columns_virtual : percona disabled until zip dict 8.0 reimplementation
-percona_sys_tablespace_encrypt : https://jira.percona.com/browse/PS-4834
 xtradb_compressed_columns_consistency_antelope_compact_set3 : percona disabled until zip dict 8.0 reimplementation
 xtradb_compressed_columns_consistency_antelope_redundant_set3 : percona disabled until zip dict 8.0 reimplementation
 xtradb_compressed_columns_consistency_barracuda_compact_set3 : percona disabled until zip dict 8.0 reimplementation

--- a/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
+++ b/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
@@ -226,7 +226,5 @@ ALTER TABLE t9 TABLESPACE=`innodb_system`;
 --source include/start_mysqld.inc
 
 --remove_file $BOOTSTRAP_SQL
---let CLEANUP_FOLDER=$MYSQL_TMP_DIR/datadir1
---source include/cleanup_folder.inc
---remove_file $MYSQL_TMP_DIR/mysecret_keyring
+--force-rmdir $MYSQL_TMP_DIR/datadir1
 --remove_file $MYSQLTEST_VARDIR/tmp/boot.log

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1737,6 +1737,17 @@ typedef bool (*rotate_encryption_master_key_t)(void);
 
 /**
   @brief
+  Fix empty UUID of tablespaces of an engine. This is used when engine encrypts
+  tablespaces as part of initialization. These tablespaces will have empty UUID
+  because UUID is generated after all plugins are initialized. This API will be
+  called by server only after UUID is available.
+  @returns false on success,
+           true on failure
+*/
+using fix_tablespaces_empty_uuid_t = bool (*)(void);
+
+/**
+  @brief
   Retrieve ha_statistics from SE.
 
   @param db_name                  Name of schema
@@ -2015,6 +2026,7 @@ struct handlerton {
   notify_exclusive_mdl_t notify_exclusive_mdl;
   notify_alter_table_t notify_alter_table;
   rotate_encryption_master_key_t rotate_encryption_master_key;
+  fix_tablespaces_empty_uuid_t fix_tablespaces_empty_uuid;
 
   get_table_statistics_t get_table_statistics;
   get_index_column_cardinality_t get_index_column_cardinality;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -6194,6 +6194,20 @@ int mysqld_main(int argc, char **argv)
   if (!server_id_supplied)
     LogErr(INFORMATION_LEVEL, ER_WARN_NO_SERVERID_SPECIFIED);
 
+  /* Server generates uuid after innodb is initialized. But during
+  initialization, if tablespaces like system, redo, temporary are encrypted,
+  they are initialized with "empty" UUID. Now UUID is available, fix the
+  empty UUID of such tablespaces now */
+  if (innodb_hton != nullptr &&
+      innodb_hton->fix_tablespaces_empty_uuid != nullptr) {
+    if (innodb_hton->fix_tablespaces_empty_uuid()) {
+      sql_print_error(
+          "Fixing empty UUID with InnoDB Engine failed. Please"
+          " check if keyring plugin is loaded and execute"
+          " \"ALTER INSTANCE ROTATE INNODB MASTER KEY\"");
+    }
+  }
+
   /*
     Add server_uuid to the sid_map.  This must be done after
     server_uuid has been initialized in init_server_auto_options and

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1771,4 +1771,11 @@ void fil_space_update_name(fil_space_t *space, const char *name);
 @param space_id	space id */
 void fil_space_set_corrupt(space_id_t space_id);
 
+using space_id_vec = std::vector<space_id_t>;
+
+/** Rotate tablespace keys of global tablespaces like system, temporary, etc.
+This is used only at startup to fix the empty UUIDs.
+@param[in]	space_ids	vector of space_ids
+@return true on success, false on failure */
+bool fil_encryption_rotate_global(const space_id_vec &space_ids);
 #endif /* fil0fil_h */

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -413,4 +413,5 @@ InnoDB extended statistics should be collected.
 MY_NODISCARD
 trx_t *innobase_get_trx_for_slow_log(void) noexcept;
 
+extern bool innodb_inited;
 #endif /* HA_INNODB_PROTOTYPES_H */

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -8283,6 +8283,12 @@ bool Encryption::fill_encryption_info(byte *key, byte *iv, byte *encrypt_info,
   memcpy(reinterpret_cast<char *>(ptr), s_uuid, sizeof(s_uuid));
   ptr += sizeof(s_uuid) - 1;
 
+  /* We should never write empty UUID. Only exemption is for
+  tablespaces when InnoDB is initializing (like system, temp, etc).
+  These tablespaces UUID will be fixed by handlerton API after server
+  generates uuid */
+  ut_ad(!innodb_inited || strlen(s_uuid) != 0);
+
   byte key_info[ENCRYPTION_KEY_LEN * 2];
 
   memset(key_info, 0x0, sizeof(key_info));


### PR DESCRIPTION
Problem:
-------

This is happening because when master key is created at innodb
initialization time, it gets server uuid. But server generates
server_uuid() only after innodb intialization is done.
So an empty uuid is given to InnoDB by server.

Since master key is created with empty uuid and all tables will
continue this.

Whats the fix then?:

Can't we not make server generate UUID before innodb is intialized.
Well, not that simple. the UUID generation code needs THD, which
inturn needs all plugins to be initialized. So it is kind of
chicken and egg problem. (InnoDB needs server_uuid() to be ready
and server_uuid() needs InnoDB to ready)

Ideally server uuid generation shouldn't have any dependencies with InnoDB
(the best fix but hard)

How upstream avoids empty UUID with tablespaces like redo(in 8.0):

1. Like system, redo is also created with empty uuid, default masterkey
2. Background threads keep checking for the default master key id and then
   tries to rotate the encryption info of a tablespace

Fix:
----
Unlike upstream, we will use a new handlerton method. This is a better
way because

1. It doesn't rely on background threads to fix empty UUID
2. Allows redo and undo encryption to be enabled from foreground threads.
   As part of variable update function
3. Fixes empty UUID for tablespaces not only at bootstrap but also for
   tablespaces that are encrypted at startup.
4. Fixes empty UUID not only innodb global tablespaces(system, temp etc),
   but also for all mysql.* ibds. They can be chosen to encrypted if
   --innodb-encrypt-tables is ON during bootstrap

Added debug asserts that crash when empty UUID is written to
tablespace header and also crash if empty UUID is read from tablespace
header.
(cherry picked from commit 30330d0f831f65d3918486d492f388aaeeb63598)