### PR TITLE
PS-5395: Huge memory usage for audit plugin when large queries are

### DIFF
--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -636,7 +636,8 @@ char *audit_log_general_record(char *buf, size_t buflen,
     endptr= endbuf;
     query= escape_string(event->general_query, event->general_query_length,
                          endptr, endbuf - endptr, &endptr, &full_outlen);
-    full_outlen+= full_outlen * my_charset_utf8mb4_general_ci.mbmaxlen;
+    full_outlen*= my_charset_utf8mb4_general_ci.mbmaxlen;
+    full_outlen+= query_length * my_charset_utf8mb4_general_ci.mbmaxlen;
   }
 
   user= escape_string(event->general_user, event->general_user_length,
@@ -1218,7 +1219,7 @@ void audit_log_notify(MYSQL_THD thd MY_ATTRIBUTE((unused)),
                                         &len);
       if (len > buflen)
       {
-        buflen= len * 4;
+        buflen= len + 1024;
         log_rec= audit_log_general_record(get_record_buffer(thd, buflen),
                                           buflen,
                                           event_general->general_command,
@@ -1226,6 +1227,7 @@ void audit_log_notify(MYSQL_THD thd MY_ATTRIBUTE((unused)),
                                           event_general->general_error_code,
                                           event_general, local->db,
                                           &len);
+        DBUG_ASSERT(log_rec);
       }
       if (log_rec)
         audit_log_write(log_rec, len);


### PR DESCRIPTION
executed

Given 10 threads each running 10 MiB queries audit plugin allocates 400
MiB of RAM.

This is because of the following:

1. Large buffer is allocated per thread
2. Its size is 4x record size
3. Record size is greater than 10 MiB
4. 10 threads are running queries

10 MiB * 4 * 10 = 400 MiB

This patch makes audit plugin to reserve less memory for the record
buffer (roughly equal the query size) down total memory to 100 MiB in
our case.