### PR TITLE
PS-5310 : Test innodb.percona_session_temp_tablespaces_encrypt is uns…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_session_temp_tablespaces_encrypt.result
+++ b/mysql-test/suite/innodb/r/percona_session_temp_tablespaces_encrypt.result
@@ -83,15 +83,5 @@ SET GLOBAL innodb_encrypt_tables=default;
 SET GLOBAL big_tables=default;
 DROP TABLE t3;
 DROP TABLE t6;
-SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES ORDER BY SPACE;
-ID	SPACE	PATH	SIZE	STATE	PURPOSE
-ID	4294501257	./#innodb_temp/temp_1.ibt	81920	INACTIVE	NONE
-ID	4294501258	./#innodb_temp/temp_2.ibt	81920	INACTIVE	NONE
-ID	4294501259	./#innodb_temp/temp_3.ibt	81920	INACTIVE	NONE
-ID	4294501260	./#innodb_temp/temp_4.ibt	81920	INACTIVE	NONE
-ID	4294501261	./#innodb_temp/temp_5.ibt	81920	INACTIVE	NONE
-ID	4294501262	./#innodb_temp/temp_6.ibt	81920	ACTIVE	INTRINSIC
-ID	4294501263	./#innodb_temp/temp_7.ibt	81920	INACTIVE	NONE
-ID	4294501264	./#innodb_temp/temp_8.ibt	81920	INACTIVE	NONE
-ID	4294501265	./#innodb_temp/temp_9.ibt	81920	INACTIVE	NONE
-ID	4294501266	./#innodb_temp/temp_10.ibt	98304	ACTIVE	INTRINSIC
+include/assert.inc [Active session temp tablespaces count should be 2]
+include/assert.inc [Inactive session temp tablespaces count should be 8]

--- a/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt.test
+++ b/mysql-test/suite/innodb/t/percona_session_temp_tablespaces_encrypt.test
@@ -95,6 +95,7 @@ SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE ID = conn
 connection default;
 disconnect con1;
 disconnect con2;
+--source include/wait_until_count_sessions.inc
 
 SET GLOBAL innodb_temp_tablespace_encrypt=default;
 SET GLOBAL innodb_encrypt_tables=default;
@@ -104,9 +105,13 @@ DROP TABLE t6;
 connect (con3, localhost, root,,);
 connection con3;
 
---replace_column 1 ID
---replace_regex /\\#innodb_temp\\temp/\/#innodb_temp\/temp/
-SELECT * FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES ORDER BY SPACE;
+--let $assert_text = Active session temp tablespaces count should be 2
+--let $assert_cond = "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE STATE = \"ACTIVE\"]" = 2
+--source include/assert.inc
+
+--let $assert_text = Inactive session temp tablespaces count should be 8
+--let $assert_cond = "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TABLESPACES WHERE STATE = \"INACTIVE\"]" = 8
+--source include/assert.inc
 
 connection default;
 disconnect con3;


### PR DESCRIPTION
…table

Problem:
--------
The test sometimes fails with difference in tablespace id used by connection id 11.

This is because connection disconnect is async. In regular case, connection 10
disconnects first and then connection 9.

Each connection disconnect releases session temporary tablespaces back to pool.
So the order of connection disconnect will decide the tablespace used by next connection.

On stress, it is observed that connection 9 disconnects first and then the connection 10.
Hence there is result content mismatch on the "tablespace id" used by connection 11.

Fix:
----
Use assert.inc on the number of expected active and inactive session temporary tablespaces
instead of displaying all tablespaces in session temporary tablespaces pool.