### PR TITLE
PS-5485 : exposing undo log tablespace encryption status through inno…

### DIFF
--- a/mysql-test/suite/innodb/r/temp_table_encrypt.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt.result
@@ -24,6 +24,7 @@ Warning	1210	 Temporary tablespace couldn't be encrypted. Check if keyring plugi
 SELECT @@innodb_temp_tablespace_encrypt;
 @@innodb_temp_tablespace_encrypt
 0
+include/assert.inc [Temporary tablespace should be unencrypted]
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 ERROR HY000: InnoDB : ENCRYPTION is not accepted syntax for CREATE/ALTER table, for tables in general/shared tablespace.
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='N';
@@ -40,6 +41,7 @@ Warning	1210	 Temporary tablespace cannot be encrypted in innodb_read_only mode
 SELECT @@innodb_temp_tablespace_encrypt;
 @@innodb_temp_tablespace_encrypt
 0
+include/assert.inc [Temporary tablespace should be unencrypted]
 # startup failure when innodb_temp_tablespace =ON and no keyring plugin
 Pattern found.
 # restart:<hidden args>
@@ -56,6 +58,7 @@ INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 SHOW WARNINGS;
 Level	Code	Message
+include/assert.inc [Temporary tablespace should be encrypted]
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 DROP TABLE t01;
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
@@ -67,3 +70,4 @@ INSERT INTO t01 VALUES (1), (2), (3);
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+include/assert.inc [Temporary tablespace should be encrypted. Once encrypted, it cannot be unencrypted]

--- a/mysql-test/suite/innodb/r/undo_encrypt_basic.result
+++ b/mysql-test/suite/innodb/r/undo_encrypt_basic.result
@@ -57,6 +57,9 @@ c1	c2
 0	aaaaa
 0	aaaaa
 # Start the DB server with undo log encryption enabled and keyring plugin loaded. It should success.
+# undo tablespace already encrypted, off at startup doesn't matter
+include/assert.inc [Undo tablespace should be encrypted]
+include/assert.inc [Undo tablespace should be encrypted]
 SELECT * FROM t1 ORDER BY c1 LIMIT 10;
 c1	c2
 0	aaaaa

--- a/mysql-test/suite/innodb/t/temp_table_encrypt.test
+++ b/mysql-test/suite/innodb/t/temp_table_encrypt.test
@@ -21,6 +21,10 @@ SELECT @@innodb_temp_tablespace_encrypt;
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 SELECT @@innodb_temp_tablespace_encrypt;
 
+--let $assert_text = Temporary tablespace should be unencrypted
+--let $assert_cond = "[SELECT ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = \"innodb_temporary\"]" = "N"
+--source include/assert.inc
+
 --error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 
@@ -33,6 +37,10 @@ CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB ENCRYPTION='N';
 SELECT @@innodb_temp_tablespace_encrypt;
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 SELECT @@innodb_temp_tablespace_encrypt;
+
+--let $assert_text = Temporary tablespace should be unencrypted
+--let $assert_cond = "[SELECT ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = \"innodb_temporary\"]" = "N"
+--source include/assert.inc
 
 --source include/shutdown_mysqld.inc
 
@@ -71,6 +79,9 @@ connection default;
 
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 SHOW WARNINGS;
+--let $assert_text = Temporary tablespace should be encrypted
+--let $assert_cond = "[SELECT ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = \"innodb_temporary\"]" = "Y"
+--source include/assert.inc
 
 connect (other2,localhost,root,,test);
 connection other2;
@@ -100,6 +111,9 @@ CREATE TEMPORARY TABLE t01 (a INT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES (1), (2), (3);
 
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+--let $assert_text = Temporary tablespace should be encrypted. Once encrypted, it cannot be unencrypted
+--let $assert_cond = "[SELECT ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = \"innodb_temporary\"]" = "Y"
+--source include/assert.inc
 
 --source include/wait_until_count_sessions.inc
 --remove_file $MYSQL_TMP_DIR/ts_encrypt_keyring

--- a/mysql-test/suite/innodb/t/undo_encrypt_basic.test
+++ b/mysql-test/suite/innodb/t/undo_encrypt_basic.test
@@ -58,7 +58,14 @@ let NEW_CMD = $MYSQLD --no-defaults --innodb_dedicated_server=OFF --initialize-i
 
 #Enable undo log encryption, should report error in server log, since keyring is not loaded.
 SET GLOBAL innodb_undo_log_encrypt = ON;
---sleep 1
+let $wait_condition = SELECT ENCRYPTION = 'N'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='innodb_undo_001';
+--source include/wait_condition.inc
+let $wait_condition = SELECT ENCRYPTION = 'N'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='innodb_undo_002';
+--source include/wait_condition.inc
 
 --error ER_CANNOT_FIND_KEY_IN_KEYRING
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
@@ -71,7 +78,14 @@ CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 
 #Enable undo log encryption, shouldn't report error in server log.
 SET GLOBAL innodb_undo_log_encrypt = ON;
---sleep 1
+let $wait_condition = SELECT ENCRYPTION = 'Y'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='innodb_undo_001';
+--source include/wait_condition.inc
+let $wait_condition = SELECT ENCRYPTION = 'Y'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='innodb_undo_002';
+--source include/wait_condition.inc
 
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION='Y' ENGINE = InnoDB;
 
@@ -105,6 +119,15 @@ SELECT * FROM t2 ORDER BY c1 LIMIT 10;
 --replace_result $MYSQL_TMP_DIR TMP_DIR $KEYRING_PLUGIN_OPT --plugin-dir=KEYRING_PATH $MYSQLD_HOME_DATA_DIR HOME_DIR $MYSQLD_UNDO_DATADIR UNDO_DIR $MYSQLD_DATADIR DATADIR $START_PAGE_SIZE PAGE_SIZE $LOG_FILE_SIZE LOG_FILE_SIZE
 --replace_regex /\.dll/.so/
 --source include/restart_mysqld_no_echo.inc
+
+--echo # undo tablespace already encrypted, off at startup doesn't matter
+--let $assert_text = Undo tablespace should be encrypted
+--let $assert_cond = "[SELECT ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = \"innodb_undo_001\"]" = "Y"
+--source include/assert.inc
+
+--let $assert_text = Undo tablespace should be encrypted
+--let $assert_cond = "[SELECT ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = \"innodb_undo_002\"]" = "Y"
+--source include/assert.inc
 
 SELECT * FROM t1 ORDER BY c1 LIMIT 10;
 SELECT * FROM t2 ORDER BY c1 LIMIT 10;


### PR DESCRIPTION
…db_tablespaces

PS-5490 : enabling temp-tablespace encryption doesn't mark innodb_temporary tablespace encryption flag

Problem:
--------
When temporary tablespace and undo tablespaces are encrypted, I_S views does not show proper status in "encryption" column output.

Fix:
----
We will use cached tablespace flags to retreive encryption status.
When upstream fix for Bug#94665 arrives, remove the fsp_is_undo_tablespace() check introduced
in this patch.