### PR TITLE
Fix PS-5487 (Test main.percona_heap_blob is unstable)

### DIFF
--- a/mysql-test/r/percona_heap_blob.result
+++ b/mysql-test/r/percona_heap_blob.result
@@ -746,7 +746,7 @@ NULL
 616100
 6200
 alter table t1 modify a char(5);
-select hex(a) from t1 order by a;
+select hex(a) from t1 order by a collate utf8mb4_bin;
 hex(a)
 NULL
 6100

--- a/mysql-test/t/percona_heap_blob.test
+++ b/mysql-test/t/percona_heap_blob.test
@@ -386,7 +386,7 @@ alter table t1 modify a varbinary(5);
 select hex(a) from t1 order by a;
 select hex(concat(a,'\0')) as b from t1 order by concat(a,'\0');
 alter table t1 modify a char(5);
-select hex(a) from t1 order by a;
+select hex(a) from t1 order by a collate utf8mb4_bin;
 select hex(concat(a,'\0')) as b from t1 order by concat(a,'\0');
 alter table t1 modify a binary(5);
 select hex(a) from t1 order by a;


### PR DESCRIPTION
Remove ORDER BY non-determinism by specifying utf8mb4_bin collation.

https://ps80.cd.percona.com/job/percona-server-8.0-param/36/