### PR TITLE
PS-4532 : Replace obsolete HAVE_purify with HAVE_VALGRIND in ha_rocks…

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4392,11 +4392,11 @@ static int rocksdb_done_func(void *const p) {
 // Disown the cache data since we're shutting down.
 // This results in memory leaks but it improved the shutdown time.
 // Don't disown when running under valgrind
-#ifndef HAVE_purify
+#ifndef HAVE_VALGRIND
   if (rocksdb_tbl_options->block_cache) {
     rocksdb_tbl_options->block_cache->DisownData();
   }
-#endif /* HAVE_purify */
+#endif  // HAVE_VALGRIND
 
   rocksdb_db_options = nullptr;
   rocksdb_tbl_options = nullptr;


### PR DESCRIPTION
…db.cc

- Replaced HAVE_purify with HAVE_VALGRIND as suggested.

(cherry picked from commit 2cdb8adbe0c902ffa1a0e6b0cd2d2cb9d178d3ff)