### PR TITLE
PS-4839 : Adjust MyRocks and TokuDB defaults for 8.0

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_block_size_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_block_size_basic.result
@@ -1,7 +1,7 @@
 SET @start_global_value = @@global.ROCKSDB_BLOCK_SIZE;
 SELECT @start_global_value;
 @start_global_value
-4096
+16384
 "Trying to set variable @@global.ROCKSDB_BLOCK_SIZE to 444. It should fail because it is readonly."
 SET @@global.ROCKSDB_BLOCK_SIZE   = 444;
 ERROR HY000: Variable 'rocksdb_block_size' is a read only variable

--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_default_cf_options_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_default_cf_options_basic.result
@@ -1,7 +1,7 @@
 SET @start_global_value = @@global.ROCKSDB_DEFAULT_CF_OPTIONS;
 SELECT @start_global_value;
 @start_global_value
-compression=kLZ4Compression;bottommost_compression=kLZ4Compression
+block_based_table_factory={cache_index_and_filter_blocks=1;filter_policy=bloomfilter:10:false;whole_key_filtering=1};level_compaction_dynamic_level_bytes=true;optimize_filters_for_hits=true;compaction_pri=kMinOverlappingRatio;compression=kLZ4Compression;bottommost_compression=kLZ4Compression;
 "Trying to set variable @@global.ROCKSDB_DEFAULT_CF_OPTIONS to 444. It should fail because it is readonly."
 SET @@global.ROCKSDB_DEFAULT_CF_OPTIONS   = 444;
 ERROR HY000: Variable 'rocksdb_default_cf_options' is a read only variable

--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_total_wal_size_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_max_total_wal_size_basic.result
@@ -1,7 +1,7 @@
 SET @start_global_value = @@global.ROCKSDB_MAX_TOTAL_WAL_SIZE;
 SELECT @start_global_value;
 @start_global_value
-0
+2147483648
 "Trying to set variable @@global.ROCKSDB_MAX_TOTAL_WAL_SIZE to 444. It should fail because it is readonly."
 SET @@global.ROCKSDB_MAX_TOTAL_WAL_SIZE   = 444;
 ERROR HY000: Variable 'rocksdb_max_total_wal_size' is a read only variable

--- a/mysql-test/suite/rocksdb/r/block_size.result
+++ b/mysql-test/suite/rocksdb/r/block_size.result
@@ -1,6 +1,6 @@
 select @@global.rocksdb_block_size;
 @@global.rocksdb_block_size
-4096
+16384
 call mtr.add_suppression("option 'rocksdb-block-size': unsigned value 12 adjusted to 1024");
 # restart:--rocksdb_block_size=12
 select @@global.rocksdb_block_size;

--- a/mysql-test/suite/rocksdb/r/mysqldump2.result
+++ b/mysql-test/suite/rocksdb/r/mysqldump2.result
@@ -4,14 +4,14 @@ Table	Op	Msg_type	Msg_text
 test.t1	optimize	status	OK
 # restart:--rocksdb_default_cf_options=write_buffer_size=64k;target_file_size_base=64k;max_bytes_for_level_base=1m;compression_per_level=kNoCompression;disable_auto_compactions=true;level0_stop_writes_trigger=1000
 select variable_value into @a from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
-select case when variable_value - @a > 20 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
-case when variable_value - @a > 20 then 'true' else 'false' end
+select case when variable_value - @a > 5 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
+case when variable_value - @a > 5 then 'true' else 'false' end
 false
 select count(*) from t1;
 count(*)
 50000
-select case when variable_value - @a > 100 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
-case when variable_value - @a > 100 then 'true' else 'false' end
+select case when variable_value - @a > 25 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
+case when variable_value - @a > 25 then 'true' else 'false' end
 true
 DROP TABLE t1;
 # restart

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -896,7 +896,7 @@ rocksdb_allow_mmap_writes	OFF
 rocksdb_allow_to_start_after_corruption	OFF
 rocksdb_block_cache_size	536870912
 rocksdb_block_restart_interval	16
-rocksdb_block_size	4096
+rocksdb_block_size	16384
 rocksdb_block_size_deviation	10
 rocksdb_bulk_load	OFF
 rocksdb_bulk_load_allow_sk	OFF
@@ -927,7 +927,7 @@ rocksdb_debug_ttl_ignore_pk	OFF
 rocksdb_debug_ttl_read_filter_ts	0
 rocksdb_debug_ttl_rec_ts	0
 rocksdb_debug_ttl_snapshot_ts	0
-rocksdb_default_cf_options	compression=kLZ4Compression;bottommost_compression=kLZ4Compression
+rocksdb_default_cf_options	block_based_table_factory={cache_index_and_filter_blocks=1;filter_policy=bloomfilter:10:false;whole_key_filtering=1};level_compaction_dynamic_level_bytes=true;optimize_filters_for_hits=true;compaction_pri=kMinOverlappingRatio;compression=kLZ4Compression;bottommost_compression=kLZ4Compression;
 rocksdb_delayed_write_rate	0
 rocksdb_delete_obsolete_files_period_micros	21600000000
 rocksdb_enable_bulk_load_api	ON
@@ -961,7 +961,7 @@ rocksdb_max_log_file_size	0
 rocksdb_max_manifest_file_size	18446744073709551615
 rocksdb_max_row_locks	1048576
 rocksdb_max_subcompactions	1
-rocksdb_max_total_wal_size	0
+rocksdb_max_total_wal_size	2147483648
 rocksdb_merge_buf_size	67108864
 rocksdb_merge_combine_read_size	1073741824
 rocksdb_merge_tmp_file_removal_delay_ms	0

--- a/mysql-test/suite/rocksdb/t/compact_deletes-master.opt
+++ b/mysql-test/suite/rocksdb/t/compact_deletes-master.opt
@@ -1,3 +1,1 @@
---loose-rocksdb_debug_optimizer_n_rows=1000
---loose-rocksdb_records_in_range=50
---loose-rocksdb_compaction_sequential_deletes_count_sd=1
+--loose-rocksdb_debug_optimizer_n_rows=1000 --loose-rocksdb_records_in_range=50 --loose-rocksdb_compaction_sequential_deletes_count_sd=1 --loose-rocksdb_block_size=4096

--- a/mysql-test/suite/rocksdb/t/index_merge_rocksdb-master.opt
+++ b/mysql-test/suite/rocksdb/t/index_merge_rocksdb-master.opt
@@ -1,1 +1,1 @@
---loose-rocksdb_strict_collation_check=off --loose-rocksdb_default_cf_options=
+--loose-rocksdb_strict_collation_check=off --loose-rocksdb_default_cf_options= --loose-rocksdb_block_size=4096

--- a/mysql-test/suite/rocksdb/t/mysqldump2.test
+++ b/mysql-test/suite/rocksdb/t/mysqldump2.test
@@ -24,12 +24,12 @@ select variable_value into @a from performance_schema.global_status where variab
 --exec $MYSQL_DUMP --skip-comments --single-transaction --master-data=2 test > /dev/null
 
 # verifying block cache was not filled
-select case when variable_value - @a > 20 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
+select case when variable_value - @a > 5 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
 
 select count(*) from t1;
 
 # verifying block cache was filled
-select case when variable_value - @a > 100 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
+select case when variable_value - @a > 25 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_block_cache_add';
 
 #cleanup
 DROP TABLE t1;

--- a/mysql-test/suite/tokudb.bugs/r/simple_icp.result
+++ b/mysql-test/suite/tokudb.bugs/r/simple_icp.result
@@ -13,7 +13,7 @@ Variable_name	Value
 Handler_read_next	0
 explain select * from foo where a between 5 and 6 and c=10;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	foo	NULL	range	a	a	5	NA	800	10.00	Using where
+1	SIMPLE	foo	NULL	range	a	a	5	NA	779	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`foo`.`a` AS `a`,`test`.`foo`.`b` AS `b`,`test`.`foo`.`c` AS `c`,`test`.`foo`.`d` AS `d`,`test`.`foo`.`e` AS `e` from `test`.`foo` where ((`test`.`foo`.`c` = 10) and (`test`.`foo`.`a` between 5 and 6))
 select * from foo where a between 5 and 6 and c=10;
@@ -67,7 +67,7 @@ Variable_name	Value
 Handler_read_prev	0
 explain select * from foo where a between 5 and 6 and c=10;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	foo	NULL	range	a	a	5	NA	800	10.00	Using where
+1	SIMPLE	foo	NULL	range	a	a	5	NA	779	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`foo`.`a` AS `a`,`test`.`foo`.`b` AS `b`,`test`.`foo`.`c` AS `c`,`test`.`foo`.`d` AS `d`,`test`.`foo`.`e` AS `e` from `test`.`foo` where ((`test`.`foo`.`c` = 10) and (`test`.`foo`.`a` between 5 and 6))
 select * from foo where a between 5 and 6 and c=10 order by a desc;
@@ -121,7 +121,7 @@ Variable_name	Value
 Handler_read_prev	0
 explain select * from foo where a > 19 and c=10;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	foo	NULL	range	a	a	5	NA	1402	10.00	Using where
+1	SIMPLE	foo	NULL	range	a	a	5	NA	568	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`foo`.`a` AS `a`,`test`.`foo`.`b` AS `b`,`test`.`foo`.`c` AS `c`,`test`.`foo`.`d` AS `d`,`test`.`foo`.`e` AS `e` from `test`.`foo` where ((`test`.`foo`.`c` = 10) and (`test`.`foo`.`a` > 19))
 select * from foo where a > 19 and c=10 order by a desc;
@@ -155,7 +155,7 @@ Variable_name	Value
 Handler_read_next	0
 explain select * from foo where a > 19 and c=10;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	foo	NULL	range	a	a	5	NA	1402	10.00	Using where
+1	SIMPLE	foo	NULL	range	a	a	5	NA	568	10.00	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`foo`.`a` AS `a`,`test`.`foo`.`b` AS `b`,`test`.`foo`.`c` AS `c`,`test`.`foo`.`d` AS `d`,`test`.`foo`.`e` AS `e` from `test`.`foo` where ((`test`.`foo`.`c` = 10) and (`test`.`foo`.`a` > 19))
 select * from foo where a > 19 and c=10;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -412,6 +412,10 @@ static constexpr ulong RDB_MAX_LOCK_WAIT_SECONDS = 1024 * 1024 * 1024;
 static constexpr ulong RDB_MAX_ROW_LOCKS = 1024 * 1024 * 1024;
 static constexpr ulong RDB_DEFAULT_ROW_LOCKS = 1024 * 1024;
 static constexpr ulong RDB_DEFAULT_BULK_LOAD_SIZE = 1000;
+static constexpr int RDB_DEFAULT_MAX_BACKGROUND_JOBS = 2;
+static constexpr ulong RDB_DEFAULT_BLOCK_SIZE = 0x4000;              // 16K
+static constexpr ulong RDB_DEFAULT_MAX_TOTAL_WAL_SIZE = 0x80000000;  // 2GB
+static constexpr ulong RDB_DEFAULT_TABLE_CACHE_NUMSHARDBITS = 6;
 static constexpr ulong RDB_MAX_BULK_LOAD_SIZE = 1024 * 1024 * 1024;
 static constexpr size_t RDB_DEFAULT_MERGE_BUF_SIZE = 64 * 1024 * 1024;
 static constexpr size_t RDB_MIN_MERGE_BUF_SIZE = 100;
@@ -502,18 +506,28 @@ static std::unique_ptr<rocksdb::DBOptions> rdb_init_rocksdb_db_options(void) {
   o->create_if_missing = true;
   o->listeners.push_back(std::make_shared<Rdb_event_listener>(&ddl_manager));
   o->info_log_level = rocksdb::InfoLogLevel::INFO_LEVEL;
+  o->max_background_jobs = RDB_DEFAULT_MAX_BACKGROUND_JOBS;
   o->max_subcompactions = DEFAULT_SUBCOMPACTIONS;
   o->max_open_files = -2;  // auto-tune to 50% open_files_limit
+  o->max_total_wal_size = RDB_DEFAULT_MAX_TOTAL_WAL_SIZE;
+  o->table_cache_numshardbits = RDB_DEFAULT_TABLE_CACHE_NUMSHARDBITS;
 
   o->two_write_queues = true;
   o->manual_wal_flush = true;
   return o;
 }
 
+static std::unique_ptr<rocksdb::BlockBasedTableOptions>
+rdb_init_rocksdb_tbl_options(void) {
+  auto o = std::unique_ptr<rocksdb::BlockBasedTableOptions>(
+      new rocksdb::BlockBasedTableOptions());
+  o->block_size = RDB_DEFAULT_BLOCK_SIZE;
+  return o;
+}
+
 /* DBOptions contains Statistics and needs to be destructed last */
 static std::unique_ptr<rocksdb::BlockBasedTableOptions> rocksdb_tbl_options =
-    std::unique_ptr<rocksdb::BlockBasedTableOptions>(
-        new rocksdb::BlockBasedTableOptions());
+    rdb_init_rocksdb_tbl_options();
 static std::unique_ptr<rocksdb::DBOptions> rocksdb_db_options =
     rdb_init_rocksdb_db_options();
 
@@ -1190,8 +1204,12 @@ static MYSQL_SYSVAR_BOOL(
 static MYSQL_SYSVAR_STR(default_cf_options, rocksdb_default_cf_options,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                         "default cf options for RocksDB", nullptr, nullptr,
-                        "compression=kLZ4Compression;"
-                        "bottommost_compression=kLZ4Compression");
+                        "block_based_table_factory={cache_index_and_filter_"
+                        "blocks=1;filter_policy=bloomfilter:10:false;whole_key_"
+                        "filtering=1};level_compaction_dynamic_level_bytes="
+                        "true;optimize_filters_for_hits=true;compaction_pri="
+                        "kMinOverlappingRatio;compression=kLZ4Compression;"
+                        "bottommost_compression=kLZ4Compression;");
 
 static MYSQL_SYSVAR_STR(override_cf_options, rocksdb_override_cf_options,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -64,7 +64,7 @@ ulong debug = 0;
 bool debug_pause_background_job_manager = false;
 #endif  // defined(TOKUDB_DEBUG) && TOKUDB_DEBUG
 bool directio = false;
-bool enable_partial_eviction = true;
+bool enable_partial_eviction = false;
 // file system reserve as a percentage of total disk space
 int fs_reserve_percent = 0;
 uint fsync_log_period = 0;
@@ -173,7 +173,7 @@ static void enable_partial_eviction_update(TOKUDB_UNUSED(THD *thd),
 
 static MYSQL_SYSVAR_BOOL(enable_partial_eviction, enable_partial_eviction, 0,
                          "enable partial node eviction", NULL,
-                         enable_partial_eviction_update, true);
+                         enable_partial_eviction_update, false);
 
 static MYSQL_SYSVAR_INT(fs_reserve_percent, fs_reserve_percent,
                         PLUGIN_VAR_READONLY,
@@ -280,7 +280,7 @@ static MYSQL_THDVAR_ULONGLONG(auto_analyze, 0,
                               30, 0, ~0U, 1);
 
 static MYSQL_THDVAR_UINT(block_size, 0, "fractal tree block size", NULL, NULL,
-                         4 << 20, 4096, ~0U, 1);
+                         1 << 18, 4096, ~0U, 1);
 
 static MYSQL_THDVAR_BOOL(bulk_fetch, PLUGIN_VAR_THDLOCAL, "enable bulk fetch",
                          NULL, NULL, true);
@@ -370,7 +370,7 @@ static MYSQL_THDVAR_BOOL(prelock_empty, 0, "prelock empty table", NULL, NULL,
                          true);
 
 static MYSQL_THDVAR_UINT(read_block_size, 0, "fractal tree read block size",
-                         NULL, NULL, 64 * 1024, 4096, ~0U, 1);
+                         NULL, NULL, 1 << 14, 4096, ~0U, 1);
 
 static MYSQL_THDVAR_UINT(read_buf_size, 0, "range query read buffer size", NULL,
                          NULL, 128 * 1024, 0, 1 * 1024 * 1024, 1);
@@ -389,7 +389,7 @@ static MYSQL_THDVAR_ENUM(
     "Specifies the compression method for a table created during this session. "
     "Possible values are TOKUDB_UNCOMPRESSED, TOKUDB_ZLIB, TOKUDB_SNAPPY, "
     "TOKUDB_QUICKLZ, TOKUDB_LZMA, TOKUDB_FAST, TOKUDB_SMALL and TOKUDB_DEFAULT",
-    NULL, NULL, SRV_ROW_FORMAT_ZLIB, &tokudb_row_format_typelib);
+    NULL, NULL, SRV_ROW_FORMAT_QUICKLZ, &tokudb_row_format_typelib);
 
 #if defined(TOKU_INCLUDE_RFR) && TOKU_INCLUDE_RFR
 static MYSQL_THDVAR_BOOL(rpl_check_readonly, PLUGIN_VAR_THDLOCAL,


### PR DESCRIPTION
- Changed default value of the rocksdb_default_cf_options to be :
        block_based_table_factory={
            cache_index_and_filter_blocks=1;
            filter_policy=bloomfilter:10:false;
            whole_key_filtering=1};
        level_compaction_dynamic_level_bytes=true;
        optimize_filters_for_hits=true;
        compaction_pri=kMinOverlappingRatio;
        compression=kLZ4Compression;
        bottommost_compression=kLZ4Compression;
- Changed default rocksdb_max_total_wal_size from rocksdb default(0) to be 2G
- Changed default rocksdb_block_size from rocksdb default(4K) to 16K
- Changed/enforced existing default of rocksdb_table_cache_numshardbits to
  current rocksdb default of 6
- Changed/enforced existing default of rocksdb_max_background_jobs to
  current rocksdb default of 2
- Changed default tokudb_enable_partial_eviction to be false.
- Changed default tokudb_block_size to be 512M.
- Changed default tokudb_read_block_size to be 16K.
- Changed default tokudb_row_format to be quicklz.
- Fixed and re-recorded tests impacted by above changes:
  - rocksdb.mysqldump2 - new block_size (4x bigger) changes value range of
    rocksdb status variable rocksdb_block_cache_add
  - rocksdb.index_merge_rocksdb - new block size changes optimizer conditions
    and causes different query plan within test for a specifically targeted
    EXPLAIN UPDATE.  Revert to old block size for this test.
  - rocksdb.compact_deletes - new block size changes WAL and SST metrics and
    causes different compaction behavior from what the test expects.  Revert
    to old block size for this test.
  - rocksdb.rocksdb - re-recorded new defaults.
  - rocksdb.block_size - re-recorded new defaults.
  - rocksdb.sys_vars.rocksdb_block_size_basic - re-recorded new defaults.
  - rocksdb.sys_vars.rocksdb_default_cf_options_basic - re-recorded new
    defaults.
  - rocksdb.sys_vars.rocksdb_max_total_wal_size_basic - re-recorded new
    defaults.
  - tokudb.bugs.simple_icp - new tree shapes produce slightly different metrics
    to optimizer which change some EXPLAIN results, re-recorded.