### PR TITLE
PS-4972 and PS-269: Fix "mysqldump --innodb-optimize-keys" (8.0)

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -232,8 +232,8 @@ collation_unordered_set<string> *ignore_table;
 
 static collation_unordered_set<std::string> *processed_compression_dictionaries;
 
-static std::list<std::string> *skipped_keys_list = nullptr;
-static std::list<std::string> *alter_constraints_list = nullptr;
+static std::list<std::string> skipped_keys_list;
+static std::list<std::string> alter_constraints_list;
 
 static struct my_option my_long_options[] = {
     {"all-databases", 'A',
@@ -2693,6 +2693,7 @@ static bool contains_autoinc_column(const char *autoinc_column,
 
   SYNOPSIS
   skip_secondary_keys()
+  table                     table name
   create_str                SHOW CREATE TABLE output
   has_pk                    TRUE, if the table has PRIMARY KEY
   (or UNIQUE key on non-nullable columns)
@@ -2706,16 +2707,30 @@ static bool contains_autoinc_column(const char *autoinc_column,
   alter_constraints_list and removes them from the input string.
 */
 
-static void skip_secondary_keys(char *create_str, bool has_pk) noexcept {
+static void skip_secondary_keys(const char *table, char *create_str,
+                                bool has_pk) noexcept {
   char *last_comma = nullptr;
   bool pk_processed = false;
   char *autoinc_column = nullptr;
   ssize_t autoinc_column_len = 0;
   bool keys_processed = false;
 
+  /* don't optimize tables with FOREIGN KEYS with REFERENCES to another table
+     as it leads to "Table 'ref' was not locked with LOCK TABLES" */
+  size_t table_len = strlen(table);
+  char *ptr = create_str;
+  while ((ptr = strstr(ptr, " REFERENCES `")) != nullptr) {
+    ptr += sizeof(" REFERENCES `") - 1;
+    const char *end = strchr(ptr, '`');
+    /* break as referenced table name is different from current table name */
+    if ((end == nullptr) || (end != ptr + table_len) ||
+        strncmp(ptr, table, table_len))
+      return;
+  }
+
   char *strend = create_str + strlen(create_str);
 
-  char *ptr = create_str;
+  ptr = create_str;
   while (*ptr && !keys_processed) {
     char *orig_ptr = ptr;
     /* Skip leading whitespace */
@@ -2759,9 +2774,9 @@ static void skip_secondary_keys(char *create_str, bool has_pk) noexcept {
           my_strndup(PSI_NOT_INSTRUMENTED, ptr, end - ptr + 1, MYF(MY_FAE));
 
       if (type == key_type_t::CONSTRAINT)
-        alter_constraints_list->emplace_front(data);
+        alter_constraints_list.emplace_back(data);
       else
-        skipped_keys_list->emplace_front(data);
+        skipped_keys_list.emplace_back(data);
 
       memmove(orig_ptr, tmp + 1, strend - tmp);
       ptr = orig_ptr;
@@ -3363,7 +3378,7 @@ static uint get_table_structure(char *table, char *db, char *table_type,
 
       const bool is_innodb_table = (strcmp(table_type, "InnoDB") == 0);
       if (opt_innodb_optimize_keys && is_innodb_table)
-        skip_secondary_keys(row[1], has_pk);
+        skip_secondary_keys(table, row[1], has_pk);
       if (is_innodb_table) {
         /*
           Search for compressed columns attributes and remove them if
@@ -4085,43 +4100,43 @@ static char *alloc_query_str(size_t size) {
 */
 
 static void dump_skipped_keys(const char *table) {
-  if (!skipped_keys_list && !alter_constraints_list) return;
+  if (skipped_keys_list.empty() && alter_constraints_list.empty()) return;
 
   verbose_msg("-- Dumping delayed secondary index definitions for table %s\n",
               table);
 
   uint keys;
 
-  if (skipped_keys_list) {
-    const auto sk_list_len = skipped_keys_list->size();
+  if (!skipped_keys_list.empty()) {
+    const auto sk_list_len = skipped_keys_list.size();
     fprintf(md_result_file, "ALTER TABLE %s%s", table,
             (sk_list_len > 1) ? "\n" : " ");
 
     for (keys = sk_list_len; keys > 0; keys--) {
-      const char *const def = skipped_keys_list->front().c_str();
+      const char *const def = skipped_keys_list.front().c_str();
 
       fprintf(md_result_file, "%sADD %s%s", (sk_list_len > 1) ? "  " : "", def,
               (keys > 1) ? ",\n" : ";\n");
 
-      skipped_keys_list->pop_front();
+      skipped_keys_list.pop_front();
     }
-    DBUG_ASSERT(skipped_keys_list->empty());
+    DBUG_ASSERT(skipped_keys_list.empty());
   }
 
-  if (alter_constraints_list) {
-    const auto ac_list_len = alter_constraints_list->size();
+  if (!alter_constraints_list.empty()) {
+    const auto ac_list_len = alter_constraints_list.size();
     fprintf(md_result_file, "ALTER TABLE %s%s", table,
             (ac_list_len > 1) ? "\n" : " ");
 
     for (keys = ac_list_len; keys > 0; keys--) {
-      const char *const def = alter_constraints_list->front().c_str();
+      const char *const def = alter_constraints_list.front().c_str();
 
       fprintf(md_result_file, "%sADD %s%s", (ac_list_len > 1) ? "  " : "", def,
               (keys > 1) ? ",\n" : ";\n");
 
-      alter_constraints_list->pop_front();
+      alter_constraints_list.pop_front();
     }
-    DBUG_ASSERT(alter_constraints_list->empty());
+    DBUG_ASSERT(alter_constraints_list.empty());
   }
 }
 

--- a/mysql-test/r/percona_mysqldump_innodb_optimize_keys.result
+++ b/mysql-test/r/percona_mysqldump_innodb_optimize_keys.result
@@ -7,7 +7,7 @@ CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY, b INT, KEY(b)) ENGINE=MyISAM;
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -25,13 +25,13 @@ CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY, b INT, KEY(b)) ENGINE=MyISAM;
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `a` int(11) NOT NULL,
   `b` int(11) DEFAULT NULL,
   PRIMARY KEY (`a`),
   KEY `b` (`b`)
-) ENGINE=MyISAM DEFAULT CHARSET=latin1;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t1` WRITE;
@@ -62,14 +62,14 @@ a INT, b VARCHAR(255), c DECIMAL(10,3),
 KEY (b),
 UNIQUE KEY uniq(c,a),
 FOREIGN KEY (a) REFERENCES t2(a) ON DELETE CASCADE
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 INSERT INTO t1(a,b,c) VALUES (0, "0", 0.0), (1, "1", 1.1), (2, "2", 2.2);
 ######################################
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -87,33 +87,32 @@ INSERT INTO t1(a,b,c) VALUES (0, "0", 0.0), (1, "1", 1.1), (2, "2", 2.2);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `a` int(11) DEFAULT NULL,
   `b` varchar(255) DEFAULT NULL,
   `c` decimal(10,3) DEFAULT NULL,
-  PRIMARY KEY (`id`) 
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uniq` (`c`,`a`),
+  KEY `b` (`b`),
+  KEY `a` (`a`),
+  CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`a`) REFERENCES `t2` (`a`) ON DELETE CASCADE
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t1` WRITE;
 /*!40000 ALTER TABLE `t1` DISABLE KEYS */;
 INSERT INTO `t1` VALUES (1,0,'0',0.000),(2,1,'1',1.100),(3,2,'2',2.200);
-ALTER TABLE `t1`
-  ADD UNIQUE KEY `uniq` (`c`,`a`),
-  ADD KEY `b` (`b`),
-  ADD KEY `a` (`a`);
-ALTER TABLE `t1` ADD CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`a`) REFERENCES `t2` (`a`) ON DELETE CASCADE;
 /*!40000 ALTER TABLE `t1` ENABLE KEYS */;
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t2`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t2` (
   `a` int(11) NOT NULL,
   PRIMARY KEY (`a`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t2` WRITE;
@@ -152,7 +151,7 @@ INSERT INTO t2 VALUES (), (), ();
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -170,11 +169,11 @@ INSERT INTO t2 VALUES (), (), ();
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   KEY `id` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t1` WRITE;
@@ -184,11 +183,11 @@ INSERT INTO `t1` VALUES (1),(2),(3);
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t2`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t2` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   UNIQUE KEY `id` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t2` WRITE;
@@ -261,7 +260,7 @@ INSERT INTO t4 SELECT * FROM t2;
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -279,11 +278,11 @@ INSERT INTO t4 SELECT * FROM t2;
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `a` int(11) NOT NULL,
   UNIQUE KEY `a` (`a`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t1` WRITE;
@@ -293,12 +292,12 @@ INSERT INTO `t1` VALUES (1),(2),(3);
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t2`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t2` (
   `a` int(11) NOT NULL,
   `b` int(11) NOT NULL,
   UNIQUE KEY `a` (`a`,`b`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t2` WRITE;
@@ -308,11 +307,11 @@ INSERT INTO `t2` VALUES (1,1),(2,2),(3,3);
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t3`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t3` (
   `a` int(11) DEFAULT NULL,
   `b` int(11) DEFAULT NULL 
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t3` WRITE;
@@ -323,12 +322,12 @@ ALTER TABLE `t3` ADD UNIQUE KEY `a` (`a`,`b`);
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t4`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t4` (
   `a` int(11) NOT NULL,
   `b` int(11) NOT NULL,
   PRIMARY KEY (`a`,`b`) 
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t4` WRITE;
@@ -370,7 +369,7 @@ INSERT INTO t2 VALUES (1, 1), (2, 2), (3, 3);
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -388,11 +387,11 @@ INSERT INTO t2 VALUES (1, 1), (2, 2), (3, 3);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t1` WRITE;
@@ -402,12 +401,12 @@ INSERT INTO `t1` VALUES (1),(2),(3);
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t2`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t2` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `a` int(11) NOT NULL,
   PRIMARY KEY (`id`) 
-) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t2` WRITE;
@@ -459,7 +458,7 @@ Warning	1831	Duplicate index 'k2' defined on the table 'test.t2'. This is deprec
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -477,14 +476,14 @@ Warning	1831	Duplicate index 'k2' defined on the table 'test.t2'. This is deprec
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `uid` int(11) NOT NULL,
   `id``` int(11) NOT NULL,
   ```id` int(11) NOT NULL,
   KEY `k3` (`id`,`uid`) 
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t1` WRITE;
@@ -497,11 +496,11 @@ ALTER TABLE `t1`
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t2`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t2` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`id`) 
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t2` WRITE;
@@ -534,7 +533,7 @@ INSERT INTO t1 VALUES (1, 1234);
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -552,12 +551,12 @@ INSERT INTO t1 VALUES (1, 1234);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL,
   `c` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`) 
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 ALTER TABLE `t1` ADD KEY `c` (`c`);
 /*!50112 SET @disable_bulk_load = IF (@is_rocksdb_supported, 'SET SESSION rocksdb_bulk_load = @old_rocksdb_bulk_load', 'SET @dummy_rocksdb_bulk_load = 0') */;
@@ -589,7 +588,7 @@ INSERT INTO t1(a) VALUES (1), (2), (3);
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -607,7 +606,7 @@ INSERT INTO t1(a) VALUES (1), (2), (3);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `a` int(11) NOT NULL,
@@ -652,7 +651,7 @@ INSERT INTO t1(`id`) VALUES (4);
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -670,7 +669,7 @@ INSERT INTO t1(`id`) VALUES (4);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL DEFAULT '0',
   `a` int(11) DEFAULT NULL,
@@ -706,7 +705,7 @@ CREATE TABLE `t1` (
 `c1` int(11) DEFAULT NULL,
 PRIMARY KEY (`id`),
 KEY `c1` (`c1`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
 /*!50100 PARTITION BY HASH (id)
 PARTITIONS 2*/;
 ######################################
@@ -714,7 +713,7 @@ PARTITIONS 2*/;
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -732,13 +731,13 @@ PARTITIONS 2*/;
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `c1` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`) 
-) ENGINE=InnoDB DEFAULT CHARSET=utf8
-/*!50100 PARTITION BY HASH (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+/*!50100 PARTITION BY HASH (`id`)
 PARTITIONS 2 */;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -777,7 +776,7 @@ INSERT INTO t1(`a`) VALUES (4);
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -795,7 +794,7 @@ INSERT INTO t1(`a`) VALUES (4);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) DEFAULT NULL,
   `a` int(11) DEFAULT NULL 
@@ -842,7 +841,7 @@ INSERT INTO t1(`id`) VALUES (4);
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -860,7 +859,7 @@ INSERT INTO t1(`id`) VALUES (4);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `id` int(11) NOT NULL DEFAULT '0',
   `a` int(11) DEFAULT NULL,
@@ -917,7 +916,7 @@ INSERT INTO t2(`prefix`) VALUES (13);
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
 /*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
-/*!40101 SET NAMES utf8 */;
+ SET NAMES utf8mb4 ;
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
@@ -935,13 +934,13 @@ INSERT INTO t2(`prefix`) VALUES (13);
 /*!50717 DEALLOCATE PREPARE s */;
 DROP TABLE IF EXISTS `t1`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t1` (
   `prefix` int(5) NOT NULL,
   `prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`prefix`),
   UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`)
-) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=5 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t1` WRITE;
@@ -951,13 +950,13 @@ INSERT INTO `t1` VALUES (1,1),(2,2),(3,3),(4,4);
 UNLOCK TABLES;
 DROP TABLE IF EXISTS `t2`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+ SET character_set_client = utf8mb4 ;
 CREATE TABLE `t2` (
   `prefix` int(5) NOT NULL,
   `prefix_autoinc` int(5) NOT NULL AUTO_INCREMENT,
   PRIMARY KEY (`prefix`),
   UNIQUE KEY `prefix_autoinc` (`prefix_autoinc`)
-) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `t2` WRITE;
@@ -981,3 +980,84 @@ UNLOCK TABLES;
 
 ######################################
 DROP TABLE t1, t2;
+CREATE TABLE t11 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t11 VALUES (0), (1), (2);
+CREATE TABLE t1 (
+id INT NOT NULL PRIMARY KEY,
+fk1 INT NOT NULL,
+fk2 INT,
+FOREIGN KEY (fk1) REFERENCES t1(id),
+FOREIGN KEY (fk2) REFERENCES t11(a) ON DELETE CASCADE
+) ENGINE=InnoDB;
+INSERT INTO t1(id,fk1,fk2) VALUES (0, 0, 1), (1, 1, 2), (2, 2, 0);
+######################################
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+ SET NAMES utf8mb4 ;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+/*!50717 SELECT COUNT(*) INTO @rocksdb_has_p_s_session_variables FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'performance_schema' AND TABLE_NAME = 'session_variables' */;
+/*!50717 SET @rocksdb_get_is_supported = IF (@rocksdb_has_p_s_session_variables, 'SELECT COUNT(*) INTO @rocksdb_is_supported FROM performance_schema.session_variables WHERE VARIABLE_NAME=\'rocksdb_bulk_load\'', 'SELECT 0') */;
+/*!50717 PREPARE s FROM @rocksdb_get_is_supported */;
+/*!50717 EXECUTE s */;
+/*!50717 DEALLOCATE PREPARE s */;
+/*!50717 SET @rocksdb_enable_bulk_load = IF (@rocksdb_is_supported, 'SET SESSION rocksdb_bulk_load = 1', 'SET @rocksdb_dummy_bulk_load = 0') */;
+/*!50717 PREPARE s FROM @rocksdb_enable_bulk_load */;
+/*!50717 EXECUTE s */;
+/*!50717 DEALLOCATE PREPARE s */;
+DROP TABLE IF EXISTS `t1`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+ SET character_set_client = utf8mb4 ;
+CREATE TABLE `t1` (
+  `id` int(11) NOT NULL,
+  `fk1` int(11) NOT NULL,
+  `fk2` int(11) DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `fk1` (`fk1`),
+  KEY `fk2` (`fk2`),
+  CONSTRAINT `t1_ibfk_1` FOREIGN KEY (`fk1`) REFERENCES `t1` (`id`),
+  CONSTRAINT `t1_ibfk_2` FOREIGN KEY (`fk2`) REFERENCES `t11` (`a`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+LOCK TABLES `t1` WRITE;
+/*!40000 ALTER TABLE `t1` DISABLE KEYS */;
+INSERT INTO `t1` VALUES (0,0,1),(1,1,2),(2,2,0);
+/*!40000 ALTER TABLE `t1` ENABLE KEYS */;
+UNLOCK TABLES;
+DROP TABLE IF EXISTS `t11`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+ SET character_set_client = utf8mb4 ;
+CREATE TABLE `t11` (
+  `a` int(11) NOT NULL,
+  PRIMARY KEY (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+LOCK TABLES `t11` WRITE;
+/*!40000 ALTER TABLE `t11` DISABLE KEYS */;
+INSERT INTO `t11` VALUES (0),(1),(2);
+/*!40000 ALTER TABLE `t11` ENABLE KEYS */;
+UNLOCK TABLES;
+/*!50112 SET @disable_bulk_load = IF (@is_rocksdb_supported, 'SET SESSION rocksdb_bulk_load = @old_rocksdb_bulk_load', 'SET @dummy_rocksdb_bulk_load = 0') */;
+/*!50112 PREPARE s FROM @disable_bulk_load */;
+/*!50112 EXECUTE s */;
+/*!50112 DEALLOCATE PREPARE s */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+######################################
+DROP TABLE t1, t11;

--- a/mysql-test/t/percona_mysqldump_innodb_optimize_keys.test
+++ b/mysql-test/t/percona_mysqldump_innodb_optimize_keys.test
@@ -35,7 +35,7 @@ CREATE TABLE t1 (
   KEY (b),
   UNIQUE KEY uniq(c,a),
   FOREIGN KEY (a) REFERENCES t2(a) ON DELETE CASCADE
-) ENGINE=InnoDB;
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 INSERT INTO t1(a,b,c) VALUES (0, "0", 0.0), (1, "1", 1.1), (2, "2", 2.2);
 
@@ -309,7 +309,7 @@ CREATE TABLE `t1` (
    `c1` int(11) DEFAULT NULL,
    PRIMARY KEY (`id`),
    KEY `c1` (`c1`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
 /*!50100 PARTITION BY HASH (id)
 PARTITIONS 2*/;
 
@@ -427,6 +427,39 @@ INSERT INTO t2(`prefix`) VALUES (13);
 --remove_file $file
 
 DROP TABLE t1, t2;
+
+#############################################################################
+# Check optimization with FOREIGN KEYs with different table names
+# (t11 is chosen deliberately as t1 is a prefix of t11)
+#############################################################################
+
+CREATE TABLE t11 (a INT PRIMARY KEY) ENGINE=InnoDB;
+INSERT INTO t11 VALUES (0), (1), (2);
+
+CREATE TABLE t1 (
+  id INT NOT NULL PRIMARY KEY,
+  fk1 INT NOT NULL,
+  fk2 INT,
+  FOREIGN KEY (fk1) REFERENCES t1(id),
+  FOREIGN KEY (fk2) REFERENCES t11(a) ON DELETE CASCADE
+) ENGINE=InnoDB;
+
+INSERT INTO t1(id,fk1,fk2) VALUES (0, 0, 1), (1, 1, 2), (2, 2, 0);
+
+
+--exec $MYSQL_DUMP --skip-comments --innodb-optimize-keys test t1 t11 >$file
+
+--echo ######################################
+--cat_file $file
+--echo ######################################
+
+# Check that the resulting dump can be imported back
+
+--exec $MYSQL test < $file
+
+--remove_file $file
+
+DROP TABLE t1, t11;
 
 
 # Wait till we reached the initial number of concurrent sessions


### PR DESCRIPTION
1. Fix SEGFAULT related to using `static std::list<std::string>* skipped_keys_list` as nullptr
2. Don't optimize tables with `FOREIGN KEYS` with `REFERENCES` to another table
3. Check optimization with FOREIGN KEYs with different table names in `main.percona_mysqldump_innodb_optimize_keys`
4. Re-record `main.percona_mysqldump_innodb_optimize_keys`