### PR TITLE
PS-5059: sys_vars: NON_PERSIST flag doesn't work without READ_ONLY (8.0)

### DIFF
--- a/mysql-test/r/read_only_persisted_variables.result
+++ b/mysql-test/r/read_only_persisted_variables.result
@@ -334,7 +334,7 @@ ERROR HY000: Variable 'innodb_page_size' is a non persistent read only variable
 SET @@persist_only.version= "";
 ERROR HY000: Variable 'version' is a non persistent read only variable
 SET @@persist_only.version_comment= "";
-ERROR HY000: Variable 'version_comment' is a non persistent read only variable
+ERROR HY000: Variable 'version_comment' is a non persistent variable
 SET @@persist_only.version_compile_machine= "";
 ERROR HY000: Variable 'version_compile_machine' is a non persistent read only variable
 SET @@persist_only.version_compile_os= "";

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -865,6 +865,12 @@ int set_var::resolve(THD *thd) {
                "non persistent read only");
       DBUG_RETURN(-1);
     }
+  } else {
+    if (type == OPT_PERSIST_ONLY && var->is_non_persistent()) {
+      my_error(ER_INCORRECT_GLOBAL_LOCAL_VAR, MYF(0), var->name.str,
+               "non persistent");
+      DBUG_RETURN(-1);
+    }
   }
   if (!var->check_scope(type)) {
     int err = (is_global_persist()) ? ER_LOCAL_VARIABLE : ER_GLOBAL_VARIABLE;


### PR DESCRIPTION
1. Add detection of the NON_PERSIST flag without the READ_ONLY flag
2. Re-record `main.read_only_persisted_variables` MTR test