### PR TITLE
PS-5492: bootstrap failure with innodb_encrypt_tables = 1

### DIFF
--- a/mysql-test/suite/innodb/r/percona_session_temp_tablespaces_encrypt_bootstrap.result
+++ b/mysql-test/suite/innodb/r/percona_session_temp_tablespaces_encrypt_bootstrap.result
@@ -1,0 +1,27 @@
+# Stop the instance which was created by MTR
+# create bootstrap file
+# Bootstrap new instance with innodb_encrypt_tables=ON
+# Start the instance with innodb_encrypt_tables=ON
+# restart: --datadir=MYSQLD_DATADIR1 --innodb_encrypt_tables=ON
+CREATE TABLE t1(a INT);
+INSERT INTO t1 (a) VALUES (1),(2),(3),(4),(5);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
+SELECT * FROM t1;
+a
+1
+2
+3
+4
+5
+CREATE TEMPORARY TABLE t2 (a INT);
+INSERT INTO t2 (a) VALUES (1),(2),(3),(4),(5);
+SELECT SPACE, PURPOSE FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+SPACE	PURPOSE
+4294501265	USER ENCRYPTED
+4294501266	INTRINSIC ENCRYTPED
+# Start default MTR instance
+# restart

--- a/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt_bootstrap-master.opt
+++ b/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt_bootstrap-master.opt
@@ -1,0 +1,3 @@
+$KEYRING_PLUGIN_OPT
+$KEYRING_PLUGIN_EARLY_LOAD
+--keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring

--- a/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt_bootstrap.test
+++ b/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt_bootstrap.test
@@ -1,0 +1,49 @@
+let $MYSQLD_BASEDIR= `select @@basedir`;
+--mkdir $MYSQL_TMP_DIR/datadir1
+
+let $MYSQLD_DATADIR1 = $MYSQL_TMP_DIR/datadir1/data;
+
+--echo # Stop the instance which was created by MTR
+--source include/shutdown_mysqld.inc
+
+--let BOOTSTRAP_SQL=$MYSQL_TMP_DIR/boot.sql
+--let KEYRING_DATA="--keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring"
+--let ERROR_LOG=$MYSQL_TMP_DIR/session_temp_encrypt_err.log
+
+--echo # create bootstrap file
+write_file $BOOTSTRAP_SQL;
+CREATE DATABASE test;
+EOF
+
+--let BOOTSTRAP_CMD = $MYSQLD_CMD --initialize-insecure --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1 --init-file=$BOOTSTRAP_SQL --innodb-encrypt-tables=ON $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD $KEYRING_DATA > $ERROR_LOG 2>&1
+
+--echo # Bootstrap new instance with innodb_encrypt_tables=ON
+--exec $BOOTSTRAP_CMD
+
+--echo # Start the instance with innodb_encrypt_tables=ON
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1
+--let $restart_parameters="restart: --datadir=$MYSQLD_DATADIR1 --innodb_encrypt_tables=ON"
+--source include/start_mysqld.inc
+
+--let $MYSQL_DATA_DIR= `select @@datadir`
+
+CREATE TABLE t1(a INT);
+
+INSERT INTO t1 (a) VALUES (1),(2),(3),(4),(5);
+
+SHOW CREATE TABLE t1;
+
+SELECT * FROM t1;
+
+CREATE TEMPORARY TABLE t2 (a INT);
+INSERT INTO t2 (a) VALUES (1),(2),(3),(4),(5);
+
+SELECT SPACE, PURPOSE FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = connection_id() ORDER BY SPACE;
+
+--echo # Start default MTR instance
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--remove_file $BOOTSTRAP_SQL
+--force-rmdir $MYSQL_TMP_DIR/datadir1
+--remove_file $ERROR_LOG

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4180,6 +4180,11 @@ a new master key and do key rotation. These tablespaces if encrypted
 during startup, will be encrypted with tablespace key which has empty UUID
 @return false on success, true on failure */
 bool innobase_fix_tablespaces_empty_uuid() {
+#ifdef UNIV_DEBUG
+  /* This API is called only after uuid is ready */
+  srv_is_uuid_ready = true;
+#endif /* UNIV_DEBUG */
+
   /* If we are in read only mode, we cannot do rotation but it
   is OK */
   if (srv_read_only_mode) {
@@ -4231,6 +4236,19 @@ bool innobase_fix_tablespaces_empty_uuid() {
 
   space_ids.push_back(srv_sys_space.space_id());
   space_ids.push_back(srv_tmp_space.space_id());
+
+#ifdef UNIV_DEBUG
+  /* Currently all session temp tablespaces that use empty uuid
+  are destroyed. So if there is encrypted sesion temp tablespace
+  we assert here */
+  const auto find_encrypted = [&](const ibt::Tablespace *ts) {
+    if (ts->is_encrypted()) {
+      ut_ad(0);
+    }
+  };
+
+  ibt::tbsp_pool->iterate_active_tbsp(find_encrypted);
+#endif /* UNIV_DEBUG */
 
   undo::spaces->s_lock();
   for (auto undo_space : undo::spaces->m_spaces) {

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -222,6 +222,10 @@ extern bool srv_downgrade_logs;
 extern bool srv_upgrade_old_undo_found;
 #endif /* INNODB_DD_TABLE */
 
+#ifdef UNIV_DEBUG
+extern bool srv_is_uuid_ready;
+#endif /* UNIV_DEBUG */
+
 extern const char *srv_main_thread_op_info;
 
 /* The monitor thread waits on this event. */

--- a/storage/innobase/include/srv0tmp.h
+++ b/storage/innobase/include/srv0tmp.h
@@ -135,8 +135,32 @@ class Tablespace {
   /** @return complete path including filename */
   std::string path() const;
 
-  /** @return true if session tablespace is encrypted, else false */
+  /** Encrypt a session temporary tablespace
+  @return true if session tablespace is encrypted, else false */
   bool encrypt();
+
+  /** @return true for encrypted purpose, else false */
+  bool is_encrypted() const { return (is_encrypted(m_purpose)); }
+
+  /** @return true for encrypted purpose, else false
+  @param[in]  purpose  the purpose of session temp tablespace */
+  static bool is_encrypted(enum tbsp_purpose purpose) {
+    switch (purpose) {
+      case TBSP_USER:
+      case TBSP_INTRINSIC:
+      case TBSP_SLAVE:
+        return (false);
+      case TBSP_ENC_USER:
+      case TBSP_ENC_INTRINSIC:
+      case TBSP_ENC_SLAVE:
+        return (true);
+      default:
+        ut_ad(0);
+    }
+    /* Make compilers happy */
+    ut_ad(0);
+    return (false);
+  }
 
  private:
   /** Remove encryption information from tablespace in-memory structure.
@@ -214,6 +238,19 @@ class Tablespace_pool {
 
     std::for_each(begin(*m_active), end(*m_active), f);
     std::for_each(begin(*m_free), end(*m_free), f);
+
+    release();
+  }
+
+  /** Iterate through the list of "active" tablespaces and perform specified
+  operation on the tablespace on every iteration.
+  @param[in]    f                Function pointer for the function to be
+  executed on every iteration */
+  template <typename F>
+  void iterate_active_tbsp(F &&f) {
+    acquire();
+
+    std::for_each(begin(*m_active), end(*m_active), f);
 
     release();
   }

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -8793,7 +8793,7 @@ bool Encryption::fill_encryption_info(byte *key, byte *iv, byte *encrypt_info,
   tablespaces when InnoDB is initializing (like system, temp, etc).
   These tablespaces UUID will be fixed by handlerton API after server
   generates uuid */
-  ut_ad(!innodb_inited || strlen(s_uuid) != 0);
+  ut_ad(!srv_is_uuid_ready || strlen(s_uuid) != 0);
 
   byte key_info[ENCRYPTION_KEY_LEN * 2];
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -112,6 +112,10 @@ bool srv_downgrade_logs = false;
 bool srv_upgrade_old_undo_found = false;
 #endif /* INNODB_DD_TABLE */
 
+#ifdef UNIV_DEBUG
+bool srv_is_uuid_ready = false;
+#endif /* UNIV_DEBUG */
+
 /* The following is the maximum allowed duration of a lock wait. */
 ulint srv_fatal_semaphore_wait_threshold = 600;
 

--- a/storage/innobase/srv/srv0tmp.cc
+++ b/storage/innobase/srv/srv0tmp.cc
@@ -64,25 +64,6 @@ Tablespace_pool *tbsp_pool = nullptr;
 /* Directory to store session temporary tablespaces, provided by user */
 char *srv_temp_dir = nullptr;
 
-/** @return true for encrypted purpose, else false */
-static bool is_encrypt(enum tbsp_purpose purpose) {
-  switch (purpose) {
-    case TBSP_USER:
-    case TBSP_INTRINSIC:
-    case TBSP_SLAVE:
-      return (false);
-    case TBSP_ENC_USER:
-    case TBSP_ENC_INTRINSIC:
-    case TBSP_ENC_SLAVE:
-      return (true);
-    default:
-      ut_ad(0);
-  }
-  /* Make compilers happy */
-  ut_ad(0);
-  return (false);
-}
-
 /** Sesssion Temporary tablespace */
 Tablespace::Tablespace()
     : m_space_id(++m_last_used_space_id), m_inited(), m_thread_id() {
@@ -186,7 +167,7 @@ bool Tablespace::encrypt() {
 }
 
 void Tablespace::decrypt() {
-  if (!is_encrypt(m_purpose)) {
+  if (!is_encrypted()) {
     return;
   }
   byte encryption_info[ENCRYPTION_INFO_SIZE];
@@ -273,7 +254,7 @@ Tablespace *Tablespace_pool::get(my_thread_id id, enum tbsp_purpose purpose) {
   }
 
   ts = m_free->back();
-  if (is_encrypt(purpose)) {
+  if (Tablespace::is_encrypted(purpose)) {
     if (!ts->encrypt()) {
       release();
       ib::error() << "Unable to encrypt a session temp tablespace. Probably due"


### PR DESCRIPTION
Problem:
--------
Bootstrap fails (asserts in debug build) with innodb_encrypt_tables = 1

This happens because server requests to create temporary table before UUID
is ready. InnoDB allocates session temp tablespace and tries to set encryption
info. The assert detects that encryption is requested before UUID is ready.

Fix:
----

1. We allow to create encrypted session temp tablespaces with empty uuid for a brief
   period of time.

2. We fix the assert to rely on a new debug variable 'srv_is_uuid_ready' instead
   of 'innodb_inited'. So any tablespaces that are encrypted at startup before
   uuid is ready, should be fixed in hanlderton API innobase_fix_tablespaces_empty_uuid()


3. For session temp tablespaces, it is observed that they are destroyed before we attempt
   fix the empty uuid. Add debug checks to catch if there are any encrypted session temp
   tablespaces.
