### PR TITLE
Fix PS-5137 (Compilation warnings on 5.6 branch with -DWITHOUT_PERFSCHEMA_STORAGE_ENGINE=ON)

### DIFF
--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -3129,13 +3129,14 @@ row_merge_file_create_low(
 	const char*	path)
 {
 	int	fd;
-    char filename[] = "Innodb Merge Temp File\0";
-    char* filepath = NULL;
-    int path_len;
     if (path == NULL) {
         path = innobase_mysql_tmpdir();
     }
 #ifdef UNIV_PFS_IO
+	char filename[] = "Innodb Merge Temp File\0";
+	char* filepath = NULL;
+	int path_len;
+
 	/* This temp file open does not go through normal
 	file APIs, add instrumentation to register with
 	performance schema */


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5137

Fixed warnings in 'storage/innobase/row/row0merge.cc' when compiling with
'-DWITHOUT_PERFSCHEMA_STORAGE_ENGINE=ON' which were introduced after upstream
5.6.42 merge.