### PR TITLE
PS-5084: innodb_buffer_pool_size is an uninitialized variable (5.7)

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -23751,15 +23751,15 @@ innodb_buffer_pool_size_validate(
 		return(1);
 	}
 
-	if (srv_buf_pool_size == static_cast<ulint>(intbuf)) {
-		/* nothing to do */
-		return(0);
-	}
-
 	ulint	requested_buf_pool_size
 		= buf_pool_size_align(static_cast<ulint>(intbuf));
 
 	*static_cast<longlong*>(save) = requested_buf_pool_size;
+
+	if (srv_buf_pool_size == static_cast<ulint>(intbuf)) {
+		/* nothing to do */
+		return(0);
+	}
 
 	if (srv_buf_pool_size == requested_buf_pool_size) {
 		push_warning_printf(thd, Sql_condition::SL_WARNING,


### PR DESCRIPTION
Fix issue in `innodb_buffer_pool_size_validate` when
```srv_buf_pool_size == static_cast<ulint>(intbuf)```
leads to
```*static_cast<longlong *>(save) = requested_buf_pool_size;```
is not called at all.
Then there is an uninitialized read of var->save_result in innodb_buffer_pool_size_update.