### PR TITLE
PS-5105: Fix 8.0.13 binlog encryption

### DIFF
--- a/plugin/group_replication/include/observer_trans.h
+++ b/plugin/group_replication/include/observer_trans.h
@@ -84,11 +84,6 @@ class Transaction_message : public Plugin_gcs_message, public Basic_ostream {
   */
   my_off_t length();
 
-  my_off_t position() const noexcept {
-    DBUG_ASSERT(0);
-    return const_cast<Transaction_message *>(this)->length();
-  }
-
  protected:
   /*
    Implementation of the template methods

--- a/sql/basic_ostream.cc
+++ b/sql/basic_ostream.cc
@@ -55,10 +55,6 @@ bool IO_CACHE_ostream::seek(my_off_t offset) {
   return reinit_io_cache(&m_io_cache, WRITE_CACHE, offset, false, true);
 }
 
-my_off_t IO_CACHE_ostream::position() const noexcept {
-  return my_b_tell(&m_io_cache);
-}
-
 bool IO_CACHE_ostream::write(const unsigned char *buffer, my_off_t length) {
   DBUG_ASSERT(my_b_inited(&m_io_cache));
   DBUG_EXECUTE_IF("simulate_ostream_write_failure", return true;);

--- a/sql/basic_ostream.h
+++ b/sql/basic_ostream.h
@@ -37,8 +37,6 @@ class Basic_ostream {
   */
   virtual bool write(const unsigned char *buffer, my_off_t length) = 0;
   virtual ~Basic_ostream() {}
-
-  virtual my_off_t position() const noexcept = 0;
 };
 
 /**
@@ -105,8 +103,6 @@ class IO_CACHE_ostream : public Truncatable_ostream {
   bool seek(my_off_t offset) override;
   bool truncate(my_off_t offset) override;
 
-  my_off_t position() const noexcept override;
-
   /**
      Flush data to IO_CACHE's file if there is any data in IO_CACHE's buffer.
 
@@ -145,10 +141,6 @@ class StringBuffer_ostream : public Basic_ostream,
   bool write(const unsigned char *buffer, my_off_t length) override {
     return StringBuffer<BUFFER_SIZE>::append(
         reinterpret_cast<const char *>(buffer), length);
-  }
-
-  virtual my_off_t position() const noexcept override {
-    return StringBuffer<BUFFER_SIZE>::length();
   }
 };
 

--- a/sql/binlog_ostream.cc
+++ b/sql/binlog_ostream.cc
@@ -76,10 +76,6 @@ bool IO_CACHE_binlog_cache_storage::reset() {
   return false;
 }
 
-my_off_t IO_CACHE_binlog_cache_storage::position() const noexcept {
-  return my_b_tell(&m_io_cache);
-}
-
 size_t IO_CACHE_binlog_cache_storage::disk_writes() const {
   return m_io_cache.disk_writes;
 }

--- a/sql/binlog_ostream.h
+++ b/sql/binlog_ostream.h
@@ -80,9 +80,6 @@ class IO_CACHE_binlog_cache_storage : public Truncatable_ostream {
   /* purecov: inspected */
   /* binlog cache doesn't need seek operation. Setting true to return error */
   bool seek(my_off_t offset MY_ATTRIBUTE((unused))) override { return true; }
-
-  my_off_t position() const noexcept override;
-
   /**
      Reset status and drop all data. It looks like a cache never was used after
      reset.
@@ -152,10 +149,6 @@ class Binlog_cache_storage : public Basic_ostream {
      @retval true  Error
   */
   bool truncate(my_off_t offset) { return m_pipeline_head->truncate(offset); }
-
-  my_off_t position() const noexcept override {
-    return m_pipeline_head->position();
-  };
 
   /**
      Reset status and drop all data. It looks like a cache was never used


### PR DESCRIPTION
Removed basic::ostream position() function, which was also added to all
inheriting classes. Binlog encryption/decryption works only on binlog
files. All binlog files interfaces already contain position function.
Thus the addition to basic::ostream was not needed.