### PR TITLE
PS-5103 Post push test fix

### DIFF
--- a/mysql-test/suite/innodb/t/innodb_scrub_background.test
+++ b/mysql-test/suite/innodb/t/innodb_scrub_background.test
@@ -1,3 +1,4 @@
+--skip # Doesn't really check that background scrubbing works
 
 let $MYSQLD_DATADIR=`select @@datadir`;
 let INNODB_PAGE_SIZE= `select @@innodb_page_size`;

--- a/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_check_interval_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_check_interval_basic.result
@@ -1,0 +1,72 @@
+SET @start_global_value = @@global.innodb_background_scrub_data_check_interval;
+#
+# default value
+#
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+3600
+set global innodb_background_scrub_data_check_interval=10;
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+10
+set global innodb_background_scrub_data_check_interval=DEFAULT;
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+3600
+set global innodb_background_scrub_data_check_interval=20;
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+20
+set global innodb_background_scrub_data_check_interval=DEFAULT;
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+3600
+#
+# exists as global only
+#
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+3600
+select @@session.innodb_background_scrub_data_check_interval;
+ERROR HY000: Variable 'innodb_background_scrub_data_check_interval' is a GLOBAL variable
+show global variables like 'innodb_background_scrub_data_check_interval';
+Variable_name	Value
+innodb_background_scrub_data_check_interval	3600
+show session variables like 'innodb_background_scrub_data_check_interval';
+Variable_name	Value
+innodb_background_scrub_data_check_interval	3600
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_check_interval';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_check_interval	3600
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_check_interval';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_check_interval	3600
+#
+# show that it's writable
+#
+set global innodb_background_scrub_data_check_interval=10;
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+10
+set global innodb_background_scrub_data_check_interval=20;
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+20
+set global innodb_background_scrub_data_check_interval=1;
+select @@global.innodb_background_scrub_data_check_interval;
+@@global.innodb_background_scrub_data_check_interval
+1
+set session innodb_background_scrub_data_check_interval=1;
+ERROR HY000: Variable 'innodb_background_scrub_data_check_interval' is a GLOBAL variable and should be set with SET GLOBAL
+#
+# incorrect types
+#
+set global innodb_background_scrub_data_check_interval=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_check_interval'
+set global innodb_background_scrub_data_check_interval=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_check_interval'
+set global innodb_background_scrub_data_check_interval="foo";
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_check_interval'
+SET @@global.innodb_background_scrub_data_check_interval = @start_global_value;

--- a/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_compressed_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_compressed_basic.result
@@ -1,0 +1,50 @@
+SET @start_global_value = @@global.innodb_background_scrub_data_compressed;
+#
+# exists as global only
+#
+select @@global.innodb_background_scrub_data_compressed;
+@@global.innodb_background_scrub_data_compressed
+0
+select @@session.innodb_background_scrub_data_compressed;
+ERROR HY000: Variable 'innodb_background_scrub_data_compressed' is a GLOBAL variable
+show global variables like 'innodb_background_scrub_data_compressed';
+Variable_name	Value
+innodb_background_scrub_data_compressed	OFF
+show session variables like 'innodb_background_scrub_data_compressed';
+Variable_name	Value
+innodb_background_scrub_data_compressed	OFF
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_compressed';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_compressed	OFF
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_compressed';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_compressed	OFF
+#
+# show that it's writable
+#
+set global innodb_background_scrub_data_compressed=ON;
+select @@global.innodb_background_scrub_data_compressed;
+@@global.innodb_background_scrub_data_compressed
+1
+set global innodb_background_scrub_data_compressed=OFF;
+select @@global.innodb_background_scrub_data_compressed;
+@@global.innodb_background_scrub_data_compressed
+0
+set global innodb_background_scrub_data_compressed=1;
+select @@global.innodb_background_scrub_data_compressed;
+@@global.innodb_background_scrub_data_compressed
+1
+set session innodb_background_scrub_data_compressed=1;
+ERROR HY000: Variable 'innodb_background_scrub_data_compressed' is a GLOBAL variable and should be set with SET GLOBAL
+#
+# incorrect types
+#
+set global innodb_background_scrub_data_compressed=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_compressed'
+set global innodb_background_scrub_data_compressed=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_compressed'
+set global innodb_background_scrub_data_compressed="foo";
+ERROR 42000: Variable 'innodb_background_scrub_data_compressed' can't be set to the value of 'foo'
+SET @@global.innodb_background_scrub_data_compressed = @start_global_value;

--- a/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_interval_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_interval_basic.result
@@ -1,0 +1,50 @@
+SET @start_global_value = @@global.innodb_background_scrub_data_interval;
+#
+# exists as global only
+#
+select @@global.innodb_background_scrub_data_interval;
+@@global.innodb_background_scrub_data_interval
+604800
+select @@session.innodb_background_scrub_data_interval;
+ERROR HY000: Variable 'innodb_background_scrub_data_interval' is a GLOBAL variable
+show global variables like 'innodb_background_scrub_data_interval';
+Variable_name	Value
+innodb_background_scrub_data_interval	604800
+show session variables like 'innodb_background_scrub_data_interval';
+Variable_name	Value
+innodb_background_scrub_data_interval	604800
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_interval';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_interval	604800
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_interval';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_interval	604800
+#
+# show that it's writable
+#
+set global innodb_background_scrub_data_interval=100;
+select @@global.innodb_background_scrub_data_interval;
+@@global.innodb_background_scrub_data_interval
+100
+set global innodb_background_scrub_data_interval=200;
+select @@global.innodb_background_scrub_data_interval;
+@@global.innodb_background_scrub_data_interval
+200
+set global innodb_background_scrub_data_interval=300;
+select @@global.innodb_background_scrub_data_interval;
+@@global.innodb_background_scrub_data_interval
+300
+set session innodb_background_scrub_data_interval=400;
+ERROR HY000: Variable 'innodb_background_scrub_data_interval' is a GLOBAL variable and should be set with SET GLOBAL
+#
+# incorrect types
+#
+set global innodb_background_scrub_data_interval=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_interval'
+set global innodb_background_scrub_data_interval=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_interval'
+set global innodb_background_scrub_data_interval="foo";
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_interval'
+SET @@global.innodb_background_scrub_data_interval = @start_global_value;

--- a/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_uncompressed_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_background_scrub_data_uncompressed_basic.result
@@ -1,0 +1,50 @@
+SET @start_global_value = @@global.innodb_background_scrub_data_uncompressed;
+#
+# exists as global only
+#
+select @@global.innodb_background_scrub_data_uncompressed;
+@@global.innodb_background_scrub_data_uncompressed
+0
+select @@session.innodb_background_scrub_data_uncompressed;
+ERROR HY000: Variable 'innodb_background_scrub_data_uncompressed' is a GLOBAL variable
+show global variables like 'innodb_background_scrub_data_uncompressed';
+Variable_name	Value
+innodb_background_scrub_data_uncompressed	OFF
+show session variables like 'innodb_background_scrub_data_uncompressed';
+Variable_name	Value
+innodb_background_scrub_data_uncompressed	OFF
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_uncompressed';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_uncompressed	OFF
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_uncompressed';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_background_scrub_data_uncompressed	OFF
+#
+# show that it's writable
+#
+set global innodb_background_scrub_data_uncompressed=ON;
+select @@global.innodb_background_scrub_data_uncompressed;
+@@global.innodb_background_scrub_data_uncompressed
+1
+set global innodb_background_scrub_data_uncompressed=OFF;
+select @@global.innodb_background_scrub_data_uncompressed;
+@@global.innodb_background_scrub_data_uncompressed
+0
+set global innodb_background_scrub_data_uncompressed=1;
+select @@global.innodb_background_scrub_data_uncompressed;
+@@global.innodb_background_scrub_data_uncompressed
+1
+set session innodb_background_scrub_data_uncompressed=1;
+ERROR HY000: Variable 'innodb_background_scrub_data_uncompressed' is a GLOBAL variable and should be set with SET GLOBAL
+#
+# incorrect types
+#
+set global innodb_background_scrub_data_uncompressed=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_uncompressed'
+set global innodb_background_scrub_data_uncompressed=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_background_scrub_data_uncompressed'
+set global innodb_background_scrub_data_uncompressed="foo";
+ERROR 42000: Variable 'innodb_background_scrub_data_uncompressed' can't be set to the value of 'foo'
+SET @@global.innodb_background_scrub_data_uncompressed = @start_global_value;

--- a/mysql-test/suite/sys_vars/r/innodb_debug_force_scrubbing_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_debug_force_scrubbing_basic.result
@@ -1,0 +1,50 @@
+SET @start_global_value = @@global.innodb_debug_force_scrubbing;
+#
+# exists as global only
+#
+select @@global.innodb_debug_force_scrubbing;
+@@global.innodb_debug_force_scrubbing
+0
+select @@session.innodb_debug_force_scrubbing;
+ERROR HY000: Variable 'innodb_debug_force_scrubbing' is a GLOBAL variable
+show global variables like 'innodb_debug_force_scrubbing';
+Variable_name	Value
+innodb_debug_force_scrubbing	OFF
+show session variables like 'innodb_debug_force_scrubbing';
+Variable_name	Value
+innodb_debug_force_scrubbing	OFF
+select * from performance_schema.global_variables
+where variable_name='innodb_debug_force_scrubbing';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_debug_force_scrubbing	OFF
+select * from performance_schema.session_variables
+where variable_name='innodb_debug_force_scrubbing';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_debug_force_scrubbing	OFF
+#
+# show that it's writable
+#
+set global innodb_debug_force_scrubbing=ON;
+select @@global.innodb_debug_force_scrubbing;
+@@global.innodb_debug_force_scrubbing
+1
+set global innodb_debug_force_scrubbing=OFF;
+select @@global.innodb_debug_force_scrubbing;
+@@global.innodb_debug_force_scrubbing
+0
+set global innodb_debug_force_scrubbing=1;
+select @@global.innodb_debug_force_scrubbing;
+@@global.innodb_debug_force_scrubbing
+1
+set session innodb_debug_force_scrubbing=1;
+ERROR HY000: Variable 'innodb_debug_force_scrubbing' is a GLOBAL variable and should be set with SET GLOBAL
+#
+# incorrect types
+#
+set global innodb_debug_force_scrubbing=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_debug_force_scrubbing'
+set global innodb_debug_force_scrubbing=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_debug_force_scrubbing'
+set global innodb_debug_force_scrubbing="foo";
+ERROR 42000: Variable 'innodb_debug_force_scrubbing' can't be set to the value of 'foo'
+SET @@global.innodb_debug_force_scrubbing = @start_global_value;

--- a/mysql-test/suite/sys_vars/r/innodb_immediate_scrub_data_uncompressed_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_immediate_scrub_data_uncompressed_basic.result
@@ -1,0 +1,50 @@
+SET @start_global_value = @@global.innodb_immediate_scrub_data_uncompressed;
+#
+# exists as global only
+#
+select @@global.innodb_immediate_scrub_data_uncompressed;
+@@global.innodb_immediate_scrub_data_uncompressed
+0
+select @@session.innodb_immediate_scrub_data_uncompressed;
+ERROR HY000: Variable 'innodb_immediate_scrub_data_uncompressed' is a GLOBAL variable
+show global variables like 'innodb_immediate_scrub_data_uncompressed';
+Variable_name	Value
+innodb_immediate_scrub_data_uncompressed	OFF
+show session variables like 'innodb_immediate_scrub_data_uncompressed';
+Variable_name	Value
+innodb_immediate_scrub_data_uncompressed	OFF
+select * from performance_schema.global_variables
+where variable_name='innodb_immediate_scrub_data_uncompressed';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_immediate_scrub_data_uncompressed	OFF
+select * from performance_schema.session_variables
+where variable_name='innodb_immediate_scrub_data_uncompressed';
+VARIABLE_NAME	VARIABLE_VALUE
+innodb_immediate_scrub_data_uncompressed	OFF
+#
+# show that it's writable
+#
+set global innodb_immediate_scrub_data_uncompressed=ON;
+select @@global.innodb_immediate_scrub_data_uncompressed;
+@@global.innodb_immediate_scrub_data_uncompressed
+1
+set global innodb_immediate_scrub_data_uncompressed=OFF;
+select @@global.innodb_immediate_scrub_data_uncompressed;
+@@global.innodb_immediate_scrub_data_uncompressed
+0
+set global innodb_immediate_scrub_data_uncompressed=1;
+select @@global.innodb_immediate_scrub_data_uncompressed;
+@@global.innodb_immediate_scrub_data_uncompressed
+1
+set session innodb_immediate_scrub_data_uncompressed=1;
+ERROR HY000: Variable 'innodb_immediate_scrub_data_uncompressed' is a GLOBAL variable and should be set with SET GLOBAL
+#
+# incorrect types
+#
+set global innodb_immediate_scrub_data_uncompressed=1.1;
+ERROR 42000: Incorrect argument type to variable 'innodb_immediate_scrub_data_uncompressed'
+set global innodb_immediate_scrub_data_uncompressed=1e1;
+ERROR 42000: Incorrect argument type to variable 'innodb_immediate_scrub_data_uncompressed'
+set global innodb_immediate_scrub_data_uncompressed="foo";
+ERROR 42000: Variable 'innodb_immediate_scrub_data_uncompressed' can't be set to the value of 'foo'
+SET @@global.innodb_immediate_scrub_data_uncompressed = @start_global_value;

--- a/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_check_interval_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_check_interval_basic.test
@@ -1,0 +1,53 @@
+# bool global
+
+SET @start_global_value = @@global.innodb_background_scrub_data_check_interval;
+
+--echo #
+--echo # default value
+--echo #
+select @@global.innodb_background_scrub_data_check_interval;
+set global innodb_background_scrub_data_check_interval=10;
+select @@global.innodb_background_scrub_data_check_interval;
+set global innodb_background_scrub_data_check_interval=DEFAULT;
+select @@global.innodb_background_scrub_data_check_interval;
+set global innodb_background_scrub_data_check_interval=20;
+select @@global.innodb_background_scrub_data_check_interval;
+set global innodb_background_scrub_data_check_interval=DEFAULT;
+select @@global.innodb_background_scrub_data_check_interval;
+
+--echo #
+--echo # exists as global only
+--echo #
+select @@global.innodb_background_scrub_data_check_interval;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_background_scrub_data_check_interval;
+show global variables like 'innodb_background_scrub_data_check_interval';
+show session variables like 'innodb_background_scrub_data_check_interval';
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_check_interval';
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_check_interval';
+
+--echo #
+--echo # show that it's writable
+--echo #
+set global innodb_background_scrub_data_check_interval=10;
+select @@global.innodb_background_scrub_data_check_interval;
+set global innodb_background_scrub_data_check_interval=20;
+select @@global.innodb_background_scrub_data_check_interval;
+set global innodb_background_scrub_data_check_interval=1;
+select @@global.innodb_background_scrub_data_check_interval;
+--error ER_GLOBAL_VARIABLE
+set session innodb_background_scrub_data_check_interval=1;
+
+--echo #
+--echo # incorrect types
+--echo #
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_check_interval=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_check_interval=1e1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_check_interval="foo";
+
+SET @@global.innodb_background_scrub_data_check_interval = @start_global_value;

--- a/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_compressed_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_compressed_basic.test
@@ -1,0 +1,40 @@
+# bool global
+
+SET @start_global_value = @@global.innodb_background_scrub_data_compressed;
+
+--echo #
+--echo # exists as global only
+--echo #
+select @@global.innodb_background_scrub_data_compressed;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_background_scrub_data_compressed;
+show global variables like 'innodb_background_scrub_data_compressed';
+show session variables like 'innodb_background_scrub_data_compressed';
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_compressed';
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_compressed';
+
+--echo #
+--echo # show that it's writable
+--echo #
+set global innodb_background_scrub_data_compressed=ON;
+select @@global.innodb_background_scrub_data_compressed;
+set global innodb_background_scrub_data_compressed=OFF;
+select @@global.innodb_background_scrub_data_compressed;
+set global innodb_background_scrub_data_compressed=1;
+select @@global.innodb_background_scrub_data_compressed;
+--error ER_GLOBAL_VARIABLE
+set session innodb_background_scrub_data_compressed=1;
+
+--echo #
+--echo # incorrect types
+--echo #
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_compressed=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_compressed=1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_background_scrub_data_compressed="foo";
+
+SET @@global.innodb_background_scrub_data_compressed = @start_global_value;

--- a/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_interval_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_interval_basic.test
@@ -1,0 +1,40 @@
+# bool global
+
+SET @start_global_value = @@global.innodb_background_scrub_data_interval;
+
+--echo #
+--echo # exists as global only
+--echo #
+select @@global.innodb_background_scrub_data_interval;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_background_scrub_data_interval;
+show global variables like 'innodb_background_scrub_data_interval';
+show session variables like 'innodb_background_scrub_data_interval';
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_interval';
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_interval';
+
+--echo #
+--echo # show that it's writable
+--echo #
+set global innodb_background_scrub_data_interval=100;
+select @@global.innodb_background_scrub_data_interval;
+set global innodb_background_scrub_data_interval=200;
+select @@global.innodb_background_scrub_data_interval;
+set global innodb_background_scrub_data_interval=300;
+select @@global.innodb_background_scrub_data_interval;
+--error ER_GLOBAL_VARIABLE
+set session innodb_background_scrub_data_interval=400;
+
+--echo #
+--echo # incorrect types
+--echo #
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_interval=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_interval=1e1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_interval="foo";
+
+SET @@global.innodb_background_scrub_data_interval = @start_global_value;

--- a/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_uncompressed_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_background_scrub_data_uncompressed_basic.test
@@ -1,0 +1,40 @@
+# bool global
+
+SET @start_global_value = @@global.innodb_background_scrub_data_uncompressed;
+
+--echo #
+--echo # exists as global only
+--echo #
+select @@global.innodb_background_scrub_data_uncompressed;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_background_scrub_data_uncompressed;
+show global variables like 'innodb_background_scrub_data_uncompressed';
+show session variables like 'innodb_background_scrub_data_uncompressed';
+select * from performance_schema.global_variables
+where variable_name='innodb_background_scrub_data_uncompressed';
+select * from performance_schema.session_variables
+where variable_name='innodb_background_scrub_data_uncompressed';
+
+--echo #
+--echo # show that it's writable
+--echo #
+set global innodb_background_scrub_data_uncompressed=ON;
+select @@global.innodb_background_scrub_data_uncompressed;
+set global innodb_background_scrub_data_uncompressed=OFF;
+select @@global.innodb_background_scrub_data_uncompressed;
+set global innodb_background_scrub_data_uncompressed=1;
+select @@global.innodb_background_scrub_data_uncompressed;
+--error ER_GLOBAL_VARIABLE
+set session innodb_background_scrub_data_uncompressed=1;
+
+--echo #
+--echo # incorrect types
+--echo #
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_uncompressed=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_background_scrub_data_uncompressed=1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_background_scrub_data_uncompressed="foo";
+
+SET @@global.innodb_background_scrub_data_uncompressed = @start_global_value;

--- a/mysql-test/suite/sys_vars/t/innodb_debug_force_scrubbing_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_debug_force_scrubbing_basic.test
@@ -1,0 +1,41 @@
+# bool global
+--source include/have_debug.inc
+
+SET @start_global_value = @@global.innodb_debug_force_scrubbing;
+
+--echo #
+--echo # exists as global only
+--echo #
+select @@global.innodb_debug_force_scrubbing;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_debug_force_scrubbing;
+show global variables like 'innodb_debug_force_scrubbing';
+show session variables like 'innodb_debug_force_scrubbing';
+select * from performance_schema.global_variables
+where variable_name='innodb_debug_force_scrubbing';
+select * from performance_schema.session_variables
+where variable_name='innodb_debug_force_scrubbing';
+
+--echo #
+--echo # show that it's writable
+--echo #
+set global innodb_debug_force_scrubbing=ON;
+select @@global.innodb_debug_force_scrubbing;
+set global innodb_debug_force_scrubbing=OFF;
+select @@global.innodb_debug_force_scrubbing;
+set global innodb_debug_force_scrubbing=1;
+select @@global.innodb_debug_force_scrubbing;
+--error ER_GLOBAL_VARIABLE
+set session innodb_debug_force_scrubbing=1;
+
+--echo #
+--echo # incorrect types
+--echo #
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_debug_force_scrubbing=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_debug_force_scrubbing=1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_debug_force_scrubbing="foo";
+
+SET @@global.innodb_debug_force_scrubbing = @start_global_value;

--- a/mysql-test/suite/sys_vars/t/innodb_immediate_scrub_data_uncompressed_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_immediate_scrub_data_uncompressed_basic.test
@@ -1,0 +1,40 @@
+# bool global
+
+SET @start_global_value = @@global.innodb_immediate_scrub_data_uncompressed;
+
+--echo #
+--echo # exists as global only
+--echo #
+select @@global.innodb_immediate_scrub_data_uncompressed;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.innodb_immediate_scrub_data_uncompressed;
+show global variables like 'innodb_immediate_scrub_data_uncompressed';
+show session variables like 'innodb_immediate_scrub_data_uncompressed';
+select * from performance_schema.global_variables
+where variable_name='innodb_immediate_scrub_data_uncompressed';
+select * from performance_schema.session_variables
+where variable_name='innodb_immediate_scrub_data_uncompressed';
+
+--echo #
+--echo # show that it's writable
+--echo #
+set global innodb_immediate_scrub_data_uncompressed=ON;
+select @@global.innodb_immediate_scrub_data_uncompressed;
+set global innodb_immediate_scrub_data_uncompressed=OFF;
+select @@global.innodb_immediate_scrub_data_uncompressed;
+set global innodb_immediate_scrub_data_uncompressed=1;
+select @@global.innodb_immediate_scrub_data_uncompressed;
+--error ER_GLOBAL_VARIABLE
+set session innodb_immediate_scrub_data_uncompressed=1;
+
+--echo #
+--echo # incorrect types
+--echo #
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_immediate_scrub_data_uncompressed=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+set global innodb_immediate_scrub_data_uncompressed=1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_immediate_scrub_data_uncompressed="foo";
+
+SET @@global.innodb_immediate_scrub_data_uncompressed = @start_global_value;


### PR DESCRIPTION
* Added missing sys_vars tests from 5.7
* Disabled the incomplete/broken innodb_scrub_background test

This doesn't fix the sys_vars test in release mode, which will be fixed by a separate commit as in 5.7 (PS-3839)