### PR TITLE
PS-269: Disable `SYS_ZIP_DICT` and `SYS_ZIP_DICT_COLS` until new DD implementation (8.0)

### DIFF
--- a/storage/innobase/include/dict0load.h
+++ b/storage/innobase/include/dict0load.h
@@ -59,8 +59,11 @@ enum dict_system_id_t {
   SYS_TABLESPACES,
   SYS_DATAFILES,
   SYS_VIRTUAL,
+// Percona commented out until zip dictionary implementation in the new DD
+#if 0
   SYS_ZIP_DICT,
   SYS_ZIP_DICT_COLS,
+#endif
 
   /* This must be last item. Defines the number of system tables. */
   SYS_NUM_SYSTEM_TABLES


### PR DESCRIPTION
Disable `SYS_ZIP_DICT` and `SYS_ZIP_DICT_COLS` until zip dictionary implementation in the new DD