### PR TITLE
Backport minor testsuite fixes from 8.0 (PS-5681)

### DIFF
--- a/mysql-test/suite/rpl/t/bug68490-slave.opt
+++ b/mysql-test/suite/rpl/t/bug68490-slave.opt
@@ -1,2 +1,3 @@
 --max_allowed_packet=1M
 --slave_max_allowed_packet=1G
+--master-retry-count=0

--- a/mysql-test/suite/rpl_encryption/r/encrypted_master_lost_key.result
+++ b/mysql-test/suite/rpl_encryption/r/encrypted_master_lost_key.result
@@ -104,6 +104,10 @@ connection server_2;
 START SLAVE SQL_THREAD;
 START SLAVE IO_THREAD;
 include/wait_for_slave_io_error.inc [errno=1236]
+include/sync_slave_sql_with_io.inc
+connection server_2;
+connection server_2;
+connection server_2;
 SHOW TABLES;
 Tables_in_test
 table1_to_encrypt

--- a/mysql-test/suite/rpl_encryption/t/encrypted_master_lost_key.test
+++ b/mysql-test/suite/rpl_encryption/t/encrypted_master_lost_key.test
@@ -139,6 +139,7 @@ START SLAVE IO_THREAD;
 --source include/wait_for_slave_io_error.inc
 --enable_connect_log
 
+--source include/sync_slave_sql_with_io.inc
 # Here we should see only table1_to_encrypt and its contents,
 # because it was logged with the initial key
 --sorted_result


### PR DESCRIPTION
The tests affected are rpl.bug68490 and
rpl_encryption.encrypted_master_lost_key.

https://ps57.cd.percona.com/job/percona-server-5.7-param/47/