### PR TITLE
PS-269: Fix main.percona_show_temp_tables_debug MTR test (8.0)

### DIFF
--- a/mysql-test/r/percona_show_temp_tables_debug.result
+++ b/mysql-test/r/percona_show_temp_tables_debug.result
@@ -20,8 +20,8 @@ test	t1	MyISAM	0
 # Bug 1614849 (INFORMATION_SCHEMA.TABLES (or other schema info table) and GLOBAL_TEMPORARY_TABLES queries running in parallel may crash or hang)
 #
 # connection con1
-SET DEBUG_SYNC="before_open_in_get_all_tables SIGNAL tables_query_ready WAIT_FOR tables_query_finish";
-SELECT * FROM INFORMATION_SCHEMA.TABLES;
+SET DEBUG_SYNC="fill_schema_table_stats SIGNAL tables_query_ready WAIT_FOR tables_query_finish";
+SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS;
 # connection con2
 SET DEBUG_SYNC="now WAIT_FOR tables_query_ready";
 SET DEBUG_SYNC="fill_global_temporary_tables_thd_item_at_tables_debug_sync SIGNAL temp_tables_query_ready WAIT_FOR temp_tables_query_finish";

--- a/mysql-test/t/percona_show_temp_tables_debug.test
+++ b/mysql-test/t/percona_show_temp_tables_debug.test
@@ -53,8 +53,8 @@ disconnect con2;
 connect (con1,localhost,root,,);
 --echo # connection con1
 
-SET DEBUG_SYNC="before_open_in_get_all_tables SIGNAL tables_query_ready WAIT_FOR tables_query_finish";
-send SELECT * FROM INFORMATION_SCHEMA.TABLES;
+SET DEBUG_SYNC="fill_schema_table_stats SIGNAL tables_query_ready WAIT_FOR tables_query_finish";
+send SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS;
 
 connect (con2,localhost,root,,);
 --echo # connection con2

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2823,6 +2823,8 @@ static int fill_schema_table_stats(THD *thd, TABLE_LIST *tables,
   TABLE *const table = tables->table;
 
   mysql_mutex_lock(&LOCK_global_table_stats);
+  DEBUG_SYNC(thd, "fill_schema_table_stats");
+
   for (const auto &it : *global_table_stats) {
     restore_record(table, s->default_values);
 
@@ -4005,9 +4007,9 @@ class Fill_global_temporary_tables final : public Do_THD_Impl {
 #ifndef DBUG_OFF
     const char *tmp_proc_info = thd->proc_info;
     if (tmp_proc_info &&
-        !strncmp(tmp_proc_info,
-                 STRING_WITH_LEN(
-                     "debug sync point: before_open_in_get_all_tables"))) {
+        !strncmp(
+            tmp_proc_info,
+            STRING_WITH_LEN("debug sync point: fill_schema_table_stats"))) {
       DEBUG_SYNC(m_client_thd,
                  "fill_global_temporary_tables_thd_item_at_tables_debug_sync");
     }


### PR DESCRIPTION
For MySQL 8.0 `SELECT * FROM INFORMATION_SCHEMA.TABLES` doesn't call `get_all_tables()` and `DEBUG_SYNC(thd, "before_open_in_get_all_tables")` anymore.
This patch replaces above to `SELECT * FROM INFORMATION_SCHEMA.TABLE_STATISTICS` and `DEBUG_SYNC(thd, "fill_schema_table_stats")` what allows to test select `TABLE_STATISTICS` and `GLOBAL_TEMPORARY_TABLES` queries running in parallel.