### PR TITLE
No need to set THR_THD to NULL

### DIFF
--- a/sql/threadpool_common.cc
+++ b/sql/threadpool_common.cc
@@ -91,7 +91,7 @@ struct Worker_thread_context
 #ifndef DBUG_OFF
     set_my_thread_var_id(thread_id);
 #endif
-    pthread_setspecific(THR_THD, 0);
+    /* pthread_setspecific(THR_THD, 0); not needed as 8.0 version */
     pthread_setspecific(THR_MALLOC, 0);
   }
 };


### PR DESCRIPTION
This line does not executed in 8.0 version, no need in 5.7 also