### PR TITLE
Post-push fix for for PS-3889: add 'override' specifier for Partition…

### DIFF
--- a/sql/partitioning/partition_base.cc
+++ b/sql/partitioning/partition_base.cc
@@ -1473,7 +1473,6 @@ void Partition_base::update_create_info(HA_CREATE_INFO *create_info)
   uint                             num_parts=
       num_subparts ? m_file_tot_parts / num_subparts : m_file_tot_parts;
   HA_CREATE_INFO dummy_info;
-  memset(&dummy_info, 0, sizeof(dummy_info));
 
   /*
   Since update_create_info() can be called from mysql_prepare_alter_table()

--- a/storage/rocksdb/ha_rockspart.h
+++ b/storage/rocksdb/ha_rockspart.h
@@ -31,17 +31,17 @@ class ha_rockspart : public native_part::Partition_base {
       : native_part::Partition_base(hton, share, part_info_arg, clone_arg,
                                     clone_mem_root_arg) {}
 
-  ~ha_rockspart() {}
+  ~ha_rockspart() override {}
 
   int open(const char *name, int mode, uint test_if_locked) override;
   int create(const char *name, TABLE *form,
              HA_CREATE_INFO *create_info) override;
 
  private:
-  virtual handler *get_file_handler(TABLE_SHARE *share, MEM_ROOT *alloc);
-  virtual handler *clone(const char *name, MEM_ROOT *mem_root);
-  virtual ulong index_flags(uint inx, uint part, bool all_parts) const;
-  virtual const char **bas_ext() const;
+  handler *get_file_handler(TABLE_SHARE *share, MEM_ROOT *alloc) override;
+  handler *clone(const char *name, MEM_ROOT *mem_root) override;
+  ulong index_flags(uint inx, uint part, bool all_parts) const override;
+  const char **bas_ext() const override;
 
   void set_pk_can_be_decoded_for_each_partition();
   mutable bool m_pk_can_be_decoded = false;

--- a/storage/tokudb/ha_tokupart.h
+++ b/storage/tokudb/ha_tokupart.h
@@ -36,13 +36,13 @@ class ha_tokupart : public native_part::Partition_base {
                                       clone_arg,
                                       clone_mem_root_arg) {}
 
-    ~ha_tokupart() {}
+    ~ha_tokupart() override {}
 
    private:
-    virtual handler *get_file_handler(TABLE_SHARE *share, MEM_ROOT *alloc);
-    virtual handler *clone(const char *name, MEM_ROOT *mem_root);
-    virtual ulong index_flags(uint inx, uint part, bool all_parts) const;
-    virtual const char **bas_ext() const;
+    handler *get_file_handler(TABLE_SHARE *share, MEM_ROOT *alloc) override;
+    handler *clone(const char *name, MEM_ROOT *mem_root) override;
+    ulong index_flags(uint inx, uint part, bool all_parts) const override;
+    const char **bas_ext() const override;
 };
 
 #endif  // _HA_TOKUPART_H


### PR DESCRIPTION
…_base descendants and remove HA_CREATE_INFO object clearing with memset().

Please wait until Tavis finish jobs. See also: https://github.com/percona/percona-server/pull/2611.