### PR TITLE
PS-4529 : MTR: index_merge_rocksdb2 inadvertently tests InnoDB instea…

### DIFF
--- a/mysql-test/include/index_merge1.inc
+++ b/mysql-test/include/index_merge1.inc
@@ -457,6 +457,9 @@ update t3 set key9=key1,keyA=key1,keyB=key1,keyC=key1;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
 --source include/restart_mysqld.inc
 
+# reset default engine after restart
+eval SET SESSION DEFAULT_STORAGE_ENGINE = $engine_type;
+
 -- disable_query_log
 -- disable_result_log
 analyze table t3;

--- a/mysql-test/include/index_merge2.inc
+++ b/mysql-test/include/index_merge2.inc
@@ -375,6 +375,9 @@ update t1 set key2=key1,key3=key1;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
 --source include/restart_mysqld.inc
 
+# reset default engine after restart
+eval SET SESSION DEFAULT_STORAGE_ENGINE = $engine_type;
+
 -- disable_query_log
 -- disable_result_log
 analyze table t1;

--- a/mysql-test/include/index_merge_ror.inc
+++ b/mysql-test/include/index_merge_ror.inc
@@ -188,6 +188,9 @@ delete from t1 where key3=100 and key4=100;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
 --source include/restart_mysqld.inc
 
+# reset default engine after restart
+eval SET SESSION DEFAULT_STORAGE_ENGINE = $engine_type;
+
 -- disable_query_log
 -- disable_result_log
 analyze table t1;

--- a/mysql-test/r/index_merge_innodb.result
+++ b/mysql-test/r/index_merge_innodb.result
@@ -295,6 +295,7 @@ alter table t3 add keyB int not null, add index iB(keyB);
 alter table t3 add keyC int not null, add index iC(keyC);
 update t3 set key9=key1,keyA=key1,keyB=key1,keyC=key1;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
+SET SESSION DEFAULT_STORAGE_ENGINE = InnoDB;
 explain select * from t3 where
 key1=1 or key2=2 or key3=3 or key4=4 or
 key5=5 or key6=6 or key7=7 or key8=8 or
@@ -704,6 +705,7 @@ key1	key2	key3	key4	filler1
 -1	-1	100	100	key4-key3
 delete from t1 where key3=100 and key4=100;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
+SET SESSION DEFAULT_STORAGE_ENGINE = InnoDB;
 explain select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t1	index_merge	key1,key2,key3,key4	key1,key2,key3,key4	5,5,5,5	NULL	4	Using union(intersect(key1,key2),intersect(key3,key4)); Using where
@@ -1135,6 +1137,7 @@ alter table t1 add index i2(key2);
 alter table t1 add index i3(key3);
 update t1 set key2=key1,key3=key1;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
+SET SESSION DEFAULT_STORAGE_ENGINE = InnoDB;
 explain select * from t1 where (key3 > 30 and key3<35) or (key2 >32 and key2 < 40);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t1	index_merge	i2,i3	i3,i2	4,4	NULL	#	Using sort_union(i3,i2); Using where

--- a/mysql-test/r/index_merge_myisam.result
+++ b/mysql-test/r/index_merge_myisam.result
@@ -301,6 +301,7 @@ alter table t3 add keyB int not null, add index iB(keyB);
 alter table t3 add keyC int not null, add index iC(keyC);
 update t3 set key9=key1,keyA=key1,keyB=key1,keyC=key1;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
+SET SESSION DEFAULT_STORAGE_ENGINE = MyISAM;
 explain select * from t3 where
 key1=1 or key2=2 or key3=3 or key4=4 or
 key5=5 or key6=6 or key7=7 or key8=8 or
@@ -734,6 +735,7 @@ key1	key2	key3	key4	filler1
 -1	-1	100	100	key4-key3
 delete from t1 where key3=100 and key4=100;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
+SET SESSION DEFAULT_STORAGE_ENGINE = MyISAM;
 explain select key1,key2,key3,key4,filler1 from t1 where key1=100 and key2=100 or key3=100 and key4=100;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t1	index_merge	key1,key2,key3,key4	key1,key2,key3,key4	5,5,5,5	NULL	152	Using union(intersect(key1,key2),intersect(key3,key4)); Using where
@@ -1174,6 +1176,7 @@ alter table t1 add index i2(key2);
 alter table t1 add index i3(key3);
 update t1 set key2=key1,key3=key1;
 SET @@GLOBAL.innodb_fast_shutdown = 0;
+SET SESSION DEFAULT_STORAGE_ENGINE = MyISAM;
 explain select * from t1 where (key3 > 30 and key3<35) or (key2 >32 and key2 < 40);
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
 1	SIMPLE	t1	index_merge	i2,i3	i3,i2	4,4	NULL	11	Using sort_union(i3,i2); Using where


### PR DESCRIPTION
…d of MyRocks

- Fixed common includes that restart server without resetting
  default_storage_engine to that specified.  Re-recorded impacted tests to
  include the new statement re-setting the default_storage_engine.