### PR TITLE
Fix PS-3581 (LP #1633993: Failing assertion: !buf_page_hash_get_low(b…

### DIFF
--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1467,19 +1467,6 @@ buf_pool_watch_is_sentinel(
 	const buf_page_t*	bpage)		/*!< in: block */
 	MY_ATTRIBUTE((nonnull, warn_unused_result));
 
-/** Add watch for the given page to be read in. Caller must have
-appropriate hash_lock for the bpage and hold the LRU list mutex to avoid a race
-condition with buf_LRU_free_page inserting the same page into the page hash.
-This function may release the hash_lock and reacquire it.
-@param[in]	page_id		page id
-@param[in,out]	hash_lock	hash_lock currently latched
-@return NULL if watch set, block if the page is in the buffer pool */
-buf_page_t*
-buf_pool_watch_set(
-	const page_id_t&	page_id,
-	rw_lock_t**		hash_lock)
-MY_ATTRIBUTE((warn_unused_result));
-
 /** Stop watching if the page has been read in.
 buf_pool_watch_set(space,offset) must have returned NULL before.
 @param[in]	page_id	page id */


### PR DESCRIPTION
…uf_pool, b->id))

This is a regression of PS-851 (LP #1395543: buf_LRU_free_page()
crashes at !buf_page_hash_get_low( buf_pool, b->space, b->offset,
fold)), whose fix was not merged to 5.7 correctly. Hence the root
cause is the same plausible schedule:

- Thread 1 calls buf_LRU_free_page(bpage, false). bpage is an
  uncompressed frame of a compressed page. The code takes the page
  hash lock, calls buf_LRU_block_remove_hashed(bpage, false), which
  removes the page from the page hash and releases the hash lock.
- Thread 53 takes the hash lock and calls buf_pool_watch_set for the
  same page. It does not find it in the page hash, unlocks the hash
  lock, locks all the hash locks, inserts a page into page hash,
  unlocks all but the original hash lock.
- Thread 1 buf_LRU_free_page takes hash lock and the page mutex, finds
  the page in page_hash, crashes.

Does not happen in upstream 5.7 because there buf_pool_watch_set
acquires the buffer pool mutex, rechecks page hash, and
buf_LRU_free_page hold the buffer pool mutex throughout the race
window.

Fix by porting the missing bits of the original fix to 5.7. At the
same time make buf_pool_watch_set static to buf0buf.cc, which is the
sole file where it's used, to make reasoning easier.

https://ps.cd.percona.com/view/5.7/job/percona-server-5.7-param/122/