### PR TITLE
Fix PS-5462 (rpl.bug62557 does not clean up after itself, failing rpl…

### DIFF
--- a/mysql-test/suite/rpl/t/bug62557.test
+++ b/mysql-test/suite/rpl/t/bug62557.test
@@ -36,3 +36,7 @@ DROP TABLE t1;
 
 # Cleanup
 --source include/rpl_end.inc
+
+# Due to server 1 being a slave to server 2, we need to force server restart
+# to clear its in-memory slave status, to avoid breaking further tests.
+--source include/force_restart.inc


### PR DESCRIPTION
…_master_pos_wait)

rpl.bug62557 is a circular replication test with topology
1->2->1. This causes server 1, which is a master but not a slave
server in other tests, to start having non-empty SHOW SLAVE STATUS
result, breaking some of the next tests on the same MTR workes,
i.e. rpl_master_pos_wait.

Fix by forcing a restart at the end of the test.

https://ps80.cd.percona.com/job/percona-server-8.0-param/58/