### PR TITLE
PS-226: Audit Log Creates Unparsable Date String

### DIFF
--- a/plugin/audit_log/audit_log.cc
+++ b/plugin/audit_log/audit_log.cc
@@ -145,7 +145,7 @@ static char *make_timestamp(char *buf, size_t buf_len, time_t t) noexcept {
   tm tm;
 
   memset(&tm, 0, sizeof(tm));
-  strftime(buf, buf_len, "%FT%T UTC", gmtime_r(&t, &tm));
+  strftime(buf, buf_len, "%FT%TZ", gmtime_r(&t, &tm));
 
   return buf;
 }


### PR DESCRIPTION
Problem:
--------
The audit log currently produces time stamps like this:

2016-11-15T12:12:34 UTC

This is not a recognized standard for ISO8601.

Fix:
----
Log time in the ISO8601 standard. Note that this change might
break any applications that parse the audit log time in old format.
```
Before fix:

<?xml version="1.0" encoding="UTF-8"?>
<AUDIT>
<AUDIT_RECORD>
  <NAME>Quit</NAME>
  <RECORD>1_2019-03-06T04:05:20</RECORD>
  <TIMESTAMP>2019-03-06T04:05:20 UTC</TIMESTAMP>
  <CONNECTION_ID>9</CONNECTION_ID>

After fix:

<?xml version="1.0" encoding="UTF-8"?>
<AUDIT>
<AUDIT_RECORD>
  <NAME>Quit</NAME>
  <RECORD>1_2019-03-06T04:01:52</RECORD>
  <TIMESTAMP>2019-03-06T04:01:52Z</TIMESTAMP>
```