### PR TITLE
PS-5550 : RHEL8 runners in 5.7 seem to be missing python

### DIFF
--- a/mysql-test/suite/innodb_stress/include/innodb_stress.inc
+++ b/mysql-test/suite/innodb_stress/include/innodb_stress.inc
@@ -41,7 +41,7 @@ if ($do_checksum)
 {
     # populate the table and store its checksum before any load.
     let $exec =
-python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records 0 0 $user $master_host $MASTER_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 0 0;
     exec $exec;
@@ -70,14 +70,14 @@ while ($num_crashes)
   if ($use_blob)
   {
     let $exec =
-python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records  $num_workers $num_transactions $user $master_host $MASTER_MYPORT
 $table 1 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_checks;
   }
   if (!$use_blob)
   {
     let $exec =
-python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records  $num_workers $num_transactions $user $master_host $MASTER_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_checks;
   }
@@ -108,7 +108,7 @@ $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_ch
     --echo applying fake updates to the slave
     let $slave_pid_file = `SELECT @@pid_file`;
     let $slave_exec =
-python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $slave_pid_file $kill_db_after
+python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $slave_pid_file $kill_db_after
 0  $num_workers $num_transactions $user $master_host $SLAVE_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator_slave 1 $checksum $secondary_index_checks;
     exec $slave_exec;

--- a/mysql-test/suite/tokudb/t/change_column_Makefile
+++ b/mysql-test/suite/tokudb/t/change_column_Makefile
@@ -1,4 +1,4 @@
-# generate tests from test generator python programs
+# generate tests from test generator python2 programs
 
 S = $(wildcard *.py)
 T = $(patsubst %.py,%.test,$(S))
@@ -6,14 +6,14 @@ T = $(patsubst %.py,%.test,$(S))
 default: $(T)
 
 %.test: %.py
-	python $< >$@
+	python2 $< >$@
 
 change_all.test: change_all.py change_all_1000_10.test change_all_1000_1.test change_all_10000_1.test
 	true
 change_all_1000_10.test: change_all.py
-	python change_all.py --experiments=1000 --nrows=10 >change_all_1000_10.test
+	python2 change_all.py --experiments=1000 --nrows=10 >change_all_1000_10.test
 change_all_1000_1.test: change_all.py
-	python change_all.py --experiments=1000 --nrows=1 >change_all_1000_1.test
+	python2 change_all.py --experiments=1000 --nrows=1 >change_all_1000_1.test
 change_all_10000_1.test: change_all.py
-	python change_all.py --experiments=10000 --nrows=1 >change_all_10000_1.test
+	python2 change_all.py --experiments=10000 --nrows=1 >change_all_10000_1.test
 

--- a/mysql-test/suite/tokudb/t/change_column_bin.py
+++ b/mysql-test/suite/tokudb/t/change_column_bin.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(n):

--- a/mysql-test/suite/tokudb/t/change_column_bin_rename.py
+++ b/mysql-test/suite/tokudb/t/change_column_bin_rename.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(n):

--- a/mysql-test/suite/tokudb/t/change_column_char.py
+++ b/mysql-test/suite/tokudb/t/change_column_char.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(n):

--- a/mysql-test/suite/tokudb/t/change_column_char_binary.py
+++ b/mysql-test/suite/tokudb/t/change_column_char_binary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(n):

--- a/mysql-test/suite/tokudb/t/change_column_char_charbinary.py
+++ b/mysql-test/suite/tokudb/t/change_column_char_charbinary.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(n):

--- a/mysql-test/suite/tokudb/t/change_column_char_rename.py
+++ b/mysql-test/suite/tokudb/t/change_column_char_rename.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(n):

--- a/mysql-test/suite/tokudb/t/change_column_int.py
+++ b/mysql-test/suite/tokudb/t/change_column_int.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(types, values):

--- a/mysql-test/suite/tokudb/t/change_column_int_key.py
+++ b/mysql-test/suite/tokudb/t/change_column_int_key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(types):

--- a/mysql-test/suite/tokudb/t/change_column_int_not_supported.py
+++ b/mysql-test/suite/tokudb/t/change_column_int_not_supported.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import sys
 def supported(from_int, from_modifier, to_int, to_modifer):
     if from_modifier != to_modifer:

--- a/mysql-test/suite/tokudb/t/change_column_int_rename.py
+++ b/mysql-test/suite/tokudb/t/change_column_int_rename.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 def gen_test(types, values):

--- a/mysql-test/suite/tokudb/t/fast_update_Makefile
+++ b/mysql-test/suite/tokudb/t/fast_update_Makefile
@@ -1,4 +1,4 @@
-# generate tests from test generator python programs
+# generate tests from test generator python2 programs
 
 S = $(wildcard *.py)
 T = $(patsubst %.py,%.test,$(S))
@@ -6,5 +6,5 @@ T = $(patsubst %.py,%.test,$(S))
 default: $(T)
 
 %.test: %.py
-	python $< >$@
+	python2 $< >$@
 


### PR DESCRIPTION
- Changed TokuDB test generator makefiles to invoke python2 explicitly rather
  than generic python.
- Changed TokuDB *.py scripts to she-bang with python2 instead of python.