### PR TITLE
PS-269: Revert Oracle's fix for fulltext search (8.0)

### DIFF
--- a/mysql-test/include/percona_ft_query_extra_word_chars.inc
+++ b/mysql-test/include/percona_ft_query_extra_word_chars.inc
@@ -12,7 +12,7 @@ if ($ft_query_extra_word_chars == 'setup')
   --echo # Setup ft_query_extra_word_chars testing
   --echo #
 
-  SET NAMES utf8;
+  SET NAMES utf8mb4;
 
   CREATE TABLE words(id INT PRIMARY KEY AUTO_INCREMENT,
                      a TEXT COLLATE utf8mb4_bin);

--- a/mysql-test/suite/innodb_fts/include/ngram.inc
+++ b/mysql-test/suite/innodb_fts/include/ngram.inc
@@ -66,7 +66,7 @@ SELECT * FROM articles_1 WHERE
 SELECT * FROM articles_1 WHERE
 	MATCH(title_varchar) AGAINST('nd');
 SELECT * FROM articles_1 WHERE
-	MATCH(title_varchar) AGAINST('50');
+	MATCH(title_varchar) AGAINST('0,');
 SELECT * FROM articles_1 WHERE
 	MATCH(title_text) AGAINST('se');
 SELECT * FROM articles_1 WHERE
@@ -201,7 +201,7 @@ SHOW CREATE TABLE articles;
 
 # natural language search
 SELECT * FROM articles WHERE
-	MATCH(c1) AGAINST('救命');
+	MATCH(c1) AGAINST('啊! ');
 SELECT * FROM articles WHERE
 	MATCH(c2) AGAINST('我幾');
 
@@ -258,7 +258,7 @@ SELECT * FROM articles WHERE
         MATCH(j3) AGAINST(">の長" IN BOOLEAN MODE);
 
 SELECT * FROM articles WHERE
-        MATCH(k2) AGAINST('-Ch +해요');
+        MATCH(k2) AGAINST('-Ch +요*');
 
 SELECT * FROM articles WHERE
         MATCH(e1) AGAINST("row1 -row" IN BOOLEAN MODE) ;
@@ -266,7 +266,7 @@ SELECT * FROM articles WHERE
 
 # Query expansion mode
 SELECT * FROM articles WHERE
-        MATCH(c1) AGAINST('命啊' WITH QUERY EXPANSION);
+        MATCH(c1) AGAINST('啊! ' WITH QUERY EXPANSION);
 SELECT * FROM articles WHERE
         MATCH(j2) AGAINST('やっそう' WITH QUERY EXPANSION);
 SELECT * FROM articles WHERE
@@ -299,7 +299,7 @@ SELECT COUNT(*) FROM articles t1,articles t2
         WHERE MATCH(t2.j1,t2.j3) AGAINST("右さ +の長" IN BOOLEAN MODE)
         AND t1.seq = t2.seq ;
 SELECT COUNT(*) FROM articles t1,articles t2
-        WHERE MATCH(t1.c1) AGAINST("命啊")
+        WHERE MATCH(t1.c1) AGAINST("啊! ")
         AND t1.seq != t2.seq
         AND MATCH(t2.k2) AGAINST("국말" IN BOOLEAN MODE) ;
 SELECT COUNT(*) FROM articles t1,articles t2
@@ -331,7 +331,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con7 (j3) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con9 (e1) WITH PARSER ngram;
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 SELECT * FROM 名字 WHERE
         MATCH(さようなら,j3) AGAINST('やっ');
 SELECT * FROM 名字 WHERE
@@ -389,7 +389,7 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
    ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 SELECT * FROM 名字 WHERE
         MATCH(さようなら,j3) AGAINST('やっ');
 SELECT * FROM 名字 WHERE
@@ -415,7 +415,7 @@ ANALYZE TABLE 名字;
 -- enable_result_log
 
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 SELECT * FROM 名字 WHERE
         MATCH(さようなら,j3) AGAINST('やっ');
 SELECT * FROM 名字 WHERE
@@ -446,7 +446,7 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
    ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 SELECT * FROM 名字 WHERE
         MATCH(さようなら,j3) AGAINST('やっ');
 SELECT * FROM 名字 WHERE
@@ -507,7 +507,7 @@ ANALYZE TABLE 名字;
 -- enable_result_log
 
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 SELECT * FROM 名字 WHERE
         MATCH(さようなら,j3) AGAINST('やっ');
 SELECT * FROM 名字 WHERE
@@ -561,7 +561,7 @@ ANALYZE TABLE 名字;
 -- enable_result_log
 
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 SELECT * FROM 名字 WHERE
         MATCH(さようなら,j3) AGAINST('やっ');
 SELECT * FROM 名字 WHERE
@@ -608,10 +608,10 @@ ANALYZE TABLE 名字;
 -- enable_result_log
 
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 UPDATE 名字 SET c1 = '你好嗎?' WHERE MATCH(c2) AGAINST('啊!');
 SELECT * FROM 名字 WHERE
-        MATCH(c1) AGAINST('命啊');
+        MATCH(c1) AGAINST('啊! ');
 DELETE FROM 名字 WHERE
         MATCH(さようなら,j3) AGAINST("てみ -雨が" IN BOOLEAN MODE);
 SELECT * FROM 名字 WHERE

--- a/mysql-test/suite/innodb_fts/r/ngram_1.result
+++ b/mysql-test/suite/innodb_fts/r/ngram_1.result
@@ -93,7 +93,7 @@ seq	title_char	title_varchar	title_text
 3	English arose in the Anglo-Saxon kingdoms	its from of England and what is now southeast Scotland	Following the extensive influence of Great Britain and the United Kingdom
 1	English is a West Germanic language	It was first spoken in early medieval England	most widely used language in the world
 SELECT * FROM articles_1 WHERE
-MATCH(title_varchar) AGAINST('50');
+MATCH(title_varchar) AGAINST('0,');
 seq	title_char	title_varchar	title_text
 7	spread across states by  United Kingdom ~ England army	The Oxford English Dictionary liSts over 250,000 distinct words+	it became the dominant language in the United States, Canada, Australia and New Zealand
 SELECT * FROM articles_1 WHERE
@@ -462,7 +462,7 @@ articles	CREATE TABLE `articles` (
   FULLTEXT KEY `con9` (`e1`) /*!50100 WITH PARSER `ngram` */ 
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('救命');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -536,14 +536,14 @@ SELECT * FROM articles WHERE
 MATCH(j3) AGAINST(">の長" IN BOOLEAN MODE);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(k2) AGAINST('-Ch +해요');
+MATCH(k2) AGAINST('-Ch +요*');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 2	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row row1 value
 SELECT * FROM articles WHERE
 MATCH(e1) AGAINST("row1 -row" IN BOOLEAN MODE) ;
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('命啊' WITH QUERY EXPANSION);
+MATCH(c1) AGAINST('啊! ' WITH QUERY EXPANSION);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -586,7 +586,7 @@ AND t1.seq = t2.seq ;
 COUNT(*)
 1
 SELECT COUNT(*) FROM articles t1,articles t2
-WHERE MATCH(t1.c1) AGAINST("命啊")
+WHERE MATCH(t1.c1) AGAINST("啊! ")
 AND t1.seq != t2.seq
 AND MATCH(t2.k2) AGAINST("국말" IN BOOLEAN MODE) ;
 COUNT(*)
@@ -621,7 +621,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con7 (j3) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con9 (e1) WITH PARSER ngram;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -854,7 +854,7 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('你好嗎?','我幾好，你呢','好耐冇見','左右','左右される','☆右折⇔左折','제 이름은 Charles입니다.','운동을 좋아해요*','row value'),
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -886,7 +886,7 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -933,7 +933,7 @@ SAVEPOINT B;
 INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -1011,7 +1011,7 @@ ROLLBACK;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -1129,7 +1129,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -1201,14 +1201,13 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 UPDATE 名字 SET c1 = '你好嗎?' WHERE MATCH(c2) AGAINST('啊!');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST("てみ -雨が" IN BOOLEAN MODE);
 SELECT * FROM 名字 WHERE
@@ -1217,12 +1216,12 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字;
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 SELECT * FROM 名字;
@@ -1323,7 +1322,7 @@ seq	title_char	title_varchar	title_text
 3	English arose in the Anglo-Saxon kingdoms	its from of England and what is now southeast Scotland	Following the extensive influence of Great Britain and the United Kingdom
 1	English is a West Germanic language	It was first spoken in early medieval England	most widely used language in the world
 SELECT * FROM articles_1 WHERE
-MATCH(title_varchar) AGAINST('50');
+MATCH(title_varchar) AGAINST('0,');
 seq	title_char	title_varchar	title_text
 7	spread across states by  United Kingdom ~ England army	The Oxford English Dictionary liSts over 250,000 distinct words+	it became the dominant language in the United States, Canada, Australia and New Zealand
 SELECT * FROM articles_1 WHERE
@@ -1692,7 +1691,7 @@ articles	CREATE TABLE `articles` (
   FULLTEXT KEY `con9` (`e1`) /*!50100 WITH PARSER `ngram` */ 
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPACT
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('救命');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -1766,14 +1765,14 @@ SELECT * FROM articles WHERE
 MATCH(j3) AGAINST(">の長" IN BOOLEAN MODE);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(k2) AGAINST('-Ch +해요');
+MATCH(k2) AGAINST('-Ch +요*');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 2	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row row1 value
 SELECT * FROM articles WHERE
 MATCH(e1) AGAINST("row1 -row" IN BOOLEAN MODE) ;
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('命啊' WITH QUERY EXPANSION);
+MATCH(c1) AGAINST('啊! ' WITH QUERY EXPANSION);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -1816,7 +1815,7 @@ AND t1.seq = t2.seq ;
 COUNT(*)
 1
 SELECT COUNT(*) FROM articles t1,articles t2
-WHERE MATCH(t1.c1) AGAINST("命啊")
+WHERE MATCH(t1.c1) AGAINST("啊! ")
 AND t1.seq != t2.seq
 AND MATCH(t2.k2) AGAINST("국말" IN BOOLEAN MODE) ;
 COUNT(*)
@@ -1851,7 +1850,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con7 (j3) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con9 (e1) WITH PARSER ngram;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -2084,7 +2083,7 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('你好嗎?','我幾好，你呢','好耐冇見','左右','左右される','☆右折⇔左折','제 이름은 Charles입니다.','운동을 좋아해요*','row value'),
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -2116,7 +2115,7 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -2163,7 +2162,7 @@ SAVEPOINT B;
 INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -2241,7 +2240,7 @@ ROLLBACK;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -2359,7 +2358,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -2431,14 +2430,13 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 UPDATE 名字 SET c1 = '你好嗎?' WHERE MATCH(c2) AGAINST('啊!');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST("てみ -雨が" IN BOOLEAN MODE);
 SELECT * FROM 名字 WHERE
@@ -2447,12 +2445,12 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字;
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 SELECT * FROM 名字;
@@ -2553,7 +2551,7 @@ seq	title_char	title_varchar	title_text
 3	English arose in the Anglo-Saxon kingdoms	its from of England and what is now southeast Scotland	Following the extensive influence of Great Britain and the United Kingdom
 1	English is a West Germanic language	It was first spoken in early medieval England	most widely used language in the world
 SELECT * FROM articles_1 WHERE
-MATCH(title_varchar) AGAINST('50');
+MATCH(title_varchar) AGAINST('0,');
 seq	title_char	title_varchar	title_text
 7	spread across states by  United Kingdom ~ England army	The Oxford English Dictionary liSts over 250,000 distinct words+	it became the dominant language in the United States, Canada, Australia and New Zealand
 SELECT * FROM articles_1 WHERE
@@ -2922,7 +2920,7 @@ articles	CREATE TABLE `articles` (
   FULLTEXT KEY `con9` (`e1`) /*!50100 WITH PARSER `ngram` */ 
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=REDUNDANT
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('救命');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -2996,14 +2994,14 @@ SELECT * FROM articles WHERE
 MATCH(j3) AGAINST(">の長" IN BOOLEAN MODE);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(k2) AGAINST('-Ch +해요');
+MATCH(k2) AGAINST('-Ch +요*');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 2	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row row1 value
 SELECT * FROM articles WHERE
 MATCH(e1) AGAINST("row1 -row" IN BOOLEAN MODE) ;
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('命啊' WITH QUERY EXPANSION);
+MATCH(c1) AGAINST('啊! ' WITH QUERY EXPANSION);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -3046,7 +3044,7 @@ AND t1.seq = t2.seq ;
 COUNT(*)
 1
 SELECT COUNT(*) FROM articles t1,articles t2
-WHERE MATCH(t1.c1) AGAINST("命啊")
+WHERE MATCH(t1.c1) AGAINST("啊! ")
 AND t1.seq != t2.seq
 AND MATCH(t2.k2) AGAINST("국말" IN BOOLEAN MODE) ;
 COUNT(*)
@@ -3081,7 +3079,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con7 (j3) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con9 (e1) WITH PARSER ngram;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -3314,7 +3312,7 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('你好嗎?','我幾好，你呢','好耐冇見','左右','左右される','☆右折⇔左折','제 이름은 Charles입니다.','운동을 좋아해요*','row value'),
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -3346,7 +3344,7 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -3393,7 +3391,7 @@ SAVEPOINT B;
 INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -3471,7 +3469,7 @@ ROLLBACK;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -3589,7 +3587,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -3661,14 +3659,13 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 UPDATE 名字 SET c1 = '你好嗎?' WHERE MATCH(c2) AGAINST('啊!');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST("てみ -雨が" IN BOOLEAN MODE);
 SELECT * FROM 名字 WHERE
@@ -3677,12 +3674,12 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字;
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 SELECT * FROM 名字;
@@ -3783,7 +3780,7 @@ seq	title_char	title_varchar	title_text
 3	English arose in the Anglo-Saxon kingdoms	its from of England and what is now southeast Scotland	Following the extensive influence of Great Britain and the United Kingdom
 1	English is a West Germanic language	It was first spoken in early medieval England	most widely used language in the world
 SELECT * FROM articles_1 WHERE
-MATCH(title_varchar) AGAINST('50');
+MATCH(title_varchar) AGAINST('0,');
 seq	title_char	title_varchar	title_text
 7	spread across states by  United Kingdom ~ England army	The Oxford English Dictionary liSts over 250,000 distinct words+	it became the dominant language in the United States, Canada, Australia and New Zealand
 SELECT * FROM articles_1 WHERE
@@ -4152,7 +4149,7 @@ articles	CREATE TABLE `articles` (
   FULLTEXT KEY `con9` (`e1`) /*!50100 WITH PARSER `ngram` */ 
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=DYNAMIC
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('救命');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -4226,14 +4223,14 @@ SELECT * FROM articles WHERE
 MATCH(j3) AGAINST(">の長" IN BOOLEAN MODE);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(k2) AGAINST('-Ch +해요');
+MATCH(k2) AGAINST('-Ch +요*');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 2	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row row1 value
 SELECT * FROM articles WHERE
 MATCH(e1) AGAINST("row1 -row" IN BOOLEAN MODE) ;
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('命啊' WITH QUERY EXPANSION);
+MATCH(c1) AGAINST('啊! ' WITH QUERY EXPANSION);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -4276,7 +4273,7 @@ AND t1.seq = t2.seq ;
 COUNT(*)
 1
 SELECT COUNT(*) FROM articles t1,articles t2
-WHERE MATCH(t1.c1) AGAINST("命啊")
+WHERE MATCH(t1.c1) AGAINST("啊! ")
 AND t1.seq != t2.seq
 AND MATCH(t2.k2) AGAINST("국말" IN BOOLEAN MODE) ;
 COUNT(*)
@@ -4311,7 +4308,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con7 (j3) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con9 (e1) WITH PARSER ngram;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -4544,7 +4541,7 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('你好嗎?','我幾好，你呢','好耐冇見','左右','左右される','☆右折⇔左折','제 이름은 Charles입니다.','운동을 좋아해요*','row value'),
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -4576,7 +4573,7 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -4623,7 +4620,7 @@ SAVEPOINT B;
 INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -4701,7 +4698,7 @@ ROLLBACK;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -4819,7 +4816,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -4891,14 +4888,13 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 UPDATE 名字 SET c1 = '你好嗎?' WHERE MATCH(c2) AGAINST('啊!');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST("てみ -雨が" IN BOOLEAN MODE);
 SELECT * FROM 名字 WHERE
@@ -4907,12 +4903,12 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字;
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 SELECT * FROM 名字;
@@ -5013,7 +5009,7 @@ seq	title_char	title_varchar	title_text
 3	English arose in the Anglo-Saxon kingdoms	its from of England and what is now southeast Scotland	Following the extensive influence of Great Britain and the United Kingdom
 1	English is a West Germanic language	It was first spoken in early medieval England	most widely used language in the world
 SELECT * FROM articles_1 WHERE
-MATCH(title_varchar) AGAINST('50');
+MATCH(title_varchar) AGAINST('0,');
 seq	title_char	title_varchar	title_text
 7	spread across states by  United Kingdom ~ England army	The Oxford English Dictionary liSts over 250,000 distinct words+	it became the dominant language in the United States, Canada, Australia and New Zealand
 SELECT * FROM articles_1 WHERE
@@ -5382,7 +5378,7 @@ articles	CREATE TABLE `articles` (
   FULLTEXT KEY `con9` (`e1`) /*!50100 WITH PARSER `ngram` */ 
 ) ENGINE=InnoDB AUTO_INCREMENT=4 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPRESSED
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('救命');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -5456,14 +5452,14 @@ SELECT * FROM articles WHERE
 MATCH(j3) AGAINST(">の長" IN BOOLEAN MODE);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(k2) AGAINST('-Ch +해요');
+MATCH(k2) AGAINST('-Ch +요*');
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 2	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row row1 value
 SELECT * FROM articles WHERE
 MATCH(e1) AGAINST("row1 -row" IN BOOLEAN MODE) ;
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 SELECT * FROM articles WHERE
-MATCH(c1) AGAINST('命啊' WITH QUERY EXPANSION);
+MATCH(c1) AGAINST('啊! ' WITH QUERY EXPANSION);
 seq	c1	c2	c3	j1	j2	j3	k1	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM articles WHERE
@@ -5506,7 +5502,7 @@ AND t1.seq = t2.seq ;
 COUNT(*)
 1
 SELECT COUNT(*) FROM articles t1,articles t2
-WHERE MATCH(t1.c1) AGAINST("命啊")
+WHERE MATCH(t1.c1) AGAINST("啊! ")
 AND t1.seq != t2.seq
 AND MATCH(t2.k2) AGAINST("국말" IN BOOLEAN MODE) ;
 COUNT(*)
@@ -5541,7 +5537,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con7 (j3) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 ALTER TABLE 名字 ADD FULLTEXT INDEX con9 (e1) WITH PARSER ngram;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 3	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -5774,7 +5770,7 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('你好嗎?','我幾好，你呢','好耐冇見','左右','左右される','☆右折⇔左折','제 이름은 Charles입니다.','운동을 좋아해요*','row value'),
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -5806,7 +5802,7 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -5853,7 +5849,7 @@ SAVEPOINT B;
 INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -5931,7 +5927,7 @@ ROLLBACK;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST('やっ');
@@ -6049,7 +6045,7 @@ ALTER TABLE 名字 ADD FULLTEXT INDEX con8 (행운을빈다) WITH PARSER ngram;
 COMMIT;
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
@@ -6121,14 +6117,13 @@ INSERT INTO 名字 (c1,c2,c3,さようなら,j2,j3,행운을빈다,k2,e1) VALUES
 ('救命啊!','火啊! 你好','生日快樂 ','雨季','雨が降りそう つやってみよう','雨雲','저분은 영어를 잘 합니다','저는 서울에서 살고 있습니다.','recording test');
 ANALYZE TABLE 名字;
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 UPDATE 名字 SET c1 = '你好嗎?' WHERE MATCH(c2) AGAINST('啊!');
 SELECT * FROM 名字 WHERE
-MATCH(c1) AGAINST('命啊');
+MATCH(c1) AGAINST('啊! ');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH(さようなら,j3) AGAINST("てみ -雨が" IN BOOLEAN MODE);
 SELECT * FROM 名字 WHERE
@@ -6137,12 +6132,12 @@ seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 SELECT * FROM 名字;
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 SELECT * FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 seq	c1	c2	c3	さようなら	j2	j3	행운을빈다	k2	e1
 0	你好嗎?	我幾好，你呢	好耐冇見	左右	左右される	☆右折⇔左折	제 이름은 Charles입니다.	운동을 좋아해요*	row value
-0	救命啊!	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
+0	你好嗎?	火啊! 你好	生日快樂	雨季	雨が降りそう つやってみよう	雨雲	저분은 영어를 잘 합니다	저는 서울에서 살고 있습니다.	recording test
 DELETE FROM 名字 WHERE
 MATCH (행운을빈다) AGAINST('니다');
 SELECT * FROM 名字;
@@ -6162,11 +6157,14 @@ INSERT INTO ft_test3 VALUES (1, 'xy,yz');
 SELECT * FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY position;
 WORD	FIRST_DOC_ID	LAST_DOC_ID	DOC_COUNT	DOC_ID	POSITION
 xy	2	2	1	2	0
+y,	2	2	1	2	1
+,y	2	2	1	2	2
 yz	2	2	1	2	3
 SELECT * FROM ft_test3 WHERE MATCH(contents) AGAINST('y,' IN BOOLEAN MODE);
 id	contents
 SELECT * FROM ft_test3 WHERE MATCH(contents) AGAINST('y,' IN NATURAl LANGUAGE MODE);
 id	contents
+1	xy,yz
 SET GLOBAL innodb_ft_enable_stopword = ON;
 SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
 DROP TABLE ft_test3;

--- a/mysql-test/suite/innodb_fts/r/percona_ft_query_extra_word_chars.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_query_extra_word_chars.result
@@ -1,7 +1,7 @@
 #
 # Setup ft_query_extra_word_chars testing
 #
-SET NAMES utf8;
+SET NAMES utf8mb4;
 CREATE TABLE words(id INT PRIMARY KEY AUTO_INCREMENT,
 a TEXT COLLATE utf8mb4_bin);
 INSERT INTO words (a) VALUES ('abcdef');

--- a/plugin/fulltext/ngram_parser/plugin_ngram.cc
+++ b/plugin/fulltext/ngram_parser/plugin_ngram.cc
@@ -42,7 +42,6 @@ static int ngram_token_size;
 @retval	0	on success
 @retval	1	on failure. */
 static int ngram_parse(MYSQL_FTPARSER_PARAM *param, const char *doc, int len,
-                       bool extra_word_chars,
                        MYSQL_FTPARSER_BOOLEAN_INFO *bool_info) {
   const CHARSET_INFO *cs = param->cs;
   char *start;
@@ -67,12 +66,8 @@ static int ngram_parse(MYSQL_FTPARSER_PARAM *param, const char *doc, int len,
     if (next + char_len > end || char_len == 0) {
       break;
     } else {
-      /* Skip SPACE or ","/"." etc as they are not words*/
-      int ctype;
-      cs->cset->ctype(cs, &ctype, (uchar *)next, (uchar *)end);
-
-      if (char_len == 1 &&
-          (*next == ' ' || !true_word_char(ctype, extra_word_chars, *next))) {
+      /* Skip SPACE */
+      if (char_len == 1 && *next == ' ') {
         start = next + 1;
         next = start;
         n_chars = 0;
@@ -151,8 +146,7 @@ static int ngram_get_token_size(const CHARSET_INFO *cs, const char *token,
 @retval	0	on success
 @retval	1	on failure. */
 static int ngram_term_convert(MYSQL_FTPARSER_PARAM *param, const char *token,
-                              int len, bool extra_word_chars,
-                              MYSQL_FTPARSER_BOOLEAN_INFO *bool_info) {
+                              int len, MYSQL_FTPARSER_BOOLEAN_INFO *bool_info) {
   MYSQL_FTPARSER_BOOLEAN_INFO token_info = {FT_TOKEN_WORD, 0, 0, 0, 0, 0,
                                             ' ',           0};
   const CHARSET_INFO *cs = param->cs;
@@ -180,7 +174,7 @@ static int ngram_term_convert(MYSQL_FTPARSER_PARAM *param, const char *token,
     ret = param->mysql_add_word(param, NULL, 0, bool_info);
     RETURN_IF_ERROR(ret);
 
-    ret = ngram_parse(param, token, len, extra_word_chars, &token_info);
+    ret = ngram_parse(param, token, len, &token_info);
     RETURN_IF_ERROR(ret);
 
     bool_info->type = FT_TOKEN_RIGHT_PAREN;
@@ -210,8 +204,7 @@ static int ngram_parser_parse(MYSQL_FTPARSER_PARAM *param) {
   switch (param->mode) {
     case MYSQL_FTPARSER_SIMPLE_MODE:
     case MYSQL_FTPARSER_WITH_STOPWORDS:
-      ret = ngram_parse(param, param->doc, param->length, extra_word_chars,
-                        &bool_info);
+      ret = ngram_parse(param, param->doc, param->length, &bool_info);
 
       break;
 
@@ -225,11 +218,11 @@ static int ngram_parser_parse(MYSQL_FTPARSER_PARAM *param) {
           if (bool_info.quot != NULL) {
             /* Phrase search */
             ret = ngram_parse(param, reinterpret_cast<char *>(word.pos),
-                              word.len, extra_word_chars, &bool_info);
+                              word.len, &bool_info);
           } else {
             /* Term serach */
             ret = ngram_term_convert(param, reinterpret_cast<char *>(word.pos),
-                                     word.len, extra_word_chars, &bool_info);
+                                     word.len, &bool_info);
             DBUG_ASSERT(bool_info.quot == NULL);
             DBUG_ASSERT(bool_info.type == FT_TOKEN_WORD);
           }


### PR DESCRIPTION
Reverted Oracle's fix for the Bug #25873310
"FULLTEXT SEARCH CAN NOT FIND WORD WHICH CONTAINS ',' OR '.'"
(commit https://github.com/mysql/mysql-server/commit/c1a5784)
as it does not allow special characters to be indexed by NGRAM
FTS parser any more which makes Percona-specific variable
'ft_query_extra_word_chars' introduced
in the fix for PS-2501
"LP #1689268: Fulltext search can not find word which contains punctuation marks"
(https://jira.percona.com/browse/PS-2501)
(commit https://github.com/percona/percona-server/commit/b7cb587ac422f1003f3fda43ba91d32910fdc8a4)
completely useless.

Changes in `innodb_fts/include/ngram.inc` were also reverted.
`innodb_fts/t/ngram_1.test` was not reverted.
`innodb_fts/r/ngram_1.result` was re-recorded as `ngram.inc` was changed.