### PR TITLE
PS-4943 : Using XA transactions with temporary TokuDB table could lea…

### DIFF
--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -662,13 +662,13 @@ static MYSQL_THDVAR_ULONGLONG(
     ~0ULL,
     1);
 
-static MYSQL_THDVAR_STR(
-    last_lock_timeout,
-    PLUGIN_VAR_MEMALLOC,
-    "last lock timeout",
-    NULL,
-    NULL,
-    NULL);
+static MYSQL_THDVAR_STR(last_lock_timeout,
+                        PLUGIN_VAR_MEMALLOC | PLUGIN_VAR_NOCMDOPT |
+                            PLUGIN_VAR_READONLY,
+                        "last lock timeout",
+                        NULL,
+                        NULL,
+                        NULL);
 
 static MYSQL_THDVAR_BOOL(
     load_save_space,


### PR DESCRIPTION
…d to a server crash

- This actually has nothing to do with either XA or temp tables.  It is due to
  the memory management around the string sysvar tokudb_last_lock_timeout which
  is not an 'input' variable but is used to relay textual information about the
  last lock wait timeout to the user.  Unfortunately, this is a mis-use/abuse of
  the MySQL SYAVAR functionality and is incompatible with the expected plugin
  memory behavior.  Changed this option to remove the command line option and
  made it read-only to prevent further problems.