### PR TITLE
PS-4950: Invalid audit log file size when audit_log_rotations is chan…

### DIFF
--- a/mysql-test/r/audit_log_rotate.result
+++ b/mysql-test/r/audit_log_rotate.result
@@ -1,1 +1,14 @@
+#
+# Rotate with "rotations" and "size" given as startup options
+#
+success
+#
+# PS-4950: Invalid audit log file size when audit_log_rotations is changed during runtime
+#
+SET @audit_log_rotations_orig = @@audit_log_rotations;
+SET @audit_log_rotate_on_size_orig = @@audit_log_rotate_on_size;
+SET GLOBAL audit_log_rotations = 3;
+SET GLOBAL audit_log_rotate_on_size = 4096;
+SET GLOBAL audit_log_rotations = @audit_log_rotations_orig;
+SET GLOBAL audit_log_rotate_on_size = @audit_log_rotate_on_size_orig;
 success

--- a/mysql-test/t/audit_log_rotate.test
+++ b/mysql-test/t/audit_log_rotate.test
@@ -3,6 +3,10 @@
 let $MYSQLD_DATADIR= `select @@datadir`;
 let MYSQLD_DATADIR= $MYSQLD_DATADIR;
 
+--echo #
+--echo # Rotate with "rotations" and "size" given as startup options
+--echo #
+
 --disable_result_log
 --disable_query_log
 --source include/audit_log_events.inc
@@ -24,6 +28,42 @@ perl;
   }
   die "Rotation doesn't work!" unless scalar(@files) > 1
 EOF
+
+--echo success
+
+--echo #
+--echo # PS-4950: Invalid audit log file size when audit_log_rotations is changed during runtime
+--echo #
+
+SET @audit_log_rotations_orig = @@audit_log_rotations;
+SET @audit_log_rotate_on_size_orig = @@audit_log_rotate_on_size;
+SET GLOBAL audit_log_rotations = 3;
+SET GLOBAL audit_log_rotate_on_size = 4096;
+
+--remove_files_wildcard $MYSQLD_DATADIR test_audit.log.*
+
+--disable_result_log
+--disable_query_log
+--source include/audit_log_events.inc
+--source include/audit_log_events.inc
+--source include/audit_log_events.inc
+--source include/audit_log_events.inc
+--enable_query_log
+--enable_result_log
+
+perl;
+  my @files = glob ($ENV{'MYSQLD_DATADIR'} . "/test_audit.log.[0-9][0-9]");
+  foreach (@files) {
+    my $size = -s $_;
+    print $_;
+    die "Files are too small!" unless $size >= 4096;
+  }
+  die "Too many rotations!" unless scalar(@files) <= 3;
+EOF
+
+SET GLOBAL audit_log_rotations = @audit_log_rotations_orig;
+SET GLOBAL audit_log_rotate_on_size = @audit_log_rotate_on_size_orig;
+
 --remove_files_wildcard $MYSQLD_DATADIR test_audit.log*
 
 --echo success

--- a/plugin/audit_log/audit_file.c
+++ b/plugin/audit_log/audit_file.c
@@ -203,10 +203,10 @@ void audit_handler_file_set_option(audit_handler_t *handler,
 
   switch (opt)
   {
-  case OPT_ROTATIONS:
+  case OPT_ROTATE_ON_SIZE:
     logger_set_size_limit(data->logger, *(ulonglong*)(val));
     break;
-  case OPT_ROTATE_ON_SIZE:
+  case OPT_ROTATIONS:
     logger_set_rotations(data->logger, *(ulonglong*)(val));
     break;
   }


### PR DESCRIPTION
…ged during runtime

audit_log_rotations and audit_log_rotate_on_size were messed up when set
at runtime.