### PR TITLE
PS-5100: percona_bug1289599 fails if USER is not defined (8.0)

### DIFF
--- a/mysql-test/t/percona_bug1289599.test
+++ b/mysql-test/t/percona_bug1289599.test
@@ -4,10 +4,7 @@
 
 --source include/have_socket_auth_plugin.inc
 
-if (`SELECT count(*) <> 0 FROM mysql.user WHERE user = '$USER'`)
-{
-  --skip Unix user present in mysql.user
-}
+--let USER=unknown
 
 connect (con1,localhost,root);
 connect (con2,localhost,root);
@@ -23,6 +20,8 @@ flush privileges;
 --replace_result $MASTER_MYSOCK MASTER_SOCKET $MASTER_MYPORT MASTER_PORT $USER USER
 --error ER_ACCESS_DENIED_ERROR
 connect (fail,localhost,$USER);
+
+connection con1;
 
 --error ER_ACCESS_DENIED_ERROR
 change_user $USER;


### PR DESCRIPTION
1. Define USER as "unknown" (ignore OS variable if defined).
2. Allow to use this MTR test as "root".
3. Add missing `connection con1;`
