### PR TITLE
Fix PS-5146 (UBSan: strncmp(nullptr, ... ) called by / is_equal / Fie…

### DIFF
--- a/sql/field.cc
+++ b/sql/field.cc
@@ -1427,11 +1427,16 @@ bool Field::send_binary(Protocol *protocol)
 bool Field::has_different_compression_attributes_with(
   const Create_field& new_field) const
 {
-  return
-    (new_field.column_format() == COLUMN_FORMAT_TYPE_COMPRESSED ||
-    column_format() == COLUMN_FORMAT_TYPE_COMPRESSED) &&
-    (new_field.column_format() != column_format() ||
-    !::is_equal(&new_field.zip_dict_name, &zip_dict_name));
+  if (new_field.column_format() != COLUMN_FORMAT_TYPE_COMPRESSED &&
+      column_format() != COLUMN_FORMAT_TYPE_COMPRESSED)
+    return false;
+
+  if (new_field.column_format() != column_format()) return true;
+
+  if ((zip_dict_name.str == NULL) && (new_field.zip_dict_name.str == NULL))
+    return false;
+
+  return !::is_equal(&new_field.zip_dict_name, &zip_dict_name);
 }
 
 


### PR DESCRIPTION
…ld::has_different_compression_attributes_with)

Backport from 8.0: avoid calling strncmp with nullptr in
is_equal(const LEX_CSTRING *, const LEX_CSTRING *) by rewriting
Field::has_different_compression_attributes_with to assume that the
compression attributes are the same if both zip_dict_name.str ==
nullptr. At the same time rewrite this method to break down a complex
bool conditional.

https://ps56.cd.percona.com/job/percona-server-5.6-param/9/