### PR TITLE
Fix PS-5578 (Test innodb.percona_log_slow_innodb is unstable)

### DIFF
--- a/mysql-test/suite/innodb/r/percona_log_slow_innodb.result
+++ b/mysql-test/suite/innodb/r/percona_log_slow_innodb.result
@@ -79,25 +79,24 @@ SELECT 5;
 [log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# No InnoDB statistics available for this query$
 [log_grep.inc] lines:   2
 LOCK TABLE t1 WRITE;
+SET SESSION long_query_time=50000;
 SET SESSION long_query_time=0;
 SET SESSION log_slow_verbosity='microtime,innodb';
 [log_start.inc] percona.slow_extended.innodb_3
 LOCK TABLE t1 WRITE;
-SET SESSION long_query_time=5000;
-SET SESSION long_query_time=0;
 SELECT SLEEP(2);
 SLEEP(2)
 0
 UNLOCK TABLES;
 [log_stop.inc] percona.slow_extended.innodb_3
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
-[log_grep.inc] lines:   5
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   5
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Bytes_sent: \d+.*$
-[log_grep.inc] lines:   5
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# InnoDB_trx_id: [1-9A-F][0-9A-F]*$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
@@ -105,23 +104,23 @@ UNLOCK TABLES;
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Filesort: (Yes|No)  Filesort_on_disk: (Yes|No)  Merge_passes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^#   InnoDB_IO_r_ops: 0  InnoDB_IO_r_bytes: 0  InnoDB_IO_r_wait: 0\.0*$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^#   InnoDB_IO_r_ops: [1-9]\d*  InnoDB_IO_r_bytes: [1-9]\d*  InnoDB_IO_r_wait: (0\.\d*[1-9]\d*|[1-9]\d*\.\d+)$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^#   InnoDB_rec_lock_wait: \d*\.\d*  InnoDB_queue_wait: \d*\.\d*$
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: InnoDB_rec_lock_wait: 0\.0*
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: InnoDB_rec_lock_wait: (0\.\d*[1-9]\d*|[1-9]\d*\.\d+)
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: InnoDB_queue_wait: 0\.0*
-[log_grep.inc] lines:   1
+[log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: InnoDB_queue_wait: (0\.\d*[1-9]\d*|[1-9]\d*\.\d+)
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^#   InnoDB_pages_distinct: [1-9]\d*$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# No InnoDB statistics available for this query$
-[log_grep.inc] lines:   4
+[log_grep.inc] lines:   2
 UNLOCK TABLES;
 BEGIN;
 SELECT * FROM t2 FOR UPDATE;
@@ -129,21 +128,19 @@ a
 1
 [log_start.inc] percona.slow_extended.innodb_4
 DELETE FROM t2 WHERE a=2;
-SET SESSION long_query_time=5000;
-SET SESSION long_query_time=0;
 SELECT SLEEP(2);
 SLEEP(2)
 0
 COMMIT;
 [log_stop.inc] percona.slow_extended.innodb_4
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
-[log_grep.inc] lines:   5
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   5
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Bytes_sent: \d+.*$
-[log_grep.inc] lines:   5
+[log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# InnoDB_trx_id: [1-9A-F][0-9A-F]*$
-[log_grep.inc] lines:   4
+[log_grep.inc] lines:   1
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
@@ -167,7 +164,8 @@ COMMIT;
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^#   InnoDB_pages_distinct: [1-9]\d*$
 [log_grep.inc] lines:   1
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# No InnoDB statistics available for this query$
-[log_grep.inc] lines:   4
+[log_grep.inc] lines:   1
+SET SESSION long_query_time=0;
 #
 # PS-4788: Setting log_slow_verbosity and enabling the slow_query_log could lead to a server crash
 #

--- a/mysql-test/suite/innodb/t/percona_log_slow_innodb.test
+++ b/mysql-test/suite/innodb/t/percona_log_slow_innodb.test
@@ -33,6 +33,10 @@ SELECT 5; # No InnoDB pages accessed
 #
 
 LOCK TABLE t1 WRITE;
+
+# Log only con2 below
+SET SESSION long_query_time=50000;
+
 --connect (con2,localhost,root,,test,,)
 --connection con2
 
@@ -47,12 +51,9 @@ send LOCK TABLE t1 WRITE;
 
 --connection default
 
-# Do not slow-log wait_condition.inc due to variable number of queries
-SET SESSION long_query_time=5000;
 let $wait_condition= SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST
     WHERE ID=$con2_id AND STATE="Waiting for table metadata lock";
 --source include/wait_condition.inc
-SET SESSION long_query_time=0;
 
 SELECT SLEEP(2);
 UNLOCK TABLES;
@@ -77,12 +78,9 @@ send DELETE FROM t2 WHERE a=2;
 
 --connection default
 
-# Do not slow-log wait_condition.inc due to variable number of queries
-SET SESSION long_query_time=5000;
 let $wait_condition= SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TRX
     WHERE TRX_STATE="LOCK WAIT";
 --source include/wait_condition.inc
-SET SESSION long_query_time=0;
 
 SELECT SLEEP(2);
 COMMIT;
@@ -93,6 +91,8 @@ reap;
 
 --disconnect con2
 --connection default
+
+SET SESSION long_query_time=0;
 
 --echo #
 --echo # PS-4788: Setting log_slow_verbosity and enabling the slow_query_log could lead to a server crash


### PR DESCRIPTION
While the actual test failures are observed on 8.0, clean up the test
in lower branches as well: for table and row lock waits, only slow-log
the actual statements that wait for the locks, removing test
coverage (and potential instability issues) from other commands.

https://ps56.cd.percona.com/job/percona-server-5.6-param/5/