### PR TITLE
PS-269: Fix collision of PLUGIN_VAR_PERSIST_AS_READ_ONLY and PLUGIN_VAR_HINTUPDATEABLE (8.0)

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -191,17 +191,15 @@ struct MYSQL_XID {
 #define PLUGIN_VAR_NOPERSIST                \
   0x10000 /* SET PERSIST_ONLY is prohibited \
           for read only variables */
-#define PLUGIN_VAR_HINTUPDATEABLE              \
-  0x20000 /* This flag enables variables to be \
-    recognized by SET_VAR() HINT. Should       \
-    be used only THDVAR()  variables, ie       \
-    variables which have session scope */
 /**
   There can be some variables which needs to be set before plugin is loaded but
   not after plugin is loaded. ex: GR specific variables. Below flag must be set
   for these kind of variables.
 */
 #define PLUGIN_VAR_PERSIST_AS_READ_ONLY 0x20000
+/* This flag enables variables to be recognized by SET_VAR() HINT. Should
+   be used only THDVAR() variables, ie variables which have session scope. */
+#define PLUGIN_VAR_HINTUPDATEABLE 0x40000
 
 struct SYS_VAR;
 struct st_mysql_value;
@@ -251,7 +249,7 @@ typedef void (*mysql_var_update_func)(MYSQL_THD thd, SYS_VAR *var,
   (PLUGIN_VAR_READONLY | PLUGIN_VAR_NOSYSVAR | PLUGIN_VAR_NOCMDOPT |   \
    PLUGIN_VAR_NOCMDARG | PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_RQCMDARG |   \
    PLUGIN_VAR_MEMALLOC | PLUGIN_VAR_NODEFAULT | PLUGIN_VAR_NOPERSIST | \
-   PLUGIN_VAR_PERSIST_AS_READ_ONLY)
+   PLUGIN_VAR_PERSIST_AS_READ_ONLY | PLUGIN_VAR_HINTUPDATEABLE)
 
 #define MYSQL_PLUGIN_VAR_HEADER \
   int flags;                    \


### PR DESCRIPTION
`PLUGIN_VAR_PERSIST_AS_READ_ONLY` and `PLUGIN_VAR_HINTUPDATEABLE` should be defined with different values.
This commit fixes `main.persisted_variables_bugs` test.
