### PR TITLE
PS-5118: Travis CI: Failed jobs should be red (8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -304,7 +304,7 @@ script:
     fi;
     echo --- Timeout $TIMEOUT_TIME seconds. CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds. Initialization time $INIT_TIME seconds.;
     $TIMEOUT_CMD $TIMEOUT_TIME make -j2;
-    if [[ "$?" == "0" ]]; then echo $TRAVIS_COMMIT > $CCACHE_DIR/last_commit.txt; fi;
+    if [[ "$?" == "0" ]]; then echo $TRAVIS_COMMIT > $CCACHE_DIR/last_commit.txt; else false; fi;
 
   - ccache --show-stats;
     BUILD_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME - $CMAKE_TIME));


### PR DESCRIPTION
Add "else false" to detect failed Travis jobs.