### PR TITLE
PS-5165: Use Xenial instead of Trusty in Travis-CI (8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-# Ubuntu 14.04
-dist: trusty
+# Ubuntu 16.04
+dist: xenial
 sudo: required
 language: cpp
 
@@ -24,7 +24,7 @@ matrix:
     - env: COMMAND=clang-test
       script:
         - curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -;
-        - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list > /dev/null;
+        - echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main" | sudo tee -a /etc/apt/sources.list > /dev/null;
         - sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
         - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install clang-format-5.0 || travis_terminate 1
         - wget https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py || travis_terminate 1
@@ -185,15 +185,19 @@ script:
       PARENT_COMMIT=$(git rev-list --first-parent --topo-order $TRAVIS_COMMIT ^master_repo_$PARENT_BRANCH | tail -1);
       TRAVIS_COMMIT_RANGE=$PARENT_COMMIT^..$TRAVIS_COMMIT;
     else
-      if [ -s "$CCACHE_DIR/last_commit.txt" ]; then TRAVIS_COMMIT_RANGE=$(cat $CCACHE_DIR/last_commit.txt)..$TRAVIS_COMMIT; fi;
+      if [ -s "$CCACHE_DIR/last_commit.txt" ]; then
+        TRAVIS_COMMIT_RANGE=$(cat $CCACHE_DIR/last_commit.txt)..$TRAVIS_COMMIT;
+      else
+        TRAVIS_COMMIT_RANGE="Force testing of this commit";
+      fi;
     fi;
     if MODIFIED_FILES=$(git diff --name-only $TRAVIS_COMMIT_RANGE 2>/dev/null); then
       echo -e "--- Modified files in $TRAVIS_COMMIT_RANGE:\n$MODIFIED_FILES";
-      if ! echo "$MODIFIED_FILES" | grep -qvE '^(doc|build-ps|mysql-test|packaging|policy|scripts|support-files)/'; then
+      if echo "$MODIFIED_FILES" | grep -qvE '^(doc|build-ps|mysql-test|packaging|policy|scripts|support-files)/'; then
+        echo "--- Code changes were found";
+      else
         echo "--- There are no code changes, stopping build process.";
         travis_terminate 0;
-      else
-        echo "--- Code changes were found";
       fi;
     else
       echo "--- Can't prepare MODIFIED_FILES for $TRAVIS_COMMIT_RANGE";
@@ -203,14 +207,10 @@ script:
     if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CC" == "clang" ]]; then
        PACKAGES="llvm-$VERSION-dev $PACKAGES";
        curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -;
-       echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-$VERSION main" | sudo tee -a /etc/apt/sources.list > /dev/null;
-       sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test";
-    fi;
-    if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$CC" == "gcc" ]]; then
-       sudo -E apt-add-repository -y "ppa:jonathonf/gcc";
+       echo "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-$VERSION main" | sudo tee -a /etc/apt/sources.list > /dev/null;
     fi;
     if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-       sudo -E apt-add-repository -y "ppa:jonathonf/mysql";
+       sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test";
     fi;
 
   - echo --- Update list of packages and download dependencies;
@@ -219,9 +219,9 @@ script:
        CC=$CC-$VERSION;
        CXX=$CXX-$VERSION;
        sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
-       sudo -E apt-get -yq --no-install-suggests --no-install-recommends install $CXX $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libmecab-dev libnuma-dev || travis_terminate 1;
-       if [[ "$INVERTED" == "ON" ]]; then
-         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install libssl-dev libevent-dev liblz4-dev liblzma-dev || travis_terminate 1;
+       sudo -E apt-get -yq --no-install-suggests --no-install-recommends install $CXX $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libmecab-dev libnuma-dev liblzma-dev libssl-dev || travis_terminate 1;
+       if [[ "$INVERTED" != "ON" ]]; then
+         sudo -E apt-get -yq --no-install-suggests --no-install-recommends install libeditline-dev libevent-dev liblz4-dev libre2-dev protobuf-compiler libprotobuf-dev libprotoc-dev libicu-dev || travis_terminate 1;
        fi;
        sudo ln -s $(which ccache) /usr/lib/ccache/$CC;
        sudo ln -s $(which ccache) /usr/lib/ccache/$CXX || echo;
@@ -265,22 +265,32 @@ script:
     else
       CMAKE_OPT+="
         -DMYSQL_MAINTAINER_MODE=ON
+        -DWITH_CURL=system
         -DWITH_MECAB=system
-        -DWITH_ICU=bundled
+        -DWITH_RAPIDJSON=bundled
+        -DWITH_SSL=system
       ";
       if [[ "$INVERTED" != "ON" ]]; then
         CMAKE_OPT+="
+          -DWITH_READLINE=system
+          -DWITH_ICU=system
+          -DWITH_LIBEVENT=system
+          -DWITH_LZ4=system
+          -DWITH_PROTOBUF=system
+          -DWITH_RE2=system
+          -DWITH_ZLIB=system
           -DWITH_NUMA=ON
         ";
       else
         CMAKE_OPT+="
-          -DWITH_NUMA=OFF
           -DWITH_EDITLINE=bundled
-          -DWITH_LIBEVENT=system
-          -DWITH_LZ4=system
-          -DWITH_LZMA=system
-          -DWITH_SSL=system
+          -DWITH_ICU=bundled
+          -DWITH_LIBEVENT=bundled
+          -DWITH_LZ4=bundled
+          -DWITH_PROTOBUF=bundled
+          -DWITH_RE2=bundled
           -DWITH_ZLIB=bundled
+          -DWITH_NUMA=OFF
           -DWITH_ARCHIVE_STORAGE_ENGINE=OFF
           -DWITH_BLACKHOLE_STORAGE_ENGINE=OFF
           -DWITH_EXAMPLE_STORAGE_ENGINE=ON
@@ -288,6 +298,10 @@ script:
           -DWITHOUT_PERFSCHEMA_STORAGE_ENGINE=ON
           -DWITH_INNODB_MEMCACHED=ON
         ";
+      fi;
+      `# disable -DWITH_PROTOBUF=system for gcc-4.8 as it causes linking issues`;
+      if [[ "$CC" == "gcc-4.8" ]]; then
+        CMAKE_OPT=${CMAKE_OPT/WITH_PROTOBUF=system/WITH_PROTOBUF=bundled};
       fi;
     fi;
 
@@ -298,7 +312,7 @@ script:
 
   - CMAKE_TIME=$(($SECONDS - $INIT_TIME - $UPDATE_TIME));
     if [[ "$TRAVIS_REPO_SLUG" == "percona/percona-server" ]]; then
-      TIMEOUT_TIME=$((116 * 60 - $SECONDS));
+      TIMEOUT_TIME=$((176 * 60 - $SECONDS));
     else
       TIMEOUT_TIME=$((46 * 60 - $SECONDS));
     fi;


### PR DESCRIPTION
1. Use Xenial image and modify addresses of repos to Xenial
2. Force to check a commit if `last_commit.txt` is not found for the trunk (solves issues when `Auto cancel branch builds` is turned on for Travis CI)
3. Remove less frequently updated `ppa:jonathonf/gcc`
4. Use system libs for faster compilation
5. Increase time limit to 180 minutes for main repo