### PR TITLE
PS-5043 (Merge MySQL 8.0.13) post-push fix: add missing macOS Travis …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -228,7 +228,7 @@ script:
     else
        TIMEOUT_CMD=gtimeout;
        brew update;
-       brew install ccache protobuf lz4 re2;
+       brew install ccache protobuf lz4 re2 rapidjson;
        export PATH="/usr/local/opt/ccache/libexec:$PATH";
     fi;
     UPDATE_TIME=$(($SECONDS - $INIT_TIME));


### PR DESCRIPTION
…dependencies

Starting with 8.0.13, -DWITH_SYSTEM_LIBS=ON build requires rapidjson
installation.

https://travis-ci.org/laurynas-biveinis/percona-server/jobs/464229831 shows build proceeding past the failure point