### PR TITLE
PS-4961 : Fix MyRocks compilation errors for Ubuntu 18.10 gcc 8.2.0

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -559,7 +559,7 @@ static void rocksdb_set_rocksdb_info_log_level(THD *const thd,
   RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   rocksdb_info_log_level = *static_cast<const uint64_t *>(save);
   rocksdb_db_options->info_log->SetInfoLogLevel(
-      static_cast<const rocksdb::InfoLogLevel>(rocksdb_info_log_level));
+      static_cast<rocksdb::InfoLogLevel>(rocksdb_info_log_level));
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
 }
 

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -101,8 +101,7 @@ Rdb_key_def::Rdb_key_def(const Rdb_key_def &k)
       m_stats(k.m_stats), m_index_flags_bitmap(k.m_index_flags_bitmap),
       m_ttl_rec_offset(k.m_ttl_rec_offset), m_ttl_duration(k.m_ttl_duration),
       m_ttl_column(k.m_ttl_column), m_pk_part_no(k.m_pk_part_no),
-      m_pack_info(k.m_pack_info), m_keyno(k.m_keyno),
-      m_key_parts(k.m_key_parts),
+      m_pack_info(nullptr), m_keyno(k.m_keyno), m_key_parts(k.m_key_parts),
       m_ttl_pk_key_part_offset(k.m_ttl_pk_key_part_offset),
       m_ttl_field_offset(UINT_MAX), m_prefix_extractor(k.m_prefix_extractor),
       m_maxlength(k.m_maxlength) {
@@ -119,13 +118,11 @@ Rdb_key_def::Rdb_key_def(const Rdb_key_def &k)
   if (k.m_pack_info) {
     const size_t size = sizeof(Rdb_field_packing) * k.m_key_parts;
 #ifdef HAVE_PSI_INTERFACE
-    m_pack_info = static_cast<Rdb_field_packing *>(
-        my_malloc(rdb_datadic_memory_key, size, MYF(0)));
+    void *buf = my_malloc(rdb_datadic_memory_key, size, MYF(0));
 #else
-    m_pack_info = static_cast<Rdb_field_packing *>(
-        my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0)));
+    void *buf = my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0));
 #endif
-    memcpy(m_pack_info, k.m_pack_info, size);
+    m_pack_info = new (buf) Rdb_field_packing(*k.m_pack_info);
   }
 
   if (k.m_pk_part_no) {
@@ -147,7 +144,10 @@ Rdb_key_def::~Rdb_key_def() {
   my_free(m_pk_part_no);
   m_pk_part_no = nullptr;
 
-  my_free(m_pack_info);
+  if (m_pack_info) {
+    m_pack_info->~Rdb_field_packing();
+    my_free(m_pack_info);
+  }
   m_pack_info = nullptr;
 }
 
@@ -222,12 +222,11 @@ void Rdb_key_def::setup(const TABLE *const tbl,
 
     const size_t size = sizeof(Rdb_field_packing) * m_key_parts;
 #ifdef HAVE_PSI_INTERFACE
-    m_pack_info = static_cast<Rdb_field_packing *>(
-        my_malloc(rdb_datadic_memory_key, size, MYF(0)));
+    void *buf = my_malloc(rdb_datadic_memory_key, size, MYF(0));
 #else
-    m_pack_info = static_cast<Rdb_field_packing *>(
-        my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0)));
+    void *buf = my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0));
 #endif
+    m_pack_info = new (buf) Rdb_field_packing;
 
     /*
       Guaranteed not to error here as checks have been made already during
@@ -1109,7 +1108,7 @@ uint Rdb_key_def::pack_record(
       // Insert TTL timestamp
       if (has_ttl() && ttl_bytes) {
         write_index_flag_field(unpack_info,
-                               reinterpret_cast<const uchar *const>(ttl_bytes),
+                               reinterpret_cast<const uchar *>(ttl_bytes),
                                Rdb_key_def::TTL_FLAG);
       }
     }
@@ -3589,6 +3588,31 @@ static int get_segment_size_from_collation(const CHARSET_INFO *const cs) {
   DBUG_ASSERT(ret < RDB_SPACE_XFRM_SIZE);
   return ret;
 }
+
+Rdb_field_packing::Rdb_field_packing(const Rdb_field_packing &o)
+    : m_max_image_len(o.m_max_image_len),
+      m_unpack_data_len(o.m_unpack_data_len),
+      m_unpack_data_offset(o.m_unpack_data_offset),
+      m_maybe_null(o.m_maybe_null), m_varchar_charset(o.m_varchar_charset),
+      m_segment_size(o.m_segment_size),
+      m_unpack_info_uses_two_bytes(o.m_unpack_info_uses_two_bytes),
+      m_covered(o.m_covered), space_xfrm(o.space_xfrm),
+      space_xfrm_len(o.space_xfrm_len), space_mb_len(o.space_mb_len),
+      m_charset_codec(o.m_charset_codec),
+      m_unpack_info_stores_value(o.m_unpack_info_stores_value),
+      m_pack_func(o.m_pack_func),
+      m_make_unpack_info_func(o.m_make_unpack_info_func),
+      m_unpack_func(o.m_unpack_func), m_skip_func(o.m_skip_func),
+      m_keynr(o.m_keynr), m_key_part(o.m_key_part) {}
+
+Rdb_field_packing::Rdb_field_packing()
+    : m_max_image_len(0), m_unpack_data_len(0), m_unpack_data_offset(0),
+      m_maybe_null(false), m_varchar_charset(nullptr), m_segment_size(0),
+      m_unpack_info_uses_two_bytes(false), m_covered(false),
+      space_xfrm(nullptr), space_xfrm_len(0), space_mb_len(0),
+      m_charset_codec(nullptr), m_unpack_info_stores_value(false),
+      m_pack_func(nullptr), m_make_unpack_info_func(nullptr),
+      m_unpack_func(nullptr), m_skip_func(nullptr), m_keynr(0), m_key_part(0) {}
 
 /*
   @brief

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -883,9 +883,9 @@ extern std::array<const Rdb_collation_codec *, MY_ALL_CHARSETS_SIZE>
 
 class Rdb_field_packing {
  public:
-  Rdb_field_packing(const Rdb_field_packing &) = delete;
+  Rdb_field_packing(const Rdb_field_packing &);
   Rdb_field_packing &operator=(const Rdb_field_packing &) = delete;
-  Rdb_field_packing() = default;
+  Rdb_field_packing();
 
   /* Length of mem-comparable image of the field, in bytes */
   int m_max_image_len;

--- a/storage/rocksdb/rdb_threads.cc
+++ b/storage/rocksdb/rdb_threads.cc
@@ -26,7 +26,7 @@ namespace myrocks {
 
 void *Rdb_thread::thread_func(void *const thread_ptr) {
   DBUG_ASSERT(thread_ptr != nullptr);
-  Rdb_thread *const thread = static_cast<Rdb_thread *const>(thread_ptr);
+  Rdb_thread *const thread = static_cast<Rdb_thread *>(thread_ptr);
   if (!thread->m_run_once.exchange(true)) {
     thread->run();
     thread->uninit();


### PR DESCRIPTION
- Fixed error storage/rocksdb/ha_rocksdb.cc:561:70: error: type qualifiers
  ignored on cast result type [-Werror=ignored-qualifiers]

- Fixed error storage/rocksdb/rdb_datadic.cc:1108:78: error: type qualifiers
  ignored on cast result type [-Werror=ignored-qualifiers]

- Fixed error storage/rocksdb/rdb_threads.cc:29:71: error: type qualifiers
  ignored on cast result type [-Werror=ignored-qualifiers]

- Fixed error storage/rocksdb/rdb_datadic.cc:124:44: error:
  ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type
  ‘class myrocks::Rdb_field_packing’ with no trivial copy-assignment
  [-Werror=class-memaccess]

(cherry picked from commit 58363baefba0dd7f7c0e32d702a9f089a47d93a3)