### PR TITLE
PS-5331 : Fix instances of 'const char* const name = "foo"' to be 'st…

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -423,22 +423,22 @@ static int rocksdb_validate_set_block_cache_size(
 //////////////////////////////////////////////////////////////////////////////
 // Options definitions
 //////////////////////////////////////////////////////////////////////////////
-static constexpr ulong RDB_MAX_LOCK_WAIT_SECONDS = 1024 * 1024 * 1024;
-static constexpr ulong RDB_MAX_ROW_LOCKS = 1024 * 1024 * 1024;
-static constexpr ulong RDB_DEFAULT_ROW_LOCKS = 1024 * 1024;
-static constexpr ulong RDB_DEFAULT_BULK_LOAD_SIZE = 1000;
-static constexpr ulong RDB_MAX_BULK_LOAD_SIZE = 1024 * 1024 * 1024;
-static constexpr size_t RDB_DEFAULT_MERGE_BUF_SIZE = 64 * 1024 * 1024;
-static constexpr size_t RDB_MIN_MERGE_BUF_SIZE = 100;
-static constexpr size_t RDB_DEFAULT_MERGE_COMBINE_READ_SIZE = 1024 * 1024 * 1024;
-static constexpr size_t RDB_MIN_MERGE_COMBINE_READ_SIZE = 100;
-static constexpr size_t RDB_DEFAULT_MERGE_TMP_FILE_REMOVAL_DELAY = 0;
-static constexpr size_t RDB_MIN_MERGE_TMP_FILE_REMOVAL_DELAY = 0;
-static constexpr int64 RDB_DEFAULT_BLOCK_CACHE_SIZE = 512 * 1024 * 1024;
-static constexpr int64 RDB_MIN_BLOCK_CACHE_SIZE = 1024;
-static constexpr int RDB_MAX_CHECKSUMS_PCT = 100;
-static constexpr uint32_t RDB_DEFAULT_FORCE_COMPUTE_MEMTABLE_STATS_CACHETIME = 60 * 1000 * 1000;
-static constexpr ulong RDB_DEADLOCK_DETECT_DEPTH = 50;
+static const constexpr ulong RDB_MAX_LOCK_WAIT_SECONDS = 1024 * 1024 * 1024;
+static const constexpr ulong RDB_MAX_ROW_LOCKS = 1024 * 1024 * 1024;
+static const constexpr ulong RDB_DEFAULT_ROW_LOCKS = 1024 * 1024;
+static const constexpr ulong RDB_DEFAULT_BULK_LOAD_SIZE = 1000;
+static const constexpr ulong RDB_MAX_BULK_LOAD_SIZE = 1024 * 1024 * 1024;
+static const constexpr size_t RDB_DEFAULT_MERGE_BUF_SIZE = 64 * 1024 * 1024;
+static const constexpr size_t RDB_MIN_MERGE_BUF_SIZE = 100;
+static const constexpr size_t RDB_DEFAULT_MERGE_COMBINE_READ_SIZE = 1024 * 1024 * 1024;
+static const constexpr size_t RDB_MIN_MERGE_COMBINE_READ_SIZE = 100;
+static const constexpr size_t RDB_DEFAULT_MERGE_TMP_FILE_REMOVAL_DELAY = 0;
+static const constexpr size_t RDB_MIN_MERGE_TMP_FILE_REMOVAL_DELAY = 0;
+static const constexpr int64 RDB_DEFAULT_BLOCK_CACHE_SIZE = 512 * 1024 * 1024;
+static const constexpr int64 RDB_MIN_BLOCK_CACHE_SIZE = 1024;
+static const constexpr int RDB_MAX_CHECKSUMS_PCT = 100;
+static const constexpr uint32_t RDB_DEFAULT_FORCE_COMPUTE_MEMTABLE_STATS_CACHETIME = 60 * 1000 * 1000;
+static const constexpr ulong RDB_DEADLOCK_DETECT_DEPTH = 50;
 
 static long long rocksdb_block_cache_size = RDB_DEFAULT_BLOCK_CACHE_SIZE;
 static long long rocksdb_sim_cache_size = 0;

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -131,7 +131,7 @@ extern const std::string DEFAULT_SYSTEM_CF_NAME;
 /*
   This is the name of the hidden primary key for tables with no pk.
 */
-const char *const HIDDEN_PK_NAME = "HIDDEN_PK_ID";
+const constexpr char HIDDEN_PK_NAME[] = "HIDDEN_PK_ID";
 
 /*
   Column family name which means "put this index into its own column family".
@@ -142,12 +142,12 @@ extern const std::string PER_INDEX_CF_NAME;
 /*
   Name for the background thread.
 */
-const char *const BG_THREAD_NAME = "myrocks-bg";
+const constexpr char BG_THREAD_NAME[] = "myrocks-bg";
 
 /*
   Name for the drop index thread.
 */
-const char *const INDEX_THREAD_NAME = "myrocks-index";
+const constexpr char INDEX_THREAD_NAME[] = "myrocks-index";
 
 /*
   Separator between partition name and the qualifier. Sample usage:
@@ -155,7 +155,7 @@ const char *const INDEX_THREAD_NAME = "myrocks-index";
   - p0_cfname=foo
   - p3_tts_col=bar
 */
-constexpr char RDB_PER_PARTITION_QUALIFIER_NAME_SEP = '_';
+const constexpr char RDB_PER_PARTITION_QUALIFIER_NAME_SEP = '_';
 
 /*
   Separator between qualifier name and value. Sample usage:
@@ -163,29 +163,29 @@ constexpr char RDB_PER_PARTITION_QUALIFIER_NAME_SEP = '_';
   - p0_cfname=foo
   - p3_tts_col=bar
 */
-constexpr char RDB_QUALIFIER_VALUE_SEP = '=';
+const constexpr char RDB_QUALIFIER_VALUE_SEP = '=';
 
 /*
   Separator between multiple qualifier assignments. Sample usage:
 
   - p0_cfname=foo;p1_cfname=bar;p2_cfname=baz
 */
-constexpr char RDB_QUALIFIER_SEP = ';';
+const constexpr char RDB_QUALIFIER_SEP = ';';
 
 /*
   Qualifier name for a custom per partition column family.
 */
-const char *const RDB_CF_NAME_QUALIFIER = "cfname";
+const constexpr char RDB_CF_NAME_QUALIFIER[] = "cfname";
 
 /*
   Qualifier name for a custom per partition ttl duration.
 */
-const char *const RDB_TTL_DURATION_QUALIFIER = "ttl_duration";
+const constexpr char RDB_TTL_DURATION_QUALIFIER[] = "ttl_duration";
 
 /*
   Qualifier name for a custom per partition ttl duration.
 */
-const char *const RDB_TTL_COL_QUALIFIER = "ttl_col";
+const constexpr char RDB_TTL_COL_QUALIFIER[] = "ttl_col";
 
 /*
   Default, minimal valid, and maximum valid sampling rate values when collecting
@@ -215,15 +215,15 @@ const char *const RDB_TTL_COL_QUALIFIER = "ttl_col";
   CPU-s and derive the values from there. This however has its own set of
   problems and we'll choose simplicity for now.
 */
-constexpr int MAX_BACKGROUND_JOBS = 64;
+const constexpr int MAX_BACKGROUND_JOBS = 64;
 
-constexpr int DEFAULT_SUBCOMPACTIONS = 1;
-constexpr int MAX_SUBCOMPACTIONS = 64;
+const constexpr int DEFAULT_SUBCOMPACTIONS = 1;
+const constexpr int MAX_SUBCOMPACTIONS = 64;
 
 /*
   Default value for rocksdb_sst_mgr_rate_bytes_per_sec = 0 (disabled).
 */
-constexpr uint64_t DEFAULT_SST_MGR_RATE_BYTES_PER_SEC = 0;
+const constexpr uint64_t DEFAULT_SST_MGR_RATE_BYTES_PER_SEC = 0;
 
 /*
   Defines the field sizes for serializing XID object to a string representation.
@@ -266,8 +266,8 @@ constexpr uint64_t DEFAULT_SST_MGR_RATE_BYTES_PER_SEC = 0;
 /*
   Maximum index prefix length in bytes.
 */
-constexpr uint MAX_INDEX_COL_LEN_LARGE = 3072;
-constexpr uint MAX_INDEX_COL_LEN_SMALL = 767;
+const constexpr uint MAX_INDEX_COL_LEN_LARGE = 3072;
+const constexpr uint MAX_INDEX_COL_LEN_SMALL = 767;
 
 /*
   MyRocks specific error codes. NB! Please make sure that you will update
@@ -341,7 +341,7 @@ class Rdb_transaction_impl;
 class Rdb_writebatch_impl;
 class Rdb_field_encoder;
 
-const char *const rocksdb_hton_name = "ROCKSDB";
+const constexpr char rocksdb_hton_name[] = "ROCKSDB";
 
 typedef struct _gl_index_id_s {
   uint32_t cf_id;

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -91,51 +91,51 @@ using rdb_index_field_pack_t =
     void (Rdb_key_def::*)(Rdb_field_packing *fpi, Field *field, uchar *buf,
                           uchar **dst, Rdb_pack_field_context *pack_ctx) const;
 
-const uint RDB_INVALID_KEY_LEN = uint(-1);
+const constexpr uint RDB_INVALID_KEY_LEN = uint(-1);
 
 /* How much one checksum occupies when stored in the record */
-const size_t RDB_CHECKSUM_SIZE = sizeof(uint32_t);
+const constexpr size_t RDB_CHECKSUM_SIZE = sizeof(uint32_t);
 
 /*
   How much the checksum data occupies in record, in total.
   It is storing two checksums plus 1 tag-byte.
 */
-const size_t RDB_CHECKSUM_CHUNK_SIZE = 2 * RDB_CHECKSUM_SIZE + 1;
+const constexpr size_t RDB_CHECKSUM_CHUNK_SIZE = 2 * RDB_CHECKSUM_SIZE + 1;
 
 /*
   Checksum data starts from CHECKSUM_DATA_TAG which is followed by two CRC32
   checksums.
 */
-const char RDB_CHECKSUM_DATA_TAG = 0x01;
+const constexpr char RDB_CHECKSUM_DATA_TAG = 0x01;
 
 /*
   Unpack data is variable length. The header is 1 tag-byte plus a two byte
   length field. The length field includes the header as well.
 */
-const char RDB_UNPACK_DATA_TAG = 0x02;
-const size_t RDB_UNPACK_DATA_LEN_SIZE = sizeof(uint16_t);
-const size_t RDB_UNPACK_HEADER_SIZE =
+const constexpr char RDB_UNPACK_DATA_TAG = 0x02;
+const constexpr size_t RDB_UNPACK_DATA_LEN_SIZE = sizeof(uint16_t);
+const constexpr size_t RDB_UNPACK_HEADER_SIZE =
     sizeof(RDB_UNPACK_DATA_TAG) + RDB_UNPACK_DATA_LEN_SIZE;
 
 /*
   This header format is 1 tag-byte plus a two byte length field plus a two byte
   covered bitmap. The length field includes the header size.
 */
-const char RDB_UNPACK_COVERED_DATA_TAG = 0x03;
-const size_t RDB_UNPACK_COVERED_DATA_LEN_SIZE = sizeof(uint16_t);
-const size_t RDB_COVERED_BITMAP_SIZE = sizeof(uint16_t);
-const size_t RDB_UNPACK_COVERED_HEADER_SIZE =
+const constexpr char RDB_UNPACK_COVERED_DATA_TAG = 0x03;
+const constexpr size_t RDB_UNPACK_COVERED_DATA_LEN_SIZE = sizeof(uint16_t);
+const constexpr size_t RDB_COVERED_BITMAP_SIZE = sizeof(uint16_t);
+const constexpr size_t RDB_UNPACK_COVERED_HEADER_SIZE =
     sizeof(RDB_UNPACK_COVERED_DATA_TAG) + RDB_UNPACK_COVERED_DATA_LEN_SIZE +
     RDB_COVERED_BITMAP_SIZE;
 
 /*
   Data dictionary index info field sizes.
 */
-constexpr size_t RDB_SIZEOF_INDEX_INFO_VERSION = sizeof(uint16);
-constexpr size_t RDB_SIZEOF_INDEX_TYPE = sizeof(uchar);
-constexpr size_t RDB_SIZEOF_KV_VERSION = sizeof(uint16);
-constexpr size_t RDB_SIZEOF_INDEX_FLAGS = sizeof(uint32);
-constexpr size_t RDB_SIZEOF_AUTO_INCREMENT_VERSION = sizeof(uint16);
+const constexpr size_t RDB_SIZEOF_INDEX_INFO_VERSION = sizeof(uint16);
+const constexpr size_t RDB_SIZEOF_INDEX_TYPE = sizeof(uchar);
+const constexpr size_t RDB_SIZEOF_KV_VERSION = sizeof(uint16);
+const constexpr size_t RDB_SIZEOF_INDEX_FLAGS = sizeof(uint32);
+const constexpr size_t RDB_SIZEOF_AUTO_INCREMENT_VERSION = sizeof(uint16);
 
 // Possible return values for rdb_index_field_unpack_t functions.
 enum {

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -147,7 +147,7 @@ namespace myrocks {
 /*
   Generic constant.
 */
-const size_t RDB_MAX_HEXDUMP_LEN = 1000;
+const constexpr size_t RDB_MAX_HEXDUMP_LEN = 1000;
 
 /*
   Helper function to get an NULL terminated uchar* out of a given MySQL String.


### PR DESCRIPTION
…atic const constexpr char name[]= "foo"'

- Subject says it all, modernize 'const' to 'constexpr'