### PR TITLE
PS-5027 : [PS8QA] handle_fatal_signal (sig=11) in THD::mark_innodb_used

### DIFF
--- a/mysql-test/include/wait_for_search_pattern.inc
+++ b/mysql-test/include/wait_for_search_pattern.inc
@@ -1,0 +1,137 @@
+
+# Purpose:
+#    Simple search with Perl for a pattern in some file that repeats the
+#    search until a timeout occurs.  Bulk of search logic copied from
+#    include/search_pattern.inc
+#
+#    The environment variables SEARCH_FILE and SEARCH_PATTERN must be set
+#    before sourcing this routine.  The environment variable SEARCH_WAIT
+#    may be set to specify the time to keep waiting for the desired
+#    pattern to appear.  The default timeout is 60 seconds.
+#
+#    In case of
+#    - SEARCH_FILE and/or SEARCH_PATTERN is not set
+#    - SEARCH_FILE cannot be opened
+#    the test will abort immediate.
+
+perl;
+    use strict;
+    my @search_files =         glob($ENV{'SEARCH_FILE'})     or die "SEARCH_FILE not set";
+    my $search_pattern=        $ENV{'SEARCH_PATTERN'}        or die "SEARCH_PATTERN not set";
+    my $search_wait=           $ENV{'SEARCH_WAIT'}     || 60;
+    my $search_echo=           $ENV{'SEARCH_ECHO'}     || "NONE";
+    my $ignore_pattern=        $ENV{'IGNORE_PATTERN'}  || "";
+    my $search_echo_ctx=       $ENV{'SEARCH_ECHO_CTX'} || 0;
+
+    my $flag= 0;
+    my $counter= $search_wait;
+
+    # We include the current line and 'n' previous lines in its context
+    # as a FIFO queue i.e., oldest entries in the queue are removed when
+    # new lines are read from the file.
+    my @context= (undef) x ($search_echo_ctx + 1);
+
+    my $line;
+
+    while ($counter)
+    {
+        foreach my $search_file (@search_files) {
+            open(FILE, "< $search_file") or die("Unable to open '$search_file': $!\n");
+
+            # Read the file line by line
+            while ($line= <FILE>)
+            {
+                my $cur_lineno= $.;
+                my $file_pos= tell(FILE);
+
+                # Context stored as a sliding window of size 'n' lines
+                shift @context;
+                push  @context, $line;
+
+                if ($line =~ /$search_pattern/)
+                {
+                    if (!(length $ignore_pattern) or !($line =~ /$ignore_pattern/))
+                    {
+                        # Line matches the specified pattern
+                        $flag= 1;
+
+                        if ($search_echo eq 'FIRST')
+                        {
+                            print_current_and_previous_n_lines($search_echo_ctx,
+                                                               $cur_lineno);
+                            print_succeeding_n_lines($search_echo_ctx, $cur_lineno)
+                              if ($search_echo_ctx > 0);
+                            last;
+                        }
+                        elsif ($search_echo eq 'ALL')
+                        {
+                            print_current_and_previous_n_lines($search_echo_ctx,
+                                                               $cur_lineno);
+
+                            if ($search_echo_ctx > 0)
+                            {
+                                print_succeeding_n_lines($search_echo_ctx, $cur_lineno);
+
+                                # Return to current file position after reading 'n'
+                                # succeeding lines
+                                seek(FILE, $file_pos, 0);
+                                $.= $cur_lineno;
+
+                                # Separate each matching line
+                                print "---\n";
+                            }
+                        }
+                    }
+                }
+            }
+            close(FILE);
+        }
+
+        if ($flag == 1)
+        {
+            print "Pattern \"$search_pattern\" found\n";
+            last;
+        }
+        sleep 1;
+        $counter--;
+    }
+    if ($flag == 0)
+    {
+        print "Pattern \"$search_pattern\" not found\n";
+    }
+
+    sub print_current_and_previous_n_lines()
+    {
+        my ($search_echo_ctx, $cur_lineno)= @_;
+        my $start_lineno= $cur_lineno - $search_echo_ctx;
+        $cur_lineno= $start_lineno > 0 ? $start_lineno: 1;
+
+        for my $ctx_line (@context)
+        {
+            next if not defined $ctx_line;
+            print "$cur_lineno: $ctx_line";
+            $cur_lineno++;
+        }
+    }
+
+    sub print_succeeding_n_lines()
+    {
+        # Read the next 'n' lines from the file (excluding the current
+        # line) and print them
+
+        my ($search_echo_ctx, $cur_lineno)= @_;
+        my $end_lineno= $cur_lineno + $search_echo_ctx;
+
+        while ($line= <FILE>)
+        {
+            last if ($. > $end_lineno);
+            print "$.: $line";
+        }
+    }
+
+EOF
+
+# Setting the env vars to default value
+let SEARCH_ECHO=NONE;
+let IGNORE_PATTERN=;
+let SEARCH_ECHO_CTX=0;

--- a/mysql-test/suite/innodb/r/percona_log_slow_innodb.result
+++ b/mysql-test/suite/innodb/r/percona_log_slow_innodb.result
@@ -178,3 +178,22 @@ SET @@GLOBAL.slow_query_log=1;
 SELECT * FROM INFORMATION_SCHEMA.TABLES;
 SET GLOBAL slow_query_log = @saved_slow_query_log;
 DROP TABLE t1, t2;
+#
+# Test for PS-5027 : handle_fatal_signal (sig=11) in THD::mark_innodb_used
+#
+# restart:--log-error=MYSQLTEST_VARDIR/tmp/percona_bug5027.err --slow_query_log=0
+include/assert.inc ["Expected slow_query_log=0"]
+CREATE TABLE t5027(c0 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=INNODB;
+BEGIN;
+SELECT database_name, table_name FROM mysql.innodb_table_stats WHERE table_name='t5027' FOR UPDATE;
+database_name	table_name
+test	t5027
+SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
+SELECT * FROM t5027;
+c0
+SET @@global.slow_query_log=on;
+INSERT INTO t5027 VALUES (),();
+Pattern "InnoDB: Cannot save table statistics for table \`test\`\.\`t5027\`: Lock wait timeout" found
+ROLLBACK;
+DROP TABLE t5027;
+# restart

--- a/mysql-test/suite/innodb/t/percona_log_slow_innodb.test
+++ b/mysql-test/suite/innodb/t/percona_log_slow_innodb.test
@@ -109,6 +109,76 @@ SELECT * FROM INFORMATION_SCHEMA.TABLES;
 SET GLOBAL slow_query_log = @saved_slow_query_log;
 
 DROP TABLE t1, t2;
+
+--echo #
+--echo # Test for PS-5027 : handle_fatal_signal (sig=11) in THD::mark_innodb_used
+--echo #
+# There are three different threads at work here and their interaction can cause
+# a segfault when the slow log is disabled, then later enabled (with extended
+# innodb stats):
+# 1 - There is the client thread (this) which has locked the
+#     innodb_table_stats (i_t_s) table.
+# 2 - There is a background thread which periodically harvests and saves
+#     statistics for innodb tables into the i_t_s.
+# 3 - There is a background thread which watches for innodb lock wait timeouts
+#     and cancels other threads from their lock wait when they encounter a
+#     timeout.
+#
+# Thread 1 locks i_t_s for update.
+# Thread 2 tries to lock i_t_s with a timeout of 0.
+# Thread 3 discovers thread 2 lock wait has timed out and cancels its lock.
+#   Part of the lock cancel in thread 3 is to update some transaction
+#   statistics(MYSQL_TRX_STAT_LOCK_WAIT_USECS) for the transaction used in
+#   thread 2.  Thread 2 though does not have a valid THD associated with it in
+#   its mysql_thd, which is where these statistics are stored, and instead, ends
+#   up passing a nullptr down through thd_report_innodb_stat.
+#
+# Without this fix, there would be a segfault in THD::mark_innodb_used within
+#   the context of thread 3 as the '(THD*)this' would be a nullptr and thus all
+#   access to member data would be through this dereferenced nullptr.
+#
+# With this fix in place, there is no segfault and instead, thread 2 gets a
+#   lock wait timeout error when trying to lock i_t_s for update and prints an
+#   error to the log.
+#
+# The server *must* be started with --slow_query_log=0, otherwise, the
+#   transaction and trx_stat structure for thread 2 will be initialized
+#   differently and will not attempt to update the trx_stats and will not hit
+#   the segfault.
+
+--let SEARCH_FILE=$MYSQLTEST_VARDIR/tmp/percona_bug5027.err
+--let $restart_parameters=restart:--log-error=$SEARCH_FILE --slow_query_log=0
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld.inc
+
+--let $assert_text="Expected slow_query_log=0"
+--let $assert_cond="[SELECT @@slow_query_log]" = 0
+--source include/assert.inc
+
+CREATE TABLE t5027(c0 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=INNODB;
+
+--let $wait_condition= SELECT COUNT(*) = 1 FROM mysql.innodb_table_stats where table_name='t5027'
+--source include/wait_condition.inc
+
+BEGIN;
+SELECT database_name, table_name FROM mysql.innodb_table_stats WHERE table_name='t5027' FOR UPDATE;
+SET SESSION log_slow_verbosity='microtime,innodb,query_plan';
+SELECT * FROM t5027;
+SET @@global.slow_query_log=on;
+INSERT INTO t5027 VALUES (),();
+
+--let SEARCH_PATTERN= InnoDB: Cannot save table statistics for table \`test\`\.\`t5027\`: Lock wait timeout
+--source include/wait_for_search_pattern.inc
+
+ROLLBACK;
+
+DROP TABLE t5027;
+
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+--remove_file $SEARCH_FILE
+
+# cleanup
 --source include/log_cleanup.inc
 
 --source include/wait_until_count_sessions.inc

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1105,6 +1105,7 @@ THD::~THD() {
 extern "C" void thd_report_innodb_stat(THD *thd, unsigned long long trx_id,
                                        enum mysql_trx_stat_type type,
                                        unsigned long long value) {
+  DBUG_ASSERT(thd && !thd_is_background_thread(thd));
   thd->mark_innodb_used(trx_id);
   switch (type) {
     case MYSQL_TRX_STAT_IO_READ_BYTES:

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -498,6 +498,8 @@ trx_t *trx_allocate_for_background(void) {
 
   trx->sess = trx_dummy_sess;
 
+  trx->stats.set(false);
+
   return (trx);
 }
 


### PR DESCRIPTION
- Added test in thd_report_innodb_stat to validate that thd is valid and not a
  background thread.

- Introduced new mtr helper wait_for_search_pattern.inc that combines the
  functionality of search_pattern.inc with a retry/wait loop similar to
  wait_condition to be able to wait for a pattern to appear in a file.  this
  is needed/useful to wait for a background thread to report an error to the
  mysqld log file.

- Added new test case that validates issue is fixed.