### PR TITLE
PS-5243 SHOW BINLOG EVENT ASSERTION

### DIFF
--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -516,7 +516,7 @@ static inline int my_b_inited(const IO_CACHE *info)
 MY_NODISCARD
 static inline int my_b_read(IO_CACHE *info, uchar *Buffer, size_t Count)
 {
-  if (info->read_pos + Count <= info->read_end)
+  if ((uint)(info->read_end - info->read_pos) >= Count)
   {
     memcpy(Buffer, info->read_pos, Count);
     info->read_pos+= Count;


### PR DESCRIPTION
Executing SHOW BINLOG EVENT from an invalid position
could result in a segmentation fault on 32bit machines.
my_b_read would try to evaluate info->read_pos + Count
which could result on an Address out of bounds error.
This will cause my_b_read enter the if and attempt to
do a memcpy which will result in a segmentation fault.

This patch ensures that the boundaries are calculated within
the info IO_CACHE and only then evaluated with Count.

mysqlbinlog was affected in the same way. This patch
also fixes mysqlbinlog.