### PR TITLE
PS-269: Fix search_pattern_multiline.inc (8.0)

### DIFF
--- a/mysql-test/include/search_pattern_multiline.inc
+++ b/mysql-test/include/search_pattern_multiline.inc
@@ -82,7 +82,4 @@ perl;
        $ENV{SEARCH_FILE} =~ s{^.*?([^/\\]+)$}{$1};
        print "$res /$search_pattern/ in $ENV{SEARCH_FILE}\n";
     }
-    elsif ( $found == 0 ) {
-       die("# ERROR: Non of the files do not contain the expected pattern  $search_pattern\n");
-    }
 EOF


### PR DESCRIPTION
This patch removes code starting with `elsif ( $found == 0 )` because
1. `$found` is never changed
2. Search errors are detected and throw in `foreach` when first not matched file is found.

It fixes files that include `search_pattern_multiline.inc`:
- auth_sec.plugin_auth_caching_sha2_password_default_qa
- innodb.innodb_page_size_func
- innodb.innodb-status-output