### PR TITLE
Fix PS-5566 (INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES queries may c…

### DIFF
--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -2712,7 +2712,8 @@ handler *handler::clone(const char *name, MEM_ROOT *mem_root) {
     the same table instance. The ha_open call is not cachable for clone.
   */
   if (new_handler->ha_open(table, name, table->db_stat,
-                           HA_OPEN_IGNORE_IF_LOCKED, NULL))
+                           HA_OPEN_IGNORE_IF_LOCKED,
+                           table->get_tmp_dd_table_ptr()))
     goto err;
 
   DBUG_RETURN(new_handler);

--- a/sql/sql_base.cc
+++ b/sql/sql_base.cc
@@ -6966,6 +6966,7 @@ TABLE *open_table_uncached(THD *thd, const char *path, const char *db,
                                            : NON_TRANSACTIONAL_TMP_TABLE);
 
   if (add_to_temporary_tables_list) {
+    tmp_table->set_tmp_dd_table_ptr(&table_def);
     tmp_table->set_binlog_drop_if_temp(
         !thd->is_current_stmt_binlog_disabled() &&
         !thd->is_current_stmt_binlog_format_row());

--- a/sql/table.h
+++ b/sql/table.h
@@ -2146,6 +2146,24 @@ struct TABLE {
             set or not
   */
   bool should_binlog_drop_if_temp(void) const;
+
+  void set_tmp_dd_table_ptr(const dd::Table *tmp_dd_table_ptr_) noexcept {
+    DBUG_ASSERT(tmp_dd_table_ptr_ != nullptr);
+    tmp_dd_table_ptr = tmp_dd_table_ptr_;
+  }
+
+  const dd::Table *get_tmp_dd_table_ptr() const noexcept {
+    return tmp_dd_table_ptr;
+  }
+
+ private:
+  /**
+     A DD object reference for temporary tables, which is otherwise present in
+     the owner thread callstack only and nowhere in the global DD data
+     structures. It is used to support
+     INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES queries.
+  */
+  const dd::Table *tmp_dd_table_ptr{nullptr};
 };
 
 static inline void empty_record(TABLE *table) {


### PR DESCRIPTION
…rash if online ALTER TABLE is running in parallel | Test percona_bug1294190 always failing)

8.0 introduced dd::Table argument on the common
handler::clone/handler::open code path, which is also used in querying
INFORMATION_SCHEMA.GLOBAL_TEMPORARY_TABLES. There, it causes a debug
build crash and almost certainly a release build failure in certain
scenario, i.e. by querying the I_S table while a parallel ALTER TABLE
is running. This happens because handler::clone always passes nullptr for
dd::Table, which then makes InnoDB DD code fail. Apparently such I_S
queries are the only case this happens.

We cannot fix this by making handler::clone e.g. query DD for the
needed dd::Table object because there is none: the temp table
dd::Table is registered with server DD only at the end of ALTER
TABLE. Until then, the dd::Table object only lives on the call
stack. Thus, fix by introducing tmp_dd_table_ptr field and
set_tmp_dd_table_ptr / get_tmp_dd_table_ptr setter/getter in
TABLE. Invoke the setter right before adding the temp table to THD
temp table list (which makes the table visible to I_S queries), and
get the dd::Table object in handler::clone.

This fixes main.percona_bug1294190 regression in 8.0.

https://ps80.cd.percona.com/job/percona-server-8.0-param/77/
>1000 failures due to recent debug build regression, reviewed the failure list that I_S.GLOBAL_TEMP_TABLES-related tests are absent