### PR TITLE
Fix PS-5484 (mysql.json std_data files have wrong char_length for mys…

### DIFF
--- a/mysql-test/std_data/dd/sdi/innodb_sdi/mysql.json
+++ b/mysql-test/std_data/dd/sdi/innodb_sdi/mysql.json
@@ -22959,7 +22959,7 @@
                 "is_virtual": false,
                 "hidden": 1,
                 "ordinal_position": 4,
-                "char_length": 8,
+                "char_length": 65535,
                 "numeric_precision": 0,
                 "numeric_scale": 0,
                 "numeric_scale_null": true,

--- a/mysql-test/std_data/dd/sdi/upgrade/mysql.json
+++ b/mysql-test/std_data/dd/sdi/upgrade/mysql.json
@@ -22959,7 +22959,7 @@
                 "is_virtual": false,
                 "hidden": 1,
                 "ordinal_position": 4,
-                "char_length": 8,
+                "char_length": 65535,
                 "numeric_precision": 0,
                 "numeric_scale": 0,
                 "numeric_scale_null": true,


### PR DESCRIPTION
…ql.compression_dictionary.data)

The affected field mysql.compression_dictionary_data is of type BLOB,
whose char length is 65535, as the test tries to check. Update the
reference files in std_data.

https://ps80.cd.percona.com/job/percona-server-8.0-param/34/