### PR TITLE
Post-push fix for PS-269 (Initial Percona Server 8.0 port)

### DIFF
--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -44,7 +44,7 @@ include/assert.inc ['Expect 625 variables in the table. Due to open Bugs, we are
 
 # Test SET PERSIST
 
-include/assert.inc [Expect 418 persisted variables in the table. Due to open Bugs, we are checking for 407]
+include/assert.inc [Expect 423 persisted variables in the table. Due to open Bugs, we are checking for 412]
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -52,9 +52,9 @@ include/assert.inc [Expect 418 persisted variables in the table. Due to open Bug
 ************************************************************
 # restart
 
-include/assert.inc [Expect 407 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 407 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 407 persisted variables with matching peristed and global values.]
+include/assert.inc [Expect 412 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 412 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 412 persisted variables with matching peristed and global values.]
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -29,16 +29,18 @@
 # added, it is the responsibility of the Dev to edit $total_persistent_vars.
 ################################################################################
 
+# Percona Server has further restricted the platform to Linux-only due to some
+# Linux-specific InnoDB system variables
 --echo ***********************************************************************
 --echo * Run only on debug build,non-windows as few server variables are not
 --echo * available on all platforms.
 --echo ***********************************************************************
 --source include/have_debug.inc
---source include/not_windows.inc
+--source include/linux.inc
 --source include/have_binlog_format_row.inc
 
 let $total_global_vars=`SELECT COUNT(*) FROM performance_schema.global_variables where variable_name NOT LIKE 'ndb_%'`;
-let $total_persistent_vars=418;
+let $total_persistent_vars=423;
 
 --echo ***************************************************************
 --echo * 0. Verify that variables present in performance_schema.global


### PR DESCRIPTION
main.all_persisted_variables test was ported to 8.0 on macOS, where
there are five less system variables than on Linux, causing test
failures there. Update the test for the Linux variable count and make
it a Linux-only test too.

https://ps80.cd.percona.com/job/percona-server-8.0-param/98/