### PR TITLE
PS-269 (Initial Percona Server 8.0.12 tree)

### DIFF
--- a/mysql-test/suite/tokudb.backup/t/backup_master_info.cnf
+++ b/mysql-test/suite/tokudb.backup/t/backup_master_info.cnf
@@ -5,8 +5,6 @@
 [mysqld.2]
 
 [mysqld.3]
-master-info-repository=TABLE
-relay-log-info-repository=TABLE
 
 [ENV]
 SERVER_MYPORT_3=		@mysqld.3.port

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave-slave.opt
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave-slave.opt
@@ -1,1 +1,0 @@
---master-info-repository=TABLE --relay-log-info-repository=TABLE

--- a/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.cnf
+++ b/mysql-test/suite/tokudb.backup/t/rpl_safe_slave.cnf
@@ -5,8 +5,6 @@
 [mysqld.2]
 
 [mysqld.3]
-master-info-repository=TABLE
-relay-log-info-repository=TABLE
 
 [ENV]
 SERVER_MYPORT_3=		@mysqld.3.port

--- a/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_row_crash_safe-slave.opt
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_row_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED
+--skip-slave-start --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED

--- a/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_stm_mixed_crash_safe-slave.opt
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_stm_mixed_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED
+--skip-slave-start --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED

--- a/mysql-test/suite/tokudb/t/fast_update_binlog_row-master.opt
+++ b/mysql-test/suite/tokudb/t/fast_update_binlog_row-master.opt
@@ -1,1 +1,0 @@
---binlog-format=row


### PR DESCRIPTION
Remove explicit server system variable settings from TokuDB tests
where they matched the new 8.0 defaults.

Testing: https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/92/, the failures _seem_ to be unrelated, but @georgelorchpercona second look would be appreciated