### PR TITLE
Fix PS-4907 (Inconsistent ResultSet is obtained for different Execution Plans) (5.6)

### DIFF
--- a/mysql-test/r/subquery_sj_all_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_all_bka_nixbnl.result
@@ -9829,10 +9829,11 @@ FROM t1 AS subquery3_t1
 )
 ;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using where; Using index
-1	PRIMARY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	<subquery3>.7,test.subquery3_t1.col_varchar_key	2	Using where
+1	PRIMARY	<subquery4>	ALL	NULL	NULL	NULL	NULL	NULL	Using where
+1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	const,<subquery4>.subquery3_field1	2	Using where
 1	PRIMARY	table2	index	NULL	PRIMARY	4	NULL	1	Using index
+1	PRIMARY	<subquery3>	eq_ref	<auto_key>	<auto_key>	4	table1.col_int_key	1	NULL
+4	MATERIALIZED	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using index
 3	MATERIALIZED	t3	ALL	NULL	NULL	NULL	NULL	0	NULL
 2	DERIVED	subquery1_t1	ALL	PRIMARY	NULL	NULL	NULL	1	NULL
 2	DERIVED	subquery1_t2	eq_ref	PRIMARY	PRIMARY	4	test.subquery1_t1.pk	1	Using index

--- a/mysql-test/r/subquery_sj_mat.result
+++ b/mysql-test/r/subquery_sj_mat.result
@@ -9912,10 +9912,11 @@ FROM t1 AS subquery3_t1
 )
 ;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using where; Using index
-1	PRIMARY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	Using join buffer (Block Nested Loop)
-1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	<subquery3>.7,test.subquery3_t1.col_varchar_key	2	Using where
+1	PRIMARY	<subquery4>	ALL	NULL	NULL	NULL	NULL	NULL	Using where
+1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	const,<subquery4>.subquery3_field1	2	Using where
+1	PRIMARY	<subquery3>	eq_ref	<auto_key>	<auto_key>	4	table1.col_int_key	1	NULL
 1	PRIMARY	table2	index	NULL	PRIMARY	4	NULL	1	Using index; Using join buffer (Block Nested Loop)
+4	MATERIALIZED	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using index
 3	MATERIALIZED	t3	ALL	NULL	NULL	NULL	NULL	0	NULL
 2	DERIVED	subquery1_t1	ALL	PRIMARY	NULL	NULL	NULL	1	NULL
 2	DERIVED	subquery1_t2	eq_ref	PRIMARY	PRIMARY	4	test.subquery1_t1.pk	1	Using index

--- a/mysql-test/r/subquery_sj_mat_bka.result
+++ b/mysql-test/r/subquery_sj_mat_bka.result
@@ -9913,10 +9913,11 @@ FROM t1 AS subquery3_t1
 )
 ;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using where; Using index
-1	PRIMARY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	Using join buffer (Block Nested Loop)
-1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	<subquery3>.7,test.subquery3_t1.col_varchar_key	2	Using where
+1	PRIMARY	<subquery4>	ALL	NULL	NULL	NULL	NULL	NULL	Using where
+1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	const,<subquery4>.subquery3_field1	2	Using where
+1	PRIMARY	<subquery3>	eq_ref	<auto_key>	<auto_key>	4	table1.col_int_key	1	NULL
 1	PRIMARY	table2	index	NULL	PRIMARY	4	NULL	1	Using index; Using join buffer (Block Nested Loop)
+4	MATERIALIZED	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using index
 3	MATERIALIZED	t3	ALL	NULL	NULL	NULL	NULL	0	NULL
 2	DERIVED	subquery1_t1	ALL	PRIMARY	NULL	NULL	NULL	1	NULL
 2	DERIVED	subquery1_t2	eq_ref	PRIMARY	PRIMARY	4	test.subquery1_t1.pk	1	Using index

--- a/mysql-test/r/subquery_sj_mat_bka_nixbnl.result
+++ b/mysql-test/r/subquery_sj_mat_bka_nixbnl.result
@@ -9903,11 +9903,10 @@ FROM t1 AS subquery3_t1
 )
 ;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using where; Using index
-1	PRIMARY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	NULL
-1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	<subquery3>.7,test.subquery3_t1.col_varchar_key	2	Using where
-1	PRIMARY	table2	index	NULL	PRIMARY	4	NULL	1	Using index
-3	MATERIALIZED	t3	ALL	NULL	NULL	NULL	NULL	0	NULL
+1	PRIMARY	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using where; Using index; Start temporary
+1	PRIMARY	t3	ALL	NULL	NULL	NULL	NULL	0	NULL
+1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	const,test.subquery3_t1.col_varchar_key	2	NULL
+1	PRIMARY	table2	index	NULL	PRIMARY	4	NULL	1	Using index; End temporary
 2	DERIVED	subquery1_t1	ALL	PRIMARY	NULL	NULL	NULL	1	NULL
 2	DERIVED	subquery1_t2	eq_ref	PRIMARY	PRIMARY	4	test.subquery1_t1.pk	1	Using index
 SELECT table1.pk AS field1

--- a/mysql-test/r/subquery_sj_mat_bkaunique.result
+++ b/mysql-test/r/subquery_sj_mat_bkaunique.result
@@ -9914,10 +9914,11 @@ FROM t1 AS subquery3_t1
 )
 ;
 id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
-1	PRIMARY	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using where; Using index
-1	PRIMARY	<subquery3>	ALL	NULL	NULL	NULL	NULL	NULL	Using join buffer (Block Nested Loop)
-1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	<subquery3>.7,test.subquery3_t1.col_varchar_key	2	Using where
+1	PRIMARY	<subquery4>	ALL	NULL	NULL	NULL	NULL	NULL	Using where
+1	PRIMARY	<derived2>	ref	<auto_key0>	<auto_key0>	9	const,<subquery4>.subquery3_field1	2	Using where
+1	PRIMARY	<subquery3>	eq_ref	<auto_key>	<auto_key>	4	table1.col_int_key	1	NULL
 1	PRIMARY	table2	index	NULL	PRIMARY	4	NULL	1	Using index; Using join buffer (Block Nested Loop)
+4	MATERIALIZED	subquery3_t1	index	col_varchar_key	col_varchar_key	9	NULL	0	Using index
 3	MATERIALIZED	t3	ALL	NULL	NULL	NULL	NULL	0	NULL
 2	DERIVED	subquery1_t1	ALL	PRIMARY	NULL	NULL	NULL	1	NULL
 2	DERIVED	subquery1_t2	eq_ref	PRIMARY	PRIMARY	4	test.subquery1_t1.pk	1	Using index

--- a/sql/sql_planner.cc
+++ b/sql/sql_planner.cc
@@ -3479,12 +3479,24 @@ void Optimize_table_order::advance_sj_state(
       The simple way to model this is to remove SJM-SCAN(...) fanout once
       we reach the point #2.
     */
-    pos->sjm_scan_need_tables=
-      emb_sj_nest->sj_inner_tables | 
-      emb_sj_nest->nested_join->sj_depends_on;
-    pos->sjm_scan_last_inner= idx;
-    Opt_trace_object(trace).add_alnum("strategy", "MaterializeScan").
-      add_alnum("choice", "deferred");
+    if (pos->sjm_scan_need_tables &&
+        emb_sj_nest != NULL &&
+        emb_sj_nest !=
+        join->positions[pos->sjm_scan_last_inner].table->emb_sj_nest)
+      /*
+        Prevent that inner tables of different semijoin nests are
+        interleaved for MatScan.
+      */
+      pos->sjm_scan_need_tables= 0;
+    else
+    {
+      pos->sjm_scan_need_tables=
+        emb_sj_nest->sj_inner_tables |
+        emb_sj_nest->nested_join->sj_depends_on;
+      pos->sjm_scan_last_inner= idx;
+      Opt_trace_object(trace).add_alnum("strategy", "MaterializeScan").
+        add_alnum("choice", "deferred");
+    }
   }
   else if (sjm_strategy == SJ_OPT_MATERIALIZE_LOOKUP)
   {


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4907

Backported optimizer fixes made silently as part of the
WL#9158 "Join Order Hints" (https://dev.mysql.com/worklog/task/?id=9158)
implementation in 8.0 branch (commit mysql/mysql-server@d2d91c3).

***
Optimize_table_order::advance_sj_state():
added a change to prevent that inner tables of different semijoin nests are
interleaved for MatScan.
***

Re-recorded the following MTR test cases:
* 'main.subquery_sj_all_bka_nixbnl'
* 'main.subquery_sj_mat'
* 'main.subquery_sj_mat_bka'
* 'main.subquery_sj_mat_bka_nixbnl'
* 'main.subquery_sj_mat_bkaunique'
because of the changed execution plan.