### PR TITLE
PS-4982, PS-4983: Fix Valgrind errors with uninitialised memory (5.7)

### DIFF
--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -1489,8 +1489,10 @@ os_file_compress_page(
 
 	len += FIL_PAGE_DATA;
 
-	if (will_be_encrypted_with_keyring)
+	if (will_be_encrypted_with_keyring) {
+		mach_write_to_8(dst + len, 0);
 		len += 8;
+	}
 
 	// For encryption with keyring keys we required that there will be at least 8 bytes left 
 	// 4 bytes for key version and 4 bytes for post encryption checksum


### PR DESCRIPTION
Fix Valgrind warnings with clearing memory allocated for keyring data in `os_file_compress_page()`
