### PR TITLE
PS-5610: Fix keyring redo encryption in 32 bit builds (8.0)

### DIFF
--- a/storage/innobase/log/log0write.cc
+++ b/storage/innobase/log/log0write.cc
@@ -2697,7 +2697,7 @@ bool log_read_encryption() {
     unsigned char *info_ptr =
         log_block_buf + LOG_HEADER_CREATOR_END + ENCRYPTION_MAGIC_SIZE;
     version = mach_read_from_4(info_ptr);
-    memcpy(iv, info_ptr + ENCRYPTION_SERVER_UUID_LEN + 8, ENCRYPTION_KEY_LEN);
+    memcpy(iv, info_ptr + ENCRYPTION_SERVER_UUID_LEN + 4, ENCRYPTION_KEY_LEN);
 #ifdef UNIV_ENCRYPT_DEBUG
     fprintf(stderr, "Using redo log encryption key version: %u\n", version);
 #endif

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -8840,7 +8840,7 @@ bool Encryption::fill_encryption_info(uint key_version, byte *iv,
   ptr += ENCRYPTION_MAGIC_SIZE;
   /* Write master key id. */
   mach_write_to_4(ptr, key_version);
-  ptr += sizeof(ulint);
+  ptr += 4;
   /* Write server uuid. */
   memcpy(ptr, s_uuid, ENCRYPTION_SERVER_UUID_LEN);
   ptr += ENCRYPTION_SERVER_UUID_LEN;


### PR DESCRIPTION
The location of the IV was dependent on a sizeof, resulting in an
incorrect data layout written in 32 bit builds.

(cherry-picked from b1bc337f848233d980a8f405b52a88f855537598)