### PR TITLE
PS-4955: Backport mysqld fix for valgrind warnings from 8.0 (to 5.7)

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -1009,6 +1009,7 @@ bool Log_event::wrapper_my_b_safe_write(IO_CACHE* file, const uchar* buf, size_t
 {
   DBUG_EXECUTE_IF("simulate_temp_file_write_error",
                   {
+                    memset(file->write_pos, 0, file->write_end - file->write_pos);
                     file->write_pos=file->write_end;
                     DBUG_SET("+d,simulate_file_write_error");
                   });


### PR DESCRIPTION
Fix valgrind warnings in `Log_event::wrapper_my_b_safe_write` when running rpl.rpl_bug72457_*
Fixed also in 8.0 at https://github.com/percona/percona-server/pull/2604