### PR TITLE
PS-269: Fix SEGFAULT in subselect_hash_sj_engine::cleanup() (8.0)

### DIFF
--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -3700,15 +3700,17 @@ subselect_hash_sj_engine::~subselect_hash_sj_engine() {
 void subselect_hash_sj_engine::cleanup() {
   DBUG_ENTER("subselect_hash_sj_engine::cleanup");
   is_materialized = false;
-  result->cleanup(); /* Resets the temp table as well. */
+  if (result != nullptr) result->cleanup(); /* Resets the temp table as well. */
   THD *const thd = item->unit->thd;
   DEBUG_SYNC(thd, "before_index_end_in_subselect");
-  TABLE *const table = tab->table();
-  if (table->file->inited)
-    table->file->ha_index_end();  // Close the scan over the index
-  free_tmp_table(thd, table);
-  // Note that tab->qep_cleanup() is not called
-  tab = NULL;
+  if (tab != nullptr) {
+    TABLE *const table = tab->table();
+    if (table->file->inited)
+      table->file->ha_index_end();  // Close the scan over the index
+    free_tmp_table(thd, table);
+    // Note that tab->qep_cleanup() is not called
+    tab = nullptr;
+  }
   materialize_engine->cleanup();
   DBUG_VOID_RETURN;
 }


### PR DESCRIPTION
The issue was introduced with a wrong merge of PS-4620 from 5.7 to 8.0 regarding changes in `sql/item_subselect.cc`:
https://github.com/percona/percona-server/commit/a5e269a7036c97a02f23acffa78c062d17d6e3d4

This commit reverts `sql/item_subselect.cc` to match 8.0 upstream what fixes `main.subselect_debug` MTR test.