### PR TITLE
PS-5668 : Ensure keyring encryption header doesn't cross MK header en…

### DIFF
--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -282,7 +282,7 @@ struct fil_space_crypt_t {
   // to be able to store this IV.
   uchar *tablespace_iv;
 
-  unsigned char iv[16];
+  unsigned char iv[CRYPT_SCHEME_1_IV_LEN];
 
   uint encrypting_with_key_version;
   unsigned int keyserver_requests;


### PR DESCRIPTION
…cryption size

Ensure that the header size written by keyring key encryption doesn't cross the
encryption header size used by Master Key encryption.
Once the header size is crossed, it will corrupt the data written for other features.

Size of MK encryption header size: ENCRYPTION_INFO_MAX_SIZE ( 115 bytes)

Size of Keyring encryption header size: fil_get_encrypt_info_size(16) = 105.

Fix:
---
Added assert that checks the size of keyring key header size (written at Page 0) is
less than the Master Key encryption header size.