### PR TITLE
PS-5529 : Test main.percona_dd_upgrade_8013 always failing

### DIFF
--- a/mysql-test/t/percona_dd_upgrade_8013.test
+++ b/mysql-test/t/percona_dd_upgrade_8013.test
@@ -4,6 +4,9 @@
 --echo # The aim of test is to ensure that compression dictionary tables have
 --echo # correct table_ids(ie se_private_id).
 --echo #
+--disable_query_log
+call mtr.add_suppression("Column count of mysql.user is wrong. Expected 51, found 50. Created with MySQL 80013, now running \\d+. Please use mysql_upgrade to fix this error");
+--enable_query_log
 
 --source include/have_debug.inc
 

--- a/sql/dd/info_schema/metadata.cc
+++ b/sql/dd/info_schema/metadata.cc
@@ -527,7 +527,8 @@ bool update_server_I_S_metadata(THD *thd) {
     3) Update the target IS version in DD.
   */
   error = error || dd::info_schema::store_server_I_S_metadata(thd) ||
-          dd::info_schema::create_system_views(thd);
+          dd::info_schema::create_system_views(thd) ||
+          dd::info_schema::create_non_dd_views(thd, true);
 
   return dd::end_transaction(thd, error);
 }


### PR DESCRIPTION
Problem:
--------
Compression dictionary I_S views are missing when datadir is upgraded from
8.0.13 to 8.0.15.

Fix
---
I_S views are deregistered and registered again when stored I_S version is
different from target I_S version (current server version).

In this case, compression dictionary views are not registered again.
Fix is to register the compression dicitonary I_S views when there is I_S
version upgrade.