### PR TITLE
Fix PS-5456 (Empty xtradb_zip_dict MTR testcase check not restored in…

### DIFF
--- a/mysql-test/include/mtr_check.sql
+++ b/mysql-test/include/mtr_check.sql
@@ -141,9 +141,8 @@ BEGIN
   -- INSTALL/UNINSTALL command
   SELECT * FROM INFORMATION_SCHEMA.PLUGINS;
 
-  -- Percona disabled until zip dictionary reimplementation in the new DD
-  -- -- Dump all created compression dictionaries
-  -- SELECT * FROM information_schema.xtradb_zip_dict ORDER BY name;
+  -- Dump all created compression dictionaries
+  SELECT * FROM INFORMATION_SCHEMA.COMPRESSION_DICTIONARY ORDER BY DICT_NAME;
 
   SHOW GLOBAL STATUS LIKE 'slave_open_temp_tables';
 

--- a/mysql-test/suite/innodb/r/xtradb_compressed_columns_read_only.result
+++ b/mysql-test/suite/innodb/r/xtradb_compressed_columns_read_only.result
@@ -85,8 +85,8 @@ DROP COMPRESSION_DICTIONARY dummy_dict;
 ERROR HY000: Running in read-only mode
 DROP COMPRESSION_DICTIONARY numbers;
 ERROR HY000: Running in read-only mode
-# Check if 'information_schema' queries for 'xtradb_zip_dict'
-# and 'xtradb_zip_dict_cols' work in read-only mode.
+# Check if 'information_schema' queries for 'compression_dictionary'
+# and 'compression_dictionary_tables' work in read-only mode.
 SET @dictionary_data = 'onetwothreefour';
 SELECT dict_name INTO @dict_name FROM information_schema.compression_dictionary WHERE dict_name = 'numbers';
 SELECT dict_data = @dictionary_data AS dictionary_data_match FROM information_schema.compression_dictionary WHERE dict_name = 'numbers';

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_read_only.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_read_only.test
@@ -66,8 +66,8 @@ DROP COMPRESSION_DICTIONARY dummy_dict;
 --error ER_READ_ONLY_MODE
 DROP COMPRESSION_DICTIONARY numbers;
 
---echo # Check if 'information_schema' queries for 'xtradb_zip_dict'
---echo # and 'xtradb_zip_dict_cols' work in read-only mode.
+--echo # Check if 'information_schema' queries for 'compression_dictionary'
+--echo # and 'compression_dictionary_tables' work in read-only mode.
 eval SET @dictionary_data = '$permanent_dictionary_data';
 SELECT dict_name INTO @dict_name FROM information_schema.compression_dictionary WHERE dict_name = 'numbers';
 SELECT dict_data = @dictionary_data AS dictionary_data_match FROM information_schema.compression_dictionary WHERE dict_name = 'numbers';

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_sp.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_sp.test
@@ -25,8 +25,8 @@ DELIMITER ;//
 CALL create_zip_dict(@numbers);
 CALL create_table_referencing_zip_dict();
 
-# check if corresponding records were added to 'xtradb_zip_dict' and
-# 'xtradb_zip_dict_cols' tables in 'information_schema'.
+# check if corresponding records were added to 'compression_dictionary' and
+# 'compression_dictionary_tables' tables in 'information_schema'.
 #
 SELECT dict_data = @numbers AS zip_dict_data_match FROM information_schema.compression_dictionary WHERE dict_name = 'dict';
 SELECT dict_name = 'dict' AS dict_names_match FROM information_schema.compression_dictionary_tables
@@ -49,8 +49,8 @@ DELIMITER ;//
 # call this procedure
 CALL create_zip_dict_and_table(@numbers);
 
-# check if corresponding records were added to 'xtradb_zip_dict' and
-# 'xtradb_zip_dict_cols' tables in 'information_schema' for the
+# check if corresponding records were added to 'compression_dictionary' and
+# 'compression_dictionary_tables' tables in 'information_schema' for the
 # compression dictionary and table created by 'create_zip_dict_and_table()' .
 SELECT dict_data = @numbers AS another_zip_dict_data_match FROM information_schema.compression_dictionary WHERE dict_name = 'another_dict';
 SELECT dict_name= 'another_dict' AS another_dict_names_match FROM information_schema.compression_dictionary_tables

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_with_dictionaries.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_with_dictionaries.test
@@ -135,7 +135,7 @@ DROP COMPRESSION_DICTIONARY d100;
 --error ER_COMPRESSION_DICTIONARY_IS_REFERENCED
 --eval DROP COMPRESSION_DICTIONARY $dict_name
 
-# dropping existing compression dictionary must be reflected in "xtradb_zip_dict"
+# dropping existing compression dictionary must be reflected in "compression_dictionary"
 DROP COMPRESSION_DICTIONARY d13;
 
 SELECT COUNT(*) = 0 AS dict_must_be_deleted
@@ -156,7 +156,7 @@ DROP COMPRESSION_DICTIONARY d11;
 DROP COMPRESSION_DICTIONARY d12;
 --eval DROP COMPRESSION_DICTIONARY $long_dictionary_name
 
-# check if the changes are reflected properly in "xtradb_zip_dict"
+# check if the changes are reflected properly in "compression_dictionary"
 SELECT dict_name, dict_data, LENGTH(dict_data)
 FROM information_schema.compression_dictionary;
 


### PR DESCRIPTION
… 8.0)

Restore the MTR testcase check that was supposed to be disabled only
temporarily, using the new 8.0 name of the
table (INFORMATION_SCHEMA.COMPRESSION_DICTIONARY). At the same time
clean up old XTRADB_ZIP_DICT and XTRADB_ZIP_DICT_COLS references in
the tests.

https://ps.cd.percona.com/view/8.0/job/percona-server-8.0-param/253/