### PR TITLE
Post-push fix for PS-5044 (Merge MySQL 8.0.14 & 8.0.15)

### DIFF
--- a/mysql-test/suite/group_replication/r/gr_recovery_updates.result
+++ b/mysql-test/suite/group_replication/r/gr_recovery_updates.result
@@ -68,6 +68,7 @@ INSERT INTO t1 VALUES (2);
 include/rpl_sync.inc
 server4
 include/assert.inc [On the recovered member, the table should exist and have 1 elements;]
+SET DEBUG_SYNC= "reset";
 #
 # Clean up
 #

--- a/mysql-test/suite/group_replication/r/gr_start_stop_recovery.result
+++ b/mysql-test/suite/group_replication/r/gr_start_stop_recovery.result
@@ -41,6 +41,7 @@ INSERT INTO t1 VALUES (1);
 server2
 include/start_group_replication.inc
 include/assert.inc [On the recovered member, the table should exist and have 1 elements;]
+SET DEBUG_SYNC= "reset";
 #
 # Clean up
 #

--- a/mysql-test/suite/group_replication/t/gr_recovery_updates.test
+++ b/mysql-test/suite/group_replication/t/gr_recovery_updates.test
@@ -166,6 +166,8 @@ INSERT INTO t1 VALUES (2);
 --let $assert_cond= [select count(*) from t1] = 2;
 --source include/assert.inc
 
+SET DEBUG_SYNC= "reset";
+
 --echo #
 --echo # Clean up
 --echo #

--- a/mysql-test/suite/group_replication/t/gr_start_stop_recovery.test
+++ b/mysql-test/suite/group_replication/t/gr_start_stop_recovery.test
@@ -101,6 +101,8 @@ INSERT INTO t1 VALUES (1);
 --let $assert_cond= [select count(*) from t1] = 1;
 --source include/assert.inc
 
+SET DEBUG_SYNC= "reset";
+
 --echo #
 --echo # Clean up
 --echo #


### PR DESCRIPTION
Our fix for PS-3532 (Launchpad 1617323) introduced a check that
session DEBUG_SYNC variable is reset at the end of testcase. Upstream
tests gr_recovery_updates and gr_start_stop_recovery in
group_replication suite do not reset it for all the servers, failing
the check. Fix by resetting the variable.

https://ps80.cd.percona.com/job/percona-server-8.0-param/68/