### PR TITLE
PS-269 (Initial Percona Server 8.0.12 tree)

### DIFF
--- a/mysql-test/suite/rocksdb.rpl/t/multiclient_2pc.test
+++ b/mysql-test/suite/rocksdb.rpl/t/multiclient_2pc.test
@@ -30,7 +30,7 @@ connection con1;
 --exec echo "$restart_parameters" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 set session debug="d,crash_commit_after_log";
 set debug_sync='rocksdb.prepared SIGNAL parked WAIT_FOR go';
---error 0,2013
+--error 0,CR_SERVER_LOST
 --send insert into t1 values (1, 1, "iamtheogthealphaandomega");
 
 connection con2;
@@ -59,7 +59,7 @@ set @@global.sync_binlog = 1;
 
 insert into t1 values (1000000, 1, "i_am_just_here_to_trigger_a_flush");
 
---error 0,2013
+--error 0,CR_SERVER_LOST
 set debug_sync='now SIGNAL go';
 
 --source include/wait_until_disconnected.inc

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_2pc_crash_recover.test
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_2pc_crash_recover.test
@@ -12,7 +12,7 @@ create table t1 (a int primary key, msg varchar(255)) engine=rocksdb;
 
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after_prepare";
---error 0,2013
+--error 0,CR_SERVER_LOST
 insert into t1 values (1, 'dogz');
 --enable_reconnect
 --source include/wait_until_connected_again.inc
@@ -20,7 +20,7 @@ select * from t1;
 
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after_log";
---error 0,2013
+--error 0,CR_SERVER_LOST
 insert into t1 values (2, 'catz'), (3, 'men');
 --enable_reconnect
 --source include/wait_until_connected_again.inc
@@ -28,7 +28,7 @@ select * from t1;
 
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="d,crash_commit_after";
---error 0,2013
+--error 0,CR_SERVER_LOST
 insert into t1 values (4, 'cars'), (5, 'foo');
 --enable_reconnect
 --source include/wait_until_connected_again.inc

--- a/mysql-test/suite/rocksdb/r/add_index_inplace_crash.result
+++ b/mysql-test/suite/rocksdb/r/add_index_inplace_crash.result
@@ -15,16 +15,12 @@ t1	CREATE TABLE `t1` (
   `b` int(11) DEFAULT NULL,
   KEY `ka` (`a`),
   KEY `kab` (`a`,`b`)
-) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 CHECK TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	check	status	OK
 DROP TABLE t1;
 CREATE TABLE t1 (i INT, j INT, k INT, PRIMARY KEY (i), KEY(j)) ENGINE = ROCKSDB PARTITION BY KEY(i) PARTITIONS 4;
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 # crash_during_index_creation_partition
 flush logs;
 SET SESSION debug="+d,crash_during_index_creation_partition";
@@ -39,14 +35,10 @@ t1	CREATE TABLE `t1` (
   `k` int(11) DEFAULT NULL,
   PRIMARY KEY (`i`),
   KEY `j` (`j`)
-) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 /*!50100 PARTITION BY KEY (i)
 PARTITIONS 4 */
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 ALTER TABLE t1 ADD INDEX kij(i,j), ALGORITHM=INPLACE;
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 SELECT * FROM t1 ORDER BY i LIMIT 10;
 i	j	k
 1	1	1
@@ -64,10 +56,6 @@ COUNT(*)
 100
 DROP TABLE t1;
 CREATE TABLE t1 (i INT, j INT, k INT, PRIMARY KEY (i), KEY(j)) ENGINE = ROCKSDB PARTITION BY KEY(i) PARTITIONS 4;
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 # crash_during_index_creation_partition
 flush logs;
 SET SESSION debug="+d,myrocks_simulate_index_create_rollback";
@@ -82,14 +70,10 @@ t1	CREATE TABLE `t1` (
   `k` int(11) DEFAULT NULL,
   PRIMARY KEY (`i`),
   KEY `j` (`j`)
-) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 /*!50100 PARTITION BY KEY (i)
 PARTITIONS 4 */
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 ALTER TABLE t1 ADD INDEX kij(i,j), ALGORITHM=INPLACE;
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
@@ -99,11 +83,9 @@ t1	CREATE TABLE `t1` (
   PRIMARY KEY (`i`),
   KEY `j` (`j`),
   KEY `kij` (`i`,`j`)
-) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 /*!50100 PARTITION BY KEY (i)
 PARTITIONS 4 */
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 100

--- a/mysql-test/suite/rocksdb/t/add_index_inplace_crash.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace_crash.test
@@ -16,7 +16,7 @@ flush logs;
 
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="+d,crash_during_online_index_creation";
---error 2013
+--error CR_SERVER_LOST
 ALTER TABLE t1 ADD INDEX kb(b), ALGORITHM=INPLACE;
 
 --enable_reconnect
@@ -49,7 +49,7 @@ flush logs;
 
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 SET SESSION debug="+d,crash_during_index_creation_partition";
---error 2013
+--error CR_SERVER_LOST
 ALTER TABLE t1 ADD INDEX kij(i,j), ALGORITHM=INPLACE;
 
 --enable_reconnect
@@ -88,7 +88,7 @@ flush logs;
 
 SET SESSION debug="+d,myrocks_simulate_index_create_rollback";
 
---error 1105
+--error ER_UNKNOWN_ERROR
 ALTER TABLE t1 ADD INDEX kij(i,j), ALGORITHM=INPLACE;
 SET SESSION debug="-d,myrocks_simulate_index_create_rollback";
 SHOW CREATE TABLE t1;

--- a/mysql-test/suite/rocksdb/t/allow_to_start_after_corruption.test
+++ b/mysql-test/suite/rocksdb/t/allow_to_start_after_corruption.test
@@ -28,7 +28,7 @@ insert into t1 values (1,1),(2,2),(3,3);
 select * from t1 where pk=1;
 set session debug= "+d,rocksdb_return_status_corrupted";
 --source include/expect_crash.inc
---error 2013
+--error CR_SERVER_LOST
 select * from t1 where pk=1;
 --source include/wait_until_disconnected.inc
 --let SEARCH_PATTERN=data corruption detected
@@ -44,7 +44,7 @@ select * from t1 where pk=1;
 select * from t1;
 set session debug= "+d,rocksdb_return_status_corrupted";
 --source include/expect_crash.inc
---error 2013
+--error CR_SERVER_LOST
 select * from t1;
 --source include/wait_until_disconnected.inc
 --let SEARCH_PATTERN=data corruption detected

--- a/mysql-test/suite/rocksdb/t/autoinc_debug.test
+++ b/mysql-test/suite/rocksdb/t/autoinc_debug.test
@@ -58,7 +58,7 @@ insert into t values ();
 insert into t values ();
 set debug="+d,crash_commit_before";
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---error 2013
+--error CR_SERVER_LOST
 commit;
 --source include/wait_until_disconnected.inc
 --enable_reconnect
@@ -74,7 +74,7 @@ insert into t values ();
 insert into t values ();
 set debug="+d,crash_commit_after_prepare";
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---error 2013
+--error CR_SERVER_LOST
 commit;
 --source include/wait_until_disconnected.inc
 --enable_reconnect
@@ -90,7 +90,7 @@ insert into t values ();
 insert into t values ();
 set debug="+d,crash_commit_after_log";
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---error 2013
+--error CR_SERVER_LOST
 commit;
 --source include/wait_until_disconnected.inc
 --enable_reconnect
@@ -106,7 +106,7 @@ insert into t values ();
 insert into t values ();
 set debug="+d,crash_commit_after";
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
---error 2013
+--error CR_SERVER_LOST
 commit;
 --source include/wait_until_disconnected.inc
 --enable_reconnect


### PR DESCRIPTION
Convert expected errors in MyRocks MTR tests to mnemonics, mostly due
to new-in-8.0 client-side error support.

https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/90/ - there are some errors which seem to be unrelated.