### PR TITLE
Post-merge fix for PS-5044 (Merge MySQL 8.0.14)

### DIFF
--- a/mysql-test/r/information_schema_cs.result
+++ b/mysql-test/r/information_schema_cs.result
@@ -1325,12 +1325,8 @@ COMPRESSION_DICTIONARY_TABLES	information_schema.COMPRESSION_DICTIONARY_TABLES	1
 ENGINES	information_schema.ENGINES	1
 EVENTS	information_schema.EVENTS	1
 FILES	information_schema.FILES	1
-<<<<<<< HEAD
 GLOBAL_TEMPORARY_TABLES	information_schema.GLOBAL_TEMPORARY_TABLES	1
 INDEX_STATISTICS	information_schema.INDEX_STATISTICS	1
-KEYWORDS	information_schema.KEYWORDS	1
-=======
->>>>>>> mysql-8.0.14
 KEY_COLUMN_USAGE	information_schema.KEY_COLUMN_USAGE	1
 OPTIMIZER_TRACE	information_schema.OPTIMIZER_TRACE	1
 PARAMETERS	information_schema.PARAMETERS	1

--- a/mysql-test/suite/funcs_1/r/is_columns_is_cs.result
+++ b/mysql-test/suite/funcs_1/r/is_columns_is_cs.result
@@ -149,7 +149,6 @@ def	information_schema	FILES	CHECK_TIME	35	NULL	YES	binary	0	0	NULL	NULL	NULL	NU
 def	information_schema	FILES	CHECKSUM	36	NULL	YES	binary	0	0	NULL	NULL	NULL	NULL	NULL	binary(0)			select			NULL
 def	information_schema	FILES	STATUS	37	NULL	YES	varchar	256	768	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(256)			select			NULL
 def	information_schema	FILES	EXTRA	38	NULL	YES	binary	0	0	NULL	NULL	NULL	NULL	NULL	binary(0)			select			NULL
-<<<<<<< HEAD
 def	information_schema	GLOBAL_TEMPORARY_TABLES	SESSION_ID	1		NO	bigint	NULL	NULL	NULL	NULL	NULL	NULL	NULL	bigint(4)			select			NULL
 def	information_schema	GLOBAL_TEMPORARY_TABLES	TABLE_SCHEMA	2		NO	varchar	21	64	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(64)			select			NULL
 def	information_schema	GLOBAL_TEMPORARY_TABLES	TABLE_NAME	3		NO	varchar	21	64	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(64)			select			NULL
@@ -165,10 +164,7 @@ def	information_schema	INDEX_STATISTICS	TABLE_SCHEMA	1		NO	varchar	64	192	NULL	N
 def	information_schema	INDEX_STATISTICS	TABLE_NAME	2		NO	varchar	64	192	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(192)			select			NULL
 def	information_schema	INDEX_STATISTICS	INDEX_NAME	3		NO	varchar	64	192	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(192)			select			NULL
 def	information_schema	INDEX_STATISTICS	ROWS_READ	4		NO	bigint	NULL	NULL	NULL	NULL	NULL	NULL	NULL	bigint(21) unsigned			select			NULL
-def	information_schema	KEYWORDS	WORD	1	NULL	YES	varchar	29	116	NULL	NULL	NULL	utf8mb4	utf8mb4_0900_ai_ci	varchar(29)			select			NULL
-=======
 def	information_schema	KEYWORDS	WORD	1	NULL	YES	varchar	29	87	NULL	NULL	NULL	utf8	utf8_general_ci	varchar(29)			select			NULL
->>>>>>> mysql-8.0.14
 def	information_schema	KEYWORDS	RESERVED	2	NULL	YES	int	NULL	NULL	10	0	NULL	NULL	NULL	int(11)			select			NULL
 def	information_schema	KEY_COLUMN_USAGE	CONSTRAINT_CATALOG	1	NULL	NO	varchar	64	192	NULL	NULL	NULL	utf8	utf8_bin	varchar(64)			select			NULL
 def	information_schema	KEY_COLUMN_USAGE	CONSTRAINT_SCHEMA	2	NULL	NO	varchar	64	192	NULL	NULL	NULL	utf8	utf8_bin	varchar(64)			select			NULL
@@ -531,11 +527,7 @@ COL_CML	DATA_TYPE	CHARACTER_SET_NAME	COLLATION_NAME
 3.3333	varchar	utf8	utf8_general_ci
 4.0000	varchar	utf8	utf8_general_ci
 3.0000	varchar	utf8	utf8_tolower_ci
-<<<<<<< HEAD
-4.0000	varchar	utf8mb4	utf8mb4_0900_ai_ci
 4.0000	varchar	utf8mb4	utf8mb4_general_ci
-=======
->>>>>>> mysql-8.0.14
 SELECT DISTINCT
 CHARACTER_OCTET_LENGTH / CHARACTER_MAXIMUM_LENGTH AS COL_CML,
 DATA_TYPE,
@@ -716,7 +708,6 @@ NULL	information_schema	FILES	CHECK_TIME	binary	0	0	NULL	NULL	binary(0)
 NULL	information_schema	FILES	CHECKSUM	binary	0	0	NULL	NULL	binary(0)
 3.0000	information_schema	FILES	STATUS	varchar	256	768	utf8	utf8_general_ci	varchar(256)
 NULL	information_schema	FILES	EXTRA	binary	0	0	NULL	NULL	binary(0)
-<<<<<<< HEAD
 NULL	information_schema	GLOBAL_TEMPORARY_TABLES	SESSION_ID	bigint	NULL	NULL	NULL	NULL	bigint(4)
 3.0476	information_schema	GLOBAL_TEMPORARY_TABLES	TABLE_SCHEMA	varchar	21	64	utf8	utf8_general_ci	varchar(64)
 3.0476	information_schema	GLOBAL_TEMPORARY_TABLES	TABLE_NAME	varchar	21	64	utf8	utf8_general_ci	varchar(64)
@@ -732,10 +723,7 @@ NULL	information_schema	GLOBAL_TEMPORARY_TABLES	UPDATE_TIME	datetime	NULL	NULL	N
 3.0000	information_schema	INDEX_STATISTICS	TABLE_NAME	varchar	64	192	utf8	utf8_general_ci	varchar(192)
 3.0000	information_schema	INDEX_STATISTICS	INDEX_NAME	varchar	64	192	utf8	utf8_general_ci	varchar(192)
 NULL	information_schema	INDEX_STATISTICS	ROWS_READ	bigint	NULL	NULL	NULL	NULL	bigint(21) unsigned
-4.0000	information_schema	KEYWORDS	WORD	varchar	29	116	utf8mb4	utf8mb4_0900_ai_ci	varchar(29)
-=======
 3.0000	information_schema	KEYWORDS	WORD	varchar	29	87	utf8	utf8_general_ci	varchar(29)
->>>>>>> mysql-8.0.14
 NULL	information_schema	KEYWORDS	RESERVED	int	NULL	NULL	NULL	NULL	int(11)
 3.0000	information_schema	KEY_COLUMN_USAGE	CONSTRAINT_CATALOG	varchar	64	192	utf8	utf8_bin	varchar(64)
 3.0000	information_schema	KEY_COLUMN_USAGE	CONSTRAINT_SCHEMA	varchar	64	192	utf8	utf8_bin	varchar(64)


### PR DESCRIPTION
…ql.compression_dictionary.data)

The affected field mysql.compression_dictionary_data is of type BLOB,
whose char length is 65535, as the test tries to check. Update the
reference files in std_data.

https://ps80.cd.percona.com/job/percona-server-8.0-param/33/