### PR TITLE
PS-5035 : rocksdb.show_table_status: 1051: Unknown table 'db_new'

### DIFF
--- a/sql/partitioning/partition_base.cc
+++ b/sql/partitioning/partition_base.cc
@@ -207,10 +207,10 @@ bool get_part_str_for_table(const char *name, std::string &result)
                                         table_name, sizeof(table_name));
 
   // Prepare the path to the .FRM file and open the file
+  // The 'name' is coming into this function already encoded in fscs.
   char    path[FN_REFLEN + 1];  //< Path to .FRM file
-  bool temp_table= (bool)is_prefix(table_name, tmp_file_prefix);
   build_table_filename(path, sizeof(path) - 1, db_name, table_name, reg_ext,
-                       temp_table ? FN_IS_TMP : 0);
+                       FN_IS_ENCODED);
 
   return get_part_str_for_path(path, result);
 }

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -573,12 +573,16 @@ size_t build_table_filename(char *buff, size_t bufflen, const char *db,
   DBUG_PRINT("enter", ("db: '%s'  table_name: '%s'  ext: '%s'  flags: %x",
                        db, table_name, ext, flags));
 
-  if (flags & FN_IS_TMP) // FN_FROM_IS_TMP | FN_TO_IS_TMP
+  if ((flags & FN_IS_TMP) ||  // FN_FROM_IS_TMP | FN_TO_IS_TMP
+      (flags & FN_IS_ENCODED))
     tab_len= my_stpnmov(tbbuff, table_name, sizeof(tbbuff)) - tbbuff;
   else
     tab_len= tablename_to_filename(table_name, tbbuff, sizeof(tbbuff));
 
-  db_len= tablename_to_filename(db, dbbuff, sizeof(dbbuff));
+  if (flags & FN_IS_ENCODED)
+    db_len= my_stpnmov(dbbuff, db, sizeof(dbbuff)) - dbbuff;
+  else
+    db_len= tablename_to_filename(db, dbbuff, sizeof(dbbuff));
 
   char *end = buff + bufflen;
   /* Don't add FN_ROOTDIR if mysql_data_home already includes it */

--- a/sql/sql_table.h
+++ b/sql/sql_table.h
@@ -144,6 +144,8 @@ static const uint FRM_ONLY=        1 << 3;
 static const uint NO_HA_TABLE=     1 << 4;
 /** Don't check foreign key constraints while renaming table */
 static const uint NO_FK_CHECKS=    1 << 5;
+/** Percona : Database and table name are encoded in fscs already */
+static const uint FN_IS_ENCODED=   1 << 6;
 
 size_t filename_to_tablename(const char *from, char *to, size_t to_length
 #ifndef DBUG_OFF


### PR DESCRIPTION
- This is not a simple test failure, it is a regression introduced as a part of
  the native partitioning implementation.
  The handler::delete_table method takes in a 'database.table' name in the
  expanded/converted format of the file system character set or fscs.  The
  character set has file system special characters expanded into '@xxxx' format
  so a '.' in a database or table name is represented as a '@002e' in the
  expanded name.
  The delete_table method needs to determine if the table is partitioned or not.
  It does this through the helper function native_part::get_part_str_for_table
  in sql/partitioning/partition_base.cc by parsing, then building the filename
  of the .frm file so that it can open and read partition info.
  This parsing makes use of the function build_table_filename in
  sql/sql_table.cc.  The build_table_filename function expects that the given
  database and table names are in system charset and again, encodes these into
  the fscs, therefore double encoding the database and table name into something
  that does not exist and can not be opened or read from.
  This results in delete_table returning ERR_TABLE_CORRUPT to the server which
  then complains that it can't DROP the database because it can't properly
  remove all of the tables within.

- Since there seems to be no other obvious helper function to take the
  database.table name in fscs encoding and turn it into a proper fully qualified
  path to the .frm file, we need to extend the flag set and functionality of
  build_table_filename that allows us to compose the full path but without the
  additional encoding.

- This is already covered by the test which revealed the issue within
  rocksdb.show_table_status so no new test is implemented.