### PR TITLE
Fix PS-5140 (Out-of-bounds reads for compression dictionary object na…

### DIFF
--- a/sql/sql_zip_dict.cc
+++ b/sql/sql_zip_dict.cc
@@ -48,8 +48,8 @@ static const constexpr uint32_t COMPRESSION_DICTIONARY_FIELD_DATA = 3;
 static const constexpr uint32_t COMPRESSION_DICTIONARY_NAME_INDEX = 1;
 static const constexpr uint32_t COMPRESSION_DICTIONARY_VERSION = 1;
 
-static const constexpr char *COMPRESSION_DICTIONARY_DB = "mysql";
-static const constexpr char *COMPRESSION_DICTIONARY_TABLE =
+static const constexpr char COMPRESSION_DICTIONARY_DB[] = "mysql";
+static const constexpr char COMPRESSION_DICTIONARY_TABLE[] =
     "compression_dictionary";
 
 /** Fields of mysql.compression_dictionary_cols table */
@@ -60,8 +60,8 @@ static const constexpr uint32_t COMPRESSION_DICTIONARY_COLS_FIELD_DICT_ID = 2;
 /** Index of compression_dictionary_cols table */
 static const constexpr uint32_t COMPRESSION_DICTIONARY_COLS_TABLE_INDEX = 0;
 
-static const constexpr char *COMPRESSION_DICTIONARY_COLS_DB = "mysql";
-static const constexpr char *COMPRESSION_DICTIONARY_COLS_TABLE =
+static const constexpr char COMPRESSION_DICTIONARY_COLS_DB[] = "mysql";
+static const constexpr char COMPRESSION_DICTIONARY_COLS_TABLE[] =
     "compression_dictionary_cols";
 
 /** Max window size (2^15) minus 262 */
@@ -174,11 +174,10 @@ delete)
 @param[in,out] thd  Session object
 @return TABLE* on success else nullptr */
 static TABLE *open_dictionary_table_write(THD *thd) {
-  TABLE_LIST tablelist;
-  tablelist.init_one_table(C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_DB),
-                           C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_TABLE),
-                           COMPRESSION_DICTIONARY_TABLE, TL_WRITE,
-                           MDL_SHARED_NO_READ_WRITE);
+  TABLE_LIST tablelist(C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_DB),
+                       C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_TABLE),
+                       COMPRESSION_DICTIONARY_TABLE, TL_WRITE,
+                       MDL_SHARED_NO_READ_WRITE);
   tablelist.next_local = tablelist.next_global = nullptr;
 
   const uint flags = (MYSQL_LOCK_IGNORE_TIMEOUT | MYSQL_OPEN_IGNORE_KILLED |
@@ -206,10 +205,9 @@ static TABLE *open_dictionary_table_read(THD *thd) {
   DBUG_ASSERT(!thd->is_attachable_ro_transaction_active());
   thd->begin_attachable_ro_transaction();
 
-  TABLE_LIST tablelist;
-  tablelist.init_one_table(C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_DB),
-                           C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_TABLE),
-                           COMPRESSION_DICTIONARY_TABLE, TL_READ);
+  TABLE_LIST tablelist(C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_DB),
+                       C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_TABLE),
+                       COMPRESSION_DICTIONARY_TABLE, TL_READ);
   tablelist.next_local = tablelist.next_global = nullptr;
 
   uint flags = (MYSQL_LOCK_IGNORE_TIMEOUT | MYSQL_OPEN_IGNORE_KILLED |
@@ -258,11 +256,10 @@ table mysql.compression_dictionary
 @return on success, a TABLE* object else nullptr on failure */
 
 static TABLE *open_dictionary_cols_table_write(THD *thd) {
-  TABLE_LIST tablelist;
-  tablelist.init_one_table(C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_COLS_DB),
-                           C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_COLS_TABLE),
-                           COMPRESSION_DICTIONARY_COLS_TABLE,
-                           TL_WRITE_CONCURRENT_DEFAULT, MDL_SHARED_WRITE);
+  TABLE_LIST tablelist(C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_COLS_DB),
+                       C_STRING_WITH_LEN(COMPRESSION_DICTIONARY_COLS_TABLE),
+                       COMPRESSION_DICTIONARY_COLS_TABLE,
+                       TL_WRITE_CONCURRENT_DEFAULT, MDL_SHARED_WRITE);
   tablelist.next_local = tablelist.next_global = nullptr;
 
   const uint flags = (MYSQL_LOCK_IGNORE_TIMEOUT | MYSQL_OPEN_IGNORE_KILLED |

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -475,12 +475,12 @@ static struct log_bitmap_struct *log_bmp_sys;
 MetadataRecover *log_online_metadata_recover = nullptr;
 
 /** File name stem for bitmap files. */
-static const constexpr char *bmp_file_name_stem = "ib_modified_log_";
+static const constexpr auto bmp_file_name_stem = "ib_modified_log_";
 
 /** File name template for bitmap files.  The 1st format tag is a directory
 name, the 2nd tag is the stem, the 3rd tag is a file sequence number, the 4th
 tag is the start LSN for the file. */
-static const constexpr char *bmp_file_name_template = "%s%s%lu_" LSN_PF ".xdb";
+static const constexpr auto bmp_file_name_template = "%s%s%lu_" LSN_PF ".xdb";
 
 /* Tests if num bit of bitmap is set */
 #define IS_BIT_SET(bitmap, num) \


### PR DESCRIPTION
…mes)

Fix out-of-bounds reads of sql_zip_dict.cc:COMPRESSION_DICTIONARY_DB,
COMPRESSION_DICTIONARY_TABLE, COMPRESSION_DICTIONARY_COLS_DB, and
COMPRESSION_DICTIONARY_COLS_TABLE caused by incorrect their constexpr
declarations, resulting in these constants being treated as
pointer (sizeof == 8 bytes) rather than string literals.

At the same time replace TALBE_LIST::init_one_table uses with
TABLE_LIST::TABLE_LIST, as recommended for new code.

At the same time audit other Percona-added constexprs for the same
issue and adjust log0online.cc:bmp_file_name_stem and
bmp_file_name_template accordingly, even though their sizeof is never
taken, hence the issue is currently benign for them.

https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/73