### PR TITLE
PS-5012: Valgrind: misused UNIV_MEM_ALLOC after ut_zalloc_nokey (5.7)

### DIFF
--- a/storage/innobase/include/buf0buf.ic
+++ b/storage/innobase/include/buf0buf.ic
@@ -836,7 +836,6 @@ buf_page_alloc_descriptor(void)
 
 	bpage = (buf_page_t*) ut_zalloc_nokey(sizeof *bpage);
 	ut_ad(bpage);
-	UNIV_MEM_ALLOC(bpage, sizeof *bpage);
 
 	return(bpage);
 }


### PR DESCRIPTION
Remove UNIV_MEM_ALLOC from `buf_page_alloc_descriptor()` as data is zeroed with `ut_zalloc_nokey()`.

Upstream Bug URL: https://bugs.mysql.com/bug.php?id=93173