### PR TITLE
PS-5652 - innodb_sys_tablespace_encrypt must not be allowed to be per…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
+++ b/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
@@ -187,3 +187,14 @@ XA PREPARE 'x1';
 # Kill and restart: --datadir=MYSQLD_DATADIR1 --innodb-sys-tablespace-encrypt=ON
 # Start default MTR instance
 # restart
+#
+# PS-5652 - innodb_sys_tablespace_encrypt must not be allowed to be persisted
+#
+SET PERSIST_ONLY innodb_sys_tablespace_encrypt = ON;
+ERROR HY000: Variable 'innodb_sys_tablespace_encrypt' is a non persistent read only variable
+SET PERSIST_ONLY innodb_sys_tablespace_encrypt = OFF;
+ERROR HY000: Variable 'innodb_sys_tablespace_encrypt' is a non persistent read only variable
+SET PERSIST innodb_sys_tablespace_encrypt = ON;
+ERROR HY000: Variable 'innodb_sys_tablespace_encrypt' is a read only variable
+SET PERSIST innodb_sys_tablespace_encrypt = OFF;
+ERROR HY000: Variable 'innodb_sys_tablespace_encrypt' is a read only variable

--- a/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
+++ b/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
@@ -263,3 +263,15 @@ disconnect con1;
 --remove_file $BOOTSTRAP_SQL
 --force-rmdir $MYSQL_TMP_DIR/datadir1
 --remove_file $MYSQLTEST_VARDIR/tmp/boot.log
+
+--echo #
+--echo # PS-5652 - innodb_sys_tablespace_encrypt must not be allowed to be persisted
+--echo #
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET PERSIST_ONLY innodb_sys_tablespace_encrypt = ON;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET PERSIST_ONLY innodb_sys_tablespace_encrypt = OFF;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET PERSIST innodb_sys_tablespace_encrypt = ON;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET PERSIST innodb_sys_tablespace_encrypt = OFF;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -22767,7 +22767,7 @@ static MYSQL_SYSVAR_BOOL(
 
 static MYSQL_SYSVAR_BOOL(
     sys_tablespace_encrypt, srv_sys_tablespace_encrypt,
-    PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
+    PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY | PLUGIN_VAR_NOPERSIST,
     "Enable this option at bootstrap to encrypt system tablespace.", nullptr,
     nullptr, false);
 


### PR DESCRIPTION
…sisted

This variable is read-only variable and effective only at bootstrap. But
SET PERSIST allows the variable to persisted with the value passed. This
will cause restart failures if value doesn't match with encryption status
of system tablespace.

Fix is to disallow SET PERSIST for the variable.