### PR TITLE
PS-5565: Better versioning with keyring redo encryption (5.7)

### DIFF
--- a/mysql-test/include/log_encrypt_2.inc
+++ b/mysql-test/include/log_encrypt_2.inc
@@ -32,15 +32,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 
 SELECT * FROM t1 LIMIT 10;
 
@@ -50,7 +50,14 @@ SELECT * FROM t1 LIMIT 10;
 
 SELECT * FROM t1 LIMIT 10;
 
-# Key rotation.
+SELECT rotate_system_key("percona_redo");
+
+if ($wait_for_key_version)
+{
+--let $wait_condition = select variable_value = 2 from performance_schema.global_status where variable_name = 'innodb_encryption_redo_key_version'
+--source include/wait_condition.inc
+}
+
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 
 DROP TABLE t1;
@@ -68,15 +75,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 
 # Restart to confirm the encryption info can be retrieved properly.
 --let restart_parameters="restart:$KEYRING_PARAMS"
@@ -84,6 +91,13 @@ INSERT INTO t1 select * from t1;
 --source include/kill_and_restart_mysqld.inc
 
 SELECT * FROM t1 LIMIT 10;
+
+let $restart_parameters = restart: $KEYRING_PARAMS --general-log --log-output=FILE --general_log_file=$MYSQL_TMP_DIR/keyring_query_log;
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT --plugin-dir=KEYRING_PLUGIN_PATH
+--replace_regex /\.dll/.so/
+--source include/restart_mysqld_no_echo.inc
+
+INSERT INTO t1 SELECT * FROM t1;
 DROP TABLE t1;
 
 let $restart_parameters = restart: $KEYRING_PARAMS --general-log --log-output=FILE --general_log_file=$MYSQL_TMP_DIR/keyring_query_log;

--- a/mysql-test/include/percona_log_encrypt_change.inc
+++ b/mysql-test/include/percona_log_encrypt_change.inc
@@ -22,7 +22,7 @@ SELECT @@innodb_redo_log_encrypt;
 --let $assert_select=Redo log encryption mode can't be switched without stopping the server and recreating the redo logs
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_count=2
---let $assert_only_after=CURRENT_TEST:innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
+--let $assert_only_after=CURRENT_TEST: innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
 --source include/assert_grep.inc
 
 # Test: using a different parameter during restart
@@ -38,7 +38,7 @@ SELECT @@innodb_redo_log_encrypt;
 --let $assert_select=Redo log encryption mode can't be switched without stopping the server and recreating the redo logs
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_count=3
---let $assert_only_after=CURRENT_TEST:innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
+--let $assert_only_after=CURRENT_TEST: innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
 --source include/assert_grep.inc
 
 # Cleanup

--- a/mysql-test/suite/innodb/r/log_encrypt_2_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_2_mk.result
@@ -21,15 +21,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 SELECT * FROM t1 LIMIT 10;
 c1	c2
 0	aaaaa
@@ -54,6 +54,9 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+SELECT rotate_system_key("percona_redo");
+rotate_system_key("percona_redo")
+1
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 DROP TABLE t1;
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
@@ -67,15 +70,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 # Kill and restart:<hidden args>
 SELECT * FROM t1 LIMIT 10;
 c1	c2
@@ -89,6 +92,7 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+INSERT INTO t1 SELECT * FROM t1;
 DROP TABLE t1;
 SET block_encryption_mode = 'aes-256-cbc';
 CREATE DATABASE tde_db;

--- a/mysql-test/suite/innodb/r/log_encrypt_2_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_2_rk.result
@@ -21,15 +21,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 SELECT * FROM t1 LIMIT 10;
 c1	c2
 0	aaaaa
@@ -54,6 +54,9 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+SELECT rotate_system_key("percona_redo");
+rotate_system_key("percona_redo")
+1
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 DROP TABLE t1;
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
@@ -67,15 +70,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 # Kill and restart:<hidden args>
 SELECT * FROM t1 LIMIT 10;
 c1	c2
@@ -89,6 +92,7 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+INSERT INTO t1 SELECT * FROM t1;
 DROP TABLE t1;
 SET block_encryption_mode = 'aes-256-cbc';
 CREATE DATABASE tde_db;

--- a/mysql-test/suite/innodb/t/log_encrypt_2_rk.test
+++ b/mysql-test/suite/innodb/t/log_encrypt_2_rk.test
@@ -1,2 +1,3 @@
 --let KEYRING_PARAMS=--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring2 $KEYRING_PLUGIN_OPT
+--let wait_for_key_version = 1
 --source include/log_encrypt_2.inc

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_change_rk.test
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_change_rk.test
@@ -1,4 +1,4 @@
 --let LOG_ENCRYPT_TYPE=KEYRING_KEY
---let LOG_ENCRYPT_TEST_END=mk
+--let LOG_ENCRYPT_TEST_END=rk
 --let LOG_ENCRYPT_OTHER_TYPE=MASTER_KEY
 --source include/percona_log_encrypt_change.inc

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk-master.opt
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk-master.opt
@@ -2,3 +2,4 @@ $KEYRING_PLUGIN_OPT
 $KEYRING_PLUGIN_EARLY_LOAD
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring_content
 --innodb_redo_log_encrypt=KEYRING_KEY
+--innodb-log_checksums=OFF

--- a/mysys/system_key.c
+++ b/mysys/system_key.c
@@ -32,7 +32,7 @@ struct Valid_percona_system_key
 */
 struct Valid_percona_system_key valid_percona_system_keys[] = { {PERCONA_BINLOG_KEY_NAME, 16, FALSE},
                                                                 {PERCONA_INNODB_KEY_NAME, 32, TRUE},
-								{PERCONA_REDO_KEY_NAME, 16, FALSE}};
+								{PERCONA_REDO_KEY_NAME, 32, FALSE}};
 const size_t valid_percona_system_keys_size = array_elements(valid_percona_system_keys);
 
 my_bool is_valid_percona_system_key(const char *key_name, size_t *key_length)

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -5868,6 +5868,34 @@ fil_io_set_keyring_encryption(IORequest& req_type,
 	mutex_exit(&space->crypt_data->mutex);
 }
 
+static void
+fil_io_set_mk_encryption(IORequest& req_type, fil_space_t* space)
+{
+	unsigned char* key = space->encryption_redo_key != NULL
+		? reinterpret_cast<unsigned char*>(space->encryption_redo_key->key)
+		: space->encryption_key;
+	uint version = space->encryption_redo_key != NULL
+		? space->encryption_redo_key->version
+		: space->encryption_key_version;
+	req_type.encryption_key(key,
+				32,
+				false,
+				space->encryption_iv,
+				version, 0, NULL, NULL);
+
+	req_type.encryption_rotation(Encryption::NO_ROTATION);
+}
+
+static
+bool
+fil_keyring_skip_encryption(const page_id_t& page_id) {
+
+	/* Don't encrypt TRX_SYS_SPACE.TRX_SYS_PAGE_NO as it contains address
+	to dblwr buffer */
+	return((page_id.space() == TRX_SYS_SPACE
+		&& page_id.page_no() == TRX_SYS_PAGE_NO) ? true : false);
+}
+
 /** Set encryption information for IORequest.
 @param[in,out]	req_type	IO request
 @param[in]	page_id		page id
@@ -5926,30 +5954,59 @@ fil_io_set_encryption(
 		return;
 	}
 
-	/* Don't encrypt the page 0 of all tablespaces,
-	   don't encrypt TRX_SYS_SPACE.TRX_SYS_PAGE_NO as it contains address to dblwr buffer */
-	if ((req_type.is_log()
-	     || (page_id.page_no() > 0
-		 && (TRX_SYS_SPACE != page_id.space()
-		     || TRX_SYS_PAGE_NO != page_id.page_no())))
-	    && space->encryption_type != Encryption::NONE) {
-		if (space->encryption_type == Encryption::KEYRING)  {
-			ut_ad(space->crypt_data != NULL);
-
-			fil_io_set_keyring_encryption(req_type, space, page_id);
-		} else {
-			ut_ad(space->encryption_type == Encryption::AES);
-			req_type.encryption_key(space->encryption_key,
-						32,
-						false,
-						space->encryption_iv,
-						0, 0, NULL, NULL); // not relevant for Master Key encryption
-
-			req_type.encryption_rotation(Encryption::NO_ROTATION);
-		}
-		req_type.encryption_algorithm(space->encryption_type);
-	} else {
+	if (space->encryption_type == Encryption::NONE) {
 		req_type.clear_encrypted();
+		return;
+	}
+
+        if (req_type.is_log())  {
+		/* redo log encryption */
+		ut_ad(page_id.space() == SRV_LOG_SPACE_FIRST_ID);
+
+		switch (space->encryption_type) {
+		case Encryption::AES:
+		case Encryption::KEYRING:
+			// Both MK and Keyrig key use same style for redo log
+			fil_io_set_mk_encryption(req_type, space);
+		        req_type.encryption_algorithm(space->encryption_type);
+			return;
+		case Encryption::NONE:
+			// Already handled above
+		default:
+			ut_a(0);
+		}
+
+	} else {
+		/* tablespace encryption */
+
+		/* Don't encrypt the page 0 of all tablespaces */
+		if (page_id.page_no() == 0) {
+		    req_type.clear_encrypted();
+		    return;
+		}
+
+		switch (space->encryption_type) {
+		case Encryption::KEYRING:
+			if (fil_keyring_skip_encryption(page_id)) {
+				req_type.clear_encrypted();
+				return;
+			} else {
+				fil_io_set_keyring_encryption(
+					req_type, space, page_id);
+				req_type.encryption_algorithm(
+						space->encryption_type);
+				return;
+			}
+
+		case Encryption::AES:
+			fil_io_set_mk_encryption(req_type, space);
+		        req_type.encryption_algorithm(space->encryption_type);
+			return;
+		case Encryption::NONE:
+			// Already handled above
+		default:
+			ut_a(0);
+		}
 	}
 }
 
@@ -7957,7 +8014,6 @@ fil_set_encryption(
 
 	if (key == NULL) {
 		Encryption::random_value(space->encryption_key);
-		space->encryption_key_version = REDO_LOG_ENCRYPT_NO_VERSION;
 	} else {
 		memcpy(space->encryption_key,
 		       key, ENCRYPTION_KEY_LEN);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1247,7 +1247,9 @@ static SHOW_VAR innodb_status_variables[]= {
   {"num_pages_decrypted",
    (char*) &export_vars.innodb_pages_decrypted,
    SHOW_LONGLONG, SHOW_SCOPE_GLOBAL },  
-  {NullS, NullS, SHOW_LONG, SHOW_SCOPE_GLOBAL}
+  {"encryption_redo_key_version",
+  (char*) &export_vars.innodb_redo_key_version, SHOW_LONGLONG, SHOW_SCOPE_GLOBAL},
+   {NullS, NullS, SHOW_LONG, SHOW_SCOPE_GLOBAL}
 };
 
 /************************************************************************//**
@@ -3930,7 +3932,7 @@ innobase_fix_tablespaces_empty_uuid()
 		if(srv_enable_redo_encryption()) {
 			srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
 		} else {
-			redo_rotate_default_key();
+			log_rotate_default_key();
 		}
 	}
 
@@ -3973,7 +3975,7 @@ innobase_fix_tablespaces_empty_uuid()
 	if (srv_enable_redo_encryption()) {
 		srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
 	} else {
-		redo_rotate_default_key();
+		log_rotate_default_key();
 	}
 
 	/** Check if sys, temp need rotation to fix the empty uuid */

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -52,6 +52,8 @@ Created 10/25/1995 Heikki Tuuri
 /** Structure containing encryption specification */
 struct fil_space_crypt_t;
 
+struct redo_log_key;
+
 #define REDO_LOG_ENCRYPT_NO_VERSION 0
 
 #ifdef UNIV_HOTBACKUP
@@ -255,6 +257,8 @@ struct fil_space_t {
 
 	/** Encrypt key version*/
 	ulint			encryption_key_version;
+	/** Only used for redo log encryption: the currently active key handle */
+	redo_log_key*           encryption_redo_key;
 
 	/** Encrypt initial vector */
         byte			encryption_iv[ENCRYPTION_KEY_LEN];

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -52,6 +52,8 @@ struct log_t;
 /** Redo log group */
 struct log_group_t;
 
+extern uint srv_redo_log_key_version;
+
 /** Magic value to use instead of log checksums when they are disabled */
 #define LOG_NO_CHECKSUM_MAGIC 0xDEADBEEFUL
 
@@ -152,7 +154,7 @@ extern redo_log_encrypt_enum existing_redo_encryption_mode;
 
 const char* log_encrypt_name(redo_log_encrypt_enum val);
 
-void redo_rotate_default_key();
+void log_rotate_default_key();
 
 /** Write the encryption info into the log file header(the 3rd block).
 It just need to flush the file header block with current master key.
@@ -172,6 +174,10 @@ log_write_encryption(
  * @return true if success. */
 bool
 log_rotate_encryption();
+
+/* Checks if there is a new redo key when using keyring encryption. */
+void
+log_check_new_key_version();
 
 /** Enables redo log encryption. */
 void

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1185,6 +1185,7 @@ struct export_var_t{
 						encrypted */
 	int64_t innodb_pages_decrypted;      /*!< Number of pages
 						decrypted */
+	int64_t innodb_redo_key_version;
 
 	/*!< Number of merge blocks encrypted */
 	int64_t innodb_n_merge_blocks_encrypted;

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -465,23 +465,30 @@ create_log_files(
 	ut_a(fil_validate());
 	ut_a(log_space != NULL);
 
-      /* Once the redo log is set to be encrypted,
-        initialize encryption information. */
-       if (srv_redo_log_encrypt != REDO_LOG_ENCRYPT_OFF) {
-               if (!Encryption::check_keyring()) {
-                       ib::error()
-                               << "Redo log encryption is enabled,"
-                               << " but keyring plugin is not loaded.";
+	/* Once the redo log is set to be encrypted,
+	   initialize encryption information. */
+	if (srv_redo_log_encrypt != REDO_LOG_ENCRYPT_OFF) {
+		if (!Encryption::check_keyring()) {
+			ib::error()
+				<< "Redo log encryption is enabled,"
+				<< " but keyring plugin is not loaded.";
 
-                       return(DB_ERROR);
-               }
+			return(DB_ERROR);
+		}
 
-               log_space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
-               err = fil_set_encryption(log_space->id,
-                                        Encryption::AES,
-                                        NULL,
-                                        NULL);
-               ut_ad(err == DB_SUCCESS);
+		Encryption::Type alg = srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK
+		       ? Encryption::KEYRING : Encryption::AES;
+
+		log_space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
+
+		redo_log_key* mkey = redo_log_key_mgr.generate_new_key_without_storing();
+		err = fil_set_encryption(log_space->id,
+					 alg,
+					 reinterpret_cast<byte*>(mkey->key),
+					 NULL);
+		log_space->encryption_redo_key = mkey;
+		log_space->encryption_key_version = REDO_LOG_ENCRYPT_NO_VERSION;
+		ut_ad(err == DB_SUCCESS);
        }
 
 


### PR DESCRIPTION
Previously keyring redo encryption only selected a version when the
redo log was created - changing the key version required recreating
the redo log.

With this change, individual pages all have separate versions. To
accomplish this, we reuse the checksum field: during encryption, we
assume that the checksum is correct, and replace it with the
checksum of the encrpyted data, plus the key version.
During reads, we calculate the checksum again, and assuma that the
difference between the written data and the calcalated value is the
key version.
An incorrect checksum will result in an incorrect key version,
resulting in quite likely a decryption error.
In the unlikely case that the checksum is wrong, but the resulting
number refers to an existing key, the decrypted data will be
garbage, and log recovery will abort later.

Since the redo key version now dynamic, it is exported as the
innodb_encryption_redo_key_version status variable.

To support this change, keyring handling of the redo log keys were
extracted to the redo_log_key_mgr global variable. This variable is
now the owner of all used keyring redo keys, and everything else
uses pointers to keys managed by it.
This way:
* keyring key handling is extracted to a common place, without
  too much code duplicated in multiple files
* key-copying races between threads changing the keys and others
writing data to the redo log are prevented, as it is a simple
pointer change now

The commit also includes minor fixes for issues previously hidden
by the limited usability of keyring redo encryption.