### PR TITLE
PS-5541: Do not try to decrypt blocks in changed page tracking. (8.0)

### DIFF
--- a/mysql-test/r/percona_changed_pages_big.result
+++ b/mysql-test/r/percona_changed_pages_big.result
@@ -1,0 +1,34 @@
+#
+# PS-5541: Changed page tracking floods the error log with decryption errors
+#
+CREATE TABLE `joinit` (
+`i` int(11) NOT NULL AUTO_INCREMENT,
+`s` varchar(64) DEFAULT NULL,
+`t` time NOT NULL,
+`g` int(11) NOT NULL,
+PRIMARY KEY (`i`),
+KEY key_g (`g`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+INSERT INTO joinit VALUES (NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60));
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+SELECT COUNT(*) AS count_innodb_changed_pages FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
+DROP TABLE joinit;

--- a/mysql-test/t/percona_changed_pages_big-master.opt
+++ b/mysql-test/t/percona_changed_pages_big-master.opt
@@ -1,0 +1,2 @@
+--innodb_track_changed_pages=1 --innodb_max_bitmap_file_size=1G
+

--- a/mysql-test/t/percona_changed_pages_big.test
+++ b/mysql-test/t/percona_changed_pages_big.test
@@ -1,0 +1,44 @@
+-- source include/big_test.inc
+
+--echo #
+--echo # PS-5541: Changed page tracking floods the error log with decryption errors
+--echo #
+
+CREATE TABLE `joinit` (
+  `i` int(11) NOT NULL AUTO_INCREMENT,
+  `s` varchar(64) DEFAULT NULL,
+  `t` time NOT NULL,
+  `g` int(11) NOT NULL,
+  PRIMARY KEY (`i`),
+  KEY key_g (`g`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+INSERT INTO joinit VALUES (NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60));
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()),  FLOOR(1 + RAND() * 60) FROM joinit;
+
+--disable_result_log
+SELECT COUNT(*) AS count_innodb_changed_pages FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
+--enable_result_log
+
+# Success: if there are no errors in the log
+
+DROP TABLE joinit;

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -636,7 +636,8 @@ static bool log_online_read_bitmap_page(
   ut_a(bitmap_file->offset <= bitmap_file->size - MODIFIED_PAGE_BLOCK_SIZE);
   ut_a(bitmap_file->offset % MODIFIED_PAGE_BLOCK_SIZE == 0);
 
-  IORequest io_request(IORequest::LOG | IORequest::READ);
+  IORequest io_request(IORequest::LOG | IORequest::READ |
+                       IORequest::NO_ENCRYPTION);
   const bool success =
       os_file_read(io_request, bitmap_file->file, page, bitmap_file->offset,
                    MODIFIED_PAGE_BLOCK_SIZE);

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -1833,7 +1833,8 @@ static dberr_t os_file_io_complete(const IORequest &type, os_file_t fh,
   ut_ad(type.validate());
 
   if (!type.is_compression_enabled()) {
-    if (type.is_log() && offset >= LOG_FILE_HDR_SIZE) {
+    if (type.is_log() && offset >= LOG_FILE_HDR_SIZE &&
+        !type.is_encryption_disabled()) {
       Encryption encryption(type.encryption_algorithm());
 
       ret = encryption.decrypt_log(type, buf, src_len, scratch, len);


### PR DESCRIPTION
Issue: changed page tracking uses the LOG flag during read
operations to follow the correct code path. Redo log encryption
backported from 8.0 tries to decrypt pages with a certain bit set,
and fails. While the end result is the same, the error log gets
flooded with decryption errors.

Solution: the NO_ENCRYPTION flag, previously ignored by log
encryption now disables decryption during log reads too.

(cherry picked from commit 48b67f85cba1c54d02e129ac862096c786324a5b)