### PR TITLE
PS-269: Fix binlog_nogtid.binlog_persist_variables (8.0)

### DIFF
--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -18,11 +18,10 @@ VARIABLE_NAME LIKE '%relay%' OR
 VARIABLE_NAME LIKE '%rpl%' OR
 VARIABLE_NAME LIKE '%semi_sync%' OR
 VARIABLE_NAME LIKE '%slave%') AND
-(VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-'innodb_master_thread_disabled_debug'))
+(VARIABLE_NAME NOT LIKE 'innodb%')
 ORDER BY VARIABLE_NAME;
 
-include/assert.inc ['Expect 80 variables in the table.']
+include/assert.inc ['Expect 83 variables in the table.']
 
 # Test SET PERSIST_ONLY
 SET PERSIST_ONLY binlog_cache_size = @@GLOBAL.binlog_cache_size;
@@ -43,9 +42,11 @@ SET PERSIST_ONLY binlog_row_image = @@GLOBAL.binlog_row_image;
 SET PERSIST_ONLY binlog_row_metadata = @@GLOBAL.binlog_row_metadata;
 SET PERSIST_ONLY binlog_row_value_options = @@GLOBAL.binlog_row_value_options;
 SET PERSIST_ONLY binlog_rows_query_log_events = @@GLOBAL.binlog_rows_query_log_events;
+SET PERSIST_ONLY binlog_space_limit = @@GLOBAL.binlog_space_limit;
 SET PERSIST_ONLY binlog_stmt_cache_size = @@GLOBAL.binlog_stmt_cache_size;
 SET PERSIST_ONLY binlog_transaction_dependency_history_size = @@GLOBAL.binlog_transaction_dependency_history_size;
 SET PERSIST_ONLY binlog_transaction_dependency_tracking = @@GLOBAL.binlog_transaction_dependency_tracking;
+SET PERSIST_ONLY encrypt_binlog = @@GLOBAL.encrypt_binlog;
 SET PERSIST_ONLY enforce_gtid_consistency = @@GLOBAL.enforce_gtid_consistency;
 SET PERSIST_ONLY gtid_executed = @@GLOBAL.gtid_executed;
 ERROR HY000: Variable 'gtid_executed' is a non persistent read only variable
@@ -54,6 +55,8 @@ SET PERSIST_ONLY gtid_mode = @@GLOBAL.gtid_mode;
 SET PERSIST_ONLY gtid_owned = @@GLOBAL.gtid_owned;
 ERROR HY000: Variable 'gtid_owned' is a non persistent read only variable
 SET PERSIST_ONLY gtid_purged = @@GLOBAL.gtid_purged;
+SET PERSIST_ONLY have_backup_safe_binlog_info = @@GLOBAL.have_backup_safe_binlog_info;
+ERROR HY000: Variable 'have_backup_safe_binlog_info' is a non persistent read only variable
 SET PERSIST_ONLY init_slave = @@GLOBAL.init_slave;
 SET PERSIST_ONLY log_bin = @@GLOBAL.log_bin;
 ERROR HY000: Variable 'log_bin' is a non persistent read only variable
@@ -119,16 +122,16 @@ SET PERSIST_ONLY sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST_ONLY sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST_ONLY sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 70 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 72 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 70 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 70 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 70 persisted variables with matching peristed and global values.']
+include/assert.inc ['Expect 72 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 72 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 72 persisted variables with matching peristed and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST. Verify persisted variable settings
@@ -148,9 +151,11 @@ RESET PERSIST binlog_row_image;
 RESET PERSIST binlog_row_metadata;
 RESET PERSIST binlog_row_value_options;
 RESET PERSIST binlog_rows_query_log_events;
+RESET PERSIST binlog_space_limit;
 RESET PERSIST binlog_stmt_cache_size;
 RESET PERSIST binlog_transaction_dependency_history_size;
 RESET PERSIST binlog_transaction_dependency_tracking;
+RESET PERSIST encrypt_binlog;
 RESET PERSIST enforce_gtid_consistency;
 RESET PERSIST gtid_executed;
 ERROR HY000: Variable gtid_executed does not exist in persisted config file
@@ -159,6 +164,8 @@ RESET PERSIST gtid_mode;
 RESET PERSIST gtid_owned;
 ERROR HY000: Variable gtid_owned does not exist in persisted config file
 RESET PERSIST gtid_purged;
+RESET PERSIST have_backup_safe_binlog_info;
+ERROR HY000: Variable have_backup_safe_binlog_info does not exist in persisted config file
 RESET PERSIST init_slave;
 RESET PERSIST log_bin;
 ERROR HY000: Variable log_bin does not exist in persisted config file

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
@@ -18,8 +18,7 @@ VARIABLE_NAME LIKE '%relay%' OR
 VARIABLE_NAME LIKE '%rpl%' OR
 VARIABLE_NAME LIKE '%semi_sync%' OR
 VARIABLE_NAME LIKE '%slave%') AND
-(VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-'innodb_master_thread_disabled_debug'))
+(VARIABLE_NAME NOT LIKE 'innodb%')
 ORDER BY VARIABLE_NAME;
 
 include/assert.inc ['Expect 83 variables in the table.']
@@ -44,6 +43,8 @@ SET PERSIST binlog_row_image = @@GLOBAL.binlog_row_image;
 SET PERSIST binlog_row_metadata = @@GLOBAL.binlog_row_metadata;
 SET PERSIST binlog_row_value_options = @@GLOBAL.binlog_row_value_options;
 SET PERSIST binlog_rows_query_log_events = @@GLOBAL.binlog_rows_query_log_events;
+SET PERSIST binlog_space_limit = @@GLOBAL.binlog_space_limit;
+ERROR HY000: Variable 'binlog_space_limit' is a read only variable
 SET PERSIST binlog_stmt_cache_size = @@GLOBAL.binlog_stmt_cache_size;
 SET PERSIST binlog_transaction_dependency_history_size = @@GLOBAL.binlog_transaction_dependency_history_size;
 SET PERSIST binlog_transaction_dependency_tracking = @@GLOBAL.binlog_transaction_dependency_tracking;
@@ -75,7 +76,6 @@ SET PERSIST log_statements_unsafe_for_binlog = @@GLOBAL.log_statements_unsafe_fo
 SET PERSIST master_info_repository = @@GLOBAL.master_info_repository;
 SET PERSIST master_verify_checksum = @@GLOBAL.master_verify_checksum;
 SET PERSIST max_binlog_cache_size = @@GLOBAL.max_binlog_cache_size;
-SET PERSIST max_binlog_files = @@GLOBAL.max_binlog_files;
 SET PERSIST max_binlog_size = @@GLOBAL.max_binlog_size;
 SET PERSIST max_binlog_stmt_cache_size = @@GLOBAL.max_binlog_stmt_cache_size;
 SET PERSIST max_relay_log_size = @@GLOBAL.max_relay_log_size;
@@ -129,16 +129,16 @@ SET PERSIST sync_master_info = @@GLOBAL.sync_master_info;
 SET PERSIST sync_relay_log = @@GLOBAL.sync_relay_log;
 SET PERSIST sync_relay_log_info = @@GLOBAL.sync_relay_log_info;
 
-include/assert.inc ['Expect 66 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 65 persisted variables in persisted_variables table.']
 
 ############################################################
 # 2. Restart server, it must preserve the persisted variable
 #    settings. Verify persisted configuration.
 # restart
 
-include/assert.inc ['Expect 66 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 66 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 66 persisted variables with matching peristed and global values.']
+include/assert.inc ['Expect 65 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 65 persisted variables shown as PERSISTED in variables_info table.']
+include/assert.inc ['Expect 65 persisted variables with matching peristed and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS. Verify persisted variable
@@ -160,6 +160,9 @@ RESET PERSIST IF EXISTS binlog_row_image;
 RESET PERSIST IF EXISTS binlog_row_metadata;
 RESET PERSIST IF EXISTS binlog_row_value_options;
 RESET PERSIST IF EXISTS binlog_rows_query_log_events;
+RESET PERSIST IF EXISTS binlog_space_limit;
+Warnings:
+Warning	3615	Variable binlog_space_limit does not exist in persisted config file
 RESET PERSIST IF EXISTS binlog_stmt_cache_size;
 RESET PERSIST IF EXISTS binlog_transaction_dependency_history_size;
 RESET PERSIST IF EXISTS binlog_transaction_dependency_tracking;
@@ -199,7 +202,6 @@ RESET PERSIST IF EXISTS log_statements_unsafe_for_binlog;
 RESET PERSIST IF EXISTS master_info_repository;
 RESET PERSIST IF EXISTS master_verify_checksum;
 RESET PERSIST IF EXISTS max_binlog_cache_size;
-RESET PERSIST IF EXISTS max_binlog_files;
 RESET PERSIST IF EXISTS max_binlog_size;
 RESET PERSIST IF EXISTS max_binlog_stmt_cache_size;
 RESET PERSIST IF EXISTS max_relay_log_size;

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -48,8 +48,7 @@ INSERT INTO rplvars (varname, varvalue)
         VARIABLE_NAME LIKE '%rpl%' OR
         VARIABLE_NAME LIKE '%semi_sync%' OR
         VARIABLE_NAME LIKE '%slave%') AND
-       (VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-        'innodb_master_thread_disabled_debug'))
+       (VARIABLE_NAME NOT LIKE 'innodb%')
        ORDER BY VARIABLE_NAME;
 --enable_warnings
 --let $countvars= `SELECT COUNT(*) FROM rplvars;`
@@ -69,14 +68,14 @@ while ( $varid <= $countvars )
   --let $varnames= `SELECT varname FROM rplvars WHERE id=$varid`
 
   # Following variables are non persistent read only variables.
-  if (`SELECT '$varnames' IN ('gtid_executed', 'gtid_owned', 'log_bin', 'log_bin_basename', 'log_bin_index', 'relay_log', 'relay_log_basename', 'relay_log_index', 'relay_log_info_file', 'slave_load_tmpdir')`)
+  if (`SELECT '$varnames' IN ('gtid_executed', 'gtid_owned', 'have_backup_safe_binlog_info', 'log_bin', 'log_bin_basename', 'log_bin_index', 'relay_log', 'relay_log_basename', 'relay_log_index', 'relay_log_info_file', 'slave_load_tmpdir')`)
   {
     --error ER_INCORRECT_GLOBAL_LOCAL_VAR
   }
   --eval SET PERSIST_ONLY $varnames = @@GLOBAL.$varnames
 
   #  TODO: Remove/update this once Bug#27322592 is FIXED.
-  if (`SELECT '$varnames' IN ('binlog_direct_non_transactional_updates', 'binlog_order_commits', 'binlog_rows_query_log_events', 'log_bin_trust_function_creators', 'log_bin_use_v1_row_events', 'log_slow_slave_statements', 'log_statements_unsafe_for_binlog', 'master_verify_checksum', 'slave_allow_batching', 'slave_compressed_protocol', 'slave_preserve_commit_order', 'slave_sql_verify_checksum', 'relay_log_purge', 'rpl_semi_sync_master_enabled', 'rpl_semi_sync_master_wait_no_slave', 'rpl_semi_sync_slave_enabled', 'binlog_gtid_simple_recovery', 'log_slave_updates', 'relay_log_recovery')`)
+  if (`SELECT '$varnames' IN ('binlog_direct_non_transactional_updates', 'binlog_order_commits', 'binlog_rows_query_log_events', 'encrypt_binlog', 'log_bin_trust_function_creators', 'log_bin_use_v1_row_events', 'log_slow_slave_statements', 'log_statements_unsafe_for_binlog', 'master_verify_checksum', 'slave_allow_batching', 'slave_compressed_protocol', 'slave_preserve_commit_order', 'slave_sql_verify_checksum', 'relay_log_purge', 'rpl_semi_sync_master_enabled', 'rpl_semi_sync_master_wait_no_slave', 'rpl_semi_sync_slave_enabled', 'binlog_gtid_simple_recovery', 'log_slave_updates', 'relay_log_recovery')`)
   {
     --disable_query_log
       --eval SELECT varvalue INTO @varvalues FROM rplvars WHERE id=$varid
@@ -88,8 +87,8 @@ while ( $varid <= $countvars )
 }
 
 --echo
---let $assert_text= 'Expect 73 persisted variables in persisted_variables table.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 73
+--let $assert_text= 'Expect 72 persisted variables in persisted_variables table.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 72
 --source include/assert.inc
 
 
@@ -101,16 +100,16 @@ while ( $varid <= $countvars )
 --source include/wait_until_connected_again.inc
 
 --echo
---let $assert_text= 'Expect 73 persisted variables in persisted_variables table.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 73
+--let $assert_text= 'Expect 72 persisted variables in persisted_variables table.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 72
 --source include/assert.inc
 
---let $assert_text= 'Expect 73 persisted variables shown as PERSISTED in variables_info table.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info WHERE variable_source="PERSISTED", count, 1] = 73
+--let $assert_text= 'Expect 72 persisted variables shown as PERSISTED in variables_info table.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info WHERE variable_source="PERSISTED", count, 1] = 72
 --source include/assert.inc
 
---let $assert_text= 'Expect 73 persisted variables with matching peristed and global values.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info vi JOIN performance_schema.persisted_variables pv JOIN performance_schema.global_variables gv ON vi.variable_name=pv.variable_name AND vi.variable_name=gv.variable_name AND pv.variable_value=gv.variable_value WHERE vi.variable_source="PERSISTED", count, 1] = 73
+--let $assert_text= 'Expect 72 persisted variables with matching peristed and global values.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info vi JOIN performance_schema.persisted_variables pv JOIN performance_schema.global_variables gv ON vi.variable_name=pv.variable_name AND vi.variable_name=gv.variable_name AND pv.variable_value=gv.variable_value WHERE vi.variable_source="PERSISTED", count, 1] = 72
 --source include/assert.inc
 
 
@@ -123,7 +122,7 @@ while ( $varid <= $countvars )
 {
   --let $varnames= `SELECT varname FROM rplvars WHERE id=$varid`
 
-  if (`SELECT '$varnames' IN ('gtid_executed', 'gtid_owned', 'log_bin', 'log_bin_basename', 'log_bin_index', 'relay_log', 'relay_log_basename', 'relay_log_index', 'relay_log_info_file', 'slave_load_tmpdir')`)
+  if (`SELECT '$varnames' IN ('gtid_executed', 'gtid_owned', 'have_backup_safe_binlog_info', 'log_bin', 'log_bin_basename', 'log_bin_index', 'relay_log', 'relay_log_basename', 'relay_log_index', 'relay_log_info_file', 'slave_load_tmpdir')`)
   {
     --error ER_VAR_DOES_NOT_EXIST
   }

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
@@ -49,8 +49,7 @@ INSERT INTO rplvars (varname, varvalue)
         VARIABLE_NAME LIKE '%rpl%' OR
         VARIABLE_NAME LIKE '%semi_sync%' OR
         VARIABLE_NAME LIKE '%slave%') AND
-       (VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-        'innodb_master_thread_disabled_debug'))
+       (VARIABLE_NAME NOT LIKE 'innodb%')
        ORDER BY VARIABLE_NAME;
 --enable_warnings
 --let $countvars= `SELECT COUNT(*) FROM rplvars;`
@@ -70,7 +69,7 @@ while ( $varid <= $countvars )
   --let $varnames= `SELECT varname FROM rplvars WHERE id=$varid;`
 
   # Following variables are either non persistent or read only variables.
-  if (`SELECT '$varnames' IN ('binlog_gtid_simple_recovery', 'encrypt_binlog', 'gtid_executed', 'gtid_next', 'gtid_owned', 'have_backup_safe_binlog_info', 'log_bin', 'log_bin_basename', 'log_bin_index', 'log_slave_updates', 'relay_log', 'relay_log_basename', 'relay_log_index', 'relay_log_index', 'relay_log_info_file', 'relay_log_recovery', 'relay_log_space_limit', 'slave_load_tmpdir', 'slave_load_tmpdir', 'slave_skip_errors')`)
+  if (`SELECT '$varnames' IN ('binlog_gtid_simple_recovery', 'binlog_space_limit', 'encrypt_binlog', 'gtid_executed', 'gtid_next', 'gtid_owned', 'have_backup_safe_binlog_info', 'log_bin', 'log_bin_basename', 'log_bin_index', 'log_slave_updates', 'relay_log', 'relay_log_basename', 'relay_log_index', 'relay_log_index', 'relay_log_info_file', 'relay_log_recovery', 'relay_log_space_limit', 'slave_load_tmpdir', 'slave_load_tmpdir', 'slave_skip_errors')`)
   {
     --error ER_INCORRECT_GLOBAL_LOCAL_VAR
   }
@@ -80,8 +79,8 @@ while ( $varid <= $countvars )
 }
 
 --echo
---let $assert_text= 'Expect 66 persisted variables in persisted_variables table.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 66
+--let $assert_text= 'Expect 65 persisted variables in persisted_variables table.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 65
 --source include/assert.inc
 
 --echo
@@ -92,16 +91,16 @@ while ( $varid <= $countvars )
 --source include/wait_until_connected_again.inc
 
 --echo
---let $assert_text= 'Expect 66 persisted variables in persisted_variables table.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 66
+--let $assert_text= 'Expect 65 persisted variables in persisted_variables table.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.persisted_variables, count, 1] = 65
 --source include/assert.inc
 
---let $assert_text= 'Expect 66 persisted variables shown as PERSISTED in variables_info table.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info WHERE variable_source="PERSISTED", count, 1] = 66
+--let $assert_text= 'Expect 65 persisted variables shown as PERSISTED in variables_info table.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info WHERE variable_source="PERSISTED", count, 1] = 65
 --source include/assert.inc
 
---let $assert_text= 'Expect 66 persisted variables with matching peristed and global values.'
---let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info vi JOIN performance_schema.persisted_variables pv JOIN performance_schema.global_variables gv ON vi.variable_name=pv.variable_name AND vi.variable_name=gv.variable_name AND pv.variable_value=gv.variable_value WHERE vi.variable_source="PERSISTED", count, 1] = 66
+--let $assert_text= 'Expect 65 persisted variables with matching peristed and global values.'
+--let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info vi JOIN performance_schema.persisted_variables pv JOIN performance_schema.global_variables gv ON vi.variable_name=pv.variable_name AND vi.variable_name=gv.variable_name AND pv.variable_value=gv.variable_value WHERE vi.variable_source="PERSISTED", count, 1] = 65
 --source include/assert.inc
 
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5321,7 +5321,8 @@ static Sys_var_have Sys_have_backup_locks(
 
 static Sys_var_have Sys_have_backup_safe_binlog_info(
     "have_backup_safe_binlog_info", "have_backup_safe_binlog_info",
-    READ_ONLY GLOBAL_VAR(have_backup_safe_binlog_info), NO_CMD_LINE);
+    READ_ONLY NON_PERSIST GLOBAL_VAR(have_backup_safe_binlog_info),
+    NO_CMD_LINE);
 
 static Sys_var_have Sys_have_snapshot_cloning(
     "have_snapshot_cloning", "have_snapshot_cloning",


### PR DESCRIPTION
1. Set `have_backup_safe_binlog_info` as `NON_PERSIST` in `sql/sys_vars.cc`
2. Mark `have_backup_safe_binlog_info` as non-persistent in `binlog_persist_only_variables.test`
3. Mark `binlog_space_limit` as read-only in `binlog_persist_variables.test`