### PR TITLE
PS-4640: FTS query with limit and mecab in file fts0que.cc line 3560

### DIFF
--- a/storage/innobase/fts/fts0ast.cc
+++ b/storage/innobase/fts/fts0ast.cc
@@ -549,8 +549,7 @@ fts_ast_node_check_union(
 	fts_ast_node_t*	node)
 {
 	if (node->type == FTS_AST_LIST
-	    || node->type == FTS_AST_SUBEXP_LIST
-	    || node->type == FTS_AST_PARSER_PHRASE_LIST) {
+	    || node->type == FTS_AST_SUBEXP_LIST) {
 
 		for (node = node->list.head; node; node = node->next) {
 			if (!fts_ast_node_check_union(node)) {
@@ -563,7 +562,8 @@ fts_ast_node_check_union(
 		       || node->oper == FTS_EXIST)) {
 
 		return(false);
-	} else if (node->type == FTS_AST_TEXT) {
+	} else if (node->type == FTS_AST_TEXT
+		   || node->type == FTS_AST_PARSER_PHRASE_LIST) {
 		/* Distance or phrase search query. */
 		return(false);
 	}

--- a/storage/innobase/fts/fts0que.cc
+++ b/storage/innobase/fts/fts0que.cc
@@ -746,6 +746,10 @@ fts_query_union_doc_id(
 
 		query->total_size += SIZEOF_RBT_NODE_ADD
 			+ sizeof(fts_ranking_t) + RANKING_WORDS_INIT_LEN;
+
+		if (query->limit != ULONG_UNDEFINED) {
+			query->n_docs++;
+		}
 	}
 }
 
@@ -3345,7 +3349,7 @@ fts_query_filter_doc_ids(
 		}
 
 		if (query->limit != ULONG_UNDEFINED
-		    && query->limit <= ++query->n_docs) {
+		    && query->n_docs >= query->limit) {
 			goto func_exit;
 		}
 	}
@@ -3357,7 +3361,6 @@ func_exit:
 	if (query->total_size > fts_result_cache_limit) {
 		return(DB_FTS_EXCEED_RESULT_CACHE_LIMIT);
 	} else {
-		query->n_docs = 0;
 		return(DB_SUCCESS);
 	}
 }
@@ -3952,6 +3955,10 @@ fts_query_can_optimize(
 	fts_ast_node_t*	node = query->root;
 
 	if (flags & FTS_EXPAND) {
+		return;
+	}
+
+	if (query->limit != ULONG_UNDEFINED) {
 		return;
 	}
 


### PR DESCRIPTION
Upstream commit 2cd0ebf97e1 introduced the fix for FTS query result
cache overflow issue.

It has couple of issues, for example, it only counts docs added from
fts_query_filter_doc_ids, while docs can also be added from
fts_query_search_phrase.

This problem was partly mitigated by commit 48e07ec3935, but not fully
resolved.

This patch reverts 48e07ec3935 and applies the patch attached to
upstream bug 87518.