### PR TITLE
PS-269: Fix `mtr main.mysqlbinlog --parallel=1` (8.0)

### DIFF
--- a/mysql-test/include/mysqlbinlog.inc
+++ b/mysql-test/include/mysqlbinlog.inc
@@ -86,7 +86,7 @@ if ($mysqlbinlog_skip_replace)
 }
 if (!$mysqlbinlog_skip_replace)
 {
-  --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+  --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
   replace_regex
     /TIMESTAMP=[0-9]*/TIMESTAMP=#/
     /#[0-9]*[ ]*[0-9]*:[0-9]*:[0-9]* server id [0-9]*/# # server id #/

--- a/mysql-test/suite/rpl/r/rpl_mdev382.result
+++ b/mysql-test/suite/rpl/r/rpl_mdev382.result
@@ -192,7 +192,7 @@ SET TIMESTAMP=#/*!*/;
 BEGIN
 /*!*/;
 SET TIMESTAMP=#/*!*/;
-LOAD DATA LOCAL INFILE 'MYSQL_TMP_DIR/SQL_LOAD_MB-#-#' INTO TABLE `t``1` FIELDS TERMINATED BY ',' ENCLOSED BY '\'' ESCAPED BY '\\' LINES TERMINATED BY '\n' (`a``1`, @`b```) SET `b``2`= @`b```, `c``3`= concat('|', "b""a'z", "!")
+LOAD DATA LOCAL INFILE 'MYSQLTEST_VARDIR/tmp/SQL_LOAD_MB-#-#' INTO TABLE `t``1` FIELDS TERMINATED BY ',' ENCLOSED BY '\'' ESCAPED BY '\\' LINES TERMINATED BY '\n' (`a``1`, @`b```) SET `b``2`= @`b```, `c``3`= concat('|', "b""a'z", "!")
 /*!*/;
 COMMIT/*!*/;
 # original_commit_timestamp= MICROSECONDS-FROM-EPOCH (YYYY-MM-DD HOURS:MINUTES:SECONDS TZ)
@@ -211,7 +211,7 @@ BEGIN
 /*!*/;
 use `test`/*!*/;
 SET TIMESTAMP=#/*!*/;
-LOAD DATA LOCAL INFILE 'MYSQL_TMP_DIR/SQL_LOAD_MB-#-#' INTO TABLE `db1``; select 'oops!'`.`t``1` FIELDS TERMINATED BY ',' ENCLOSED BY '\'' ESCAPED BY '\\' LINES TERMINATED BY '\n' (`a``1`, `b``2`) SET `c``3`= concat('|', "b""a'z", "!")
+LOAD DATA LOCAL INFILE 'MYSQLTEST_VARDIR/tmp/SQL_LOAD_MB-#-#' INTO TABLE `db1``; select 'oops!'`.`t``1` FIELDS TERMINATED BY ',' ENCLOSED BY '\'' ESCAPED BY '\\' LINES TERMINATED BY '\n' (`a``1`, `b``2`) SET `c``3`= concat('|', "b""a'z", "!")
 /*!*/;
 COMMIT/*!*/;
 SET @@SESSION.GTID_NEXT= '#' /* added by mysqlbinlog */ /*!*/;

--- a/mysql-test/suite/rpl/t/rpl_mdev382.test
+++ b/mysql-test/suite/rpl/t/rpl_mdev382.test
@@ -115,9 +115,9 @@ let $pos2= query_get_value(SHOW MASTER STATUS, Position, 1);
 
 --source include/show_binlog_events.inc
 let $MYSQLD_DATADIR= `select @@datadir`;
---let $mysqlbinlog_parameters=--short-form --start-position=$binlog_start --stop-position=$pos2 $MYSQLD_DATADIR/master-bin.000001
+--let $mysqlbinlog_parameters=--short-form --local-load=$MYSQLTEST_VARDIR/tmp/ --start-position=$binlog_start --stop-position=$pos2 $MYSQLD_DATADIR/master-bin.000001
 --source include/mysqlbinlog.inc
---remove_files_wildcard $MYSQL_TMP_DIR SQL_LOAD_MB*
+--remove_files_wildcard $MYSQLTEST_VARDIR/tmp/ SQL_LOAD_MB*
 
 sync_slave_with_master;
 connection slave;


### PR DESCRIPTION
`mtr main.mysqlbinlog --parallel=1` returns:
```
-LOAD DATA LOCAL INFILE 'MYSQLTEST_VARDIR/tmp/SQL_LOAD_MB
+LOAD DATA LOCAL INFILE 'MYSQL_TMP_DIR/SQL_LOAD_MB
```

1. Remove `replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR` from `mysqlbinlog.inc` which causes issues with `--parallel=1`.
2. Fix and re-record `rpl.rpl_mdev382` by adding `--local-load=$MYSQLTEST_VARDIR/tmp/`.