### PR TITLE
Fix PS-5523 (Debug build sporadic-binlog-dump-fail max-binlog-dump-ev…

### DIFF
--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -1037,7 +1037,7 @@ int Binlog_sender::send_format_description_event(File_reader *reader,
   // Let's check if next event is Start encryption event
   // If we go outside the file read_event will also return an error
   const auto binlog_pos_after_fdle = reader->position();
-  if (read_event(reader, &event_ptr, &event_len)) {
+  if (read_event(reader, &event_ptr, &event_len, true)) {
     reader->seek(binlog_pos_after_fdle);
     set_last_pos(binlog_pos_after_fdle);
     DBUG_RETURN(0);
@@ -1121,7 +1121,8 @@ const char *Binlog_sender::log_read_error_msg(
 }
 
 inline int Binlog_sender::read_event(File_reader *reader, uchar **event_ptr,
-                                     uint32 *event_len) {
+                                     uint32 *event_len,
+                                     bool readahead MY_ATTRIBUTE((unused))) {
   DBUG_ENTER("Binlog_sender::read_event");
 
   if (reset_transmit_packet(0, 0)) DBUG_RETURN(1);
@@ -1159,7 +1160,7 @@ inline int Binlog_sender::read_event(File_reader *reader, uchar **event_ptr,
   DBUG_PRINT("info", ("Read event %s", Log_event::get_type_str(Log_event_type(
                                            (*event_ptr)[EVENT_TYPE_OFFSET]))));
 #ifndef DBUG_OFF
-  if (check_event_count()) DBUG_RETURN(1);
+  if (!readahead && check_event_count()) DBUG_RETURN(1);
 #endif
   DBUG_RETURN(0);
 }

--- a/sql/rpl_binlog_sender.h
+++ b/sql/rpl_binlog_sender.h
@@ -290,12 +290,14 @@ class Binlog_sender : Gtid_mode_copy {
      @param[in] reader        File_reader of the binlog file.
      @param[out] event_ptr    The buffer used to store the event.
      @param[out] event_len    Length of the event.
+     @param[in] readahead     Whether this read is to peek but not process the
+                              next event in the stream
 
      @retval 0 Succeed
      @retval 1 Fail
   */
   inline int read_event(File_reader *reader, uchar **event_ptr,
-                        uint32 *event_len);
+                        uint32 *event_len, bool readahead = false);
   /**
     Check if it is allowed to send this event type.
 


### PR DESCRIPTION
…ents counting broken)

For debug builds, there are command-line options
sporadic-binlog-dump-fail and max-binlog-dump-events, which are
supposed to make the binlog dump thread fail on every
max-binlog-dump-events event written. However, the actual failure
logic is implemented on reading the event from master binlog. Our
feature PS-5326 (support for pre-8.0.15 binlog encryption) broke 1:1
relationship between binlog dump thread binlog reads and writes by
introducing a peek upon having read a FDLE, whether the next event is
not a pre-8.0.15 Start_binlog_encryption event. This resulted in the
failure triggering too often, and binlog dump thread / slave failing
to make progress on the binlog, resulting in testcase timeout.

Fix by introducing a readahead flag for Binlog_sender::read_event,
which is only set to true for the above event peek, and which does not
bump the counter of written binlog events.

https://ps80.cd.percona.com/view/8.0/job/percona-server-8.0-param/51/