### PR TITLE
PS-4951: Post push fix. Many libc-related Valgrind errors on CentOS7 (8.0)

### DIFF
--- a/mysql-test/valgrind.supp
+++ b/mysql-test/valgrind.supp
@@ -2121,5 +2121,5 @@
    fun:exit
    fun:*mysqld_exit*
    fun:*mysqld_main*
-   fun:main
+   fun:*main*
 }


### PR DESCRIPTION
Add support for a different valgrind or glibc version that reports:
`(below main) (libc-start.c:287)`
instead of
`main (main.cc:30)`.
This patch fixes issues with debian:jessie.