### PR TITLE
PS-5148 : [PS8QA] compression dictionary operations not handled under innodb-force-recovery

### DIFF
--- a/mysql-test/suite/innodb/r/percona_compression_dict_force_recovery.result
+++ b/mysql-test/suite/innodb/r/percona_compression_dict_force_recovery.result
@@ -1,0 +1,92 @@
+CREATE COMPRESSION_DICTIONARY d1('blah');
+CREATE TABLE `t1` (`a` text COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY `d1`) ENGINE=InnoDB;
+INSERT INTO t1 VALUES('satya');
+#########################################################
+# restart: --innodb_force_recovery=6
+#########################################################
+# drop existing compression dictionary with references by tables
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Running in read-only mode
+# drop existing table
+DROP TABLE t1;
+ERROR HY000: Storage engine can't drop table 'test.t1'
+# drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Running in read-only mode
+# create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d1('blah');
+ERROR HY000: Running in read-only mode
+#########################################################
+# restart: --innodb_force_recovery=5
+#########################################################
+# drop existing compression dictionary with references by tables
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Table 'compression_dictionary' is read only
+# drop existing table
+DROP TABLE t1;
+ERROR HY000: Storage engine can't drop table 'test.t1'
+# drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Table 'compression_dictionary' is read only
+# create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d1('blah');
+ERROR HY000: Table 'compression_dictionary' is read only
+#########################################################
+# restart: --innodb_force_recovery=4
+#########################################################
+# drop existing compression dictionary with references by tables
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Table 'compression_dictionary' is read only
+# drop existing table
+DROP TABLE t1;
+ERROR HY000: Table 'tablespace_files' is read only
+# drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Table 'compression_dictionary' is read only
+# create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d1('blah');
+ERROR HY000: Table 'compression_dictionary' is read only
+#########################################################
+# restart: --innodb_force_recovery=3
+#########################################################
+# drop existing compression dictionary with references by tables
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Operation not allowed when innodb_forced_recovery > 0.
+# drop existing table
+DROP TABLE t1;
+ERROR HY000: Operation not allowed when innodb_forced_recovery > 0.
+# drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Operation not allowed when innodb_forced_recovery > 0.
+# create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d2('blah');
+#########################################################
+# restart: --innodb_force_recovery=2
+#########################################################
+# drop existing compression dictionary with references by tables
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Compression dictionary 'd1' is in use
+# drop existing table
+DROP TABLE t1;
+# drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+# create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d1('blah');
+CREATE TABLE `t1` (`a` text COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY `d1`) ENGINE=InnoDB;
+#########################################################
+# restart: --innodb_force_recovery=1
+#########################################################
+# drop existing compression dictionary with references by tables
+DROP COMPRESSION_DICTIONARY d1;
+ERROR HY000: Compression dictionary 'd1' is in use
+# drop existing table
+DROP TABLE t1;
+# drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+# create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d1('blah');
+CREATE TABLE `t1` (`a` text COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY `d1`) ENGINE=InnoDB;
+# restart
+DROP TABLE t1;
+DROP COMPRESSION_DICTIONARY d1;
+DROP COMPRESSION_DICTIONARY d2;

--- a/mysql-test/suite/innodb/t/percona_compression_dict_force_recovery.test
+++ b/mysql-test/suite/innodb/t/percona_compression_dict_force_recovery.test
@@ -1,0 +1,139 @@
+--disable_query_log
+call mtr.add_suppression("Skip re-populating collations and character sets tables in InnoDB read-only mode");
+call mtr.add_suppression("Skipped updating resource group metadata in InnoDB read only mode");
+call mtr.add_suppression("Skip updating information_schema metadata in InnoDB read-only mode");
+call mtr.add_suppression("innodb_force_recovery is on. We do not allow database modifications by the user. Shut down mysqld and edit my.cnf to set innodb_force_recovery=0");
+--enable_query_log
+
+
+CREATE COMPRESSION_DICTIONARY d1('blah');
+CREATE TABLE `t1` (`a` text COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY `d1`) ENGINE=InnoDB;
+INSERT INTO t1 VALUES('satya');
+
+--echo #########################################################
+--let $restart_parameters = "restart: --innodb_force_recovery=6"
+--source include/restart_mysqld.inc
+--echo #########################################################
+
+--echo # drop existing compression dictionary with references by tables
+--error ER_READ_ONLY_MODE
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # drop existing table
+--error ER_ENGINE_CANT_DROP_TABLE
+DROP TABLE t1;
+
+--echo # drop existing compression dictionary with no references
+--error ER_READ_ONLY_MODE
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # create new compression dictionary
+--error ER_READ_ONLY_MODE
+CREATE COMPRESSION_DICTIONARY d1('blah');
+
+--echo #########################################################
+--let $restart_parameters = "restart: --innodb_force_recovery=5"
+--source include/restart_mysqld.inc
+--echo #########################################################
+
+--echo # drop existing compression dictionary with references by tables
+--error ER_OPEN_AS_READONLY
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # drop existing table
+--error ER_ENGINE_CANT_DROP_TABLE
+DROP TABLE t1;
+
+--echo # drop existing compression dictionary with no references
+--error ER_OPEN_AS_READONLY
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # create new compression dictionary
+--error ER_OPEN_AS_READONLY
+CREATE COMPRESSION_DICTIONARY d1('blah');
+
+--echo #########################################################
+--let $restart_parameters = "restart: --innodb_force_recovery=4"
+--source include/restart_mysqld.inc
+--echo #########################################################
+
+--echo # drop existing compression dictionary with references by tables
+--error ER_OPEN_AS_READONLY
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # drop existing table
+--error ER_OPEN_AS_READONLY
+DROP TABLE t1;
+
+--echo # drop existing compression dictionary with no references
+--error ER_OPEN_AS_READONLY
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # create new compression dictionary
+--error ER_OPEN_AS_READONLY
+CREATE COMPRESSION_DICTIONARY d1('blah');
+
+
+--echo #########################################################
+--let $restart_parameters = "restart: --innodb_force_recovery=3"
+--source include/restart_mysqld.inc
+--echo #########################################################
+
+--echo # drop existing compression dictionary with references by tables
+--error ER_INNODB_FORCED_RECOVERY
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # drop existing table
+--error ER_INNODB_FORCED_RECOVERY
+DROP TABLE t1;
+
+--echo # drop existing compression dictionary with no references
+--error ER_INNODB_FORCED_RECOVERY
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d2('blah');
+
+--echo #########################################################
+--let $restart_parameters = "restart: --innodb_force_recovery=2"
+--source include/restart_mysqld.inc
+--echo #########################################################
+
+--echo # drop existing compression dictionary with references by tables
+--error ER_COMPRESSION_DICTIONARY_IS_REFERENCED
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # drop existing table
+DROP TABLE t1;
+
+--echo # drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d1('blah');
+CREATE TABLE `t1` (`a` text COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY `d1`) ENGINE=InnoDB;
+
+--echo #########################################################
+--let $restart_parameters = "restart: --innodb_force_recovery=1"
+--source include/restart_mysqld.inc
+--echo #########################################################
+
+--echo # drop existing compression dictionary with references by tables
+--error ER_COMPRESSION_DICTIONARY_IS_REFERENCED
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # drop existing table
+DROP TABLE t1;
+
+--echo # drop existing compression dictionary with no references
+DROP COMPRESSION_DICTIONARY d1;
+
+--echo # create new compression dictionary
+CREATE COMPRESSION_DICTIONARY d1('blah');
+CREATE TABLE `t1` (`a` text COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY `d1`) ENGINE=InnoDB;
+
+--let $restart_parameters = 
+--source include/restart_mysqld.inc
+DROP TABLE t1;
+DROP COMPRESSION_DICTIONARY d1;
+DROP COMPRESSION_DICTIONARY d2;

--- a/sql/sql_zip_dict.cc
+++ b/sql/sql_zip_dict.cc
@@ -426,10 +426,18 @@ int create_zip_dict(THD *thd, const char *name, ulong name_len,
         break;
       case HA_ERR_RECORD_FILE_FULL:
         error = ER_RECORD_FILE_FULL;
-        my_error(error, MYF(0), "compression_dictionary");
+        my_error(error, MYF(0), COMPRESSION_DICTIONARY_TABLE);
         break;
       case HA_ERR_TOO_MANY_CONCURRENT_TRXS:
         error = ER_TOO_MANY_CONCURRENT_TRXS;
+        my_error(error, MYF(0));
+        break;
+      case HA_ERR_TABLE_READONLY:
+        error = ER_OPEN_AS_READONLY;
+        my_error(error, MYF(0), COMPRESSION_DICTIONARY_TABLE);
+        break;
+      case HA_ERR_INNODB_FORCED_RECOVERY:
+        error = ER_INNODB_FORCED_RECOVERY;
         my_error(error, MYF(0));
         break;
       default:
@@ -578,6 +586,14 @@ int drop_zip_dict(THD *thd, const char *name, ulong name_len, bool if_exists) {
       break;
     case HA_ERR_TOO_MANY_CONCURRENT_TRXS:
       error = ER_TOO_MANY_CONCURRENT_TRXS;
+      my_error(error, MYF(0));
+      break;
+    case HA_ERR_TABLE_READONLY:
+      error = ER_OPEN_AS_READONLY;
+      my_error(error, MYF(0), COMPRESSION_DICTIONARY_TABLE);
+      break;
+    case HA_ERR_INNODB_FORCED_RECOVERY:
+      error = ER_INNODB_FORCED_RECOVERY;
       my_error(error, MYF(0));
       break;
     default:
@@ -767,13 +783,16 @@ static bool cols_table_delete_low(TABLE *table, uint64 table_id,
     ret = table->file->ha_delete_row(table->record[0]);
   }
 
-  if (ret == 0) {
-    return (false);
-  } else {
-    DBUG_ASSERT(0);
-    int error = ER_UNKNOWN_ERROR;
-    my_error(error, MYF(0));
-    return (true);
+  switch (ret) {
+    case 0:
+      return (false);
+    case HA_ERR_INNODB_FORCED_RECOVERY:
+      my_error(ER_INNODB_FORCED_RECOVERY, MYF(0));
+      return (true);
+    default:
+      DBUG_ASSERT(0);
+      my_error(ER_UNKNOWN_ERROR, MYF(0));
+      return (true);
   }
 }
 

--- a/sql/sql_zip_dict.h
+++ b/sql/sql_zip_dict.h
@@ -48,13 +48,20 @@ data from 5.7 SYS_ZIP_DICT to 8.0 mysql.compression_dictionary table
 @return false on success, true on failure */
 bool upgrade_transfer_compression_dict_data(THD *thd);
 
-/** @return true if the table is hardcoded compression dictionary tables
+/** @return true if the table is a hardcoded compression dictionary table
 @param[in] schema     schema name
 @param[in] table_name table name */
 inline bool is_hardcoded(const dd::String_type &schema,
                          const dd::String_type &table_name) {
   return (schema == "mysql" && (table_name == "compression_dictionary" ||
                                 table_name == "compression_dictionary_cols"));
+}
+
+/** @return true if the table is a hardcoded compression dictionary table
+@param[in]  name  name in "db/table" format */
+inline bool is_hardcoded(const char *name) {
+  return (strcmp(name, "mysql/compression_dictionary") == 0 ||
+          strcmp(name, "mysql/compression_dictionary_cols") == 0);
 }
 
 /**

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -83,6 +83,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "current_thd.h"
 #include "my_dbug.h"
 #include "my_io.h"
+#include "sql/sql_zip_dict.h"
 
 static const char *MODIFICATIONS_NOT_ALLOWED_MSG_FORCE_RECOVERY =
     "innodb_force_recovery is on. We do not allow database modifications"
@@ -2017,7 +2018,9 @@ static dberr_t row_insert_for_mysql_using_ins_graph(const byte *mysql_rec,
     return (row_mysql_get_table_status(prebuilt->table, trx, true));
   } else if (srv_force_recovery &&
              !(srv_force_recovery < SRV_FORCE_NO_UNDO_LOG_SCAN &&
-               dict_sys_t::is_dd_table_id(prebuilt->table->id))) {
+               (dict_sys_t::is_dd_table_id(prebuilt->table->id) ||
+                compression_dict::is_hardcoded(
+                    prebuilt->table->name.m_name)))) {
     /* Allow to modify hardcoded DD tables in some scenario to
     make DDL work */
 
@@ -2698,7 +2701,19 @@ static dberr_t row_update_for_mysql_using_upd_graph(const byte *mysql_rec,
   make DDL work */
   if (srv_force_recovery > 0 &&
       !(srv_force_recovery < SRV_FORCE_NO_UNDO_LOG_SCAN &&
-        dict_sys_t::is_dd_table_id(prebuilt->table->id))) {
+        (dict_sys_t::is_dd_table_id(prebuilt->table->id) ||
+         compression_dict::is_hardcoded(prebuilt->table->name.m_name)))) {
+    ib::error(ER_IB_MSG_985) << MODIFICATIONS_NOT_ALLOWED_MSG_FORCE_RECOVERY;
+    DBUG_RETURN(DB_READ_ONLY);
+  }
+
+  /* For compression dictionary delete, trx is already active because of the
+  search before delete. With the trx active, we cannot assign rseg with
+  srv_force_recovery >= SRV_FORCE_NO_TRX_UNDO. See trx_set_rw_mode().
+  For srv_force_recovery > SRV_FORCE_NO_TRX_UNDO, DB is readonly mode.
+  So we disallow compression dictionary operation in SRV_FORCE_NO_TRX_UNDO.*/
+  if (srv_force_recovery == SRV_FORCE_NO_TRX_UNDO &&
+      compression_dict::is_hardcoded(prebuilt->table->name.m_name)) {
     ib::error(ER_IB_MSG_985) << MODIFICATIONS_NOT_ALLOWED_MSG_FORCE_RECOVERY;
     DBUG_RETURN(DB_READ_ONLY);
   }


### PR DESCRIPTION
Problem:
--------
Compression dictionary operations are not handled when innodb_force_recovery > 0.

Fix:
----
We treat compression dictionary operations like DDL operations (The reason to allow DDL is to be able
to drop corrupted table).

For value <  3, compression dictionary operations are allowed, DDLs are allowed
For value == 3, compression dictionary operations are not allowed, DDLs are allowed (On why compression dictionary operation are not allowed, see below)
For values > 3, InnoDB is in read-only mode

Reason for disallowing compression dictionary operation in innodb_force_recovery == 3 
--------------
other DDLs would need rsegs too. In case of other DDLs, the trx is not active and the rsegs are assigned via different path.

For compression dictionary delete operation, first there is search operation on the row, makes the trx active (without rsegs assigned) and then the delete operation, cannot assign rsegs anymore.

Infact, this should have affected regular BEGIN; SELECT FOR UPDATE; DELETE;. What prevents the issue is,  DELETE on user tables is not allowed. If the check is skipped, we get same issue/assert failure: ut_ad(trx_is_rseg_assigned(trx));