### PR TITLE
PS-4953 : rocksdb.truncate_table3 unstable

### DIFF
--- a/mysql-test/suite/rocksdb/r/truncate_table3.result
+++ b/mysql-test/suite/rocksdb/r/truncate_table3.result
@@ -1,3 +1,5 @@
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
 set global rocksdb_compact_cf = 'cf1';
 set global rocksdb_compact_cf = 'rev:cf2';
 set global rocksdb_signal_drop_index_thread = 1;

--- a/mysql-test/suite/rocksdb/t/truncate_table3.test
+++ b/mysql-test/suite/rocksdb/t/truncate_table3.test
@@ -1,5 +1,7 @@
 --source include/have_rocksdb.inc
 
+call mtr.add_suppression("Column family 'cf1' not found");
+call mtr.add_suppression("Column family 'rev:cf2' not found");
 -- let $truncate_table = 1
 -- let $drop_table = 0
 -- source suite/rocksdb/include/drop_table3.inc


### PR DESCRIPTION
- Test is missing error log suppressions that will occur if test is run on a
  clean data-dir.  Added missing suppressions.