### PR TITLE
Fix PS-4933 ([PS8QA] Assertion `innodb_trx_id == 0 || innodb_trx_id =…

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2510,7 +2510,6 @@ void THD::cleanup_after_query()
   if (rli_slave)
     rli_slave->cleanup_after_query();
 #endif
-  approx_distinct_pages.clear();
 }
 
 LEX_CSTRING *
@@ -4400,8 +4399,7 @@ void THD::clear_slow_extended()
   tmp_tables_disk_used=         0;
   tmp_tables_size=              0;
   innodb_was_used=              false;
-  if (!(server_status & SERVER_STATUS_IN_TRANS))
-    innodb_trx_id=                0;
+  innodb_trx_id=                0;
   innodb_io_reads=              0;
   innodb_io_read=               0;
   innodb_io_reads_wait_timer=   0;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -2227,8 +2227,9 @@ public:
 
   void mark_innodb_used(ulonglong trx_id)
   {
-    DBUG_ASSERT(innodb_trx_id == 0 || innodb_trx_id == trx_id);
-    innodb_trx_id= trx_id;
+    DBUG_ASSERT(innodb_slow_log_enabled());
+    DBUG_ASSERT(innodb_trx_id == 0 || innodb_trx_id == trx_id || trx_id == 0);
+    if (trx_id) innodb_trx_id= trx_id;
     innodb_was_used= true;
   }
 
@@ -2245,7 +2246,6 @@ public:
 
   bool innodb_slow_log_data_logged() const
   {
-    DBUG_ASSERT(!innodb_was_used || innodb_slow_log_enabled());
     return innodb_was_used;
   }
 

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1274,7 +1274,6 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
     the slow log only if opt_log_slow_admin_statements is set.
   */
   thd->enable_slow_log= TRUE;
-  thd->clear_slow_extended();
   thd->lex->sql_command= SQLCOM_END; /* to avoid confusing VIEW detectors */
   thd->set_time();
   if (thd->is_valid_time() == false)


### PR DESCRIPTION
…= trx_id || is_attachable_transaction_active()' failed.)

While the failing assert triggers on 8.0 only, the root cause is
present on 5.7 as well: InnoDB slow query log extensions try to set
InnoDB transaction ID once per transaction. This becomes problematic
with attachable transactions (5.7), DD transactions (8.0) etc., where
the 1:1 mapping between user transactions and InnoDB transaction IDs
is broken. Hence simplify the transaction ID logic:
- in THD, do not save the reported InnoDB transaction ID across
  statements and do not clear it only at user transaction
  boundary. Clear it for each statement instead, leaving it to the
  InnoDB to report it anew, which it already does;
- allow transaction ID of 0 to be reported to the server layer after
  it has already seen a non-0 ID, and only save the ID there if it's
  non-0;
- remove now-too-strict assert from
  THD::innodb_slow_log_data_logged(), which checked that if InnoDB
  data has been collected, then slow log verbosity must include
  InnoDB (this is not true for the statement that resets
  verbosity). Add a similar assert in THD::mark_innodb_used;
- remove redundannt approximate distinct pages clearing in
  THD::cleanup_after_query;
- remove redundant THD->clear_slow_extended call from
  dispatch_command.

https://ps57.cd.percona.com/job/percona-server-5.7-param/8/