### PR TITLE
Fix PS-5369 (buf_pool_zip_hash mutex declared with buf_pool_zip_free …

### DIFF
--- a/storage/innobase/sync/sync0debug.cc
+++ b/storage/innobase/sync/sync0debug.cc
@@ -1356,7 +1356,7 @@ sync_latch_meta_init()
 			buf_pool_zip_free_mutex_key);
 
 	LATCH_ADD_MUTEX(BUF_POOL_ZIP_HASH, SYNC_BUF_ZIP_HASH,
-			buf_pool_zip_free_mutex_key);
+			buf_pool_zip_hash_mutex_key);
 
 	LATCH_ADD_MUTEX(BUF_POOL_FLUSH_STATE, SYNC_BUF_FLUSH_STATE,
 			buf_pool_flush_state_mutex_key);


### PR DESCRIPTION
…key)

Backport a trivial fix [1] from upstream 8.0.14: buf_pool_zip_hash
mutex was declared with the wrong key (buf_pool_zip_free). Do not
bother with cherry-picking due to fix triviality.

[1]:

commit 5ce335439e2fe2bda98c2292116f41959cfda8da
Author: Rahul Agarkar <rahul.agarkar@oracle.com>
Date:   Wed Sep 26 10:12:25 2018 +0530

    Bug#28556539 LOCK_ORDER: CYCLE INVOLVING BUF_POOL_FREE_LIST_MUTEX AND
    BUF_POOL_ZIP_FREE_MUTEX

    Problem:
    The LOCK_ORDER tool reports a cycle in innodb mutex locks because of
    incorrectly mapped key while creating a mutex. Because of this incorrect
    mapping, the tool assumes there is a cycle between two mutexes
    potentially leading to a deadlock.

    Solution:
    Replaced the incorrect key with the correct one

    RB: 20610
    Reviewed By: Debarun Banerjee (debarun.banerjee@oracle.com)

https://ps.cd.percona.com/view/5.7/job/percona-server-5.7-param/92/