### PR TITLE
PS-4998: Valgrind: compilation fails with writing with no trivial copy-assignment (5.7)

### DIFF
--- a/storage/innobase/buf/buf0buddy.cc
+++ b/storage/innobase/buf/buf0buddy.cc
@@ -370,7 +370,7 @@ buf_buddy_alloc_zip(
 
 	if (buf) {
 		/* Trash the page other than the BUF_BUDDY_STAMP_NONFREE. */
-		UNIV_MEM_TRASH(buf, ~i, BUF_BUDDY_STAMP_OFFSET);
+		UNIV_MEM_TRASH(buf->stamp.bytes, ~i, BUF_BUDDY_STAMP_OFFSET);
 		UNIV_MEM_TRASH(BUF_BUDDY_STAMP_OFFSET + 4
 			       + buf->stamp.bytes, ~i,
 			       (BUF_BUDDY_LOW << i)


### PR DESCRIPTION
Fix compilation failure with Valgrind using `buf->stamp.bytes` instead of `buf` in buf_buddy_alloc_zip().

Upstream Bug URL:
https://bugs.mysql.com/bug.php?id=93105