### PR TITLE
PS-4881: Add LLVM/clang 7 to Travis-CI (5.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,33 +41,37 @@ matrix:
       os: osx
     # 2
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6.0  BUILD=RelWithDebInfo
+      env: VERSION=7  BUILD=RelWithDebInfo
       compiler: clang
     # 3
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5.0  BUILD=Debug
+      env: VERSION=6.0  BUILD=Debug
       compiler: clang
     # 4
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=4.0  BUILD=Debug
+      env: VERSION=5.0  BUILD=Debug
       compiler: clang
     # 5
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=8    BUILD=Debug
-      compiler: gcc
+      env: VERSION=4.0  BUILD=Debug
+      compiler: clang
     # 6
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=Debug
+      env: VERSION=8    BUILD=Debug
       compiler: gcc
     # 7
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=Debug
+      env: VERSION=7    BUILD=Debug
       compiler: gcc
     # 8
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=Debug
+      env: VERSION=6    BUILD=Debug
       compiler: gcc
     # 9
+    - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=Debug
+      compiler: gcc
+    # 10
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=Debug
       compiler: gcc
@@ -81,33 +85,37 @@ matrix:
       os: osx
     # 2
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=6.0  BUILD=Debug
+      env: VERSION=7  BUILD=Debug
       compiler: clang
     # 3
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=5.0  BUILD=RelWithDebInfo
+      env: VERSION=6.0  BUILD=RelWithDebInfo
       compiler: clang
     # 4
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=4.0  BUILD=RelWithDebInfo
+      env: VERSION=5.0  BUILD=RelWithDebInfo
       compiler: clang
     # 5
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=8    BUILD=RelWithDebInfo
-      compiler: gcc
+      env: VERSION=4.0  BUILD=RelWithDebInfo
+      compiler: clang
     # 6
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo
+      env: VERSION=8    BUILD=RelWithDebInfo
       compiler: gcc
     # 7
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo
+      env: VERSION=7    BUILD=RelWithDebInfo
       compiler: gcc
     # 8
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo
+      env: VERSION=6    BUILD=RelWithDebInfo
       compiler: gcc
     # 9
+    - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo
+      compiler: gcc
+    # 10
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo
       compiler: gcc
@@ -116,33 +124,37 @@ matrix:
     # Configurations to be run after merging a pull request for percona/percona-server
     # 1
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6.0  BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=7  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 2
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5.0  BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=6.0  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 3
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=4.0  BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=5.0  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 4
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
-      compiler: gcc
+      env: VERSION=4.0  BUILD=RelWithDebInfo  INVERTED=ON
+      compiler: clang
     # 5
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 6
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 7
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
+      compiler: gcc
+    # 8
+    - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
-    #8
+    # 9
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
@@ -155,7 +167,7 @@ script:
     echo --- JOB_NUMBER=$JOB_NUMBER TRAVIS_COMMIT=$TRAVIS_COMMIT TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
 
   - echo --- Perform all Travis jobs or only jobs that are included in ENV_VAR_JOB_NUMBERS list if it is defined;
-    JOB_NUMBERS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27";
+    JOB_NUMBERS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30";
     if [[ "$ENV_VAR_JOB_NUMBERS" != "" ]]; then
        JOB_NUMBERS=$ENV_VAR_JOB_NUMBERS;
     fi;
@@ -165,13 +177,15 @@ script:
        travis_terminate 0; 
     fi;
 
-  # For the trunk use TRAVIS_COMMIT_RANGE but "Auto cancel branch builds" has to be turned off at https://travis-ci.org/percona/percona-server/settings
   # For pull requests and feature branches replace TRAVIS_COMMIT_RANGE with the range from the root to the tip of the branch
+  # For the trunk use the commit number of last successful build if exists
   - if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]] || [[ "$TRAVIS_REPO_SLUG" != "percona/percona-server" ]]; then
       if [[ "$TRAVIS_EVENT_TYPE" == "pull_request" ]]; then TRAVIS_COMMIT=$TRAVIS_COMMIT^2; fi;
       git fetch https://github.com/percona/percona-server.git $PARENT_BRANCH:master_repo_$PARENT_BRANCH;
       PARENT_COMMIT=$(git rev-list --first-parent --topo-order $TRAVIS_COMMIT ^master_repo_$PARENT_BRANCH | tail -1);
       TRAVIS_COMMIT_RANGE=$PARENT_COMMIT^..$TRAVIS_COMMIT;
+    else
+      if [ -s "$CCACHE_DIR/last_commit.txt" ]; then TRAVIS_COMMIT_RANGE=$(cat $CCACHE_DIR/last_commit.txt)..$TRAVIS_COMMIT; fi;
     fi;
     if MODIFIED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE 2>/dev/null); then
       echo -e "--- Modified files in $TRAVIS_COMMIT_RANGE:\n$MODIFIED_FILES";
@@ -269,9 +283,12 @@ script:
     echo --- CMAKE_OPT=\"$CMAKE_OPT\";
     echo --- ENV_VAR_CMAKE_OPT=\"$ENV_VAR_CMAKE_OPT\";
     cmake .. $CMAKE_OPT $ENV_VAR_CMAKE_OPT;
-    CMAKE_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME));
-    echo --- CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.
-  - make -j2
+
+  - CMAKE_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME));
+    echo --- CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.;
+    make -j2;
+    if [[ "$?" == "0" ]]; then echo $TRAVIS_COMMIT > $CCACHE_DIR/last_commit.txt; fi;
+
   - ccache --show-stats;
     BUILD_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME - $CMAKE_TIME));
     echo --- Total time $SECONDS seconds. Build time $BUILD_TIME seconds. CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.


### PR DESCRIPTION
1. Add clang-7 to the list of compilers
2. Cache the commit number of last successful build and use it for pushes to the trunk.
   It fixes issues when "Auto cancel branch builds" is turned on at https://travis-ci.org/percona/percona-server/settings