### PR TITLE
PS-5447: Changed page tracking is missing pages changed by the in-place

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_5447.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_5447.result
@@ -1,0 +1,10 @@
+select @@innodb_track_changed_pages;
+@@innodb_track_changed_pages
+1
+CREATE TABLE t (a INT);
+# restart
+RESET CHANGED_PAGE_BITMAPS;
+ALTER TABLE t ADD INDEX (a);
+FLUSH CHANGED_PAGE_BITMAPS;
+# restart
+DROP TABLE t;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_5447-master.opt
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_5447-master.opt
@@ -1,0 +1,1 @@
+--innodb_track_changed_pages=1

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_5447.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_5447.test
@@ -1,0 +1,41 @@
+#
+# PS-5447: Changed page tracking is missing pages changed by the in-place DDL
+#
+
+--source include/have_innodb.inc
+
+select @@innodb_track_changed_pages;
+
+CREATE TABLE t (a INT);
+
+let $i=0;
+
+disable_query_log;
+while ($i < 1000)
+{
+  eval INSERT INTO t (a) VALUES ($i);
+  inc $i;
+}
+enable_query_log;
+
+# Delete any existing bitmaps
+--source include/restart_mysqld.inc
+RESET CHANGED_PAGE_BITMAPS;
+
+ALTER TABLE t ADD INDEX (a);
+
+FLUSH CHANGED_PAGE_BITMAPS;
+
+--source include/restart_mysqld.inc
+
+let $space_id=`SELECT SPACE FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = 'test/t'`;
+let $npages=`SELECT COUNT(DISTINCT page_id) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES WHERE SPACE_ID = $space_id`;
+let $file_size=`SELECT FILE_SIZE FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE SPACE = $space_id`;
+let $tracked_size=`SELECT $npages * 16 * 1024`;
+
+if ($tracked_size != $file_size)
+{
+  echo Number of changed pages $npages does not match the file size $file_size;
+}
+
+DROP TABLE t;

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -886,6 +886,14 @@ log_online_parse_redo_log(void)
 
 				ut_a(len >= 3);
 				log_online_set_page_bit(space, page_no);
+				if (type == MLOG_INDEX_LOAD) {
+					const ulint space_size =
+						fil_space_get_size(space);
+					for (ulint i = 0; i < space_size; i++) {
+						log_online_set_page_bit(
+							space, i);
+					}
+				}
 			}
 
 			ptr += len;


### PR DESCRIPTION
DDL

In-place DDL does not redo log changes. The only redo log record it logs
is the MLOG_INDEX_LOAD with space_id and the root page of the changed
index. Fix is to mark all pages of affected tablespace as changed.