### PR TITLE
Fix PS-5307 (mysqldump: memory leak and needless allocation in compre…

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -2995,8 +2995,7 @@ static void print_optional_create_compression_dictionary(
         "FROM `INFORMATION_SCHEMA`.`COMPRESSION_DICTIONARY` "
         "WHERE `DICT_NAME` = '%s'";
 
-    processed_compression_dictionaries->emplace(
-        my_strdup(PSI_NOT_INSTRUMENTED, dictionary_name, MYF(0)));
+    processed_compression_dictionaries->emplace(dictionary_name);
 
     char query_buff[QUERY_LENGTH];
     snprintf(query_buff, sizeof(query_buff), get_zip_dict_data_stmt,


### PR DESCRIPTION
…ssion dictionaries)

processed_compression_dictionaries was converted from HASH to
set<std::string> in 8.0, and strings instead by
emplace(my_strdup(...)). This caused two allocations, one by strdup,
another by std::string constructor. The first one is needless and
leaking, fix trivally.

https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/143/