### PR TITLE
PS-5554: System keys not thread safe

### DIFF
--- a/plugin/keyring/common/i_keyring_key.h
+++ b/plugin/keyring/common/i_keyring_key.h
@@ -32,6 +32,7 @@ struct IKey : public Keyring_alloc
   virtual size_t get_key_data_size()= 0;
   virtual size_t get_key_pod_size() const = 0;
   virtual uchar* release_key_data()= 0;
+  virtual void xor_data(uchar *data, size_t data_len) = 0;
   virtual void xor_data()= 0;
   virtual void set_key_data(uchar *key_data, size_t key_data_size)= 0;
   virtual void set_key_type(const std::string *key_type)= 0;

--- a/plugin/keyring/common/keyring_key.cc
+++ b/plugin/keyring/common/keyring_key.cc
@@ -185,13 +185,18 @@ size_t Key::get_key_pod_size() const
   return key_pod_size_aligned;
 }
 
+void Key::xor_data(uchar *data, size_t data_len) {
+  static const char *obfuscate_str = "*305=Ljt0*!@$Hnm(*-9-w;:";
+  for (uint i = 0, l = 0; i < data_len;
+       ++i, l = ((l + 1) % strlen(obfuscate_str)))
+    data[i] ^= obfuscate_str[l];
+}
+
 void Key::xor_data()
 {
   if (key == NULL)
     return;
-  static const char *obfuscate_str="*305=Ljt0*!@$Hnm(*-9-w;:";
-  for(uint i=0, l=0; i < key_len; ++i, l=((l+1) % strlen(obfuscate_str)))
-    key.get()[i]^= obfuscate_str[l];
+  xor_data(key.get(), key_len);
 }
 
 my_bool Key::is_key_id_valid()

--- a/plugin/keyring/common/keyring_key.h
+++ b/plugin/keyring/common/keyring_key.h
@@ -44,6 +44,7 @@ struct Key : IKey
   size_t get_key_data_size();
   size_t get_key_pod_size() const;
   uchar* release_key_data();
+  void xor_data(uchar *data, size_t data_len);
   void xor_data();
   void set_key_data(uchar *key_data, size_t key_data_size);
   void set_key_type(const std::string *key_type);

--- a/plugin/keyring/common/system_key_adapter.cc
+++ b/plugin/keyring/common/system_key_adapter.cc
@@ -16,6 +16,7 @@
 
 #include "system_key_adapter.h"
 #include "secure_string.h"
+#include "my_atomic.h"
 
 namespace keyring
 {
@@ -25,27 +26,62 @@ namespace keyring
   {
     Secure_ostringstream system_key_data_version_prefix_ss;
     system_key_data_version_prefix_ss << key_version << ':';
-    Secure_string system_key_data_version_prefix = system_key_data_version_prefix_ss.str();
-    system_key_data.allocate(system_key_data_version_prefix.length() + keyring_key->get_key_data_size());
+    Secure_string system_key_data_version_prefix =
+        system_key_data_version_prefix_ss.str();
+    size_t system_key_data_candidate_size = system_key_data_version_prefix.length() +
+                                            keyring_key->get_key_data_size();
+    uchar* system_key_data_candidate = new(std::nothrow) uchar[system_key_data_candidate_size];
+    if (system_key_data_candidate == NULL) {
+      return;
+    }
+    memcpy(system_key_data_candidate, system_key_data_version_prefix.c_str(),
+           system_key_data_version_prefix.length());
+    memcpy(
+        system_key_data_candidate + system_key_data_version_prefix.length(),
+        keyring_key->get_key_data(), keyring_key->get_key_data_size());
+    
+    // need to "de"-xor keying key data
+    keyring_key->xor_data(system_key_data_candidate + system_key_data_version_prefix.length(),
+                          keyring_key->get_key_data_size());
+    // next xor system key data as a whole
+    keyring_key->xor_data(system_key_data_candidate, system_key_data_candidate_size);
 
-    // need to "de"-xor keying key data to be able to add to it key version prefix
-    keyring_key->xor_data();
-    memcpy(system_key_data.get_key_data(), system_key_data_version_prefix.c_str(), system_key_data_version_prefix.length());
-    memcpy(system_key_data.get_key_data() + system_key_data_version_prefix.length(), keyring_key->get_key_data(),
-           keyring_key->get_key_data_size());
+    void *null_system_key_data= NULL;
+    void *addr= & this->system_key_data.key_data;
+    void * volatile * typed_addr= static_cast<void * volatile *>(addr);
 
-    size_t keyring_key_data_size = keyring_key->get_key_data_size();
-    uchar *keyring_key_data = keyring_key->release_key_data();
+    if (my_atomic_casptr(typed_addr, &null_system_key_data, system_key_data_candidate)) {
+      system_key_data.key_data_size = system_key_data_candidate_size;
+      DBUG_ASSERT(system_key_data.key_data == system_key_data_candidate);
+    } else {
+      delete []system_key_data_candidate; // too late - system key data was already constructed
+    }
+  }
 
-    // Using keyring_key's xor function to xor system key data, next
-    // restoring keyring key data
-    keyring_key->set_key_data(system_key_data.get_key_data(), system_key_data.get_key_data_size());
-    keyring_key->xor_data();
+  size_t System_key_adapter::get_key_data_size()
+  {
+    DBUG_ASSERT(keyring_key != NULL);
 
-    keyring_key->release_key_data();
-    keyring_key->set_key_data(keyring_key_data, keyring_key_data_size);
+    void *addr= & this->system_key_data.key_data;
+    void * volatile * typed_addr= static_cast<void * volatile *>(addr);
 
-    keyring_key->xor_data();
+    if (my_atomic_loadptr(typed_addr) == NULL)
+      construct_system_key_data();
+
+    return system_key_data.key_data_size;
+  }
+
+  uchar* System_key_adapter::get_key_data()
+  {
+    DBUG_ASSERT(keyring_key != NULL);
+
+    void *addr= & this->system_key_data.key_data;
+    void * volatile * typed_addr= static_cast<void * volatile *>(addr);
+
+    if (my_atomic_loadptr(typed_addr) == NULL)
+      construct_system_key_data();
+
+    return system_key_data.key_data;
   }
 
   System_key_adapter::System_key_data::System_key_data()
@@ -58,18 +94,6 @@ namespace keyring
     free();
   }
 
-  bool System_key_adapter::System_key_data::allocate(size_t key_data_size)
-  {
-    free();
-    key_data = new uchar[key_data_size];
-    if (key_data)
-    {
-      this->key_data_size = key_data_size;
-      return false;
-    }
-    return true;
-  }
-
   void System_key_adapter::System_key_data::free()
   {
     if (key_data)
@@ -80,15 +104,5 @@ namespace keyring
       key_data = NULL;
       key_data_size = 0;
     }
-  }
-
-  uchar* System_key_adapter::System_key_data::get_key_data()
-  {
-    return key_data;
-  }
-
-  size_t System_key_adapter::System_key_data::get_key_data_size()
-  {
-    return key_data_size;
   }
 } //namespace keyring

--- a/plugin/keyring/common/system_key_adapter.h
+++ b/plugin/keyring/common/system_key_adapter.h
@@ -65,24 +65,10 @@ public:
     DBUG_ASSERT(keyring_key != NULL);
     return keyring_key->get_user_id();
   }
-  virtual uchar* get_key_data()
-  {
-    DBUG_ASSERT(keyring_key != NULL);
+  virtual uchar* get_key_data();
 
-    if (system_key_data.get_key_data() == NULL)
-      construct_system_key_data();
+  virtual size_t get_key_data_size();
 
-    return system_key_data.get_key_data();
-  }
-  virtual size_t get_key_data_size()
-  {
-    DBUG_ASSERT(keyring_key != NULL);
-
-    if (system_key_data.get_key_data() == NULL)
-      construct_system_key_data();
-
-    return system_key_data.get_key_data_size();
-  }
   virtual size_t get_key_pod_size() const
   {
     DBUG_ASSERT(FALSE);
@@ -92,6 +78,10 @@ public:
   {
     DBUG_ASSERT(FALSE);
     return NULL;
+  }
+  virtual void xor_data(uchar*, size_t)
+  {
+    DBUG_ASSERT(FALSE);
   }
   virtual void xor_data()
   {
@@ -144,11 +134,7 @@ private:
     System_key_data();
     ~System_key_data();
 
-    bool allocate(size_t key_data_size);
     void free();
-    uchar *get_key_data();
-    size_t get_key_data_size();
-  private:
     uchar *key_data;
     size_t key_data_size;
   };

--- a/plugin/keyring_vault/vault_key.cc
+++ b/plugin/keyring_vault/vault_key.cc
@@ -25,6 +25,11 @@ void Vault_key::xor_data()
   /* We do not xor data in keyring_vault */
 }
 
+void Vault_key::xor_data(uchar *, size_t)
+{
+  /* We do not xor data in keyring_vault */
+}
+
 uchar* Vault_key::get_key_data() const
 {
   return key.get();

--- a/plugin/keyring_vault/vault_key.h
+++ b/plugin/keyring_vault/vault_key.h
@@ -34,6 +34,7 @@ struct Vault_key : public Key, public ISerialized_object
   virtual my_bool get_next_key(IKey **key);
   virtual my_bool has_next_key();
   virtual void create_key_signature() const;
+  virtual void xor_data(uchar *, size_t);
   virtual void xor_data();
 
 protected:


### PR DESCRIPTION
System keys are lazy initialized. This means creating the key's body
only when it is requested. The same key can be requested by multiple
threads. Which means the initialization can be requested by multiple threads
simultaneously. To cope with this a lock-free CAS was used. The same
system key can be requested by multiple threads but only one thread
will be first and thus will set the key body.