### PR TITLE
Fix PS-5442 (Intermittent sql/log.cc:1479: bool Query_logger::slow_lo…

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -1476,7 +1476,7 @@ void Query_logger::cleanup()
 bool Query_logger::slow_log_write(THD *thd, const char *query,
                                   size_t query_length)
 {
-  DBUG_ASSERT(thd->enable_slow_log && opt_slow_log);
+  DBUG_ASSERT(thd->enable_slow_log);
 
   if (!(*slow_log_handler_list))
     return false;


### PR DESCRIPTION
…g_write(THD*, const char*, size_t): Assertion `thd->enable_slow_log && opt_slow_log' failed)

"DBUG_ASSERT(thd->enable_slow_log && opt_slow_log);" is problematic:
1) tests two conditions at once;
2) is racy with respect to opt_slow_log check, because it might change
after the current thread has already made the decision to log.

Remove opt_slow_log check from the assert.

https://ps2.cd.percona.com/view/5.7/job/percona-server-5.7-param/29/