### PR TITLE
PS-269: Fix innodb.percona_sys_tablespace_encrypt_dblwr test random

### DIFF
--- a/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt_dblwr.result
+++ b/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt_dblwr.result
@@ -27,11 +27,12 @@ flush tables t1 for export;
 unlock tables;
 begin;
 insert into t1 values (6, repeat('%', 12));
-# Make the first page dirty for table t1
-set global innodb_saved_page_number_debug = 3;
+# Make the 4th page dirty, which is the last page written
+# by above flush tables for export
+set global innodb_saved_page_number_debug = 4;
 set global innodb_fil_make_page_dirty_debug = @space_id;
 # Kill the server
-# Make the 3rd page of the user tablespace
+# Make the 4th page of the user tablespace
 # corrupted
 # restart: --datadir=MYSQLD_DATADIR1 --innodb-sys-tablespace-encrypt=ON
 check table t1;
@@ -66,6 +67,7 @@ commit work;
 select space from information_schema.innodb_tables
 where name = 'test/t1' into @space_id;
 # Wait for purge to complete
+SET GLOBAL innodb_checkpoint_disabled = true;
 begin;
 insert into t1 values (6, repeat('%', 12));
 # Make the first page dirty for table t1

--- a/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt_dblwr.test
+++ b/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt_dblwr.test
@@ -59,16 +59,17 @@ unlock tables;
 begin;
 insert into t1 values (6, repeat('%', 12));
 
---echo # Make the first page dirty for table t1
-set global innodb_saved_page_number_debug = 3;
+--echo # Make the 4th page dirty, which is the last page written
+--echo # by above flush tables for export
+set global innodb_saved_page_number_debug = 4;
 set global innodb_fil_make_page_dirty_debug = @space_id;
 
 --source include/kill_mysqld.inc
 
---echo # Make the 3rd page of the user tablespace
+--echo # Make the 4th page of the user tablespace
 --echo # corrupted
 --let IBD_FILE=$MYSQLD_DATADIR/test/t1.ibd
---let PAGE_NUM=3
+--let PAGE_NUM=4
 --source ../include/corrupt_page.inc
 
 --replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1
@@ -104,6 +105,7 @@ where name = 'test/t1' into @space_id;
 --echo # Wait for purge to complete
 --source include/wait_innodb_all_purged.inc
 
+SET GLOBAL innodb_checkpoint_disabled = true;
 begin;
 insert into t1 values (6, repeat('%', 12));
 
@@ -133,7 +135,5 @@ drop table t1;
 --source include/restart_mysqld.inc
 
 --remove_file $BOOTSTRAP_SQL
---let CLEANUP_FOLDER=$MYSQL_TMP_DIR/datadir1
---source include/cleanup_folder.inc
---remove_file $MYSQL_TMP_DIR/mysecret_keyring
+--force-rmdir $MYSQL_TMP_DIR/datadir1
 --remove_file $MYSQLTEST_VARDIR/tmp/boot.log


### PR DESCRIPTION
failure

Problem:

-------------

There are two parts to this test and both are failing

1. Test encryption of doublwrite buffer in system tablespace

Flush tables for export is used to do single page flushing to write
system tablespace doublewrite buffer. The last page written is available
in system doublewrite buffer. The test cannot find the dirtied page 3
in doublewrite buffer.

Fix:
In 8.0, there is SDI page which takes page no 3, the first user index
b-tre pages is now 4. So corrupt page number 4 now instead of page
number 3.

-------------

2. Test encryption of parallel doublewrite buffer


Test fails because the corrupted page couldn't be found in doublewrite
buffer.

The page is not found because of concurrent checkpoint. 8.0 has a
dedicated log_checkpointer thread. In 5.7, we have disabled background
master thread that can do checkpoints. It is not sufficient for 8.0

Fix:
Use innodb_checkpoint_disabled variable to disable checkpoints from
log_checkpointer thread.