### PR TITLE
PS-4998: Valgrind: compilation fails with writing with no trivial copy-assignment (8.0)

### DIFF
--- a/storage/innobase/buf/buf0buddy.cc
+++ b/storage/innobase/buf/buf0buddy.cc
@@ -323,7 +323,7 @@ static buf_buddy_free_t *buf_buddy_alloc_zip(buf_pool_t *buf_pool, ulint i) {
 
   if (buf) {
     /* Trash the page other than the BUF_BUDDY_STAMP_NONFREE. */
-    UNIV_MEM_TRASH(buf, ~i, BUF_BUDDY_STAMP_OFFSET);
+    UNIV_MEM_TRASH(buf->stamp.bytes, ~i, BUF_BUDDY_STAMP_OFFSET);
     UNIV_MEM_TRASH(BUF_BUDDY_STAMP_OFFSET + 4 + buf->stamp.bytes, ~i,
                    (BUF_BUDDY_LOW << i) - (BUF_BUDDY_STAMP_OFFSET + 4));
     ut_ad(mach_read_from_4(buf->stamp.bytes + BUF_BUDDY_STAMP_OFFSET) ==


### PR DESCRIPTION
Fix compilation failure with Valgrind using `buf->stamp.bytes` instead of `buf` in `buf_buddy_alloc_zip()`.

Upstream Bug URL:
https://bugs.mysql.com/bug.php?id=93105