### PR TITLE
PS-5645: Travis-CI clang-format check: output diffstat first (8.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -;
         - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list > /dev/null;
         - sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
-        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install clang-format-5.0 || travis_terminate 1
+        - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install diffstat clang-format-5.0 || travis_terminate 1
         - wget https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py || travis_terminate 1
         - chmod a+x clang-format-diff.py
         - git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | ./clang-format-diff.py -binary=clang-format-5.0 -style=file -p1 >_GIT_DIFF


### PR DESCRIPTION
Install the package 'diffstat'.