### PR TITLE
PS-269: Fix bug49336 and percona_mysqlbinlog_ssl_compress (8.0)

### DIFF
--- a/mysql-test/r/percona_mysqlbinlog_ssl_compress.result
+++ b/mysql-test/r/percona_mysqlbinlog_ssl_compress.result
@@ -1,20 +1,41 @@
+SET @old_binlog_format=@@binlog_format;
+SET GLOBAL binlog_format='STATEMENT';
+SET SESSION binlog_format='STATEMENT';
 reset master;
-set timestamp=1000000000;
-drop table if exists t1;
 create table t1 (word varchar(20));
 insert into t1 values ("abirvalg");
 flush logs;
 
 --- --start-position --
+include/mysqlbinlog.inc
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=1*/;
+/*!50003 SET @OLD_COMPLETION_TYPE=@@COMPLETION_TYPE,COMPLETION_TYPE=0*/;
 DELIMITER /*!*/;
-/*!\C latin1 *//*!*/;
+# original_commit_timestamp= MICROSECONDS-FROM-EPOCH (YYYY-MM-DD HOURS:MINUTES:SECONDS TZ)
+# immediate_commit_timestamp= MICROSECONDS-FROM-EPOCH (YYYY-MM-DD HOURS:MINUTES:SECONDS TZ)
+/*!80001 SET @@session.original_commit_timestamp= MICROSECONDS-FROM-EPOCH*//*!*/;
+SET @@SESSION.GTID_NEXT= '#'/*!*/;
+SET TIMESTAMP=#/*!*/;
+SET @@session.pseudo_thread_id=#/*!*/;
+SET @@session.foreign_key_checks=1, @@session.sql_auto_is_null=0, @@session.unique_checks=1, @@session.autocommit=1/*!*/;
+SET @@session.sql_mode=1168113696/*!*/;
+SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/;
+/*!\C utf8mb4 *//*!*/;
+SET @@session.character_set_client=255,@@session.collation_connection=255,@@session.collation_server=255/*!*/;
+SET @@session.lc_time_names=0/*!*/;
+SET @@session.collation_database=DEFAULT/*!*/;
+/*!80005 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
 BEGIN
 /*!*/;
 use `test`/*!*/;
+SET TIMESTAMP=#/*!*/;
 insert into t1 values ("abirvalg")
 /*!*/;
 COMMIT/*!*/;
+SET @@SESSION.GTID_NEXT= '#' /* added by mysqlbinlog */ /*!*/;
 DELIMITER ;
 # End of log file
-ROLLBACK /* added by mysqlbinlog */;
+/*!50003 SET COMPLETION_TYPE=@OLD_COMPLETION_TYPE*/;
+/*!50530 SET @@SESSION.PSEUDO_SLAVE_MODE=0*/;
 drop table t1;
+SET GLOBAL binlog_format = @old_binlog_format;

--- a/mysql-test/t/bug49336.test
+++ b/mysql-test/t/bug49336.test
@@ -35,7 +35,7 @@ FLUSH LOGS;
 # run mysqlbinlog and make sure it ends normally
 
 let $MYSQLD_DATADIR= `SELECT @@datadir`;
---exec cat $MYSQLD_DATADIR/master-bin.000001 | $MYSQL_BINLOG - >/dev/null
+--exec cat $MYSQLD_DATADIR/binlog.000001 | $MYSQL_BINLOG - >/dev/null
 
 DROP TABLE t1;
 RESET MASTER;

--- a/mysql-test/t/percona_mysqlbinlog_ssl_compress.test
+++ b/mysql-test/t/percona_mysqlbinlog_ssl_compress.test
@@ -13,13 +13,6 @@ CALL mtr.add_suppression("Unsafe statement written to the binary log using state
 # Deletes all the binary logs
 reset master;
 
-# we need this for getting fixed timestamps inside of this test
-set timestamp=1000000000;
-
---disable_warnings
-drop table if exists t1;
---enable_warnings
-
 create table t1 (word varchar(20));
 
 --let $binlog_start_pos=query_get_value(SHOW MASTER STATUS, Position, 1)
@@ -31,8 +24,8 @@ flush logs;
 --disable_query_log
 select "--- --start-position --" as "";
 --enable_query_log
---replace_regex /.*SET .*$//[i]
---exec $MYSQL_BINLOG --short-form --local-load=$MYSQLTEST_VARDIR/tmp/ --read-from-remote-server --start-position=$binlog_start_pos --user=root --host=127.0.0.1 --port=$MASTER_MYPORT --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem --compress master-bin.000001
+--let $mysqlbinlog_parameters=--short-form --local-load=$MYSQLTEST_VARDIR/tmp/ --read-from-remote-server --start-position=$binlog_start_pos --user=root --host=127.0.0.1 --port=$MASTER_MYPORT --ssl-key=$MYSQL_TEST_DIR/std_data/client-key.pem --ssl-cert=$MYSQL_TEST_DIR/std_data/client-cert.pem --compress binlog.000001
+--source include/mysqlbinlog.inc
 
 drop table t1;
 


### PR DESCRIPTION
1. Replace `master-bin` with `binlog` for both tests
2. Add output masking with `mysqlbinlog.inc` for `percona_mysqlbinlog_ssl_compress`
3. Re-record `percona_mysqlbinlog_ssl_compress.result`