### PR TITLE
PS-269: Fix `max_statement_time` and `backup_safe_binlog_info` (8.0)

### DIFF
--- a/mysql-test/r/backup_safe_binlog_info.result
+++ b/mysql-test/r/backup_safe_binlog_info.result
@@ -3,4 +3,5 @@ INSERT INTO t1 VALUES (1);
 CREATE TABLE t2(a INT) ENGINE=MyISAM;
 INSERT INTO t2 VALUES(2);
 LOCK TABLES FOR BACKUP;
+Pattern "InnoDB: Last MySQL binlog file position 0 1120, file name binlog.000001" found
 DROP TABLE t1;

--- a/mysql-test/r/max_statement_time.result
+++ b/mysql-test/r/max_statement_time.result
@@ -65,6 +65,8 @@ Warnings:
 Warning	3125	MAX_EXECUTION_TIME hint is supported by top-level standalone SELECT statements only
 CREATE TABLE /*+ MAX_EXECUTION_TIME(100) */ t4 (a int);
 CREATE /*+ MAX_EXECUTION_TIME(100) */ TABLE t5 (a int);
+Warnings:
+Warning	3125	MAX_EXECUTION_TIME hint is supported by top-level standalone SELECT statements only
 DELETE /*+ MAX_EXECUTION_TIME(100) */ FROM t1;
 Warnings:
 Warning	3125	MAX_EXECUTION_TIME hint is supported by top-level standalone SELECT statements only
@@ -73,6 +75,8 @@ Warnings:
 Warning	3125	MAX_EXECUTION_TIME hint is supported by top-level standalone SELECT statements only
 ALTER TABLE /*+ MAX_EXECUTION_TIME(100) */ t1 ADD b VARCHAR(200);
 ALTER /*+ MAX_EXECUTION_TIME(100) */ TABLE t1 ADD c VARCHAR(200);
+Warnings:
+Warning	3125	MAX_EXECUTION_TIME hint is supported by top-level standalone SELECT statements only
 SELECT /*+ MAX_EXECUTION_TIME(0) */ * FROM t1;
 a	b	c
 DROP TABLE t1, t2, t3, t4, t5;

--- a/mysql-test/t/backup_safe_binlog_info.test
+++ b/mysql-test/t/backup_safe_binlog_info.test
@@ -16,7 +16,7 @@ INSERT INTO t2 VALUES(2);
 
 LOCK TABLES FOR BACKUP;
 
---exec echo "restart: --log-error=$MYSQLTEST_VARDIR/log/my_restart.err" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--exec echo "restart: --log-error=$MYSQLTEST_VARDIR/log/my_restart.err" --log-error-verbosity=3 > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --shutdown_server 0
 
 --enable_reconnect


### PR DESCRIPTION
1. Fix `main.backup_safe_binlog_info` by adding `--log-error-verbosity=3` as
   default value for MySQL >= 8.0.4 is 2.
2. Re-record `main.max_statement_time` as https://github.com/percona/percona-server/commit/56043e5abd89
   changed that more hints are parsed by ALTER/CREATE.