### PR TITLE
PS-5576 : Server stalls because ALTER TABLE on partitioned table hold…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_truncate_table_ahi.result
+++ b/mysql-test/suite/innodb/r/percona_truncate_table_ahi.result
@@ -1,0 +1,40 @@
+CREATE TABLE t1(a INT, b INT, KEY k1(b));
+INSERT INTO t1 VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+CREATE TABLE t2 AS SELECT * FROM t1;
+FLUSH TABLES;
+SET GLOBAL innodb_limit_optimistic_insert_debug=2;
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1280
+SET DEBUG='+d, simulate_long_ahi';
+SET DEBUG_SYNC = 'truncate_table SIGNAL truncate_started WAIT_FOR resume_truncate';
+TRUNCATE TABLE t1;;
+#connection con1
+SET DEBUG_SYNC = 'now WAIT_FOR truncate_started';
+SET DEBUG_SYNC = 'open_dict_table SIGNAL resume_truncate';
+SET @t_start:=unix_timestamp(now(6));
+SELECT * FROM t2;
+a	b
+1	1
+2	2
+3	3
+4	4
+5	5
+SET @t_end:=unix_timestamp(now(6));
+SET @duration:=@t_end-@t_start;
+include/assert.inc [The time taken for SELECT should be less than 5 seconds]
+# connection default
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+DROP TABLE t2;
+SET GLOBAL innodb_limit_optimistic_insert_debug=default;
+SET GLOBAL innodb_adaptive_hash_index = default;

--- a/mysql-test/suite/innodb/t/percona_truncate_table_ahi.test
+++ b/mysql-test/suite/innodb/t/percona_truncate_table_ahi.test
@@ -1,0 +1,51 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+CREATE TABLE t1(a INT, b INT, KEY k1(b));
+INSERT INTO t1 VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+CREATE TABLE t2 AS SELECT * FROM t1;
+FLUSH TABLES;
+
+SET GLOBAL innodb_limit_optimistic_insert_debug=2;
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+SELECT COUNT(*) FROM t1;
+
+SET DEBUG='+d, simulate_long_ahi';
+SET DEBUG_SYNC = 'truncate_table SIGNAL truncate_started WAIT_FOR resume_truncate';
+--send TRUNCATE TABLE t1;
+
+connect (con1,localhost,root,,);
+--connection con1
+--echo #connection con1
+SET DEBUG_SYNC = 'now WAIT_FOR truncate_started';
+SET DEBUG_SYNC = 'open_dict_table SIGNAL resume_truncate';
+SET @t_start:=unix_timestamp(now(6));
+SELECT * FROM t2;
+SET @t_end:=unix_timestamp(now(6));
+SET @duration:=@t_end-@t_start;
+
+--let $assert_text= The time taken for SELECT should be less than 5 seconds
+--let $assert_cond= [SELECT @duration] < 5
+--source include/assert.inc
+
+--connection default
+--echo # connection default
+--reap
+SET DEBUG_SYNC = 'RESET';
+--disconnect con1
+
+DROP TABLE t1;
+DROP TABLE t2;
+SET GLOBAL innodb_limit_optimistic_insert_debug=default;
+SET GLOBAL innodb_adaptive_hash_index = default;
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -1436,6 +1436,9 @@ btr_search_drop_page_hash_when_freed(
 
 	ut_d(export_vars.innodb_ahi_drop_lookups++);
 
+	/* Sleep 10ms */
+	DBUG_EXECUTE_IF("simulate_long_ahi", os_thread_sleep(10000););
+
 	mtr_start(&mtr);
 
 	/* If the caller has a latch on the page, then the caller must

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -1118,7 +1118,8 @@ bool
 dict_drop_index_tree(
 	rec_t*		rec,
 	btr_pcur_t*	pcur,
-	mtr_t*		mtr)
+	mtr_t*		mtr,
+	bool		is_truncate)
 {
 	const byte*	ptr;
 	ulint		len;
@@ -1175,7 +1176,7 @@ dict_drop_index_tree(
 	}
 
 	btr_free_if_exists(page_id_t(space, root_page_no), page_size,
-			   mach_read_from_8(ptr), mtr);
+			   mach_read_from_8(ptr), mtr, is_truncate);
 
 	return(true);
 }
@@ -1202,7 +1203,7 @@ dict_drop_index_tree_in_mem(
 	tablespace and the .ibd file is missing do nothing,
 	else free the all the pages */
 	if (root_page_no != FIL_NULL && found) {
-		btr_free(page_id_t(space, root_page_no), page_size);
+		btr_free(page_id_t(space, root_page_no), page_size, false);
 	}
 }
 
@@ -1345,7 +1346,7 @@ dict_truncate_index_tree_in_mem(
 	tablespace objects. */
 
 	if (truncate) {
-		btr_free(page_id_t(space, root_page_no), page_size);
+		btr_free(page_id_t(space, root_page_no), page_size, false);
 	}
 
 	mtr_start(&mtr);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7352,6 +7352,9 @@ ha_innobase::open_dict_table(
 	dict_err_ignore_t	ignore_err)
 {
 	DBUG_ENTER("ha_innobase::open_dict_table");
+
+	DEBUG_SYNC_C("open_dict_table");
+
 	dict_table_t*	ib_table = dict_table_open_on_name(norm_name, FALSE,
 							   TRUE, ignore_err);
 

--- a/storage/innobase/include/btr0btr.h
+++ b/storage/innobase/include/btr0btr.h
@@ -336,13 +336,16 @@ btr_create(
 @param[in]	page_id		root page id
 @param[in]	page_size	page size
 @param[in]	index_id	PAGE_INDEX_ID contents
-@param[in,out]	mtr		mini-transaction */
+@param[in,out]	mtr		mini-transaction
+@param[in]	is_truncate	true for drop index during
+				truncate operation */
 void
 btr_free_if_exists(
 	const page_id_t&	page_id,
 	const page_size_t&	page_size,
 	index_id_t		index_id,
-	mtr_t*			mtr);
+	mtr_t*			mtr,
+	bool			is_truncate);
 
 /** Free an index tree in a temporary tablespace or during TRUNCATE TABLE.
 @param[in]	page_id		root page id
@@ -350,7 +353,8 @@ btr_free_if_exists(
 void
 btr_free(
 	const page_id_t&	page_id,
-	const page_size_t&	page_size);
+	const page_size_t&	page_size,
+	bool			is_truncate);
 
 /*************************************************************//**
 Makes tree one level higher by splitting the root, and inserts

--- a/storage/innobase/include/dict0crea.h
+++ b/storage/innobase/include/dict0crea.h
@@ -137,15 +137,18 @@ dict_recreate_index_tree(
 					committed and restarted in this call. */
 
 /** Drop the index tree associated with a row in SYS_INDEXES table.
-@param[in,out]	rec	SYS_INDEXES record
-@param[in,out]	pcur	persistent cursor on rec
-@param[in,out]	mtr	mini-transaction
+@param[in,out]	rec		SYS_INDEXES record
+@param[in,out]	pcur		persistent cursor on rec
+@param[in,out]	mtr		mini-transaction
+@param[in]	is_truncate	true for drop index operations from truncate
+				(used for skipping AHI checks)
 @return	whether freeing the B-tree was attempted */
 bool
 dict_drop_index_tree(
 	rec_t*		rec,
 	btr_pcur_t*	pcur,
-	mtr_t*		mtr);
+	mtr_t*		mtr,
+	bool		is_truncate);
 
 /***************************************************************//**
 Creates an index tree for the index if it is not a member of a cluster.

--- a/storage/innobase/row/row0trunc.cc
+++ b/storage/innobase/row/row0trunc.cc
@@ -944,7 +944,7 @@ DropIndex::operator()(mtr_t* mtr, btr_pcur_t* pcur) const
 {
 	rec_t*	rec = btr_pcur_get_rec(pcur);
 
-	bool	freed = dict_drop_index_tree(rec, pcur, mtr);
+	bool	freed = dict_drop_index_tree(rec, pcur, mtr, true);
 
 #ifdef UNIV_DEBUG
 	{
@@ -1856,6 +1856,8 @@ row_truncate_table_for_mysql(
 	row_mysql_lock_data_dictionary(trx);
 	ut_ad(mutex_own(&dict_sys->mutex));
 	ut_ad(rw_lock_own(dict_operation_lock, RW_LOCK_X));
+
+	DEBUG_SYNC_C("truncate_table");
 
 	/* Step-4: Stop all the background process associated with table. */
 	dict_stats_wait_bg_to_stop_using_table(table, trx);
@@ -2920,7 +2922,7 @@ truncate_t::drop_indexes(
 			const page_id_t	root_page_id(space_id, root_page_no);
 
 			btr_free_if_exists(
-				root_page_id, page_size, it->m_id, &mtr);
+				root_page_id, page_size, it->m_id, &mtr, true);
 		}
 
 		/* If tree is already freed then we might return immediately

--- a/storage/innobase/row/row0uins.cc
+++ b/storage/innobase/row/row0uins.cc
@@ -126,7 +126,8 @@ row_undo_ins_remove_clust_rec(
 		ut_ad(node->trx->dict_operation_lock_mode == RW_X_LATCH);
 
 		dict_drop_index_tree(
-			btr_pcur_get_rec(&node->pcur), &(node->pcur), &mtr);
+			btr_pcur_get_rec(&node->pcur), &(node->pcur), &mtr,
+			false);
 
 		mtr_commit(&mtr);
 

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -2889,7 +2889,8 @@ row_upd_clust_step(
 		ut_ad(!dict_index_is_online_ddl(index));
 
 		dict_drop_index_tree(
-			btr_pcur_get_rec(pcur), pcur, &mtr);
+			btr_pcur_get_rec(pcur), pcur, &mtr,
+			false);
 
 		mtr_commit(&mtr);
 


### PR DESCRIPTION
…s dict mutex

Why there is stall?
-------------------
1. Truncate holds dict_mutex and tries to free indexes. When indexes are huge (in
tera bytes), the dropping will take time.

See fseg_free_extent()->btr_search_drop_page_hash_when_freed()->buf_page_hash_get_low().

For every extent, for every page that is not marked free, there is check if page exists
in buffer pool (only peek, doesn't bring the page if it is not in buffer pool). This
check is mainly for AHI. Unfortunately, even if AHI is disabled, this check exists.


This iteration of extents * page in extents times hash searches take time. The dictionary
mutex is held for the entire duration.

Why concurrent inserts need dict_mutex?
---------------------------------------

Ideally not all inserts would need dict_mutex. This would have been terrible.
Only those inserts, where the TABLE* of table is not in cache, server has to open the table
from SE. InnoDB SE open tries to acquire dict_mutex to open table.

So all such inserts get blocked and they wait for dict_mutex. Remember they can be on different
tables. The inserts on truncated table are anyway blocked because of MDL.

Block of unrelated inserts on different tables is the core problem here. TRUNCATE TABLE t1 can
cause INSERT INTO t2 ..() or SELECT on t2 can also be blocked.

Fix:
----
Avoid buffer pool page hash lookups when AHI is disabled. This will reduce the time taken for
dict_sys mutex. So this patch solves only the TRUNCATE problem with innodb_adaptive_hash_index=OFF.