### PR TITLE
Fix PS-5560 (New server warning in MTR testcase rpl_gtid.rpl_check_gtid)

### DIFF
--- a/mysql-test/suite/rpl_gtid/r/rpl_check_gtid.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_check_gtid.result
@@ -7,6 +7,7 @@ call mtr.add_suppression("Recovery from master pos .*");
 call mtr.add_suppression("Error in Log_event::read_log_event()");
 call mtr.add_suppression("Failed to read information on Previous GTIDs.");
 call mtr.add_suppression("Error reading GTIDs from binary log");
+call mtr.add_suppression("binlog truncated in the middle of event; consider out of disk space");
 CREATE TABLE t1(id INTEGER) ENGINE= Innodb;
 ==== Part 1 ====
 include/rpl_reset.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_check_gtid.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_check_gtid.test
@@ -79,6 +79,7 @@ call mtr.add_suppression("Recovery from master pos .*");
 call mtr.add_suppression("Error in Log_event::read_log_event()");
 call mtr.add_suppression("Failed to read information on Previous GTIDs.");
 call mtr.add_suppression("Error reading GTIDs from binary log");
+call mtr.add_suppression("binlog truncated in the middle of event; consider out of disk space");
 --enable_warnings
 
 CREATE TABLE t1(id INTEGER) ENGINE= Innodb;


### PR DESCRIPTION
PS-5105 made server print extra diagnostics to the error log on binlog
read errors, but rpl_gtid.rpl_check_gtid was not updated to match. Fix
trivially.

https://ps80.cd.percona.com/job/percona-server-8.0-param/64/