### PR TITLE
PS-5043: post-merge fix for mysqltest

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -1180,15 +1180,15 @@ void handle_error(struct st_command *command, std::uint32_t err_errno,
   }
 
   if (expected_errors->count()) {
-    if (expected_errors->type() == ERR_ERRNO &&
-        err_errno == ER_NO_SUCH_THREAD) {
+    if (err_errno == ER_NO_SUCH_THREAD) {
       /* No such thread id, let's dump the available ones */
       fprintf(stderr,
               "mysqltest: query '%s returned ER_NO_SUCH_THREAD, "
               "dumping processlist\n",
               command->query);
       show_query(&cur_con->mysql, "SHOW PROCESSLIST");
-    } else if (expected_errors->count() == 1) {
+    }
+    if (expected_errors->count() == 1) {
       die("Query '%s' failed with wrong error %d: '%s', should have failed "
           "with error '%s'.",
           command->query, err_errno, err_error,

--- a/mysql-test/r/mysqltest.result
+++ b/mysql-test/r/mysqltest.result
@@ -1040,7 +1040,8 @@ Rows_sent	0
 Rows_examined	0
 ========================
 
-mysqltest: At line 1: query 'KILL QUERY 276447231' failed: 1094: 
+mysqltest: At line 1: Query 'KILL QUERY 276447231' failed.
+ERROR 1094 (00000): 
 # PROCESSLIST should not be dumped if error was expected
 KILL QUERY 276447231;
 ERROR HY000: Unknown thread id: 276447231
@@ -1082,7 +1083,7 @@ Rows_sent	0
 Rows_examined	0
 ========================
 
-mysqltest: At line 1: query 'KILL QUERY 276447231' failed with wrong errno 1094: '', instead of 1064...
+mysqltest: At line 1: Query 'KILL QUERY 276447231' failed with wrong error 1094: '', should have failed with error '1064'.
 End of tests
 # To test cat_file command can handle \r\n at the 256th place
 # This test file will contain \r at the 256th position and in its


### PR DESCRIPTION
Fix an obvious merge error which resulted in SHOW PROCESSLIST not
issued if ER_NO_SUCH_THREAD was returned by the tested server, and
there was a different error expected by the test. Re-record now-fixed
main.mysqltest.