### PR TITLE
PS-4904 : UBSAN sql/log_event.cc:8652:22: runtime error: load of valu…

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -10148,7 +10148,7 @@ Rows_log_event::decide_row_lookup_algorithm_and_key()
     if (delete_update_lookup_condition &&
         table->s->primary_key == MAX_KEY)
     {
-        if (!table->s->rfr_lookup_warning)
+        if (table->s->rfr_lookup_warning != 0)
         {
           sql_print_warning("Slave: read free replication is disabled "
                             "for tokudb table `%s.%s` "


### PR DESCRIPTION
…e 190, which is not a valid value for type 'bool'

- Fixed minor logic issue which tripped UBSAN.