### PR TITLE
PS-5593: Assertion failure this == space->crypt_data in encryption

### DIFF
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -832,8 +832,11 @@ fil_crypt_read_crypt_data(fil_space_t* space) {
 					      page_size, RW_S_LATCH, &mtr)) {
 		mutex_enter(&fil_system->mutex);
 		if (!space->crypt_data) {
-			space->crypt_data = fil_space_read_crypt_data(
-				page_size, block->frame);
+			fil_space_crypt_t *crypt_data =
+				fil_space_read_crypt_data(page_size, block->frame);
+			if (crypt_data != NULL) {
+				space->crypt_data = crypt_data;
+			}
 		}
 		mutex_exit(&fil_system->mutex);
 	}


### PR DESCRIPTION
threads

When KEYRING encryption is started for a space by encryption thread
a crypt_data is generated for this space. However there is a race
when setting this crypt data for space (changing from
space->crypt_data == nullptr).
fil_crypt_read_crypt_data can be called at the moment when
crypt_data is being set. If it discovers that crypt_data is nullptr
it will try to read crypt_data from page0 and assign it to space. It can
read it as a nullptr and override the crypt_data created by
start_encrypting_space - as there could be a race here.
Normally this is secured by taking a lock on crypt_data->mutex.
Which is not possible here, as crypt_data doest not exist yet.

Other solution would be to add some additional synchronization here,
however since fil_crypt_read_crypt_data can be called periodically
by encryption threads it may add additional contention.
start_encrypting_space could also try to set this crypt_data in
loop, however this seems like better solution.