### PR TITLE
PS-5134 : handle_fatal_signal (sig=11) in thd_get_thread_id

### DIFF
--- a/mysql-test/suite/innodb/r/percona_print_lock_wait_timeout_trx.result
+++ b/mysql-test/suite/innodb/r/percona_print_lock_wait_timeout_trx.result
@@ -19,6 +19,19 @@ COMMIT;
 Grepping the error log for lock wait timeout info
 Pattern "Lock wait timeout info:" found
 DROP TABLE t;
+#
+# Test for PS-5134 : handle_fatal_signal (sig=11) in thd_get_thread_id
+#
+CREATE TABLE t5134(c0 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=INNODB;
+BEGIN;
+SELECT database_name, table_name FROM mysql.innodb_table_stats WHERE table_name='t5134' FOR UPDATE;
+database_name	table_name
+test	t5134
+INSERT INTO t5134 VALUES (), ();
+Grepping the error log for lock wait timeout info
+Pattern "Requested thread id: <background>" found
+ROLLBACK;
+DROP TABLE t5134;
 SET GLOBAL innodb_lock_wait_timeout = @innodb_lock_wait_timeout_saved;
 SET GLOBAL innodb_print_lock_wait_timeout_info =
 @innodb_print_lock_wait_timeout_info_saved;

--- a/mysql-test/suite/innodb/t/percona_print_lock_wait_timeout_trx.test
+++ b/mysql-test/suite/innodb/t/percona_print_lock_wait_timeout_trx.test
@@ -40,9 +40,39 @@ COMMIT;
 --let SEARCH_FILE= $log_error_path
 --let SEARCH_PATTERN= Lock wait timeout info:
 --source include/search_pattern.inc
---remove_file $log_error_path
 
 DROP TABLE t;
+
+--echo #
+--echo # Test for PS-5134 : handle_fatal_signal (sig=11) in thd_get_thread_id
+--echo #
+# When a background thread (innodb_table_stats harvester) encounters a lock wait
+# timeout and innodb_print_lock_wait_timeout_info is enabled, the background
+# thread will segfault when printing the info while trying to access the
+# trx.mysql_thd thread id as the trx.mysql_thd will be nullptr in the background
+# thread.  The fix checks for this and instead prints <background> for the
+# thread id.
+CREATE TABLE t5134(c0 INT UNSIGNED AUTO_INCREMENT PRIMARY KEY) ENGINE=INNODB;
+
+--let $wait_condition= SELECT COUNT(*) = 1 FROM mysql.innodb_table_stats where table_name='t5134'
+--source include/wait_condition.inc
+
+BEGIN;
+SELECT database_name, table_name FROM mysql.innodb_table_stats WHERE table_name='t5134' FOR UPDATE;
+INSERT INTO t5134 VALUES (), ();
+
+--echo Grepping the error log for lock wait timeout info
+--let SEARCH_FILE= $log_error_path
+--let SEARCH_PATTERN= Requested thread id: <background>
+--source include/wait_for_search_pattern.inc
+
+ROLLBACK;
+DROP TABLE t5134;
+
+
+# cleanup
+--remove_file $log_error_path
+
 SET GLOBAL innodb_lock_wait_timeout = @innodb_lock_wait_timeout_saved;
 SET GLOBAL innodb_print_lock_wait_timeout_info =
   @innodb_print_lock_wait_timeout_info_saved;

--- a/storage/innobase/lock/lock0wait.cc
+++ b/storage/innobase/lock/lock0wait.cc
@@ -196,10 +196,16 @@ static void print_lock_wait_timeout(const trx_t &trx,
   size_t unused;
 
   outs << "Lock wait timeout info:\n";
-  outs << "Requested thread id: " << thd_get_thread_id(trx.mysql_thd) << "\n";
+  if (trx.mysql_thd)
+    outs << "Requested thread id: " << thd_get_thread_id(trx.mysql_thd) << "\n";
+  else
+    outs << "Requested thread id: " << "<background>" << "\n";
   outs << "Requested trx id: " << trx_get_id_for_print(&trx) << "\n";
-  outs << "Requested query: "
-       << innobase_get_stmt_unsafe(trx.mysql_thd, &unused) << "\n";
+  if (trx.mysql_thd)
+    outs << "Requested query: "
+         << innobase_get_stmt_unsafe(trx.mysql_thd, &unused) << "\n";
+  else
+    outs << "Requested query: <unknown>\n";
 
   outs << "Total blocking transactions count: " << blocking_count << "\n";
 


### PR DESCRIPTION
- Fixed SEGFAULT in innodb print_lock_wait_timeout when the thread that timed
  out is a background thread and has no trx.mysql_thd.  Now when this happens,
  the lock wait info will contain "<background>" for the thread id and
  "<unknown>" for the SQL.  Added test scenario.