### PR TITLE
Fixed PS-5561 (5.7->8.0 null merge followup (remove error code 42 ASan suppressions from MTR test cases))

### DIFF
--- a/mysql-test/include/log_encrypt_4.inc
+++ b/mysql-test/include/log_encrypt_4.inc
@@ -72,7 +72,7 @@ DROP TABLE tab1,tab2;
 let NEW_CMD = $MYSQLD $extra_args --initialize-insecure --datadir=$MYSQLD_DATADIR2 --init-file=$BOOTSTRAP_SQL  --secure-file-priv="" --innodb_redo_log_encrypt=$redo_log_mode >>$MYSQLD_LOG 2>&1;
 
 --echo # Run the bootstrap command of datadir2, it should fail since the keyring is not loaded.
---error 1,42
+--error 1
 --exec $NEW_CMD
 --sleep 10
 

--- a/mysql-test/include/log_encrypt_6.inc
+++ b/mysql-test/include/log_encrypt_6.inc
@@ -87,7 +87,7 @@ DROP DATABASE tde_db;
 
 --echo # Try starting without keyring : Error
 let NEW_CMD = $MYSQLD --no-defaults --innodb_undo_tablespaces=2 --innodb_page_size=$START_PAGE_SIZE --innodb_log_file_size=$LOG_FILE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1  --secure-file-priv="" --console </dev/null>>$MYSQL_TMP_DIR/wl9290.err 2>&1;
---error 1,42
+--error 1
 --exec $NEW_CMD
 
 --echo # Search for error message


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5561

Removed "42" from the list of acceptable return codes in
'mysql-test\include\log_encrypt_4.inc' and
'mysql-test\include\log_encrypt_6.inc'.

This change will not allow MTR to suppress ASan errors.
Instead the following bugs should be fixed properly:
* PS-5008 "Memory leak in sync_latch_meta_init() after mysqld shutdown detected by ASan"
  (https://jira.percona.com/browse/PS-5008)
* Oracle's Bug #93165 "Memory leak in sync_latch_meta_init() after mysqld shutdown detected by ASan"
  (https://bugs.mysql.com/bug.php?id=93165)