### PR TITLE
PS-5108 (Assertion `info->read_pos == info->read_end' failed | size_t…

### DIFF
--- a/mysql-test/r/read_only_persisted_plugin_variables.result
+++ b/mysql-test/r/read_only_persisted_plugin_variables.result
@@ -117,7 +117,7 @@ set @@persist_only.extra_port=1111;
 # Must return 100 rows.
 SELECT count(*) from performance_schema.persisted_variables;
 count(*)
-102
+100
 # Restart server
 CALL mtr.add_suppression("Plugin audit_log reported *");
 # Both queries must return 100 rows.

--- a/mysys/mf_iocache.cc
+++ b/mysys/mf_iocache.cc
@@ -110,8 +110,8 @@ MY_NODISCARD
 static int _my_b_cache_write_r(IO_CACHE *info, const uchar *Buffer,
                                size_t Count);
 
-static io_cache_encr_read_function _my_b_encr_read = NULL;
-static io_cache_encr_write_function _my_b_encr_write = NULL;
+static io_cache_encr_read_function _my_b_encr_read = nullptr;
+static io_cache_encr_write_function _my_b_encr_write = nullptr;
 static size_t io_cache_encr_block_size = 0, io_cache_encr_header_size = 0;
 
 /*
@@ -203,10 +203,10 @@ void init_io_cache_encryption_ext(io_cache_encr_read_function read_function,
                                   size_t encr_block_size,
                                   size_t encr_header_size) {
   DBUG_ENTER("init_io_cache_encryption_ext");
-  DBUG_ASSERT(
-      (read_function == NULL && write_function == NULL &&
-       encr_block_size == 0 && encr_header_size == 0) ||
-      (read_function != NULL && write_function != NULL && encr_block_size > 0));
+  DBUG_ASSERT((read_function == nullptr && write_function == nullptr &&
+               encr_block_size == 0 && encr_header_size == 0) ||
+              (read_function != nullptr && write_function != nullptr &&
+               encr_block_size > 0));
 
   _my_b_encr_read = read_function;
   _my_b_encr_write = write_function;

--- a/sql/binlog_ostream.cc
+++ b/sql/binlog_ostream.cc
@@ -110,7 +110,7 @@ bool IO_CACHE_binlog_cache_storage::begin(unsigned char **buffer,
 
 bool IO_CACHE_binlog_cache_storage::next(unsigned char **buffer,
                                          my_off_t *length) {
-  my_b_fill(&m_io_cache);
+  if (my_b_bytes_in_cache(&m_io_cache) == 0) my_b_fill(&m_io_cache);
 
   *buffer = m_io_cache.read_pos;
   *length = my_b_bytes_in_cache(&m_io_cache);


### PR DESCRIPTION
… my_b_fill(IO_CACHE*))

Fix a regression from 8.0.13 merge where newly-introduced
IO_CACHE_binlog_cache_storage (WL#10956) always calls my_b_fill for
reinited cache instead of consuming the in-memory buffer first,
whereas the encrypted cache expects the in-memory buffer to be
consumed before any read.

Fix by returning the memory buffer on the first
IO_CACHE_binlog_cache_storage read, at the begin method. The
alternative was to change the IOCACHE code to support reads without
used up memory buffer, but this would be less efficient too.

At the same time do minor C++'ification for the encrypted IOCACHE
code.

https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/66/#showFailuresLink - no main.encrypt_tmp_files failures nor binlog suite regressions.

@percona-ysorokin (author of the feature) @robgolebiowski (working with WL#10956) adding both you as reviewers, but IMHO one review will be enough