### PR TITLE
PS-4917 : Assertion failure: dict0dd.cc:5784:space->flags == flags

### DIFF
--- a/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
+++ b/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("Found 1 prepared XA transactions");
 # Do tests on un-encrypted system tablespace
 SELECT @@innodb_sys_tablespace_encrypt;
 @@innodb_sys_tablespace_encrypt
@@ -156,5 +157,15 @@ ALTER TABLE t9 TABLESPACE=`innodb_system`;
 # make sure that system tablespace is encrypted
 Pattern not found.
 Pattern not found.
+#
+# PS-4917 : Assertion failure: dict0dd.cc:5784:space->flags == flags
+#
+# restart: --datadir=MYSQLD_DATADIR1 --innodb-sys-tablespace-encrypt=ON
+XA START 'x1';
+INSERT INTO t1 (a) VALUES ('Abracadabra is of unknown origin, and its first occurrence is');
+INSERT INTO t5 (a) VALUES ('Abracadabra is of unknown origin, and its first occurrence is');
+XA END 'x1';
+XA PREPARE 'x1';
+# Kill and restart: --datadir=MYSQLD_DATADIR1 --innodb-sys-tablespace-encrypt=ON
 # Start default MTR instance
 # restart

--- a/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
+++ b/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
@@ -1,4 +1,5 @@
 # Test system tablespace encryption
+call mtr.add_suppression("Found 1 prepared XA transactions");
 
 let $MYSQLD_BASEDIR= `select @@basedir`;
 --mkdir $MYSQL_TMP_DIR/datadir1
@@ -221,9 +222,30 @@ ALTER TABLE t9 TABLESPACE=`innodb_system`;
 --let $grep_output= boolean
 --source include/grep_pattern.inc
 
+--echo #
+--echo # PS-4917 : Assertion failure: dict0dd.cc:5784:space->flags == flags
+--echo #
+
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1
+--let $restart_parameters="restart: --datadir=$MYSQLD_DATADIR1 --innodb-sys-tablespace-encrypt=ON"
+--source include/start_mysqld.inc
+
+connect (con1,localhost,root);
+XA START 'x1';
+INSERT INTO t1 (a) VALUES ('Abracadabra is of unknown origin, and its first occurrence is');
+INSERT INTO t5 (a) VALUES ('Abracadabra is of unknown origin, and its first occurrence is');
+XA END 'x1';
+
+XA PREPARE 'x1';
+connection default;
+disconnect con1;
+
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1
+--source include/kill_and_restart_mysqld.inc
+
 --echo # Start default MTR instance
 --let $restart_parameters=
---source include/start_mysqld.inc
+--source include/restart_mysqld.inc
 
 --remove_file $BOOTSTRAP_SQL
 --force-rmdir $MYSQL_TMP_DIR/datadir1

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4827,7 +4827,7 @@ static int innobase_init_files(dict_init_mode_t dict_init_mode,
     static char se_private_data_innodb_system[len];
     static char se_private_data_dd[len];
     snprintf(se_private_data_innodb_system, len, fmt, TRX_SYS_SPACE,
-             predefined_flags, DD_SPACE_CURRENT_SRV_VERSION,
+             srv_sys_space.flags(), DD_SPACE_CURRENT_SRV_VERSION,
              DD_SPACE_CURRENT_SPACE_VERSION);
     snprintf(se_private_data_dd, len, fmt, dict_sys_t::s_space_id,
              predefined_flags, DD_SPACE_CURRENT_SRV_VERSION,


### PR DESCRIPTION
Problem:
--------
When innodb system tablespace is encrypted, on crash recovery,
the system tablespace flags are mismatching. i.e the flags from
data dictionary are mismatching with the flags from ibdata1 file.

Fix:
---
Store correct InnoDB system tablespace flags in DD