### PR TITLE
Fix PS-5570 (Slow log data not cleared before COM_QUIT)

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1493,6 +1493,11 @@ bool dispatch_command(THD *thd, const COM_DATA *com_data,
     the slow log only if opt_log_slow_admin_statements is set.
   */
   thd->enable_slow_log = true;
+  // Both this and the call THD::reset_for_next_command are required, even if
+  // clear_slow_extended ends up being called twice in common execution path
+  // between successive commands, because some COM_* skip one or another, i.e.
+  // COM_QUIT needs this one.
+  thd->clear_slow_extended();
   thd->lex->sql_command = SQLCOM_END; /* to avoid confusing VIEW detectors */
   thd->set_time();
   if (IS_TIME_T_VALID_FOR_TIMESTAMP(thd->query_start_in_secs()) == false) {


### PR DESCRIPTION
PS-4933 erroneously removed clear_slow_extended() call from
dispatch_command, considering that the call from
THD::reset_for_next_command is enough. This is not the case for all
COM_* though, fix by restoring it back, this time with comment so that
it survives the next optimization attempt.

(cherry picked from commit 643c282905090ccae542bbf97488f596b23fb21b)

https://ps80.cd.percona.com/job/percona-server-8.0-param/80/