### PR TITLE
PS-5574: innodb.log_corruption / innodb.log_file_size_checkpoint

### DIFF
--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -7528,13 +7528,13 @@ static std::tuple<bool, bool> get_mysql_ibd_page_0_io() {
   /* page0 of mysql.ibd is not in the buffer, try direct io */
   auto buf = ut_make_unique_ptr_nokey(2 * UNIV_PAGE_SIZE);
 
-  bool successful_read = false;
+  bool successfully_opened = false;
 
   pfs_os_file_t file = os_file_create_simple_no_error_handling(
       innodb_data_file_key, dict_sys_t::s_dd_space_file_name, OS_FILE_OPEN,
-      OS_FILE_READ_ONLY, srv_read_only_mode, &successful_read);
+      OS_FILE_READ_ONLY, srv_read_only_mode, &successfully_opened);
 
-  if (!successful_read) {
+  if (!successfully_opened) {
     return (result);
   }
 
@@ -7544,7 +7544,8 @@ static std::tuple<bool, bool> get_mysql_ibd_page_0_io() {
   ut_ad(page == page_align(page));
 
   IORequest request(IORequest::READ);
-  dberr_t err = os_file_read_first_page(request, file, page, UNIV_PAGE_SIZE);
+  dberr_t err =
+      os_file_read_first_page_noexit(request, file, page, UNIV_PAGE_SIZE);
 
   os_file_close(file);
 

--- a/storage/innobase/include/os0file.ic
+++ b/storage/innobase/include/os0file.ic
@@ -300,11 +300,13 @@ os_file_read() which requests a synchronous read operation.
 @param[in]	n		number of bytes to read
 @param[in]	src_file	file name where func invoked
 @param[in]	src_line	line where the func invoked
+@param[in]	exit_on_err	if true then exit on error
 @return DB_SUCCESS if request was successful */
 UNIV_INLINE
 dberr_t pfs_os_file_read_first_page_func(IORequest &type, pfs_os_file_t file,
                                          void *buf, ulint n,
-                                         const char *src_file, uint src_line) {
+                                         const char *src_file, uint src_line,
+                                         bool exit_on_err) {
   PSI_file_locker_state state;
   struct PSI_file_locker *locker = NULL;
 
@@ -315,7 +317,7 @@ dberr_t pfs_os_file_read_first_page_func(IORequest &type, pfs_os_file_t file,
 
   dberr_t result;
 
-  result = os_file_read_first_page_func(type, file.m_file, buf, n);
+  result = os_file_read_first_page_func(type, file.m_file, buf, n, exit_on_err);
 
   register_pfs_file_io_end(locker, n);
 

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -5901,13 +5901,14 @@ Requests a synchronous positioned read operation of page 0 of IBD file
 @param[in]	file		handle to an open file
 @param[out]	buf		buffer where to read
 @param[in]	n		number of bytes to read, starting from offset
+@param[in]	exit_on_err	if true then exit on error
 @return DB_SUCCESS or error code */
 dberr_t os_file_read_first_page_func(IORequest &type, os_file_t file, void *buf,
-                                     ulint n) {
+                                     ulint n, bool exit_on_err) {
   ut_ad(type.is_read());
 
   dberr_t err = os_file_read_page(type, file, buf, 0, UNIV_ZIP_SIZE_MIN,
-                                  nullptr, true, nullptr);
+                                  nullptr, exit_on_err, nullptr);
 
   if (err == DB_SUCCESS) {
     ulint flags = fsp_header_get_flags(static_cast<byte *>(buf));

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2533,8 +2533,6 @@ files_checked:
       return (srv_init_abort(err));
     }
 
-    bool mysql_ibd_page_0_present_in_redo = is_mysql_ibd_page_0_in_redo();
-
     /* We need to start log threads before asking to flush
     all dirty pages. That's because some dirty pages could
     be dirty because of ibuf merges. The ibuf merges could
@@ -2695,23 +2693,6 @@ files_checked:
       RECOVERY_CRASH(5);
 
       log_sys_close();
-
-      // We have set mysql's dd flags based on what we read from page 0. This
-      // was before redo log was applied. Now we have applied changes from redo
-      // log. If there were changes in redo for page 0 of mysql.ibd we check if
-      // encryption flag has changed. If it did we amend mysql's dd encryption
-      // flags accordingly.
-      if (mysql_ibd_page_0_present_in_redo) {
-        fil_space_t *mysql_space = fil_space_get(dict_sys_t::s_space_id);
-        ut_ad(mysql_space !=
-              nullptr);  // if mysql.ibd was in redo it should have been
-                         // loaded
-        if (mysql_space == nullptr ||
-            dd_fix_mysql_ibd_encryption_flag_if_needed(current_thd,
-                                                       mysql_space->flags)) {
-          return (srv_init_abort(DB_ERROR));
-        }
-      }
 
       ib::info(ER_IB_MSG_1143);
 


### PR DESCRIPTION
regression on trunk

The innodb.log_corruption error:
dict_detect_encryption_of_mysql_ibd calls os_file_read_first_page. This
function causes server to abort when the first page cannot be read.
Introduced new function os_file_read_first_page_noexit, which does not
abort the server when first page cannot be read.

The innodb.log_file_size_checkpoint error:
The redo was checked for any log records that apply to the first page of
mysql.ibd. This was done as part of PS-5333. In PS-5333 we did:
- set mysql's DD encryption flag to the value read from its page0
- execute redo
- correct mysql's DD encryption flag if there were changes to mysql's
page0 during redo
It turns out that the last part is not needed. System tablespace
encryption is a bootstrap only option for MK encryption and for keyring
encryption the encryption flag will be corrected by encryption threads.