### PR TITLE
(8.0)PS-5562 : index_merge + partitioning + MyRocks crashes the server

### DIFF
--- a/mysql-test/suite/rocksdb/r/partition_handler_clone.result
+++ b/mysql-test/suite/rocksdb/r/partition_handler_clone.result
@@ -7,3 +7,35 @@ INSERT INTO t1  VALUES (5,'Bozo', NULL),(6,'Ronald', NULL),(7,'Kinko', NULL),(8,
 SELECT * FROM t1 WHERE b IS NULL or a IS NULL;
 a	b	c
 DROP TABLE t1;
+#
+# PS-5562 - index_merge + partitioning + MyRocks crashes the server
+#
+CREATE TABLE `t1` (
+`id` bigint(20) NOT NULL AUTO_INCREMENT,
+`e` varchar(150) NOT NULL DEFAULT '',
+`l` int(12) unsigned NOT NULL,
+`dd` int(6) unsigned NOT NULL DEFAULT '0',
+`p` int(10) unsigned NOT NULL DEFAULT '0',
+`f1` varchar(150) DEFAULT NULL,
+`f2` varchar(150) DEFAULT NULL,
+`f3` varchar(150) DEFAULT NULL,
+`f4` varchar(150) DEFAULT NULL,
+`f5` varchar(150) DEFAULT NULL,
+`f6` varchar(150) DEFAULT NULL,
+`f7` varchar(150) DEFAULT NULL,
+`f8` varchar(150) DEFAULT NULL,
+`f9` varchar(150) DEFAULT NULL,
+`f0` varchar(150) DEFAULT NULL,
+PRIMARY KEY (`id`,`p`,`l`),
+KEY `e` (`e`),
+KEY `dd` (`dd`)
+) ENGINE=ROCKSDB AUTO_INCREMENT=1950201 DEFAULT CHARSET=utf8mb4
+PARTITION BY LIST (`p`)
+SUBPARTITION BY HASH (`l`)
+SUBPARTITIONS 5
+(PARTITION p0 VALUES IN (0) ENGINE = ROCKSDB,
+PARTITION p1 VALUES IN (1) ENGINE = ROCKSDB,
+PARTITION p2 VALUES IN (2) ENGINE = ROCKSDB);
+SELECT /*+ INDEX_MERGE(t1) */ id  FROM `t1` WHERE `l` = 281523560 AND `dd` = 0 AND `e` = '';
+id
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/partition_handler_clone.test
+++ b/mysql-test/suite/rocksdb/t/partition_handler_clone.test
@@ -9,3 +9,46 @@ INSERT INTO t1  VALUES (1,'Bozo', NULL),(2,'Ronald', NULL),(3,'Kinko', NULL),(4,
 INSERT INTO t1  VALUES (5,'Bozo', NULL),(6,'Ronald', NULL),(7,'Kinko', NULL),(8,'Mr. Floppy', NULL);
 SELECT * FROM t1 WHERE b IS NULL or a IS NULL;
 DROP TABLE t1;
+
+--echo #
+--echo # PS-5562 - index_merge + partitioning + MyRocks crashes the server
+--echo #
+CREATE TABLE `t1` (
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `e` varchar(150) NOT NULL DEFAULT '',
+  `l` int(12) unsigned NOT NULL,
+  `dd` int(6) unsigned NOT NULL DEFAULT '0',
+  `p` int(10) unsigned NOT NULL DEFAULT '0',
+  `f1` varchar(150) DEFAULT NULL,
+  `f2` varchar(150) DEFAULT NULL,
+  `f3` varchar(150) DEFAULT NULL,
+  `f4` varchar(150) DEFAULT NULL,
+  `f5` varchar(150) DEFAULT NULL,
+  `f6` varchar(150) DEFAULT NULL,
+  `f7` varchar(150) DEFAULT NULL,
+  `f8` varchar(150) DEFAULT NULL,
+  `f9` varchar(150) DEFAULT NULL,
+  `f0` varchar(150) DEFAULT NULL,
+  PRIMARY KEY (`id`,`p`,`l`),
+  KEY `e` (`e`),
+  KEY `dd` (`dd`)
+) ENGINE=ROCKSDB AUTO_INCREMENT=1950201 DEFAULT CHARSET=utf8mb4
+PARTITION BY LIST (`p`)
+SUBPARTITION BY HASH (`l`)
+SUBPARTITIONS 5
+(PARTITION p0 VALUES IN (0) ENGINE = ROCKSDB,
+ PARTITION p1 VALUES IN (1) ENGINE = ROCKSDB,
+ PARTITION p2 VALUES IN (2) ENGINE = ROCKSDB);
+
+--disable_query_log
+--let $i=0
+while ($i < 10) {
+insert into t1 values (null, uuid(), FLOOR(RAND()*(2-0+1)+0) , FLOOR(RAND()*(2-0+1)+0) ,FLOOR(RAND()*(2-0+1)+0) , uuid(), uuid(), uuid(), uuid(), uuid(), uuid(), uuid(), uuid(), uuid(), uuid());
+--inc $i
+}
+--enable_query_log
+
+--let $i=0
+
+SELECT /*+ INDEX_MERGE(t1) */ id  FROM `t1` WHERE `l` = 281523560 AND `dd` = 0 AND `e` = '';
+DROP TABLE t1;

--- a/sql/partitioning/partition_base.cc
+++ b/sql/partitioning/partition_base.cc
@@ -294,18 +294,25 @@ const uint32 Partition_base::NO_CURRENT_PART_ID = NOT_A_PARTITION_ID;
 */
 
 Partition_base::Partition_base(handlerton *hton, TABLE_SHARE *share)
-    : handler(hton, share), Partition_helper(this) {
+    : handler(hton, share),
+      Partition_helper(this),
+      m_clone_base(nullptr),
+      m_clone_mem_root(nullptr) {
   DBUG_ENTER("Partition_base::Partition_base(table)");
   init_handler_variables();
   DBUG_VOID_RETURN;
 }
 
 Partition_base::Partition_base(handlerton *hton, TABLE_SHARE *share,
-                               Handler_share **ha_share)
-    : handler(hton, share), Partition_helper(this) {
+                               Partition_base *clone_base,
+                               MEM_ROOT *clone_mem_root)
+    : handler(hton, share),
+      Partition_helper(this),
+      m_clone_base(clone_base),
+      m_clone_mem_root(clone_mem_root) {
   DBUG_ENTER("Partition_base::Partition_base(table, ha_share)");
   init_handler_variables();
-  set_ha_share_ref(ha_share);
+  set_ha_share_ref(&share->ha_share);
   DBUG_VOID_RETURN;
 }
 
@@ -1498,10 +1505,15 @@ bool Partition_base::init_partition_bitmaps() {
   }
   bitmap_clear_all(&m_partitions_to_reset);
 
-  /* Initialize the bitmap for read/lock_partitions */
-  if (m_part_info->set_partition_bitmaps(nullptr)) {
-    free_partition_bitmaps();
-    DBUG_RETURN(true);
+  /* When Partition_base is cloned, both the clone and the original object
+  share partition_info object (m_part_info). Do not reset the partition
+  bitmaps. */
+  if (!m_clone_base) {
+    /* Initialize the bitmap for read/lock_partitions */
+    if (m_part_info->set_partition_bitmaps(nullptr)) {
+      free_partition_bitmaps();
+      DBUG_RETURN(true);
+    }
   }
 
   DBUG_RETURN(false);
@@ -1533,6 +1545,7 @@ int Partition_base::open(const char *name, int mode, uint test_if_locked,
                          const dd::Table *table_def) {
   int error = HA_ERR_INITIALIZATION;
   handler **file;
+  handler **clone_base_file = nullptr;
   ulonglong check_table_flags;
   DBUG_ENTER("Partition_base::open");
 
@@ -1541,9 +1554,11 @@ int Partition_base::open(const char *name, int mode, uint test_if_locked,
   ref_length = 0;
   m_mode = mode;
 
+  MEM_ROOT *mem_root =
+      m_clone_mem_root != nullptr ? m_clone_mem_root : &table->mem_root;
+
   /* The following functions must be called only after m_part_info set */
-  if (initialize_partition(&table->mem_root) || init_part_share() ||
-      init_with_fields())
+  if (initialize_partition(mem_root) || init_part_share() || init_with_fields())
     DBUG_RETURN(true);
 
   /* Check/update the partition share. */
@@ -1583,6 +1598,9 @@ int Partition_base::open(const char *name, int mode, uint test_if_locked,
   DBUG_ASSERT(m_part_info);
 
   file = m_file;
+  if (m_clone_base != nullptr) {
+    clone_base_file = m_clone_base->m_file;
+  }
 
   if (!foreach_partition([&](const partition_element *parent_part_elem,
                              const partition_element *part_elem) -> bool {
@@ -1590,10 +1608,22 @@ int Partition_base::open(const char *name, int mode, uint test_if_locked,
         part_name(name_buff, name,
                   parent_part_elem ? parent_part_elem->partition_name : nullptr,
                   part_elem->partition_name);
+
+        if (m_clone_base != nullptr) {
+          uint ref_length = (*clone_base_file)->ref_length;
+          (*file)->ref =
+              (uchar *)alloc_root(m_clone_mem_root, ALIGN_SIZE(ref_length) * 2);
+        }
+
         if ((error = (*file)->ha_open(table, name_buff, mode, test_if_locked,
                                       table_def)))
           return false;
+
         ++file;
+        if (m_clone_base != nullptr) {
+          ++clone_base_file;
+        }
+
         return true;
       }))
     goto err_handler;

--- a/sql/partitioning/partition_base.h
+++ b/sql/partitioning/partition_base.h
@@ -109,6 +109,14 @@ class Partition_base : public handler,
   /** keep track of partitions to call ha_reset */
   MY_BITMAP m_partitions_to_reset;
 
+  /** Used when Partiton_base is cloned. Specifically it is used to retrieve
+  each handler ref_length */
+  Partition_base *m_clone_base;
+  /** For clone operation, memory will be allocated from this mem_root instead
+  of TABLE->mem_root. The clone can be destroyed by optimizer immediately. So
+  this allows to release the memory used by cloned object quickly */
+  MEM_ROOT *m_clone_mem_root;
+
  public:
   handler *clone(const char *name, MEM_ROOT *mem_root) override = 0;
 
@@ -126,7 +134,7 @@ class Partition_base : public handler,
   Partition_base(handlerton *hton, TABLE_SHARE *table);
 
   Partition_base(handlerton *hton, TABLE_SHARE *table,
-                 Handler_share **ha_share);
+                 Partition_base *clone_base, MEM_ROOT *clone_mem_root);
 
   ~Partition_base() override;
   bool init_with_fields() override;

--- a/storage/rocksdb/ha_rockspart.cc
+++ b/storage/rocksdb/ha_rockspart.cc
@@ -74,7 +74,9 @@ handler *ha_rockspart::clone(const char *name, MEM_ROOT *mem_root) {
   if (!table)
     DBUG_RETURN(nullptr);
 
-  new_handler = new (mem_root) ha_rockspart(ht, table_share, m_part_info);
+  new_handler =
+      new (mem_root) ha_rockspart(ht, table_share, m_part_info, this, mem_root);
+
   if (!new_handler)
     DBUG_RETURN(nullptr);
 

--- a/storage/rocksdb/ha_rockspart.h
+++ b/storage/rocksdb/ha_rockspart.h
@@ -24,8 +24,11 @@ class ha_rockspart : public native_part::Partition_base {
       : Partition_base(hton, table_arg){};
 
   ha_rockspart(handlerton *hton, TABLE_SHARE *table_arg,
-               partition_info *part_info)
-      : native_part::Partition_base(hton, table_arg, &table_arg->ha_share) {
+               partition_info *part_info,
+               native_part::Partition_base *clone_base,
+               MEM_ROOT *clone_mem_root)
+      : native_part::Partition_base(hton, table_arg, clone_base,
+                                    clone_mem_root) {
     this->get_partition_handler()->set_part_info(part_info, true);
   }
 

--- a/storage/tokudb/ha_tokupart.cc
+++ b/storage/tokudb/ha_tokupart.cc
@@ -46,7 +46,8 @@ handler *ha_tokupart::clone(const char *name, MEM_ROOT *mem_root) {
   not opened. Prohibit cloning such handler. */
   if (!table) DBUG_RETURN(nullptr);
 
-  new_handler = new (mem_root) ha_tokupart(ht, table_share, m_part_info);
+  new_handler =
+      new (mem_root) ha_tokupart(ht, table_share, m_part_info, this, mem_root);
 
   if (!new_handler) DBUG_RETURN(nullptr);
 

--- a/storage/tokudb/ha_tokupart.h
+++ b/storage/tokudb/ha_tokupart.h
@@ -26,8 +26,10 @@ class ha_tokupart : public native_part::Partition_base {
       : Partition_base(hton, table_arg){};
 
   ha_tokupart(handlerton *hton, TABLE_SHARE *table_arg,
-              partition_info *part_info)
-      : native_part::Partition_base(hton, table_arg, &table_arg->ha_share) {
+              partition_info *part_info,
+              native_part::Partition_base *clone_base, MEM_ROOT *clone_mem_root)
+      : native_part::Partition_base(hton, table_arg, clone_base,
+                                    clone_mem_root) {
     this->get_partition_handler()->set_part_info(part_info, true);
   }
 


### PR DESCRIPTION
Problem:
--------
With native paritioning and index_merge, the native partition handler
is cloned.

One important point missed when fixing PS-5206 is that both the original
and clone share the parition_info object (m_part_info). It has bitmap of
partitions read and used.

The cloned handler, which has reference to the shared to partition_info
object, resets the partition bitmap during creation. This causes problem
during the actual index scan.

Fix:
----
1. Create context to identify if the native partition handler creation is
from clone or brand new.

2. When it is clone, do not reset the partition bitmaps (i.e avoid calling
m_part_info->set_partition_bitmaps()). This is the core fix.

3. Additionally, we fix the cloned object creation to use clone mem_root
instead of TABLE->mem_root. Optimizer can destroy the cloned handler
immediately after its use. (See QUICK_RANGE_SELECT::~QUICK_RANGE_SELECT).
So the memory used by cloned handler objects is freed immediately at end
of query execution.
(cherry picked from commit 744f4e1c44d8debcdebd5a83f127cbbc28c261e4)