### PR TITLE
PS-5100: percona_bug1289599 fails if USER is not defined (5.6)

### DIFF
--- a/mysql-test/r/percona_bug1289599.result
+++ b/mysql-test/r/percona_bug1289599.result
@@ -7,7 +7,7 @@ ERROR 28000: Access denied for user 'USER'@'localhost' (using password: NO)
 install plugin auth_socket soname 'auth_socket.so';
 connect(localhost,USER,,test,MASTER_PORT,MASTER_SOCKET);
 Got one of the listed errors
-Got one of the listed errors
+ERROR 28000: Access denied for user 'USER'@'localhost' (using password: NO)
 executing update mysql.user set plugin='<old_plugin_value>'
 flush privileges;
 uninstall plugin auth_socket;

--- a/mysql-test/t/percona_bug1289599.test
+++ b/mysql-test/t/percona_bug1289599.test
@@ -4,10 +4,7 @@
 
 --source include/have_socket_auth_plugin.inc
 
-if (`SELECT count(*) <> 0 FROM mysql.user WHERE user = '$USER'`)
-{
-  --skip Unix user present in mysql.user
-}
+--let USER=unknown
 
 connect (con1,localhost,root);
 connect (con2,localhost,root);
@@ -22,6 +19,8 @@ flush privileges;
 --error ER_ACCESS_DENIED_ERROR
 connect (fail,localhost,$USER);
 
+connection con1;
+
 --error ER_ACCESS_DENIED_ERROR
 change_user $USER;
 
@@ -35,8 +34,7 @@ connect (fail,localhost,$USER);
 
 connection con2;
 
-# CR_SERVER_LOST, CR_SERVER_GONE_ERROR
---error 2006,2013
+--error ER_ACCESS_DENIED_ERROR
 change_user $USER;
 
 connection default;

--- a/mysql-test/t/percona_bug1289599.test
+++ b/mysql-test/t/percona_bug1289599.test
@@ -4,10 +4,7 @@
 
 --source include/have_socket_auth_plugin.inc
 
-if (`SELECT count(*) <> 0 FROM mysql.user WHERE user = '$USER'`)
-{
-  --skip Unix user present in mysql.user
-}
+--let USER=unknown
 
 update mysql.user set plugin='auth_socket';
 flush privileges;


### PR DESCRIPTION
1. Define USER as "unknown" (ignore OS variable if defined).
2. Allow to use this MTR test as "root".
3. Replace `error 2006,2013` with `error ER_ACCESS_DENIED_ERROR` (backported from 5.7)
4. Add missing `connection con1;`