### PR TITLE
PS-5263: no tmpdir space can lead to assert in THD::send_statement_status (8.0)

### DIFF
--- a/mysql-test/suite/rpl/include/rpl_bug72457.inc
+++ b/mysql-test/suite/rpl/include/rpl_bug72457.inc
@@ -1,9 +1,19 @@
 --source include/master-slave.inc
 
-call mtr.add_suppression("Slave SQL for channel '': The incident LOST_EVENTS occurred on the master\\. Message: The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log\\. Error_code:");
-call mtr.add_suppression("The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log\\. An incident event has been written to the binary log which will stop the slaves\\.");
+CALL mtr.add_suppression("An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.");
+CALL mtr.add_suppression("Error writing file.*(errno: 28 - No space left on device)");
 
-SET @saved_binlog_error_action = @@global.binlog_error_action;
+--echo # Restart master with a custom error log
+--let $rpl_server_number= 1
+--let $rpl_server_parameters= --log-error=$MYSQLTEST_VARDIR/tmp/rpl_bug72457.err
+--let $rpl_omit_print_server_parameters= 1
+--source include/rpl_restart_server.inc
+--exec echo "                               [parameters: --log-error=ERROR_LOG_FILE]"
+
+--let $rpl_only_running_threads= 1
+--source include/rpl_reset.inc
+
+let $saved_binlog_error_action=`SELECT @@GLOBAL.binlog_error_action`;
 SET GLOBAL binlog_error_action = IGNORE_ERROR;
 
 CREATE TABLE t1(f1 TEXT) ENGINE=MyISAM;
@@ -18,24 +28,45 @@ while($i)
 --source include/sync_slave_sql_with_master.inc
 
 --source include/rpl_connection_master.inc
+
+--let $log_pos_before = query_get_value("SHOW BINARY LOGS", File_size, 1)
+
 SET SESSION debug = "+d,simulate_tmpdir_partition_full";
 --replace_regex /Error writing file .*/Error writing file <tmp_file_name> (Errcode: ##)/
---error 3
 INSERT INTO t1 SELECT * FROM t1;
 SET SESSION debug = "-d,simulate_tmpdir_partition_full";
 
+--echo # Check if INSERT is committed
+--let $assert_cond = COUNT(*) = 2048 FROM t1;
+--let $assert_text = Count of elements in t1 should be 2048.
+--source include/assert.inc
+
+--echo # Cleanup and stop slave
 --source include/rpl_connection_slave.inc
---let $slave_sql_errno = convert_error(ER_SLAVE_INCIDENT)
---let $show_slave_sql_error = 1
---source include/wait_for_slave_sql_error.inc
---source include/stop_slave_io.inc
-RESET SLAVE;
 DROP TABLE t1;
+--source include/stop_slave.inc
+
+--echo # Binlog is closed due to above error. Restart the server to
+--echo # enable the binlog again to continue the test. Use default error log.
+--let $rpl_server_number= 1
+--let $rpl_server_parameters=
+--let $rpl_omit_print_server_parameters= 0
+--source include/rpl_restart_server.inc
 
 --source include/rpl_connection_master.inc
+--echo # Only "Stop" should be logged
+--let $binlog_start= $log_pos_before
+--source include/show_binlog_events.inc
+
+--echo # Make sure that the warnings are present in a custom error log.
+let SEARCH_FILE= $MYSQLTEST_VARDIR/tmp/rpl_bug72457.err;
+let SEARCH_PATTERN= An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.;
+--source include/search_pattern.inc
+--remove_file $SEARCH_FILE
+
 DROP TABLE t1;
 
-SET GLOBAL binlog_error_action = @saved_binlog_error_action;
+--eval SET GLOBAL binlog_error_action= $saved_binlog_error_action
 
 --let $rpl_only_running_threads = 1
 --source include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_bug72457_innodb.result
+++ b/mysql-test/suite/rpl/r/rpl_bug72457_innodb.result
@@ -15,9 +15,12 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-call mtr.add_suppression("Slave SQL for channel '': The incident LOST_EVENTS occurred on the master\\. Message: The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log\\. Error_code:");
-call mtr.add_suppression("The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log\\. An incident event has been written to the binary log which will stop the slaves\\.");
-SET @saved_binlog_error_action = @@global.binlog_error_action;
+CALL mtr.add_suppression("An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.");
+CALL mtr.add_suppression("Error writing file.*(errno: 28 - No space left on device)");
+# Restart master with a custom error log
+include/rpl_restart_server.inc [server_number=1]
+                               [parameters: --log-error=ERROR_LOG_FILE]
+include/rpl_reset.inc
 SET GLOBAL binlog_error_action = IGNORE_ERROR;
 CREATE TABLE t1(f1 TEXT) ENGINE=MyISAM;
 INSERT INTO t1 VALUES(MD5(1));
@@ -35,15 +38,26 @@ include/sync_slave_sql_with_master.inc
 [connection master]
 SET SESSION debug = "+d,simulate_tmpdir_partition_full";
 INSERT INTO t1 SELECT * FROM t1;
-ERROR HY000: Error writing file <tmp_file_name> (Errcode: ##)
+Warnings:
+Error	3	Error writing file <tmp_file_name> (Errcode: ##)
+Error	1026	Error writing file <tmp_file_name> (Errcode: ##)
 SET SESSION debug = "-d,simulate_tmpdir_partition_full";
+# Check if INSERT is committed
+include/assert.inc [Count of elements in t1 should be 2048.]
+# Cleanup and stop slave
 [connection slave]
-include/wait_for_slave_sql_error.inc [errno=13119]
-Last_SQL_Error = 'The incident LOST_EVENTS occurred on the master. Message: The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log.'
-include/stop_slave_io.inc
-RESET SLAVE;
 DROP TABLE t1;
+include/stop_slave.inc
+# Binlog is closed due to above error. Restart the server to
+# enable the binlog again to continue the test. Use default error log.
+include/rpl_restart_server.inc [server_number=1]
 [connection master]
+# Only "Stop" should be logged
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Stop	#	#	
+# Make sure that the warnings are present in a custom error log.
+Pattern "An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'." found
 DROP TABLE t1;
-SET GLOBAL binlog_error_action = @saved_binlog_error_action;
+SET GLOBAL binlog_error_action= ABORT_SERVER;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_bug72457_myisam.result
+++ b/mysql-test/suite/rpl/r/rpl_bug72457_myisam.result
@@ -15,9 +15,12 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-call mtr.add_suppression("Slave SQL for channel '': The incident LOST_EVENTS occurred on the master\\. Message: The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log\\. Error_code:");
-call mtr.add_suppression("The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log\\. An incident event has been written to the binary log which will stop the slaves\\.");
-SET @saved_binlog_error_action = @@global.binlog_error_action;
+CALL mtr.add_suppression("An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.");
+CALL mtr.add_suppression("Error writing file.*(errno: 28 - No space left on device)");
+# Restart master with a custom error log
+include/rpl_restart_server.inc [server_number=1]
+                               [parameters: --log-error=ERROR_LOG_FILE]
+include/rpl_reset.inc
 SET GLOBAL binlog_error_action = IGNORE_ERROR;
 CREATE TABLE t1(f1 TEXT) ENGINE=MyISAM;
 INSERT INTO t1 VALUES(MD5(1));
@@ -35,15 +38,26 @@ include/sync_slave_sql_with_master.inc
 [connection master]
 SET SESSION debug = "+d,simulate_tmpdir_partition_full";
 INSERT INTO t1 SELECT * FROM t1;
-ERROR HY000: Error writing file <tmp_file_name> (Errcode: ##)
+Warnings:
+Error	3	Error writing file <tmp_file_name> (Errcode: ##)
+Error	1026	Error writing file <tmp_file_name> (Errcode: ##)
 SET SESSION debug = "-d,simulate_tmpdir_partition_full";
+# Check if INSERT is committed
+include/assert.inc [Count of elements in t1 should be 2048.]
+# Cleanup and stop slave
 [connection slave]
-include/wait_for_slave_sql_error.inc [errno=13119]
-Last_SQL_Error = 'The incident LOST_EVENTS occurred on the master. Message: The content of the statement cache is corrupted while writing a rollback record of the transaction to the binary log.'
-include/stop_slave_io.inc
-RESET SLAVE;
 DROP TABLE t1;
+include/stop_slave.inc
+# Binlog is closed due to above error. Restart the server to
+# enable the binlog again to continue the test. Use default error log.
+include/rpl_restart_server.inc [server_number=1]
 [connection master]
+# Only "Stop" should be logged
+include/show_binlog_events.inc
+Log_name	Pos	Event_type	Server_id	End_log_pos	Info
+master-bin.000001	#	Stop	#	#	
+# Make sure that the warnings are present in a custom error log.
+Pattern "An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'." found
 DROP TABLE t1;
-SET GLOBAL binlog_error_action = @saved_binlog_error_action;
+SET GLOBAL binlog_error_action= ABORT_SERVER;
 include/rpl_end.inc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -8594,7 +8594,10 @@ void MYSQL_BIN_LOG::handle_binlog_flush_or_sync_error(THD *thd,
       binlog_error_action=IGNORE_ERROR, clear the error
       and allow the commit to happen in storage engine.
     */
-    if (check_write_error(thd)) thd->clear_error();
+    if (check_write_error(thd)) { /* we have DA_ERROR */
+      thd->clear_error(); /* sets thd->get_stmt_da()->status() to DA_EMPTY */
+      my_ok(thd);         /* sets thd->get_stmt_da()->status() to DA_OK */
+    }
 
     if (need_lock_log) mysql_mutex_unlock(&LOCK_log);
     DEBUG_SYNC(thd, "after_binlog_closed_due_to_error");


### PR DESCRIPTION
1. Update `handle_binlog_flush_or_sync_error()` to set `my_ok(thd)` after `thd->clear_error()`.
2. Update `rpl_bug72457.inc` to support errorless statements that disable binary logging.
3. Re-record `rpl_bug72457_innodb` and `rpl_bug72457_myisam`.