### PR TITLE
PS-5126: SHOW BINLOG EVENTS FROM <bad offset> is not diagnosed (8.0)

### DIFF
--- a/mysql-test/suite/rpl/r/bug75480.result
+++ b/mysql-test/suite/rpl/r/bug75480.result
@@ -15,7 +15,6 @@ INSERT INTO t (a, b) VALUES (4, 4);
 INSERT INTO t (a, b) VALUES (5, 5);
 INSERT INTO t (a, b) VALUES (6, 6);
 INSERT INTO t (a, b) VALUES (7, 7);
-SHOW BINLOG EVENTS FROM 5;
-ERROR HY000: Error when executing command SHOW BINLOG EVENTS: Wrong offset or I/O error
+include/sync_slave_sql_with_master.inc
 DROP TABLE t;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/bug75480.test
+++ b/mysql-test/suite/rpl/t/bug75480.test
@@ -20,10 +20,54 @@ INSERT INTO t (a, b) VALUES (5, 5);
 INSERT INTO t (a, b) VALUES (6, 6);
 INSERT INTO t (a, b) VALUES (7, 7);
 
-sync_slave_with_master;
+--source include/sync_slave_sql_with_master.inc
 
+# 'mix', 'row', and 'stmt' generate different outputs
+--disable_query_log
+--disable_result_log
+
+--let $binlog_end_pos= query_get_value(SHOW MASTER STATUS, Position, 1)
+--let $end_pos= 0
+--let $row_number= 1
+
+# no error for binlog position 0
+SHOW BINLOG EVENTS FROM 0 LIMIT 1;
+
+# expect error for binlog position 1
 --error ER_ERROR_WHEN_EXECUTING_COMMAND
-SHOW BINLOG EVENTS FROM 5;
+SHOW BINLOG EVENTS FROM 1 LIMIT 1;
+
+while ($end_pos < $binlog_end_pos)
+{
+  --let $start_pos= query_get_value(SHOW BINLOG EVENTS, Pos, $row_number)
+  --let $end_pos= query_get_value(SHOW BINLOG EVENTS, End_log_pos, $row_number)
+  --inc $row_number
+  --let $start_pos_prev= $start_pos
+  --dec $start_pos_prev
+  --let $start_pos_next= $start_pos
+  --inc $start_pos_next
+
+  # expect error for $start_pos - 1
+  --error ER_ERROR_WHEN_EXECUTING_COMMAND
+  --eval SHOW BINLOG EVENTS FROM $start_pos_prev LIMIT 1
+
+  # no error for $start_pos
+  --eval SHOW BINLOG EVENTS FROM $start_pos LIMIT 1
+
+  # expect error for $start_pos + 1
+  --error ER_ERROR_WHEN_EXECUTING_COMMAND
+  --eval SHOW BINLOG EVENTS FROM $start_pos_next LIMIT 1
+}
+
+# no error for $binlog_end_pos
+--eval SHOW BINLOG EVENTS FROM $binlog_end_pos LIMIT 1
+
+# no error for $binlog_end_pos + 1 (Incorrect and should be fixed)
+--inc $binlog_end_pos
+--eval SHOW BINLOG EVENTS FROM $binlog_end_pos LIMIT 1
+
+--enable_query_log
+--enable_result_log
 
 connection master;
 

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -3166,8 +3166,7 @@ bool show_binlog_events(THD *thd, MYSQL_BIN_LOG *binary_log) {
     LEX_MASTER_INFO *lex_mi = &thd->lex->mi;
     SELECT_LEX_UNIT *unit = thd->lex->unit;
     ha_rows event_count, limit_start, limit_end;
-    my_off_t pos =
-        max<my_off_t>(BIN_LOG_HEADER_SIZE, lex_mi->pos);  // user-friendly
+    my_off_t pos = lex_mi->pos;
     char search_file_name[FN_REFLEN], *name;
     const char *log_file_name = lex_mi->log_file_name;
 
@@ -3225,7 +3224,8 @@ bool show_binlog_events(THD *thd, MYSQL_BIN_LOG *binary_log) {
 
       DEBUG_SYNC(thd, "wait_in_show_binlog_events_loop");
       if (event_count >= limit_start &&
-          ev->net_send(protocol, linfo.log_file_name, pos)) {
+          ev->net_send(protocol, linfo.log_file_name,
+                       max<my_off_t>(BIN_LOG_HEADER_SIZE, pos))) {
         errmsg = "Net error";
         delete ev;
         goto err;

--- a/sql/binlog_istream.cc
+++ b/sql/binlog_istream.cc
@@ -50,6 +50,8 @@ const char *Binlog_read_error::get_str() const {
     case BAD_BINLOG_MAGIC:
       return "Binlog has bad magic number;  It's not a binary log file "
              "that can be used by this version of MySQL";
+    case INVALID_OFFSET:
+      return "Wrong offset or I/O error";
     case DECRYPT_INIT_FAILURE:
       return "Failed to initialize binlog encryption. Please make sure that "
              "the correct keyring "

--- a/sql/binlog_istream.h
+++ b/sql/binlog_istream.h
@@ -59,6 +59,8 @@ class Binlog_read_error {
     HEADER_IO_FAILURE,
     // The binlog magic is incorrect
     BAD_BINLOG_MAGIC,
+    // Invalid starting offset e.g. "SHOW BINLOG EVENTS FROM 5"
+    INVALID_OFFSET,
     // Failed to initialize binlog decryption
     DECRYPT_INIT_FAILURE,
     // Encrypted event decryption failure

--- a/sql/binlog_reader.h
+++ b/sql/binlog_reader.h
@@ -291,6 +291,13 @@ class Basic_binlog_file_reader {
     m_data_istream.reset_crypto();
 
     Format_description_log_event *fd = read_fdle(offset);
+
+    /* Invalid starting offset e.g. "SHOW BINLOG EVENTS FROM 5" */
+    if (offset > 0 && position() > offset) {
+      if (fd) delete fd;
+      return m_error.set_type(Binlog_read_error::INVALID_OFFSET);
+    }
+
     if (!fd) return has_fatal_error();
 
     if (position() < offset && seek(offset)) {

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -12886,7 +12886,7 @@ binlog_in:
         ;
 
 binlog_from:
-          /* empty */        { Lex->mi.pos = 4; /* skip magic number */ }
+          /* empty */        { Lex->mi.pos = 0; }
         | FROM ulonglong_num { Lex->mi.pos = $2; }
         ;
 


### PR DESCRIPTION
There are 3 separate cases for `SHOW BINLOG EVENTS FROM offset` to return `ER_ERROR_WHEN_EXECUTING_COMMAND`:
1. At the beginning, inside `Format_description_log_events` (detected by this commit)
2. In the middle (detected by code from upstream)
3. After the last valid offset (to do, currently not detected)

This commit fixes `rpl.bug75480`.