### PR TITLE
PS-269 (Initial Percona Server 8.0.12 tree)

### DIFF
--- a/mysql-test/suite/rocksdb.rpl/rpl_1slave_base.cnf
+++ b/mysql-test/suite/rocksdb.rpl/rpl_1slave_base.cnf
@@ -23,7 +23,6 @@ innodb_use_native_aio = 0
 log-bin=                    slave-bin
 relay-log=                  slave-relay-bin
 
-log-slave-updates
 master-retry-count=         10
 
 # Values reported by slave when it connect to master
@@ -48,4 +47,3 @@ MASTER_MYSOCK=              @mysqld.1.socket
 
 SLAVE_MYPORT=               @mysqld.2.port
 SLAVE_MYSOCK=               @mysqld.2.socket
-

--- a/mysql-test/suite/rocksdb.rpl/t/multiclient_2pc-master.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/multiclient_2pc-master.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates --log-error-verbosity=3
+--gtid_mode=ON --enforce_gtid_consistency --log-error-verbosity=3

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_2pc_crash_recover-master.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_2pc_crash_recover-master.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates --loose-rocksdb_flush_log_at_trx_commit=1 --loose-rocksdb_write_disable_wal=OFF
+--gtid_mode=ON --enforce_gtid_consistency --loose-rocksdb_flush_log_at_trx_commit=1 --loose-rocksdb_write_disable_wal=OFF

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_2pc_crash_recover-slave.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_2pc_crash_recover-slave.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates
+--gtid_mode=ON --enforce_gtid_consistency

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_consistent_shapshot_mixed_engines-master.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_consistent_shapshot_mixed_engines-master.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates
+--gtid_mode=ON --enforce_gtid_consistency

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_crash_safe-slave.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_row_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED
+--skip-slave-start --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot-master.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot-master.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates
+--gtid_mode=ON --enforce_gtid_consistency

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot-slave.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_snapshot-slave.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates
+--gtid_mode=ON --enforce_gtid_consistency

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_stm_mixed_consistent_shapshot_mixed_engines-master.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_stm_mixed_consistent_shapshot_mixed_engines-master.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates --loose-rocksdb_unsafe_for_binlog=true
+--gtid_mode=ON --enforce_gtid_consistency --loose-rocksdb_unsafe_for_binlog=true

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_stm_mixed_crash_safe-slave.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_rocksdb_stm_mixed_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---skip-slave-start --relay-log-info-repository=TABLE --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED
+--skip-slave-start --relay-log-recovery=1 --transaction_isolation=READ-COMMITTED

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_skip_trx_api_binlog_format-master.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_skip_trx_api_binlog_format-master.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_slave_updates --binlog_format=STATEMENT
+--gtid_mode=ON --enforce_gtid_consistency --binlog_format=STATEMENT

--- a/mysql-test/suite/rocksdb.rpl/t/rpl_skip_trx_api_binlog_format-slave.opt
+++ b/mysql-test/suite/rocksdb.rpl/t/rpl_skip_trx_api_binlog_format-slave.opt
@@ -1,1 +1,1 @@
---gtid_mode=ON --enforce_gtid_consistency --log_slave_updates --sync_binlog=1000 --relay_log_recovery=1
+--gtid_mode=ON --enforce_gtid_consistency --sync_binlog=1000 --relay_log_recovery=1

--- a/mysql-test/suite/rocksdb/t/2pc_group_commit-master.opt
+++ b/mysql-test/suite/rocksdb/t/2pc_group_commit-master.opt
@@ -1,1 +1,0 @@
---binlog-format=row

--- a/mysql-test/suite/rocksdb/t/autoinc_crash_safe-master.opt
+++ b/mysql-test/suite/rocksdb/t/autoinc_crash_safe-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/autoinc_crash_safe-slave.opt
+++ b/mysql-test/suite/rocksdb/t/autoinc_crash_safe-slave.opt
@@ -1,1 +1,1 @@
---binlog_format=row --slave_parallel_workers=1
+--slave_parallel_workers=1

--- a/mysql-test/suite/rocksdb/t/autoinc_crash_safe_partition-master.opt
+++ b/mysql-test/suite/rocksdb/t/autoinc_crash_safe_partition-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/autoinc_crash_safe_partition-slave.opt
+++ b/mysql-test/suite/rocksdb/t/autoinc_crash_safe_partition-slave.opt
@@ -1,1 +1,1 @@
---binlog_format=row --slave_parallel_workers=1
+--slave_parallel_workers=1

--- a/mysql-test/suite/rocksdb/t/autoinc_debug-master.opt
+++ b/mysql-test/suite/rocksdb/t/autoinc_debug-master.opt
@@ -1,1 +1,0 @@
---binlog-format=row

--- a/mysql-test/suite/rocksdb/t/gap_lock_issue254-master.opt
+++ b/mysql-test/suite/rocksdb/t/gap_lock_issue254-master.opt
@@ -1,1 +1,1 @@
---binlog-format=row --binlog-row-image=full
+--binlog-row-image=full

--- a/mysql-test/suite/rocksdb/t/i_s_trx_rpl-master.opt
+++ b/mysql-test/suite/rocksdb/t/i_s_trx_rpl-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/i_s_trx_rpl-slave.opt
+++ b/mysql-test/suite/rocksdb/t/i_s_trx_rpl-slave.opt
@@ -1,1 +1,1 @@
---binlog_format=row --slave_parallel_workers=1 --loose-rocksdb_rpl_skip_tx_api=ON
+--slave_parallel_workers=1 --loose-rocksdb_rpl_skip_tx_api=ON

--- a/mysql-test/suite/rocksdb/t/index_merge_rocksdb2-master.opt
+++ b/mysql-test/suite/rocksdb/t/index_merge_rocksdb2-master.opt
@@ -1,1 +1,1 @@
---loose-rocksdb_strict_collation_check=off --transaction-isolation='READ-COMMITTED' --binlog_format=row --log-bin --loose-rocksdb_records_in_range=2
+--loose-rocksdb_strict_collation_check=off --transaction-isolation='READ-COMMITTED' --loose-rocksdb_records_in_range=2

--- a/mysql-test/suite/rocksdb/t/mysqlbinlog_gtid_skip_empty_trans_rocksdb-master.opt
+++ b/mysql-test/suite/rocksdb/t/mysqlbinlog_gtid_skip_empty_trans_rocksdb-master.opt
@@ -1,1 +1,1 @@
---binlog_format=row --gtid_mode=ON --enforce_gtid_consistency --log_bin --log_slave_updates
+--gtid_mode=ON --enforce_gtid_consistency

--- a/mysql-test/suite/rocksdb/t/mysqldump-master.opt
+++ b/mysql-test/suite/rocksdb/t/mysqldump-master.opt
@@ -1,1 +1,1 @@
---force-restart --binlog_format=row
+--force-restart

--- a/mysql-test/suite/rocksdb/t/mysqldump2-master.opt
+++ b/mysql-test/suite/rocksdb/t/mysqldump2-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/read_only_tx-master.opt
+++ b/mysql-test/suite/rocksdb/t/read_only_tx-master.opt
@@ -1,1 +1,1 @@
---loose-rocksdb_default_cf_options=write_buffer_size=16k --binlog_format=row --gtid_mode=ON --enforce_gtid_consistency --log-slave-updates
+--loose-rocksdb_default_cf_options=write_buffer_size=16k --gtid_mode=ON --enforce_gtid_consistency

--- a/mysql-test/suite/rocksdb/t/rpl_read_free-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_read_free-master.opt
@@ -1,1 +1,1 @@
---sync_binlog=0 --binlog_format=row --loose-rocksdb_read_free_rpl_tables="t.*" --slave-exec-mode=strict
+--sync_binlog=0 --loose-rocksdb_read_free_rpl_tables="t.*"

--- a/mysql-test/suite/rocksdb/t/rpl_read_free-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_read_free-slave.opt
@@ -1,1 +1,1 @@
---sync_binlog=0 --binlog_format=row --loose-rocksdb_read_free_rpl_tables="t.*" --slave-exec-mode=strict --loose-rocksdb_default_cf_options=write_buffer_size=16k;target_file_size_base=16k
+--sync_binlog=0 --loose-rocksdb_read_free_rpl_tables="t.*"  --loose-rocksdb_default_cf_options=write_buffer_size=16k;target_file_size_base=16k

--- a/mysql-test/suite/rocksdb/t/rpl_row_not_found-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_not_found-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_not_found-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_not_found-slave.opt
@@ -1,1 +1,1 @@
---binlog_format=row --slave_parallel_workers=4 --loose-rocksdb_lock_wait_timeout=5
+--slave_parallel_workers=4 --loose-rocksdb_lock_wait_timeout=5

--- a/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_rocksdb-slave.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_stats-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_stats-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_row_stats-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_stats-slave.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_savepoint-master.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_savepoint-master.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/rpl_savepoint-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_savepoint-slave.opt
@@ -1,1 +1,0 @@
---binlog_format=row

--- a/mysql-test/suite/rocksdb/t/shutdown-master.opt
+++ b/mysql-test/suite/rocksdb/t/shutdown-master.opt
@@ -1,1 +1,1 @@
---log-bin --binlog_format=row --loose-rocksdb_default_cf_options=write_buffer_size=64k
+--loose-rocksdb_default_cf_options=write_buffer_size=64k

--- a/mysql-test/suite/rocksdb/t/trx_info_rpl-master.opt
+++ b/mysql-test/suite/rocksdb/t/trx_info_rpl-master.opt
@@ -1,1 +1,0 @@
---binlog-format=row

--- a/mysql-test/suite/rocksdb/t/trx_info_rpl-slave.opt
+++ b/mysql-test/suite/rocksdb/t/trx_info_rpl-slave.opt
@@ -1,1 +1,1 @@
---binlog-format=row --slave-parallel-workers=1 --loose-rocksdb-rpl-skip-tx-api=ON
+--slave-parallel-workers=1 --loose-rocksdb-rpl-skip-tx-api=ON


### PR DESCRIPTION
Remove explicit server system variable settings from MyRocks tests
where they matched the new 8.0 defaults.

https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/94/