### PR TITLE
PS-269: Fix main.percona_ssl_connections_count MTR test (8.0)

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2714,7 +2714,7 @@ class THD : public MDL_context_owner,
   // We don't want to load/unload plugins for unit tests.
   bool m_enable_plugins;
 
-  THD(bool enable_plugins = true);
+  explicit THD(bool enable_plugins = true);
 
   /*
     The THD dtor is effectively split in two:

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -375,7 +375,7 @@ void update_global_user_stats(THD *thd, bool create_user, ulonglong now) {
     if (thread_it != global_thread_stats->cend())
       update_global_thread_stats_with_thread(*thd, &thread_it->second, now);
     else if (create_user)
-      increment_count_by_id(thread_id, global_thread_stats, thd);
+      increment_count_by_id(thread_id, global_thread_stats, *thd);
   }
 
   thd->last_global_update_time = now;
@@ -947,7 +947,7 @@ static bool login_connection(THD *thd, bool extra_port_connection) {
     thd->reset_stats();
 
     // Updates global user connection stats.
-    increment_connection_count(thd, true);
+    increment_connection_count(*thd, true);
   }
 
   DBUG_RETURN(0);


### PR DESCRIPTION
1. Fixed by changing a parameter of a call to `increment_connection_count()`
from a pointer to a reference (in sql_connect.cc)
2. Declare `THD::THD(bool enable_plugins = true)` as `explicit` to detect above-described issues