### PR TITLE
PS-5446: FLUSH CHANGED_PAGE_BITMAPS leaves gaps between the last written

### DIFF
--- a/mysql-test/suite/innodb/include/log_read_tracked_lsn.inc
+++ b/mysql-test/suite/innodb/include/log_read_tracked_lsn.inc
@@ -1,0 +1,2 @@
+--replace_regex /.*Log tracked up to[[:space:]]*([0-9]+).*/\1/gso /InnoDB//
+let $tracked_lsn=`SHOW ENGINE INNODB STATUS`;

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush_5446.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush_5446.result
@@ -1,0 +1,8 @@
+call mtr.add_suppression("Log writer is waiting for tracker to to catch up lag");
+SET GLOBAL innodb_monitor_enable = module_log;
+FLUSH CHANGED_PAGE_BITMAPS;
+CREATE TABLE t (a INT, b TEXT);
+FLUSH CHANGED_PAGE_BITMAPS;
+FLUSH CHANGED_PAGE_BITMAPS;
+DROP TABLE t;
+SET GLOBAL innodb_monitor_enable = default;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush_5446-master.opt
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush_5446-master.opt
@@ -1,0 +1,1 @@
+--innodb_track_changed_pages=TRUE

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush_5446.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush_5446.test
@@ -1,0 +1,45 @@
+
+call mtr.add_suppression("Log writer is waiting for tracker to to catch up lag");
+
+# Enable InnoDB metrics
+
+SET GLOBAL innodb_monitor_enable = module_log;
+
+# check that FLUSH does not hang
+FLUSH CHANGED_PAGE_BITMAPS;
+
+CREATE TABLE t (a INT, b TEXT);
+
+let $i=0;
+
+--disable_query_log
+while ($i < 500)
+{
+  INSERT INTO t (a, b) VALUES (1, REPEAT('b', 6000)), (1, REPEAT('b', 6000));
+  inc $i;
+}
+--enable_query_log
+
+--source ../include/log_read_checkpoint_lsn.inc
+
+FLUSH CHANGED_PAGE_BITMAPS;
+
+--source ../include/log_read_tracked_lsn.inc
+
+if ($checkpoint_lsn > $tracked_lsn) {
+  --echo "checkpoint lsn is greater than tracked lsn $checkpoint_lsn vs $tracked_lsn"
+}
+
+# Wait for all dirty pages to be flushed.
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+# check that FLUSH does not hang
+FLUSH CHANGED_PAGE_BITMAPS;
+
+
+DROP TABLE t;
+
+--disable_warnings
+SET GLOBAL innodb_monitor_enable = default;
+--enable_warnings

--- a/storage/innobase/include/log0online.h
+++ b/storage/innobase/include/log0online.h
@@ -52,6 +52,14 @@ void log_online_shutdown(void) noexcept;
 changed page bitmap which is then written to disk.
 
 @return true if log tracking succeeded, false if bitmap write I/O error */
+MY_NODISCARD
+bool log_online_follow_redo_log_one_pass(void);
+
+/** Read and parse redo log for thr FLUSH CHANGED_PAGE_BITMAPS command.
+Make sure that the checkpoint LSN measured at the beginning of the command
+is tracked.
+
+@return true if log tracking succeeded, false if bitmap write I/O error */
 bool log_online_follow_redo_log(void);
 
 /** Delete all the bitmap files for data less than the specified LSN.

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -761,7 +761,7 @@ static void log_online_track_missing_on_startup(
     ib::info() << "Reading the log to advance the last tracked LSN.";
 
     log_bmp_sys->start_at(std::max(last_tracked_lsn, MIN_TRACKED_LSN));
-    if (!log_online_follow_redo_log()) {
+    if (!log_online_follow_redo_log_one_pass()) {
       exit(1);
     }
     ut_ad(log_bmp_sys->end_lsn == tracking_start_lsn);
@@ -1317,12 +1317,10 @@ static void log_online_parse_complete_recs_past_previous_checkpoint() noexcept {
 page bitmap which is then written to disk.
 
 @return true if log tracking succeeded, false if bitmap write I/O error */
-bool log_online_follow_redo_log(void) {
+bool log_online_follow_redo_log_one_pass(void) {
   ut_ad(!srv_read_only_mode);
 
   if (!srv_track_changed_pages) return true;
-
-  DEBUG_SYNC_C("log_online_follow_redo_log");
 
   mutex_enter(&log_bmp_sys_mutex);
 
@@ -1350,10 +1348,31 @@ bool log_online_follow_redo_log(void) {
   if (result) {
     result = log_online_write_bitmap();
     log_bmp_sys->start_lsn = log_bmp_sys->end_lsn;
-    log_sys->tracked_lsn.store(log_bmp_sys->start_lsn);
+    log_sys->tracked_lsn.store(log_bmp_sys->parse_buf.get_current_lsn());
   }
 
   mutex_exit(&log_bmp_sys_mutex);
+  return result;
+}
+
+/** Read and parse redo log for thr FLUSH CHANGED_PAGE_BITMAPS command.
+Make sure that the checkpoint LSN measured at the beginning of the command
+is tracked.
+
+@return true if log tracking succeeded, false if bitmap write I/O error */
+bool log_online_follow_redo_log(void) {
+  ut_ad(!srv_read_only_mode);
+
+  const auto last_checkpoint_lsn = log_get_checkpoint_lsn(*log_sys);
+  bool result = true;
+
+  DEBUG_SYNC_C("log_online_follow_redo_log");
+
+  while (result && srv_track_changed_pages &&
+         last_checkpoint_lsn > log_sys->tracked_lsn.load()) {
+    result = log_online_follow_redo_log_one_pass();
+  }
+
   return result;
 }
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2051,7 +2051,7 @@ void srv_redo_log_follow_thread() {
 
     if (srv_track_changed_pages &&
         srv_shutdown_state < SRV_SHUTDOWN_LAST_PHASE) {
-      if (!log_online_follow_redo_log()) {
+      if (!log_online_follow_redo_log_one_pass()) {
         /* TODO: sync with I_S log tracking status? */
         ib::error() << "Log tracking bitmap write "
                        "failed, stopping log tracking thread!";

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2676,7 +2676,7 @@ files_checked:
         const lsn_t checkpoint_lsn = log_sys->last_checkpoint_lsn;
         ib::info() << "Tracking redo log synchronously until "
                    << checkpoint_lsn;
-        if (!log_online_follow_redo_log()) {
+        if (!log_online_follow_redo_log_one_pass()) {
           return (srv_init_abort(DB_ERROR));
         }
       }


### PR DESCRIPTION
bitmap LSN and InnoDB checkpoint LSN

Analysis.

xtrabackup determines the checkpoint lsn at the beginning of the backup
and starts the redo log copying. Then it invokes FLUSH
CHANGED_PAGE_BITMAPS.

FLUSH CHANGED_PAGE_BITMAPS implementation simply runs
log_online_follow_redo_log which may finish scanning before reaching
checkpoint lsn.

xtrabackup will than see that tracked lsn is less than checkpoint lsn
and changed page bitmaps are unusable.

Fix.

Fix is to save checkpoint lsn at the beginning of the flush
command. This lsn will be greater or equal to the one xtrabackup
has. Then run log_online_follow_redo_log until tracked lsn is greater or
equal to saved checkpoint lsn.