### PR TITLE
PS-5610: Fix keyring redo encryption in 32 bit builds (5.7)

### DIFF
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -919,7 +919,7 @@ fsp_header_fill_encryption_info(
 
 	/* Write master key id. */
 	mach_write_to_4(ptr, key_version);
-	ptr += sizeof(ulint);
+	ptr += 4;
 
 	/* Write server uuid. */
 	memcpy(ptr, Encryption::uuid, ENCRYPTION_SERVER_UUID_LEN);

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1139,7 +1139,7 @@ log_read_encryption()
 		unsigned char* info_ptr = log_block_buf + LOG_HEADER_CREATOR_END + ENCRYPTION_MAGIC_SIZE;
 	        uint version = mach_read_from_4(info_ptr);
 
-		memcpy(iv, info_ptr + ENCRYPTION_SERVER_UUID_LEN + 8, ENCRYPTION_KEY_LEN);
+		memcpy(iv, info_ptr + ENCRYPTION_SERVER_UUID_LEN + 4, ENCRYPTION_KEY_LEN);
 
 #ifdef UNIV_ENCRYPT_DEBUG
 			fprintf(stderr, "Using redo log encryption key version: %u\n", version);


### PR DESCRIPTION
The location of the IV was dependent on a sizeof, resulting in an
incorrect data layout written in 32 bit builds.