### PR TITLE
PS-269: Remove an unnecessary warning with ./mysql-test/mtr

### DIFF
--- a/sql/derror.cc
+++ b/sql/derror.cc
@@ -242,7 +242,7 @@ bool MY_LOCALE_ERRMSGS::read_texts() {
              key_file_ERRMSG,
              fn_format(name, ERRMSG_FILE, lc_messages_dir, "", 4), O_RDONLY,
              MYF(0))) < 0) {
-      LogErr(ERROR_LEVEL, ER_ERRMSG_CANT_FIND_FILE, name);
+      if (!opt_help) LogErr(ERROR_LEVEL, ER_ERRMSG_CANT_FIND_FILE, name);
       goto open_err;
     }
 


### PR DESCRIPTION
The warning was introduced because of added `--basedir` to MTR parameters list.