### PR TITLE
PS-5565: Better versioning with keyring redo encryption (8.0)

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -182,14 +182,7 @@ innodb.tablespace_encrypt_6 : BUG#5102 work in progress
 innodb.innodb_row_log_encryption : BUG#5102 work in progress
 innodb.tablespace_encrypt_1 : BUG#5102 work in progress
 main.percona_dd_upgrade_encrypted : BUG#5102 work in progress
-innodb.log_encrypt_1_mk : BUG#5102 work in progress
-innodb.log_encrypt_1_rk : BUG#5102 work in progress
-innodb.log_encrypt_3_mk : BUG#5102 work in progress
-innodb.log_encrypt_3_rk : BUG#5102 work in progress
 main.mysql_80_inplace_upgrade : BUG#5102 work in progress
-innodb.log_encrypt_5_mk : BUG#5102 work in progress
-innodb.log_encrypt_5_rk : BUG#5102 work in progress
-innodb.log_encrypt_kill : BUG#5102 work in progress
 main.dd_upgrade_cs : BUG#5102 work in progress
 main.dd_upgrade_error_debug : BUG#5102 work in progress
 main.histograms : BUG#5102 work in progress
@@ -199,5 +192,4 @@ innodb.table_encrypt_1 : BUG#5102 work in progress
 innodb.tablespace_encrypt_4 : BUG#5102 work in progress
 innodb.tablespace_encrypt_8 : BUG#5102 work in progress
 innodb.temp_table_encrypt : BUG#5102 work in progress
-sys_vars.innodb_redo_log_encrypt_basic : BUG#5102 work in progress
 innodb.percona_log_encrypt_failure : BUG#5102 work in progress

--- a/mysql-test/include/log_encrypt_2.inc
+++ b/mysql-test/include/log_encrypt_2.inc
@@ -34,15 +34,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 
 SELECT * FROM t1 LIMIT 10;
 
@@ -54,7 +54,14 @@ SHOW VARIABLES LIKE "%innodb_redo_log_encrypt%";
 
 SELECT * FROM t1 LIMIT 10;
 
-# Key rotation.
+SELECT rotate_system_key("percona_redo");
+
+if ($wait_for_key_version)
+{
+--let $wait_condition = select variable_value = 2 from performance_schema.global_status where variable_name = 'innodb_encryption_redo_key_version'
+--source include/wait_condition.inc
+}
+
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 
 DROP TABLE t1;
@@ -72,15 +79,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 
 # Restart to confirm the encryption info can be retrieved properly.
 --let restart_parameters="restart:$KEYRING_PARAMS --innodb_redo_log_encrypt=$redo_log_mode"
@@ -90,6 +97,13 @@ INSERT INTO t1 select * from t1;
 SHOW VARIABLES LIKE "%innodb_redo_log_encrypt%";
 
 SELECT * FROM t1 LIMIT 10;
+
+let $restart_parameters = restart: $KEYRING_PARAMS --general-log --log-output=FILE --general_log_file=$MYSQL_TMP_DIR/keyring_query_log;
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT --plugin-dir=KEYRING_PLUGIN_PATH
+--replace_regex /\.dll/.so/
+--source include/restart_mysqld_no_echo.inc
+
+INSERT INTO t1 SELECT * FROM t1;
 DROP TABLE t1;
 
 let $restart_parameters = restart: $KEYRING_PARAMS --general-log --log-output=FILE --innodb_redo_log_encrypt=$redo_log_mode --general_log_file=$MYSQL_TMP_DIR/keyring_query_log;

--- a/mysql-test/include/log_encrypt_5.inc
+++ b/mysql-test/include/log_encrypt_5.inc
@@ -11,7 +11,6 @@ call mtr.add_suppression("Encryption can't find master key, please check the key
 call mtr.add_suppression("Failed to find tablespace for table `\.\.*`\.`\.\.*` in the cache.");
 call mtr.add_suppression("ibd can't be decrypted , please confirm the keyfile is match and keyring plugin is loaded.");
 call mtr.add_suppression("Ignoring tablespace .* because it could not be opened");
-call mtr.add_suppression("Redo log key generation failed");
 call mtr.add_suppression("InnoDB: Resizing redo log from");
 call mtr.add_suppression("InnoDB: Starting to delete and rewrite log files.");
 call mtr.add_suppression("InnoDB: New log files created, LSN=");

--- a/mysql-test/include/percona_log_encrypt_change.inc
+++ b/mysql-test/include/percona_log_encrypt_change.inc
@@ -19,7 +19,7 @@ SELECT @@innodb_redo_log_encrypt;
 --let $assert_select=Redo log encryption mode can't be switched without stopping the server and recreating the redo logs
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_count=2
---let $assert_only_after=CURRENT_TEST:innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
+--let $assert_only_after=CURRENT_TEST: innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
 --source include/assert_grep.inc
 
 # Test: using a different parameter during restart
@@ -35,7 +35,7 @@ SELECT @@innodb_redo_log_encrypt;
 --let $assert_select=Redo log encryption mode can't be switched without stopping the server and recreating the redo logs
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
 --let $assert_count=3
---let $assert_only_after=CURRENT_TEST:innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
+--let $assert_only_after=CURRENT_TEST: innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
 --source include/assert_grep.inc
 
 # Cleanup

--- a/mysql-test/suite/innodb/r/log_encrypt_2_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_2_mk.result
@@ -27,15 +27,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 SELECT * FROM t1 LIMIT 10;
 c1	c2
 0	aaaaa
@@ -63,6 +63,9 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+SELECT rotate_system_key("percona_redo");
+rotate_system_key("percona_redo")
+1
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 DROP TABLE t1;
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
@@ -76,15 +79,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 # Kill and restart:<hidden args>
 SHOW VARIABLES LIKE "%innodb_redo_log_encrypt%";
 Variable_name	Value
@@ -101,6 +104,7 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+INSERT INTO t1 SELECT * FROM t1;
 DROP TABLE t1;
 SHOW VARIABLES LIKE "%innodb_redo_log_encrypt%";
 Variable_name	Value

--- a/mysql-test/suite/innodb/r/log_encrypt_2_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_2_rk.result
@@ -27,15 +27,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 SELECT * FROM t1 LIMIT 10;
 c1	c2
 0	aaaaa
@@ -63,6 +63,9 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+SELECT rotate_system_key("percona_redo");
+rotate_system_key("percona_redo")
+1
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 DROP TABLE t1;
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
@@ -76,15 +79,15 @@ INSERT INTO t1 VALUES(6, "ggggg");
 INSERT INTO t1 VALUES(7, "hhhhh");
 INSERT INTO t1 VALUES(8, "iiiii");
 INSERT INTO t1 VALUES(9, "jjjjj");
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
-INSERT INTO t1 select * from t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
 # Kill and restart:<hidden args>
 SHOW VARIABLES LIKE "%innodb_redo_log_encrypt%";
 Variable_name	Value
@@ -101,6 +104,7 @@ c1	c2
 7	hhhhh
 8	iiiii
 9	jjjjj
+INSERT INTO t1 SELECT * FROM t1;
 DROP TABLE t1;
 SHOW VARIABLES LIKE "%innodb_redo_log_encrypt%";
 Variable_name	Value

--- a/mysql-test/suite/innodb/t/log_encrypt_2_rk.test
+++ b/mysql-test/suite/innodb/t/log_encrypt_2_rk.test
@@ -1,3 +1,4 @@
 --let KEYRING_PARAMS=--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring2 $KEYRING_PLUGIN_OPT
 --let $redo_log_mode=KEYRING_KEY
+--let wait_for_key_version = 1
 --source include/log_encrypt_2.inc

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk-master.opt
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_content_rk-master.opt
@@ -2,3 +2,4 @@ $KEYRING_PLUGIN_OPT
 $KEYRING_PLUGIN_EARLY_LOAD
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring_content
 --innodb_redo_log_encrypt=KEYRING_KEY
+--innodb-log-checksums=OFF

--- a/mysys/system_key.cc
+++ b/mysys/system_key.cc
@@ -37,7 +37,7 @@ struct Valid_percona_system_key {
    system key's name and system key's version.
 */
 struct Valid_percona_system_key valid_percona_system_keys[] = {
-    {PERCONA_INNODB_KEY_NAME, 32, true}};
+    {PERCONA_INNODB_KEY_NAME, 32, true}, {PERCONA_REDO_KEY_NAME, 32, false}};
 const size_t valid_percona_system_keys_size =
     array_elements(valid_percona_system_keys);
 

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -29,6 +29,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "mtr0types.h"
 #include "page0size.h"
 #include "page0zip.h"
+#include "system_key.h"
 #ifndef UNIV_INNOCHECKSUM
 #include <my_crypt.h>
 #include "btr0scrub.h"
@@ -2993,3 +2994,169 @@ bool fil_space_verify_crypt_checksum(byte *page, ulint page_size,
 
   return (encrypted);
 }
+
+redo_log_key *redo_log_keys::load_latest_key(bool generate) {
+  size_t klen = 0;
+  char *key_type = nullptr;
+  byte *rkey = nullptr;
+
+  if (my_key_fetch(PERCONA_REDO_KEY_NAME, &key_type, nullptr,
+                   reinterpret_cast<void **>(&rkey), &klen) ||
+      rkey == nullptr || strncmp(key_type, "AES", 4) != 0) {
+    /* There is no key yet, we'll try to generate one */
+    my_free(rkey);
+    return generate ? generate_and_store_new_key() : nullptr;
+  }
+
+  uint version = 0;
+  byte *rkey2 = nullptr;
+  size_t klen2 = 0;
+  const bool err = (parse_system_key(rkey, klen, &version, &rkey2, &klen2) ==
+                    reinterpret_cast<uchar *>(NullS));
+  if (err) {
+    my_free(rkey);
+    my_free(rkey2);
+    my_free(key_type);
+    return nullptr;
+  }
+
+  ut_ad(klen2 == ENCRYPTION_KEY_LEN);
+
+  auto it = m_keys.find(version);
+
+  if (it != m_keys.end() && it->second.present) {
+    ut_ad(memcmp(it->second.key, rkey2, ENCRYPTION_KEY_LEN) == 0);
+    return &it->second;
+  }
+
+  redo_log_key *rk = &m_keys[version];
+  rk->version = version;
+  rk->present = true;
+  memcpy(rk->key, rkey2, ENCRYPTION_KEY_LEN);
+
+  my_free(rkey);
+  my_free(rkey2);
+  my_free(key_type);
+
+  return rk;
+}
+
+redo_log_key *redo_log_keys::load_key_version(uint version) {
+  auto it = m_keys.find(version);
+
+  if (it != m_keys.end() && it->second.present) {
+    return &it->second;
+  }
+
+  size_t klen = 0;
+  char *key_type = nullptr;
+  byte *rkey = nullptr;
+
+  std::ostringstream percona_redo_with_ver_ss;
+  percona_redo_with_ver_ss << PERCONA_REDO_KEY_NAME << ':' << version;
+  if (my_key_fetch(percona_redo_with_ver_ss.str().c_str(), &key_type, nullptr,
+                   reinterpret_cast<void **>(&rkey), &klen) ||
+      rkey == nullptr || strncmp(key_type, "AES", 4) != 0) {
+    my_free(rkey);
+    my_free(key_type);
+    ib::error() << "Failed to load redo key version " << version;
+    return nullptr;
+  }
+
+  ut_ad(klen == ENCRYPTION_KEY_LEN);
+
+  redo_log_key *rk = &m_keys[version];
+  rk->version = version;
+  rk->present = true;
+  memcpy(rk->key, rkey, ENCRYPTION_KEY_LEN);
+
+  my_free(rkey);
+  my_free(key_type);
+
+  return rk;
+}
+
+redo_log_key *redo_log_keys::generate_and_store_new_key() {
+  if (my_key_generate(PERCONA_REDO_KEY_NAME, "AES", nullptr,
+                      ENCRYPTION_KEY_LEN)) {
+    ib::error() << "Redo log key generation failed.";
+    return nullptr;
+  }
+
+  char *redo_key_type = nullptr;
+  byte *rkey = nullptr;
+  size_t klen = 0;
+
+  if (my_key_fetch(PERCONA_REDO_KEY_NAME, &redo_key_type, nullptr,
+                   reinterpret_cast<void **>(&rkey), &klen)) {
+    ib::error() << "Couldn't fetch newly generated redo key.";
+    my_free(redo_key_type);
+    my_free(rkey);
+    return nullptr;
+  }
+
+  ut_ad(rkey != nullptr);
+  byte *rkey2 = nullptr;
+  size_t klen2 = 0;
+  uint version = 0;
+
+  bool err = (parse_system_key(rkey, klen, &version, &rkey2, &klen2) ==
+              reinterpret_cast<uchar *>(NullS));
+
+  ut_ad(klen2 == ENCRYPTION_KEY_LEN);
+
+  if (err) {
+    ib::error() << "Couldn't parse system key: " << rkey;
+    my_free(redo_key_type);
+    my_free(rkey);
+    return nullptr;
+  }
+
+  redo_log_key *rk = &m_keys[version];
+  rk->version = version;
+  memcpy(rk->key, rkey2, ENCRYPTION_KEY_LEN);
+  rk->present = true;
+
+  my_free(redo_key_type);
+  my_free(rkey);
+  my_free(rkey2);
+
+  return rk;
+}
+
+redo_log_key *redo_log_keys::generate_new_key_without_storing() {
+  ut_ad(m_keys.empty());
+  Encryption::random_value(reinterpret_cast<byte *>(&m_keys[0].key));
+  return &m_keys[0];
+}
+
+bool redo_log_keys::store_used_keys() noexcept {
+  /* This is a for loop, but it really only should store a key with current
+  version 0 */
+  for (const auto &item : m_keys) {
+    if (!item.second.persisted()) {
+      ut_ad(item.first == 0);
+      if (my_key_store(PERCONA_REDO_KEY_NAME, "AES", nullptr, item.second.key,
+                       ENCRYPTION_KEY_LEN)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+void redo_log_keys::unload_old_keys() noexcept {
+  if (m_keys.size() == 0) {
+    return;
+  }
+  redo_log_key *last = &(--m_keys.end())->second;
+  for (auto &item : m_keys) {
+    if (&item.second != last) {
+      item.second.present = false;
+      memset(item.second.key, 0, ENCRYPTION_KEY_LEN);
+    }
+  }
+}
+
+redo_log_keys redo_log_key_mgr;

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -718,7 +718,7 @@ Datafile::ValidateOutput Datafile::validate_first_page(space_id_t space_id,
       m_encryption_iv =
           static_cast<byte *>(ut_zalloc_nokey(ENCRYPTION_KEY_LEN));
 #ifdef UNIV_ENCRYPT_DEBUG
-      fprintf(stderr, "Got from file %lu:", m_space_id);
+      fprintf(stderr, "Got from file " SPACE_ID_PFS ":", m_space_id);
 #endif
 
       if (!fsp_header_get_encryption_key(m_flags, m_encryption_key,

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1343,6 +1343,9 @@ static SHOW_VAR innodb_status_variables[] = {
     {"encryption_n_rowlog_blocks_decrypted",
      (char *)&export_vars.innodb_n_rowlog_blocks_decrypted, SHOW_LONGLONG,
      SHOW_SCOPE_GLOBAL},
+    {"encryption_redo_key_version",
+     (char *)&export_vars.innodb_redo_key_version, SHOW_LONGLONG,
+     SHOW_SCOPE_GLOBAL},
     {NullS, NullS, SHOW_LONG, SHOW_SCOPE_GLOBAL},
     /* Encryption */
     {"encryption_rotation_pages_read_from_cache",
@@ -4371,7 +4374,7 @@ bool innobase_fix_tablespaces_empty_uuid() {
     if (srv_enable_redo_encryption()) {
       srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
     } else {
-      redo_rotate_default_key();
+      log_rotate_default_key();
     }
   }
 
@@ -4411,7 +4414,7 @@ bool innobase_fix_tablespaces_empty_uuid() {
   if (srv_enable_redo_encryption()) {
     srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
   } else {
-    redo_rotate_default_key();
+    log_rotate_default_key();
   }
 
   /** Check if sys, temp need rotation to fix the empty uuid */

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -327,6 +327,57 @@ struct fil_space_scrub_status_t {
   ulint current_scrub_max_page_number; /*!< current scrub max page no */
 };
 
+struct redo_log_key final {
+  uint version;
+  char key[ENCRYPTION_KEY_LEN];
+  ulint read_count;
+  ulint write_count;
+  bool present;
+
+  bool persisted() const noexcept { return version != 0; }
+};
+
+/** Handles the fetching/generation/storing/etc of keyring redo log keys.
+
+This class is *NOT* thread safe, as thread safety is not required.
+Data is only accessed/modified on the following points:
+* When the redo space is created, at startup
+* During redo log recovery, at startup
+* When the server UUID is generated, at startup
+* When the user requests a new key version, checked periodically in the
+   master thread
+
+As these can't happen in parallel, no lock is used. */
+class redo_log_keys final {
+ public:
+  /** Loads the latest redo log key from the keyring.
+  @param[in]	generate If true, a key is generated if an existing key can't
+  be loaded. */
+  MY_NODISCARD
+  redo_log_key *load_latest_key(bool generate);
+  MY_NODISCARD
+  redo_log_key *load_key_version(uint version);
+
+  MY_NODISCARD
+  redo_log_key *generate_and_store_new_key();
+
+  /** These two methods are used during bootstrap encryption, when wo do not yet
+  have an uuid */
+  MY_NODISCARD
+  redo_log_key *generate_new_key_without_storing();
+
+  MY_NODISCARD
+  bool store_used_keys() noexcept;
+
+  void unload_old_keys() noexcept;
+
+ private:
+  using key_map = std::map<ulint, redo_log_key>;
+  key_map m_keys;
+};
+
+extern redo_log_keys redo_log_key_mgr;
+
 /*********************************************************************
 Init space crypt */
 void fil_space_crypt_init();

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -55,6 +55,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 #define REDO_LOG_ENCRYPT_NO_VERSION 0
 
+struct redo_log_key;
+
 /** Structure containing encryption specification */
 struct fil_space_crypt_t;
 
@@ -312,6 +314,9 @@ struct fil_space_t {
   byte encryption_iv[ENCRYPTION_KEY_LEN];
 
   ulint encryption_key_version;
+
+  /** Only used for redo log encryption: the currently active key handle */
+  redo_log_key *encryption_redo_key;
 
   /** Encryption is in progress */
   encryption_op_type encryption_op_in_progress;

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -53,6 +53,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "log0test.h"
 #include "log0types.h"
 
+extern uint srv_redo_log_key_version;
+
 /** Prefix for name of log file, e.g. "ib_logfile" */
 constexpr const char *const ib_logfile_basename = "ib_logfile";
 
@@ -792,7 +794,7 @@ extern redo_log_encrypt_enum existing_redo_encryption_mode;
 
 const char *log_encrypt_name(redo_log_encrypt_enum val);
 
-void redo_rotate_default_key();
+void log_rotate_default_key();
 
 /** Write the encryption info into the log file header(the 3rd block).
 It just need to flush the file header block with current master key.
@@ -809,6 +811,9 @@ It will re-encrypt the redo log encryption metadata and write it to
 redo log file header.
 @return true if success. */
 bool log_rotate_encryption();
+
+/* Checks if there is a new redo key when using keyring encryption. */
+void log_check_new_key_version();
 
 /** Requests a sharp checkpoint write for provided or greater lsn.
 @param[in,out]	log	redo log

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1277,6 +1277,9 @@ struct export_var_t {
                                   encrypted */
   int64_t innodb_pages_decrypted; /*!< Number of pages
                                   decrypted */
+
+  /* Current redo log encryption key versison for keyring encryption */
+  int64_t innodb_redo_key_version;
   ulint innodb_encryption_rotation_pages_read_from_cache;
   ulint innodb_encryption_rotation_pages_read_from_disk;
   ulint innodb_encryption_rotation_pages_modified;

--- a/storage/innobase/log/log0write.cc
+++ b/storage/innobase/log/log0write.cc
@@ -54,6 +54,7 @@ the file COPYING.Google.
 #include "buf0flu.h"
 #include "dict0boot.h"
 #include "dict0stats_bg.h"
+#include "fil0crypt.h"
 #endif /* !UNIV_HOTBACKUP */
 #include "fil0fil.h"
 #include "log0log.h"
@@ -2697,6 +2698,8 @@ bool log_read_encryption() {
 
   bool encryption_magic = false;
   bool encrypted_log = false;
+  redo_log_key *mkey = nullptr;
+  Encryption::Type encryption_type = Encryption::NONE;
   uint version = 0;
   if (memcmp(log_block_buf + LOG_HEADER_CREATOR_END, ENCRYPTION_KEY_MAGIC_RK,
              ENCRYPTION_MAGIC_SIZE) == 0) {
@@ -2717,22 +2720,12 @@ bool log_read_encryption() {
     fprintf(stderr, "Using redo log encryption key version: %u\n", version);
 #endif
 
-    unique_ptr_my_free<char> key_type;
-    unique_ptr_my_free<unsigned char> rkey;
-    std::ostringstream percona_redo_with_ver_ss;
-    percona_redo_with_ver_ss << PERCONA_REDO_KEY_NAME << ':' << version;
-    size_t klen;
-    if (my_key_fetch_safe(percona_redo_with_ver_ss.str().c_str(), key_type,
-                          nullptr, rkey, &klen) ||
-        rkey == nullptr) {
-      ib::error() << "Couldn't fetch redo log encryption key: "
-                  << percona_redo_with_ver_ss.str() << ".";
-    } else if (key_type == nullptr || strncmp(key_type.get(), "AES", 3) != 0) {
-      ib::error() << "Unknown redo log encryption type: " << key_type.get()
-                  << ".";
-    } else {
+    mkey = redo_log_key_mgr.load_key_version(version);
+    if (mkey != nullptr) {
       encrypted_log = true;
-      memcpy(key, rkey.get(), ENCRYPTION_KEY_LEN);
+      memcpy(key, mkey->key, ENCRYPTION_KEY_LEN);
+      encryption_type = Encryption::KEYRING;
+      srv_redo_log_key_version = mkey->version;
     }
   }
 
@@ -2751,6 +2744,7 @@ bool log_read_encryption() {
     if (Encryption::decode_encryption_info(
             key, iv, log_block_buf + LOG_HEADER_CREATOR_END)) {
       encrypted_log = true;
+      encryption_type = Encryption::AES;
     }
   }
 
@@ -2771,7 +2765,8 @@ bool log_read_encryption() {
        redo log blocks. */
     fil_space_t *space = fil_space_get(log_space_id);
     fsp_flags_set_encryption(space->flags);
-    dberr_t err = fil_set_encryption(space->id, Encryption::AES, key, iv);
+    space->encryption_redo_key = mkey;
+    dberr_t err = fil_set_encryption(space->id, encryption_type, key, iv);
     space->encryption_key_version = version;
     if (err == DB_SUCCESS) {
       ut_free(log_block_buf_ptr);
@@ -2891,7 +2886,23 @@ bool log_rotate_encryption() {
       static_cast<redo_log_encrypt_enum>(srv_redo_log_encrypt)));
 }
 
-void redo_rotate_default_key() {
+void log_check_new_key_version() {
+  const space_id_t log_space_id = dict_sys_t::s_log_space_first_id;
+  fil_space_t *space = fil_space_get(log_space_id);
+  if (!FSP_FLAGS_GET_ENCRYPTION(space->flags)) {
+    return;
+  }
+  if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK) {
+    /* re-fetch latest key */
+    redo_log_key *mkey = redo_log_key_mgr.load_latest_key(false);
+    if (mkey != nullptr) {
+      space->encryption_redo_key = mkey;
+      srv_redo_log_key_version = mkey->version;
+    }
+  }
+}
+
+void log_rotate_default_key() {
   fil_space_t *space = fil_space_get(dict_sys_t::s_log_space_first_id);
 
   if (srv_shutdown_state != SRV_SHUTDOWN_NONE) {
@@ -2902,50 +2913,34 @@ void redo_rotate_default_key() {
   We also need the server_uuid initialized. */
   if (space->encryption_type != Encryption::NONE &&
       Encryption::s_master_key_id == ENCRYPTION_DEFAULT_MASTER_KEY_ID &&
-      !srv_read_only_mode && strlen(server_uuid) > 0 &&
+      !srv_read_only_mode &&
       (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_MK ||
        srv_redo_log_encrypt == REDO_LOG_ENCRYPT_ON)) {
     ut_a(FSP_FLAGS_GET_ENCRYPTION(space->flags));
+    ut_a(strlen(server_uuid) > 0);
 
     log_write_encryption(nullptr, nullptr, false, REDO_LOG_ENCRYPT_MK);
   }
 
   if (space->encryption_type != Encryption::NONE &&
       space->encryption_key_version == REDO_LOG_ENCRYPT_NO_VERSION &&
-      !srv_read_only_mode && strlen(server_uuid) > 0 &&
-      srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK) {
+      !srv_read_only_mode && srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK) {
+    ut_a(strlen(server_uuid) > 0);
     /* This only happens when the server uuid was just generated, so we can
      * save the key to the keyring */
-    if (my_key_store(PERCONA_REDO_KEY_NAME, "AES", nullptr,
-                     space->encryption_key, ENCRYPTION_KEY_LEN)) {
+    if (!redo_log_key_mgr.store_used_keys()) {
       srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
       ib::error() << "Can't store redo log encryption key.";
     }
-    uint version = 0;
-    size_t klen = 0;
-    size_t klen2 = 0;
-    unique_ptr_my_free<char> redo_key_type;
-    unique_ptr_my_free<unsigned char> rkey;
-    unique_ptr_my_free<unsigned char> rkey2;
-    if (my_key_fetch_safe(PERCONA_REDO_KEY_NAME, redo_key_type, nullptr, rkey,
-                          &klen)) {
-      srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
-      ib::error() << "Can't fetch latest redo log encryption key.";
-    }
-    const bool err =
-        (parse_system_key(rkey.get(), klen, &version, rkey2, &klen2) ==
-         reinterpret_cast<uchar *>(NullS));
-    if (err) {
-      srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
-      ib::error() << "Can't parse latest redo log encryption key.";
-    }
-    space->encryption_key_version = version;
-    if (!log_write_encryption(nullptr, nullptr, false, REDO_LOG_ENCRYPT_RK)) {
-      ib::error() << "Can't write redo log encryption information.";
-    }
+    redo_log_key *key = redo_log_key_mgr.load_latest_key(true);
+    space->encryption_key_version = key->version;
+    space->encryption_redo_key = key;
+    srv_redo_log_key_version = key->version;
   }
 }
 
-  /* @} */
+/* @} */
+
+uint srv_redo_log_key_version = 0;
 
 #endif /* !UNIV_HOTBACKUP */

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1789,6 +1789,8 @@ void srv_export_innodb_status(void) {
 
   export_vars.innodb_scrub_log = srv_stats.n_log_scrubs;
 
+  export_vars.innodb_redo_key_version = srv_redo_log_key_version;
+
   if (!srv_read_only_mode) {
     export_vars.innodb_encryption_rotation_pages_read_from_cache =
         crypt_stat.pages_read_from_cache;
@@ -2806,51 +2808,18 @@ bool srv_enable_redo_encryption_rk() {
   byte iv[ENCRYPTION_KEY_LEN];
   uint version;
 
-  Encryption::random_value(key);
+  Encryption::random_value(iv);
 
   // load latest key & write version
 
-  char *redo_key_type = nullptr;
-  byte *rkey = nullptr;
-  size_t klen = 0;
-
-  if (my_key_fetch(PERCONA_REDO_KEY_NAME, &redo_key_type, nullptr,
-                   reinterpret_cast<void **>(&rkey), &klen) ||
-      rkey == nullptr) {
-    if (my_key_generate(PERCONA_REDO_KEY_NAME, "AES", nullptr,
-                        ENCRYPTION_KEY_LEN)) {
-      ib::error() << "Redo log key generation failed.";
-      my_free(redo_key_type);
-      my_free(rkey);
-      return true;
-    } else if (my_key_fetch(PERCONA_REDO_KEY_NAME, &redo_key_type, nullptr,
-                            reinterpret_cast<void **>(&rkey), &klen)) {
-      ib::error() << "Couldn't fetch newly generated redo key.";
-      my_free(redo_key_type);
-      my_free(rkey);
-      return true;
-    }
-  }
-
-  DBUG_ASSERT(rkey != nullptr);
-  byte *rkey2 = nullptr;
-  size_t klen2 = 0;
-  bool parse_err = (parse_system_key(rkey, klen, &version, &rkey2, &klen2) ==
-                    reinterpret_cast<uchar *>(NullS));
-  if (parse_err) {
-    ib::error() << "Couldn't parse system key: " << rkey;
-    my_free(redo_key_type);
-    my_free(rkey);
+  redo_log_key *mkey = redo_log_key_mgr.load_latest_key(true);
+  if (mkey == nullptr) {
     return true;
   }
-  ut_ad(klen2 == ENCRYPTION_KEY_LEN);
-  memcpy(key, rkey2, ENCRYPTION_KEY_LEN);
-  my_free(rkey2);
 
-  ut_ad(redo_key_type && strcmp(redo_key_type, "AES") == 0);
-
-  my_free(redo_key_type);
-  my_free(rkey);
+  version = mkey->version;
+  srv_redo_log_key_version = version;
+  memcpy(key, mkey->key, ENCRYPTION_KEY_LEN);
 
 #ifdef UNIV_ENCRYPT_DEBUG
   fprintf(stderr, "Fetched redo key: %s.\n", key);
@@ -2862,9 +2831,10 @@ bool srv_enable_redo_encryption_rk() {
     return true;
   }
 
+  space->encryption_redo_key = mkey;
   space->flags |= FSP_FLAGS_MASK_ENCRYPTION;
   space->encryption_key_version = version;
-  dberr_t err = fil_set_encryption(space->id, Encryption::AES, key, iv);
+  dberr_t err = fil_set_encryption(space->id, Encryption::KEYRING, key, iv);
 
   if (err != DB_SUCCESS) {
     ib::error() << "Can't set redo log tablespace to be encrypted.";
@@ -3050,6 +3020,8 @@ loop:
         undo_rotate_default_master_key();
       }
     }
+
+    log_check_new_key_version();
   }
 
   while (srv_shutdown_state != SRV_SHUTDOWN_EXIT_THREADS &&


### PR DESCRIPTION
Previously keyring redo encryption only selected a version when the
redo log was created - changing the key version required recreating
the redo log.

With this change, individual pages all have separate versions. To
accomplish this, we reuse the checksum field: during encryption, we
assume that the checksum is correct, and replace it with the
checksum of the encrypted data, plus the key version.
During reads, we calculate the checksum again, and assume that the
difference between the written data and the calculated value is the
key version.
An incorrect checksum will result in an incorrect key version,
resulting in quite likely a decryption error.
In the unlikely case that the checksum is wrong, but the resulting
number refers to an existing key, the decrypted data will be
garbage and log recovery will abort later.

Since the redo key version now dynamic, it is exported as the
innodb_encryption_redo_key_version status variable.

To support this change, keyring handling of the redo log keys were
extracted to the redo_log_key_mgr global variable. This variable is
now the owner of all used keyring redo keys, and everything else
uses pointers to keys managed by it.
This way:
* keyring key handling is extracted to a common place, without
  too much code duplicated in multiple files
* key-copying races between threads changing the keys and others
writing data to the redo log are prevented, as it is a simple
pointer change now

The commit also includes minor fixes for issues previously hidden
by the limited usability of keyring redo encryption.

(cherry picked from commit 56e845e4a111249208d7285ae07075340e05d8cf)