### PR TITLE
PS-269: Fix persisted system variables (8.0)

### DIFF
--- a/mysql-test/r/read_only_persisted_variables.result
+++ b/mysql-test/r/read_only_persisted_variables.result
@@ -333,8 +333,6 @@ SET @@persist_only.innodb_page_size= "";
 ERROR HY000: Variable 'innodb_page_size' is a non persistent read only variable
 SET @@persist_only.version= "";
 ERROR HY000: Variable 'version' is a non persistent read only variable
-SET @@persist_only.version_comment= "";
-ERROR HY000: Variable 'version_comment' is a non persistent read only variable
 SET @@persist_only.version_compile_machine= "";
 ERROR HY000: Variable 'version_compile_machine' is a non persistent read only variable
 SET @@persist_only.version_compile_os= "";
@@ -351,6 +349,12 @@ SET @@persist_only.lower_case_file_system= "";
 ERROR HY000: Variable 'lower_case_file_system' is a non persistent read only variable
 SET @@persist_only.innodb_buffer_pool_load_at_startup= "";
 ERROR HY000: Variable 'innodb_buffer_pool_load_at_startup' is a non persistent read only variable
+SET @@persist_only.have_backup_locks = FALSE;
+ERROR HY000: Variable 'have_backup_locks' is a non persistent read only variable
+SET @@persist_only.have_backup_safe_binlog_info = FALSE;
+ERROR HY000: Variable 'have_backup_safe_binlog_info' is a non persistent read only variable
+SET @@persist_only.have_snapshot_cloning = FALSE;
+ERROR HY000: Variable 'have_snapshot_cloning' is a non persistent read only variable
 RESET PERSIST;
 DROP USER wl9787;
 #

--- a/mysql-test/t/read_only_persisted_variables.test
+++ b/mysql-test/t/read_only_persisted_variables.test
@@ -367,8 +367,6 @@ SET @@persist_only.innodb_page_size= "";
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SET @@persist_only.version= "";
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
-SET @@persist_only.version_comment= "";
---error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SET @@persist_only.version_compile_machine= "";
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SET @@persist_only.version_compile_os= "";
@@ -385,6 +383,14 @@ SET @@persist_only.protocol_version= "";
 SET @@persist_only.lower_case_file_system= "";
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR
 SET @@persist_only.innodb_buffer_pool_load_at_startup= "";
+
+# added by Percona
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@persist_only.have_backup_locks = FALSE;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@persist_only.have_backup_safe_binlog_info = FALSE;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET @@persist_only.have_snapshot_cloning = FALSE;
 
 # cleanup
 RESET PERSIST;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2519,22 +2519,6 @@ static Sys_var_ulonglong Sys_max_heap_table_size(
     VALID_RANGE(16384, (ulonglong) ~(intptr)0), DEFAULT(16 * 1024 * 1024),
     BLOCK_SIZE(1024));
 
-static ulong mdl_locks_cache_size_unused;
-static Sys_var_ulong Sys_metadata_locks_cache_size(
-    "metadata_locks_cache_size", "Has no effect, deprecated",
-    READ_ONLY GLOBAL_VAR(mdl_locks_cache_size_unused),
-    CMD_LINE(REQUIRED_ARG, OPT_MDL_CACHE_SIZE), VALID_RANGE(1, 1024 * 1024),
-    DEFAULT(1024), BLOCK_SIZE(1), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
-    ON_UPDATE(0), DEPRECATED(""));
-
-static ulong mdl_locks_hash_partitions_unused;
-static Sys_var_ulong Sys_metadata_locks_hash_instances(
-    "metadata_locks_hash_instances", "Has no effect, deprecated",
-    READ_ONLY GLOBAL_VAR(mdl_locks_hash_partitions_unused),
-    CMD_LINE(REQUIRED_ARG, OPT_MDL_HASH_INSTANCES), VALID_RANGE(1, 1024),
-    DEFAULT(8), BLOCK_SIZE(1), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
-    ON_UPDATE(0), DEPRECATED(""));
-
 // relies on DBUG_ASSERT(sizeof(my_thread_id) == 4);
 static Sys_var_uint Sys_pseudo_thread_id(
     "pseudo_thread_id", "This variable is for internal server use",
@@ -4651,7 +4635,7 @@ static Sys_var_charptr Sys_version_suffix("version_suffix", "version_suffix",
 static char *server_version_comment_ptr;
 static Sys_var_charptr Sys_version_comment(
     "version_comment", "version_comment",
-    NON_PERSIST GLOBAL_VAR(server_version_comment_ptr), NO_CMD_LINE,
+    GLOBAL_VAR(server_version_comment_ptr), NO_CMD_LINE,
     IN_SYSTEM_CHARSET, DEFAULT(MYSQL_COMPILATION_COMMENT));
 
 static char *server_version_compile_machine_ptr;
@@ -5324,7 +5308,7 @@ static Sys_var_have Sys_have_profiling(
 
 static Sys_var_have Sys_have_backup_locks(
     "have_backup_locks", "have_backup_locks",
-    READ_ONLY GLOBAL_VAR(have_backup_locks), NO_CMD_LINE);
+    READ_ONLY NON_PERSIST GLOBAL_VAR(have_backup_locks), NO_CMD_LINE);
 
 static Sys_var_have Sys_have_backup_safe_binlog_info(
     "have_backup_safe_binlog_info", "have_backup_safe_binlog_info",
@@ -5333,7 +5317,7 @@ static Sys_var_have Sys_have_backup_safe_binlog_info(
 
 static Sys_var_have Sys_have_snapshot_cloning(
     "have_snapshot_cloning", "have_snapshot_cloning",
-    READ_ONLY GLOBAL_VAR(have_snapshot_cloning), NO_CMD_LINE);
+    READ_ONLY NON_PERSIST GLOBAL_VAR(have_snapshot_cloning), NO_CMD_LINE);
 
 static Sys_var_have Sys_have_query_cache(
     "have_query_cache",


### PR DESCRIPTION
1. Remove `NON_PERSIST` from the `version_comment` variable.
2. Add `NON_PERSIST` to `have_backup_locks` and `have_snapshot_cloning` (both were `READ_ONLY` already).
3. Remove `metadata_locks_hash_instances`, `metadata_locks_cache_size` (wrong merge from 5.7).
4. Update and re-record `main.read_only_persisted_variables`.