### PR TITLE
PS-269 (Initial Percona Server 8.0.12 tree)

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_create_checkpoint_basic.test
+++ b/mysql-test/suite/rocksdb.sys_vars/t/rocksdb_create_checkpoint_basic.test
@@ -25,5 +25,5 @@
 --eval SET @@global.ROCKSDB_CREATE_CHECKPOINT = @start_value
 
 # clean up
---exec rm -r $MYSQL_TMP_DIR/abc
---exec rm -r $MYSQL_TMP_DIR/def
+--force-rmdir $MYSQL_TMP_DIR/abc
+--force-rmdir $MYSQL_TMP_DIR/def

--- a/mysql-test/suite/rocksdb/include/set_checkpoint.inc
+++ b/mysql-test/suite/rocksdb/include/set_checkpoint.inc
@@ -14,7 +14,7 @@ if ($succeeds)
   --exec ls $checkpoint/CURRENT | sed s/.*CURRENT/CURRENT/g
 
   # Cleanup
-  --exec rm -rf $checkpoint
+  --force-rmdir $checkpoint
 }
 if (!$succeeds)
 {

--- a/mysql-test/suite/rocksdb/t/allow_to_start_after_corruption.test
+++ b/mysql-test/suite/rocksdb/t/allow_to_start_after_corruption.test
@@ -66,7 +66,7 @@ select * from t1;
 --echo #  Remove corruption file and restart cleanly
 --echo #
 
---exec rm $MYSQLTEST_VARDIR/mysqld.$_server_id/data/.rocksdb/ROCKSDB_CORRUPTED
+--remove_file $MYSQLTEST_VARDIR/mysqld.$_server_id/data/.rocksdb/ROCKSDB_CORRUPTED
 --let $restart_parameters=
 --source include/start_mysqld.inc
 

--- a/mysql-test/suite/rocksdb/t/checkpoint.test
+++ b/mysql-test/suite/rocksdb/t/checkpoint.test
@@ -79,7 +79,7 @@ let $checkpoint = $MYSQL_TMP_DIR/already-existing-directory;
 --mkdir $checkpoint
 let $succeeds = 0;
 --source suite/rocksdb/include/set_checkpoint.inc
---exec rm -rf $checkpoint
+--force-rmdir $checkpoint
 
 --disable_result_log
 truncate table t1;

--- a/mysql-test/suite/rocksdb/t/compact_deletes.test
+++ b/mysql-test/suite/rocksdb/t/compact_deletes.test
@@ -28,8 +28,8 @@ while ($i<1000)
 set global rocksdb_force_flush_memtable_now=1;
 optimize table r1;
 
---exec echo Test 1: Do a bunch of updates without setting the compaction sysvar
---exec echo Expect: no compaction
+--echo Test 1: Do a bunch of updates without setting the compaction sysvar
+--echo Expect: no compaction
 let $window = 0;
 let $deletes = 0;
 let $file_size = 0;
@@ -38,8 +38,8 @@ let $primary = 1;
 let $no_more_deletes = 0;
 --source suite/rocksdb/include/compact_deletes_test.inc
 
---exec echo Test 2: Do a bunch of updates and set the compaction sysvar
---exec echo Expect: compaction
+--echo Test 2: Do a bunch of updates and set the compaction sysvar
+--echo Expect: compaction
 let $window = 1000;
 let $deletes = 990;
 let $file_size = 0;
@@ -48,8 +48,8 @@ let $primary = 1;
 let $no_more_deletes = 1;
 --source suite/rocksdb/include/compact_deletes_test.inc
 
---exec echo Test 3: Do a bunch of updates and set the compaction sysvar and a file size to something large
---exec echo Expect: no compaction
+--echo Test 3: Do a bunch of updates and set the compaction sysvar and a file size to something large
+--echo Expect: no compaction
 let $window = 1000;
 let $deletes = 1000;
 let $file_size = 1000000;
@@ -58,8 +58,8 @@ let $primary = 1;
 let $no_more_deletes = 0;
 --source suite/rocksdb/include/compact_deletes_test.inc
 
---exec echo Test 4: Do a bunch of secondary key updates and set the compaction sysvar
---exec echo Expect: compaction
+--echo Test 4: Do a bunch of secondary key updates and set the compaction sysvar
+--echo Expect: compaction
 let $window = 1000;
 let $deletes = 50;
 let $file_size = 0;
@@ -68,9 +68,9 @@ let $primary = 0;
 let $no_more_deletes = 1;
 --source suite/rocksdb/include/compact_deletes_test.inc
 
---exec echo Test 5: Do a bunch of secondary key updates and set the compaction sysvar,
---exec echo and rocksdb_compaction_sequential_deletes_count_sd turned on
---exec echo Expect: compaction
+--echo Test 5: Do a bunch of secondary key updates and set the compaction sysvar,
+--echo and rocksdb_compaction_sequential_deletes_count_sd turned on
+--echo Expect: compaction
 let $window = 1000;
 let $deletes = 50;
 let $file_size = 0;

--- a/mysql-test/suite/rocksdb/t/persistent_cache.test
+++ b/mysql-test/suite/rocksdb/t/persistent_cache.test
@@ -28,6 +28,6 @@ SELECT * FROM t1 WHERE a = 1;
 # not cross platform safe, but there is a nested directory hierarchy in place
 # that would need discovering and manual removal since 5.7 seems not to support
 # the force-rmdir command yet
---exec rm -rf $cache_dir_name
+--force-rmdir $cache_dir_name
 
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/rocksdb_datadir.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_datadir.test
@@ -31,7 +31,7 @@ exec ls $rdb_ddir/MANIFEST-0000* | wc -l;
 
 # Clean up
 remove_files_wildcard $ddir *;
-exec rm -rf $ddir;
+force-rmdir $ddir;
 remove_files_wildcard $rdb_ddir *;
-exec rm -rf $rdb_ddir;
+force-rmdir $rdb_ddir;
 remove_file $sql_file;

--- a/mysql-test/suite/rocksdb/t/statistics.test
+++ b/mysql-test/suite/rocksdb/t/statistics.test
@@ -54,7 +54,7 @@ SELECT table_name, data_length>0, index_length>0 FROM information_schema.tables 
 --source include/restart_mysqld.inc
 
 # give the server a chance to load in statistics
---exec sleep 5
+--sleep 5
 
 SELECT table_name, table_rows FROM information_schema.tables WHERE table_schema = DATABASE();
 SELECT table_name, data_length>0, index_length>0 FROM information_schema.tables WHERE table_schema = DATABASE();


### PR DESCRIPTION
Partially clean up MyRocks testcases not to use shell commands when a
mysqltest alternative is available, mainly because of force-rmdir
mysqltest command, introduced in 8.0.

Testing [1] shows some failures, but no diff against baseline [2]
[1] https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/85/#showFailuresLink
[2] https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/84/#showFailuresLink