### PR TITLE
PS-5309 : rpl.rpl_corruption always failing

### DIFF
--- a/mysql-test/suite/rpl/t/rpl_corruption.test
+++ b/mysql-test/suite/rpl/t/rpl_corruption.test
@@ -26,6 +26,10 @@ call mtr.add_suppression('event read from binlog did not pass crc check');
 call mtr.add_suppression('Replication event checksum verification failed');
 call mtr.add_suppression('Event crc check failed! Most likely there is event corruption');
 call mtr.add_suppression("Slave SQL for channel '': Error initializing relay log position: I/O error reading event at position .*, Error_code: MY-013117");
+if ($encryption_test)
+{
+  call mtr.add_suppression('Event decryption failure');
+}
 
 SET @old_master_verify_checksum = @@master_verify_checksum;
 

--- a/mysql-test/suite/rpl_encryption/r/encrypted_master_lost_key.result
+++ b/mysql-test/suite/rpl_encryption/r/encrypted_master_lost_key.result
@@ -101,6 +101,7 @@ connection master;
 #         This behavior is confirmed in MDEV-11323
 #####################################################
 connection server_2;
+call mtr.add_suppression('Event decryption failure');
 START SLAVE SQL_THREAD;
 START SLAVE IO_THREAD;
 include/wait_for_slave_io_error.inc [errno=13114 # ER_SERVER_MASTER_FATAL_ERROR_READING_BINLOG]

--- a/mysql-test/suite/rpl_encryption/r/rpl_corruption.result
+++ b/mysql-test/suite/rpl_encryption/r/rpl_corruption.result
@@ -9,6 +9,7 @@ call mtr.add_suppression('event read from binlog did not pass crc check');
 call mtr.add_suppression('Replication event checksum verification failed');
 call mtr.add_suppression('Event crc check failed! Most likely there is event corruption');
 call mtr.add_suppression("Slave SQL for channel '': Error initializing relay log position: I/O error reading event at position .*, Error_code: MY-013117");
+call mtr.add_suppression('Event decryption failure');
 SET @old_master_verify_checksum = @@master_verify_checksum;
 # 1. Creating test table/data and set corruption position for testing
 * insert/update/delete rows in table t1 *

--- a/mysql-test/suite/rpl_encryption/t/encrypted_master_lost_key.test
+++ b/mysql-test/suite/rpl_encryption/t/encrypted_master_lost_key.test
@@ -132,6 +132,8 @@ INSERT INTO table3_to_encrypt SELECT NULL,NOW(),b FROM table3_to_encrypt;
 --echo #####################################################
 --connection server_2
 
+call mtr.add_suppression('Event decryption failure');
+
 --disable_connect_log
 START SLAVE SQL_THREAD;
 START SLAVE IO_THREAD;

--- a/mysql-test/suite/rpl_encryption/t/rpl_corruption.test
+++ b/mysql-test/suite/rpl_encryption/t/rpl_corruption.test
@@ -1,1 +1,2 @@
+--let $encryption_test=1
 --source suite/rpl/t/rpl_corruption.test

--- a/sql/binlog_reader.cc
+++ b/sql/binlog_reader.cc
@@ -161,8 +161,8 @@ bool Binlog_event_data_istream::fill_event_data(
                                               checksum_alg) &&
         !DBUG_EVALUATE_IF("simulate_unknown_ignorable_log_event", 1, 0)) {
       return m_error->set_type(crypto_data.is_enabled()
-                                   ? Binlog_read_error::CHECKSUM_FAILURE
-                                   : Binlog_read_error::DECRYPT);
+                                   ? Binlog_read_error::DECRYPT
+                                   : Binlog_read_error::CHECKSUM_FAILURE);
     }
   }
   return false;


### PR DESCRIPTION
Decryption error was reported for corruption failures instead of
corruption error. Also corruption error was generated instead of
decryption error. The fix was to swap those two errors.