### PR TITLE
PS-5153 : Ensure InnoDB session temporary tablespaces are covered by …

### DIFF
--- a/mysql-test/suite/innodb/r/percona_session_temp_tablespaces_encrypt.result
+++ b/mysql-test/suite/innodb/r/percona_session_temp_tablespaces_encrypt.result
@@ -1,0 +1,97 @@
+# restart
+SELECT @@innodb_temp_tablespace_encrypt;
+@@innodb_temp_tablespace_encrypt
+0
+SET GLOBAL big_tables=ON;
+# Create a new connection.
+# A session tablespace will be allocated to connection 1
+# for explicit temporary tables and state will be active
+SELECT @@session.big_tables;
+@@session.big_tables
+1
+CREATE TEMPORARY TABLE test.t1(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t2(a INT, b BLOB);
+CREATE TABLE t3 like t1;
+INSERT INTO t1 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t2 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t3 SELECT * FROM t1;
+INSERT INTO t3 SELECT * FROM t2;
+INSERT INTO t3 SELECT * FROM t3;
+INSERT INTO t3 SELECT * FROM t3;
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+ID	SPACE	PATH	SIZE	STATE	PURPOSE
+ID	4294566160	./#innodb_temp/temp_8.ibt	98304	ACTIVE	INTRINSIC
+ID	4294566161	./#innodb_temp/temp_9.ibt	114688	ACTIVE	USER
+SET GLOBAL innodb_encrypt_tables=ON;
+CREATE TEMPORARY TABLE test.t4(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t5(a INT, b BLOB);
+CREATE TABLE t6 like t1;
+INSERT INTO t4 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t5 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t6 SELECT * FROM t4;
+INSERT INTO t6 SELECT * FROM t5;
+INSERT INTO t6 SELECT * FROM t6;
+INSERT INTO t6 SELECT * FROM t6;
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+ID	SPACE	PATH	SIZE	STATE	PURPOSE
+ID	4294566158	./#innodb_temp/temp_6.ibt	98304	ACTIVE	INTRINSIC ENCRYTPED
+ID	4294566159	./#innodb_temp/temp_7.ibt	114688	ACTIVE	USER ENCRYPTED
+ID	4294566160	./#innodb_temp/temp_8.ibt	98304	ACTIVE	INTRINSIC
+ID	4294566161	./#innodb_temp/temp_9.ibt	114688	ACTIVE	USER
+SET GLOBAL innodb_encrypt_tables=OFF;
+DROP TABLE t3, t6;
+SET GLOBAL innodb_temp_tablespace_encrypt=ON;
+SELECT @@innodb_encrypt_tables;
+@@innodb_encrypt_tables
+OFF
+# Create a new connection.
+SELECT @@session.big_tables;
+@@session.big_tables
+1
+# Ensure entries in information_schema.processlist and
+# information_schema.innodb_session_temp_tablespaces are
+# in sync
+CREATE TEMPORARY TABLE test.t1(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t2(a INT, b BLOB);
+CREATE TABLE t3 like t1;
+INSERT INTO t1 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t2 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t3 SELECT * FROM t1;
+INSERT INTO t3 SELECT * FROM t2;
+INSERT INTO t3 SELECT * FROM t3;
+INSERT INTO t3 SELECT * FROM t3;
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+ID	SPACE	PATH	SIZE	STATE	PURPOSE
+ID	4294566156	./#innodb_temp/temp_4.ibt	98304	ACTIVE	INTRINSIC ENCRYTPED
+ID	4294566157	./#innodb_temp/temp_5.ibt	114688	ACTIVE	USER ENCRYPTED
+SET GLOBAL innodb_encrypt_tables=ON;
+CREATE TEMPORARY TABLE test.t4(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t5(a INT, b BLOB);
+CREATE TABLE t6 like t1;
+INSERT INTO t4 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t5 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t6 SELECT * FROM t4;
+INSERT INTO t6 SELECT * FROM t5;
+INSERT INTO t6 SELECT * FROM t6;
+INSERT INTO t6 SELECT * FROM t6;
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+ID	SPACE	PATH	SIZE	STATE	PURPOSE
+ID	4294566156	./#innodb_temp/temp_4.ibt	98304	ACTIVE	INTRINSIC ENCRYTPED
+ID	4294566157	./#innodb_temp/temp_5.ibt	147456	ACTIVE	USER ENCRYPTED
+SET GLOBAL innodb_temp_tablespace_encrypt=default;
+SET GLOBAL innodb_encrypt_tables=default;
+SET GLOBAL big_tables=default;
+DROP TABLE t3;
+DROP TABLE t6;
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES ORDER BY SPACE;
+ID	SPACE	PATH	SIZE	STATE	PURPOSE
+ID	4294566153	./#innodb_temp/temp_1.ibt	81920	INACTIVE	NONE
+ID	4294566154	./#innodb_temp/temp_2.ibt	81920	INACTIVE	NONE
+ID	4294566155	./#innodb_temp/temp_3.ibt	81920	INACTIVE	NONE
+ID	4294566156	./#innodb_temp/temp_4.ibt	81920	INACTIVE	NONE
+ID	4294566157	./#innodb_temp/temp_5.ibt	81920	INACTIVE	NONE
+ID	4294566158	./#innodb_temp/temp_6.ibt	81920	ACTIVE	INTRINSIC
+ID	4294566159	./#innodb_temp/temp_7.ibt	81920	INACTIVE	NONE
+ID	4294566160	./#innodb_temp/temp_8.ibt	81920	INACTIVE	NONE
+ID	4294566161	./#innodb_temp/temp_9.ibt	81920	INACTIVE	NONE
+ID	4294566162	./#innodb_temp/temp_10.ibt	98304	ACTIVE	INTRINSIC

--- a/mysql-test/suite/innodb/r/temp_table_encrypt.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt.result
@@ -1,5 +1,6 @@
 call mtr.add_suppression("\\[InnoDB\\] Check keyring plugin fail, please check the keyring plugin is loaded.");
 call mtr.add_suppression("\\[InnoDB\\] Can't set temporary tablespace to be encrypted because keyring plugin is not available.");
+call mtr.add_suppression("\\[InnoDB\\] Unable to encrypt a session temp tablespace. Probably due to missing keyring plugin");
 #
 # PS-4727: instrinsic temp table behaviour shouldn't depend on innodb_encrypt_tables
 #
@@ -8,6 +9,7 @@ INSERT INTO t1 VALUES (1, 'hello'), (2, 'hi'), (3, 'satya');
 SET GLOBAL innodb_encrypt_tables=ON;
 SET big_tables=ON;
 INSERT INTO t1 SELECT * FROM t1;
+ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 DROP TABLE t1;
 SET big_tables=default;
 SET GLOBAL innodb_encrypt_tables=default;
@@ -23,9 +25,9 @@ SELECT @@innodb_temp_tablespace_encrypt;
 @@innodb_temp_tablespace_encrypt
 0
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
-ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+ERROR HY000: InnoDB : ENCRYPTION is not accepted syntax for CREATE/ALTER table, for tables in general/shared tablespace.
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='N';
-DROP TABLE t01;
+ERROR HY000: InnoDB : ENCRYPTION is not accepted syntax for CREATE/ALTER table, for tables in general/shared tablespace.
 SET GLOBAL innodb_fast_shutdown = 0;
 # restart: --innodb-read-only
 # in innodb_read_only mode, temp tablespace cannot be encrypted
@@ -41,19 +43,27 @@ SELECT @@innodb_temp_tablespace_encrypt;
 # startup failure when innodb_temp_tablespace =ON and no keyring plugin
 Pattern found.
 # restart:<hidden args>
+CREATE TABLE t1 (a INT, b BLOB);
+INSERT INTO t1 VALUES (1, 'hello'), (2, 'hi'), (3, 'satya');
+SET GLOBAL innodb_encrypt_tables=ON;
+SET big_tables=ON;
+INSERT INTO t1 SELECT * FROM t1;
+DROP TABLE t1;
+SET big_tables=default;
+SET GLOBAL innodb_encrypt_tables=default;
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 SHOW WARNINGS;
 Level	Code	Message
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
-ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+DROP TABLE t01;
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_encrypt_tables=ON;
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t01 VALUES (1), (2), (3);
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;

--- a/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt-master.opt
+++ b/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt-master.opt
@@ -1,0 +1,4 @@
+$KEYRING_PLUGIN_OPT
+$KEYRING_PLUGIN_EARLY_LOAD
+--keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+--bootstrap --innodb-page-size=16k

--- a/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt.test
+++ b/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt.test
@@ -1,0 +1,114 @@
+let $MYSQLD_DATADIR=`SELECT @@datadir`;
+
+--source include/restart_mysqld.inc
+
+--source include/count_sessions.inc
+
+# Using on disk tablespace for intrinsic optimiser tables
+SELECT @@innodb_temp_tablespace_encrypt;
+SET GLOBAL big_tables=ON;
+
+--echo # Create a new connection.
+connect (con1, localhost, root,,);
+
+connection con1;
+
+--echo # A session tablespace will be allocated to connection 1
+--echo # for explicit temporary tables and state will be active
+SELECT @@session.big_tables;
+
+CREATE TEMPORARY TABLE test.t1(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t2(a INT, b BLOB);
+CREATE TABLE t3 like t1;
+INSERT INTO t1 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t2 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+
+INSERT INTO t3 SELECT * FROM t1;
+INSERT INTO t3 SELECT * FROM t2;
+INSERT INTO t3 SELECT * FROM t3;
+INSERT INTO t3 SELECT * FROM t3;
+
+--replace_column 1 ID
+--replace_regex /\\#innodb_temp\\temp/\/#innodb_temp\/temp/
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+
+SET GLOBAL innodb_encrypt_tables=ON;
+
+CREATE TEMPORARY TABLE test.t4(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t5(a INT, b BLOB);
+CREATE TABLE t6 like t1;
+INSERT INTO t4 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t5 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t6 SELECT * FROM t4;
+INSERT INTO t6 SELECT * FROM t5;
+INSERT INTO t6 SELECT * FROM t6;
+INSERT INTO t6 SELECT * FROM t6;
+
+--replace_column 1 ID
+--replace_regex /\\#innodb_temp\\temp/\/#innodb_temp\/temp/
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+SET GLOBAL innodb_encrypt_tables=OFF;
+DROP TABLE t3, t6;
+
+SET GLOBAL innodb_temp_tablespace_encrypt=ON;
+SELECT @@innodb_encrypt_tables;
+--echo # Create a new connection.
+connect (con2, localhost, root,,);
+connection con2;
+SELECT @@session.big_tables;
+
+--echo # Ensure entries in information_schema.processlist and
+--echo # information_schema.innodb_session_temp_tablespaces are
+--echo # in sync
+
+CREATE TEMPORARY TABLE test.t1(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t2(a INT, b BLOB);
+CREATE TABLE t3 like t1;
+INSERT INTO t1 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t2 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+
+INSERT INTO t3 SELECT * FROM t1;
+INSERT INTO t3 SELECT * FROM t2;
+INSERT INTO t3 SELECT * FROM t3;
+INSERT INTO t3 SELECT * FROM t3;
+
+--replace_column 1 ID
+--replace_regex /\\#innodb_temp\\temp/\/#innodb_temp\/temp/
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+
+SET GLOBAL innodb_encrypt_tables=ON;
+
+CREATE TEMPORARY TABLE test.t4(a INT, b BLOB);
+CREATE TEMPORARY TABLE test.t5(a INT, b BLOB);
+CREATE TABLE t6 like t1;
+INSERT INTO t4 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t5 values (1, 'hello'), (2, 'hi'), (3, 'wl11613'), (4, 'temp'), (5, 'tablespace');
+INSERT INTO t6 SELECT * FROM t4;
+INSERT INTO t6 SELECT * FROM t5;
+INSERT INTO t6 SELECT * FROM t6;
+INSERT INTO t6 SELECT * FROM t6;
+
+--replace_column 1 ID
+--replace_regex /\\#innodb_temp\\temp/\/#innodb_temp\/temp/
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+
+connection default;
+disconnect con1;
+disconnect con2;
+
+SET GLOBAL innodb_temp_tablespace_encrypt=default;
+SET GLOBAL innodb_encrypt_tables=default;
+SET GLOBAL big_tables=default;
+DROP TABLE t3;
+DROP TABLE t6;
+connect (con3, localhost, root,,);
+connection con3;
+
+--replace_column 1 ID
+--replace_regex /\\#innodb_temp\\temp/\/#innodb_temp\/temp/
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES ORDER BY SPACE;
+
+connection default;
+disconnect con3;
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/innodb/t/temp_table_encrypt.test
+++ b/mysql-test/suite/innodb/t/temp_table_encrypt.test
@@ -1,5 +1,6 @@
 call mtr.add_suppression("\\[InnoDB\\] Check keyring plugin fail, please check the keyring plugin is loaded.");
 call mtr.add_suppression("\\[InnoDB\\] Can't set temporary tablespace to be encrypted because keyring plugin is not available.");
+call mtr.add_suppression("\\[InnoDB\\] Unable to encrypt a session temp tablespace. Probably due to missing keyring plugin");
 
 --echo #
 --echo # PS-4727: instrinsic temp table behaviour shouldn't depend on innodb_encrypt_tables
@@ -8,6 +9,7 @@ CREATE TABLE t1 (a INT, b BLOB);
 INSERT INTO t1 VALUES (1, 'hello'), (2, 'hi'), (3, 'satya');
 SET GLOBAL innodb_encrypt_tables=ON;
 SET big_tables=ON;
+--error ER_CANNOT_FIND_KEY_IN_KEYRING
 INSERT INTO t1 SELECT * FROM t1;
 DROP TABLE t1;
 SET big_tables=default;
@@ -22,8 +24,8 @@ SELECT @@innodb_temp_tablespace_encrypt;
 --error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 
+--error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='N';
-DROP TABLE t01;
 
 --source include/restart_innodb_read_only.inc
 
@@ -49,6 +51,15 @@ SELECT @@innodb_temp_tablespace_encrypt;
 --let $restart_parameters = restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/ts_encrypt_keyring $KEYRING_PLUGIN_OPT
 --source include/start_mysqld.inc
 
+CREATE TABLE t1 (a INT, b BLOB);
+INSERT INTO t1 VALUES (1, 'hello'), (2, 'hi'), (3, 'satya');
+SET GLOBAL innodb_encrypt_tables=ON;
+SET big_tables=ON;
+INSERT INTO t1 SELECT * FROM t1;
+DROP TABLE t1;
+SET big_tables=default;
+SET GLOBAL innodb_encrypt_tables=default;
+
 --source include/count_sessions.inc
 connect (other1,localhost,root,,test);
 connection other1;
@@ -64,10 +75,10 @@ SHOW WARNINGS;
 connect (other2,localhost,root,,test);
 connection other2;
 
---error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
+DROP TABLE t01;
 
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 
 disconnect other2;
@@ -85,7 +96,7 @@ connection default;
 disconnect other2;
 disconnect other1;
 
-CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -177,6 +177,38 @@ dberr_t dict_build_tablespace(
   return (err);
 }
 
+/** Determine the session temporary tablespace for temp or intrinsic tables
+@param[in]   innodb_session   InnoDB session context(thd)
+@param[in]   is_intrinsic     true if temp table is created by optimizer
+@param[in]   is_slave_thd     true if temp table is created by slave thread
+                              (happens only with binlog row format)
+@return Session temporary tablespace on success, else nullptr on failure */
+static ibt::Tablespace *determine_session_temp_tblsp(
+    innodb_session_t *innodb_session, bool is_intrinsic, bool is_slave_thd) {
+  ibt::Tablespace *tblsp = nullptr;
+  if (srv_encrypt_tables == SRV_ENCRYPT_TABLES_ON ||
+      srv_encrypt_tables == SRV_ENCRYPT_TABLES_FORCE ||
+      srv_tmp_tablespace_encrypt) {
+    if (is_slave_thd) {
+      tblsp = ibt::get_enc_rpl_slave_tblsp();
+    } else if (is_intrinsic) {
+      tblsp = innodb_session->get_enc_instrinsic_temp_tblsp();
+    } else {
+      tblsp = innodb_session->get_enc_usr_temp_tblsp();
+    }
+
+  } else if (srv_encrypt_tables == SRV_ENCRYPT_TABLES_OFF) {
+    if (is_slave_thd) {
+      tblsp = ibt::get_rpl_slave_tblsp();
+    } else if (is_intrinsic) {
+      tblsp = innodb_session->get_instrinsic_temp_tblsp();
+    } else {
+      tblsp = innodb_session->get_usr_temp_tblsp();
+    }
+  }
+  return (tblsp);
+}
+
 /** Builds a tablespace to contain a table, using file-per-table=1.
 @param[in,out]	table	Table to build in its own tablespace.
 @param[in,out]	trx	Transaction
@@ -314,16 +346,11 @@ dberr_t dict_build_tablespace_for_table(
       ut_ad(dict_tf_get_rec_format(table->flags) != REC_FORMAT_COMPRESSED);
 
       innodb_session_t *innodb_session = thd_to_innodb_session(trx->mysql_thd);
-      ibt::Tablespace *tblsp = nullptr;
 
       bool is_slave_thd = thd_is_replication_slave_thread(trx->mysql_thd);
-      if (is_slave_thd) {
-        tblsp = ibt::get_rpl_slave_tblsp();
-      } else if (table->is_intrinsic()) {
-        tblsp = innodb_session->get_instrinsic_temp_tblsp();
-      } else {
-        tblsp = innodb_session->get_usr_temp_tblsp();
-      }
+      bool is_intrinsic = table->is_intrinsic();
+      const ibt::Tablespace *tblsp = determine_session_temp_tblsp(
+          innodb_session, is_intrinsic, is_slave_thd);
 
       /* Session temporary tablespace couldn't be allocated. This means,
       we have run out of disk space */

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -7407,8 +7407,10 @@ void fil_io_set_encryption(IORequest &req_type, const page_id_t &page_id,
   }
 
   /* For writing temporary tablespace, if encryption for temporary
-  tablespace is disabled, skip setting encryption. */
-  if (fsp_is_system_temporary(space->id) && !srv_tmp_tablespace_encrypt &&
+  tablespace is disabled, skip setting encryption.
+  Encryption of session temporary tablespaces is independent of
+  innodb_temp_tablespace_encrypt */
+  if (fsp_is_global_temporary(space->id) && !srv_tmp_tablespace_encrypt &&
       req_type.is_write()) {
     req_type.clear_encrypted();
     return;
@@ -9135,10 +9137,6 @@ static bool encryption_rotate_low(fil_space_t *space) {
 @return DB_SUCCESS or error code */
 dberr_t fil_reset_encryption(space_id_t space_id) {
   ut_ad(space_id != TRX_SYS_SPACE);
-
-  if (fsp_is_system_or_temp_tablespace(space_id)) {
-    return (DB_IO_NO_ENCRYPT_TABLESPACE);
-  }
 
   auto shard = fil_system->shard_by_id(space_id);
 

--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -7089,12 +7089,7 @@ static int i_s_innodb_session_temp_tablespaces_fill_one(
 
   ibt::tbsp_purpose purpose = ts->purpose();
 
-  const char *p =
-      purpose == ibt::TBSP_NONE
-          ? "NONE"
-          : (purpose == ibt::TBSP_USER
-                 ? "USER"
-                 : (purpose == ibt::TBSP_INTRINSIC ? "INTRINSIC" : "SLAVE"));
+  const char *p = ibt::get_purpose_str(purpose);
 
   OK(field_store_string(fields[INNODB_SESSION_TEMP_TABLESPACES_PURPOSE], p));
 
@@ -7125,7 +7120,14 @@ static int i_s_innodb_session_temp_tablespaces_fill(THD *thd,
      mutex again */
   check_trx_exists(thd);
   innodb_session_t *innodb_session = thd_to_innodb_session(thd);
-  innodb_session->get_instrinsic_temp_tblsp();
+  if (srv_encrypt_tables == SRV_ENCRYPT_TABLES_ON ||
+      srv_encrypt_tables == SRV_ENCRYPT_TABLES_FORCE ||
+      srv_tmp_tablespace_encrypt) {
+    innodb_session->get_enc_instrinsic_temp_tblsp();
+  } else {
+    innodb_session->get_instrinsic_temp_tblsp();
+  }
+
   auto print = [&](const ibt::Tablespace *ts) {
     i_s_innodb_session_temp_tablespaces_fill_one(thd, ts, tables->table);
   };

--- a/storage/innobase/include/sess0sess.h
+++ b/storage/innobase/include/sess0sess.h
@@ -76,7 +76,9 @@ class innodb_session_t {
         m_open_tables(),
         m_dict_mutex_locked(0),
         m_usr_temp_tblsp(),
-        m_intrinsic_temp_tblsp() {
+	m_enc_usr_temp_tblsp(),
+        m_intrinsic_temp_tblsp(),
+        m_enc_intrinsic_temp_tblsp() {
     /* Do nothing. */
   }
 
@@ -93,8 +95,16 @@ class innodb_session_t {
       ibt::free_tmp(m_usr_temp_tblsp);
     }
 
+    if (m_enc_usr_temp_tblsp != nullptr) {
+      ibt::free_tmp(m_enc_usr_temp_tblsp);
+    }
+
     if (m_intrinsic_temp_tblsp != nullptr) {
       ibt::free_tmp(m_intrinsic_temp_tblsp);
+    }
+
+    if (m_enc_intrinsic_temp_tblsp != nullptr) {
+      ibt::free_tmp(m_enc_intrinsic_temp_tblsp);
     }
   }
 
@@ -138,6 +148,7 @@ class innodb_session_t {
     return m_dict_mutex_locked != 0;
   }
 
+  /** @return un-encrypted tablespace of user created temp tables */
   ibt::Tablespace *get_usr_temp_tblsp() {
     if (m_usr_temp_tblsp == nullptr) {
       my_thread_id id = thd_thread_id(m_trx->mysql_thd);
@@ -147,6 +158,17 @@ class innodb_session_t {
     return (m_usr_temp_tblsp);
   }
 
+  /** @return encrypted tablespace of user created temp tables */
+  ibt::Tablespace *get_enc_usr_temp_tblsp() {
+    if (m_enc_usr_temp_tblsp == nullptr) {
+      my_thread_id id = thd_thread_id(m_trx->mysql_thd);
+      m_enc_usr_temp_tblsp = ibt::tbsp_pool->get(id, ibt::TBSP_ENC_USER);
+    }
+
+    return (m_enc_usr_temp_tblsp);
+  }
+
+  /** @return un-encrypted tablespace of optimizer created temp tables */
   ibt::Tablespace *get_instrinsic_temp_tblsp() {
     if (m_intrinsic_temp_tblsp == nullptr) {
       my_thread_id id = thd_thread_id(m_trx->mysql_thd);
@@ -154,6 +176,16 @@ class innodb_session_t {
     }
 
     return (m_intrinsic_temp_tblsp);
+  }
+
+  /** @return encrypted tablespace of optimizer created temp tables */
+  ibt::Tablespace *get_enc_instrinsic_temp_tblsp() {
+    if (m_enc_intrinsic_temp_tblsp == nullptr) {
+      my_thread_id id = thd_thread_id(m_trx->mysql_thd);
+      m_enc_intrinsic_temp_tblsp = ibt::tbsp_pool->get(id, ibt::TBSP_ENC_INTRINSIC);
+    }
+
+    return (m_enc_intrinsic_temp_tblsp);
   }
 
  public:
@@ -177,9 +209,12 @@ class innodb_session_t {
 
   /** Current session's user temp tablespace */
   ibt::Tablespace *m_usr_temp_tblsp;
-
+  /** Current session's encrypted user temp tablespace */
+  ibt::Tablespace *m_enc_usr_temp_tblsp;
   /** Current session's optimizer temp tablespace */
   ibt::Tablespace *m_intrinsic_temp_tblsp;
+  /** Current session's encrypted optimizer temp tablespace */
+  ibt::Tablespace *m_enc_intrinsic_temp_tblsp;
 };
 
 /** A guard class which sets dict_mutex locked flag for the provided innodb

--- a/storage/innobase/include/srv0tmp.h
+++ b/storage/innobase/include/srv0tmp.h
@@ -32,14 +32,49 @@ namespace ibt {
 /** Purpose for using tablespace */
 enum tbsp_purpose {
   TBSP_NONE = 0,  /*!< Tablespace is not being used for any
-                 temporary table */
+                  temporary table */
   TBSP_USER,      /*!< Tablespace is used for user temporary
-                 tables */
+                  tables */
   TBSP_INTRINSIC, /*!< Tablespace is used for intrinsic
                   tables */
-  TBSP_SLAVE      /*!< Tablespace is used by the slave node
+  TBSP_SLAVE,     /*!< Tablespace is used by the slave node
                   in a replication setup */
+
+  TBSP_ENC_USER,  /*!< Tablespace is used for encrypted user temporary
+                  tables */
+  TBSP_ENC_INTRINSIC, /*!< Tablespace is used for encrypted intrinsic
+                  tables */
+  TBSP_ENC_SLAVE, /*!< Tablespace is used by the slave node
+                  in a replication setup for encrypted purpose */
 };
+
+/** @return const string for session tablespace purpose enum
+@param[in]   purpose   purpose of the session temp tablespace */
+inline const char *get_purpose_str(enum tbsp_purpose purpose) {
+  switch (purpose) {
+    case TBSP_NONE:
+      return ("NONE");
+    case TBSP_USER:
+      return ("USER");
+    case TBSP_INTRINSIC:
+      return ("INTRINSIC");
+    case TBSP_SLAVE:
+      return ("SLAVE");
+    case TBSP_ENC_USER:
+      return ("USER ENCRYPTED");
+    case TBSP_ENC_INTRINSIC:
+      return ("INTRINSIC ENCRYTPED");
+    case TBSP_ENC_SLAVE:
+      return ("SLAVE ENCRYPTED");
+    default:
+      ut_ad(0);
+      return ("");
+  }
+  /* to make compiler happy */
+  ut_ad(0);
+  return ("");
+}
+
 /** Create the session temporary tablespaces on startup
 @param[in] create_new_db	true if bootstrapping
 @return DB_SUCCESS on success, else DB_ERROR on failure */
@@ -100,7 +135,14 @@ class Tablespace {
   /** @return complete path including filename */
   std::string path() const;
 
+  /** @return true if session tablespace is encrypted, else false */
+  bool encrypt();
+
  private:
+  /** Remove encryption information from tablespace in-memory structure.
+  On-disk changes are not necessary */
+  void decrypt();
+
   /** The id used for name on disk temp_1.ibt, temp_2.ibt, etc
   @return the offset based on s_m_temp_space_id. The minimum offset is 1 */
   uint32_t file_id() const;
@@ -229,5 +271,11 @@ void close_files();
 slave threads. Note this slave session tablespace could
 be used from many slave worker threads */
 Tablespace *get_rpl_slave_tblsp();
+
+/** @return a encrypted session tablespace dedicated for replication
+slave threads. Note this slave session tablespace could
+be used from many slave worker threads */
+Tablespace *get_enc_rpl_slave_tblsp();
+
 }  // namespace ibt
 #endif


### PR DESCRIPTION
…innodb_temp_tablespace_encrypt

Problem:
--------
With 8.0.13, session temporary tablespaces are introduced and all temp tables and intrinsic
tables (optimizer created temp tables) go to session temporary tablespaces.

Our encryption variable innodb_temp_tablespace_encrypt only encrypts ibtmp1 and doesn't encrypt
session temporary tablespaces.

Fix:
----
New rules:
----------
New rules for CREATE TEMPORARY:
1. encryption attribute(ENCRYPTION="Y"/"N") disallowed
2. tablespace attribute (TABLESPACE=`innodb_temporary`) disallowed

innodb_temp_tablespace_encrypt = OFF
-------------------------------------
1. ibtmp1 unencrypted (only undo logs go to ibtmp1)
2. temp table and intrinstic temp tables go to unencrypted session temporary tablespace
3. innodb_encrypt_tables = ON/FORCE, tables go to encrypted session temporary tablespace

innodb_temp_tablespace_encrypt=ON
----------------------------------
1. ibtmp1 encrypted (only undo logs go to ibtmp1)
2. temp table and intrinstic temp tables go to encrypted session temp
3. innodb_encrypt_tables = ON/FORCE, tables go to encrypted session temporary tablespace

Tests fixed: innodb.temp_tablespace_encrypt, innodb.tablespace_encrypt_*
Test Introduced: innodb.percona_session_temp_tablespaces_encrypt