### PR TITLE
PS-5333: Remove need for innodb_encrypt_tables to ON/FORCE when

### DIFF
--- a/mysql-test/r/percona_dd_upgrade_encrypted.result
+++ b/mysql-test/r/percona_dd_upgrade_encrypted.result
@@ -3,7 +3,8 @@
 # Unzip the zip file.
 # Stop DB server which was created by MTR default
 # Start the 8.0 server on 5.7 datadir
-# restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=MYSQLD_DATADIR1 --innodb-encrypt-tables=ON --keyring_file_data=MYSQL_TMP_DIR/data57_encrypted/mysecret_keyring --innodb_sys_tablespace_encrypt=ON KEYRING_PLUGIN_OPT KEYRING_PLUGIN_EARLY_LOAD
+# PS-5333: Remove need for innodb_encrypt_tables to ON/FORCE when mysql.ibd is encrypted
+# restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=MYSQLD_DATADIR1 --keyring_file_data=MYSQL_TMP_DIR/data57_encrypted/mysecret_keyring --innodb_sys_tablespace_encrypt=ON KEYRING_PLUGIN_OPT KEYRING_PLUGIN_EARLY_LOAD
 # Execute mysql_upgrade
 mysql.columns_priv                                 OK
 mysql.component                                    OK
@@ -79,3 +80,5 @@ t6	CREATE TABLE `t6` (
 # Remove copied files
 # Restart the server with default options.
 # restart
+# PS-5333: Remove need for innodb_encrypt_tables to ON/FORCE when mysql.ibd is encrypted
+# restart:--innodb-encrypt-tables=OFF

--- a/mysql-test/t/percona_dd_upgrade_encrypted.test
+++ b/mysql-test/t/percona_dd_upgrade_encrypted.test
@@ -64,7 +64,8 @@ let $MYSQLD_DATADIR1 = $MYSQL_TMP_DIR/data57_encrypted/data;
 --source include/shutdown_mysqld.inc
 
 --echo # Start the 8.0 server on 5.7 datadir
---let $restart_parameters = "restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=$MYSQLD_DATADIR1 --innodb-encrypt-tables=ON --keyring_file_data=$MYSQL_TMP_DIR/data57_encrypted/mysecret_keyring --innodb_sys_tablespace_encrypt=ON $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD"
+--echo # PS-5333: Remove need for innodb_encrypt_tables to ON/FORCE when mysql.ibd is encrypted
+--let $restart_parameters = "restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=$MYSQLD_DATADIR1 --keyring_file_data=$MYSQL_TMP_DIR/data57_encrypted/mysecret_keyring --innodb_sys_tablespace_encrypt=ON $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD"
 --replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1 $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD KEYRING_PLUGIN_EARLY_LOAD
 --source include/start_mysqld.inc
 
@@ -91,3 +92,7 @@ SHOW CREATE TABLE test.t6;
 --echo # Restart the server with default options.
 --let $restart_parameters=
 --source include/start_mysqld.inc
+
+--echo # PS-5333: Remove need for innodb_encrypt_tables to ON/FORCE when mysql.ibd is encrypted
+--let $restart_parameters="restart:--innodb-encrypt-tables=OFF"
+--source include/restart_mysqld.inc

--- a/sql/dd/types/init_mode.h
+++ b/sql/dd/types/init_mode.h
@@ -1,0 +1,37 @@
+/*
+   Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2019 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License, version 2.0,
+   as published by the Free Software Foundation.
+
+   This program is also distributed with certain software (including
+   but not limited to OpenSSL) that is licensed under separate terms,
+   as designated in a particular file or component or in included license
+   documentation.  The authors of MySQL hereby grant you an additional
+   permission to link the program and your derivative works with the
+   separately licensed software that they have included with MySQL.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License, version 2.0, for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+*/
+
+#ifndef DD_INIT_MODE_T_H_INCLUDED
+#define DD_INIT_MODE_T_H_INCLUDED
+
+/** Mode for initializing the data dictionary. */
+enum dict_init_mode_t {
+  DICT_INIT_CREATE_FILES,      //< Create all required SE files
+  DICT_INIT_CHECK_FILES,       //< Verify existence of expected files
+  DICT_INIT_UPGRADE_57_FILES,  //< Used for upgrade from mysql-5.7
+  DICT_INIT_IGNORE_FILES       //< Don't care about files at all
+};
+
+#endif  // DD_INIT_MODE_T_H_INCLUDED

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -57,6 +57,7 @@
 #include "mysql_com.h"
 #include "sql/dd/object_id.h"  // dd::Object_id
 #include "sql/dd/string_type.h"
+#include "sql/dd/types/init_mode.h"
 #include "sql/dd/types/object_table.h"  // dd::Object_table
 #include "sql/discrete_interval.h"      // Discrete_interval
 #include "sql/key.h"
@@ -1614,14 +1615,6 @@ typedef SE_cost_constants *(*get_cost_constants_t)(uint storage_category);
 */
 typedef void (*replace_native_transaction_in_thd_t)(THD *thd, void *new_trx_arg,
                                                     void **ptr_trx_arg);
-
-/** Mode for initializing the data dictionary. */
-enum dict_init_mode_t {
-  DICT_INIT_CREATE_FILES,      ///< Create all required SE files
-  DICT_INIT_CHECK_FILES,       ///< Verify existence of expected files
-  DICT_INIT_UPGRADE_57_FILES,  ///< Used for upgrade from mysql-5.7
-  DICT_INIT_IGNORE_FILES       ///< Don't care about files at all
-};
 
 /**
   Initialize the SE for being used to store the DD tables. Create

--- a/storage/innobase/dict/dict0dd.cc
+++ b/storage/innobase/dict/dict0dd.cc
@@ -68,6 +68,7 @@ Data dictionary interface */
 #include "query_options.h"
 #include "sql_base.h"
 #include "sql_table.h"
+#include "thd_raii.h"
 #endif /* !UNIV_HOTBACKUP */
 
 const char *DD_instant_col_val_coder::encode(const byte *stream, size_t in_len,
@@ -6082,4 +6083,106 @@ bool dd_is_table_in_encrypted_tablespace(const dict_table_t *table) {
     return false;
   }
 }
+
+/* false on success, true on failure */
+static bool dd_update_tablespace_dd_flags(
+    THD *thd, const char *space_name, std::function<void(uint32 &)> update) {
+  Disable_autocommit_guard autocommit_guard(thd);
+  dd::cache::Dictionary_client *client = dd::get_dd_client(thd);
+  dd::cache::Dictionary_client::Auto_releaser releaser(client);
+
+  dd::Tablespace *dd_space = nullptr;
+
+  trx_t *trx = check_trx_exists(thd);
+  trx_start_if_not_started(trx, true);
+
+  if (dd::acquire_exclusive_tablespace_mdl(thd, space_name, false)) {
+    ut_a(false);
+  }
+
+  if (client->acquire_for_modification<dd::Tablespace>(space_name, &dd_space) ||
+      dd_space == nullptr) {
+    return (true);
+  }
+
+  uint32_t dd_space_flags = 0;
+
+  if (dd_space->se_private_data().get(
+          dd_space_key_strings[DD_SPACE_FLAGS], &dd_space_flags)) {
+    return (true);
+  }
+
+  update(dd_space_flags);
+
+  /* Update DD flags for tablespace */
+  dd_space->se_private_data().set(dd_space_key_strings[DD_SPACE_FLAGS],
+                                  static_cast<uint32>(dd_space_flags));
+
+  if (dd::commit_or_rollback_tablespace_change(thd, dd_space, false)) {
+    return (true);
+  }
+
+  return (false);
+}
+
+bool dd_set_encryption_flag(THD *thd, const char *space_name) {
+  auto update_func = [](uint32_t &dd_space_flags) {
+    dd_space_flags |= (1U << FSP_FLAGS_POS_ENCRYPTION);
+  };
+  return dd_update_tablespace_dd_flags(thd, space_name, update_func);
+}
+
+bool dd_clear_encryption_flag(THD *thd, const char *space_name) {
+  auto update_func = [](uint32_t &dd_space_flags) {
+    dd_space_flags &= ~(1U << FSP_FLAGS_POS_ENCRYPTION);
+  };
+  return dd_update_tablespace_dd_flags(thd, space_name, update_func);
+}
+
+static bool dd_get_tablespace_flags(THD *thd, const char *space_name,
+                                    uint32_t &dd_space_flags) {
+  const dd::Tablespace *dd_space = nullptr;
+  dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
+
+  return thd->dd_client()->acquire(space_name, &dd_space) ||
+         dd_space == nullptr ||
+         dd_space->se_private_data().get(
+             dd_space_key_strings[DD_SPACE_FLAGS], &dd_space_flags);
+}
+
+bool dd_set_flags(THD *thd, const char *space_name,
+                  const uint32_t space_flags) {
+  auto set_flags = [](uint32_t &dd_space_flags, uint32_t space_flags) {
+    // currently we are using this function only for correcting encryption flag
+    ut_ad(dd_space_flags == space_flags ||
+          FSP_FLAGS_GET_ENCRYPTION(dd_space_flags) !=
+              FSP_FLAGS_GET_ENCRYPTION(space_flags));
+    dd_space_flags = space_flags;
+  };
+  auto update_func = std::bind(set_flags, std::placeholders::_1, space_flags);
+  return dd_update_tablespace_dd_flags(thd, space_name, update_func);
+}
+
+bool dd_fix_mysql_ibd_encryption_flag_if_needed(THD *thd,
+                                                uint32_t space_flags) {
+  uint32_t dd_space_flags;
+  if (dd_get_tablespace_flags(thd, dict_sys_t::s_dd_space_name,
+                              dd_space_flags)) {
+    return true;
+  }
+  if (FSP_FLAGS_GET_ENCRYPTION(dd_space_flags) ==
+      FSP_FLAGS_GET_ENCRYPTION(space_flags)) {
+    return false;
+  }
+  // exclude encryption flag from validation
+  dd_space_flags &= ~FSP_FLAGS_MASK_ENCRYPTION;
+  space_flags &= ~FSP_FLAGS_MASK_ENCRYPTION;
+  if (dd_space_flags != space_flags) {
+    // this should not happen - some other flags other than encryption flag are
+    // mismatched
+    return true;
+  }
+  return dd_set_flags(thd, dict_sys_t::s_dd_space_name, space_flags);
+}
+
 #endif /* !UNIV_HOTBACKUP */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5257,7 +5257,7 @@ static bool dd_open_hardcoded(space_id_t space_id, const char *filename,
     ut_ad(space->flags == flags);
 
     if (strstr(space->files.front().name, filename) != 0 &&
-        space->flags == predefined_flags) {
+        space->flags == flags) {
       fil_space_open_if_needed(space);
 
     } else {
@@ -5279,12 +5279,6 @@ static bool dd_open_hardcoded(space_id_t space_id, const char *filename,
   }
 
   if (fail) {
-    const char *str =
-        srv_encrypt_tables == SRV_ENCRYPT_TABLES_OFF ? "ON or FORCE" : "OFF";
-
-    ib::error(ER_XB_MSG_2)
-        << "If mysql.ibd opening failed with flags mismatch, try startup with"
-        << " innodb_encrypt_tables = " << str;
     my_error(ER_CANT_OPEN_FILE, MYF(0), filename, 0, "");
   }
 
@@ -5392,15 +5386,20 @@ static int innobase_init_files(dict_init_mode_t dict_init_mode,
     btr_search_enabled = old_btr_search_value;
   }
 
-  bool do_encrypt =
-      dict_detect_encryption(srv_is_upgrade_mode, upgrade_mysql_plugin_space);
+  bool do_encrypt = false;
+  bool ret = dict_detect_encryption_of_mysql_ibd(
+      dict_init_mode, upgrade_mysql_plugin_space,
+      dict_sys_t::s_dd_space_file_name, do_encrypt);
+  if (!ret) {
+    ib::error(ER_XB_MSG_2) << "Failed to determine if mysql.ibd is encrypted. "
+                              "Have you not deleted it?";
+    DBUG_RETURN(innodb_init_abort());
+  }
 
   if (do_encrypt && !Encryption::check_keyring()) {
     my_error(ER_CANNOT_FIND_KEY_IN_KEYRING, MYF(0));
     DBUG_RETURN(innodb_init_abort());
   }
-
-  bool ret;
 
   const ulint dd_space_flags =
       do_encrypt ? predefined_flags | FSP_FLAGS_MASK_ENCRYPTION

--- a/storage/innobase/include/dict0dd.h
+++ b/storage/innobase/include/dict0dd.h
@@ -1222,5 +1222,9 @@ bool dd_tablespace_update_cache(THD *thd);
 @return true if it does. */
 bool dd_is_table_in_encrypted_tablespace(const dict_table_t *table);
 
+bool dd_set_encryption_flag(THD *thd, const char *space_name);
+bool dd_clear_encryption_flag(THD *thd, const char *space_name);
+bool dd_fix_mysql_ibd_encryption_flag_if_needed(THD *thd, uint32_t space_flags);
+bool dd_set_flags(THD *thd, const char *space_name, const uint32_t space_flags);
 #include "dict0dd.ic"
 #endif

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -49,6 +49,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "rem0types.h"
 #include "row0types.h"
 #include "sql/dd/object_id.h"
+#include "sql/dd/types/init_mode.h"  // dict_init_mode_t
 #include "sync0rw.h"
 #include "trx0types.h"
 #include "univ.i"
@@ -1795,12 +1796,18 @@ dberr_t dict_get_dictionary_info_by_id(ulint dict_id, char **name,
 This can happen if Percona Server is bootstrapped with
 --innodb-encrypt-tables=ON If yes or if srv_encrypt_tables is ON/FORCE, during
 upgrade, mysql.ibd should be encrpted.
-@param[in]  is_upgrade          true in upgrade mode
+In no upgrade scenario it fetches encryption flag from first page of mysql.ibd
+to check whether it is encrypted.
+@param[in]  dict_init_mode      initalization mode
 @param[in]  mysql_plugin_space  space_id of mysql/plugin table. Used only
                                 during upgrade
-@return true if encrypted, false if not encrypted */
-bool dict_detect_encryption(bool is_upgrade, space_id_t mysql_plugin_space);
-
+@param[in]  filepath            mysql.ibd filepath
+@param[out] do_encrypt          true if encrypted, false if not encrypted
+@return true if success, false if failure */
+bool dict_detect_encryption_of_mysql_ibd(dict_init_mode_t dict_init_mode,
+                                         space_id_t mysql_plugin_space,
+                                         const char *filepath,
+                                         bool &encrypt_mysql);
 #include "dict0dict.ic"
 
 #endif

--- a/storage/innobase/include/log0recv.h
+++ b/storage/innobase/include/log0recv.h
@@ -260,6 +260,8 @@ pages.
                                 own the log mutex */
 void recv_apply_hashed_log_recs(log_t &log, bool allow_ibuf);
 
+bool is_mysql_ibd_page_0_in_redo();
+
 #if defined(UNIV_DEBUG) || defined(UNIV_HOTBACKUP)
 /** Return string name of the redo log record type.
 @param[in]	type	record log record enum

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -710,6 +710,10 @@ static recv_addr_t *recv_get_rec(space_id_t space_id, page_no_t page_no) {
   return (nullptr);
 }
 
+bool is_mysql_ibd_page_0_in_redo() {
+  return recv_get_rec(dict_sys_t::s_space_id, 0) != nullptr;
+}
+
 #ifndef UNIV_HOTBACKUP
 /** Store the collected persistent dynamic metadata to
 mysql.innodb_dynamic_metadata */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2528,6 +2528,8 @@ files_checked:
       return (srv_init_abort(err));
     }
 
+    bool mysql_ibd_page_0_present_in_redo = is_mysql_ibd_page_0_in_redo();
+
     /* We need to start log threads before asking to flush
     all dirty pages. That's because some dirty pages could
     be dirty because of ibuf merges. The ibuf merges could
@@ -2688,6 +2690,20 @@ files_checked:
       RECOVERY_CRASH(5);
 
       log_sys_close();
+
+      // We have set mysql's dd flags based on what we read from page0. This was
+      // before redo log was applied. Now we have applied changes from redo log.
+      // If there were changes in redo for page 0 of mysql.ibd we check if
+      // encryption flag has changed. If it did we amend mysql's dd encryption
+      // flags accordingly.
+      if (mysql_ibd_page_0_present_in_redo) {
+        fil_space_t *mysql_space = fil_space_get(dict_sys_t::s_space_id);
+        if (mysql_space == nullptr ||
+            dd_fix_mysql_ibd_encryption_flag_if_needed(current_thd,
+                                                       mysql_space->flags)) {
+          return (srv_init_abort(DB_ERROR));
+        }
+      }
 
       ib::info(ER_IB_MSG_1143);
 


### PR DESCRIPTION
mysql.ibd is encrypted

PS-5117 introduced requirement that innodb_encrypt_tables need to be set
to ON/FORCE on server startup when mysql.ibd is encrypted. This
requirement was added because there was a need for mysql.ibd space flags
validation against hardcoded, predefined flags. In PS mysql.ibd can be
encrypted and have encrypted flag set - thus generating a mismatch with
predefined flags. In order to check whether mysql.ibd is encrypted we
will check flags from the first page of the tablespace instead of
relaying on innodb_encrypt_tables. Apart from improvement from user
point of view it will also ease keyring encryption threads development
in 8.0 as encryption threads can also change the mysql.ibd's encryption
flag.