### PR TITLE
Add thd_wait_begin & thd_wait_end call for BINLOG dump

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1929,15 +1929,19 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
       break;
     case COM_BINLOG_DUMP_GTID:
       // TODO: access of protocol_classic should be removed
+      thd_wait_begin(thd, THD_WAIT_BINLOG);
       error = com_binlog_dump_gtid(
           thd, (char *)thd->get_protocol_classic()->get_raw_packet(),
           thd->get_protocol_classic()->get_packet_length());
+      thd_wait_end(thd);
       break;
     case COM_BINLOG_DUMP:
       // TODO: access of protocol_classic should be removed
+      thd_wait_begin(thd, THD_WAIT_BINLOG);
       error = com_binlog_dump(
           thd, (char *)thd->get_protocol_classic()->get_raw_packet(),
           thd->get_protocol_classic()->get_packet_length());
+      thd_wait_end(thd);
       break;
     case COM_REFRESH: {
       int not_used;

--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -137,7 +137,8 @@ int threadpool_add_connection(THD *thd) {
   int retval = 1;
   Worker_thread_context worker_context;
 
-  my_thread_init();
+  /* this function is executed when worker started */
+  /* my_thread_init(); */
 
   /* Create new PSI thread for use with the THD. */
 #ifdef HAVE_PSI_THREAD_INTERFACE


### PR DESCRIPTION
To decrease the active thread count under thread pool mode, else active_thread_pool may not be zero for specific thread group