### PR TITLE
Fix PS-5328 (fil0crypt.h:123:7: error: 'memset_s' was not declared in…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,6 +520,9 @@ ELSE()
   ENDIF()
 ENDIF()
 
+# Portably get access to memset_s
+ADD_DEFINITIONS(-D__STDC_WANT_LIB_EXT1__=1)
+
 # Run platform tests
 INCLUDE(configure.cmake)
 


### PR DESCRIPTION
… this scope on illumos)

memset_s in C11 is only guaranteed to be available if
__STDC_LIB_EXT1__ is defined by the implementation and if user defines
__STDC_WANT_LIB_EXT1__, which we didn't do. Thus add the latter define
to CMake default defines, before the feature checks.

https://ps.cd.percona.com/view/5.7/job/percona-server-5.7-param/85/