### PR TITLE
PS-4781: sql_yacc.yy uses SQLCOM_SELECT instead of SQLCOM_SHOW_XXXX_STATS (5.6)

### DIFF
--- a/mysql-test/r/percona_userstat.result
+++ b/mysql-test/r/percona_userstat.result
@@ -61,10 +61,10 @@ SHOW TABLE_STATISTICS;
 Table_schema	Table_name	Rows_read	Rows_changed	Rows_changed_x_#indexes
 SHOW THREAD_STATISTICS;
 Thread_id	Total_connections	Concurrent_connections	Connected_time	Busy_time	Cpu_time	Bytes_received	Bytes_sent	Binlog_bytes_written	Rows_fetched	Rows_updated	Table_rows_read	Select_commands	Update_commands	Other_commands	Commit_transactions	Rollback_transactions	Denied_connections	Lost_connections	Access_denied	Empty_queries	Total_ssl_connections
-THREAD_ID	1	0	CONNECTED_TIME	BUSY_TIME	CPU_TIME	350	0	0	4	0	0	8	0	0	0	0	0	0	0	4	0
+THREAD_ID	1	0	CONNECTED_TIME	BUSY_TIME	CPU_TIME	350	0	0	3	0	0	5	0	3	0	0	0	0	0	2	0
 SHOW USER_STATISTICS;
 User	Total_connections	Concurrent_connections	Connected_time	Busy_time	Cpu_time	Bytes_received	Bytes_sent	Binlog_bytes_written	Rows_fetched	Rows_updated	Table_rows_read	Select_commands	Update_commands	Other_commands	Commit_transactions	Rollback_transactions	Denied_connections	Lost_connections	Access_denied	Empty_queries	Total_ssl_connections
-root	1	0	CONNECTED_TIME	BUSY_TIME	CPU_TIME	413	0	0	5	0	0	9	0	1	0	0	0	0	0	4	0
+root	1	0	CONNECTED_TIME	BUSY_TIME	CPU_TIME	413	0	0	3	0	0	5	0	5	0	0	0	0	0	2	0
 SET GLOBAL thread_statistics= @thread_statistics_old;
 SELECT
 Select_commands, Update_commands, Other_commands, Rows_fetched

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -480,6 +480,11 @@ void init_update_queries(void)
   sql_command_flags[SQLCOM_SHOW_TABLE_STATUS]= (CF_STATUS_COMMAND |
                                                 CF_SHOW_TABLE_COMMAND |
                                                 CF_REEXECUTION_FRAGILE);
+  sql_command_flags[SQLCOM_SHOW_USER_STATS]=   CF_STATUS_COMMAND;
+  sql_command_flags[SQLCOM_SHOW_TABLE_STATS]=  CF_STATUS_COMMAND;
+  sql_command_flags[SQLCOM_SHOW_INDEX_STATS]=  CF_STATUS_COMMAND;
+  sql_command_flags[SQLCOM_SHOW_CLIENT_STATS]= CF_STATUS_COMMAND;
+  sql_command_flags[SQLCOM_SHOW_THREAD_STATS]= CF_STATUS_COMMAND;
 
   sql_command_flags[SQLCOM_CREATE_USER]=       CF_CHANGES_DATA;
   sql_command_flags[SQLCOM_RENAME_USER]=       CF_CHANGES_DATA;
@@ -3084,6 +3089,11 @@ mysql_execute_command(THD *thd)
   case SQLCOM_SHOW_COLLATIONS:
   case SQLCOM_SHOW_STORAGE_ENGINES:
   case SQLCOM_SHOW_PROFILE:
+  case SQLCOM_SHOW_USER_STATS:
+  case SQLCOM_SHOW_TABLE_STATS:
+  case SQLCOM_SHOW_INDEX_STATS:
+  case SQLCOM_SHOW_CLIENT_STATS:
+  case SQLCOM_SHOW_THREAD_STATS:
   case SQLCOM_SELECT:
   {
     thd->status_var.last_query_cost= 0.0;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -12860,35 +12860,35 @@ show_param:
         | CLIENT_STATS_SYM wild_and_where
           {
            LEX *lex= Lex;
-           Lex->sql_command= SQLCOM_SELECT;
+           Lex->sql_command= SQLCOM_SHOW_CLIENT_STATS;
            if (prepare_schema_table(YYTHD, lex, 0, SCH_CLIENT_STATS))
              MYSQL_YYABORT;
           }
         | USER_STATS_SYM wild_and_where
           {
            LEX *lex= Lex;
-           lex->sql_command= SQLCOM_SELECT;
+           lex->sql_command= SQLCOM_SHOW_USER_STATS;
            if (prepare_schema_table(YYTHD, lex, 0, SCH_USER_STATS))
              MYSQL_YYABORT;
           }
         | THREAD_STATS_SYM wild_and_where
           {
            LEX *lex= Lex;
-           Lex->sql_command= SQLCOM_SELECT;
+           Lex->sql_command= SQLCOM_SHOW_THREAD_STATS;
            if (prepare_schema_table(YYTHD, lex, 0, SCH_THREAD_STATS))
              MYSQL_YYABORT;
           }
         | TABLE_STATS_SYM wild_and_where
           {
            LEX *lex= Lex;
-           lex->sql_command= SQLCOM_SELECT;
+           lex->sql_command= SQLCOM_SHOW_TABLE_STATS;
            if (prepare_schema_table(YYTHD, lex, 0, SCH_TABLE_STATS))
              MYSQL_YYABORT;
           }
         | INDEX_STATS_SYM wild_and_where
           {
            LEX *lex= Lex;
-           lex->sql_command= SQLCOM_SELECT;
+           lex->sql_command= SQLCOM_SHOW_INDEX_STATS;
            if (prepare_schema_table(YYTHD, lex, 0, SCH_INDEX_STATS))
              MYSQL_YYABORT;
           }


### PR DESCRIPTION
1. Add missing SQLCOM_SHOW_USER_STATS, SQLCOM_SHOW_TABLE_STATS, SQLCOM_SHOW_INDEX_STATS, SQLCOM_SHOW_CLIENT_STATS, SQLCOM_SHOW_THREAD_STATS to init_sql_command_flags() and mysql_execute_command()
2. Use proper SQLCOM_SHOW_XXXX_STATS in sql_yacc.yy for SHOW XXXX_STATISTICS; instead of SQLCOM_SELECT
3. Re-record percona_userstat.result
