### PR TITLE
PS-5014: LOCK TABLES FOR BACKUP should depend on BACKUP_ADMIN instead of RELOAD (8.0)

### DIFF
--- a/mysql-test/r/backup_locks.result
+++ b/mysql-test/r/backup_locks.result
@@ -475,5 +475,20 @@ DROP TABLE t1;
 #-----------------------------------------------------------------------
 SET GLOBAL lock_wait_timeout=default;
 DROP USER user@localhost;
+#
+# End of 5.7 tests
+#
+# 8.0: LOCK TABLES FOR BACKUP should require BACKUP_ADMIN instead of RELOAD
+CREATE USER u1@localhost;
+LOCK TABLES FOR BACKUP;
+ERROR 42000: Access denied; you need (at least one of) the BACKUP_ADMIN privilege(s) for this operation
+GRANT RELOAD ON *.* TO u1@localhost;
+LOCK TABLES FOR BACKUP;
+ERROR 42000: Access denied; you need (at least one of) the BACKUP_ADMIN privilege(s) for this operation
+REVOKE RELOAD ON *.* FROM u1@localhost;
+GRANT BACKUP_ADMIN ON *.* TO u1@localhost;
+LOCK TABLES FOR BACKUP;
+UNLOCK TABLES;
+DROP USER u1@localhost;
 DROP VIEW v_innodb, v_myisam, v_memory, v_csv, v_blackhole, v_archive;
 DROP TABLE t_innodb, t_myisam, t_memory, t_csv, t_blackhole, t_archive;

--- a/mysql-test/t/backup_locks.test
+++ b/mysql-test/t/backup_locks.test
@@ -662,6 +662,36 @@ DROP USER user@localhost;
 --disconnect con1
 --disconnect con2
 
+--echo #
+--echo # End of 5.7 tests
+--echo #
+
+--echo # 8.0: LOCK TABLES FOR BACKUP should require BACKUP_ADMIN instead of RELOAD
+CREATE USER u1@localhost;
+--connect (con3, localhost, u1)
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+LOCK TABLES FOR BACKUP;
+
+--connection default
+GRANT RELOAD ON *.* TO u1@localhost;
+
+--connection con3
+--error ER_SPECIFIC_ACCESS_DENIED_ERROR
+LOCK TABLES FOR BACKUP;
+
+--connection default
+REVOKE RELOAD ON *.* FROM u1@localhost;
+GRANT BACKUP_ADMIN ON *.* TO u1@localhost;
+
+--connection con3
+LOCK TABLES FOR BACKUP;
+UNLOCK TABLES;
+--disconnect con3
+
+--connection default
+DROP USER u1@localhost;
+
+
 --source include/wait_until_count_sessions.inc
 
 DROP VIEW v_innodb, v_myisam, v_memory, v_csv, v_blackhole, v_archive;

--- a/sql/sql_backup_lock.cc
+++ b/sql/sql_backup_lock.cc
@@ -44,7 +44,7 @@
   @retval true   A user doesn't have the privilege BACKUP_ADMIN
 */
 
-static bool check_backup_admin_privilege(THD *thd) {
+bool check_backup_admin_privilege(THD *thd) {
   Security_context *sctx = thd->security_context();
 
   if (!sctx->has_global_grant(STRING_WITH_LEN("BACKUP_ADMIN")).first) {

--- a/sql/sql_backup_lock.h
+++ b/sql/sql_backup_lock.h
@@ -73,6 +73,18 @@ class Sql_cmd_unlock_instance : public Sql_cmd {
 };
 
 /**
+  Check if a current user has the privilege BACKUP_ADMIN required to run
+  LOCK INSTANCE FOR BACKUP and LOCK TABLES FOR BACKUP.
+
+  @param thd    Current thread
+
+  @retval false  A user has the privilege BACKUP_ADMIN
+  @retval true   A user doesn't have the privilege BACKUP_ADMIN
+*/
+
+bool check_backup_admin_privilege(THD *thd);
+
+/**
   Acquire exclusive Backup Lock.
 
   @param[in] thd                Current thread context

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -2431,7 +2431,7 @@ err:
 static bool lock_tables_for_backup(THD *thd) {
   DBUG_ENTER("lock_tables_for_backup");
 
-  if (check_global_access(thd, RELOAD_ACL)) DBUG_RETURN(true);
+  if (check_backup_admin_privilege(thd)) DBUG_RETURN(true);
 
   if (delay_key_write_options == DELAY_KEY_WRITE_ALL) {
     my_error(ER_OPTION_PREVENTS_STATEMENT, MYF(0), "delay_key_write=ALL");


### PR DESCRIPTION
1. Use `check_backup_admin_privilege()` instead of `check_global_access(thd, RELOAD_ACL)`.
2. Add tests for RELOAD and BACKUP_ADMIN in `main.backup_locks`.