### PR TITLE
PS-4971 : Setting utf8mb4 as a key in MyRocks table could lead to a s…

### DIFF
--- a/mysql-test/suite/rocksdb/r/type_varchar.result
+++ b/mysql-test/suite/rocksdb/r/type_varchar.result
@@ -809,3 +809,18 @@ check table t;
 Table	Op	Msg_type	Msg_text
 test.t	check	status	OK
 drop table t;
+# PS-4971 : Setting utf8mb4 as a key in MyRocks table could lead to a server crash
+create table t1 (
+str varchar(255) character set utf8mb4,
+key str (str(2))) default character set utf8mb4 engine=rocksdb;
+insert INTO t1 values("1111111111111111111111111111111111111111111111111111");
+drop table t1;
+create table t1(
+t_vers varchar(4) not null,
+key ix_5 (t_vers)
+) charset latin1 engine=rocksdb;
+insert into t1 values ('7.6 ');
+select t_vers from t1 where t_vers = '7.6';
+t_vers
+7.6 
+drop table t1;

--- a/mysql-test/suite/rocksdb/t/type_varchar.test
+++ b/mysql-test/suite/rocksdb/t/type_varchar.test
@@ -80,3 +80,24 @@ check table t;
 alter table t modify h varchar(31) character set cp1257 collate cp1257_bin not null;
 check table t;
 drop table t;
+
+--echo # PS-4971 : Setting utf8mb4 as a key in MyRocks table could lead to a server crash
+# This sequence would overwrite memory, eventually assert at the end of
+# Rdb_key_def::pack_record and, if successful, would leave a badly malformed and
+# stored secondary key entry.
+create table t1 (
+  str varchar(255) character set utf8mb4,
+  key str (str(2))) default character set utf8mb4 engine=rocksdb;
+insert INTO t1 values("1111111111111111111111111111111111111111111111111111");
+drop table t1;
+
+# With a partial fix, this sequence would find the row in the secondary key but
+# would fail to unpack the t_vers value from the secondary key with a data
+# coruption error.
+create table t1(
+  t_vers varchar(4) not null,
+  key ix_5 (t_vers)
+) charset latin1 engine=rocksdb;
+insert into t1 values ('7.6 ');
+select t_vers from t1 where t_vers = '7.6';
+drop table t1;

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2764,17 +2764,23 @@ void Rdb_key_def::pack_with_varchar_space_pad(
   const CHARSET_INFO *const charset = field->charset();
   const auto field_var = static_cast<Field_varstring *>(field);
 
+  const char *src =
+      reinterpret_cast<const char *>(field_var->ptr + field_var->length_bytes);
+
   const size_t value_length = (field_var->length_bytes == 1)
                                   ? (uint)*field->ptr
                                   : uint2korr(field->ptr);
 
-  const size_t trimmed_len = charset->cset->lengthsp(
-      charset, (const char *)field_var->ptr + field_var->length_bytes,
-      value_length);
+  const size_t trimmed_len =
+      charset->cset->lengthsp(charset, src, value_length);
+
+  const size_t max_xfrm_len = charset->cset->charpos(
+      charset, src, src + trimmed_len, field_var->char_length());
+
   const size_t xfrm_len = charset->coll->strnxfrm(
       charset, buf, fpi->m_max_image_len, field_var->char_length(),
-      field_var->ptr + field_var->length_bytes, trimmed_len,
-      MY_STRXFRM_NOPAD_WITH_SPACE);
+      reinterpret_cast<const uchar *>(src),
+      std::min<size_t>(trimmed_len, max_xfrm_len), MY_STRXFRM_NOPAD_WITH_SPACE);
 
   /* Got a mem-comparable image in 'buf'. Now, produce varlength encoding */
   uchar *const buf_end = buf + xfrm_len;


### PR DESCRIPTION
…erver crash

- 8.0 changes the behavior of the character set strnxfrm methods in a way that
  alters what was a once 'defined' behavior in 5.7 to a now 'undefined'
  behavior.  Quoted right from m_ctype.h "@param num_codepoints Treat the string
  as if it were of type CHAR(num_codepoints)." ... "If the string has more than
  "num_codepoints" codepoints, behavior is undefined; may truncate, may crash,
  or do something else entirely."  The 5.7 behavior was to truncate the result
  to the num_codepoints length and is what the MyRocks packing code expected.
  This patch alters MyRocks to now tell strnxfrm what the srclen is based on the
  lesser of Field_varstring codepoint size or trimmed value length rather than
  always passing it the trimmed value length of the incoming value.