### PR TITLE
Fix PS-5510 (Intermittent shutdown crashes if threadpool is enabled)

### DIFF
--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -907,11 +907,7 @@ static int wake_thread(thread_group_t *thread_group) noexcept {
 }
 
 /**
-  Initiate shutdown for thread group.
-
-  The shutdown is asynchronous, we only care to  wake all threads in here, so
-  they can finish. We do not wait here until threads terminate. Final cleanup
-  of the group (thread_group_destroy) will be done by the last exiting threads.
+  Shutdown for thread group
 */
 
 static void thread_group_close(thread_group_t *thread_group) noexcept {
@@ -949,6 +945,16 @@ static void thread_group_close(thread_group_t *thread_group) noexcept {
   }
 
   mysql_mutex_unlock(&thread_group->mutex);
+
+  mysql_mutex_lock(&thread_group->mutex);
+  while (thread_group->thread_count > 0) {
+    mysql_mutex_unlock(&thread_group->mutex);
+    my_sleep(10000);
+    mysql_mutex_lock(&thread_group->mutex);
+  }
+  mysql_mutex_unlock(&thread_group->mutex);
+
+  thread_group_destroy(thread_group);
 
   DBUG_VOID_RETURN;
 }
@@ -1440,13 +1446,7 @@ static void *worker_main(void *param) {
 
   mysql_mutex_lock(&thread_group->mutex);
   add_thread_count(thread_group, -1);
-  /* last thread in group exits */
-  const bool last_thread =
-      ((thread_group->thread_count == 0) && thread_group->shutdown);
   mysql_mutex_unlock(&thread_group->mutex);
-
-  /* Last thread in group exits and pool is terminating, destroy group.*/
-  if (last_thread) thread_group_destroy(thread_group);
 
   my_thread_end();
   return nullptr;


### PR DESCRIPTION
Threadpool shutdown, initiated by tp_end call, asks for worker threads
to quit, asynchronously, in thread_group_close. There was no further
synchronization pas this, hence, those threads might be attempting to
access server data structures which are deallocated further in
shutdown, for example, performance schema data structures. This led to
release build crashes with various stacktraces. Debug build and
pre-8.0 versions do not crash because they have extra synchronization
between worker thread my_thread_end and main thread
my_thread_global_end. This was removed in 8.0 release builds by [1].

Fix by synchronizing thread_group_close with worker threads actually
quiting.

[1]:

commit 13ccce6f380844fd030e33a06be10afaa91d56c2
Author: Jon Olav Hauglid <jon.hauglid@oracle.com>
Date: Thu Sep 10 14:46:25 2015 +0100
Bug#21802367: STOP ALLOCATING MEMORY FOR MYSYS THREAD LOCAL STORAGE STRUCT
After this patch, my_thread_init() will no longer allocate
memory for the mysys thread local variables struct for release builds.
This means that not being able to call my_thread_end() will no
longer lead to memory leak.
After several earlier patches, only two members remained in the
mysys thread local struct - both ints related to error handling.
These are now put into separate thread local entries.
With this patch, the problem which lead to the creation of
WL#6817 "Getting rid of mysql_thread_end() and thread local
storage in libmysqlclient" has been fixed.

https://ps80.cd.percona.com/view/8.0/job/percona-server-8.0-param/43/