### PR TITLE
PS-4949: Bad select+order by+limit performance in 5.7

### DIFF
--- a/mysql-test/include/range.inc
+++ b/mysql-test/include/range.inc
@@ -1048,7 +1048,8 @@ alter table t2 add index (a,b);
 
 # 500 rows, 1 row
 
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
+--echo Access method can be range/ALL with #rows >= 500.
+--echo Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 
 drop table t1, t2;
@@ -2534,6 +2535,7 @@ UPDATE mysql.innodb_table_stats SET n_rows=3001 WHERE TABLE_name='transactions';
 FLUSH TABLE transactions;
 --enable_query_log
 
+--replace_column 10 # 11 #
 eval EXPLAIN $query1;
 
 SET optimizer_trace="enabled=on";

--- a/mysql-test/r/opt_hints.result
+++ b/mysql-test/r/opt_hints.result
@@ -99,44 +99,44 @@ Note	1003	/* select#1 */ select /*+ NO_RANGE_OPTIMIZATION(`t3`@`select#1` `PRIMA
 # NO_ICP hint testing
 set optimizer_switch='index_condition_pushdown=on';
 EXPLAIN SELECT  f2 FROM
-(SELECT f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+(SELECT f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t3	NULL	ref	PRIMARY,f2_idx,f3_idx	f3_idx	35	const	16	96.43	Using index condition
+1	SIMPLE	t3	NULL	range	PRIMARY,f2_idx,f3_idx	PRIMARY	4	NULL	35	20.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 2) and (`test`.`t3`.`f1` > 2))
+Note	1003	/* select#1 */ select `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 27) and (`test`.`t3`.`f1` > 27))
 EXPLAIN SELECT /*+ NO_ICP(t3@qb1 f3_idx) */ f2 FROM
-(SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+(SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t3	NULL	ref	PRIMARY,f2_idx,f3_idx	f3_idx	35	const	16	96.43	Using where
+1	SIMPLE	t3	NULL	range	PRIMARY,f2_idx,f3_idx	PRIMARY	4	NULL	35	20.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`QB1` `f3_idx`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 2) and (`test`.`t3`.`f1` > 2))
+Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`QB1` `f3_idx`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 27) and (`test`.`t3`.`f1` > 27))
 EXPLAIN SELECT /*+ NO_ICP(t3@qb1) */ f2 FROM
-(SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+(SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t3	NULL	ref	PRIMARY,f2_idx,f3_idx	f3_idx	35	const	16	96.43	Using where
+1	SIMPLE	t3	NULL	range	PRIMARY,f2_idx,f3_idx	PRIMARY	4	NULL	35	20.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`QB1`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 2) and (`test`.`t3`.`f1` > 2))
+Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`QB1`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 27) and (`test`.`t3`.`f1` > 27))
 # Expected warning for f1_idx key, unresolved name.
 EXPLAIN SELECT f2 FROM
-(SELECT /*+ NO_ICP(t3 f3_idx, f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+(SELECT /*+ NO_ICP(t3 f3_idx, f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t3	NULL	ref	PRIMARY,f2_idx,f3_idx	f3_idx	35	const	16	96.43	Using where
+1	SIMPLE	t3	NULL	range	PRIMARY,f2_idx,f3_idx	PRIMARY	4	NULL	35	20.00	Using where
 Warnings:
 Warning	3128	Unresolved name `t3`@`select#2` `f1_idx` for NO_ICP hint
-Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`select#2` `f3_idx`) NO_ICP(`t3`@`select#2` `f2_idx`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 2) and (`test`.`t3`.`f1` > 2))
+Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`select#2` `f3_idx`) NO_ICP(`t3`@`select#2` `f2_idx`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 27) and (`test`.`t3`.`f1` > 27))
 # ICP should still be used.
 EXPLAIN SELECT f2 FROM
-(SELECT /*+ NO_ICP(t3 f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+(SELECT /*+ NO_ICP(t3 f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t3	NULL	ref	PRIMARY,f2_idx,f3_idx	f3_idx	35	const	16	96.43	Using index condition
+1	SIMPLE	t3	NULL	range	PRIMARY,f2_idx,f3_idx	PRIMARY	4	NULL	35	20.00	Using where
 Warnings:
 Warning	3128	Unresolved name `t3`@`select#2` `f1_idx` for NO_ICP hint
-Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`select#2` `f2_idx`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 2) and (`test`.`t3`.`f1` > 2))
+Note	1003	/* select#1 */ select /*+ NO_ICP(`t3`@`select#2` `f2_idx`) */ `test`.`t3`.`f2` AS `f2` from `test`.`t3` where ((`test`.`t3`.`f3` = 'poiu') and (`test`.`t3`.`f1` > 27) and (`test`.`t3`.`f1` > 27))
 # BKA & NO_BKA hint testing
 set optimizer_switch=default;
 set optimizer_switch='batched_key_access=off,mrr_cost_based=off';

--- a/mysql-test/r/range_all.result
+++ b/mysql-test/r/range_all.result
@@ -1356,9 +1356,8 @@ insert into t2 select A.a + 10 * (B.a + 10 * C.a), 10, 'filler' from t1 A,
 t1 B, t1 C where A.a < 5;
 insert into t2 select 1000, b, 'filler' from t2;
 alter table t2 add index (a,b);
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
-Z
-In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)
+Access method can be range/ALL with #rows >= 500.
+Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t2	NULL	range	a	a	10	NULL	502	100.00	Using index condition; Using MRR
@@ -3669,7 +3668,7 @@ FROM transactions
 WHERE created > '2017-10-23 01:01:01' AND tbl = 1 AND trans_type in (3)
 GROUP BY '2017-10-23 01:01:01', HOUR(created), source_lvl1, source_lvl2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	8	NULL	1	100.00	Using index condition; Using where; Using MRR; Using filesort
+1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	created_idx	4	NULL	#	#	Using index condition; Using where; Using MRR; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select '2017-10-23 01:01:01' AS `2017-10-23 01:01:01`,hour(`test`.`transactions`.`created`) AS `HOUR(created)`,`test`.`transactions`.`source_lvl1` AS `source_lvl1`,`test`.`transactions`.`source_lvl2` AS `source_lvl2`,count(distinct `test`.`transactions`.`app_trans_id`) AS `COUNT(DISTINCT(app_trans_id))` from `test`.`transactions` where ((`test`.`transactions`.`trans_type` = 3) and (`test`.`transactions`.`tbl` = 1) and (`test`.`transactions`.`created` > '2017-10-23 01:01:01')) group by '2017-10-23 01:01:01',hour(`test`.`transactions`.`created`),`test`.`transactions`.`source_lvl1`,`test`.`transactions`.`source_lvl2`
 SET optimizer_trace="enabled=on";

--- a/mysql-test/r/range_icp.result
+++ b/mysql-test/r/range_icp.result
@@ -1356,12 +1356,11 @@ insert into t2 select A.a + 10 * (B.a + 10 * C.a), 10, 'filler' from t1 A,
 t1 B, t1 C where A.a < 5;
 insert into t2 select 1000, b, 'filler' from t2;
 alter table t2 add index (a,b);
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
-Z
-In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)
+Access method can be range/ALL with #rows >= 500.
+Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t2	NULL	ref	a	a	5	const	502	33.33	Using index condition
+1	SIMPLE	t2	NULL	ALL	a	NULL	NULL	NULL	1000	50.20	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where ((`test`.`t2`.`a` = 1000) and (`test`.`t2`.`b` < 11))
 drop table t1, t2;
@@ -3621,7 +3620,7 @@ WHERE id IN (66136539, 68983258, 89628210, 77869520, 82543198, 67538272,
 70923271, 68066180)
 AND (giant_table.flags & 0x01) = 0 AND giant_table.some_other_id = 0;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	giant_table	NULL	range	PRIMARY,some_other_id	some_other_id	8	NULL	20	100.00	Using index condition; Using where
+1	SIMPLE	giant_table	NULL	range	PRIMARY,some_other_id	PRIMARY	4	NULL	20	0.36	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`giant_table`.`id` AS `id`,`test`.`giant_table`.`something` AS `something`,`test`.`giant_table`.`comment` AS `comment`,`test`.`giant_table`.`time_created` AS `time_created`,`test`.`giant_table`.`one_id` AS `one_id`,`test`.`giant_table`.`other_id` AS `other_id`,`test`.`giant_table`.`some_other_id` AS `some_other_id`,`test`.`giant_table`.`flags` AS `flags` from `test`.`giant_table` where ((`test`.`giant_table`.`some_other_id` = 0) and (`test`.`giant_table`.`id` in (66136539,68983258,89628210,77869520,82543198,67538272,84673401,61069031,68214385,77282865,76991297,64569216,89481638,74534074,70396537,80076375,63308530,77908270,70923271,68066180)) and ((`test`.`giant_table`.`flags` & 0x01) = 0))
 DROP PROCEDURE p;
@@ -3669,7 +3668,7 @@ FROM transactions
 WHERE created > '2017-10-23 01:01:01' AND tbl = 1 AND trans_type in (3)
 GROUP BY '2017-10-23 01:01:01', HOUR(created), source_lvl1, source_lvl2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	8	NULL	1	100.00	Using index condition; Using where; Using filesort
+1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	created_idx	4	NULL	#	#	Using index condition; Using where; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select '2017-10-23 01:01:01' AS `2017-10-23 01:01:01`,hour(`test`.`transactions`.`created`) AS `HOUR(created)`,`test`.`transactions`.`source_lvl1` AS `source_lvl1`,`test`.`transactions`.`source_lvl2` AS `source_lvl2`,count(distinct `test`.`transactions`.`app_trans_id`) AS `COUNT(DISTINCT(app_trans_id))` from `test`.`transactions` where ((`test`.`transactions`.`trans_type` = 3) and (`test`.`transactions`.`tbl` = 1) and (`test`.`transactions`.`created` > '2017-10-23 01:01:01')) group by '2017-10-23 01:01:01',hour(`test`.`transactions`.`created`),`test`.`transactions`.`source_lvl1`,`test`.`transactions`.`source_lvl2`
 SET optimizer_trace="enabled=on";

--- a/mysql-test/r/range_icp_mrr.result
+++ b/mysql-test/r/range_icp_mrr.result
@@ -1356,9 +1356,8 @@ insert into t2 select A.a + 10 * (B.a + 10 * C.a), 10, 'filler' from t1 A,
 t1 B, t1 C where A.a < 5;
 insert into t2 select 1000, b, 'filler' from t2;
 alter table t2 add index (a,b);
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
-Z
-In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)
+Access method can be range/ALL with #rows >= 500.
+Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t2	NULL	range	a	a	10	NULL	502	100.00	Using index condition; Using MRR
@@ -3669,7 +3668,7 @@ FROM transactions
 WHERE created > '2017-10-23 01:01:01' AND tbl = 1 AND trans_type in (3)
 GROUP BY '2017-10-23 01:01:01', HOUR(created), source_lvl1, source_lvl2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	8	NULL	1	100.00	Using index condition; Using where; Using MRR; Using filesort
+1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	created_idx	4	NULL	#	#	Using index condition; Using where; Using MRR; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select '2017-10-23 01:01:01' AS `2017-10-23 01:01:01`,hour(`test`.`transactions`.`created`) AS `HOUR(created)`,`test`.`transactions`.`source_lvl1` AS `source_lvl1`,`test`.`transactions`.`source_lvl2` AS `source_lvl2`,count(distinct `test`.`transactions`.`app_trans_id`) AS `COUNT(DISTINCT(app_trans_id))` from `test`.`transactions` where ((`test`.`transactions`.`trans_type` = 3) and (`test`.`transactions`.`tbl` = 1) and (`test`.`transactions`.`created` > '2017-10-23 01:01:01')) group by '2017-10-23 01:01:01',hour(`test`.`transactions`.`created`),`test`.`transactions`.`source_lvl1`,`test`.`transactions`.`source_lvl2`
 SET optimizer_trace="enabled=on";

--- a/mysql-test/r/range_mrr.result
+++ b/mysql-test/r/range_mrr.result
@@ -1356,9 +1356,8 @@ insert into t2 select A.a + 10 * (B.a + 10 * C.a), 10, 'filler' from t1 A,
 t1 B, t1 C where A.a < 5;
 insert into t2 select 1000, b, 'filler' from t2;
 alter table t2 add index (a,b);
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
-Z
-In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)
+Access method can be range/ALL with #rows >= 500.
+Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t2	NULL	range	a	a	10	NULL	502	100.00	Using where; Using MRR
@@ -3669,7 +3668,7 @@ FROM transactions
 WHERE created > '2017-10-23 01:01:01' AND tbl = 1 AND trans_type in (3)
 GROUP BY '2017-10-23 01:01:01', HOUR(created), source_lvl1, source_lvl2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	8	NULL	1	100.00	Using where; Using MRR; Using filesort
+1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	created_idx	4	NULL	#	#	Using where; Using MRR; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select '2017-10-23 01:01:01' AS `2017-10-23 01:01:01`,hour(`test`.`transactions`.`created`) AS `HOUR(created)`,`test`.`transactions`.`source_lvl1` AS `source_lvl1`,`test`.`transactions`.`source_lvl2` AS `source_lvl2`,count(distinct `test`.`transactions`.`app_trans_id`) AS `COUNT(DISTINCT(app_trans_id))` from `test`.`transactions` where ((`test`.`transactions`.`trans_type` = 3) and (`test`.`transactions`.`tbl` = 1) and (`test`.`transactions`.`created` > '2017-10-23 01:01:01')) group by '2017-10-23 01:01:01',hour(`test`.`transactions`.`created`),`test`.`transactions`.`source_lvl1`,`test`.`transactions`.`source_lvl2`
 SET optimizer_trace="enabled=on";

--- a/mysql-test/r/range_mrr_cost.result
+++ b/mysql-test/r/range_mrr_cost.result
@@ -1356,12 +1356,11 @@ insert into t2 select A.a + 10 * (B.a + 10 * C.a), 10, 'filler' from t1 A,
 t1 B, t1 C where A.a < 5;
 insert into t2 select 1000, b, 'filler' from t2;
 alter table t2 add index (a,b);
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
-Z
-In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)
+Access method can be range/ALL with #rows >= 500.
+Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t2	NULL	ref	a	a	5	const	502	33.33	Using where
+1	SIMPLE	t2	NULL	ALL	a	NULL	NULL	NULL	1000	50.20	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where ((`test`.`t2`.`a` = 1000) and (`test`.`t2`.`b` < 11))
 drop table t1, t2;
@@ -3621,7 +3620,7 @@ WHERE id IN (66136539, 68983258, 89628210, 77869520, 82543198, 67538272,
 70923271, 68066180)
 AND (giant_table.flags & 0x01) = 0 AND giant_table.some_other_id = 0;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	giant_table	NULL	range	PRIMARY,some_other_id	some_other_id	8	NULL	20	100.00	Using where
+1	SIMPLE	giant_table	NULL	range	PRIMARY,some_other_id	PRIMARY	4	NULL	20	0.36	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`giant_table`.`id` AS `id`,`test`.`giant_table`.`something` AS `something`,`test`.`giant_table`.`comment` AS `comment`,`test`.`giant_table`.`time_created` AS `time_created`,`test`.`giant_table`.`one_id` AS `one_id`,`test`.`giant_table`.`other_id` AS `other_id`,`test`.`giant_table`.`some_other_id` AS `some_other_id`,`test`.`giant_table`.`flags` AS `flags` from `test`.`giant_table` where ((`test`.`giant_table`.`some_other_id` = 0) and (`test`.`giant_table`.`id` in (66136539,68983258,89628210,77869520,82543198,67538272,84673401,61069031,68214385,77282865,76991297,64569216,89481638,74534074,70396537,80076375,63308530,77908270,70923271,68066180)) and ((`test`.`giant_table`.`flags` & 0x01) = 0))
 DROP PROCEDURE p;
@@ -3669,7 +3668,7 @@ FROM transactions
 WHERE created > '2017-10-23 01:01:01' AND tbl = 1 AND trans_type in (3)
 GROUP BY '2017-10-23 01:01:01', HOUR(created), source_lvl1, source_lvl2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	8	NULL	1	100.00	Using where; Using filesort
+1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	created_idx	4	NULL	#	#	Using where; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select '2017-10-23 01:01:01' AS `2017-10-23 01:01:01`,hour(`test`.`transactions`.`created`) AS `HOUR(created)`,`test`.`transactions`.`source_lvl1` AS `source_lvl1`,`test`.`transactions`.`source_lvl2` AS `source_lvl2`,count(distinct `test`.`transactions`.`app_trans_id`) AS `COUNT(DISTINCT(app_trans_id))` from `test`.`transactions` where ((`test`.`transactions`.`trans_type` = 3) and (`test`.`transactions`.`tbl` = 1) and (`test`.`transactions`.`created` > '2017-10-23 01:01:01')) group by '2017-10-23 01:01:01',hour(`test`.`transactions`.`created`),`test`.`transactions`.`source_lvl1`,`test`.`transactions`.`source_lvl2`
 SET optimizer_trace="enabled=on";

--- a/mysql-test/r/range_none.result
+++ b/mysql-test/r/range_none.result
@@ -1355,12 +1355,11 @@ insert into t2 select A.a + 10 * (B.a + 10 * C.a), 10, 'filler' from t1 A,
 t1 B, t1 C where A.a < 5;
 insert into t2 select 1000, b, 'filler' from t2;
 alter table t2 add index (a,b);
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
-Z
-In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)
+Access method can be range/ALL with #rows >= 500.
+Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t2	NULL	ref	a	a	5	const	502	33.33	Using where
+1	SIMPLE	t2	NULL	ALL	a	NULL	NULL	NULL	1000	50.20	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t2`.`filler` AS `filler` from `test`.`t2` where ((`test`.`t2`.`a` = 1000) and (`test`.`t2`.`b` < 11))
 drop table t1, t2;
@@ -3620,7 +3619,7 @@ WHERE id IN (66136539, 68983258, 89628210, 77869520, 82543198, 67538272,
 70923271, 68066180)
 AND (giant_table.flags & 0x01) = 0 AND giant_table.some_other_id = 0;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	giant_table	NULL	range	PRIMARY,some_other_id	some_other_id	8	NULL	20	100.00	Using where
+1	SIMPLE	giant_table	NULL	range	PRIMARY,some_other_id	PRIMARY	4	NULL	20	0.36	Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`giant_table`.`id` AS `id`,`test`.`giant_table`.`something` AS `something`,`test`.`giant_table`.`comment` AS `comment`,`test`.`giant_table`.`time_created` AS `time_created`,`test`.`giant_table`.`one_id` AS `one_id`,`test`.`giant_table`.`other_id` AS `other_id`,`test`.`giant_table`.`some_other_id` AS `some_other_id`,`test`.`giant_table`.`flags` AS `flags` from `test`.`giant_table` where ((`test`.`giant_table`.`some_other_id` = 0) and (`test`.`giant_table`.`id` in (66136539,68983258,89628210,77869520,82543198,67538272,84673401,61069031,68214385,77282865,76991297,64569216,89481638,74534074,70396537,80076375,63308530,77908270,70923271,68066180)) and ((`test`.`giant_table`.`flags` & 0x01) = 0))
 DROP PROCEDURE p;
@@ -3668,7 +3667,7 @@ FROM transactions
 WHERE created > '2017-10-23 01:01:01' AND tbl = 1 AND trans_type in (3)
 GROUP BY '2017-10-23 01:01:01', HOUR(created), source_lvl1, source_lvl2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	8	NULL	1	100.00	Using where; Using filesort
+1	SIMPLE	transactions	NULL	range	tbl_id_idx,created_idx,trans_type_created_idx	created_idx	4	NULL	#	#	Using where; Using filesort
 Warnings:
 Note	1003	/* select#1 */ select '2017-10-23 01:01:01' AS `2017-10-23 01:01:01`,hour(`test`.`transactions`.`created`) AS `HOUR(created)`,`test`.`transactions`.`source_lvl1` AS `source_lvl1`,`test`.`transactions`.`source_lvl2` AS `source_lvl2`,count(distinct `test`.`transactions`.`app_trans_id`) AS `COUNT(DISTINCT(app_trans_id))` from `test`.`transactions` where ((`test`.`transactions`.`trans_type` = 3) and (`test`.`transactions`.`tbl` = 1) and (`test`.`transactions`.`created` > '2017-10-23 01:01:01')) group by '2017-10-23 01:01:01',hour(`test`.`transactions`.`created`),`test`.`transactions`.`source_lvl1`,`test`.`transactions`.`source_lvl2`
 SET optimizer_trace="enabled=on";

--- a/mysql-test/r/range_with_memory_limit.result
+++ b/mysql-test/r/range_with_memory_limit.result
@@ -1564,9 +1564,8 @@ insert into t2 select A.a + 10 * (B.a + 10 * C.a), 10, 'filler' from t1 A,
 t1 B, t1 C where A.a < 5;
 insert into t2 select 1000, b, 'filler' from t2;
 alter table t2 add index (a,b);
-select 'In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)' Z;
-Z
-In following EXPLAIN the access method should be ref or range, #rows~=500 (and not 2)
+Access method can be range/ALL with #rows >= 500.
+Or it can be ref with #rows = 2, only when there is memory limit.
 explain select * from t2 where a=1000 and b<11;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
 1	SIMPLE	t2	NULL	ref	a	a	5	const	2	33.33	Using index condition
@@ -4185,7 +4184,7 @@ FROM transactions
 WHERE created > '2017-10-23 01:01:01' AND tbl = 1 AND trans_type in (3)
 GROUP BY '2017-10-23 01:01:01', HOUR(created), source_lvl1, source_lvl2;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	transactions	NULL	ref	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	4	const	1	33.33	Using index condition; Using where; Using filesort
+1	SIMPLE	transactions	NULL	ref	tbl_id_idx,created_idx,trans_type_created_idx	trans_type_created_idx	4	const	#	#	Using index condition; Using where; Using filesort
 Warnings:
 Warning	3170	Memory capacity of 50 bytes for 'range_optimizer_max_mem_size' exceeded. Range optimization was not done for this query.
 Note	1003	/* select#1 */ select '2017-10-23 01:01:01' AS `2017-10-23 01:01:01`,hour(`test`.`transactions`.`created`) AS `HOUR(created)`,`test`.`transactions`.`source_lvl1` AS `source_lvl1`,`test`.`transactions`.`source_lvl2` AS `source_lvl2`,count(distinct `test`.`transactions`.`app_trans_id`) AS `COUNT(DISTINCT(app_trans_id))` from `test`.`transactions` where ((`test`.`transactions`.`trans_type` = 3) and (`test`.`transactions`.`tbl` = 1) and (`test`.`transactions`.`created` > '2017-10-23 01:01:01')) group by '2017-10-23 01:01:01',hour(`test`.`transactions`.`created`),`test`.`transactions`.`source_lvl1`,`test`.`transactions`.`source_lvl2`

--- a/mysql-test/suite/opt_trace/include/bugs.inc
+++ b/mysql-test/suite/opt_trace/include/bugs.inc
@@ -480,25 +480,29 @@ DROP TABLE B,C,CC;
 CREATE TABLE t1 (
   a TINYTEXT NOT NULL,
   b TINYINT(3) UNSIGNED NOT NULL,
-  PRIMARY KEY (a(32),b),
-  KEY b_idx(b)
-) ENGINE=INNODB;
-INSERT INTO t1 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
+  PRIMARY KEY (a(32),b)
+) ENGINE=MyISAM, CHARSET utf8mb4;
+CREATE TABLE t2 (
+  a TINYTEXT NOT NULL,
+  b TINYINT(3) UNSIGNED NOT NULL,
+  PRIMARY KEY (a(32),b)
+) ENGINE=INNODB, CHARSET utf8mb4;
+
+INSERT INTO t1 VALUES ('a',1),('a',2);
+INSERT INTO t2 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
 ANALYZE TABLE t1;
+ANALYZE TABLE t2;
 
-SET @optimizer_switch_saved=@@session.optimizer_switch;
-SET @@session.optimizer_switch=default;
-
-SELECT COUNT(*) FROM t1;
-# Uses "access_type_changed" to use range over ref despite b_idx not being the
-# cheapest in range.
-EXPLAIN SELECT * FROM t1 WHERE a IN ('a', 'b') AND b = 2;
+# range uses more keyparts than ref, so range is chosen.
+EXPLAIN SELECT * FROM t1 WHERE a='a' AND b in (1,2);
 SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
-SELECT @trace RLIKE "rerunning_range_optimizer_for_single_index";
+SELECT @trace RLIKE "range_uses_more_keyparts";
 
-SET @@session.optimizer_switch=@optimizer_switch_saved;
+EXPLAIN SELECT * FROM t2 WHERE a='a' AND b in (1,2);
+SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+SELECT @trace RLIKE "range_uses_more_keyparts";
 
-DROP TABLE t1;
+DROP TABLE t1, t2;
 
 --echo #
 --echo # Bug #23227428: SQL PLAN IS NOT ACCORDING WITH OPTIMIZER_TRACE

--- a/mysql-test/suite/opt_trace/r/bugs_no_prot_all.result
+++ b/mysql-test/suite/opt_trace/r/bugs_no_prot_all.result
@@ -3490,29 +3490,40 @@ DROP TABLE B,C,CC;
 CREATE TABLE t1 (
 a TINYTEXT NOT NULL,
 b TINYINT(3) UNSIGNED NOT NULL,
-PRIMARY KEY (a(32),b),
-KEY b_idx(b)
-) ENGINE=INNODB;
-INSERT INTO t1 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
+PRIMARY KEY (a(32),b)
+) ENGINE=MyISAM, CHARSET utf8mb4;
+CREATE TABLE t2 (
+a TINYTEXT NOT NULL,
+b TINYINT(3) UNSIGNED NOT NULL,
+PRIMARY KEY (a(32),b)
+) ENGINE=INNODB, CHARSET utf8mb4;
+INSERT INTO t1 VALUES ('a',1),('a',2);
+INSERT INTO t2 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
 ANALYZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
-SET @optimizer_switch_saved=@@session.optimizer_switch;
-SET @@session.optimizer_switch=default;
-SELECT COUNT(*) FROM t1;
-COUNT(*)
-7
-EXPLAIN SELECT * FROM t1 WHERE a IN ('a', 'b') AND b = 2;
+ANALYZE TABLE t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+EXPLAIN SELECT * FROM t1 WHERE a='a' AND b in (1,2);
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	PRIMARY,b_idx	b_idx	35	NULL	2	100.00	Using index condition; Using where
+1	SIMPLE	t1	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`b` = 2) and (`test`.`t1`.`a` in ('a','b')))
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`a` = 'a') and (`test`.`t1`.`b` in (1,2)))
 SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
-SELECT @trace RLIKE "rerunning_range_optimizer_for_single_index";
-@trace RLIKE "rerunning_range_optimizer_for_single_index"
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
 1
-SET @@session.optimizer_switch=@optimizer_switch_saved;
-DROP TABLE t1;
+EXPLAIN SELECT * FROM t2 WHERE a='a' AND b in (1,2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b` from `test`.`t2` where ((`test`.`t2`.`a` = 'a') and (`test`.`t2`.`b` in (1,2)))
+SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
+1
+DROP TABLE t1, t2;
 #
 # Bug #23227428: SQL PLAN IS NOT ACCORDING WITH OPTIMIZER_TRACE
 #

--- a/mysql-test/suite/opt_trace/r/bugs_no_prot_none.result
+++ b/mysql-test/suite/opt_trace/r/bugs_no_prot_none.result
@@ -2651,29 +2651,40 @@ DROP TABLE B,C,CC;
 CREATE TABLE t1 (
 a TINYTEXT NOT NULL,
 b TINYINT(3) UNSIGNED NOT NULL,
-PRIMARY KEY (a(32),b),
-KEY b_idx(b)
-) ENGINE=INNODB;
-INSERT INTO t1 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
+PRIMARY KEY (a(32),b)
+) ENGINE=MyISAM, CHARSET utf8mb4;
+CREATE TABLE t2 (
+a TINYTEXT NOT NULL,
+b TINYINT(3) UNSIGNED NOT NULL,
+PRIMARY KEY (a(32),b)
+) ENGINE=INNODB, CHARSET utf8mb4;
+INSERT INTO t1 VALUES ('a',1),('a',2);
+INSERT INTO t2 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
 ANALYZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
-SET @optimizer_switch_saved=@@session.optimizer_switch;
-SET @@session.optimizer_switch=default;
-SELECT COUNT(*) FROM t1;
-COUNT(*)
-7
-EXPLAIN SELECT * FROM t1 WHERE a IN ('a', 'b') AND b = 2;
+ANALYZE TABLE t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+EXPLAIN SELECT * FROM t1 WHERE a='a' AND b in (1,2);
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	PRIMARY,b_idx	b_idx	35	NULL	2	100.00	Using index condition; Using where
+1	SIMPLE	t1	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`b` = 2) and (`test`.`t1`.`a` in ('a','b')))
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`a` = 'a') and (`test`.`t1`.`b` in (1,2)))
 SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
-SELECT @trace RLIKE "rerunning_range_optimizer_for_single_index";
-@trace RLIKE "rerunning_range_optimizer_for_single_index"
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
 1
-SET @@session.optimizer_switch=@optimizer_switch_saved;
-DROP TABLE t1;
+EXPLAIN SELECT * FROM t2 WHERE a='a' AND b in (1,2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b` from `test`.`t2` where ((`test`.`t2`.`a` = 'a') and (`test`.`t2`.`b` in (1,2)))
+SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
+1
+DROP TABLE t1, t2;
 #
 # Bug #23227428: SQL PLAN IS NOT ACCORDING WITH OPTIMIZER_TRACE
 #

--- a/mysql-test/suite/opt_trace/r/bugs_ps_prot_all.result
+++ b/mysql-test/suite/opt_trace/r/bugs_ps_prot_all.result
@@ -3331,29 +3331,40 @@ DROP TABLE B,C,CC;
 CREATE TABLE t1 (
 a TINYTEXT NOT NULL,
 b TINYINT(3) UNSIGNED NOT NULL,
-PRIMARY KEY (a(32),b),
-KEY b_idx(b)
-) ENGINE=INNODB;
-INSERT INTO t1 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
+PRIMARY KEY (a(32),b)
+) ENGINE=MyISAM, CHARSET utf8mb4;
+CREATE TABLE t2 (
+a TINYTEXT NOT NULL,
+b TINYINT(3) UNSIGNED NOT NULL,
+PRIMARY KEY (a(32),b)
+) ENGINE=INNODB, CHARSET utf8mb4;
+INSERT INTO t1 VALUES ('a',1),('a',2);
+INSERT INTO t2 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
 ANALYZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
-SET @optimizer_switch_saved=@@session.optimizer_switch;
-SET @@session.optimizer_switch=default;
-SELECT COUNT(*) FROM t1;
-COUNT(*)
-7
-EXPLAIN SELECT * FROM t1 WHERE a IN ('a', 'b') AND b = 2;
+ANALYZE TABLE t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+EXPLAIN SELECT * FROM t1 WHERE a='a' AND b in (1,2);
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	PRIMARY,b_idx	b_idx	35	NULL	2	100.00	Using index condition; Using where
+1	SIMPLE	t1	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`b` = 2) and (`test`.`t1`.`a` in ('a','b')))
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`a` = 'a') and (`test`.`t1`.`b` in (1,2)))
 SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
-SELECT @trace RLIKE "rerunning_range_optimizer_for_single_index";
-@trace RLIKE "rerunning_range_optimizer_for_single_index"
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
 1
-SET @@session.optimizer_switch=@optimizer_switch_saved;
-DROP TABLE t1;
+EXPLAIN SELECT * FROM t2 WHERE a='a' AND b in (1,2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b` from `test`.`t2` where ((`test`.`t2`.`a` = 'a') and (`test`.`t2`.`b` in (1,2)))
+SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
+1
+DROP TABLE t1, t2;
 #
 # Bug #23227428: SQL PLAN IS NOT ACCORDING WITH OPTIMIZER_TRACE
 #

--- a/mysql-test/suite/opt_trace/r/bugs_ps_prot_none.result
+++ b/mysql-test/suite/opt_trace/r/bugs_ps_prot_none.result
@@ -2532,29 +2532,40 @@ DROP TABLE B,C,CC;
 CREATE TABLE t1 (
 a TINYTEXT NOT NULL,
 b TINYINT(3) UNSIGNED NOT NULL,
-PRIMARY KEY (a(32),b),
-KEY b_idx(b)
-) ENGINE=INNODB;
-INSERT INTO t1 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
+PRIMARY KEY (a(32),b)
+) ENGINE=MyISAM, CHARSET utf8mb4;
+CREATE TABLE t2 (
+a TINYTEXT NOT NULL,
+b TINYINT(3) UNSIGNED NOT NULL,
+PRIMARY KEY (a(32),b)
+) ENGINE=INNODB, CHARSET utf8mb4;
+INSERT INTO t1 VALUES ('a',1),('a',2);
+INSERT INTO t2 VALUES ('a',1),('a',2),('a',3),('b',1),('c',1),('c',4),('e',2);
 ANALYZE TABLE t1;
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
-SET @optimizer_switch_saved=@@session.optimizer_switch;
-SET @@session.optimizer_switch=default;
-SELECT COUNT(*) FROM t1;
-COUNT(*)
-7
-EXPLAIN SELECT * FROM t1 WHERE a IN ('a', 'b') AND b = 2;
+ANALYZE TABLE t2;
+Table	Op	Msg_type	Msg_text
+test.t2	analyze	status	OK
+EXPLAIN SELECT * FROM t1 WHERE a='a' AND b in (1,2);
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	PRIMARY,b_idx	b_idx	35	NULL	2	100.00	Using index condition; Using where
+1	SIMPLE	t1	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`b` = 2) and (`test`.`t1`.`a` in ('a','b')))
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b` from `test`.`t1` where ((`test`.`t1`.`a` = 'a') and (`test`.`t1`.`b` in (1,2)))
 SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
-SELECT @trace RLIKE "rerunning_range_optimizer_for_single_index";
-@trace RLIKE "rerunning_range_optimizer_for_single_index"
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
 1
-SET @@session.optimizer_switch=@optimizer_switch_saved;
-DROP TABLE t1;
+EXPLAIN SELECT * FROM t2 WHERE a='a' AND b in (1,2);
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	range	PRIMARY	PRIMARY	131	NULL	2	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b` from `test`.`t2` where ((`test`.`t2`.`a` = 'a') and (`test`.`t2`.`b` in (1,2)))
+SELECT TRACE into @trace FROM INFORMATION_SCHEMA.OPTIMIZER_TRACE;
+SELECT @trace RLIKE "range_uses_more_keyparts";
+@trace RLIKE "range_uses_more_keyparts"
+1
+DROP TABLE t1, t2;
 #
 # Bug #23227428: SQL PLAN IS NOT ACCORDING WITH OPTIMIZER_TRACE
 #

--- a/mysql-test/suite/opt_trace/r/eq_range_statistics.result
+++ b/mysql-test/suite/opt_trace/r/eq_range_statistics.result
@@ -605,9 +605,8 @@ EXPLAIN SELECT * FROM t1 WHERE a=5 AND (b=2 OR b=3 OR b=4)	{
                     {
                       "access_type": "ref",
                       "index": "a",
-                      "rows": 3,
-                      "cost": 1.6039,
-                      "chosen": true
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "rows_to_scan": 3,
@@ -617,25 +616,16 @@ EXPLAIN SELECT * FROM t1 WHERE a=5 AND (b=2 OR b=3 OR b=4)	{
                       } /* range_details */,
                       "resulting_rows": 3,
                       "cost": 2.2139,
-                      "chosen": false
+                      "chosen": true
                     }
                   ] /* considered_access_paths */
                 } /* best_access_path */,
-                "condition_filtering_pct": 29.767,
-                "rows_for_plan": 0.893,
-                "cost_for_plan": 1.6039,
+                "condition_filtering_pct": 100,
+                "rows_for_plan": 3,
+                "cost_for_plan": 2.2139,
                 "chosen": true
               }
             ] /* considered_execution_plans */
-          },
-          {
-            "access_type_changed": {
-              "table": "`t1`",
-              "index": "a",
-              "old_type": "ref",
-              "new_type": "range",
-              "cause": "uses_more_keyparts"
-            } /* access_type_changed */
           },
           {
             "attaching_conditions_to_tables": {
@@ -823,9 +813,8 @@ EXPLAIN SELECT * FROM t1 WHERE a=5 AND (b=2 OR b=3 OR b>4)	{
                     {
                       "access_type": "ref",
                       "index": "a",
-                      "rows": 3,
-                      "cost": 1.6039,
-                      "chosen": true
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "rows_to_scan": 3,
@@ -835,25 +824,16 @@ EXPLAIN SELECT * FROM t1 WHERE a=5 AND (b=2 OR b=3 OR b>4)	{
                       } /* range_details */,
                       "resulting_rows": 3,
                       "cost": 2.2139,
-                      "chosen": false
+                      "chosen": true
                     }
                   ] /* considered_access_paths */
                 } /* best_access_path */,
-                "condition_filtering_pct": 47.322,
-                "rows_for_plan": 1.4197,
-                "cost_for_plan": 1.6039,
+                "condition_filtering_pct": 100,
+                "rows_for_plan": 3,
+                "cost_for_plan": 2.2139,
                 "chosen": true
               }
             ] /* considered_execution_plans */
-          },
-          {
-            "access_type_changed": {
-              "table": "`t1`",
-              "index": "a",
-              "old_type": "ref",
-              "new_type": "range",
-              "cause": "uses_more_keyparts"
-            } /* access_type_changed */
           },
           {
             "attaching_conditions_to_tables": {
@@ -1040,9 +1020,8 @@ EXPLAIN SELECT * FROM t1 WHERE a=5 AND (b=2 OR b=3 OR b IS NULL)	{
                     {
                       "access_type": "ref",
                       "index": "a",
-                      "rows": 3,
-                      "cost": 1.6039,
-                      "chosen": true
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "rows_to_scan": 3,
@@ -1052,25 +1031,16 @@ EXPLAIN SELECT * FROM t1 WHERE a=5 AND (b=2 OR b=3 OR b IS NULL)	{
                       } /* range_details */,
                       "resulting_rows": 3,
                       "cost": 2.2139,
-                      "chosen": false
+                      "chosen": true
                     }
                   ] /* considered_access_paths */
                 } /* best_access_path */,
-                "condition_filtering_pct": 29.767,
-                "rows_for_plan": 0.893,
-                "cost_for_plan": 1.6039,
+                "condition_filtering_pct": 100,
+                "rows_for_plan": 3,
+                "cost_for_plan": 2.2139,
                 "chosen": true
               }
             ] /* considered_execution_plans */
-          },
-          {
-            "access_type_changed": {
-              "table": "`t1`",
-              "index": "a",
-              "old_type": "ref",
-              "new_type": "range",
-              "cause": "uses_more_keyparts"
-            } /* access_type_changed */
           },
           {
             "attaching_conditions_to_tables": {

--- a/mysql-test/suite/opt_trace/r/range_no_prot.result
+++ b/mysql-test/suite/opt_trace/r/range_no_prot.result
@@ -5164,7 +5164,7 @@ INSERT INTO t1 VALUES (1, 1, 9,'a'), (2, 2, 8,'b'), (3, 3, 7,'c'),
 # Covering ROR intersect not chosen: only one scan used
 EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND v = 'a' AND pk < 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	ref	PRIMARY,i1_idx,v_idx	i1_idx	5	const	1	20.00	Using index condition; Using where
+1	SIMPLE	t1	NULL	range	PRIMARY,i1_idx,v_idx	v_idx	13	NULL	1	100.00	Using where; Using index
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t1`.`v` AS `v` from `test`.`t1` where ((`test`.`t1`.`v` = 'a') and (`test`.`t1`.`i1` = 1) and (`test`.`t1`.`pk` < 3))
 
@@ -5383,16 +5383,14 @@ EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND v = 'a' AND pk < 3	{
                     {
                       "access_type": "ref",
                       "index": "i1_idx",
-                      "rows": 1,
-                      "cost": 1.2,
-                      "chosen": true
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "access_type": "ref",
                       "index": "v_idx",
-                      "rows": 1,
-                      "cost": 1.2,
-                      "chosen": false
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "rows_to_scan": 1,
@@ -5402,79 +5400,16 @@ EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND v = 'a' AND pk < 3	{
                       } /* range_details */,
                       "resulting_rows": 1,
                       "cost": 1.41,
-                      "chosen": false
+                      "chosen": true
                     }
                   ] /* considered_access_paths */
                 } /* best_access_path */,
-                "condition_filtering_pct": 20,
-                "rows_for_plan": 0.2,
-                "cost_for_plan": 1.2,
+                "condition_filtering_pct": 100,
+                "rows_for_plan": 1,
+                "cost_for_plan": 1.41,
                 "chosen": true
               }
             ] /* considered_execution_plans */
-          },
-          {
-            "rerunning_range_optimizer_for_single_index": [
-              {
-                "table_scan": {
-                  "rows": 5,
-                  "cost": 4.1
-                } /* table_scan */,
-                "potential_range_indexes": [
-                  {
-                    "index": "PRIMARY",
-                    "usable": false,
-                    "cause": "not_applicable"
-                  },
-                  {
-                    "index": "i1_idx",
-                    "usable": true,
-                    "key_parts": [
-                      "i1",
-                      "pk"
-                    ] /* key_parts */
-                  },
-                  {
-                    "index": "v_idx",
-                    "usable": false,
-                    "cause": "not_applicable"
-                  }
-                ] /* potential_range_indexes */,
-                "best_covering_index_scan": {
-                  "index": "v_idx",
-                  "cost": 2.0063,
-                  "chosen": true
-                } /* best_covering_index_scan */,
-                "setup_range_conditions": [
-                ] /* setup_range_conditions */,
-                "group_index_range": {
-                  "chosen": false,
-                  "cause": "not_group_by_or_distinct"
-                } /* group_index_range */,
-                "analyzing_range_alternatives": {
-                  "range_scan_alternatives": [
-                    {
-                      "index": "i1_idx",
-                      "ranges": [
-                        "1 <= i1 <= 1 AND pk < 3"
-                      ] /* ranges */,
-                      "index_dives_for_eq_ranges": true,
-                      "rowid_ordered": true,
-                      "using_mrr": false,
-                      "index_only": false,
-                      "rows": 1,
-                      "cost": 2.21,
-                      "chosen": false,
-                      "cause": "cost"
-                    }
-                  ] /* range_scan_alternatives */,
-                  "analyzing_roworder_intersect": {
-                    "usable": false,
-                    "cause": "too_few_roworder_scans"
-                  } /* analyzing_roworder_intersect */
-                } /* analyzing_range_alternatives */
-              } /* range_analysis */
-            ] /* rerunning_range_optimizer_for_single_index */
           },
           {
             "attaching_conditions_to_tables": {
@@ -5484,7 +5419,7 @@ EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND v = 'a' AND pk < 3	{
               "attached_conditions_summary": [
                 {
                   "table": "`t1`",
-                  "attached": "((`t1`.`v` = 'a') and (`t1`.`pk` < 3))"
+                  "attached": "((`t1`.`v` = 'a') and (`t1`.`i1` = 1) and (`t1`.`pk` < 3))"
                 }
               ] /* attached_conditions_summary */
             } /* attaching_conditions_to_tables */
@@ -5492,9 +5427,7 @@ EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND v = 'a' AND pk < 3	{
           {
             "refine_plan": [
               {
-                "table": "`t1`",
-                "pushed_index_condition": "(`t1`.`pk` < 3)",
-                "table_condition_attached": "(`t1`.`v` = 'a')"
+                "table": "`t1`"
               }
             ] /* refine_plan */
           }
@@ -5519,7 +5452,7 @@ test.t1	analyze	status	OK
 # Covering ROR intersect not chosen: Index with more keyparts found.
 EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND i2 = 1  AND v = 'a' AND pk < 3;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	PRIMARY,v_idx,i1_i2_idx	v_idx	13	NULL	1	20.00	Using index condition; Using where
+1	SIMPLE	t1	NULL	index_merge	PRIMARY,v_idx,i1_i2_idx	v_idx,PRIMARY	13,4	NULL	1	20.00	Using intersect(v_idx,PRIMARY); Using where
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t1`.`v` AS `v` from `test`.`t1` where ((`test`.`t1`.`v` = 'a') and (`test`.`t1`.`i2` = 1) and (`test`.`t1`.`i1` = 1) and (`test`.`t1`.`pk` < 3))
 
@@ -5765,16 +5698,14 @@ EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND i2 = 1  AND v = 'a' AND pk < 3	{
                     {
                       "access_type": "ref",
                       "index": "v_idx",
-                      "rows": 1,
-                      "cost": 1.2,
-                      "chosen": true
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "access_type": "ref",
                       "index": "i1_i2_idx",
-                      "rows": 1,
-                      "cost": 1.2,
-                      "chosen": false
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "rows_to_scan": 1,
@@ -5784,96 +5715,16 @@ EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND i2 = 1  AND v = 'a' AND pk < 3	{
                       } /* range_details */,
                       "resulting_rows": 0.2,
                       "cost": 1.3,
-                      "chosen": false
+                      "chosen": true
                     }
                   ] /* considered_access_paths */
                 } /* best_access_path */,
-                "condition_filtering_pct": 20,
+                "condition_filtering_pct": 100,
                 "rows_for_plan": 0.2,
-                "cost_for_plan": 1.2,
+                "cost_for_plan": 1.3,
                 "chosen": true
               }
             ] /* considered_execution_plans */
-          },
-          {
-            "rerunning_range_optimizer_for_single_index": [
-              {
-                "table_scan": {
-                  "rows": 5,
-                  "cost": 4.1
-                } /* table_scan */,
-                "potential_range_indexes": [
-                  {
-                    "index": "PRIMARY",
-                    "usable": false,
-                    "cause": "not_applicable"
-                  },
-                  {
-                    "index": "v_idx",
-                    "usable": true,
-                    "key_parts": [
-                      "v",
-                      "i1",
-                      "pk"
-                    ] /* key_parts */
-                  },
-                  {
-                    "index": "i1_i2_idx",
-                    "usable": false,
-                    "cause": "not_applicable"
-                  }
-                ] /* potential_range_indexes */,
-                "setup_range_conditions": [
-                ] /* setup_range_conditions */,
-                "group_index_range": {
-                  "chosen": false,
-                  "cause": "not_group_by_or_distinct"
-                } /* group_index_range */,
-                "analyzing_range_alternatives": {
-                  "range_scan_alternatives": [
-                    {
-                      "index": "v_idx",
-                      "ranges": [
-                        "a <= v <= a AND 1 <= i1 <= 1 AND pk < 3"
-                      ] /* ranges */,
-                      "index_dives_for_eq_ranges": true,
-                      "rowid_ordered": true,
-                      "using_mrr": false,
-                      "index_only": false,
-                      "rows": 1,
-                      "cost": 2.21,
-                      "chosen": true
-                    }
-                  ] /* range_scan_alternatives */,
-                  "analyzing_roworder_intersect": {
-                    "usable": false,
-                    "cause": "too_few_roworder_scans"
-                  } /* analyzing_roworder_intersect */
-                } /* analyzing_range_alternatives */,
-                "chosen_range_access_summary": {
-                  "range_access_plan": {
-                    "type": "range_scan",
-                    "index": "v_idx",
-                    "rows": 1,
-                    "ranges": [
-                      "a <= v <= a AND 1 <= i1 <= 1 AND pk < 3"
-                    ] /* ranges */
-                  } /* range_access_plan */,
-                  "rows_for_plan": 1,
-                  "cost_for_plan": 2.21,
-                  "chosen": true
-                } /* chosen_range_access_summary */
-              } /* range_analysis */
-            ] /* rerunning_range_optimizer_for_single_index */
-          },
-          {
-            "access_type_changed": {
-              "table": "`t1`",
-              "index": "v_idx",
-              "old_type": "ref",
-              "new_type": "range",
-              "cause": "uses_more_keyparts"
-            } /* access_type_changed */
           },
           {
             "attaching_conditions_to_tables": {
@@ -5891,9 +5742,7 @@ EXPLAIN SELECT v FROM t1 WHERE i1 = 1 AND i2 = 1  AND v = 'a' AND pk < 3	{
           {
             "refine_plan": [
               {
-                "table": "`t1`",
-                "pushed_index_condition": "((`t1`.`v` = 'a') and (`t1`.`i1` = 1) and (`t1`.`pk` < 3))",
-                "table_condition_attached": "(`t1`.`i2` = 1)"
+                "table": "`t1`"
               }
             ] /* refine_plan */
           }
@@ -5917,7 +5766,7 @@ INSERT INTO t1 VALUES (1,1),(1,2),(1,0),(1,3);
 # Test trace for "access_type_changed 'ref' to 'range'"
 EXPLAIN SELECT MAX(b), a FROM t1 WHERE b < 2 AND a = 1 GROUP BY a;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	PRIMARY,b	PRIMARY	8	NULL	2	100.00	Using where; Using index for group-by
+1	SIMPLE	t1	NULL	range	PRIMARY,b	b	4	NULL	2	25.00	Using where; Using index
 Warnings:
 Note	1003	/* select#1 */ select max(`test`.`t1`.`b`) AS `MAX(b)`,`test`.`t1`.`a` AS `a` from `test`.`t1` where ((`test`.`t1`.`a` = 1) and (`test`.`t1`.`b` < 2)) group by `test`.`t1`.`a`
 
@@ -6118,9 +5967,8 @@ EXPLAIN SELECT MAX(b), a FROM t1 WHERE b < 2 AND a = 1 GROUP BY a	{
                     {
                       "access_type": "ref",
                       "index": "PRIMARY",
-                      "rows": 2,
-                      "cost": 1.4019,
-                      "chosen": true
+                      "chosen": false,
+                      "cause": "range_uses_more_keyparts"
                     },
                     {
                       "rows_to_scan": 2,
@@ -6130,131 +5978,19 @@ EXPLAIN SELECT MAX(b), a FROM t1 WHERE b < 2 AND a = 1 GROUP BY a	{
                       } /* range_details */,
                       "resulting_rows": 0.5,
                       "cost": 1.8115,
-                      "chosen": false
+                      "chosen": true,
+                      "use_tmp_table": true
                     }
                   ] /* considered_access_paths */
                 } /* best_access_path */,
-                "condition_filtering_pct": 50,
-                "rows_for_plan": 1,
-                "cost_for_plan": 1.4019,
+                "condition_filtering_pct": 100,
+                "rows_for_plan": 0.5,
+                "cost_for_plan": 1.8115,
+                "sort_cost": 0.5,
+                "new_cost_for_plan": 2.3115,
                 "chosen": true
               }
             ] /* considered_execution_plans */
-          },
-          {
-            "rerunning_range_optimizer_for_single_index": [
-              {
-                "table_scan": {
-                  "rows": 4,
-                  "cost": 3.9
-                } /* table_scan */,
-                "potential_range_indexes": [
-                  {
-                    "index": "PRIMARY",
-                    "usable": true,
-                    "key_parts": [
-                      "a",
-                      "b"
-                    ] /* key_parts */
-                  },
-                  {
-                    "index": "b",
-                    "usable": false,
-                    "cause": "not_applicable"
-                  }
-                ] /* potential_range_indexes */,
-                "best_covering_index_scan": {
-                  "index": "b",
-                  "cost": 1.8044,
-                  "chosen": true
-                } /* best_covering_index_scan */,
-                "setup_range_conditions": [
-                ] /* setup_range_conditions */,
-                "group_index_range": {
-                  "potential_group_range_indexes": [
-                    {
-                      "index": "PRIMARY",
-                      "covering": true,
-                      "index_dives_for_eq_ranges": true,
-                      "ranges": [
-                        "1 <= a <= 1 AND b < 2"
-                      ] /* ranges */,
-                      "rows": 2,
-                      "cost": 1.6
-                    }
-                  ] /* potential_group_range_indexes */
-                } /* group_index_range */,
-                "best_group_range_summary": {
-                  "type": "index_group",
-                  "index": "PRIMARY",
-                  "group_attribute": "b",
-                  "min_aggregate": false,
-                  "max_aggregate": true,
-                  "distinct_aggregate": false,
-                  "rows": 2,
-                  "cost": 1.6,
-                  "key_parts_used_for_access": [
-                    "a"
-                  ] /* key_parts_used_for_access */,
-                  "ranges": [
-                    "1 <= a <= 1 AND b < 2"
-                  ] /* ranges */,
-                  "chosen": true
-                } /* best_group_range_summary */,
-                "analyzing_range_alternatives": {
-                  "range_scan_alternatives": [
-                    {
-                      "index": "PRIMARY",
-                      "ranges": [
-                        "1 <= a <= 1 AND b < 2"
-                      ] /* ranges */,
-                      "index_dives_for_eq_ranges": true,
-                      "rowid_ordered": true,
-                      "using_mrr": false,
-                      "index_only": true,
-                      "rows": 2,
-                      "cost": 2.41,
-                      "chosen": false,
-                      "cause": "cost"
-                    }
-                  ] /* range_scan_alternatives */,
-                  "analyzing_roworder_intersect": {
-                    "usable": false,
-                    "cause": "too_few_roworder_scans"
-                  } /* analyzing_roworder_intersect */
-                } /* analyzing_range_alternatives */,
-                "chosen_range_access_summary": {
-                  "range_access_plan": {
-                    "type": "index_group",
-                    "index": "PRIMARY",
-                    "group_attribute": "b",
-                    "min_aggregate": false,
-                    "max_aggregate": true,
-                    "distinct_aggregate": false,
-                    "rows": 2,
-                    "cost": 1.6,
-                    "key_parts_used_for_access": [
-                      "a"
-                    ] /* key_parts_used_for_access */,
-                    "ranges": [
-                      "1 <= a <= 1 AND b < 2"
-                    ] /* ranges */
-                  } /* range_access_plan */,
-                  "rows_for_plan": 2,
-                  "cost_for_plan": 1.6,
-                  "chosen": true
-                } /* chosen_range_access_summary */
-              } /* range_analysis */
-            ] /* rerunning_range_optimizer_for_single_index */
-          },
-          {
-            "access_type_changed": {
-              "table": "`t1`",
-              "index": "PRIMARY",
-              "old_type": "ref",
-              "new_type": "range",
-              "cause": "uses_more_keyparts"
-            } /* access_type_changed */
           },
           {
             "attaching_conditions_to_tables": {

--- a/mysql-test/t/opt_hints.test
+++ b/mysql-test/t/opt_hints.test
@@ -62,26 +62,26 @@ EXPLAIN SELECT /*+ NO_RANGE_OPTIMIZATION(t3 PRIMARY) NO_RANGE_OPTIMIZATION(t3 f2
 set optimizer_switch='index_condition_pushdown=on';
 
 EXPLAIN SELECT  f2 FROM
-  (SELECT f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-    WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+  (SELECT f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+    WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 
 EXPLAIN SELECT /*+ NO_ICP(t3@qb1 f3_idx) */ f2 FROM
-  (SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-    WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+  (SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+    WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 
 EXPLAIN SELECT /*+ NO_ICP(t3@qb1) */ f2 FROM
-  (SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-    WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+  (SELECT /*+ QB_NAME(QB1) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+    WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 
 --echo # Expected warning for f1_idx key, unresolved name.
 EXPLAIN SELECT f2 FROM
-  (SELECT /*+ NO_ICP(t3 f3_idx, f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-    WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+  (SELECT /*+ NO_ICP(t3 f3_idx, f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+    WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 
 --echo # ICP should still be used.
 EXPLAIN SELECT f2 FROM
-  (SELECT /*+ NO_ICP(t3 f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 2 AND f3 = 'poiu') AS TD
-    WHERE TD.f1 > 2 AND TD.f3 = 'poiu';
+  (SELECT /*+ NO_ICP(t3 f1_idx, f2_idx) */ f2, f3, f1 FROM t3 WHERE f1 > 27 AND f3 = 'poiu') AS TD
+    WHERE TD.f1 > 27 AND TD.f3 = 'poiu';
 
 --echo # BKA & NO_BKA hint testing
 set optimizer_switch=default;

--- a/sql/sql_planner.cc
+++ b/sql/sql_planner.cc
@@ -498,8 +498,6 @@ Key_use* Optimize_table_order::find_best_ref(JOIN_TAB *tab,
               on the same index,
               (2) and that quick select uses more keyparts (i.e. it will
               scan equal/smaller interval then this ref(const))
-              (3) and E(#rows) for quick select is higher then our
-              estimate,
               Then use E(#rows) from quick select.
 
               One observation is that when there are multiple
@@ -515,11 +513,12 @@ Key_use* Optimize_table_order::find_best_ref(JOIN_TAB *tab,
               TODO: figure this out and adjust the plan choice if needed.
             */
             if (!table_deps && table->quick_keys.is_set(key) &&     // (1)
-                table->quick_key_parts[key] > cur_used_keyparts &&  // (2)
-                cur_fanout <= (double)table->quick_rows[key])        // (3)
+                table->quick_key_parts[key] > cur_used_keyparts)    // (2)
                 {
-                  cur_fanout= (double)table->quick_rows[key];
+                  trace_access_idx.add("chosen", false)
+                      .add_alnum("cause", "range_uses_more_keyparts");
                   is_dodgy= true;
+                  continue;
                 }
 
             tmp_fanout= cur_fanout;


### PR DESCRIPTION
Optimizer choosing ref-access when range access is more optimal. This is
related to upstream bug #26727773 (commit ddd9d614a32). This bug was
fixed differently in 5.7 and 8.0. 5.7 fix doesn't work for this query
and 8.0 looks more robust. It is choosing range access over ref access
if ref access using more keyparts.

Fixed by taking fix and test cases from 8.0.

Take 8.0 version of fix for #26727773

fix/re-record some test cases