### PR TITLE
PS-269: Fix MTR tests from main (8.0)

### DIFF
--- a/mysql-test/include/parser-big.inc
+++ b/mysql-test/include/parser-big.inc
@@ -52,7 +52,7 @@ eval CALL p1($min20087571, $max20087571, 100000);
 SELECT LENGTH(@terms);
 # Double stack size for sparc/developer studio.
 # --replace_result 524288 262144 393216 196608
---replace_result 573440 286720 442368 286720 221184 286720
+--replace_result 860160 286720 573440 286720 442368 286720 221184 286720
 SELECT @@global.thread_stack, @@global.max_allowed_packet;
 
 DROP FUNCTION f1;

--- a/mysql-test/r/view.result
+++ b/mysql-test/r/view.result
@@ -3762,7 +3762,7 @@ id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered
 1	SIMPLE	userrole	NULL	ref	idx_person_id,idx_role_id	idx_person_id	4	const	#	#	NULL
 1	SIMPLE	role	NULL	eq_ref	PRIMARY	PRIMARY	4	test.userrole.role_id	#	#	NULL
 Warnings:
-Note	1003	/* select#1 */ select '6' AS `a`,'6' AS `b` from `test`.`t1` `profile` join `test`.`t2` `userrole` join `test`.`t3` `role` where ((`test`.`role`.`role_id` = `test`.`userrole`.`role_id`) and (`test`.`userrole`.`person_id` = 6)) order by '6',`test`.`role`.`app_name`,`test`.`role`.`role_name`
+Note	1003	/* select#1 */ select '6' AS `a`,'6' AS `b` from `test`.`t1` `profile` join `test`.`t2` `userrole` join `test`.`t3` `role` where ((`role`.`role_id` = `userrole`.`role_id`) and (`userrole`.`person_id` = 6)) order by '6',`role`.`app_name`,`role`.`role_name`
 SELECT t.person_id AS a, t.person_id AS b FROM v1 t WHERE t.person_id=6;
 a	b
 6	6

--- a/mysql-test/r/with_recursive_wl9248.result
+++ b/mysql-test/r/with_recursive_wl9248.result
@@ -276,9 +276,9 @@ sum(b*c)
 show status like 'Created_tmp_disk_tables';
 Variable_name	Value
 Created_tmp_disk_tables	1
-set @@tmp_table_size=60000,@@max_heap_table_size=60000;
+set @@tmp_table_size=60000,@@max_heap_table_size=61000;
 Warnings:
-Warning	1292	Truncated incorrect max_heap_table_size value: '60000'
+Warning	1292	Truncated incorrect max_heap_table_size value: '61000'
 set cte_max_recursion_depth=5000;
 flush status;
 with recursive q (b) as

--- a/mysql-test/t/with_recursive_wl9248.test
+++ b/mysql-test/t/with_recursive_wl9248.test
@@ -65,7 +65,7 @@ set @@tmp_table_size=1024,@@max_heap_table_size=16384;
 set @@tmp_table_size=30000,@@max_heap_table_size=30000;
 --source include/with_recursive_wl9248.inc
 
-set @@tmp_table_size=60000,@@max_heap_table_size=60000;
+set @@tmp_table_size=60000,@@max_heap_table_size=61000;
 --source include/with_recursive_wl9248.inc
 
 --echo # cleanup

--- a/sql/table.h
+++ b/sql/table.h
@@ -912,7 +912,7 @@ struct TABLE_SHARE {
     without explicit pk and corresponding warning was issued to disable
     repeated warning.
   */
-  bool rfr_lookup_warning;
+  bool rfr_lookup_warning{false};
 
   /// For materialized derived tables; @see add_derived_key().
   SELECT_LEX *owner_of_possible_tmp_keys{nullptr};


### PR DESCRIPTION
Fixed:
main.parser-big-64bit (Fix output when using UBSAN)
main.view (re-record)
main.with_recursive_wl9248 (increase max_heap_table_size, fix UBSan warning)
