### PR TITLE
PS-269: Fix `main.backup_locks` MTR test (8.0)

### DIFF
--- a/mysql-test/r/backup_locks.result
+++ b/mysql-test/r/backup_locks.result
@@ -25,16 +25,8 @@ LOCK TABLES t_innodb READ FOR BACKUP;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FOR BACKUP' at line 1
 LOCK TABLES t_innodb FOR BACKUP READ;
 ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'FOR BACKUP READ' at line 1
-LOCK BINLOG t_innodb FOR BACKUP;
-ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 't_innodb FOR BACKUP' at line 1
-LOCK BINLOG t_innodb READ FOR BACKUP;
-ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 't_innodb READ FOR BACKUP' at line 1
-LOCK BINLOG t_innodb FOR BACKUP READ;
-ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 't_innodb FOR BACKUP READ' at line 1
 LOCK TABLES FOR BACKUP;
 UNLOCK TABLES;
-LOCK BINLOG FOR BACKUP;
-UNLOCK BINLOG;
 #-----------------------------------------------------------------------
 # No backup locks are allowed in stored routines
 #-----------------------------------------------------------------------
@@ -43,20 +35,9 @@ BEGIN
 LOCK TABLES FOR BACKUP;
 END|
 ERROR 0A000: LOCK is not allowed in stored procedures
-CREATE PROCEDURE p2()
-BEGIN
-LOCK BINLOG FOR BACKUP;
-END|
-ERROR 0A000: LOCK is not allowed in stored procedures
 CREATE FUNCTION f1() RETURNS INT DETERMINISTIC
 BEGIN
 LOCK TABLES FOR BACKUP;
-RETURN 1;
-END|
-ERROR 0A000: LOCK is not allowed in stored procedures
-CREATE FUNCTION f2() RETURNS INT DETERMINISTIC
-BEGIN
-LOCK BINLOG FOR BACKUP;
 RETURN 1;
 END|
 ERROR 0A000: LOCK is not allowed in stored procedures
@@ -74,15 +55,6 @@ UNLOCK TABLES;
 SHOW STATUS LIKE 'Com_unlock_tables';
 Variable_name	Value
 Com_unlock_tables	1
-LOCK BINLOG FOR BACKUP;
-LOCK BINLOG FOR BACKUP;
-SHOW STATUS LIKE 'Com_lock_binlog_for_backup';
-Variable_name	Value
-Com_lock_binlog_for_backup	2
-UNLOCK BINLOG;
-SHOW STATUS LIKE 'Com_unlock_binlog';
-Variable_name	Value
-Com_unlock_binlog	1
 LOCK TABLES FOR BACKUP;
 DELETE FROM t_innodb;
 INSERT INTO t_innodb VALUES(0);
@@ -142,8 +114,12 @@ ERROR HY000: Can't execute the query because you have a conflicting backup lock
 SELECT * FROM t_csv;
 a
 DELETE FROM t_blackhole;
+Warnings:
+Warning	1870	Row events are not logged for DELETE statements that modify BLACKHOLE tables in row format. Table(s): 't_blackhole.'
 INSERT INTO t_blackhole VALUES(0);
 UPDATE t_blackhole SET a = 1;
+Warnings:
+Warning	1870	Row events are not logged for UPDATE statements that modify BLACKHOLE tables in row format. Table(s): 't_blackhole.'
 REPLACE INTO t_blackhole VALUES(1);
 SELECT * FROM t_blackhole;
 a
@@ -225,16 +201,6 @@ DROP DATABASE test;
 ERROR HY000: Can't execute the query because you have a conflicting backup lock
 CREATE DATABASE test1;
 ERROR HY000: Can't execute the query because you have a conflicting backup lock
-CREATE PROCEDURE p1()
-BEGIN
-SELECT 1;
-END|
-ERROR HY000: Can't execute the query because you have a conflicting backup lock
-CREATE FUNCTION f1() RETURNS INT DETERMINISTIC
-BEGIN
-RETURN 1;
-END|
-ERROR HY000: Can't execute the query because you have a conflicting backup lock
 CREATE VIEW v1 AS SELECT * FROM t_innodb;
 ERROR HY000: Can't execute the query because you have a conflicting backup lock
 INSERT INTO v_innodb VALUES(1);
@@ -248,134 +214,6 @@ ERROR HY000: Can't execute the query because you have a conflicting backup lock
 INSERT INTO v_archive VALUES(1);
 ERROR HY000: Can't execute the query because you have a conflicting backup lock
 UNLOCK TABLES;
-LOCK BINLOG FOR BACKUP;
-DELETE FROM t_innodb;
-INSERT INTO t_innodb VALUES(0);
-UPDATE t_innodb SET a = 1;
-REPLACE INTO t_innodb VALUES(1);
-SELECT * from t_innodb;
-a
-1
-1
-HANDLER t_innodb OPEN;
-HANDLER t_innodb READ a FIRST;
-a
-1
-HANDLER t_innodb CLOSE;
-DELETE FROM t_myisam;
-INSERT INTO t_myisam VALUES(0);
-UPDATE t_myisam SET a = 1;
-REPLACE INTO t_myisam VALUES(1);
-SELECT * from t_myisam;
-a
-1
-1
-HANDLER t_myisam OPEN;
-HANDLER t_myisam READ a FIRST;
-a
-1
-HANDLER t_myisam CLOSE;
-DELETE FROM t_memory;
-INSERT INTO t_memory VALUES(0);
-UPDATE t_memory SET a = 1;
-REPLACE INTO t_memory VALUES(1);
-SELECT * from t_memory;
-a
-1
-1
-DELETE FROM t_archive;
-INSERT INTO t_archive VALUES(0);
-SELECT * from t_archive;
-a
-0
-DELETE FROM t_csv;
-INSERT INTO t_csv VALUES(0);
-UPDATE t_csv SET a = 1;
-REPLACE INTO t_csv VALUES(1);
-SELECT * from t_csv;
-a
-1
-1
-DELETE FROM t_blackhole;
-INSERT INTO t_blackhole VALUES(0);
-UPDATE t_blackhole SET a = 1;
-REPLACE INTO t_blackhole VALUES(1);
-SELECT * from t_blackhole;
-a
-CREATE TABLE tt_innodb(a INT NOT NULL) ENGINE=InnoDB;
-CREATE TABLE tt_myisam(a INT NOT NULL) ENGINE=MyISAM;
-CREATE TABLE tt_memory(a INT NOT NULL) ENGINE=MEMORY;
-CREATE TABLE tt_csv(a INT NOT NULL) ENGINE=CSV;
-CREATE TABLE tt_blackhole(a INT NOT NULL) ENGINE=BLACKHOLE;
-CREATE TABLE tt_archive(a INT NOT NULL) ENGINE=ARCHIVE;
-DROP TABLE tt_innodb;
-DROP TABLE tt_myisam;
-DROP TABLE tt_memory;
-DROP TABLE tt_csv;
-DROP TABLE tt_blackhole;
-DROP TABLE tt_archive;
-DROP TABLE non_existing;
-ERROR 42S02: Unknown table 'test.non_existing'
-TRUNCATE TABLE t_innodb;
-TRUNCATE TABLE t_myisam;
-TRUNCATE TABLE t_memory;
-TRUNCATE TABLE t_csv;
-TRUNCATE TABLE t_blackhole;
-RENAME TABLE t_innodb TO tmp, tmp TO t_innodb;
-RENAME TABLE t_myisam TO tmp, tmp TO t_myisam;
-RENAME TABLE t_memory TO tmp, tmp TO t_memory;
-RENAME TABLE t_csv TO tmp, tmp TO t_csv;
-RENAME TABLE t_blackhole TO tmp, tmp TO t_blackhole;
-RENAME TABLE t_archive TO tmp, tmp TO t_archive;
-ALTER TABLE t_innodb ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_innodb DROP COLUMN b;
-ALTER TABLE t_myisam ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_myisam DROP COLUMN b;
-ALTER TABLE t_memory ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_memory DROP COLUMN b;
-ALTER TABLE t_csv ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_csv DROP COLUMN b;
-ALTER TABLE t_blackhole ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_blackhole DROP COLUMN b;
-ALTER TABLE t_archive ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_archive DROP COLUMN b;
-ALTER TABLE t_innodb ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_innodb'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_innodb DROP KEY tmp;
-ALTER TABLE t_myisam ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_myisam'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_myisam DROP KEY tmp;
-ALTER TABLE t_memory ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_memory'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_memory DROP KEY tmp;
-ALTER TABLE t_blackhole ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_blackhole'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_blackhole DROP KEY tmp;
-CREATE DATABASE test1;
-DROP DATABASE test1;
-CREATE PROCEDURE p1()
-BEGIN
-SELECT 1;
-END|
-DROP PROCEDURE p1|
-CREATE FUNCTION f1() RETURNS INT DETERMINISTIC
-BEGIN
-RETURN 1;
-END|
-DROP FUNCTION f1|
-CREATE VIEW v1 AS SELECT * FROM t_innodb;
-DROP VIEW v1;
-INSERT INTO v_innodb VALUES(1);
-INSERT INTO v_blackhole VALUES(1);
-INSERT INTO v_myisam VALUES(1);
-INSERT INTO v_csv VALUES(1);
-INSERT INTO v_memory VALUES(1);
-INSERT INTO v_archive VALUES(1);
-UNLOCK BINLOG;
 SELECT @@delay_key_write;
 @@delay_key_write
 ON
@@ -410,62 +248,7 @@ INSERT INTO tt_memory VALUES(5);
 INSERT INTO tt_csv VALUES(5);
 INSERT INTO tt_blackhole VALUES(5);
 INSERT INTO tt_archive VALUES(5);
-LOCK BINLOG FOR BACKUP;
-START TRANSACTION;
-SELECT * FROM tt_archive;
-a
-5
-SELECT * FROM tt_blackhole;
-a
-SELECT * FROM tt_memory;
-a
-5
-SELECT * FROM tt_innodb;
-a
-5
-SELECT * FROM tt_myisam;
-a
-5
-INSERT INTO tt_innodb VALUES(6);
-INSERT INTO tt_myisam VALUES(6);
-INSERT INTO tt_memory VALUES(6);
-INSERT INTO tt_csv VALUES(6);
-INSERT INTO tt_blackhole VALUES(6);
-INSERT INTO tt_archive VALUES(6);
-COMMIT;
-SELECT * FROM tt_archive;
-a
-5
-6
-SELECT * FROM tt_blackhole;
-a
-SELECT * FROM tt_memory;
-a
-5
-6
-SELECT * FROM tt_innodb;
-a
-5
-6
-SELECT * FROM tt_myisam;
-a
-5
-6
-DROP TEMPORARY TABLE tt_innodb;
-DROP TEMPORARY TABLE tt_myisam;
-DROP TEMPORARY TABLE tt_memory;
-DROP TEMPORARY TABLE tt_csv;
-DROP TEMPORARY TABLE tt_blackhole;
-DROP TEMPORARY TABLE tt_archive;
-UNLOCK BINLOG;
 UNLOCK TABLES;
-SELECT @@log_bin;
-@@log_bin
-0
-LOCK BINLOG FOR BACKUP;
-INSERT INTO t_innodb VALUES(1);
-INSERT INTO t_myisam VALUES(1);
-UNLOCK BINLOG;
 SET @old_general_log = @@general_log;
 SET @old_slow_query_log = @@slow_query_log;
 SET @old_log_output = @@log_output;
@@ -478,11 +261,6 @@ LOCK TABLES FOR BACKUP;
 SELECT 1;
 1
 1
-LOCK BINLOG FOR BACKUP;
-SELECT 1;
-1
-1
-UNLOCK BINLOG;
 UNLOCK TABLES;
 SET SESSION long_query_time = @old_long_query_time;
 SET GLOBAL log_output = @old_log_output;
@@ -559,66 +337,7 @@ INSERT INTO tt_csv VALUES(5);
 INSERT INTO tt_blackhole VALUES(5);
 INSERT INTO tt_archive VALUES(5);
 # connection default
-LOCK BINLOG FOR BACKUP;
-# connection con1
-START TRANSACTION;
-SELECT * FROM tt_archive;
-a
-5
-SELECT * FROM tt_blackhole;
-a
-SELECT * FROM tt_memory;
-a
-5
-SELECT * FROM tt_innodb;
-a
-5
-SELECT * FROM tt_myisam;
-a
-5
-INSERT INTO tt_innodb VALUES(6);
-INSERT INTO tt_myisam VALUES(6);
-INSERT INTO tt_memory VALUES(6);
-INSERT INTO tt_csv VALUES(6);
-INSERT INTO tt_blackhole VALUES(6);
-INSERT INTO tt_archive VALUES(6);
-COMMIT;
-SELECT * FROM tt_archive;
-a
-5
-6
-SELECT * FROM tt_blackhole;
-a
-SELECT * FROM tt_memory;
-a
-5
-6
-SELECT * FROM tt_innodb;
-a
-5
-6
-SELECT * FROM tt_myisam;
-a
-5
-6
-DROP TEMPORARY TABLE tt_innodb;
-DROP TEMPORARY TABLE tt_myisam;
-DROP TEMPORARY TABLE tt_memory;
-DROP TEMPORARY TABLE tt_csv;
-DROP TEMPORARY TABLE tt_blackhole;
-DROP TEMPORARY TABLE tt_archive;
-# connection default
-UNLOCK BINLOG;
 UNLOCK TABLES;
-LOCK BINLOG FOR BACKUP;
-# connection con1
-SELECT @@log_bin;
-@@log_bin
-0
-INSERT INTO t_innodb VALUES(1);
-INSERT INTO t_myisam VALUES(1);
-# connection default
-UNLOCK BINLOG;
 # connection default
 LOCK TABLES FOR BACKUP;
 # connection con1
@@ -641,9 +360,6 @@ SELECT * FROM t_myisam;
 a
 0
 0
-1
-1
-1
 HANDLER t_myisam OPEN;
 HANDLER t_myisam READ a FIRST;
 a
@@ -653,21 +369,21 @@ INSERT INTO t_memory VALUES(0);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT * FROM t_memory;
 a
-1
 INSERT INTO t_archive VALUES(0);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT * FROM t_archive;
 a
-0
-1
 INSERT INTO t_csv VALUES(0);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 SELECT * FROM t_csv;
 a
-1
 DELETE FROM t_blackhole;
+Warnings:
+Warning	1870	Row events are not logged for DELETE statements that modify BLACKHOLE tables in row format. Table(s): 't_blackhole.'
 INSERT INTO t_blackhole VALUES(0);
 UPDATE t_blackhole SET a = 1;
+Warnings:
+Warning	1870	Row events are not logged for UPDATE statements that modify BLACKHOLE tables in row format. Table(s): 't_blackhole.'
 REPLACE INTO t_blackhole VALUES(1);
 SELECT * FROM t_blackhole;
 a
@@ -689,16 +405,10 @@ DROP DATABASE test;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 CREATE DATABASE test1;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
-CREATE PROCEDURE p1() SELECT 1;
+INSERT INTO t_myisam VALUES(0);
 # connection default
-KILL QUERY #;
 # connection con1
-ERROR 70100: Query execution was interrupted
-CREATE FUNCTION f1() RETURNS INT DETERMINISTIC RETURN 1;
-# connection default
-KILL QUERY #;
-# connection con1
-ERROR 70100: Query execution was interrupted
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 CREATE VIEW v1 AS SELECT * FROM t_innodb;
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 INSERT INTO v_innodb VALUES(1);
@@ -707,137 +417,6 @@ INSERT INTO v_myisam VALUES(1);
 ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 # connection default
 UNLOCK TABLES;
-LOCK BINLOG FOR BACKUP;
-# connection con1
-DELETE FROM t_innodb;
-INSERT INTO t_innodb VALUES(0);
-UPDATE t_innodb SET a = 1;
-REPLACE INTO t_innodb VALUES(1);
-SELECT * from t_innodb;
-a
-1
-1
-HANDLER t_innodb OPEN;
-HANDLER t_innodb READ a FIRST;
-a
-1
-HANDLER t_innodb CLOSE;
-DELETE FROM t_myisam;
-INSERT INTO t_myisam VALUES(0);
-UPDATE t_myisam SET a = 1;
-REPLACE INTO t_myisam VALUES(1);
-SELECT * from t_myisam;
-a
-1
-1
-HANDLER t_myisam OPEN;
-HANDLER t_myisam READ a FIRST;
-a
-1
-HANDLER t_myisam CLOSE;
-DELETE FROM t_memory;
-INSERT INTO t_memory VALUES(0);
-UPDATE t_memory SET a = 1;
-REPLACE INTO t_memory VALUES(1);
-SELECT * from t_memory;
-a
-1
-1
-INSERT INTO t_archive VALUES(0);
-SELECT * from t_archive;
-a
-0
-1
-0
-DELETE FROM t_csv;
-INSERT INTO t_csv VALUES(0);
-UPDATE t_csv SET a = 1;
-REPLACE INTO t_csv VALUES(1);
-SELECT * from t_csv;
-a
-1
-1
-DELETE FROM t_blackhole;
-INSERT INTO t_blackhole VALUES(0);
-UPDATE t_blackhole SET a = 1;
-REPLACE INTO t_blackhole VALUES(1);
-SELECT * from t_blackhole;
-a
-CREATE TABLE tt_innodb(a INT NOT NULL) ENGINE=InnoDB;
-CREATE TABLE tt_myisam(a INT NOT NULL) ENGINE=MyISAM;
-CREATE TABLE tt_memory(a INT NOT NULL) ENGINE=MEMORY;
-CREATE TABLE tt_csv(a INT NOT NULL) ENGINE=CSV;
-CREATE TABLE tt_blackhole(a INT NOT NULL) ENGINE=BLACKHOLE;
-CREATE TABLE tt_archive(a INT NOT NULL) ENGINE=ARCHIVE;
-DROP TABLE tt_innodb;
-DROP TABLE tt_myisam;
-DROP TABLE tt_memory;
-DROP TABLE tt_csv;
-DROP TABLE tt_blackhole;
-DROP TABLE tt_archive;
-DROP TABLE non_existing;
-ERROR 42S02: Unknown table 'test.non_existing'
-TRUNCATE TABLE t_innodb;
-TRUNCATE TABLE t_myisam;
-TRUNCATE TABLE t_memory;
-TRUNCATE TABLE t_csv;
-TRUNCATE TABLE t_blackhole;
-RENAME TABLE t_innodb TO tmp, tmp TO t_innodb;
-RENAME TABLE t_myisam TO tmp, tmp TO t_myisam;
-RENAME TABLE t_memory TO tmp, tmp TO t_memory;
-RENAME TABLE t_csv TO tmp, tmp TO t_csv;
-RENAME TABLE t_blackhole TO tmp, tmp TO t_blackhole;
-RENAME TABLE t_archive TO tmp, tmp TO t_archive;
-ALTER TABLE t_innodb ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_innodb DROP COLUMN b;
-ALTER TABLE t_myisam ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_myisam DROP COLUMN b;
-ALTER TABLE t_memory ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_memory DROP COLUMN b;
-ALTER TABLE t_csv ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_csv DROP COLUMN b;
-ALTER TABLE t_blackhole ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_blackhole DROP COLUMN b;
-ALTER TABLE t_archive ADD COLUMN b CHAR(10) NOT NULL;
-ALTER TABLE t_archive DROP COLUMN b;
-ALTER TABLE t_innodb ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_innodb'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_innodb DROP KEY tmp;
-ALTER TABLE t_myisam ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_myisam'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_myisam DROP KEY tmp;
-ALTER TABLE t_memory ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_memory'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_memory DROP KEY tmp;
-ALTER TABLE t_blackhole ADD KEY tmp (a);
-Warnings:
-Warning	1831	Duplicate index 'tmp' defined on the table 'test.t_blackhole'. This is deprecated and will be disallowed in a future release.
-ALTER TABLE t_blackhole DROP KEY tmp;
-CREATE DATABASE test1;
-DROP DATABASE test1;
-CREATE PROCEDURE p1()
-BEGIN
-SELECT 1;
-END|
-DROP PROCEDURE p1|
-CREATE FUNCTION f1() RETURNS INT DETERMINISTIC
-BEGIN
-RETURN 1;
-END|
-DROP FUNCTION f1|
-CREATE VIEW v1 AS SELECT * FROM t_innodb;
-DROP VIEW v1;
-INSERT INTO v_innodb VALUES(1);
-INSERT INTO v_blackhole VALUES(1);
-INSERT INTO v_myisam VALUES(1);
-INSERT INTO v_csv VALUES(1);
-INSERT INTO v_memory VALUES(1);
-INSERT INTO v_archive VALUES(1);
-# connection default
-UNLOCK BINLOG;
 SET @old_general_log = @@general_log;
 SET @old_slow_query_log = @@slow_query_log;
 SET @old_log_output = @@log_output;
@@ -852,14 +431,6 @@ SELECT 1;
 1
 1
 # connection default
-LOCK BINLOG FOR BACKUP;
-SELECT 1;
-1
-1
-# connection con1
-SET SESSION long_query_time = @old_long_query_time;
-# connection default
-UNLOCK BINLOG;
 UNLOCK TABLES;
 SET GLOBAL log_output = @old_log_output;
 SET GLOBAL slow_query_log = @old_slow_query_log;
@@ -899,16 +470,6 @@ FLUSH TABLES WITH READ LOCK;
 ERROR HY000: Can't execute the query because you have a conflicting backup lock
 UNLOCK TABLES;
 DROP TABLE t1;
-CREATE TABLE t(a int) ENGINE=InnoDB;
-FLUSH TABLES t FOR EXPORT;
-LOCK BINLOG FOR BACKUP;
-UNLOCK TABLES;
-UNLOCK BINLOG;
-DROP TABLE t;
-CREATE TABLE t(a INT);
-LOCK TABLE t READ;
-LOCK BINLOG FOR BACKUP;
-DROP TABLE t;
 #-----------------------------------------------------------------------
 # Cleanup
 #-----------------------------------------------------------------------

--- a/mysql-test/t/backup_locks.test
+++ b/mysql-test/t/backup_locks.test
@@ -231,21 +231,6 @@ DROP DATABASE test;
 --error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
 CREATE DATABASE test1;
 
-delimiter |;
---error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
-CREATE PROCEDURE p1()
-BEGIN
-  SELECT 1;
-END|
-
---error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
-CREATE FUNCTION f1() RETURNS INT DETERMINISTIC
-BEGIN
-  RETURN 1;
-END|
-
-delimiter ;|
-
 --error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
 CREATE VIEW v1 AS SELECT * FROM t_innodb;
 
@@ -475,6 +460,9 @@ INSERT INTO tt_csv VALUES(5);
 INSERT INTO tt_blackhole VALUES(5);
 INSERT INTO tt_archive VALUES(5);
 
+--connection default
+--echo # connection default
+
 UNLOCK TABLES;
 
 #
@@ -549,53 +537,22 @@ DROP DATABASE test;
 --error ER_LOCK_WAIT_TIMEOUT
 CREATE DATABASE test1;
 
-# The server overrides lock_wait_timeout to 1 year when opening system
-# tables. So ER_LOCK_WAIT_TIMEOUT can't be used here.
 
---let $id=`SELECT CONNECTION_ID()`
-
---send CREATE PROCEDURE p1() SELECT 1
+--send INSERT INTO t_myisam VALUES(0)
 
 --connection default
 --echo # connection default
 
 let $wait_condition=
     SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST
-    WHERE STATE = "Waiting for backup lock" AND
-    INFO = "CREATE PROCEDURE p1() SELECT 1";
+    WHERE STATE = "Waiting for table backup lock" AND
+    INFO = "INSERT INTO t_myisam VALUES(0)";
 --source include/wait_condition.inc
-
---disable_query_log
---echo KILL QUERY #;
---eval KILL QUERY $id
---enable_query_log
 
 --connection con1
 --echo # connection con1
 
---error ER_QUERY_INTERRUPTED
---reap
-
---send CREATE FUNCTION f1() RETURNS INT DETERMINISTIC RETURN 1
-
---connection default
---echo # connection default
-
-let $wait_condition=
-    SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST
-    WHERE STATE = "Waiting for backup lock" AND
-    INFO = "CREATE FUNCTION f1() RETURNS INT DETERMINISTIC RETURN 1";
---source include/wait_condition.inc
-
---disable_query_log
---echo KILL QUERY #;
---eval KILL QUERY $id
---enable_query_log
-
---connection con1
---echo # connection con1
-
---error ER_QUERY_INTERRUPTED
+--error ER_LOCK_WAIT_TIMEOUT
 --reap
 
 --error ER_LOCK_WAIT_TIMEOUT
@@ -632,6 +589,9 @@ SET @old_long_query_time = @@SESSION.long_query_time;
 SET SESSION long_query_time = 0;
 
 SELECT 1;
+
+--connection default
+--echo # connection default
 
 UNLOCK TABLES;
 


### PR DESCRIPTION
1. Remove `CREATE PROCEDURE` and `CREATE FUNCTION` as they are transactional in 8.0.
2. Add missing `--connection`.