### PR TITLE
PS-4985: Two log encryption tests crashed with eatmydata.

### DIFF
--- a/mysql-test/include/log_encrypt_5.inc
+++ b/mysql-test/include/log_encrypt_5.inc
@@ -41,7 +41,7 @@ CREATE DATABASE test;
 EOF
 --echo # Stop the MTR default DB server
 --source include/shutdown_mysqld.inc
-let NEW_CMD = $MYSQLD --no-defaults --initialize-insecure --innodb_log_file_size=$LOG_FILE_SIZE --innodb_page_size=$START_PAGE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1 --init-file=$BOOTSTRAP_SQL --innodb_undo_directory=$MYSQLD_UNDO_DATADIR --innodb_undo_tablespaces=2 --secure-file-priv="" >$MYSQLTEST_VARDIR/tmp/bootstrap1.log 2>&1;
+let NEW_CMD = $MYSQLD --no-defaults --initialize-insecure --innodb_log_file_size=$LOG_FILE_SIZE --innodb_page_size=$START_PAGE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1 --init-file=$BOOTSTRAP_SQL --innodb_undo_directory=$MYSQLD_UNDO_DATADIR --innodb_undo_tablespaces=2 --secure-file-priv="" >$MYSQL_TMP_DIR/bootstrap1.log 2>&1;
 
 --echo # Run the bootstrap command of datadir1
 --exec $NEW_CMD
@@ -119,7 +119,7 @@ DROP DATABASE tde_db;
 
 --force-rmdir $MYSQL_TMP_DIR/log_encrypt_dir1
 --force-rmdir $MYSQL_TMP_DIR/innodb_undo_data_dir
---remove_file $MYSQLTEST_VARDIR/tmp/bootstrap1.log
+--remove_file $MYSQL_TMP_DIR/bootstrap1.log
 --remove_file $BOOTSTRAP_SQL
 --disable_query_log
 eval SET GLOBAL innodb_file_per_table=$old_innodb_file_per_table;

--- a/mysql-test/include/log_encrypt_6.inc
+++ b/mysql-test/include/log_encrypt_6.inc
@@ -35,7 +35,7 @@ EOF
 --echo # Stop the MTR default DB server
 --source include/shutdown_mysqld.inc
 
-let NEW_CMD = $MYSQLD --no-defaults --initialize-insecure --innodb_log_file_size=$LOG_FILE_SIZE --innodb_page_size=$START_PAGE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1 --init-file=$BOOTSTRAP_SQL --secure-file-priv="" --innodb_redo_log_encrypt=$redo_log_encrypt_mode --innodb_undo_tablespaces=2 --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --keyring_file_data=$MYSQL_TMP_DIR/my_key_redo4 $KEYRING_PLUGIN_OPT </dev/null>>$MYSQLTEST_VARDIR/tmp/bootstrap1.log 2>&1;
+let NEW_CMD = $MYSQLD --no-defaults --initialize-insecure --innodb_log_file_size=$LOG_FILE_SIZE --innodb_page_size=$START_PAGE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1 --init-file=$BOOTSTRAP_SQL --secure-file-priv="" --innodb_redo_log_encrypt=$redo_log_encrypt_mode --innodb_undo_tablespaces=2 --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --keyring_file_data=$MYSQL_TMP_DIR/my_key_redo4 $KEYRING_PLUGIN_OPT </dev/null>>$MYSQL_TMP_DIR/bootstrap1.log 2>&1;
 
 --echo # Run the bootstrap command of datadir1
 --exec $NEW_CMD

--- a/mysql-test/suite/innodb/t/disabled.def
+++ b/mysql-test/suite/innodb/t/disabled.def
@@ -9,7 +9,3 @@
 #  Do not use any TAB characters for whitespace.
 #
 ##############################################################################
-log_encrypt_4_mk : PS-4958 2018-10-24 Zsolt Parragi Testcase crashes with eatmydata in LD_PRELOAD
-log_encrypt_4_rk : PS-4958 2018-10-24 Zsolt Parragi Testcase crashes with eatmydata in LD_PRELOAD
-log_encrypt_6_mk : PS-4958 2018-10-24 Zsolt Parragi Testcase crashes with eatmydata in LD_PRELOAD
-log_encrypt_6_rk : PS-4958 2018-10-24 Zsolt Parragi Testcase crashes with eatmydata in LD_PRELOAD

--- a/mysql-test/suite/innodb/t/log_encrypt_2_mk.test
+++ b/mysql-test/suite/innodb/t/log_encrypt_2_mk.test
@@ -1,2 +1,2 @@
---let KEYRING_PARAMS=--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring1 $KEYRING_PLUGIN_OPT
+--let KEYRING_PARAMS=--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring2 $KEYRING_PLUGIN_OPT
 --source include/log_encrypt_2.inc

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3909,6 +3909,8 @@ innobase_fix_tablespaces_empty_uuid()
 		return(false);
 	}
 
+	log_enable_encryption_if_set();
+
 	/* We only need to handle the case when an encrypted tablespace
 	is created at startup. If it is 0, there is no encrypted tablespace,
 	If it is > 1, it means we already have fixed the UUID */
@@ -3947,7 +3949,7 @@ innobase_fix_tablespaces_empty_uuid()
 	space_ids.push_back(srv_sys_space.space_id());
 	space_ids.push_back(srv_tmp_space.space_id());
 
-	bool	ret = !fil_encryption_rotate_global(space_ids);
+	bool	ret = !fil_encryption_rotate_global(space_ids) || !log_rotate_encryption();
 
 	my_free(master_key);
 
@@ -4004,7 +4006,7 @@ innobase_encryption_key_rotation()
                 return(true);
         }
 
-	ret = !fil_encryption_rotate();
+	ret = !fil_encryption_rotate() || !log_rotate_encryption();
 
 	my_free(master_key);
 

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -62,6 +62,8 @@ Created 12/9/1995 Heikki Tuuri
 
 #include "system_key.h"
 
+static redo_log_encrypt_enum found_log_encryption_mode = REDO_LOG_ENCRYPT_OFF;
+
 /*
 General philosophy of InnoDB redo-logs:
 
@@ -1123,6 +1125,7 @@ log_read_encryption()
 	if (memcmp(log_block_buf + LOG_HEADER_CREATOR_END,
 		   ENCRYPTION_KEY_MAGIC_RK, ENCRYPTION_MAGIC_SIZE) == 0) {
 		encryption_magic = true;
+		found_log_encryption_mode = REDO_LOG_ENCRYPT_RK;
 
 		/* Make sure the keyring is loaded. */
 		if (!Encryption::check_keyring()) {
@@ -1165,6 +1168,7 @@ log_read_encryption()
 	if (memcmp(log_block_buf + LOG_HEADER_CREATOR_END,
 		   ENCRYPTION_KEY_MAGIC_V2, ENCRYPTION_MAGIC_SIZE) == 0) {
 		encryption_magic = true;
+		found_log_encryption_mode = REDO_LOG_ENCRYPT_MK;
 
 		/* Make sure the keyring is loaded. */
 		if (!Encryption::check_keyring()) {
@@ -1298,7 +1302,8 @@ log_write_encryption(
 	}
 
 	log_write_mutex_enter();
-	if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_MK) {
+	if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_MK || 
+	    found_log_encryption_mode == REDO_LOG_ENCRYPT_MK) {
 		if (!log_file_header_fill_encryption(log_block_buf,
 						     key,
 						     iv)) {
@@ -1306,7 +1311,8 @@ log_write_encryption(
 			log_write_mutex_exit();
 			return(false);
 		}
-	} else if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK) {
+	} else if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK ||
+		   found_log_encryption_mode == REDO_LOG_ENCRYPT_RK) {
 		if (!log_file_header_fill_encryption(log_block_buf,
 						     version,
 						     iv)) {

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2879,8 +2879,6 @@ loop:
 			srv_master_do_idle_tasks();
 		}
 
-		log_enable_encryption_if_set();
-
 		srv_enable_undo_encryption_if_set();
 	}
 


### PR DESCRIPTION
The issue wasn't realeted directly to libeatmydata, it was only a side effect.
Eatmydata made the boostrap too quick: the master thread loop wasn't executed fully even once during bootstrap.
As undo/redo encryption headers were only written out in this loop, the log files contained encrypted data, but didn't contain any information about the keys.

This change writes encryption info out immediately after the server UUID is available, fixing this issue.