### PR TITLE
PS-4758: A sequence of LOCK TABLES FOR BACKUP and STOP SLAVE SQL_THREAD

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_backup_locks.result
+++ b/mysql-test/suite/rpl/r/rpl_backup_locks.result
@@ -37,5 +37,23 @@ INSERT INTO t_innodb VALUES (1);
 include/check_slave_param.inc [Exec_Master_Log_Pos]
 UNLOCK BINLOG;
 # connection master
+# connection slave
+LOCK TABLES FOR BACKUP;
+# connection master
+INSERT INTO t_myisam VALUES (0);
+# connection slave
+STOP SLAVE SQL_THREAD;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+UNLOCK TABLES;
+# connection master
+# connection slave
+LOCK BINLOG FOR BACKUP;
+# connection master
+INSERT INTO t_innodb VALUES (1);
+# connection slave
+STOP SLAVE SQL_THREAD;
+ERROR HY000: Can't execute the given command because you have active locked tables or an active transaction
+UNLOCK BINLOG;
+# connection master
 DROP TABLE t_innodb, t_myisam;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_backup_locks.test
+++ b/mysql-test/suite/rpl/t/rpl_backup_locks.test
@@ -121,6 +121,66 @@ UNLOCK BINLOG;
 --connection master
 --echo # connection master
 
+############################################################################
+# PS-4758: A sequence of LOCK TABLES FOR BACKUP and STOP SLAVE SQL_THREAD
+#          can cause replication to be blocked and cannot be restarted
+#          normally
+############################################################################
+
+--connection slave
+--echo # connection slave
+
+LOCK TABLES FOR BACKUP;
+
+--connection master
+--echo # connection master
+
+INSERT INTO t_myisam VALUES (0);
+
+--connection slave
+--echo # connection slave
+
+let $wait_condition=
+    SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST
+    WHERE STATE = "Waiting for backup lock" AND
+    (INFO = "INSERT INTO t_myisam VALUES (0)" OR INFO IS NULL);
+--source include/wait_condition.inc
+
+--error ER_LOCK_OR_ACTIVE_TRANSACTION
+STOP SLAVE SQL_THREAD;
+UNLOCK TABLES;
+
+--connection master
+--echo # connection master
+
+sync_slave_with_master;
+
+--connection slave
+--echo # connection slave
+
+LOCK BINLOG FOR BACKUP;
+
+--connection master
+--echo # connection master
+
+INSERT INTO t_innodb VALUES (1);
+
+--connection slave
+--echo # connection slave
+
+let $wait_condition=
+    SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST
+    WHERE STATE = "Waiting for binlog lock" AND
+    (INFO = "INSERT INTO t_innodb VALUES (1)" OR INFO IS NULL);
+--source include/wait_condition.inc
+
+--error ER_LOCK_OR_ACTIVE_TRANSACTION
+STOP SLAVE SQL_THREAD;
+UNLOCK BINLOG;
+
+--connection master
+--echo # connection master
+
 DROP TABLE t_innodb, t_myisam;
 sync_slave_with_master;
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -3655,7 +3655,10 @@ end_with_restore_list:
     client thread has locked tables
   */
   if (thd->locked_tables_mode ||
-      thd->in_active_multi_stmt_transaction() || thd->global_read_lock.is_acquired())
+      thd->in_active_multi_stmt_transaction() ||
+      thd->global_read_lock.is_acquired() ||
+      thd->backup_tables_lock.is_acquired() ||
+      thd->backup_binlog_lock.is_acquired())
   {
     my_message(ER_LOCK_OR_ACTIVE_TRANSACTION,
                ER(ER_LOCK_OR_ACTIVE_TRANSACTION), MYF(0));


### PR DESCRIPTION
can cause replication to be blocked and cannot be restarted normally

When after LOCK TABLES FOR BACKUP / LOCK BINLOG FOR BACKUP slave SQL
thread is waiting for backup / binlog lock subsequent STOP SLAVE
SQL_THREAD causing deadlock. SQL thread is waiting for backup lock, STOP
SLAVE is waiting for SQL thread to complete current statement.

Fix is to throw an error when the thread which acquired the backup lock
is trying to stop slave.