### PR TITLE
Fix PS-5395 in 8.0

### DIFF
--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -636,7 +636,8 @@ char *audit_log_general_record(char *buf, size_t buflen,
     endptr= endbuf;
     query= escape_string(event->general_query, event->general_query_length,
                          endptr, endbuf - endptr, &endptr, &full_outlen);
-    full_outlen+= full_outlen * my_charset_utf8mb4_general_ci.mbmaxlen;
+    full_outlen*= my_charset_utf8mb4_general_ci.mbmaxlen;
+    full_outlen+= query_length * my_charset_utf8mb4_general_ci.mbmaxlen;
   }
 
   user= escape_string(event->general_user, event->general_user_length,
@@ -1218,7 +1219,7 @@ void audit_log_notify(MYSQL_THD thd MY_ATTRIBUTE((unused)),
                                         &len);
       if (len > buflen)
       {
-        buflen= len * 4;
+        buflen= len + 1024;
         log_rec= audit_log_general_record(get_record_buffer(thd, buflen),
                                           buflen,
                                           event_general->general_command,
@@ -1226,6 +1227,7 @@ void audit_log_notify(MYSQL_THD thd MY_ATTRIBUTE((unused)),
                                           event_general->general_error_code,
                                           event_general, local->db,
                                           &len);
+        DBUG_ASSERT(log_rec);
       }
       if (log_rec)
         audit_log_write(log_rec, len);


### PR DESCRIPTION
https://ps2.cd.percona.com/view/8.0/job/percona-server-8.0-param/22/

Looks like audit log tests are not run by default. Test case failures don't seem to be related to this patch. Something is wrong with logging connects and disconnects it seems.