### PR TITLE
PS-269: Fix valgrind warnings with rpl.rpl_bug72457 (8.0)

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1256,6 +1256,7 @@ bool Log_event::wrapper_my_b_safe_write(IO_CACHE *file, const uchar *buf,
   if (size == 0) return false;
 
   DBUG_EXECUTE_IF("simulate_temp_file_write_error", {
+    memset(file->write_pos, 0, file->write_end - file->write_pos);
     file->write_pos = file->write_end;
     DBUG_SET("+d,simulate_file_write_error");
   });


### PR DESCRIPTION
Add missing `memset` to `Log_event::wrapper_my_b_safe_write`.
It fixes valgring warnings for `rpl.rpl_bug72457_innodb` and `rpl.rpl_bug72457_myisam`.