### PR TITLE
Fix PS-5441 (Redundant -master.opt files for some tokudb.parts tests)

### DIFF
--- a/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb-master.opt
+++ b/mysql-test/suite/tokudb.parts/t/partition_debug_sync_tokudb-master.opt
@@ -1,1 +1,0 @@
---innodb_file_per_table=1

--- a/mysql-test/suite/tokudb.parts/t/partition_debug_tokudb-master.opt
+++ b/mysql-test/suite/tokudb.parts/t/partition_debug_tokudb-master.opt
@@ -1,1 +1,0 @@
---innodb-file-format-check --innodb-file-per-table=1

--- a/mysql-test/suite/tokudb.parts/t/partition_special_tokudb-master.opt
+++ b/mysql-test/suite/tokudb.parts/t/partition_special_tokudb-master.opt
@@ -1,1 +1,0 @@
---innodb_lock_wait_timeout=2 --innodb-file-per-table=1


### PR DESCRIPTION
Remove redundant copy-pasted-from-InnoDB MTR option files.

https://ps2.cd.percona.com/view/5.6/job/percona-server-5.6-param/10/

Obvious, self approving