### PR TITLE
PS-5043: MTR fixes

### DIFF
--- a/mysql-test/r/percona_log_slow_admin_statements-config_foo.result
+++ b/mysql-test/r/percona_log_slow_admin_statements-config_foo.result
@@ -1,4 +1,4 @@
-call mtr.add_suppression("option 'log_slow_admin_statements': boolean value 'foo' wasn't recognized. Set to OFF.");
+call mtr.add_suppression("option 'log_slow_admin_statements': boolean value 'foo' was not recognized. Set to OFF.");
 SHOW GLOBAL VARIABLES like 'log_slow_admin_statements';
 Variable_name	Value
 log_slow_admin_statements	OFF

--- a/mysql-test/r/pool_of_threads_high_prio_tickets.result
+++ b/mysql-test/r/pool_of_threads_high_prio_tickets.result
@@ -565,50 +565,44 @@ attainments
 fanatic
 measures
 rightfulness
-select distinct fld3,count(*) from t2 group by companynr asc,fld3 asc limit 10;
-fld3	count(*)
-affixed	1
-and	1
-annoyers	1
-Anthony	1
-assayed	1
-assurers	1
-attendants	1
-bedlam	1
-bedpost	1
-boasted	1
-Warnings:
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
+select distinct companynr, fld3,count(*) from t2 group by companynr,fld3  order by companynr, fld3 limit 10;
+companynr	fld3	count(*)
+00	affixed	1
+00	and	1
+00	annoyers	1
+00	Anthony	1
+00	assayed	1
+00	assurers	1
+00	attendants	1
+00	bedlam	1
+00	bedpost	1
+00	boasted	1
 SET BIG_TABLES=1;
-select distinct fld3,count(*) from t2 group by companynr asc,fld3 asc limit 10;
-fld3	count(*)
-affixed	1
-and	1
-annoyers	1
-Anthony	1
-assayed	1
-assurers	1
-attendants	1
-bedlam	1
-bedpost	1
-boasted	1
-Warnings:
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
+select distinct companynr, fld3,count(*) from t2 group by companynr,fld3 order by companynr, fld3 limit 10;
+companynr	fld3	count(*)
+00	affixed	1
+00	and	1
+00	annoyers	1
+00	Anthony	1
+00	assayed	1
+00	assurers	1
+00	attendants	1
+00	bedlam	1
+00	bedpost	1
+00	boasted	1
 SET BIG_TABLES=0;
 select distinct fld3,repeat("a",length(fld3)),count(*) from t2 group by companynr,fld3 limit 100,10;
 fld3	repeat("a",length(fld3))	count(*)
-chancellor	aaaaaaaaaa	1
-Chippewa	aaaaaaaa	1
-circumference	aaaaaaaaaaaaa	1
-circus	aaaaaa	1
-cited	aaaaa	1
-congresswoman	aaaaaaaaaaaaa	1
-contrition	aaaaaaaaaa	1
-corny	aaaaa	1
-cultivation	aaaaaaaaaaa	1
-definiteness	aaaaaaaaaaaa	1
+bivalves	aaaaaaaa	1
+incurring	aaaaaaaaa	1
+Adolph	aaaaaa	1
+pithed	aaaaaa	1
+emergency	aaaaaaaaa	1
+Miles	aaaaa	1
+trimmings	aaaaaaaaa	1
+tragedies	aaaaaaaaa	1
+skulking	aaaaaaaa	1
+flint	aaaaa	1
 select distinct companynr,rtrim(space(512+companynr)) from t3 order by 1,2;
 companynr	rtrim(space(512+companynr))
 37	
@@ -1579,14 +1573,12 @@ id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered
 1	SIMPLE	t2	NULL	ALL	NULL	NULL	NULL	NULL	#	#	Using where
 Warnings:
 Note	1003	/* select#1 */ select count(0) AS `count(*)`,min(`test`.`t2`.`fld4`) AS `min(fld4)`,max(`test`.`t2`.`fld4`) AS `max(fld4)`,sum(`test`.`t2`.`fld1`) AS `sum(fld1)`,avg(`test`.`t2`.`fld1`) AS `avg(fld1)`,std(`test`.`t2`.`fld1`) AS `std(fld1)`,variance(`test`.`t2`.`fld1`) AS `variance(fld1)` from `test`.`t2` where ((`test`.`t2`.`companynr` = 34) and (`test`.`t2`.`fld4` <> ''))
-select companynr,count(*),min(fld4),max(fld4),sum(fld1),avg(fld1),std(fld1),variance(fld1) from t2 group by companynr asc limit 3;
+select companynr,count(*),min(fld4),max(fld4),sum(fld1),avg(fld1),std(fld1),variance(fld1) from t2 group by companynr order by companynr limit 3;
 companynr	count(*)	min(fld4)	max(fld4)	sum(fld1)	avg(fld1)	std(fld1)	variance(fld1)
 00	82	Anthony	windmills	10355753	126289.6707	115550.97568479746	13352027981.708656
 29	95	abut	wetness	14473298	152350.5053	8368.547956641249	70032594.90260443
 34	70	absentee	vest	17788966	254128.0857	3272.5939722090234	10709871.306938833
-Warnings:
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
-select companynr,t2nr,count(price),sum(price),min(price),max(price),avg(price) from t3 where companynr = 37 group by companynr asc,t2nr asc limit 10;
+select companynr,t2nr,count(price),sum(price),min(price),max(price),avg(price) from t3 where companynr = 37 group by companynr,t2nr order by companynr,t2nr limit 10;
 companynr	t2nr	count(price)	sum(price)	min(price)	max(price)	avg(price)
 37	1	1	5987435	5987435	5987435	5987435.0000
 37	2	1	28357832	28357832	28357832	28357832.0000
@@ -1598,11 +1590,8 @@ companynr	t2nr	count(price)	sum(price)	min(price)	max(price)	avg(price)
 37	22	1	28357832	28357832	28357832	28357832.0000
 37	23	1	39654943	39654943	39654943	39654943.0000
 37	31	1	5987435	5987435	5987435	5987435.0000
-Warnings:
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
 select /*! SQL_SMALL_RESULT */
-companynr,t2nr,count(price),sum(price),min(price),max(price),avg(price) from t3 where companynr = 37 group by companynr asc, t2nr asc limit 10;
+companynr,t2nr,count(price),sum(price),min(price),max(price),avg(price) from t3 where companynr = 37 group by companynr, t2nr order by companynr,t2nr limit 10;
 companynr	t2nr	count(price)	sum(price)	min(price)	max(price)	avg(price)
 37	1	1	5987435	5987435	5987435	5987435.0000
 37	2	1	28357832	28357832	28357832	28357832.0000
@@ -1614,9 +1603,6 @@ companynr	t2nr	count(price)	sum(price)	min(price)	max(price)	avg(price)
 37	22	1	28357832	28357832	28357832	28357832.0000
 37	23	1	39654943	39654943	39654943	39654943.0000
 37	31	1	5987435	5987435	5987435	5987435.0000
-Warnings:
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
-Warning	1287	'GROUP BY with ASC/DESC' is deprecated and will be removed in a future release. Please use GROUP BY ... ORDER BY ... ASC/DESC instead
 select companynr,count(price),sum(price),min(price),max(price),avg(price) from t3 group by companynr ;
 companynr	count(price)	sum(price)	min(price)	max(price)	avg(price)
 37	12543	309394878010	5987435	39654943	24666736.6667
@@ -2085,7 +2071,7 @@ count(*)
 4181
 explain select min(fld1),max(fld1),count(*) from t2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	NULL	NULL	NULL	NULL	NULL	NULL	NULL	#	#	Select tables optimized away
+1	SIMPLE	t2	NULL	index	NULL	fld1	4	NULL	#	#	Using index
 Warnings:
 Note	1003	/* select#1 */ select min(`test`.`t2`.`fld1`) AS `min(fld1)`,max(`test`.`t2`.`fld1`) AS `max(fld1)`,count(0) AS `count(*)` from `test`.`t2`
 select min(fld1),max(fld1),count(*) from t2;
@@ -2175,10 +2161,10 @@ analyze table t2;
 Table	Op	Msg_type	Msg_text
 test.t2	analyze	status	OK
 show keys from t2;
-Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible
-t2	0	PRIMARY	1	auto	A	#	NULL	NULL		BTREE			YES
-t2	0	fld1	1	fld1	A	#	NULL	NULL		BTREE			YES
-t2	1	fld3	1	fld3	A	#	NULL	NULL		BTREE			YES
+Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_part	Packed	Null	Index_type	Comment	Index_comment	Visible	Expression
+t2	0	PRIMARY	1	auto	A	#	NULL	NULL		BTREE			YES	NULL
+t2	0	fld1	1	fld1	A	#	NULL	NULL		BTREE			YES	NULL
+t2	1	fld3	1	fld3	A	#	NULL	NULL		BTREE			YES	NULL
 drop table t4, t3, t2, t1;
 SET sql_mode = 'NO_ENGINE_SUBSTITUTION';
 CREATE TABLE t1 (

--- a/mysql-test/suite/encryption/t/encrypt_and_grep.test
+++ b/mysql-test/suite/encryption/t/encrypt_and_grep.test
@@ -1,12 +1,4 @@
 #--skip # Test unstable on Jenkins
-#-- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-
-# embedded does not support restart
-#-- source include/not_embedded.inc
-
-#--echo $KEYRING_PLUGIN_OPT
-#--echo $KEYRING_PLUGIN_LOAD
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";

--- a/mysql-test/suite/encryption/t/encryption_force.test
+++ b/mysql-test/suite/encryption/t/encryption_force.test
@@ -1,8 +1,3 @@
--- source include/have_innodb.inc
--- source include/have_partition.inc
-# embedded does not support restart
--- source include/not_embedded.inc
-
 select @@innodb_encrypt_tables;
 
 set global innodb_encrypt_tables='KEYRING_FORCE';

--- a/mysql-test/suite/encryption/t/encryption_rotation.test
+++ b/mysql-test/suite/encryption/t/encryption_rotation.test
@@ -1,6 +1,3 @@
---source include/have_innodb.inc
---source include/not_embedded.inc
-
 CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(8)) ENGINE=InnoDB ENCRYPTION='Y';
 
 #ALTER TABLE t1 ENCRYPTION='KEYRING';

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change.test
@@ -1,7 +1,3 @@
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# embedded does not support restart
--- source include/not_embedded.inc
 --source include/have_64bit.inc
 
 #

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
@@ -1,8 +1,4 @@
 --skip
---source include/have_innodb.inc
-# embedded does not support restart
--- source include/not_embedded.inc
-#-- source filekeys_plugin_exists.inc
 #
 # MDEV-8750: Server crashes in page_cur_is_after_last on altering table using a wrong encryption key
 # MDEV-8769: Server crash at file btr0btr.ic line 122 when defragmenting encrypted table using incorrect keys

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change3.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change3.test
@@ -1,6 +1,3 @@
---source include/have_innodb.inc
-# embedded does not support restart
--- source include/not_embedded.inc
 -- source include/not_valgrind.inc
 
 call mtr.add_suppression("cannot be decrypted. Are you using correct keyring that contain the");

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change4.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change4.test
@@ -1,7 +1,4 @@
 --source include/have_64bit.inc
---source include/have_innodb.inc
-# embedded does not support restart
--- source include/not_embedded.inc
 #
 # MDEV-8769: Server crash at file btr0btr.ic line 122 when defragmenting encrypted table using incorrect keys
 # MDEV-8768: Server crash at file btr0btr.ic line 122 when checking encrypted table using incorrect keys

--- a/mysql-test/suite/encryption/t/innodb-corrupt-row-compressed.test
+++ b/mysql-test/suite/encryption/t/innodb-corrupt-row-compressed.test
@@ -3,11 +3,6 @@
 # MDEV-11759: Encryption code in MariaDB 10.1/10.2 causes compatibility problems
 #
 
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# Don't test under embedded
--- source include/not_embedded.inc
-
 call mtr.add_suppression("InnoDB: The page \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\] in file '.*test.t[123]\\.ibd' cannot be decrypted\\.");
 call mtr.add_suppression("failed to read or decrypt \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\]");
 

--- a/mysql-test/suite/encryption/t/innodb-encryption-alter.test
+++ b/mysql-test/suite/encryption/t/innodb-encryption-alter.test
@@ -1,6 +1,3 @@
---source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-
 #
 # MDEV-8817: Failing assertion: new_state->key_version != ENCRYPTION_KEY_VERSION_INVALID
 #

--- a/mysql-test/suite/encryption/t/innodb-first-page-read.test
+++ b/mysql-test/suite/encryption/t/innodb-first-page-read.test
@@ -1,7 +1,4 @@
 --skip
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
--- source include/not_embedded.inc
 
 --disable_warnings
 SET GLOBAL innodb_file_format = `Barracuda`;

--- a/mysql-test/suite/encryption/t/innodb-force-corrupt.test
+++ b/mysql-test/suite/encryption/t/innodb-force-corrupt.test
@@ -2,11 +2,6 @@
 # MDEV-11759: Encryption code in MariaDB 10.1/10.2 causes compatibility problems
 #
 
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# Don't test under embedded
--- source include/not_embedded.inc
-
 call mtr.add_suppression("InnoDB: The page \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\] in file '.*test.t[123]\\.ibd' cannot be decrypted\\.");
 call mtr.add_suppression("failed to read or decrypt \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\]");
 

--- a/mysql-test/suite/encryption/t/innodb-key-rotation-disable.test
+++ b/mysql-test/suite/encryption/t/innodb-key-rotation-disable.test
@@ -1,8 +1,3 @@
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# not embedded because of restarts
--- source include/not_embedded.inc
-
 SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
 SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0;
 

--- a/mysql-test/suite/encryption/t/innodb-key-rotation.test
+++ b/mysql-test/suite/encryption/t/innodb-key-rotation.test
@@ -1,9 +1,4 @@
 --skip
--- source include/have_innodb.inc
--- source include/not_embedded.inc
-
-#--echo $KEYRING_PLUGIN_OPT
-#--echo $KEYRING_PLUGIN_LOAD
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";

--- a/mysql-test/suite/encryption/t/innodb-missing-key.test
+++ b/mysql-test/suite/encryption/t/innodb-missing-key.test
@@ -1,8 +1,4 @@
 --source include/have_64bit.inc
---source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# embedded does not support restart
--- source include/not_embedded.inc
 
 #
 # MDEV-11004: Unable to start (Segfault or os error 2) when encryption key missing

--- a/mysql-test/suite/encryption/t/innodb-page_encryption-32k.test
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption-32k.test
@@ -1,10 +1,7 @@
 --skip
 --source include/no_valgrind_without_big.inc
---source include/not_embedded.inc
 # Tests for setting innodb-page-size=32k;
---source include/have_innodb.inc
 --source include/have_innodb_32k.inc
-#--source include/have_file_key_management_plugin.inc
 
 create table innodb_normal(c1 bigint not null, b char(200)) engine=innodb;
 create table innodb_compact(c1 bigint not null, b char(200)) engine=innodb row_format=compact ENCRYPTION='KEYRING' encryption_key_id=1;

--- a/mysql-test/suite/encryption/t/innodb-page_encryption.test
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption.test
@@ -1,6 +1,3 @@
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-
 create table innodb_normal(c1 bigint not null, b char(200)) engine=innodb;
 create table innodb_compact(c1 bigint not null, b char(200)) engine=innodb row_format=compact ENCRYPTION='KEYRING' encryption_key_id=1;
 create table innodb_compressed(c1 bigint not null, b char(200)) engine=innodb row_format=compressed ENCRYPTION='KEYRING' encryption_key_id=2;

--- a/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
@@ -1,7 +1,4 @@
 --skip # Test unstable on Jenkins centos6
--- source include/have_innodb.inc
--- source include/not_embedded.inc
-#-- source include/have_file_key_management_plugin.inc
 
 #let $innodb_compression_algorithm_orig=`SELECT @@innodb_compression_algorithm`;
 

--- a/mysql-test/suite/encryption/t/innodb-read-only.test
+++ b/mysql-test/suite/encryption/t/innodb-read-only.test
@@ -1,7 +1,3 @@
-#--source suite/encryption/include/have_file_key_management_plugin.inc
---source include/have_innodb.inc
---source include/not_embedded.inc
-
 --echo # Wait max 10 min for key encryption threads to encrypt all spaces
 let $cnt=600;
 while ($cnt)

--- a/mysql-test/suite/encryption/t/innodb-redo-nokeys.test
+++ b/mysql-test/suite/encryption/t/innodb-redo-nokeys.test
@@ -1,8 +1,4 @@
 --skip
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# embedded does not support restart
--- source include/not_embedded.inc
 --source include/have_64bit.inc
 
 call mtr.add_suppression("mysqld: File .*");

--- a/mysql-test/suite/encryption/t/innodb-spatial-index.test
+++ b/mysql-test/suite/encryption/t/innodb-spatial-index.test
@@ -1,7 +1,4 @@
 --skip
---source include/have_innodb.inc
-#--source include/have_file_key_management_plugin.inc
-
 #
 # MDEV-11974: MariaDB 10.2 encryption does not support spatial indexes
 #

--- a/mysql-test/suite/encryption/t/innodb_aborted_flush.test
+++ b/mysql-test/suite/encryption/t/innodb_aborted_flush.test
@@ -1,9 +1,7 @@
 --skip # Test unstable on jenkins
---source include/have_innodb.inc
 --source include/have_debug.inc
 --source include/have_debug_sync.inc
 --source include/not_valgrind.inc
---source include/not_embedded.inc
 
 --let $error_log=$MYSQL_TMP_DIR/my_restart.err
 --let $restart_parameters=restart:--innodb-encryption-threads=0 --log-error=$error_log

--- a/mysql-test/suite/encryption/t/innodb_alter_mk_to_rk.test
+++ b/mysql-test/suite/encryption/t/innodb_alter_mk_to_rk.test
@@ -1,8 +1,4 @@
 --skip
--- source include/have_innodb.inc
-# embedded does not support restart
--- source include/not_embedded.inc
-
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";

--- a/mysql-test/suite/encryption/t/innodb_alters.test
+++ b/mysql-test/suite/encryption/t/innodb_alters.test
@@ -1,7 +1,3 @@
--- source include/have_innodb.inc
-# embedded does not support restart
--- source include/not_embedded.inc
-
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";
 

--- a/mysql-test/suite/encryption/t/innodb_default_key.test
+++ b/mysql-test/suite/encryption/t/innodb_default_key.test
@@ -1,7 +1,3 @@
--- source include/have_innodb.inc
-# embedded does not support restart
--- source include/not_embedded.inc
-
 --disable_warnings
 SET GLOBAL innodb_file_per_table = ON;
 SET GLOBAL innodb_file_format = `Barracuda`;

--- a/mysql-test/suite/encryption/t/innodb_encryption-page-compression.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption-page-compression.test
@@ -1,9 +1,5 @@
 --skip # Test unstable on Jenkins
--- source include/have_innodb.inc
-#-- source include/have_example_key_management_plugin.inc
--- source include/not_embedded.inc
 
-#call mtr.add_suppression(".*");
 --disable_query_log
 let $innodb_encrypt_tables_orig = `SELECT @@innodb_encrypt_tables`;
 let $innodb_encryption_threads_orig = `SELECT @@innodb_encryption_threads`;

--- a/mysql-test/suite/encryption/t/innodb_encryption.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption.test
@@ -1,12 +1,7 @@
 #
 #
 #
--- source include/have_innodb.inc
-#-- source include/have_example_key_management_plugin.inc
 #-- source include/innodb_undo_tablespaces.inc # TODO:Robert: to sa kombinacje undo_tablespaces w MariaDB
-
-# embedded does not support restart
--- source include/not_embedded.inc
 
 SET @start_global_value = @@global.innodb_encryption_threads;
 

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation.inc
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation.inc
@@ -1,8 +1,6 @@
---source include/have_innodb.inc
 --source include/have_debug.inc
 --source include/have_debug_sync.inc
 --source include/not_valgrind.inc
---source include/not_embedded.inc
 
 # This test is to check if tables get rotated correctly with new version of encryption
 # key in case of server crash

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation.inc
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation.inc
@@ -1,8 +1,6 @@
---source include/have_innodb.inc
 --source include/have_debug.inc
 --source include/have_debug_sync.inc
 --source include/not_valgrind.inc
---source include/not_embedded.inc
 
 # This test is to check if tables get rotated correctly in case of server crash
 # 1) Rotate 100 pages in t1

--- a/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
@@ -1,7 +1,5 @@
 --skip
---source include/have_innodb.inc
 --source include/not_valgrind.inc
---source include/not_embedded.inc
 
 call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table `[^`]+`.`[^`]+` is set as discarded\\.");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Page [[:digit:]]+ at offset [[:digit:]]+ looks corrupted in file");

--- a/mysql-test/suite/encryption/t/innodb_encryption_row_compressed.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_row_compressed.test
@@ -1,7 +1,3 @@
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
--- source include/not_embedded.inc
-
 create table innodb_compressed1(c1 bigint not null primary key, d int, a varchar(20), b char(200)) engine=innodb row_format=compressed ENCRYPTION='KEYRING';
 create table innodb_compressed2(c1 bigint not null primary key, d int, a varchar(20), b char(200)) engine=innodb row_format=compressed key_block_size=1 ENCRYPTION='KEYRING';
 create table innodb_compressed3(c1 bigint not null primary key, d int, a varchar(20), b char(200)) engine=innodb row_format=compressed key_block_size=2 ENCRYPTION='KEYRING';

--- a/mysql-test/suite/encryption/t/innodb_encryption_row_compressed_big_table.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_row_compressed_big_table.test
@@ -1,7 +1,4 @@
 --skip
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
--- source include/not_embedded.inc
 
 CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB row_format=compressed encryption='KEYRING';
 

--- a/mysql-test/suite/encryption/t/innodb_encryption_row_compressed_corrupted.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_row_compressed_corrupted.test
@@ -1,7 +1,4 @@
 --skip
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
--- source include/not_embedded.inc
 
 create table innodb_compressed1(c1 bigint not null primary key, d int, a varchar(20), b char(200)) engine=innodb row_format=compressed ENCRYPTION='KEYRING';
 create table innodb_compressed2(c1 bigint not null primary key, d int, a varchar(20), b char(200)) engine=innodb row_format=compressed key_block_size=1 ENCRYPTION='KEYRING';

--- a/mysql-test/suite/encryption/t/innodb_encryption_tables.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_tables.test
@@ -1,7 +1,3 @@
--- source include/have_innodb.inc
-#-- source include/have_example_key_management_plugin.inc
--- source include/not_embedded.inc
-
 create table innodb_normal(c1 bigint not null, b char(200)) engine=innodb;
 create table innodb_compact(c1 bigint not null, b char(200)) engine=innodb row_format=compact;
 create table innodb_dynamic(c1 bigint not null, b char(200)) engine=innodb row_format=dynamic;

--- a/mysql-test/suite/encryption/t/innodb_first_page.test
+++ b/mysql-test/suite/encryption/t/innodb_first_page.test
@@ -3,9 +3,6 @@
 # MDEV-8021 "InnoDB: Tablespace id 4 encrypted but encryption service not available. Can't continue opening tablespace" on server restart when there are encrypted tables
 #
 
---source include/have_innodb.inc
-#--source include/have_file_key_management_plugin.inc
-
 let $datadir=`select @@datadir`;
 --source include/shutdown_mysqld.inc
 

--- a/mysql-test/suite/encryption/t/innodb_lotoftables.test
+++ b/mysql-test/suite/encryption/t/innodb_lotoftables.test
@@ -1,10 +1,5 @@
 --skip # Test is unstable on Jenkins
--- source include/have_innodb.inc
-#-- source include/have_example_key_management_plugin.inc
 -- source include/big_test.inc
-
-# embedded does not support restart
--- source include/not_embedded.inc
 
 --disable_query_log
 let $innodb_encryption_threads_orig = `SELECT @@global.innodb_encryption_threads`;

--- a/mysql-test/suite/encryption/t/innodb_onlinealter_encryption.test
+++ b/mysql-test/suite/encryption/t/innodb_onlinealter_encryption.test
@@ -1,8 +1,3 @@
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# test uses restart
--- source include/not_embedded.inc
-
 CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB encryption='KEYRING';
 CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
 CREATE TABLE t3 (id INT, a VARCHAR(255)) ENGINE=InnoDB encryption='KEYRING';

--- a/mysql-test/suite/encryption/t/innodb_page_encryption_key_change.test
+++ b/mysql-test/suite/encryption/t/innodb_page_encryption_key_change.test
@@ -1,8 +1,4 @@
 --source include/have_64bit.inc
---source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-# embedded does not support restart
---source include/not_embedded.inc
 
 --let $MYSQLD_DATADIR=`select @@datadir`
 --let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd

--- a/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk.test
+++ b/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk.test
@@ -1,12 +1,4 @@
 --skip
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-
-# embedded does not support restart
--- source include/not_embedded.inc
-
-#--echo $KEYRING_PLUGIN_OPT
-#--echo $KEYRING_PLUGIN_LOAD
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";

--- a/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk_post_enc_checksum_fail.test
+++ b/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk_post_enc_checksum_fail.test
@@ -1,13 +1,5 @@
 --skip
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
 --source include/have_debug.inc
-
-# embedded does not support restart
--- source include/not_embedded.inc
-
-#--echo $KEYRING_PLUGIN_OPT
-#--echo $KEYRING_PLUGIN_LOAD
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";

--- a/mysql-test/suite/encryption/t/uninstall_keyring.test
+++ b/mysql-test/suite/encryption/t/uninstall_keyring.test
@@ -1,9 +1,4 @@
 --skip # Test unstable on centos6
--- source include/have_innodb.inc
-#-- source include/have_file_key_management_plugin.inc
-
-# embedded does not support restart
---source include/not_embedded.inc
 
 call mtr.add_suppression("\\[Error\\] InnoDB: Encryption can't generate tablespace key");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_file reported: 'File .*keyring' not found .*");

--- a/mysql-test/suite/rpl/r/bug89504.result
+++ b/mysql-test/suite/rpl/r/bug89504.result
@@ -5,4 +5,4 @@ CALL mtr.add_suppression("Skip re-populating collations and character sets table
 CALL mtr.add_suppression("Skip updating information_schema metadata in InnoDB read-only mode");
 CALL mtr.add_suppression("Skipped updating resource group metadata in InnoDB read only mode");
 INSTALL PLUGIN rpl_semi_sync_master SONAME 'SEMISYNC_MASTER_PLUGIN';
-ERROR HY000: Got error 1 - 'Operation not permitted' from storage engine
+ERROR HY000: Error installing plugin 'rpl_semi_sync_master': got 'Operation not permitted' writing to mysql.plugin

--- a/mysql-test/suite/rpl/r/rpl_mdev382.result
+++ b/mysql-test/suite/rpl/r/rpl_mdev382.result
@@ -180,7 +180,8 @@ SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/
 SET @@session.character_set_client=255,@@session.collation_connection=255,@@session.collation_server=255/*!*/;
 SET @@session.lc_time_names=0/*!*/;
 SET @@session.collation_database=DEFAULT/*!*/;
-/*!80005 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
+/*!80011 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 CREATE TABLE `t``1` (`a``1` VARCHAR(4) PRIMARY KEY, `b``2` VARCHAR(3),
 `c``3` VARCHAR(7))
 /*!*/;
@@ -189,9 +190,11 @@ CREATE TABLE `t``1` (`a``1` VARCHAR(4) PRIMARY KEY, `b``2` VARCHAR(3),
 /*!80001 SET @@session.original_commit_timestamp= MICROSECONDS-FROM-EPOCH*//*!*/;
 SET @@SESSION.GTID_NEXT= '#'/*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 BEGIN
 /*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 LOAD DATA LOCAL INFILE 'MYSQLTEST_VARDIR/tmp/SQL_LOAD_MB-#-#' INTO TABLE `t``1` FIELDS TERMINATED BY ',' ENCLOSED BY '\'' ESCAPED BY '\\' LINES TERMINATED BY '\n' (`a``1`, @`b```) SET `b``2`= @`b```, `c``3`= concat('|', "b""a'z", "!")
 /*!*/;
 COMMIT/*!*/;
@@ -200,6 +203,7 @@ COMMIT/*!*/;
 /*!80001 SET @@session.original_commit_timestamp= MICROSECONDS-FROM-EPOCH*//*!*/;
 SET @@SESSION.GTID_NEXT= '#'/*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 truncate `t``1`
 /*!*/;
 # original_commit_timestamp= MICROSECONDS-FROM-EPOCH (YYYY-MM-DD HOURS:MINUTES:SECONDS TZ)
@@ -207,10 +211,12 @@ truncate `t``1`
 /*!80001 SET @@session.original_commit_timestamp= MICROSECONDS-FROM-EPOCH*//*!*/;
 SET @@SESSION.GTID_NEXT= '#'/*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 BEGIN
 /*!*/;
 use `test`/*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 LOAD DATA LOCAL INFILE 'MYSQLTEST_VARDIR/tmp/SQL_LOAD_MB-#-#' INTO TABLE `db1``; select 'oops!'`.`t``1` FIELDS TERMINATED BY ',' ENCLOSED BY '\'' ESCAPED BY '\\' LINES TERMINATED BY '\n' (`a``1`, `b``2`) SET `c``3`= concat('|', "b""a'z", "!")
 /*!*/;
 COMMIT/*!*/;
@@ -251,6 +257,14 @@ INSERT INTO t1 VALUES (-9223372036854775808,42,9223372036854775807,1844674407370
 SELECT @`a``1`:=a1, @`a``2`:=a2, @`a``3`:=a3, @`a``4`:=a4, @`b```:=b, @```c`:=c, @```d```:=d FROM t1;
 @`a``1`:=a1	@`a``2`:=a2	@`a``3`:=a3	@`a``4`:=a4	@`b```:=b	@```c`:=c	@```d```:=d
 -9223372036854775808	42	9223372036854775807	18446744073709551615	-1.234560123456789e125	-1234501234567890123456789012345678901234567890123456789.0123456789	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+Warnings:
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Please set variables in separate statements instead.
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Please set variables in separate statements instead.
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Please set variables in separate statements instead.
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Please set variables in separate statements instead.
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Please set variables in separate statements instead.
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Please set variables in separate statements instead.
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Please set variables in separate statements instead.
 INSERT INTO t1 VALUES (@`a``1`+1, @`a``2`*100, @`a``3`-1, @`a``4`-1, @`b```/2, @```c`, substr(@```d```, 2, 98));
 include/show_binlog_events.inc
 Log_name	Pos	Event_type	Server_id	End_log_pos	Info
@@ -287,7 +301,8 @@ SET @@session.auto_increment_increment=1, @@session.auto_increment_offset=1/*!*/
 SET @@session.character_set_client=255,@@session.collation_connection=255,@@session.collation_server=255/*!*/;
 SET @@session.lc_time_names=0/*!*/;
 SET @@session.collation_database=DEFAULT/*!*/;
-/*!80005 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
+/*!80011 SET @@session.default_collation_for_utf8mb4=255*//*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 CREATE TABLE t1 (a1 BIGINT PRIMARY KEY, a2 BIGINT, a3 BIGINT, a4 BIGINT UNSIGNED, b DOUBLE, c DECIMAL(65,10), d VARCHAR(100))
 /*!*/;
 # original_commit_timestamp= MICROSECONDS-FROM-EPOCH (YYYY-MM-DD HOURS:MINUTES:SECONDS TZ)
@@ -295,9 +310,11 @@ CREATE TABLE t1 (a1 BIGINT PRIMARY KEY, a2 BIGINT, a3 BIGINT, a4 BIGINT UNSIGNED
 /*!80001 SET @@session.original_commit_timestamp= MICROSECONDS-FROM-EPOCH*//*!*/;
 SET @@SESSION.GTID_NEXT= '#'/*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 BEGIN
 /*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 INSERT INTO t1 VALUES (-9223372036854775808,42,9223372036854775807,18446744073709551615,-1234560123456789e110, -1234501234567890123456789012345678901234567890123456789.0123456789, REPEAT("x", 100))
 /*!*/;
 COMMIT/*!*/;
@@ -306,6 +323,7 @@ COMMIT/*!*/;
 /*!80001 SET @@session.original_commit_timestamp= MICROSECONDS-FROM-EPOCH*//*!*/;
 SET @@SESSION.GTID_NEXT= '#'/*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 BEGIN
 /*!*/;
 SET @`a``1`:=-9223372036854775808/*!*/;
@@ -316,6 +334,7 @@ SET @`b```:=-1.2345601234568e+125/*!*/;
 SET @```c`:=-1234501234567890123456789012345678901234567890123456789.0123456789/*!*/;
 SET @```d```:=_utf8mb4 0x78787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878 COLLATE `utf8mb4_0900_ai_ci`/*!*/;
 SET TIMESTAMP=#/*!*/;
+/*!80013 SET @@session.sql_require_primary_key=0*//*!*/;
 INSERT INTO t1 VALUES (@`a``1`+1, @`a``2`*100, @`a``3`-1, @`a``4`-1, @`b```/2, @```c`, substr(@```d```, 2, 98))
 /*!*/;
 COMMIT/*!*/;

--- a/mysql-test/suite/rpl/t/bug89504.test
+++ b/mysql-test/suite/rpl/t/bug89504.test
@@ -9,5 +9,5 @@ CALL mtr.add_suppression("Skip updating information_schema metadata in InnoDB re
 CALL mtr.add_suppression("Skipped updating resource group metadata in InnoDB read only mode");
 
 --replace_result $SEMISYNC_MASTER_PLUGIN SEMISYNC_MASTER_PLUGIN
---error ER_GET_ERRNO
+--error ER_PLUGIN_INSTALL_ERROR
 eval INSTALL PLUGIN rpl_semi_sync_master SONAME '$SEMISYNC_MASTER_PLUGIN';

--- a/mysql-test/suite/tokudb.bugs/t/5469.test
+++ b/mysql-test/suite/tokudb.bugs/t/5469.test
@@ -4,8 +4,6 @@
 --echo *** Bug #23945 ***
 
 
-# --source include/have_innodb.inc
-# SET DEFAULT_STORAGE_ENGINE = InnoDB;
 --source include/have_tokudb.inc
 SET DEFAULT_STORAGE_ENGINE = tokudb;
 

--- a/mysql-test/t/percona_log_slow_admin_statements-config_foo.test
+++ b/mysql-test/t/percona_log_slow_admin_statements-config_foo.test
@@ -1,3 +1,3 @@
-call mtr.add_suppression("option 'log_slow_admin_statements': boolean value 'foo' wasn't recognized. Set to OFF.");
+call mtr.add_suppression("option 'log_slow_admin_statements': boolean value 'foo' was not recognized. Set to OFF.");
 SHOW GLOBAL VARIABLES like 'log_slow_admin_statements';
 SELECT * FROM performance_schema.global_variables WHERE VARIABLE_NAME='log_slow_admin_statements';

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_2_keyring.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_2_keyring.test
@@ -3,8 +3,6 @@
 
 --source include/have_keyring_vault_plugin.inc
 --source include/no_valgrind_without_big.inc
---source include/have_innodb.inc
---source include/not_embedded.inc
 
 --source generate_default_conf_files.inc
 --source is_vault_server_up.inc


### PR DESCRIPTION
- Re-record main.percona_log_slow_admin_statements-config_foo for
  minor warning message difference;
- re-record main.pool_of_threads_high_prio_tickets for its upstream
  include file doing different queries
- remove have_innodb.inc, not_embedded.inc, have_partition.inc
  includes from various testcases, mostly from the newly-ported 5.7
  encryption features;
- update rpl.bug89504 for different error being returned;
- re-record rpl.rpl_mdev382 for different mysqldump behavior.