### PR TITLE
Fix PS-5388 (Enable hardware CRC32 under Valgrind)

### DIFF
--- a/storage/innobase/ut/ut0crc32.cc
+++ b/storage/innobase/ut/ut0crc32.cc
@@ -287,26 +287,7 @@ ut_crc32_init()
 	ut_cpuid(vend, &model, &family, &stepping,
 		 &features_ecx, &features_edx);
 
-	/* Valgrind does not understand the CRC32 instructions:
-
-	vex amd64->IR: unhandled instruction bytes: 0xF2 0x48 0xF 0x38 0xF0 0xA
-	valgrind: Unrecognised instruction at address 0xad3db5.
-	Your program just tried to execute an instruction that Valgrind
-	did not recognise.  There are two possible reasons for this.
-	1. Your program has a bug and erroneously jumped to a non-code
-	   location.  If you are running Memcheck and you just saw a
-	   warning about a bad jump, it's probably your program's fault.
-	2. The instruction is legitimate but Valgrind doesn't handle it,
-	   i.e. it's Valgrind's fault.  If you think this is the case or
-	   you are not sure, please let us know and we'll try to fix it.
-	Either way, Valgrind will now raise a SIGILL signal which will
-	probably kill your program.
-
-	*/
-#ifndef UNIV_DEBUG_VALGRIND
 	ut_crc32_sse2_enabled = (features_ecx >> 20) & 1;
-#endif /* UNIV_DEBUG_VALGRIND */
-
 #endif /* defined(__GNUC__) && defined(__x86_64__) */
 
 	if (ut_crc32_sse2_enabled) {


### PR DESCRIPTION
Valgrind started supporting CRC32 instruction starting with version
3.6.1, released in 2011. Thus remove the fallback to software
implementation in case running under Valgrind.

https://ps2.cd.percona.com/view/5.6/job/percona-server-5.6-param/3/