### PR TITLE
PS-5158 : *** buffer overflow detected *** in mysqld on INSERT query

### DIFF
--- a/mysql-test/suite/tokudb.bugs/r/PS-5158.result
+++ b/mysql-test/suite/tokudb.bugs/r/PS-5158.result
@@ -1,0 +1,7 @@
+include/assert.inc [Requires tokudb_dir_per_db=1]
+CREATE DATABASE `new..............................................end`;
+USE `new..............................................end`;
+CREATE TABLE t1(a INT KEY,b INT)ENGINE=TokuDB;
+INSERT INTO t1 VALUES(1,11),(2,12),(3,13),(4,14),(5,15);
+USE test;
+DROP DATABASE `new..............................................end`;

--- a/mysql-test/suite/tokudb.bugs/t/PS-5158-master.opt
+++ b/mysql-test/suite/tokudb.bugs/t/PS-5158-master.opt
@@ -1,0 +1,2 @@
+--loose-tokudb_dir_per_db=ON
+

--- a/mysql-test/suite/tokudb.bugs/t/PS-5158.test
+++ b/mysql-test/suite/tokudb.bugs/t/PS-5158.test
@@ -1,0 +1,27 @@
+# Test for PS-5163 : [PS8QA] handle_fatal_signal (sig=11) in DsMrr_impl::dsmrr_init
+# and PS-4828 : Inserting data into TokuDB database with name that contains non-alphanumerical characters can lead to the ZN9ha_tokudb16bulk_insert_pollEPvf assertion
+#
+# The cause is a buffer overrun in LOADER_CONTEXT where the char buffer used for
+# maintaining the proc info string was too small and no validation or prevention
+# was being done to ensure the string stayed within the limits of the buffer.
+# Normally this would have been difficult to hit, but, now with the combination
+# of tokudb_dir_per_db=ON and the expansion of the database name from latin1
+# (or whatever) to the fscs encoding the space required for a max length
+# db.table name could be quite larger than the buffer was originally sized.
+
+--source include/have_tokudb.inc
+
+--let $assert_text= Requires tokudb_dir_per_db=1
+--let $assert_cond= [SELECT @@tokudb_dir_per_db] = 1
+--source include/assert.inc
+
+CREATE DATABASE `new..............................................end`;
+USE `new..............................................end`;
+CREATE TABLE t1(a INT KEY,b INT)ENGINE=TokuDB;
+
+#
+# TokuDB bulk_insert_poll would crash here
+#
+INSERT INTO t1 VALUES(1,11),(2,12),(3,13),(4,14),(5,15);
+USE test;
+DROP DATABASE `new..............................................end`;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -3365,15 +3365,17 @@ void ha_tokudb::start_bulk_insert(ha_rows rows) {
 int ha_tokudb::bulk_insert_poll(void* extra, float progress) {
     LOADER_CONTEXT context = (LOADER_CONTEXT)extra;
     if (thd_killed(context->thd)) {
-        sprintf(context->write_status_msg,
-                "The process has been killed, aborting bulk load.");
+        snprintf(context->write_status_msg,
+                 sizeof(context->write_status_msg),
+                 "The process has been killed, aborting bulk load.");
         return ER_ABORTING_CONNECTION;
     }
     float percentage = progress * 100;
-    sprintf(context->write_status_msg,
-            "Loading of data t %s about %.1f%% done",
-            context->ha->share->full_table_name(),
-            percentage);
+    snprintf(context->write_status_msg,
+             sizeof(context->write_status_msg),
+             "Loading of data t %s about %.1f%% done",
+             context->ha->share->full_table_name(),
+             percentage);
     thd_proc_info(context->thd, context->write_status_msg);
 #ifdef HA_TOKUDB_HAS_THD_PROGRESS
     thd_progress_report(context->thd, (unsigned long long)percentage, 100);
@@ -8523,15 +8525,17 @@ cleanup:
 int ha_tokudb::tokudb_add_index_poll(void* extra, float progress) {
     LOADER_CONTEXT context = (LOADER_CONTEXT)extra;
     if (thd_killed(context->thd)) {
-        sprintf(context->write_status_msg,
-                "The process has been killed, aborting add index.");
+        snprintf(context->write_status_msg,
+                 sizeof(context->write_status_msg),
+                 "The process has been killed, aborting add index.");
         return ER_ABORTING_CONNECTION;
     }
     float percentage = progress * 100;
-    sprintf(context->write_status_msg,
-            "Adding of indexes to %s about %.1f%% done",
-            context->ha->share->full_table_name(),
-            percentage);
+    snprintf(context->write_status_msg,
+             sizeof(context->write_status_msg),
+             "Adding of indexes to %s about %.1f%% done",
+             context->ha->share->full_table_name(),
+             percentage);
     thd_proc_info(context->thd, context->write_status_msg);
 #ifdef HA_TOKUDB_HAS_THD_PROGRESS
     thd_progress_report(context->thd, (unsigned long long)percentage, 100);

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -41,7 +41,7 @@ class ha_tokudb;
 
 typedef struct loader_context {
     THD* thd;
-    char write_status_msg[200];
+    char write_status_msg[1024];
     ha_tokudb* ha;
 } *LOADER_CONTEXT;
 


### PR DESCRIPTION
- For table/index names expanded into fscs, bulk load status buffer was too
  small to contain entire name and message.  Also, code was using unsafe
  sprintf instead of snprintf.  Made buffer large enought to always contain
  full path and fscs table name as well as converted to using snprintf.
- Created new test that would trigger the overrun/segfault without the fix.
    
- This must be cherry-picked forward from 5.6 as test passage requires the fix
  from commit 53371b029266587b8624d544d33b753d93f2d9ff to be present which is
  not yet behind the 5.6->5.7 GCA point.
