### PR TITLE
PS-4979 : Dropping TokuDB table with non-alphanumeric characters coul…

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/PS-4979.result
+++ b/mysql-test/suite/tokudb.bugs/r/PS-4979.result
@@ -1,0 +1,2 @@
+CREATE TABLE `#mysql50#q.q`(f1 INT KEY) ENGINE=TOKUDB;
+ERROR HY000: Got error 1632 from storage engine

--- a/mysql-test/suite/tokudb.bugs/t/PS-4979.test
+++ b/mysql-test/suite/tokudb.bugs/t/PS-4979.test
@@ -1,0 +1,12 @@
+--source include/have_tokudb.inc
+# PS-4979 : Dropping TokuDB table with non-alphanumeric characters could lead
+#           to a crash
+#
+# `#mysql50#q.q` is an invalid table name, but the server side doesn't detect it
+# and complain.  Instead it passes in an empty table name to the engine.  The
+# engine expects a table name in the form of a relative path like
+# "./databasename/tablename".  InnoDB detects this in parsing the table name
+# during the creation and returns an error.
+
+--error ER_GET_ERRNO
+CREATE TABLE `#mysql50#q.q`(f1 INT KEY) ENGINE=TOKUDB;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -7252,6 +7252,16 @@ int ha_tokudb::create(
     tokudb_trx_data *trx = NULL;
     THD* thd = ha_thd();
 
+    String database_name, table_name, dictionary_name;
+    tokudb_split_dname(name, database_name, table_name, dictionary_name);
+    if (database_name.is_empty() || table_name.is_empty()) {
+        push_warning_printf(thd,
+                            Sql_condition::WARN_LEVEL_WARN,
+                            ER_TABLE_NAME,
+                            "TokuDB: Table Name or Database Name is empty");
+        DBUG_RETURN(ER_TABLE_NAME);
+    }
+
     memset(&kc_info, 0, sizeof(kc_info));
 
 #if 100000 <= MYSQL_VERSION_ID && MYSQL_VERSION_ID <= 100999


### PR DESCRIPTION
…d lead to a crash

- There seems to be cases where the server doesn't detect an invalid table name
  and somehow ends up passing in an empty table name during the create call. The
  engine expects a table name in the form of a relative path like
  "./databasename/tablename".  InnoDB detects this in parsing the table name
  during the creation and returns an error.  TokuDB does not.

- This commit adds an up-front parsing of the database and table names during
  creation and fails in the same way that InnoDB does if anything empty or
  unexpected is discovered.  Also added a new simple test that illustrates the
  detection of the empty table name and error.