### PR TITLE
Fix PS-5311 (create_zip_dict: debug output may access past string end)

### DIFF
--- a/sql/sql_zip_dict.cc
+++ b/sql/sql_zip_dict.cc
@@ -310,11 +310,15 @@ int create_zip_dict(THD *thd, const char *name, ulong name_len,
   DBUG_ENTER("mysql_create_zip_dict");
   handlerton *hton = ha_default_handlerton(thd);
 
+#ifndef DBUG_OFF
+  const std::string name_str(name, name_len);
+  const std::string data_str(data, data_len);
   DBUG_LOG("zip_dict",
-           "thd->query: " << thd->query().str << " dict_name: " << name
-                          << " dict_name_len: " << name_len << " data: " << data
-                          << " data_len: " << data_len
+           "thd->query: " << thd->query().str << " dict_name: " << name_str
+                          << " dict_name_len: " << name_len
+                          << " data: " << data_str << " data_len: " << data_len
                           << " if_not_exists: " << if_not_exists);
+#endif
   int error;
 
   /* thd is from bootstrap thread and the default storage engine
@@ -490,9 +494,13 @@ int drop_zip_dict(THD *thd, const char *name, ulong name_len, bool if_exists) {
   DBUG_ENTER("mysql_drop_zip_dict");
   handlerton *hton = ha_default_handlerton(thd);
 
-  DBUG_LOG("zip_dict", "thd->query: " << thd->query().str << " dict_name: "
-                                      << name << " dict_name_len: " << name_len
+#ifndef DBUG_OFF
+  const std::string name_str(name, name_len);
+  DBUG_LOG("zip_dict", "thd->query: " << thd->query().str
+                                      << " dict_name: " << name_str
+                                      << " dict_name_len: " << name_len
                                       << " if_exists: " << if_exists);
+#endif
 
   int error;
   if (!ha_check_storage_engine_flag(hton, HTON_SUPPORTS_COMPRESSED_COLUMNS)) {


### PR DESCRIPTION
In create_zip_dict and drop_zip_dict, name and data args are pointers
to char arrays whose length is determined by other args rathen by
terminating NULs. Thus, passing them as-is to operator<< in DBUG_LOG
results in reads past array end. Fix by creating temp std::string
objects using the passed lengths, and passing that to operator<<.

https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/151/