### PR TITLE
PS-4825: Backport innodb MTR fixes from 8.0 to 5.7

### DIFF
--- a/mysql-test/suite/innodb/r/general_ts_encrypt.result
+++ b/mysql-test/suite/innodb/r/general_ts_encrypt.result
@@ -159,3 +159,4 @@ DROP TABLESPACE ts_encrypted;
 DROP TABLESPACE ts_encrypted_new;
 DROP TABLESPACE ts_unencrypted;
 DROP TABLESPACE ts_unencrypted_new;
+DROP TABLESPACE ts_valid2;

--- a/mysql-test/suite/innodb/r/percona_force_encryption.result
+++ b/mysql-test/suite/innodb/r/percona_force_encryption.result
@@ -234,4 +234,5 @@ drop table t5_off_explicit_off_dup;
 drop table t7_partitioned;
 drop tablespace ts_encrypted1;
 drop tablespace ts_encrypted2;
+drop tablespace ts_unencrypted1;
 set global innodb_encrypt_tables=OFF;

--- a/mysql-test/suite/innodb/t/general_ts_encrypt.test
+++ b/mysql-test/suite/innodb/t/general_ts_encrypt.test
@@ -262,3 +262,4 @@ DROP TABLESPACE ts_encrypted;
 DROP TABLESPACE ts_encrypted_new;
 DROP TABLESPACE ts_unencrypted;
 DROP TABLESPACE ts_unencrypted_new;
+DROP TABLESPACE ts_valid2;

--- a/mysql-test/suite/innodb/t/percona_force_encryption.test
+++ b/mysql-test/suite/innodb/t/percona_force_encryption.test
@@ -132,6 +132,7 @@ drop table t7_partitioned;
 
 drop tablespace ts_encrypted1;
 drop tablespace ts_encrypted2;
+drop tablespace ts_unencrypted1;
 
 eval set global innodb_encrypt_tables=$initial_encrypt_tables_value;
 


### PR DESCRIPTION
1. Add `DROP TABLESPACE ts_valid2;` in suite/innodb/t/general_ts_encrypt.test
2. Add `drop tablespace ts_unencrypted1;` in suite/innodb/t/percona_force_encryption.test