### PR TITLE
PS-5117 : Cannot upgrade from PS 5.7 to 8.0 if datadir is bootstrappe…

### DIFF
--- a/mysql-test/r/dd_upgrade_encrypted.result
+++ b/mysql-test/r/dd_upgrade_encrypted.result
@@ -1,0 +1,81 @@
+# Set different paths for --datadir
+# Check that the file exists in the working folder.
+# Unzip the zip file.
+# Stop DB server which was created by MTR default
+# Start the 8.0 server on 5.7 datadir
+# restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=MYSQLD_DATADIR1 --innodb-encrypt-tables=ON --keyring_file_data=MYSQL_TMP_DIR/data57_encrypted/mysecret_keyring --innodb_sys_tablespace_encrypt=ON KEYRING_PLUGIN_OPT KEYRING_PLUGIN_EARLY_LOAD
+# Execute mysql_upgrade
+mysql.columns_priv                                 OK
+mysql.component                                    OK
+mysql.db                                           OK
+mysql.default_roles                                OK
+mysql.engine_cost                                  OK
+mysql.func                                         OK
+mysql.general_log                                  OK
+mysql.global_grants                                OK
+mysql.gtid_executed                                OK
+mysql.help_category                                OK
+mysql.help_keyword                                 OK
+mysql.help_relation                                OK
+mysql.help_topic                                   OK
+mysql.innodb_index_stats                           OK
+mysql.innodb_table_stats                           OK
+mysql.ndb_binlog_index                             OK
+mysql.password_history                             OK
+mysql.plugin                                       OK
+mysql.procs_priv                                   OK
+mysql.proxies_priv                                 OK
+mysql.role_edges                                   OK
+mysql.server_cost                                  OK
+mysql.servers                                      OK
+mysql.slave_master_info                            OK
+mysql.slave_relay_log_info                         OK
+mysql.slave_worker_info                            OK
+mysql.slow_log                                     OK
+mysql.tables_priv                                  OK
+mysql.time_zone                                    OK
+mysql.time_zone_leap_second                        OK
+mysql.time_zone_name                               OK
+mysql.time_zone_transition                         OK
+mysql.time_zone_transition_type                    OK
+mysql.user                                         OK
+sys.sys_config                                     OK
+test.t1                                            OK
+test.t2                                            OK
+test.t3                                            OK
+test.t4                                            OK
+test.t5                                            OK
+test.t6                                            OK
+SHOW CREATE TABLE test.t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+SHOW CREATE TABLE test.t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `a` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='N'
+SHOW CREATE TABLE test.t3;
+Table	Create Table
+t3	CREATE TABLE `t3` (
+  `a` int(11) DEFAULT NULL
+) /*!50100 TABLESPACE `ts_unenc` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='N'
+SHOW CREATE TABLE test.t4;
+Table	Create Table
+t4	CREATE TABLE `t4` (
+  `a` int(11) DEFAULT NULL
+) /*!50100 TABLESPACE `ts_unenc` */ ENGINE=InnoDB DEFAULT CHARSET=latin1
+SHOW CREATE TABLE test.t5;
+Table	Create Table
+t5	CREATE TABLE `t5` (
+  `a` int(11) DEFAULT NULL
+) /*!50100 TABLESPACE `ts_enc` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+SHOW CREATE TABLE test.t6;
+Table	Create Table
+t6	CREATE TABLE `t6` (
+  `a` int(11) DEFAULT NULL
+) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+# Remove copied files
+# Restart the server with default options.
+# restart

--- a/mysql-test/t/dd_upgrade_encrypted.test
+++ b/mysql-test/t/dd_upgrade_encrypted.test
@@ -1,0 +1,93 @@
+# This test contains keyring file created on 64bit which is not
+# portable
+--source include/have_64bit.inc
+--source include/no_valgrind_without_big.inc
+--source include/have_util_unzip.inc
+
+--disable_query_log
+call mtr.add_suppression("Resizing redo log from");
+call mtr.add_suppression("Upgrading redo log");
+call mtr.add_suppression("Starting to delete and rewrite log files");
+call mtr.add_suppression("New log files created");
+call mtr.add_suppression("Unknown system variable 'show_compatibility_56'");
+call mtr.add_suppression("You need to use --log-bin to make --binlog-format work");
+call mtr.add_suppression("Creating routine without parsing routine body");
+call mtr.add_suppression("Resolving dependency for the view");
+call mtr.add_suppression("references invalid");
+call mtr.add_suppression("doesn't exist");
+call mtr.add_suppression("information_schema");
+call mtr.add_suppression("Storage engine '.*' does not support system tables. \\[mysql.*\\]");
+call mtr.add_suppression("Table 'mysql.component' doesn't exist");
+call mtr.add_suppression("is expected to be transactional");
+call mtr.add_suppression("table is missing or has an incorrect definition");
+call mtr.add_suppression("ACL DDLs will not work unless mysql_upgrade is executed");
+call mtr.add_suppression("Native table .* has the wrong structure");
+call mtr.add_suppression("Column count of mysql.* is wrong");
+call mtr.add_suppression("Cannot open table mysql/version from the internal data dictionary of InnoDB though the .frm file for the table exists");
+call mtr.add_suppression("Column count of performance_schema.events_statements_summary_by_digest is wrong");
+call mtr.add_suppression("The privilege system failed to initialize correctly");
+call mtr.add_suppression("Missing system table mysql.global_grants");
+# InnoDB reports "Lock wait timeout" warnings when it tries to drop persistent
+# statistics while persistent statistics table is altered during upgrade.
+# This issue doesn't seem to cause any further trouble (as there is no persistent
+# stats for persistent stats table anyway), so we ignore these warnings here.
+call mtr.add_suppression("Unable to delete statistics for table mysql.");
+# new fields were added to these tables
+call mtr.add_suppression("Column count of performance_schema.replication_group_members is wrong. Expected 7, found 5");
+call mtr.add_suppression("Column count of performance_schema.replication_group_member_stats is wrong. Expected 13, found 9");
+call mtr.add_suppression("Column count of performance_schema.threads is wrong. Expected 18, found 17");
+call mtr.add_suppression("ACL table mysql.[a-zA-Z_]* missing. Some operations may fail.");
+call mtr.add_suppression("Info table is not ready to be used. Table 'mysql.slave_master_info' cannot be opened");
+call mtr.add_suppression("Error in checking mysql.slave_master_info repository info type of TABLE");
+call mtr.add_suppression("Error creating master info: Error checking repositories.");
+call mtr.add_suppression("Slave: Failed to initialize the master info structure for channel");
+call mtr.add_suppression("Failed to create or recover replication info repositories.");
+call mtr.add_suppression("db.opt file not found for test database. Using default Character set");
+call mtr.add_suppression("Skip re-populating collations and character sets tables in InnoDB read-only mode");
+call mtr.add_suppression("Skipped updating resource group metadata in InnoDB read only mode");
+--enable_query_log
+
+--echo # Set different paths for --datadir
+let $MYSQLD_DATADIR1 = $MYSQL_TMP_DIR/data57_encrypted/data;
+
+--copy_file $MYSQLTEST_VARDIR/std_data/data57_encrypted.zip $MYSQL_TMP_DIR/data57_encrypted.zip
+
+--echo # Check that the file exists in the working folder.
+--file_exists $MYSQL_TMP_DIR/data57_encrypted.zip
+
+--echo # Unzip the zip file.
+--exec unzip -qo $MYSQL_TMP_DIR/data57_encrypted.zip -d $MYSQL_TMP_DIR
+
+--let $MYSQLD_DATADIR=`SELECT @@datadir`
+
+--echo # Stop DB server which was created by MTR default
+--source include/shutdown_mysqld.inc
+
+--echo # Start the 8.0 server on 5.7 datadir
+--let $restart_parameters = "restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=$MYSQLD_DATADIR1 --innodb-encrypt-tables=ON --keyring_file_data=$MYSQL_TMP_DIR/data57_encrypted/mysecret_keyring --innodb_sys_tablespace_encrypt=ON $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD"
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1 $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD KEYRING_PLUGIN_EARLY_LOAD
+--source include/start_mysqld.inc
+
+--echo # Execute mysql_upgrade
+
+--source include/mysql_upgrade_preparation.inc
+--exec $MYSQL_UPGRADE --skip-verbose --force 2>&1
+--source include/mysql_upgrade_cleanup.inc
+
+SHOW CREATE TABLE test.t1;
+SHOW CREATE TABLE test.t2;
+SHOW CREATE TABLE test.t3;
+SHOW CREATE TABLE test.t4;
+SHOW CREATE TABLE test.t5;
+SHOW CREATE TABLE test.t6;
+
+--source include/shutdown_mysqld.inc
+
+--echo # Remove copied files
+--remove_file $MYSQL_TMP_DIR/data57_encrypted.zip
+
+--force-rmdir $MYSQL_TMP_DIR/data57_encrypted
+
+--echo # Restart the server with default options.
+--let $restart_parameters=
+--source include/start_mysqld.inc

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -18463,6 +18463,9 @@ ER_XB_MSG_1
 ER_COMPRESSION_DICTIONARY_NO_CREATE
   eng "Cannot create compression dictionary tables in %s%sread-only mode."
 
+ER_XB_MSG_2
+  eng "%s"
+
 #
 # End of Percona Server 8.0 server error log messages
 #

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -7443,3 +7443,22 @@ dberr_t dict_get_dictionary_info_by_id(ulint dict_id, char **name,
 
   return err;
 }
+
+bool dict_detect_encryption(bool is_upgrade) {
+  bool encrypt_mysql = false;
+  if (is_upgrade) {
+    space_id_t space_id = fil_space_get_id_by_name("mysql/plugin");
+    ut_ad(space_id != SPACE_UNKNOWN);
+
+    fil_space_t *space = fil_space_get(space_id);
+    ut_ad(space != nullptr);
+
+    if (space == nullptr) {
+      return (false);
+    }
+    encrypt_mysql = FSP_FLAGS_GET_ENCRYPTION(space->flags);
+  }
+
+  return (encrypt_mysql || srv_encrypt_tables == SRV_ENCRYPT_TABLES_ON ||
+          srv_encrypt_tables == SRV_ENCRYPT_TABLES_FORCE);
+}

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -1786,6 +1786,14 @@ dberr_t dict_get_dictionary_info_by_id(ulint dict_id, char **name,
                                        ulint *name_len, char **data,
                                        ulint *data_len);
 
+/** Detect if Percona Server 5.7 mysql database has encrypted InnoDB tables.
+This can happen if Percona Server is bootstrapped with
+--innodb-encrypt-tables=ON If yes or if srv_encrypt_tables is ON/FORCE, during
+upgrade, mysql.ibd should be encrpted.
+@param[in]  is_upgrade true in upgrade mode
+@return true if encrypted, false if not encrypted */
+bool dict_detect_encryption(bool is_upgrade);
+
 #include "dict0dict.ic"
 
 #endif


### PR DESCRIPTION
…d with --innodb-encrypt-tables


Problem:
-------

Upgrade from 5.7 to 8.0 doesn't work in the following scenarios.

1. 5.7 datadir has encrypted tables like mysql.plugin/servers (due to
   --innodb-encrypted-tables=ON during bootstrap)

2. presence of --innodb-encrypt-tables as mysqld option during upgrade
   (ie when PS-8.0 mysqld is started on 5.7 datadir)

Symptoms:
For 1) mysql_upgrade fails at "ALTER TABLE mysql.plugin TABLESPACE=mysql" with
error saying "source is encrypted and Destination tablespace (mysql) is unencrypted

For 2) In Debug builds, there is assertion failure when dd_properties table creation
fails. Error message "mysql tablespace cannot contain encrypted table".

Fix:
----
For 1) Detect during upgrade if table in mysql database in encrypted, and create
mysqld.ibd as encrypted.

For 2) If --innodb-encrypt-tables is present during upgrade or normal bootstrap
encrypt mysql.ibd

Once mysql.ibd is encrypted, next startup requires innodb_encrypt_tables=ON.
Note that it can be turned off later.
