### PR TITLE
PS-5305: Fix log encryption issues reported by ASAN (8.0)

### DIFF
--- a/include/mysql/service_mysql_keyring.h
+++ b/include/mysql/service_mysql_keyring.h
@@ -106,4 +106,24 @@ int my_key_generate(const char *, const char *, const char *, size_t);
 
 #endif
 
+#ifndef MYSQL_ABI_CHECK
+
+#include "map_helpers.h"
+
+inline int my_key_fetch_safe(const char *key_id,
+                             unique_ptr_my_free<char> &key_type,
+                             const char *user_id,
+                             unique_ptr_my_free<unsigned char> &key,
+                             size_t *key_len) {
+  char *key_type_tmp = nullptr;
+  void *key_tmp = nullptr;
+  const int result =
+      my_key_fetch(key_id, &key_type_tmp, user_id, &key_tmp, key_len);
+  key_type.reset(key_type_tmp);
+  key.reset(static_cast<unsigned char *>(key_tmp));
+  return result;
+}
+
+#endif  // MYSQL_ABI_CHECK
+
 #endif  // MYSQL_SERVICE_MYSQL_PLUGIN_KEYRING_INCLUDED

--- a/include/system_key.h
+++ b/include/system_key.h
@@ -17,6 +17,7 @@
 #ifndef SYSTEM_KEY_INCLUDED
 #define SYSTEM_KEY_INCLUDED
 
+#include "map_helpers.h"
 #include "my_inttypes.h"
 
 #define PERCONA_BINLOG_KEY_NAME "percona_binlog"
@@ -40,4 +41,10 @@ bool is_valid_percona_system_key(const char *key_name, size_t *key_length);
 extern uchar *parse_system_key(const uchar *key, const size_t key_length,
                                uint *key_version, uchar **key_data,
                                size_t *key_data_length) noexcept;
+
+extern uchar *parse_system_key(const uchar *key, const size_t key_length,
+                               uint *key_version,
+                               unique_ptr_my_free<uchar> &key_data,
+                               size_t *key_data_length) noexcept;
+
 #endif  // SYSTEM_KEY_INCLUDED

--- a/mysys/system_key.cc
+++ b/mysys/system_key.cc
@@ -24,30 +24,30 @@
 #include "mysql/psi/psi_base.h"
 #include "mysql/service_mysql_alloc.h"
 
-struct Valid_percona_system_key
-{
+struct Valid_percona_system_key {
   const char *key_name;
   size_t key_length;
-  bool is_prefix; // If set valid percona key must start with prefix key_name. If is_prefix is not set
-                  // valid key must match exactly the name from key_name
+  bool is_prefix;  // If set valid percona key must start with prefix key_name.
+                   // If is_prefix is not set valid key must match exactly the
+                   // name from key_name
 };
 
-/** 
+/**
    System keys cannot have ':' in their name. We use ':' as a separator between
    system key's name and system key's version.
 */
-struct Valid_percona_system_key valid_percona_system_keys[] = { {PERCONA_BINLOG_KEY_NAME, 16, false},
-                                                                {PERCONA_INNODB_KEY_NAME, 32, true} };
-const size_t valid_percona_system_keys_size = array_elements(valid_percona_system_keys);
+struct Valid_percona_system_key valid_percona_system_keys[] = {
+    {PERCONA_BINLOG_KEY_NAME, 16, false}, {PERCONA_INNODB_KEY_NAME, 32, true}};
+const size_t valid_percona_system_keys_size =
+    array_elements(valid_percona_system_keys);
 
-bool is_valid_percona_system_key(const char *key_name, size_t *key_length)
-{
-  uint i= 0;
-  for(; i < valid_percona_system_keys_size; ++i)
-  {
-    if ((valid_percona_system_keys[i].is_prefix && strstr(key_name, valid_percona_system_keys[i].key_name) == key_name) ||
-        (!valid_percona_system_keys[i].is_prefix && strcmp(valid_percona_system_keys[i].key_name, key_name) == 0))
-    {
+bool is_valid_percona_system_key(const char *key_name, size_t *key_length) {
+  uint i = 0;
+  for (; i < valid_percona_system_keys_size; ++i) {
+    if ((valid_percona_system_keys[i].is_prefix &&
+         strstr(key_name, valid_percona_system_keys[i].key_name) == key_name) ||
+        (!valid_percona_system_keys[i].is_prefix &&
+         strcmp(valid_percona_system_keys[i].key_name, key_name) == 0)) {
       *key_length = valid_percona_system_keys[i].key_length;
       return true;
     }
@@ -55,46 +55,59 @@ bool is_valid_percona_system_key(const char *key_name, size_t *key_length)
   return false;
 }
 
-// Only parse the latest key - from system_keys_container - do not parse keys from keys_container
-uchar* parse_system_key(const uchar *key, const size_t key_length, uint *key_version,
-                        uchar **key_data, size_t *key_data_length) noexcept {
-  size_t key_version_length= 0;
+// Only parse the latest key - from system_keys_container - do not parse keys
+// from keys_container
+uchar *parse_system_key(const uchar *key, const size_t key_length,
+                        uint *key_version, uchar **key_data,
+                        size_t *key_data_length) noexcept {
+  size_t key_version_length = 0;
 
-  if (key == nullptr || key_length == 0)
-    return nullptr;
+  if (key == nullptr || key_length == 0) return nullptr;
 
-  for (; key[key_version_length] != ':' && key_version_length < key_length; ++key_version_length);
+  for (; key[key_version_length] != ':' && key_version_length < key_length;
+       ++key_version_length)
+    ;
   if (key_version_length == 0 || key_version_length == key_length)
-    return nullptr; // no version found
+    return nullptr;  // no version found
 
-  char *version= (char*)(my_malloc(PSI_NOT_INSTRUMENTED, key_version_length+1, MYF(0)));
-  if (version == nullptr)
-    return nullptr;
+  char *version =
+      (char *)(my_malloc(PSI_NOT_INSTRUMENTED, key_version_length + 1, MYF(0)));
+  if (version == nullptr) return nullptr;
 
   memcpy(version, key, key_version_length);
-  version[key_version_length]= '\0';
-  char *endptr= version;
+  version[key_version_length] = '\0';
+  char *endptr = version;
 
-  const ulong ulong_key_version= strtoul(version, &endptr, 10);
-  if (ulong_key_version > UINT_MAX || *endptr != '\0')
-  {
+  const ulong ulong_key_version = strtoul(version, &endptr, 10);
+  if (ulong_key_version > UINT_MAX || *endptr != '\0') {
     my_free(version);
-    return nullptr; // conversion failed
+    return nullptr;  // conversion failed
   }
   my_free(version);
 
-  DBUG_ASSERT(ulong_key_version <= UINT_MAX); // sanity check
+  DBUG_ASSERT(ulong_key_version <= UINT_MAX);  // sanity check
 
-  *key_data_length= key_length - (key_version_length + 1); // skip ':' after key version
-  if (*key_data_length == 0)
-    return nullptr;
+  *key_data_length =
+      key_length - (key_version_length + 1);  // skip ':' after key version
+  if (*key_data_length == 0) return nullptr;
   DBUG_ASSERT(*key_data_length <= 512);
 
-  *key_data= (uchar*)(my_malloc(PSI_NOT_INSTRUMENTED, sizeof(uchar)*(*key_data_length), MYF(0)));
-  if (*key_data == nullptr)
-    return nullptr;
+  *key_data = (uchar *)(my_malloc(PSI_NOT_INSTRUMENTED,
+                                  sizeof(uchar) * (*key_data_length), MYF(0)));
+  if (*key_data == nullptr) return nullptr;
 
-  memcpy(*key_data, key+key_version_length+1, *key_data_length); // skip ':' after key version
-  *key_version= (uint)ulong_key_version;
+  memcpy(*key_data, key + key_version_length + 1,
+         *key_data_length);  // skip ':' after key version
+  *key_version = (uint)ulong_key_version;
   return *key_data;
+}
+
+uchar *parse_system_key(const uchar *key, const size_t key_length,
+                        uint *key_version, unique_ptr_my_free<uchar> &key_data,
+                        size_t *key_data_length) noexcept {
+  uchar *key_data_tmp = nullptr;
+  auto result = parse_system_key(key, key_length, key_version, &key_data_tmp,
+                                 key_data_length);
+  key_data.reset(key_data_tmp);
+  return result;
 }

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -8813,9 +8813,9 @@ bool Encryption::fill_encryption_info(uint key_version, byte *iv,
   ptr += ENCRYPTION_SERVER_UUID_LEN;
   /* Write tablespace iv. */
   memcpy(ptr, iv, ENCRYPTION_KEY_LEN);
-  ptr += ENCRYPTION_KEY_LEN * 2;
+  ptr += ENCRYPTION_KEY_LEN;
   /* Write checksum bytes. */
-  crc = ut_crc32(encrypt_info, ENCRYPTION_KEY_LEN * 2);
+  crc = ut_crc32(encrypt_info, ENCRYPTION_KEY_LEN);
   mach_write_to_4(ptr, crc);
 #ifdef UNIV_ENCRYPT_DEBUG
   fprintf(stderr, "Encrypting log with key version: %u\n", key_version);


### PR DESCRIPTION
* Memory allocated by keyring functions weren't freed, resulting in leaks
* Reduced the offset of the CRC field, which was unneccessarily far from the encryption info.
  While this worked in 5.7, in 8.0 longer previous fields moved the CRC out of the allocated buffer, and it wasn't written out.
  With this change, the logical structure of the code remains the same in 5.7 and 8.0, except for the different field lengths.

(cherry picked from commit 79a9a6842bfe0b3a77d7504fa0e4d4d6fe8406f0)