### PR TITLE
PS-4859 : UBSAN storage/rocksdb/rocksdb/util/coding.h:384:3: runtime …

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -166,6 +166,10 @@ ELSE()
   SET(PIC_EXT "")
 ENDIF()
 
+IF(DEFINED WITH_UBSAN)
+  add_definitions(-DROCKSDB_UBSAN_RUN)
+ENDIF()
+
 SET(ROCKSDB_SOURCES
   ha_rocksdb.cc ha_rocksdb.h ha_rocksdb_proto.h
   logger.h


### PR DESCRIPTION
…error: load of misaligned address

PS-4860 : UBSAN storage/rocksdb/rocksdb/util/coding.h:367:3: runtime error: store to misaligned address

- Upstream RocksDB actually has this mostly handled when building stand alone.
  The problem is that MyRocks does not build RocksDB as a subproject, instead it
  'sources' the files directly into the MyRocks compilation module.  By doing
  this, the CMakeLists.txt magic that sets up RocksDB for UBSAN runs within
  the RocksDB project is never invoked.  The fix is to copy some of the logic
  from within the RocksDB CMakeLists.txt into the MyRocks CMakeLists.txt.