### PR TITLE
PS-5043 (Merge MySQL 8.0.13) post-push fix: macOS release build warnings

### DIFF
--- a/sql/event_crypt.cc
+++ b/sql/event_crypt.cc
@@ -42,7 +42,7 @@ bool decrypt_event(const Binlog_crypt_data &crypto, uchar *buf, uchar *ebuf,
 }
 
 bool Event_encrypter::init(Basic_ostream *ostream, uchar *header,
-                           size_t buf_len) {
+                           size_t buf_len MY_ATTRIBUTE((unused))) {
   uchar iv[binary_log::Start_encryption_event::IV_LENGTH];
   crypto->set_iv(iv, ostream->position());
   if (ctx != nullptr) {


### PR DESCRIPTION
Fix

/Users/laurynas/percona/percona-8.0/sql/event_crypt.cc:45:35: warning: unused parameter 'buf_len' [-Wunused-parameter]
                           size_t buf_len) {
                                  ^
by marking the argument unused.