### PR TITLE
PS-5121: clang-7 warnings with -Wself-assign-overloaded (5.7)

### DIFF
--- a/unittest/gunit/gis_algos-t.cc
+++ b/unittest/gunit/gis_algos-t.cc
@@ -252,10 +252,6 @@ TEST_F(GeometryManipulationTest, PolygonManipulationTest)
                      ls0->get_flags(), ls0->get_srid());
   Gis_line_string ls00(*ls0);
 
-  ls= ls;
-  ls00= ls00;
-  plgn= plgn;
-
   Geometry_buffer buffer3;
   String wkt3, str3;
 


### PR DESCRIPTION
Backport changes by upstream in 8.0:
https://github.com/percona/percona-server/commit/86b3039e9dc7c7a0e038ea34f559a517edc1ff3e