### PR TITLE
PS-269: Fix broken HEAP index backward scans (8.0)

### DIFF
--- a/storage/heap/hp_rlast.cc
+++ b/storage/heap/hp_rlast.cc
@@ -38,6 +38,8 @@ int heap_rlast(HP_INFO *info, uchar *record, int inx) {
     if ((pos = (uchar *)tree_search_edge(&keyinfo->rb_tree, info->parents,
                                          &info->last_pos,
                                          offsetof(TREE_ELEMENT, right)))) {
+      memcpy(&pos, pos + (*keyinfo->get_key_length)(keyinfo, pos),
+             sizeof(uchar *));
       if (hp_extract_record(info, record, pos)) DBUG_RETURN(my_errno());
       info->current_ptr = pos;
       info->update = HA_STATE_AKTIV;


### PR DESCRIPTION
This commit fixes a merge error that broke HEAP index backward scans.
It resores missing `memcpy` in `heap_rlast()`.
It also fixes `main.heap_btree`.