### PR TITLE
PS-5538: innodb_encrypt_tables accepts FORCE only as a STRING

### DIFF
--- a/mysql-test/suite/innodb/r/percona_force_encryption.result
+++ b/mysql-test/suite/innodb/r/percona_force_encryption.result
@@ -13,7 +13,7 @@ create table t3_on_default (a int) engine=innodb;
 create table t4_on_explicit_off (a int) engine=innodb encryption="N";
 create table t_unencrypted_tablespace (a text) tablespace ts_unencrypted1 ENGINE="InnoDB";
 ERROR HY000: InnoDB: Tablespace `ts_unencrypted1` cannot contain an ENCRYPTED table.
-set global innodb_encrypt_tables='FORCE';
+set global innodb_encrypt_tables=FORCE;
 create table t5_force_explicit_off (a int) engine=innodb encryption="N";
 ERROR HY000: InnoDB: Only Master Key encrypted tables (ENCRYPTION='Y') can be created with innodb_encrypt_tables=FORCE.
 create table t6_force_default (a int) engine=innodb;
@@ -35,7 +35,7 @@ partition by range (a) partitions 2 (
 partition p1 values less than (20),
 partition p2 values less than (40) tablespace ts_encrypted2);
 ERROR HY000: InnoDB : A partitioned table is not allowed in a shared tablespace.
-set global innodb_encrypt_tables='FORCE';
+set global innodb_encrypt_tables=FORCE;
 insert into t1_default_explicit_on values (42);
 insert into t2_default_explicit_off values (42);
 insert into t3_on_default values (42);
@@ -105,7 +105,7 @@ alter table t4_on_explicit_off encryption="N";
 alter table t6_force_default encryption="N", ALGORITHM=INPLACE;
 ERROR 0A000: ALGORITHM=INPLACE is not supported. Reason: Cannot alter encryption attribute by inplace algorithm.. Try ALGORITHM=COPY.
 alter table t4_on_explicit_off change a b int;
-set global innodb_encrypt_tables='FORCE';
+set global innodb_encrypt_tables=FORCE;
 alter table t4_on_explicit_off change b a int;
 show create table t1_default_explicit_on;
 Table	Create Table

--- a/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
+++ b/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
@@ -32,7 +32,7 @@ ERROR HY000: InnoDB : ENCRYPTION is not accepted syntax for CREATE/ALTER table, 
 CREATE TABLE t8(a TEXT) TABLESPACE = innodb_system;
 ERROR HY000: InnoDB: Tablespace `innodb_system` cannot contain an ENCRYPTED table.
 # System is unencrypted, test with innodb_encrypt_tables=FORCE
-SET GLOBAL innodb_encrypt_tables="FORCE";
+SET GLOBAL innodb_encrypt_tables=FORCE;
 SELECT @@innodb_encrypt_tables;
 @@innodb_encrypt_tables
 FORCE
@@ -86,7 +86,7 @@ ERROR HY000: InnoDB : ENCRYPTION is not accepted syntax for CREATE/ALTER table, 
 CREATE TABLE t5_2(a TEXT) TABLESPACE = innodb_system, ENCRYPTION='Y';
 ERROR HY000: InnoDB : ENCRYPTION is not accepted syntax for CREATE/ALTER table, for tables in general/shared tablespace.
 # System is encrypted, test with innodb_encrypt_tables=FORCE
-SET GLOBAL innodb_encrypt_tables="FORCE";
+SET GLOBAL innodb_encrypt_tables=FORCE;
 SELECT @@innodb_encrypt_tables;
 @@innodb_encrypt_tables
 FORCE

--- a/mysql-test/suite/innodb/t/percona_force_encryption.test
+++ b/mysql-test/suite/innodb/t/percona_force_encryption.test
@@ -18,7 +18,7 @@ create table t3_on_default (a int) engine=innodb;
 create table t4_on_explicit_off (a int) engine=innodb encryption="N";
 --error ER_ILLEGAL_HA_CREATE_OPTION
 create table t_unencrypted_tablespace (a text) tablespace ts_unencrypted1 ENGINE="InnoDB";
-set global innodb_encrypt_tables='FORCE';
+set global innodb_encrypt_tables=FORCE;
 --error ER_INVALID_ENCRYPTION_OPTION
 create table t5_force_explicit_off (a int) engine=innodb encryption="N";
 create table t6_force_default (a int) engine=innodb;
@@ -40,7 +40,7 @@ create table t7_partitioned_fail (a int, primary key(a))
 	partition by range (a) partitions 2 (
 		partition p1 values less than (20),
 		partition p2 values less than (40) tablespace ts_encrypted2);
-set global innodb_encrypt_tables='FORCE';
+set global innodb_encrypt_tables=FORCE;
 
 insert into t1_default_explicit_on values (42);
 insert into t2_default_explicit_off values (42);
@@ -85,7 +85,7 @@ alter table t6_force_default encryption="N", ALGORITHM=INPLACE;
 # Even when it's ON or FORCE, non encrypted tables can be altered,
 # without changing their encryption settings
 alter table t4_on_explicit_off change a b int;
-set global innodb_encrypt_tables='FORCE';
+set global innodb_encrypt_tables=FORCE;
 alter table t4_on_explicit_off change b a int;
 
 show create table t1_default_explicit_on;

--- a/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
+++ b/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
@@ -46,7 +46,7 @@ CREATE TABLE t8(a TEXT) TABLESPACE = innodb_system, ENCRYPTION='Y';
 CREATE TABLE t8(a TEXT) TABLESPACE = innodb_system;
 
 --echo # System is unencrypted, test with innodb_encrypt_tables=FORCE
-SET GLOBAL innodb_encrypt_tables="FORCE";
+SET GLOBAL innodb_encrypt_tables=FORCE;
 SELECT @@innodb_encrypt_tables;
 
 --error ER_ILLEGAL_HA_CREATE_OPTION
@@ -156,7 +156,7 @@ CREATE TABLE t5_1(a TEXT) TABLESPACE = innodb_system, ENCRYPTION='N';
 CREATE TABLE t5_2(a TEXT) TABLESPACE = innodb_system, ENCRYPTION='Y';
 
 --echo # System is encrypted, test with innodb_encrypt_tables=FORCE
-SET GLOBAL innodb_encrypt_tables="FORCE";
+SET GLOBAL innodb_encrypt_tables=FORCE;
 SELECT @@innodb_encrypt_tables;
 CREATE TABLE t5_3(a TEXT) TABLESPACE = innodb_system;
 DROP TABLE t5_3;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -14870,6 +14870,10 @@ set_expr_or_default:
           {
             $$= NEW_PTN Item_string(@$, "SYSTEM", 6, system_charset_info);
           }
+        | FORCE_SYM
+          {
+            $$= NEW_PTN Item_string(@$, "FORCE", 5, system_charset_info);
+          }
         ;
 
 /* Lock function */


### PR DESCRIPTION
The problem was that FORCE is defined in global parser scope as a boolean
variable. The fix was to add a FORCE string option in set variable scope,
which overrides the global FORCE.