### PR TITLE
PS-5476: Report error when redo log encryption is requested without a keyring (5.7)

### DIFF
--- a/mysql-test/include/log_encrypt_3.inc
+++ b/mysql-test/include/log_encrypt_3.inc
@@ -70,7 +70,7 @@ let $restart_parameters = restart: --early-plugin-load="keyring_file=$KEYRING_PL
 --source include/restart_mysqld_no_echo.inc
 
 SELECT @@global.innodb_redo_log_encrypt;
-SET GLOBAL innodb_redo_log_encrypt = 1;
+eval SET GLOBAL innodb_redo_log_encrypt = $redo_log_encrypt_mode;
 SELECT @@global.innodb_redo_log_encrypt;
 
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;

--- a/mysql-test/include/percona_log_encrypt_content.inc
+++ b/mysql-test/include/percona_log_encrypt_content.inc
@@ -1,0 +1,34 @@
+# InnoDB transparent tablespace data encryption
+# This test case will verify that no unencrypted data is in the logs
+
+--source include/no_valgrind_without_big.inc
+--source include/have_innodb.inc
+--source include/not_embedded.inc
+
+# Test: command line parameter
+
+--let ABORT_ON=FOUND
+--source include/percona_log_encrypt_content_test.inc
+
+# Test: variable
+
+# Restart the server with keyring loaded
+--let restart_parameters="restart:$KEYRING_PARAMS"
+--source include/restart_mysqld_no_echo.inc
+
+--eval SET GLOBAL innodb_redo_log_encrypt=$LOG_ENCRYPT_TYPE
+
+--source include/percona_log_encrypt_content_test.inc
+
+# Restart the server with keyring loaded
+--let restart_parameters="restart:$KEYRING_PARAMS"
+--source include/restart_mysqld_no_echo.inc
+SET GLOBAL innodb_redo_log_encrypt=OFF;
+
+--let ABORT_ON=NOT_FOUND
+--source include/percona_log_encrypt_content_test.inc
+
+# Cleanup
+--eval SET GLOBAL innodb_redo_log_encrypt=$LOG_ENCRYPT_TYPE
+--remove_file $MYSQL_TMP_DIR/mysecret_keyring_content
+

--- a/mysql-test/include/percona_log_encrypt_content_test.inc
+++ b/mysql-test/include/percona_log_encrypt_content_test.inc
@@ -1,0 +1,14 @@
+
+CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;
+
+INSERT INTO t1 VALUES(0, "asdfghjkl");
+INSERT INTO t1 VALUES(1, "qwertyuio");
+INSERT INTO t1 VALUES(2, "zxcvbnm");
+
+# Check file content
+--let $MYSQLD_DATADIR= `select @@datadir`
+--let SEARCH_PATTERN= asdfghjkl
+-- let SEARCH_FILE= $MYSQLD_DATADIR/ib_logfile0
+-- source include/search_pattern_in_file.inc
+
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
@@ -34,7 +34,7 @@ UNINSTALL PLUGIN keyring_file;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
 master_key
-SET GLOBAL innodb_redo_log_encrypt = 1;
+SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
 master_key

--- a/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
@@ -34,10 +34,10 @@ UNINSTALL PLUGIN keyring_file;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
 keyring_key
-SET GLOBAL innodb_redo_log_encrypt = 1;
+SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+keyring_key
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_content_mk.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_content_mk.result
@@ -1,0 +1,18 @@
+CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "asdfghjkl");
+INSERT INTO t1 VALUES(1, "qwertyuio");
+INSERT INTO t1 VALUES(2, "zxcvbnm");
+DROP TABLE t1;
+SET GLOBAL innodb_redo_log_encrypt=MASTER_KEY;
+CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "asdfghjkl");
+INSERT INTO t1 VALUES(1, "qwertyuio");
+INSERT INTO t1 VALUES(2, "zxcvbnm");
+DROP TABLE t1;
+SET GLOBAL innodb_redo_log_encrypt=OFF;
+CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "asdfghjkl");
+INSERT INTO t1 VALUES(1, "qwertyuio");
+INSERT INTO t1 VALUES(2, "zxcvbnm");
+DROP TABLE t1;
+SET GLOBAL innodb_redo_log_encrypt=MASTER_KEY;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_content_rk.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_content_rk.result
@@ -1,0 +1,18 @@
+CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "asdfghjkl");
+INSERT INTO t1 VALUES(1, "qwertyuio");
+INSERT INTO t1 VALUES(2, "zxcvbnm");
+DROP TABLE t1;
+SET GLOBAL innodb_redo_log_encrypt=KEYRING_KEY;
+CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "asdfghjkl");
+INSERT INTO t1 VALUES(1, "qwertyuio");
+INSERT INTO t1 VALUES(2, "zxcvbnm");
+DROP TABLE t1;
+SET GLOBAL innodb_redo_log_encrypt=OFF;
+CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "asdfghjkl");
+INSERT INTO t1 VALUES(1, "qwertyuio");
+INSERT INTO t1 VALUES(2, "zxcvbnm");
+DROP TABLE t1;
+SET GLOBAL innodb_redo_log_encrypt=KEYRING_KEY;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_failure.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_failure.result
@@ -1,0 +1,7 @@
+call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
+call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+select @@innodb_redo_log_encrypt;
+@@innodb_redo_log_encrypt
+off
+Pattern "Can't set redo log tablespace to be encrypted." found
+Pattern "Encryption can't find master key, please check the keyring plugin is loaded." found

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_content_mk-master.opt
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_content_mk-master.opt
@@ -1,0 +1,4 @@
+$KEYRING_PLUGIN_OPT
+$KEYRING_PLUGIN_EARLY_LOAD
+--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring_content
+--innodb_redo_log_encrypt=MASTER_KEY

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_content_mk.test
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_content_mk.test
@@ -1,0 +1,2 @@
+--let LOG_ENCRYPT_TYPE=MASTER_KEY
+--source include/percona_log_encrypt_content.inc

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk-master.opt
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk-master.opt
@@ -1,0 +1,4 @@
+$KEYRING_PLUGIN_OPT
+$KEYRING_PLUGIN_EARLY_LOAD
+--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring_content
+--innodb_redo_log_encrypt=KEYRING_KEY

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk.test
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk.test
@@ -1,0 +1,2 @@
+--let LOG_ENCRYPT_TYPE=KEYRING_KEY
+--source include/percona_log_encrypt_content.inc

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_failure-master.opt
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_failure-master.opt
@@ -1,0 +1,1 @@
+--innodb-redo-log-encrypt=MASTER_KEY

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_failure.test
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_failure.test
@@ -1,0 +1,11 @@
+call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
+call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+select @@innodb_redo_log_encrypt;
+
+
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let SEARCH_PATTERN=Can't set redo log tablespace to be encrypted.
+--source include/search_pattern.inc
+--let SEARCH_PATTERN=Encryption can't find master key, please check the keyring plugin is loaded.
+--source include/search_pattern.inc
+

--- a/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
@@ -28,10 +28,10 @@ set global innodb_redo_log_encrypt='MASTER_KEY';
 set global innodb_redo_log_encrypt='KEYRING_KEY';
 select * from performance_schema.global_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	keyring_key
+innodb_redo_log_encrypt	off
 select * from performance_schema.session_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	keyring_key
+innodb_redo_log_encrypt	off
 set @@global.innodb_redo_log_encrypt=0;
 select @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3910,6 +3910,8 @@ static bool innobase_is_supported_system_table(const char *db,
 /* mutex protecting the master_key_id */
 ib_mutex_t	master_key_id_mutex;
 
+void srv_enable_undo_encryption_if_set();
+
 /** Fix the empty UUID of tablespaces like system, temp etc by generating
 a new master key and do key rotation. These tablespaces if encrypted
 during startup, will be encrypted with tablespace key which has empty UUID
@@ -3917,20 +3919,25 @@ during startup, will be encrypted with tablespace key which has empty UUID
 bool
 innobase_fix_tablespaces_empty_uuid()
 {
+	if (Encryption::master_key_id == 0) {
+		/* We have to call srv_enable_redo_encryption during every
+		 startup, to report errors generated in this function correctly.
+		 Without this call here, some illegal configurations, such as
+		 enabling encryption without a keyring are silently accepted,
+		 and result in errors later during the server run.
+		 These functions are also called later, when the 
+		 master key is correctly set up, later in this function. */
+		if(srv_enable_redo_encryption()) {
+			srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
+		} else {
+			redo_rotate_default_key();
+		}
+	}
+
 	/* If we are in read only mode, we cannot do rotation but it
 	is OK */
 	if (srv_read_only_mode) {
 		return(false);
-	}
-
-	if (Encryption::master_key_id == 0 && srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK) {
-		/* redo log can be encrypted with keyring_key, which has to be 
-		   initialized even when nothing's encrypted with master_key - in
-		   which case, master_key_id == 0, so this condition succeeds. 
-		   We call this function here, because otherwise, if the redo log
-		   is encrypted with master_key, log encryption has to be initialized
-		   after Encryption::create_master_key. */
-		log_enable_encryption_if_set();
 	}
 
 	/* We only need to handle the case when an encrypted tablespace
@@ -3963,7 +3970,11 @@ innobase_fix_tablespaces_empty_uuid()
 		return(true);
 	}
 
-	log_enable_encryption_if_set();
+	if (srv_enable_redo_encryption()) {
+		srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
+	} else {
+		redo_rotate_default_key();
+	}
 
 	/** Check if sys, temp need rotation to fix the empty uuid */
 	/* Also, in future, it is possible to fix empty uuid for redo & undo
@@ -21437,12 +21448,36 @@ innodb_temp_tablespace_encryption_update(
 @param[in]	save	immediate result from check function */
 static
 void
-innodb_redo_encryption_update(
+update_innodb_redo_log_encrypt(
 	THD*				thd,
 	struct st_mysql_sys_var*	var,
 	void*				var_ptr,
 	const void*			save)
 {
+	const ulong target = *static_cast<const ulong *>(save);
+
+	if (srv_redo_log_encrypt == target) {
+		/* No change */
+		return;
+	}
+
+	if (target == REDO_LOG_ENCRYPT_OFF) {
+  		srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
+ 		return;
+	}
+
+	if (srv_redo_log_encrypt != REDO_LOG_ENCRYPT_OFF
+	    && srv_redo_log_encrypt != target) {
+		push_warning_printf(
+			thd, Sql_condition::SL_WARNING,
+			ER_WRONG_ARGUMENTS,
+			" Redo log encryption mode"
+			" can't be switched without stopping the server and"
+			" recreating the redo logs.");
+	    return;
+	}
+
+
 	if (srv_read_only_mode) {
 		push_warning_printf(
 			thd, Sql_condition::SL_WARNING,
@@ -21452,10 +21487,30 @@ innodb_redo_encryption_update(
 		return;
 	}
 
-	*static_cast<ulong*>(var_ptr) =
-		*static_cast<const ulong*>(save);
+	byte iv[ENCRYPTION_KEY_LEN];
+	Encryption::random_value(iv);
 
-	log_enable_encryption_if_set();
+	if (target == REDO_LOG_ENCRYPT_MK) {
+		ut_ad(strlen(server_uuid) > 0);
+		if(srv_enable_redo_encryption_mk()) {
+			return;
+		}
+
+		srv_redo_log_encrypt = target;
+		return;
+	}
+
+	if (target == REDO_LOG_ENCRYPT_RK) {
+		ut_ad(strlen(server_uuid) > 0);
+		if(srv_enable_redo_encryption_rk()) {
+			return;
+		}
+
+		srv_redo_log_encrypt = target;
+		return;
+	}
+
+	ut_ad(0);
 }
 
 static SHOW_VAR innodb_status_variables_export[]= {
@@ -22521,7 +22576,7 @@ static MYSQL_SYSVAR_ENUM(default_row_format, innodb_default_row_format,
 static MYSQL_SYSVAR_ENUM(redo_log_encrypt, srv_redo_log_encrypt,
   PLUGIN_VAR_OPCMDARG,
   "Enable or disable Encryption of REDO tablespace. Possible values: OFF, MASTER_KEY, KEYRING_KEY.",
-  NULL, innodb_redo_encryption_update, REDO_LOG_ENCRYPT_OFF, &redo_log_encrypt_typelib);
+  NULL, update_innodb_redo_log_encrypt, REDO_LOG_ENCRYPT_OFF, &redo_log_encrypt_typelib);
 
 #ifdef UNIV_DEBUG
 static MYSQL_SYSVAR_UINT(trx_rseg_n_slots_debug, trx_rseg_n_slots_debug,

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -142,6 +142,14 @@ Closes the log.
 lsn_t
 log_close(void);
 
+enum redo_log_encrypt_enum {
+	REDO_LOG_ENCRYPT_OFF = 0,
+	REDO_LOG_ENCRYPT_MK = 1,
+	REDO_LOG_ENCRYPT_RK = 2,
+};
+
+void redo_rotate_default_key();
+
 /** Write the encryption info into the log file header(the 3rd block).
 It just need to flush the file header block with current master key.
 @param[in]	key	encryption key
@@ -151,7 +159,8 @@ It just need to flush the file header block with current master key.
 bool
 log_write_encryption(
 	byte*	key,
-	byte*	iv);
+	byte*	iv,
+	redo_log_encrypt_enum redo_log_encrypt);
 
 /** Rotate the redo log encryption
  * It will re-encrypt the redo log encryption metadata and write it to
@@ -162,7 +171,7 @@ log_rotate_encryption();
 
 /** Enables redo log encryption. */
 void
-log_enable_encryption_if_set();
+redo_rotate_default_master_key();
 /************************************************************//**
 Gets the current lsn.
 @return current lsn */

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -355,12 +355,6 @@ extern ulong	srv_n_log_files;
 
 extern ulong	srv_redo_log_encrypt;
 
-enum redo_log_encrypt_enum {
-	REDO_LOG_ENCRYPT_OFF = 0,
-	REDO_LOG_ENCRYPT_MK = 1,
-	REDO_LOG_ENCRYPT_RK = 2,
-};
-
 /** At startup, this is the current redo log file size.
 During startup, if this is different from srv_log_file_size_requested
 (innodb_log_file_size), the redo log will be rebuilt and this size
@@ -1052,6 +1046,19 @@ srv_was_tablespace_truncated(const fil_space_t* space);
 bool
 srv_is_undo_tablespace(
 	ulint	space_id);
+
+/** Enables master key redo encryption. 
+Doesn't depend on the srv_redo_log_encrypt variable, used by 
+SET innodb_redo_log_encrypt = MK. */
+bool srv_enable_redo_encryption_mk();
+
+/** Enables keyring key redo encryption. 
+Doesn't depend on the srv_redo_log_encrypt variable, used by 
+SET innodb_redo_log_encrypt = RK. */
+bool srv_enable_redo_encryption_rk();
+
+/** Enables redo log encryption based on srv_redo_log_encrypt. */
+bool srv_enable_redo_encryption();
 
 #ifdef UNIV_DEBUG
 /** Disables master thread. It's used by:

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -79,6 +79,7 @@ Created 10/8/1995 Heikki Tuuri
 #include "handler.h"
 #include "ha_innodb.h"
 #include "fil0crypt.h"
+#include "system_key.h"
 
 
 #ifndef UNIV_PFS_THREAD
@@ -3523,6 +3524,141 @@ srv_is_undo_tablespace(
 	       && space_id < (srv_undo_space_id_start
 			      + srv_undo_tablespaces_open));
 }
+
+bool
+srv_enable_redo_encryption()
+{
+	if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_MK) {
+		return srv_enable_redo_encryption_mk();
+	}
+
+	if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK) {
+		return srv_enable_redo_encryption_rk();
+	}
+
+	return false;
+}
+
+bool
+srv_enable_redo_encryption_mk()
+{
+	fil_space_t *space = fil_space_get(dict_sys_t::s_log_space_first_id);
+	if (FSP_FLAGS_GET_ENCRYPTION(space->flags)) {
+		return false;
+	}
+	byte key[ENCRYPTION_KEY_LEN];
+	byte iv[ENCRYPTION_KEY_LEN];
+	
+	Encryption::random_value(iv);
+	Encryption::random_value(key);
+
+	if (!log_write_encryption(key, iv, REDO_LOG_ENCRYPT_MK)) {
+
+		ib::error() << "Can't set redo log tablespace to be encrypted.";
+		return true;
+	}
+
+	space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
+
+	const dberr_t err = fil_set_encryption(space->id, Encryption::AES, key, iv);
+	if (err != DB_SUCCESS) {
+		ib::error() << "Can't set redo log tablespace to be encrypted.";
+		return true;
+	}
+
+	ib::info() << "Redo log encryption is enabled.";
+
+	return false;
+}
+
+
+bool
+srv_enable_redo_encryption_rk()
+{
+	fil_space_t *space = fil_space_get(dict_sys_t::s_log_space_first_id);
+	if (FSP_FLAGS_GET_ENCRYPTION(space->flags))
+	{
+		return false;
+	}
+
+	byte key[ENCRYPTION_KEY_LEN];
+        byte iv[ENCRYPTION_KEY_LEN];
+	uint version;
+
+	Encryption::random_value(key);
+	
+	// load latest key & write version
+
+	char *redo_key_type = NULL;
+	byte *rkey = NULL;
+	size_t klen = 0;
+
+	if (my_key_fetch(PERCONA_REDO_KEY_NAME, &redo_key_type, NULL,
+				reinterpret_cast<void**>(&rkey), &klen) || rkey == NULL)
+	{
+		if (my_key_generate(PERCONA_REDO_KEY_NAME, "AES", NULL, ENCRYPTION_KEY_LEN)) {
+			ib::error() << "Redo log key generation failed.";
+			my_free(redo_key_type);
+			my_free(rkey);
+			return true;
+		} else if (my_key_fetch(PERCONA_REDO_KEY_NAME, &redo_key_type, NULL,
+					reinterpret_cast<void**>(&rkey), &klen)) {
+			ib::error() << "Couldn't fetch newly generated redo key.";
+			my_free(redo_key_type);
+			my_free(rkey);
+			return true;
+		} else {
+			DBUG_ASSERT(rkey != NULL);
+			byte *rkey2 = NULL;
+			size_t klen2 = 0;
+			bool err = (parse_system_key(rkey, klen, &version, &rkey2, &klen2)
+					== reinterpret_cast<uchar*>(NullS));
+			ut_ad(klen2 ==  ENCRYPTION_KEY_LEN);
+			if (err) {
+				ib::error() << "Couldn't parse system key: " << rkey;
+				my_free(redo_key_type);
+				my_free(rkey);
+				return true;
+			} else {
+				memcpy(key, rkey2, ENCRYPTION_KEY_LEN);
+			}
+			my_free(rkey2);
+		}
+	} else {
+		memcpy(key, rkey, ENCRYPTION_KEY_LEN);
+	}
+
+	ut_ad(redo_key_type && strcmp(redo_key_type, "AES") == 0);
+
+	my_free(redo_key_type);
+	my_free(rkey);
+
+#ifdef UNIV_ENCRYPT_DEBUG
+	fprintf(stderr, "Fetched redo key: %s.\n", key);
+#endif
+
+	if (!log_write_encryption(key, iv, REDO_LOG_ENCRYPT_RK)) {
+		ib::error() << "Can't set redo log tablespace to be"
+			" encrypted.";
+		return true;
+	}
+
+	space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
+	space->encryption_key_version = version;
+	dberr_t err = fil_set_encryption(
+			space->id, Encryption::AES,
+			key, iv);
+
+	if(err != DB_SUCCESS) {
+		ib::error() << "Can't set redo log tablespace to be encrypted.";
+		return true;
+	}
+
+	ib::info() << "Redo log encryption is enabled.";
+
+	return false;
+}
+
 
 /** Enable the undo log encryption if it is set.
 It will try to enable the undo log encryption and write the metadata to

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -524,8 +524,8 @@ create_log_files(
 	if redo log is set with encryption. */
 	if (FSP_FLAGS_GET_ENCRYPTION(log_space->flags)) {
 		if (!log_write_encryption(log_space->encryption_key,
-					  log_space->encryption_iv
-					  )) {
+					  log_space->encryption_iv,
+					  static_cast<redo_log_encrypt_enum>(srv_redo_log_encrypt))) {
 			return(DB_ERROR);
 		}
 	}


### PR DESCRIPTION
    Issue: when the server is started without a keyring, the redo log encryption
    checks were never performed, redo log encrytpion wasn't initialized, but the
    setting was left on, misleading the user. Later operations which triggered
    this check could possibly fail.

    Issue #2: redo log encryption didn't work properly when it was turned on using
    the command line: in some cases, the redo log remained unencrypted (until
    another operation triggered the redo log encryption setup methods to be called
    again)

    Both issues were caused by the refactoring of the periodic, once every
    second encryption checks in upstream, in PS-5189.

    This commit:

    * changes the code so redo log encryption routienes are called at least twice
    during every startup with the encryption settings on. This fixes issue #2.
    * changes the code so redo log encryption routines are called at least once
    during evrey startup, even without a keyring, or a read only server: this fixes
    issues #1
    * adds a test ensuring that in an invalid configuration (without a keyring) the
    server remains running, but the redo log encryption setting correctly displays the
    OFF status
    * adds a test ensuring that when the redo log is correctly configured (using the
    dynamic variable or a command line parameter) the log is encrypted, and no unencrypted
    data is present in it.
