### PR TITLE
PS-269: Fix a crash on querying GLOBAL_TEMPORARY_TABLES along with partitioned InnoDB tables (8.0)

### DIFF
--- a/mysql-test/r/percona_bug1193264.result
+++ b/mysql-test/r/percona_bug1193264.result
@@ -1,4 +1,3 @@
-DROP TABLE IF EXISTS t1;
 CREATE TABLE t1(a INT PRIMARY KEY, b INT, c INT) ENGINE=InnoDB PARTITION BY HASH(a) PARTITIONS 2;
 INSERT INTO t1 VALUES (1, 1, 1);
 SET DEBUG_SYNC= 'innodb_alter_commit_after_lock_table SIGNAL alter_ready WAIT_FOR i_s_completed';

--- a/storage/innobase/handler/ha_innopart.cc
+++ b/storage/innobase/handler/ha_innopart.cc
@@ -294,6 +294,8 @@ bool Ha_innopart_share::open_table_parts(THD *thd, const TABLE *table,
   char partition_name[FN_REFLEN];
   bool index_loaded = true;
 
+  if (dd_table == nullptr) return (true);
+
 #ifdef UNIV_DEBUG
   if (m_table_share->tmp_table == NO_TMP_TABLE) {
     mysql_mutex_assert_owner(&m_table_share->LOCK_ha_data);


### PR DESCRIPTION
`dd_table` can be `nullptr` e.g. in case when it's a cloned handler for I_S.GLOBAL_TEMPORARY_TABLES query.
This commit fixes the issue by detection of `dd_table == nullptr` in `Ha_innopart_share::open_table_parts`.
It also fixes `main.percona_bug1193264` MTR tests.