### PR TITLE
Fix PS-5195 (Possible to enable expand_fast_index_creation variable w…

### DIFF
--- a/mysql-test/r/PS-5195.result
+++ b/mysql-test/r/PS-5195.result
@@ -1,0 +1,9 @@
+SELECT @@GLOBAL.expand_fast_index_creation;
+@@GLOBAL.expand_fast_index_creation
+0
+SET PERSIST_ONLY expand_fast_index_creation=ON;
+ERROR HY000: Variable 'expand_fast_index_creation' is a non persistent read only variable
+# restart
+SELECT @@GLOBAL.expand_fast_index_creation;
+@@GLOBAL.expand_fast_index_creation
+0

--- a/mysql-test/t/PS-5195-master.opt
+++ b/mysql-test/t/PS-5195-master.opt
@@ -1,0 +1,1 @@
+--expand_fast_index_creation=ON

--- a/mysql-test/t/PS-5195.test
+++ b/mysql-test/t/PS-5195.test
@@ -1,0 +1,8 @@
+SELECT @@GLOBAL.expand_fast_index_creation;
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET PERSIST_ONLY expand_fast_index_creation=ON;
+
+--source include/restart_mysqld.inc
+
+SELECT @@GLOBAL.expand_fast_index_creation;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9914,6 +9914,10 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
   global_system_variables.long_query_time =
       (ulonglong)(global_system_variables.long_query_time_double * 1e6);
 
+  // Override any value specified on command line until the functionality
+  // is ported to 8.0.
+  global_system_variables.expand_fast_index_creation = false;
+
   init_log_slow_verbosity();
   init_slow_query_log_use_global_control();
   init_log_slow_sp_statements();

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1795,8 +1795,8 @@ static Sys_var_bool Sys_expand_fast_index_creation(
     "Enable/disable improvements to the InnoDB fast index creation "
     "functionality. Has no effect when fast index creation is disabled with "
     "the fast-index-creation option",
-    READ_ONLY SESSION_VAR(expand_fast_index_creation), CMD_LINE(OPT_ARG),
-    DEFAULT(false));
+    READ_ONLY NON_PERSIST SESSION_VAR(expand_fast_index_creation),
+    CMD_LINE(OPT_ARG), DEFAULT(false));
 
 static Sys_var_ulong Sys_expire_logs_days(
     "expire_logs_days",


### PR DESCRIPTION
…hen functionality not implemented)

Prevent enabling expand_fast_index_creation:
- by command line option: reset it to false after command line options
  have been processed;
- by SET PERSIST: mark it as non-persistable.