### PR TITLE
PS-3829: Post push fix. Fixed zipped page compression encryption by r…

### DIFF
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -1718,9 +1718,6 @@ fil_crypt_rotate_page(
 			/* force rotation by dummy updating page */
 			mlog_write_ulint(frame + FIL_PAGE_SPACE_ID,
 					 space_id, MLOG_4BYTES, &mtr);
-			// assign key version to a page in a buffer - so it would not be rotated more times
-			mlog_write_ulint(frame + FIL_PAGE_ENCRYPTION_KEY_VERSION, crypt_data->encrypting_with_key_version, MLOG_4BYTES, &mtr);
-
 			/* statistics */
 			state->crypt_stat.pages_modified++;
 		} else {

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -10442,7 +10442,6 @@ Encryption::encrypt(
 #endif
 		ut_ad(m_key_version != 0); // Since we are encrypting key_version cannot be 0 (i.e. page unencrypted)
 
-		mach_write_to_4(src + FIL_PAGE_ENCRYPTION_KEY_VERSION, m_key_version);
 
 		if (page_type == FIL_PAGE_COMPRESSED) {
 			mach_write_to_4(dst +  FIL_PAGE_DATA, m_checksum);


### PR DESCRIPTION
…emoving assigning key_version to pages in buffers. Key version should not be updated in buffers as there are no guarantees that the page's header being flushed is the only copy of the header in the buffer. This true for instance for zipped pages. Also with parallel double write buffer pages are copied so the os0file layer will update only the key version in the copy of the header.