### PR TITLE
Fix PS-1827 (LP #1736921: Inconsistent and unsafe FLUSH behavior in terms of replication) (5.6)

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -123,6 +123,9 @@ The following options may be given as the first argument:
  FULL).
  --binlog-rows-query-log-events 
  Allow writing of Rows_query_log events into binary log.
+ --binlog-skip-flush-commands 
+ If set to TRUE, FLUSH <XXX> commands will not be be
+ written to the binary log
  --binlog-stmt-cache-size=# 
  The size of the statement cache for updates to
  non-transactional engines for the binary log. If you
@@ -1188,6 +1191,7 @@ binlog-order-commits TRUE
 binlog-row-event-max-size 8192
 binlog-row-image FULL
 binlog-rows-query-log-events FALSE
+binlog-skip-flush-commands FALSE
 binlog-stmt-cache-size 32768
 binlogging-impossible-mode IGNORE_ERROR
 block-encryption-mode aes-128-ecb

--- a/mysql-test/suite/binlog/r/percona_binlog_skip_flush_commands.result
+++ b/mysql-test/suite/binlog/r/percona_binlog_skip_flush_commands.result
@@ -1,0 +1,1163 @@
+#
+# This is an MTR test case for the new 'binlog_skip_flush_commands' global
+# system variable introduced as a fix for
+# Bug #88720 "Inconsistent and unsafe FLUSH behavior in terms of replication"
+# (https://bugs.mysql.com/bug.php?id=88720)
+# PS-1827 "LP #1736921: Inconsistent and unsafe FLUSH behavior in terms of replication" 
+# (https://jira.percona.com/browse/PS-1827)
+#
+CREATE USER 'wo_reload'@'localhost';
+GRANT ALL PRIVILEGES ON *.* TO 'wo_reload'@'localhost';
+REVOKE SUPER ON *.* FROM 'wo_reload'@'localhost';
+REVOKE RELOAD ON *.* FROM 'wo_reload'@'localhost';
+CREATE USER 'wo_super'@'localhost';
+GRANT ALL PRIVILEGES ON *.* TO 'wo_super'@'localhost';
+REVOKE SUPER ON *.* FROM 'wo_super'@'localhost';
+SET @saved_read_only = @@global.read_only;
+SET @saved_super_read_only = @@global.super_read_only;
+SET @saved_binlog_skip_flush_commands = @@global.binlog_skip_flush_commands;
+CREATE TABLE t1(f1 int);
+INSERT INTO t1 VALUES(1);
+SELECT 1;
+1
+1
+CREATE TEMPORARY TABLE flush_statement(
+id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+value VARCHAR(64) NOT NULL
+);
+INSERT INTO flush_statement(value) VALUES
+('ERROR LOGS'),
+('ENGINE LOGS'),
+('GENERAL LOGS'),
+('SLOW LOGS'),
+('RELAY LOGS'),
+('QUERY CACHE'),
+('HOSTS'),
+('PRIVILEGES'),
+('STATUS'),
+('CLIENT_STATISTICS'),
+('USER_STATISTICS'),
+('THREAD_STATISTICS'),
+('TABLE_STATISTICS'),
+('INDEX_STATISTICS'),
+('DES_KEY_FILE'),
+('USER_RESOURCES'),
+('CHANGED_PAGE_BITMAPS')
+;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH ERROR LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH ERROR LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH ERROR LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ERROR LOGS;
+include/assert.inc [FLUSH ERROR LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH ENGINE LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH ENGINE LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH ENGINE LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH ENGINE LOGS;
+include/assert.inc [FLUSH ENGINE LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH GENERAL LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH GENERAL LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH GENERAL LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH GENERAL LOGS;
+include/assert.inc [FLUSH GENERAL LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH SLOW LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH SLOW LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH SLOW LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH SLOW LOGS;
+include/assert.inc [FLUSH SLOW LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH RELAY LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH RELAY LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH RELAY LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH RELAY LOGS;
+include/assert.inc [FLUSH RELAY LOGS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH QUERY CACHE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH QUERY CACHE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH QUERY CACHE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH QUERY CACHE;
+include/assert.inc [FLUSH QUERY CACHE with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH HOSTS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH HOSTS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH HOSTS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH HOSTS;
+include/assert.inc [FLUSH HOSTS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH PRIVILEGES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH PRIVILEGES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH PRIVILEGES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH PRIVILEGES;
+include/assert.inc [FLUSH PRIVILEGES with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH STATUS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH STATUS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH STATUS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH STATUS;
+include/assert.inc [FLUSH STATUS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH CLIENT_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH CLIENT_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH CLIENT_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CLIENT_STATISTICS;
+include/assert.inc [FLUSH CLIENT_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH USER_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH USER_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH USER_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_STATISTICS;
+include/assert.inc [FLUSH USER_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH THREAD_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH THREAD_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH THREAD_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH THREAD_STATISTICS;
+include/assert.inc [FLUSH THREAD_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH TABLE_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH TABLE_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH TABLE_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH TABLE_STATISTICS;
+include/assert.inc [FLUSH TABLE_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH INDEX_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH INDEX_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH INDEX_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH INDEX_STATISTICS;
+include/assert.inc [FLUSH INDEX_STATISTICS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH DES_KEY_FILE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH DES_KEY_FILE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH DES_KEY_FILE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH DES_KEY_FILE;
+include/assert.inc [FLUSH DES_KEY_FILE with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH USER_RESOURCES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH USER_RESOURCES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH USER_RESOURCES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+ERROR 42000: Access denied; you need (at least one of) the RELOAD privilege(s) for this operation
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH USER_RESOURCES;
+include/assert.inc [FLUSH USER_RESOURCES with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = OFF;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CHANGED_PAGE_BITMAPS;
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (read_only = OFF, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = OFF;
+SET GLOBAL read_only = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CHANGED_PAGE_BITMAPS;
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (read_only = ON, super_read_only = OFF) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL super_read_only = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o RELOAD)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (user w/o SUPER)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+FLUSH CHANGED_PAGE_BITMAPS;
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to OFF must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = ON;
+FLUSH CHANGED_PAGE_BITMAPS;
+include/assert.inc [FLUSH CHANGED_PAGE_BITMAPS with binlog_skip_flush_commands set to ON must not change gtid (super_read_only = ON) (SUPER user)]
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SET GLOBAL binlog_skip_flush_commands = @saved_binlog_skip_flush_commands;
+SET GLOBAL super_read_only = @saved_super_read_only;
+SET GLOBAL read_only = @saved_read_only;
+DROP TABLE t1;
+DROP USER 'wo_super'@'localhost';
+DROP USER 'wo_reload'@'localhost';

--- a/mysql-test/suite/binlog/t/percona_binlog_skip_flush_commands-master.opt
+++ b/mysql-test/suite/binlog/t/percona_binlog_skip_flush_commands-master.opt
@@ -1,0 +1,1 @@
+--gtid_mode=ON --enforce-gtid-consistency --log-slave-updates

--- a/mysql-test/suite/binlog/t/percona_binlog_skip_flush_commands.test
+++ b/mysql-test/suite/binlog/t/percona_binlog_skip_flush_commands.test
@@ -1,0 +1,205 @@
+--source include/have_log_bin.inc
+
+--echo #
+--echo # This is an MTR test case for the new 'binlog_skip_flush_commands' global
+--echo # system variable introduced as a fix for
+--echo # Bug #88720 "Inconsistent and unsafe FLUSH behavior in terms of replication"
+--echo # (https://bugs.mysql.com/bug.php?id=88720)
+--echo # PS-1827 "LP #1736921: Inconsistent and unsafe FLUSH behavior in terms of replication" 
+--echo # (https://jira.percona.com/browse/PS-1827)
+--echo #
+
+# creating a user without SUPER and RELOAD privileges
+CREATE USER 'wo_reload'@'localhost';
+GRANT ALL PRIVILEGES ON *.* TO 'wo_reload'@'localhost';
+REVOKE SUPER ON *.* FROM 'wo_reload'@'localhost';
+REVOKE RELOAD ON *.* FROM 'wo_reload'@'localhost';
+
+# creating a user without SUPER privilege
+CREATE USER 'wo_super'@'localhost';
+GRANT ALL PRIVILEGES ON *.* TO 'wo_super'@'localhost';
+REVOKE SUPER ON *.* FROM 'wo_super'@'localhost';
+
+--source include/count_sessions.inc
+
+--connect(wo_reload_con,localhost,wo_reload)
+--connect(wo_super_con,localhost,wo_super)
+
+--connection default
+
+SET @saved_read_only = @@global.read_only;
+SET @saved_super_read_only = @@global.super_read_only;
+SET @saved_binlog_skip_flush_commands = @@global.binlog_skip_flush_commands;
+
+CREATE TABLE t1(f1 int);
+INSERT INTO t1 VALUES(1);
+SELECT 1;
+
+--let $gtid_prefix_length = 40
+
+CREATE TEMPORARY TABLE flush_statement(
+  id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  value VARCHAR(64) NOT NULL
+);
+INSERT INTO flush_statement(value) VALUES
+  ('ERROR LOGS'),
+  ('ENGINE LOGS'),
+  ('GENERAL LOGS'),
+  ('SLOW LOGS'),
+  ('RELAY LOGS'),
+  ('QUERY CACHE'),
+  ('HOSTS'),
+  ('PRIVILEGES'),
+  ('STATUS'),
+  ('CLIENT_STATISTICS'),
+  ('USER_STATISTICS'),
+  ('THREAD_STATISTICS'),
+  ('TABLE_STATISTICS'),
+  ('INDEX_STATISTICS'),
+  ('DES_KEY_FILE'),
+  ('USER_RESOURCES'),
+  ('CHANGED_PAGE_BITMAPS')
+;
+
+--let $statement_idx = 1
+--let $number_of_statements = `SELECT COUNT(*) FROM flush_statement`
+
+while($statement_idx <= $number_of_statements)
+{
+  --connection default
+  --let $statement = `SELECT CONCAT('FLUSH ', value) FROM flush_statement WHERE id = $statement_idx`
+
+  --let $read_only_mode_idx = 0
+  while($read_only_mode_idx < 3)
+  {
+    --connection default
+    if($read_only_mode_idx == 0)
+    {
+      SET GLOBAL super_read_only = OFF;
+      SET GLOBAL read_only = OFF;
+      --let $read_only_mode_label = (read_only = OFF, super_read_only = OFF)
+    }
+    if($read_only_mode_idx == 1)
+    {
+      SET GLOBAL super_read_only = OFF;
+      SET GLOBAL read_only = ON;
+      --let $read_only_mode_label = (read_only = ON, super_read_only = OFF)
+    }
+    if($read_only_mode_idx == 2)
+    {
+      SET GLOBAL super_read_only = ON;
+      --let $read_only_mode_label = (super_read_only = ON)
+    }
+
+    --let $user_type_idx = 0
+    while($user_type_idx < 3)
+    {
+      if($user_type_idx == 0)
+      {
+        --let $custom_conection = wo_reload_con
+        --let $user_type_label = (user w/o RELOAD)
+        # users without RELOAD privilege should always get ER_SPECIFIC_ACCESS_DENIED_ERROR
+        --let $eval_should_fail = 1
+        # users without RELOAD privilege should never change gtid_executed
+        --let $eval_should_change_gtid_executed = 0
+      }
+      if($user_type_idx == 1)
+      {
+        --let $custom_conection = wo_super_con
+        --let $user_type_label = (user w/o SUPER)
+        # users with RELOAD privilege should succeed executing FLUSH XXX
+        --let $eval_should_fail = 0
+        # users with RELOAD privilege should change gtid_executed only when read_only = OFF and super_read_only = OFF
+        --let $eval_should_change_gtid_executed = 0
+        if($read_only_mode_idx == 0)
+        {
+          --let $eval_should_change_gtid_executed = 1
+        }
+        # FLUSH CHANGED_PAGE_BITMAPS is an exception - it requires SUPER privilege to be executed
+        if($statement == "FLUSH CHANGED_PAGE_BITMAPS")
+        {
+          --let $eval_should_fail = 1
+          --let $eval_should_change_gtid_executed = 0
+        }
+      }
+      if($user_type_idx == 2)
+      {
+        --let $custom_conection = default
+        --let $user_type_label = (SUPER user)
+        # users with SUPER privilege should succeed executing FLUSH XXX
+        --let $eval_should_fail = 0
+        # users with SUPER privilege should change gtid_executed only when super_read_only != OFF
+        --let $eval_should_change_gtid_executed = 1
+        if($read_only_mode_idx == 2)
+        {
+          --let $eval_should_change_gtid_executed = 0
+        }
+      }
+
+      --connection default
+      --let $previous_gtid = `SELECT SUBSTR(@@global.gtid_executed, $gtid_prefix_length)`
+
+      --connection $custom_conection
+      if($eval_should_fail)
+      {
+        --error ER_SPECIFIC_ACCESS_DENIED_ERROR
+        --eval $statement
+      }
+      if(!$eval_should_fail)
+      {
+        --eval $statement
+      }
+
+      --connection default
+      --let $current_gtid = `SELECT SUBSTR(@@global.gtid_executed, $gtid_prefix_length)`
+      if($eval_should_change_gtid_executed)
+      {
+        --let $assert_cond= $previous_gtid + 1 = $current_gtid
+        --let $assert_text= $statement with binlog_skip_flush_commands set to OFF must change gtid $read_only_mode_label $user_type_label
+      }
+      if(!$eval_should_change_gtid_executed)
+      {
+        --let $assert_cond= $previous_gtid = $current_gtid
+        --let $assert_text= $statement with binlog_skip_flush_commands set to OFF must not change gtid $read_only_mode_label $user_type_label
+      }
+      --source include/assert.inc
+      SET GLOBAL binlog_skip_flush_commands = ON;
+      --let $previous_gtid  = $current_gtid
+
+      --connection $custom_conection
+      if($eval_should_fail)
+      {
+        --error ER_SPECIFIC_ACCESS_DENIED_ERROR
+        --eval $statement
+      }
+      if(!$eval_should_fail)
+      {
+        --eval $statement
+      }
+      --connection default
+      --let $current_gtid = `SELECT SUBSTR(@@global.gtid_executed, $gtid_prefix_length)`
+      --let $assert_cond= $previous_gtid = $current_gtid
+      --let $assert_text= $statement with binlog_skip_flush_commands set to ON must not change gtid $read_only_mode_label $user_type_label
+      --source include/assert.inc
+      SET GLOBAL binlog_skip_flush_commands = OFF;
+
+      --inc $user_type_idx
+    }
+    --inc $read_only_mode_idx
+  }
+  --inc $statement_idx
+}
+
+SET GLOBAL binlog_skip_flush_commands = @saved_binlog_skip_flush_commands;
+SET GLOBAL super_read_only = @saved_super_read_only;
+SET GLOBAL read_only = @saved_read_only;
+
+DROP TABLE t1;
+
+--disconnect wo_reload_con
+--disconnect wo_super_con
+
+--source include/wait_until_count_sessions.inc
+
+DROP USER 'wo_super'@'localhost';
+DROP USER 'wo_reload'@'localhost';

--- a/mysql-test/suite/sys_vars/r/binlog_skip_flush_commands_basic.result
+++ b/mysql-test/suite/sys_vars/r/binlog_skip_flush_commands_basic.result
@@ -1,0 +1,102 @@
+SET @start_global_value = @@global.binlog_skip_flush_commands;
+SELECT @start_global_value;
+@start_global_value
+0
+SELECT @@global.binlog_skip_flush_commands IN (0, 1);
+@@global.binlog_skip_flush_commands IN (0, 1)
+1
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+0
+SELECT @@session.binlog_skip_flush_commands;
+ERROR HY000: Variable 'binlog_skip_flush_commands' is a GLOBAL variable
+SHOW GLOBAL  VARIABLES LIKE 'binlog_skip_flush_commands';
+Variable_name	Value
+binlog_skip_flush_commands	OFF
+SHOW SESSION VARIABLES LIKE 'binlog_skip_flush_commands';
+Variable_name	Value
+binlog_skip_flush_commands	OFF
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SET GLOBAL binlog_skip_flush_commands = ON;
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+1
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	ON
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	ON
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+0
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SET GLOBAL binlog_skip_flush_commands = 'ON';
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+1
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	ON
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	ON
+SET GLOBAL binlog_skip_flush_commands = 'OFF';
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+0
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SET GLOBAL binlog_skip_flush_commands = 1;
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+1
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	ON
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	ON
+SET GLOBAL binlog_skip_flush_commands = 0;
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+0
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+VARIABLE_NAME	VARIABLE_VALUE
+BINLOG_SKIP_FLUSH_COMMANDS	OFF
+SET SESSION binlog_skip_flush_commands = 'OFF';
+ERROR HY000: Variable 'binlog_skip_flush_commands' is a GLOBAL variable and should be set with SET GLOBAL
+SET @@session.binlog_skip_flush_commands = 'ON';
+ERROR HY000: Variable 'binlog_skip_flush_commands' is a GLOBAL variable and should be set with SET GLOBAL
+SET GLOBAL binlog_skip_flush_commands = 1.1;
+ERROR 42000: Incorrect argument type to variable 'binlog_skip_flush_commands'
+SET GLOBAL binlog_skip_flush_commands = 1e1;
+ERROR 42000: Incorrect argument type to variable 'binlog_skip_flush_commands'
+SET GLOBAL binlog_skip_flush_commands = 2;
+ERROR 42000: Variable 'binlog_skip_flush_commands' can't be set to the value of '2'
+SET GLOBAL binlog_skip_flush_commands = -3;
+ERROR 42000: Variable 'binlog_skip_flush_commands' can't be set to the value of '-3'
+SET GLOBAL binlog_skip_flush_commands = 'AUTO';
+ERROR 42000: Variable 'binlog_skip_flush_commands' can't be set to the value of 'AUTO'
+SET GLOBAL binlog_skip_flush_commands = @start_global_value;
+SELECT @@global.binlog_skip_flush_commands;
+@@global.binlog_skip_flush_commands
+0

--- a/mysql-test/suite/sys_vars/t/binlog_skip_flush_commands_basic.test
+++ b/mysql-test/suite/sys_vars/t/binlog_skip_flush_commands_basic.test
@@ -1,0 +1,79 @@
+#
+# binlog_skip_flush_commands
+#
+
+SET @start_global_value = @@global.binlog_skip_flush_commands;
+SELECT @start_global_value;
+
+#
+# exists as global only
+#
+
+# valid values are 'ON' and 'OFF'
+SELECT @@global.binlog_skip_flush_commands IN (0, 1);
+SELECT @@global.binlog_skip_flush_commands;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.binlog_skip_flush_commands;
+SHOW GLOBAL  VARIABLES LIKE 'binlog_skip_flush_commands';
+SHOW SESSION VARIABLES LIKE 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+
+#
+# show that it's writable
+#
+SET GLOBAL binlog_skip_flush_commands = ON;
+SELECT @@global.binlog_skip_flush_commands;
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+
+SET GLOBAL binlog_skip_flush_commands = OFF;
+SELECT @@global.binlog_skip_flush_commands;
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+
+SET GLOBAL binlog_skip_flush_commands = 'ON';
+SELECT @@global.binlog_skip_flush_commands;
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+
+SET GLOBAL binlog_skip_flush_commands = 'OFF';
+SELECT @@global.binlog_skip_flush_commands;
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+
+SET GLOBAL binlog_skip_flush_commands = 1;
+SELECT @@global.binlog_skip_flush_commands;
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+
+SET GLOBAL binlog_skip_flush_commands = 0;
+SELECT @@global.binlog_skip_flush_commands;
+SELECT * FROM information_schema.global_variables  WHERE variable_name = 'binlog_skip_flush_commands';
+SELECT * FROM information_schema.session_variables WHERE variable_name = 'binlog_skip_flush_commands';
+
+--error ER_GLOBAL_VARIABLE
+SET SESSION binlog_skip_flush_commands = 'OFF';
+--error ER_GLOBAL_VARIABLE
+SET @@session.binlog_skip_flush_commands = 'ON';
+
+#
+# incorrect types
+#
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL binlog_skip_flush_commands = 1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL binlog_skip_flush_commands = 1e1;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL binlog_skip_flush_commands = 2;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL binlog_skip_flush_commands = -3;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL binlog_skip_flush_commands = 'AUTO';
+
+#
+# cleanup
+#
+
+SET GLOBAL binlog_skip_flush_commands = @start_global_value;
+SELECT @@global.binlog_skip_flush_commands;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -508,6 +508,7 @@ my_bool enforce_gtid_consistency;
 my_bool binlog_gtid_simple_recovery;
 ulong binlog_error_action;
 const char *binlog_error_action_list[]= {"IGNORE_ERROR", "ABORT_SERVER", NullS};
+my_bool opt_binlog_skip_flush_commands= 0;
 bool gtid_deployment_step= false;
 bool opt_gtid_deployment_step= false;
 ulong gtid_mode;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -246,6 +246,8 @@ enum enum_binlog_error_action
   ABORT_SERVER= 1
 };
 extern const char *binlog_error_action_list[];
+extern my_bool opt_binlog_skip_flush_commands;
+
 enum enum_gtid_mode
 {
   /// Support only anonymous groups, not GTIDs.

--- a/sql/sql_reload.cc
+++ b/sql/sql_reload.cc
@@ -411,7 +411,39 @@ bool reload_acl_and_cache(THD *thd, unsigned long options,
     }
   }
  if (*write_to_binlog != -1)
-   *write_to_binlog= tmp_write_to_binlog;
+ {
+   if (thd == NULL || thd->security_ctx == NULL)
+   {
+     *write_to_binlog=
+       opt_binlog_skip_flush_commands ? 0 : tmp_write_to_binlog;
+   }
+   else if ((thd->security_ctx->master_access & SUPER_ACL) != 0)
+   {
+     /*
+       For users with 'SUPER' privilege 'FLUSH XXX' statements must not be
+       binlogged if 'super_read_only' is set to 'ON'.
+     */
+     if (opt_super_readonly)
+       *write_to_binlog= 0;
+     else
+       *write_to_binlog=
+         opt_binlog_skip_flush_commands ? 0 : tmp_write_to_binlog;
+   }
+   else
+   {
+     /*
+       For users without 'SUPER' privilege 'FLUSH XXX' statements must not be
+       binlogged if 'read_only' or 'super_read_only' is set to 'ON'.
+       Checking only 'opt_readonly' here as in 'super_read_only' mode this
+       variable is implicitly set to 'true'.
+     */
+     if (opt_readonly)
+       *write_to_binlog= 0;
+     else
+       *write_to_binlog=
+         opt_binlog_skip_flush_commands ? 0 : tmp_write_to_binlog;
+   }
+ }
  /*
    If the query was killed then this function must fail.
  */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -1591,6 +1591,13 @@ static Sys_var_enum Sys_binlog_error_action(
        "continue, or abort.", GLOBAL_VAR(binlog_error_action),
        CMD_LINE(REQUIRED_ARG), binlog_error_action_list, DEFAULT(IGNORE_ERROR));
 
+static Sys_var_mybool Sys_binlog_skip_flush_commands(
+       "binlog_skip_flush_commands",
+       "If set to TRUE, FLUSH <XXX> commands will not be be written "
+       "to the binary log",
+       GLOBAL_VAR(opt_binlog_skip_flush_commands),
+       CMD_LINE(OPT_ARG), DEFAULT(FALSE));
+
 static Sys_var_enum Sys_binlogging_impossible_mode(
        "binlogging_impossible_mode",
        "On a fatal error when statements cannot be binlogged the behaviour can "


### PR DESCRIPTION
https://jira.percona.com/browse/PS-1827

Introduced new global boolean system variable 'binlog_skip_flush_commands'.
When set to 'ON', all 'FLUSH <XXX>' statements are not written to the binary
log.

Added 'binlog.bug88720' MTR test case which checks if various 'FLUSH <XXX>'
statements change 'gtid_executed' when 'binlog_skip_flush_commands' is set
to 'ON'.

Added 'sys_vars.binlog_skip_flush_commands_basic' MTR test case which checks
basic global boolean system variable functionality.

Re-recorded 'main.mysqld--help-notwin' MTR test case because of the new
variable added.