### PR TITLE
PS-269: Fix x.connection_tls_version

### DIFF
--- a/mysql-test/suite/x/include/connection_tls_version.inc
+++ b/mysql-test/suite/x/include/connection_tls_version.inc
@@ -25,12 +25,19 @@ EOF
 --exec $MYSQLXTEST -ux_root --file=$xtest_file 2>&1
 
 --let $XTESTPARAMS= -u user5_mysqlx --password='auth_string' --file=$xtest_file --ssl-cipher='DHE-RSA-AES256-SHA'
-# each of the below regexps has 2 replaces
-# 1: general OpenSSL
-# 2: OpenSSL on Debian Stretch
---let $ERROR1= /in main, line 0:ERROR: error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:socket layer receive error/Application terminated with expected error/ /in main, line 0:ERROR: error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:unsupported protocol/Application terminated with expected error/ /in main, line 0:ERROR: error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version/Application terminated with expected error/ /in main, line 0:ERROR: error:14171102:SSL routines:tls_process_server_hello:unsupported protocol/Application terminated with expected error/ /in main, line 0:ERROR: not in error state /Application terminated with expected error /
+# each of the below regexps replaces the following errors:
+#
+# CentOS 6/7, Xenial:
+# Application terminated with expected error: error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:unsupported protocol (code 2026)
+# Application terminated with expected error: error:00000000:lib(0):func(0):reason(0) (code 2026)
+#
+# Bionic, Stretch:
+# Application terminated with expected error: error:14171102:SSL routines:tls_process_server_hello:unsupported protocol (code 2026)
+# Application terminated with expected error: error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version (code 2026)
 
---let $ERROR5= /in main, line 0:ERROR: error:00000000:lib\(0\):func\(0\):reason\(0\)/Application terminated with expected error: socket layer receive error/ /in main, line 0:ERROR: error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version/Application terminated with expected error: socket layer receive error/ /in main, line 0:ERROR: not in error state /Application terminated with expected error: socket layer receive error /
+--let $ERROR1= /Application terminated with expected error: error:14077102:SSL routines:SSL23_GET_SERVER_HELLO:/Application terminated with expected error: / /Application terminated with expected error: error:14171102:SSL routines:tls_process_server_hello:/Application terminated with expected error: /
+
+--let $ERROR5= /Application terminated with expected error: error:00000000:lib\(0\):func\(0\):reason\(0\)/Application terminated with expected error: socket layer receive error/ /Application terminated with expected error: error:1409442E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version/Application terminated with expected error: socket layer receive error/
 
 --exec $MYSQLXTEST                                     $XTESTPARAMS 2>&1
 --exec $MYSQLXTEST --tls-version=TLSv1,TLSv1.1,TLSv1.2 $XTESTPARAMS 2>&1

--- a/mysql-test/suite/x/r/connection_tls_version.result
+++ b/mysql-test/suite/x/r/connection_tls_version.result
@@ -164,7 +164,7 @@ Mysqlx.Ok {
   msg: "bye!"
 }
 ok
-Application terminated with expected error: protocol version mismatch (code 2026)
+Application terminated with expected error: unsupported protocol (code 2026)
 ok
 CONNECTION_TYPE
 SSL/TLS
@@ -179,7 +179,7 @@ Mysqlx.Ok {
   msg: "bye!"
 }
 ok
-Application terminated with expected error: protocol version mismatch (code 2026)
+Application terminated with expected error: unsupported protocol (code 2026)
 ok
 Application terminated with expected error: TLS version is invalid (code 2026)
 ok
@@ -422,7 +422,7 @@ Mysqlx.Ok {
   msg: "bye!"
 }
 ok
-Application terminated with expected error: protocol version mismatch (code 2026)
+Application terminated with expected error: unsupported protocol (code 2026)
 ok
 CONNECTION_TYPE
 SSL/TLS
@@ -437,7 +437,7 @@ Mysqlx.Ok {
   msg: "bye!"
 }
 ok
-Application terminated with expected error: protocol version mismatch (code 2026)
+Application terminated with expected error: unsupported protocol (code 2026)
 ok
 Application terminated with expected error: TLS version is invalid (code 2026)
 ok


### PR DESCRIPTION
Fix regexps to match SSL errors from 8.0.