### PR TITLE
PS-5100: percona_bug1289599 fails if USER is not defined (5.7)

### DIFF
--- a/mysql-test/t/percona_bug1289599.test
+++ b/mysql-test/t/percona_bug1289599.test
@@ -4,10 +4,7 @@
 
 --source include/have_socket_auth_plugin.inc
 
-if (`SELECT count(*) <> 0 FROM mysql.user WHERE user = '$USER'`)
-{
-  --skip Unix user present in mysql.user
-}
+--let USER=unknown
 
 update mysql.user set plugin='auth_socket';
 flush privileges;


### PR DESCRIPTION
1. Define USER as "unknown" (ignore OS variable if defined).
2. Allow to use this MTR test as "root".
3. Add missing `connection con1;`