### PR TITLE
Fix PS-5678 (Parallel doublewrite mustcrash server on I/O error)

### DIFF
--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -1331,8 +1331,13 @@ buf_dblwr_flush_buffered_writes(
 	      * srv_doublewrite_batch_size * UNIV_PAGE_SIZE);
 #endif
 
-	os_file_write(io_req, parallel_dblwr_buf.path, parallel_dblwr_buf.file,
-		      write_buf, file_pos, len);
+	dberr_t err = os_file_write(io_req, parallel_dblwr_buf.path,
+				    parallel_dblwr_buf.file, write_buf,
+				    file_pos, len);
+	if (UNIV_UNLIKELY(err != DB_SUCCESS)) {
+		ib::fatal() << "Parallel doublewrite buffer write failed, "
+			"crashing the server to avoid data loss";
+	}
 
 	ut_ad(dblwr_shard->first_free <= srv_doublewrite_batch_size);
 


### PR DESCRIPTION
buf_dblwr_flush_buffered_writes must crash server on an I/O error to
the doublewrite, as there is no way to continue flushing in such
event: proceeding with write to the data file defeats the purpose of
the doublewrite buffer. This was done in upstream legacy doublewrite,
however parallel doublewrite implementation changed the write call
from fil_io (which fails on error) to os_file_write (which returns
error to caller).

Fix by checking the return code of os_file_write and calling ib::fatal
on error.

https://ps57.cd.percona.com/job/percona-server-5.7-param/44/