### PR TITLE
Fix PS-5271 (5.6 ASan: intermittent thread stack overrun on rpl.rpl_r…

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_row_sp011-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_row_sp011-master.opt
@@ -1,1 +1,2 @@
 ${?PB_HOST_SPECIFIC_MYSQLD_ARGS}
+--thread_stack=409600

--- a/mysql-test/suite/rpl/t/rpl_row_sp011.test
+++ b/mysql-test/suite/rpl/t/rpl_row_sp011.test
@@ -2,8 +2,11 @@
 # Original Author: JBM                                                      #
 # Original Date: Aug/18/2005                                                #
 # Updated: 08/29/2005  turned on diff and commented out debug SQL statements#
+# Updated: sep/16/2015                                                      #
+#          This testcase requires minimum stack size of 300KB to run on WIN.#
+#          Modified *-master.opt file to increase the thread_stack to 400KB.#
 #############################################################################
-#TEST: SP to test alter table and nested SP calls                           #
+# TEST: SP to test alter table and nested SP calls                          #
 #############################################################################
 
 # Includes


### PR DESCRIPTION
…ow_sp011)

by cherry-picking the commit below:

Bug #21161874 -TEST:RPL.RPL_ROW_SP011 FAILS WITH THREAD STACK OVERRRUN. rpl_row_sp011 test was failing due to thread stack overrun problem.Fix: increased the thread stack size for the test in the opt file.

(cherry picked from commit 71d72830c2c6b487058eab9b2823d6313a133745)

https://ps.cd.percona.com/view/5.6/job/percona-server-5.6-param/31/