### PR TITLE
Post-merge fix to PS-5044 (Merge MySQL 8.0.14 & 8.0.15)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,6 @@ matrix:
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=5    BUILD=Debug
       compiler: gcc
-    # 10
-    - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=4.8  BUILD=Debug
-      compiler: gcc
 
 
     # Configurations for a pull request and after merging for percona/percona-server
@@ -115,10 +111,6 @@ matrix:
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=5    BUILD=RelWithDebInfo
       compiler: gcc
-    # 10
-    - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=4.8  BUILD=RelWithDebInfo
-      compiler: gcc
 
 
     # Configurations to be run after merging a pull request for percona/percona-server
@@ -153,10 +145,6 @@ matrix:
     # 8
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
-      compiler: gcc
-    # 9
-    - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=4.8  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
 
 


### PR DESCRIPTION
Remove GCC 4.9 from Travis-CI test matrix because of this version not
being used for any of official packages, and having bugs whose
workarounds are not trivial. Moreover, MySQL 8.0.16 is C++14, which is
fully supported starting with GCC 5 only.