### PR TITLE
PS-269: Fix main.percona_encrypt_tmp_files

### DIFF
--- a/mysql-test/r/percona_encrypt_tmp_files.result
+++ b/mysql-test/r/percona_encrypt_tmp_files.result
@@ -30,7 +30,7 @@ CREATE TABLE seq_16_to_30 (seq INT) ENGINE=InnoDB;
 INSERT INTO  seq_16_to_30 SELECT seq FROM universal_seq WHERE seq <= 30 AND seq >= 16 ORDER BY seq;
 CREATE TABLE seq_31_to_40 (seq INT) ENGINE=InnoDB;
 INSERT INTO  seq_31_to_40 SELECT seq FROM universal_seq WHERE seq <= 40 AND seq >= 31 ORDER BY seq;
-CREATE TABLE t1(v VARCHAR(10), c CHAR(10), t TEXT, KEY(v), KEY(c), KEY(t(10)));
+CREATE TABLE t1(v VARCHAR(10), c CHAR(10), t TEXT, KEY(v), KEY(c), KEY(t(10))) CHARACTER SET=latin1;
 INSERT INTO t1(v) SELECT CONCAT(CHAR(ASCII('a') + s2.seq), REPEAT(' ', s1.seq))
 FROM seq_0_to_9 AS s1, seq_0_to_26 AS s2;
 UPDATE t1 SET c = v, t = v;

--- a/mysql-test/t/percona_encrypt_tmp_files.test
+++ b/mysql-test/t/percona_encrypt_tmp_files.test
@@ -47,7 +47,7 @@ INSERT INTO  seq_31_to_40 SELECT seq FROM universal_seq WHERE seq <= 40 AND seq 
 #
 # filesort, my_b_pread, seeks in READ_CACHE
 #
-CREATE TABLE t1(v VARCHAR(10), c CHAR(10), t TEXT, KEY(v), KEY(c), KEY(t(10)));
+CREATE TABLE t1(v VARCHAR(10), c CHAR(10), t TEXT, KEY(v), KEY(c), KEY(t(10))) CHARACTER SET=latin1;
 INSERT INTO t1(v) SELECT CONCAT(CHAR(ASCII('a') + s2.seq), REPEAT(' ', s1.seq))
   FROM seq_0_to_9 AS s1, seq_0_to_26 AS s2;
 UPDATE t1 SET c = v, t = v;

--- a/sql/mf_iocache_encr.cc
+++ b/sql/mf_iocache_encr.cc
@@ -151,9 +151,12 @@ static int my_b_encr_read(IO_CACHE *info, uchar *Buffer, size_t Count) {
 
     copied = MY_MIN(Count, length - pos_offset);
 
-    memcpy(Buffer, info->buffer + pos_offset, copied);
-    Count -= copied;
-    Buffer += copied;
+    if (copied) {
+      DBUG_ASSERT(Buffer != nullptr);
+      memcpy(Buffer, info->buffer + pos_offset, copied);
+      Count -= copied;
+      Buffer += copied;
+    }
 
     info->read_pos = info->buffer + pos_offset + copied;
     info->read_end = info->buffer + length;
@@ -182,6 +185,10 @@ static int my_b_encr_write(IO_CACHE *info, const uchar *Buffer, size_t Count) {
     if (!Count) DBUG_RETURN(0);
   }
 
+#ifndef DBUG_OFF
+  if (info->pos_in_file == 0) crypt_data->block_length = 0;
+#endif
+
   if (info->seek_not_done) {
     DBUG_ASSERT(info->pos_in_file % info->buffer_length == 0);
     size_t wpos =
@@ -202,10 +209,6 @@ static int my_b_encr_write(IO_CACHE *info, const uchar *Buffer, size_t Count) {
       DBUG_RETURN(1);
     }
     crypt_data->counter = 0;
-
-#ifndef DBUG_OFF
-    crypt_data->block_length = 0;
-#endif
   }
 
   do {


### PR DESCRIPTION
1. Fix UBSan error when `copied==0` in `my_b_encr_read()`
2. Add `CHARACTER SET=latin1` to t1 table
3. Fix valgrind error: usage of crypt_data->block_length before initialization in `my_b_encr_write()`