### PR TITLE
PS-5151 : Handle upgrade of encrypted general tablespaces from 5.7 to…

### DIFF
--- a/mysql-test/r/dd_upgrade_encrypted.result
+++ b/mysql-test/r/dd_upgrade_encrypted.result
@@ -60,7 +60,7 @@ SHOW CREATE TABLE test.t3;
 Table	Create Table
 t3	CREATE TABLE `t3` (
   `a` int(11) DEFAULT NULL
-) /*!50100 TABLESPACE `ts_unenc` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='N'
+) /*!50100 TABLESPACE `ts_unenc` */ ENGINE=InnoDB DEFAULT CHARSET=latin1
 SHOW CREATE TABLE test.t4;
 Table	Create Table
 t4	CREATE TABLE `t4` (
@@ -70,12 +70,12 @@ SHOW CREATE TABLE test.t5;
 Table	Create Table
 t5	CREATE TABLE `t5` (
   `a` int(11) DEFAULT NULL
-) /*!50100 TABLESPACE `ts_enc` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) /*!50100 TABLESPACE `ts_enc` */ ENGINE=InnoDB DEFAULT CHARSET=latin1
 SHOW CREATE TABLE test.t6;
 Table	Create Table
 t6	CREATE TABLE `t6` (
   `a` int(11) DEFAULT NULL
-) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=latin1
 # Remove copied files
 # Restart the server with default options.
 # restart

--- a/storage/innobase/dict/dict0upgrade.cc
+++ b/storage/innobase/dict/dict0upgrade.cc
@@ -937,6 +937,19 @@ bool dd_upgrade_table(THD *thd, const char *db_name, const char *table_name,
 
   dd_set_table_options(dd_table, ib_table);
 
+  /* Tables in encrypted general tablespace from PS-5.7 have
+  encryption attribute. Remove this attribute as tables in
+  general tablespace shouldn't have it. General tablespace
+  should have encryption attribute */
+  if (!dict_table_is_file_per_table(ib_table) &&
+      ib_table->tablespace != nullptr) {
+    dd::Table *dd_table_def = &(dd_table->table());
+    dd::Properties &options = dd_table_def->options();
+    if (options.exists("encrypt_type")) {
+      options.remove("encrypt_type");
+    }
+  }
+
   /* The number of indexes has to match. */
   DBUG_EXECUTE_IF("dd_upgrade_strict_mode",
                   ut_ad(dd_table->indexes()->size() ==
@@ -1123,6 +1136,12 @@ int dd_upgrade_tablespace(THD *thd) {
         upgrade_space.name = new_tablespace_name.c_str();
       } else {
         upgrade_space.name = name;
+        /* Set encryption attribute for encrypted general tablespaces */
+        if (FSP_FLAGS_GET_ENCRYPTION(flags)) {
+          dd::Properties &space_options = dd_space->options();
+          dd::String_type encrypt_type("y");
+          space_options.set("encryption", encrypt_type);
+        }
       }
 
       mutex_enter(&dict_sys->mutex);


### PR DESCRIPTION
… 8.0.13

Problem:
--------
Since 8.0.13, encryption is tablespace attribute and not table attribute.
Upgrade from Percona Server 5.7 with encrypted tablespace doesn't follow the above rules
This affects the ALTER behaviour and other problems when moving tables around. Also
SHOW CREATE table shows encryption attribute for tables in general tablespace.

Fix:
----
During upgrade of encrypted general tablespaces and tables, the following is done.

1. Do not register encryption attribute in dd::Table for tables in general tablespace.
2. Register encryption attribute for dd::Tablespace of general tablespaces.