### PR TITLE
PS-4836: Missing PFS signed variable aggregation (5.7)

### DIFF
--- a/storage/perfschema/pfs_variable.cc
+++ b/storage/perfschema/pfs_variable.cc
@@ -740,7 +740,9 @@ bool PFS_status_variable_cache::can_aggregate(enum_mysql_show_type variable_type
     case SHOW_DOUBLE_STATUS:
     case SHOW_HA_ROWS:
     case SHOW_LONG_NOFLUSH:
+    case SHOW_SIGNED_INT:
     case SHOW_SIGNED_LONG:
+    case SHOW_SIGNED_LONGLONG:
     default:
       return false;
       break;


### PR DESCRIPTION
Add missing `SHOW_SIGNED_INT` and `SHOW_SIGNED_LONGLONG` to switch() in `PFS_status_variable_cache::can_aggregate`.