### PR TITLE
PS-5322 Keyring encrypted tablespace import/export is broken

### DIFF
--- a/include/my_base.h
+++ b/include/my_base.h
@@ -998,6 +998,8 @@ Information in the data-dictionary needs to be updated. */
 #define HA_ERR_ERRORS (HA_ERR_LAST - HA_ERR_FIRST + 1)
 
 #define HA_ERR_ENCRYPTION_KEY_MISSING 501
+#define HA_ERR_EXPORT_ENC_THREADS_RUNNING \
+  502 /* Cannot flush, encryption threads operate on table */
 
 /* Other constants */
 

--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -159,7 +159,4 @@ tokudb_rpl.rpl_partition_tokudb : BUG#0 exchange partition is not supported
 
 # encryption suite tests
 encryption.innodb_lotoftables : BUG#5817 Align Keyring encryption and default_table_encryption
-encryption.innodb-bad-key-change2 : BUG#5322 Keyring encrypted tablespace import/export is broken
-encryption.innodb-bad-key-change3 : BUG#5322 Keyring encrypted tablespace import/export is broken
-encryption.innodb_encryption_discard_import : BUG#5322 Keyring encrypted tablespace import/export is broken
 encryption.create_or_replace : BUG#6987 encryption threads report space unencrypted

--- a/mysql-test/include/innodb-util.inc
+++ b/mysql-test/include/innodb-util.inc
@@ -22,8 +22,6 @@ sub ib_backup_ibd_file {
 		File::Spec->catfile($tmpd, $ibd_file));
 
     copy(@args) or die "copy @args failed: $!";
-
-    copy(@args) or die "copy @args failed: $!";
 }
 
 sub ib_backup_cfg_file {

--- a/mysql-test/suite/encryption/r/import_half_mk_rotated.result
+++ b/mysql-test/suite/encryption/r/import_half_mk_rotated.result
@@ -1,0 +1,108 @@
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+create procedure innodb_insert_proc (repeat_count int)
+begin
+declare current_num int;
+set current_num = 0;
+while current_num < repeat_count do
+insert into t1 values (current_num,repeat('foobar',42));
+set current_num = current_num + 1;
+end while;
+end//
+commit;
+set autocommit=0;
+call innodb_insert_proc(10000);
+commit;
+set autocommit=1;
+include/assert.inc [Make sure encryption is disabled]
+include/assert.inc [Make sure t1 is encrypted]
+# We want only first 100 pages to be rotated
+SET GLOBAL debug="+d,rotate_only_first_x_pages_from_t1";
+# Start rotation to online keyring encrypted (tables do not have crypt data stored in page 0)
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 1;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+# Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
+# have been rotatted.
+# Disable rotation threads
+SET GLOBAL innodb_encryption_threads = 0;
+# Disable rotation of only first 100 pages
+SET GLOBAL debug="-d,rotate_only_first_x_pages_from_t1";
+# Make sure that t1 deos not contain foobar - if first 100 pages should be
+# KEYRING encrypted and the remaining pages should be Master Key encrypted.
+# Or check if t1 is not encrypted if we requested only first 100 pages to
+# be KEYRING encrypted and rest un-encrypted.
+# Now let's restart with encryption threads diabled and check whether
+# the table can be FLUSH FOR EXPORT
+# restart:--default-table-encryption=OFF --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+FLUSH TABLE t1 FOR EXPORT;
+backup: t1
+UNLOCK TABLES;
+DROP TABLE t1;
+# Now we have backup of t1 which has first 100 pages keyring encrypted and remaining
+# pages master key encrypted. We will test now the following scenarios:
+# 1) Disable encryption threads, import t1.
+# 2) Import t1, enable encryption threads with rotation to unencryted.
+# 3) Import t1, enable encryption threads with rotation to encrypted.
+# 4) Enable encryption threads with rotation to unencryted, import t1.
+# 5) Enable encryption threads with rotation to encrypted, import t1.
+# Scenario: 1) Disable encryption threads, import t1.
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+ALTER TABLE t1 IMPORT TABLESPACE;
+include/assert.inc [Make sure t1 is readable]
+# Scenario: 2) Import t1, enable encryption threads with rotation to unencryted.
+# t1 was already imported in Scenario 1.
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+# Scenario: 3) Import t1, enable encryption threads with rotation to encrypted.
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+ALTER TABLE t1 IMPORT TABLESPACE;
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+# 4) Enable encryption threads with rotation to unencryted, import t1.
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+ALTER TABLE t1 IMPORT TABLESPACE;
+include/assert.inc [Make sure t1 is readable]
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+# 5) Enable encryption threads with rotation to encrypted, import t1.
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+ALTER TABLE t1 IMPORT TABLESPACE;
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/r/import_half_rotated.result
+++ b/mysql-test/suite/encryption/r/import_half_rotated.result
@@ -1,0 +1,107 @@
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ;
+create procedure innodb_insert_proc (repeat_count int)
+begin
+declare current_num int;
+set current_num = 0;
+while current_num < repeat_count do
+insert into t1 values (current_num,repeat('foobar',42));
+set current_num = current_num + 1;
+end while;
+end//
+commit;
+set autocommit=0;
+call innodb_insert_proc(10000);
+commit;
+set autocommit=1;
+include/assert.inc [Make sure encryption is disabled]
+include/assert.inc [Make sure t1 is not encrypted]
+# We want only first 100 pages to be rotated
+SET GLOBAL debug="+d,rotate_only_first_x_pages_from_t1";
+# Start rotation to online keyring encrypted (tables do not have crypt data stored in page 0)
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 1;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+# Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
+# have been rotatted.
+# Disable rotation threads
+SET GLOBAL innodb_encryption_threads = 0;
+# Disable rotation of only first 100 pages
+SET GLOBAL debug="-d,rotate_only_first_x_pages_from_t1";
+# Make sure that t1 deos not contain foobar - if first 100 pages should be
+# KEYRING encrypted and the remaining pages should be Master Key encrypted.
+# Or check if t1 is not encrypted if we requested only first 100 pages to
+# be KEYRING encrypted and rest un-encrypted.
+# Now let's restart with encryption threads diabled and check whether
+# the table can be FLUSH FOR EXPORT
+# restart:--default-table-encryption=OFF --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+FLUSH TABLE t1 FOR EXPORT;
+backup: t1
+UNLOCK TABLES;
+DROP TABLE t1;
+# Now we have backup of t1 which has first 100 pages keyring encrypted and remaining
+# pages master key encrypted. We will test now the following scenarios:
+# 1) Disable encryption threads, import t1.
+# 2) Import t1, enable encryption threads with rotation to unencryted.
+# 3) Import t1, enable encryption threads with rotation to encrypted.
+# 4) Enable encryption threads with rotation to unencryted, import t1.
+# 5) Enable encryption threads with rotation to encrypted, import t1.
+SET GLOBAL debug="+d,importing_half_encrypted";
+# Scenario: 1) Disable encryption threads, import t1.
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+ALTER TABLE t1 IMPORT TABLESPACE;
+include/assert.inc [Make sure t1 is readable]
+# Scenario: 2) Import t1, enable encryption threads with rotation to unencryted.
+# t1 was already imported in Scenario 1.
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+# Scenario: 3) Import t1, enable encryption threads with rotation to encrypted.
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+ALTER TABLE t1 IMPORT TABLESPACE;
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+# 4) Enable encryption threads with rotation to unencryted, import t1.
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+ALTER TABLE t1 IMPORT TABLESPACE;
+include/assert.inc [Make sure t1 is readable]
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+# 5) Enable encryption threads with rotation to encrypted, import t1.
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+ALTER TABLE t1 IMPORT TABLESPACE;
+include/assert.inc [Make sure t1 is readable]
+# We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+UNLOCK TABLES;
+DROP TABLE t1;
+SET GLOBAL debug="-d,importing_half_encrypted";
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/r/import_while_threads_run.result
+++ b/mysql-test/suite/encryption/r/import_while_threads_run.result
@@ -1,0 +1,55 @@
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+CREATE PROCEDURE innodb_insert_proc (repeat_count INT)
+BEGIN
+DECLARE current_num INT;
+SET current_num = 0;
+WHILE current_num < repeat_count DO
+INSERT INTO t1 VALUES (current_num,repeat('foobar',42));
+INSERT INTO t2 VALUES (current_num,repeat('foobar',42));
+SET current_num = current_num + 1;
+END WHILE;
+END//
+COMMIT;
+SET autocommit=0;
+call innodb_insert_proc(10000);
+COMMIT;
+SET autocommit=1;
+include/assert.inc [Make sure encryption is disabled]
+include/assert.inc [Make sure t1 is not encrypted]
+include/assert.inc [Make sure t2 is not encrypted]
+# We want t1 to hang on starting rotation with one thread active on it.
+SET GLOBAL debug="+d,hang_on_t1_rotation";
+# Start rotation to online keyring encrypted (tables do not have crypt data stored in page 0)
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
+# All tables should get encrypted. tables_count - 2 because temporary tablespace is not encrypted and t1 will hang
+# on starting rotation with one thread active on it.
+# Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
+# have been rotatted.
+include/assert.inc [Make sure t1 is not encrypted]
+include/assert.inc [Make sure t2 is encrypted]
+FLUSH TABLE t1 FOR EXPORT;
+ERROR HY000: Tablespace t1 cannot be flushed for export as tablespace is being currently encrypted/decrypted by encryption threads.
+FLUSH TABLE t2 FOR EXPORT;
+backup: t2
+UNLOCK TABLES;
+SET GLOBAL debug="-d,hang_on_t1_rotation";
+# Wait for t1 to be fully encrypted
+include/assert.inc [Make sure t1 is encrypted]
+FLUSH TABLE t1 FOR EXPORT;
+backup: t1
+UNLOCK TABLES;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t2 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+restore: t2 .ibd and .cfg files
+ALTER TABLE t1 IMPORT TABLESPACE;
+ALTER TABLE t2 IMPORT TABLESPACE;
+include/assert.inc [Make sure t1 is readable]
+include/assert.inc [Make sure t2 is readable]
+DROP TABLE t1,t2;
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;
+DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/r/innodb-bad-key-change2.result
+++ b/mysql-test/suite/encryption/r/innodb-bad-key-change2.result
@@ -1,0 +1,58 @@
+call mtr.add_suppression("\\[InnoDB\\] Tablespace id [0-9]+ in file t1\.ibd is encrypted but keyring or used key_id 4 is not available\. Can't continue reading table\. Please provide the correct keyring\.");
+call mtr.add_suppression("\\[InnoDB\\] Table `test`\.`t1` does not have an \.ibd file in the database directory\.");
+CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(8)) ENGINE=InnoDB ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4;
+INSERT INTO t1 VALUES (1,'foo'),(2,'bar');
+# restart:--keyring-file-data=MYSQLTEST_VARDIR/std_data/keys3.txt
+SET GLOBAL innodb_stats_persistent=OFF;
+SELECT * FROM t1;
+ERROR HY000: Got error 501 'Table encrypted but decryption key was not found. Is correct keyring loaded?' from InnoDB
+SHOW WARNINGS;
+Level	Code	Message
+Error	1296	Got error 501 'Table encrypted but decryption key was not found. Is correct keyring loaded?' from InnoDB
+ALTER TABLE t1 ENGINE=InnoDB;
+ERROR HY000: Got error 501 'Table encrypted but decryption key was not found. Is correct keyring loaded?' from InnoDB
+SHOW WARNINGS;
+Level	Code	Message
+Error	1296	Got error 501 'Table encrypted but decryption key was not found. Is correct keyring loaded?' from InnoDB
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	Error	Got error 501 'Table encrypted but decryption key was not found. Is correct keyring loaded?' from InnoDB
+test.t1	optimize	error	Corrupt
+SHOW WARNINGS;
+Level	Code	Message
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	Error	Got error 501 'Table encrypted but decryption key was not found. Is correct keyring loaded?' from InnoDB
+test.t1	check	error	Corrupt
+SHOW WARNINGS;
+Level	Code	Message
+# restart:--keyring-file-data=MYSQLTEST_VARDIR/std_data/keys2.txt
+SET GLOBAL innodb_stats_persistent=OFF;
+FLUSH TABLES t1 FOR EXPORT;
+backup: t1
+UNLOCK TABLES;
+# restart:--keyring-file-data=MYSQLTEST_VARDIR/std_data/keys3.txt
+SET GLOBAL innodb_stats_persistent=OFF;
+ALTER TABLE t1 DISCARD TABLESPACE;
+ERROR HY000: Got error 501 'Table encrypted but decryption key was not found. Is correct keyring loaded?' from InnoDB
+# restart:--keyring-file-data=MYSQLTEST_VARDIR/std_data/keys2.txt
+ALTER TABLE t1 DISCARD TABLESPACE;
+restore: t1 .ibd and .cfg files
+SET GLOBAL innodb_stats_persistent=OFF;
+ALTER TABLE t1 IMPORT TABLESPACE;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `pk` int NOT NULL,
+  `f` varchar(8) DEFAULT NULL,
+  PRIMARY KEY (`pk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4
+# restart: --keyring-file-data=MYSQLTEST_VARDIR/std_data/keys3.txt
+SET GLOBAL innodb_stats_persistent=OFF;
+RENAME TABLE t1 TO t1new;
+ERROR HY000: Error on rename of './test/t1' to './test/t1new' (errno: 155 - The table does not exist in engine)
+ALTER TABLE t1new RENAME TO t2new;
+ERROR 42S02: Table 'test.t1new' doesn't exist
+DROP TABLE t1new;
+ERROR 42S02: Unknown table 'test.t1new'
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/r/innodb-bad-key-change3.result
+++ b/mysql-test/suite/encryption/r/innodb-bad-key-change3.result
@@ -1,23 +1,21 @@
-call mtr.add_suppression("cannot be decrypted. Are you using correct keyring that contain the");
-call mtr.add_suppression("InnoDB: Tablespace for table .* is set as discarded.");
-call mtr.add_suppression("InnoDB: Cannot calculate statistics for table .* because the .ibd file is missing. Please refer to .* for how to resolve the issue.");
-call mtr.add_suppression("InnoDB: Trying to access missing tablespace [0-9]+");
-call mtr.add_suppression("InnoDB: Cannot save statistics for table .* because the .ibd file is missing.");
+call mtr.add_suppression("\\[InnoDB\\] Tablespace id [0-9]+ in file t1\.ibd is encrypted but keyring or used key_id 4 is not available\. Can't continue reading table\. Please provide the correct keyring\.");
+call mtr.add_suppression("\\[InnoDB\\] Tablespace for table `test`\.`t1` is set as discarded\.");
+call mtr.add_suppression("\\[InnoDB\\] Cannot calculate statistics for table .* because the \.ibd file is missing\. Please refer to .* for how to resolve the issue\.");
+call mtr.add_suppression("\\[InnoDB\\] Encryption can't find tablespace key_id = 4");
 CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4;
 SHOW WARNINGS;
 Level	Code	Message
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `pk` int(11) NOT NULL,
+  `pk` int NOT NULL,
   `f` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`pk`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4
 INSERT INTO t1 VALUES (1,'foobar'),(2,'barfoo');
 FLUSH TABLE t1 FOR EXPORT;
 # List before copying files
 t1.cfg
-t1.frm
 t1.ibd
 backup: t1
 UNLOCK TABLES;
@@ -25,14 +23,14 @@ ALTER TABLE t1 DISCARD TABLESPACE;
 restore: t1 .ibd and .cfg files
 # restart:--keyring-file-data=MYSQLTEST_VARDIR/keys2.txt
 ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Got error 500 'Table encrypted but decryption failed. This could be because correct encryption management plugin is not loaded, used encryption key is not available or encryption method does not match.' from InnoDB
+ERROR HY000: You are importing table that is encrypted but keyring or used key is not available. Can't continue importing this table. Please provide the correct keyring.
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `pk` int(11) NOT NULL,
+  `pk` int NOT NULL,
   `f` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`pk`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4
 SELECT * FROM t1;
 ERROR HY000: Tablespace has been discarded for table 't1'
 # Tablespaces should be still encrypted

--- a/mysql-test/suite/encryption/r/innodb_encryption-page-compression.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption-page-compression.result
@@ -131,6 +131,8 @@ update innodb_page_compressed6 set c1 = c1 + 1;
 update innodb_page_compressed7 set c1 = c1 + 1;
 update innodb_page_compressed8 set c1 = c1 + 1;
 update innodb_page_compressed9 set c1 = c1 + 1;
+# Wait max 10 min for key encryption threads to decrypt all spaces as it is
+# impossible to flush pages if encryption threads are still working on them.
 flush tables innodb_page_compressed1, innodb_page_compressed2,
 innodb_page_compressed3, innodb_page_compressed4,
 innodb_page_compressed5, innodb_page_compressed6,

--- a/mysql-test/suite/encryption/r/innodb_encryption_discard_import.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_discard_import.result
@@ -1,8 +1,11 @@
-call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table `[^`]+`.`[^`]+` is set as discarded\\.");
-call mtr.add_suppression("\\[Warning\\] InnoDB: Page [[:digit:]]+ at offset [[:digit:]]+ looks corrupted in file");
-call mtr.add_suppression("\\[ERROR\\] InnoDB: os_file_read\\(\\) failed");
-CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='KEYRING';
+call mtr.add_suppression("\\[InnoDB\\] Tablespace id .* in file t[1-8]\.ibd is encrypted but keyring or used key_id [4-5] is not available\. Can't continue reading table\. Please provide the correct keyring\.");
+call mtr.add_suppression("\\[InnoDB\\] Tablespace for table `test`\.`t[1-8]` is set as discarded\.");
+call mtr.add_suppression("\\[InnoDB\\] Cannot calculate statistics for table .* because the \.ibd file is missing\. Please refer to .* for how to resolve the issue\.");
+call mtr.add_suppression("\\[InnoDB\\] Encryption can't find tablespace key_id = 5");
 CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='KEYRING';
 CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib" ENCRYPTION='KEYRING';
 CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib";
 CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING';
@@ -33,21 +36,13 @@ SET autocommit = 1;
 # Wait max 2 min for key encryption threads to encrypt all spaces
 include/assert.inc [Make sure t7 is not encrypted]
 # tablespaces should be now encrypted
-t1.frm
 t1.ibd
-t2.frm
 t2.ibd
-t3.frm
 t3.ibd
-t4.frm
 t4.ibd
-t5.frm
 t5.ibd
-t6.frm
 t6.ibd
-t7.frm
 t7.ibd
-t8.frm
 t8.ibd
 FLUSH TABLES t1, t2, t3, t4, t5, t6, t7, t8 FOR EXPORT;
 backup: t1
@@ -59,28 +54,20 @@ backup: t6
 backup: t7
 backup: t8
 t1.cfg
-t1.frm
 t1.ibd
 t2.cfg
-t2.frm
 t2.ibd
 t3.cfg
-t3.frm
 t3.ibd
 t4.cfg
-t4.frm
 t4.ibd
 t5.cfg
-t5.frm
 t5.ibd
 t6.cfg
-t6.frm
 t6.ibd
 t7.cfg
-t7.frm
 t7.ibd
 t8.cfg
-t8.frm
 t8.ibd
 UNLOCK TABLES;
 ALTER TABLE t1 DISCARD TABLESPACE;
@@ -116,72 +103,76 @@ include/assert.inc [Make sure t7 is readable]
 ALTER TABLE t8 IMPORT TABLESPACE;
 include/assert.inc [Make sure t8 is readable]
 # tablespaces should remain encrypted after import, apart from t7
-ALTER TABLE t1 ENGINE InnoDB;
-SHOW CREATE TABLE t1;
-Table	Create Table
-t1	CREATE TABLE `t1` (
-  `id` int(11) NOT NULL,
-  `a` varchar(255) DEFAULT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=0
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption = OFF;
 ALTER TABLE t2 ENGINE InnoDB;
 SHOW CREATE TABLE t2;
 Table	Create Table
 t2	CREATE TABLE `t2` (
-  `id` int(11) NOT NULL,
+  `id` int NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='Y'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
+ALTER TABLE t1 ENGINE InnoDB;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int NOT NULL,
+  `a` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='KEYRING'
 ALTER TABLE t3 ENGINE InnoDB;
 SHOW CREATE TABLE t3;
 Table	Create Table
 t3	CREATE TABLE `t3` (
-  `id` int(11) NOT NULL,
+  `id` int NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMPRESSION='zlib' ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMPRESSION='zlib' ENCRYPTION='KEYRING'
 ALTER TABLE t4 ENGINE InnoDB;
 SHOW CREATE TABLE t4;
 Table	Create Table
 t4	CREATE TABLE `t4` (
-  `id` int(11) NOT NULL,
+  `id` int NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 COMPRESSION='zlib' ENCRYPTION_KEY_ID=0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMPRESSION='zlib'
 ALTER TABLE t5 ENGINE InnoDB;
 SHOW CREATE TABLE t5;
 Table	Create Table
 t5	CREATE TABLE `t5` (
-  `id` int(11) NOT NULL,
+  `id` int NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING'
 ALTER TABLE t6 ENGINE InnoDB;
 SHOW CREATE TABLE t6;
 Table	Create Table
 t6	CREATE TABLE `t6` (
-  `id` int(11) NOT NULL,
+  `id` int NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED ENCRYPTION_KEY_ID=0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ROW_FORMAT=COMPRESSED
 ALTER TABLE t7 ENGINE InnoDB;
 SHOW CREATE TABLE t7;
 Table	Create Table
 t7	CREATE TABLE `t7` (
-  `id` int(11) NOT NULL,
+  `id` int NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION='N'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 ALTER TABLE t8 ENGINE InnoDB;
 SHOW CREATE TABLE t8;
 Table	Create Table
 t8	CREATE TABLE `t8` (
-  `id` int(11) NOT NULL,
+  `id` int NOT NULL,
   `a` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1 ENCRYPTION_KEY_ID=0
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # Restarting server
-# restart
+# restart:<hidden args>
 # Done restarting server
 # Verify that tables are still usable
 include/assert.inc [Make sure t1 is readable]
@@ -195,28 +186,20 @@ include/assert.inc [Make sure t8 is readable]
 # Tablespaces should be encrypted after restart
 include/assert.inc [Make sure all tables, apart from t7, are encrypted]
 t1.cfg
-t1.frm
 t1.ibd
 t2.cfg
-t2.frm
 t2.ibd
 t3.cfg
-t3.frm
 t3.ibd
 t4.cfg
-t4.frm
 t4.ibd
 t5.cfg
-t5.frm
 t5.ibd
 t6.cfg
-t6.frm
 t6.ibd
 t7.cfg
-t7.frm
 t7.ibd
 t8.cfg
-t8.frm
 t8.ibd
 FLUSH TABLES t1, t2, t3, t4, t5, t6, t7, t8 FOR EXPORT;
 backup: t1
@@ -228,28 +211,20 @@ backup: t6
 backup: t7
 backup: t8
 t1.cfg
-t1.frm
 t1.ibd
 t2.cfg
-t2.frm
 t2.ibd
 t3.cfg
-t3.frm
 t3.ibd
 t4.cfg
-t4.frm
 t4.ibd
 t5.cfg
-t5.frm
 t5.ibd
 t6.cfg
-t6.frm
 t6.ibd
 t7.cfg
-t7.frm
 t7.ibd
 t8.cfg
-t8.frm
 t8.ibd
 UNLOCK TABLES;
 ALTER TABLE t1 DISCARD TABLESPACE;
@@ -273,69 +248,74 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL default_table_encryption = OFF;
 ALTER TABLE t1 IMPORT TABLESPACE;
 include/assert.inc [Make sure t1 has encrypted flag set after importing]
-include/assert.inc [Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t1 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t1 is readable]
 ALTER TABLE t2 IMPORT TABLESPACE;
 include/assert.inc [Make sure t2 has encrypted flag set after importing]
-include/assert.inc [Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t2 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t2 is readable]
 ALTER TABLE t3 IMPORT TABLESPACE;
 include/assert.inc [Make sure t3 has encrypted flag set after importing]
-include/assert.inc [Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t3 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t3 is readable]
 ALTER TABLE t4 IMPORT TABLESPACE;
 include/assert.inc [Make sure t4 has encrypted flag set after importing]
-include/assert.inc [Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t4 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t4 is readable]
 ALTER TABLE t5 IMPORT TABLESPACE;
 include/assert.inc [Make sure t5 has encrypted flag set after importing]
-include/assert.inc [Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t5 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t5 is readable]
 ALTER TABLE t6 IMPORT TABLESPACE;
 include/assert.inc [Make sure t6 has encrypted flag set after importing]
-include/assert.inc [Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t6 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t6 is readable]
 ALTER TABLE t7 IMPORT TABLESPACE;
 include/assert.inc [Make sure t7 does not have encrypted flag set after importing]
-include/assert.inc [Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)]
+include/assert.inc [Make sure t7 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)]
 include/assert.inc [Make sure t7 is readable]
 ALTER TABLE t8 IMPORT TABLESPACE;
 include/assert.inc [Make sure t8 has encrypted flag set after importing]
-include/assert.inc [Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t8 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t8 is readable]
 # tablespaces should be encrypted, apart from t7
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Wait max 2 min for key encryption threads to decrypt all spaces, apart from t1, t3 and t5
 include/assert.inc [Make sure t1 has encrypted flag set]
-include/assert.inc [Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t1 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t1 is readable]
 include/assert.inc [Make sure t2 does not have encrypted flag set]
-include/assert.inc [Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
+include/assert.inc [Make sure t2 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0]
 include/assert.inc [Make sure t2 is readable]
 include/assert.inc [Make sure t3 has encrypted flag set]
-include/assert.inc [Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t3 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t3 is readable]
 include/assert.inc [Make sure t4 does not have encrypted flag set]
-include/assert.inc [Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
+include/assert.inc [Make sure t4 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0]
 include/assert.inc [Make sure t4 is readable]
 include/assert.inc [Make sure t5 has encrypted flag set]
-include/assert.inc [Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1]
+include/assert.inc [Make sure t5 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1]
 include/assert.inc [Make sure t5 is readable]
 include/assert.inc [Make sure t6 does not have encrypted flag set]
-include/assert.inc [Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
+include/assert.inc [Make sure t6 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0]
 include/assert.inc [Make sure t6 is readable]
 include/assert.inc [Make sure t7 does not have encrypted flag set]
-include/assert.inc [Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)]
+include/assert.inc [Make sure t7 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)]
 include/assert.inc [Make sure t7 is readable]
 include/assert.inc [Make sure t8 does not have encrypted flag set]
-include/assert.inc [Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0]
+include/assert.inc [Make sure t8 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0]
 include/assert.inc [Make sure t8 is readable]
 # tablespaces should not be encrypted, apart from t1,t3 and t5
-# Now let's backup keyring file, change encryption key id of encrypt-able tables (all but t7) 
+# Now let's backup keyring file, change encryption key id of encrypt-able tables (all but t7 and temporary)
 # export and dicard them. Next restart the server with backuped keyring file and make sure that
-# server starts, but tables cannot be imported gracefully
+# server starts, but tables cannot be imported gracefully.
+SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
 # Wait max 2 min for key encryption threads to encrypt all spaces
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption = OFF;
 ALTER TABLE t1 encryption_key_id = 5;
 ALTER TABLE t2 encryption_key_id = 5;
 Warnings:
@@ -346,28 +326,20 @@ ALTER TABLE t5 encryption_key_id = 5;
 ALTER TABLE t6 encryption_key_id = 5;
 ALTER TABLE t8 encryption_key_id = 5;
 t1.cfg
-t1.frm
 t1.ibd
 t2.cfg
-t2.frm
 t2.ibd
 t3.cfg
-t3.frm
 t3.ibd
 t4.cfg
-t4.frm
 t4.ibd
 t5.cfg
-t5.frm
 t5.ibd
 t6.cfg
-t6.frm
 t6.ibd
 t7.cfg
-t7.frm
 t7.ibd
 t8.cfg
-t8.frm
 t8.ibd
 FLUSH TABLES t1, t2, t3, t4, t5, t6, t8 FOR EXPORT;
 backup: t1
@@ -378,28 +350,20 @@ backup: t5
 backup: t6
 backup: t8
 t1.cfg
-t1.frm
 t1.ibd
 t2.cfg
-t2.frm
 t2.ibd
 t3.cfg
-t3.frm
 t3.ibd
 t4.cfg
-t4.frm
 t4.ibd
 t5.cfg
-t5.frm
 t5.ibd
 t6.cfg
-t6.frm
 t6.ibd
 t7.cfg
-t7.frm
 t7.ibd
 t8.cfg
-t8.frm
 t8.ibd
 UNLOCK TABLES;
 ALTER TABLE t1 DISCARD TABLESPACE;
@@ -416,22 +380,25 @@ restore: t4 .ibd and .cfg files
 restore: t5 .ibd and .cfg files
 restore: t6 .ibd and .cfg files
 restore: t8 .ibd and .cfg files
-# restart:--loose-keyring_file_data=/home/yura/addon/percona-build-5.7-debug_min/mysql-test/var/tmp/mysecret_keyring_backup
+# restart:<hidden args>
 ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t1` : Data structure corruption
+ERROR HY000: You are importing table that is encrypted but keyring or used key is not available. Can't continue importing this table. Please provide the correct keyring.
 ALTER TABLE t2 IMPORT TABLESPACE;
 Warnings:
 Warning	1814	InnoDB: Tablespace has been discarded for table 't2'
 ALTER TABLE t3 IMPORT TABLESPACE;
-ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t3` : Page decompress failed after reading from disk
+ERROR HY000: You are importing table that is encrypted but keyring or used key is not available. Can't continue importing this table. Please provide the correct keyring.
 ALTER TABLE t4 IMPORT TABLESPACE;
-ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t4` : Page decompress failed after reading from disk
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't4'
 ALTER TABLE t5 IMPORT TABLESPACE;
-ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t5` : Data structure corruption
+ERROR HY000: You are importing table that is encrypted but keyring or used key is not available. Can't continue importing this table. Please provide the correct keyring.
 ALTER TABLE t6 IMPORT TABLESPACE;
-ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t6` : Data structure corruption
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't6'
 ALTER TABLE t8 IMPORT TABLESPACE;
-ERROR HY000: Internal error: Cannot reset LSNs in table `test`.`t8` : Data structure corruption
-# restart:--loose-keyring_file_data=/home/yura/addon/percona-build-5.7-debug_min/mysql-test/var/tmp/mysecret_keyring
+Warnings:
+Warning	1814	InnoDB: Tablespace has been discarded for table 't8'
+# restart:<hidden args>
 DROP PROCEDURE innodb_insert_proc;
 DROP TABLE t1, t2, t3, t4, t5, t6, t7, t8;

--- a/mysql-test/suite/encryption/t/export_half_rotated.inc
+++ b/mysql-test/suite/encryption/t/export_half_rotated.inc
@@ -1,0 +1,101 @@
+
+eval CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB $t1_table_type;
+
+delimiter //;
+create procedure innodb_insert_proc (repeat_count int)
+begin
+  declare current_num int;
+  set current_num = 0;
+  while current_num < repeat_count do
+    insert into t1 values (current_num,repeat('foobar',42));
+    set current_num = current_num + 1;
+  end while;
+end//
+delimiter ;//
+commit;
+
+set autocommit=0;
+eval call innodb_insert_proc($number_of_records);
+commit;
+set autocommit=1;
+
+# Make sure encryption is disabled
+--let $assert_text= Make sure encryption is disabled
+--let $assert_cond= "[SELECT @@GLOBAL.default_table_encryption]" = 0
+--source include/assert.inc
+
+
+if ($is_encrypted)
+{
+--let $assert_text= Make sure t1 is encrypted
+--let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME=\\'test/t1\\']" = 8192
+--source include/assert.inc
+}
+
+if (!$is_encrypted)
+{
+--let $assert_text= Make sure t1 is not encrypted
+--let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME=\\'test/t1\\']" = 0
+--source include/assert.inc
+}
+--echo # We want only first 100 pages to be rotated
+SET GLOBAL debug="+d,rotate_only_first_x_pages_from_t1";
+
+--echo # Start rotation to online keyring encrypted (tables do not have crypt data stored in page 0)
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 1;
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+# All tables should get encrypted. tables_count - 2 because temporary tablespace is not encrypted and t1 will only
+# have half of the pages encrypted and thus min_key_version will still be 0
+--let $wait_condition=SELECT COUNT(*) = $tables_count - 2 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+--echo # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
+--echo # have been rotatted.
+--let $wait_timeout= 600
+--let $wait_condition=SELECT name = 'test/t1' FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND ROTATING_OR_FLUSHING = 1
+--source include/wait_condition.inc
+
+--echo # Disable rotation threads
+SET GLOBAL innodb_encryption_threads = 0;
+--echo # Disable rotation of only first 100 pages
+SET GLOBAL debug="-d,rotate_only_first_x_pages_from_t1";
+
+--source include/shutdown_mysqld.inc
+
+--echo # Make sure that t1 deos not contain foobar - if first 100 pages should be
+--echo # KEYRING encrypted and the remaining pages should be Master Key encrypted.
+--echo # Or check if t1 is not encrypted if we requested only first 100 pages to
+--echo # be KEYRING encrypted and rest un-encrypted.
+--let SEARCH_PATTERN=foobar
+if ($is_encrypted)
+{
+--let ABORT_ON=FOUND
+}
+if (!$is_encrypted)
+{
+--let ABORT_ON=NOT_FOUND
+}
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+--echo # Now let's restart with encryption threads diabled and check whether
+--echo # the table can be FLUSH FOR EXPORT
+--let $restart_parameters=restart:--default-table-encryption=OFF --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+--source include/start_mysqld.inc
+
+FLUSH TABLE t1 FOR EXPORT;
+
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_backup_tablespaces("test", "t1");
+EOF
+
+UNLOCK TABLES;
+DROP TABLE t1;
+

--- a/mysql-test/suite/encryption/t/import_half_mk_rotated-master.opt
+++ b/mysql-test/suite/encryption/t/import_half_mk_rotated-master.opt
@@ -1,4 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/import_half_mk_rotated.test
+++ b/mysql-test/suite/encryption/t/import_half_mk_rotated.test
@@ -1,0 +1,176 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/not_valgrind.inc
+
+# This test is to check if table which is half rotated from Master Key encryption
+# to Keyring encryption gets rotated correctly in case it was exported and imported
+# back.
+# In order to prepare such table we rotate only first 100 pages in t1.
+
+let MYSQLD_DATADIR = `SELECT @@datadir`;
+
+--let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd
+--let $number_of_records = 10000
+
+let $is_encrypted=1;
+let $t1_table_type=ENCRYPTION='Y';
+--source export_half_rotated.inc
+
+--echo # Now we have backup of t1 which has first 100 pages keyring encrypted and remaining
+--echo # pages master key encrypted. We will test now the following scenarios:
+--echo # 1) Disable encryption threads, import t1.
+--echo # 2) Import t1, enable encryption threads with rotation to unencryted.
+--echo # 3) Import t1, enable encryption threads with rotation to encrypted.
+--echo # 4) Enable encryption threads with rotation to unencryted, import t1.
+--echo # 5) Enable encryption threads with rotation to encrypted, import t1.
+
+--echo # Scenario: 1) Disable encryption threads, import t1.
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # Scenario: 2) Import t1, enable encryption threads with rotation to unencryted.
+--echo # t1 was already imported in Scenario 1.
+
+# decrypt all the tables
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+--echo # Scenario: 3) Import t1, enable encryption threads with rotation to encrypted.
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+# encrypt all the tables
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 1
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+--echo # 4) Enable encryption threads with rotation to unencryted, import t1.
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+# decrypt all the tables
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+--echo # 5) Enable encryption threads with rotation to encrypted, import t1.
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+# encrypt all the tables
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 1
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+# cleanup
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/t/import_half_rotated-master.opt
+++ b/mysql-test/suite/encryption/t/import_half_rotated-master.opt
@@ -1,4 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/import_half_rotated.test
+++ b/mysql-test/suite/encryption/t/import_half_rotated.test
@@ -1,0 +1,175 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/not_valgrind.inc
+
+# This test is to check if table which is half encrypted with encryption threads
+# gets rotated correctly in case it was exported and imported back.
+# In order to prepare such table we rotate only first 100 pages in t1.
+
+let MYSQLD_DATADIR = `SELECT @@datadir`;
+
+--let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd
+--let $number_of_records = 10000
+
+let $t1_table_type= ;
+let $is_encrypted=0;
+--source export_half_rotated.inc
+
+--echo # Now we have backup of t1 which has first 100 pages keyring encrypted and remaining
+--echo # pages master key encrypted. We will test now the following scenarios:
+--echo # 1) Disable encryption threads, import t1.
+--echo # 2) Import t1, enable encryption threads with rotation to unencryted.
+--echo # 3) Import t1, enable encryption threads with rotation to encrypted.
+--echo # 4) Enable encryption threads with rotation to unencryted, import t1.
+--echo # 5) Enable encryption threads with rotation to encrypted, import t1.
+
+SET GLOBAL debug="+d,importing_half_encrypted";
+
+--echo # Scenario: 1) Disable encryption threads, import t1.
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # Scenario: 2) Import t1, enable encryption threads with rotation to unencryted.
+--echo # t1 was already imported in Scenario 1.
+
+# decrypt all the tables
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+--echo # Scenario: 3) Import t1, enable encryption threads with rotation to encrypted.
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+# encrypt all the tables
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 1
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+--echo # 4) Enable encryption threads with rotation to unencryted, import t1.
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+# decrypt all the tables
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got decrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+--echo # 5) Enable encryption threads with rotation to encrypted, import t1.
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+ALTER TABLE t1 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+EOF
+
+# encrypt all the tables
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 1
+--source include/wait_condition.inc
+
+--let $assert_text = Make sure t1 is readable
+--let $assert_cond = [SELECT COUNT(1) FROM t1] = $number_of_records
+--source include/assert.inc
+
+--echo # We FLUSH TABLE t1 FOR EXPORT to grep t1.ibd to check if it really got encrypted.
+FLUSH TABLE t1 FOR EXPORT;
+--let SEARCH_PATTERN=foobar
+--let ABORT_ON=FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+UNLOCK TABLES;
+DROP TABLE t1;
+
+# cleanup
+SET GLOBAL debug="-d,importing_half_encrypted";
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/t/import_while_threads_run-master.opt
+++ b/mysql-test/suite/encryption/t/import_while_threads_run-master.opt
@@ -1,4 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/import_while_threads_run.test
+++ b/mysql-test/suite/encryption/t/import_while_threads_run.test
@@ -1,0 +1,143 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+# This test is to check if table being currently encrypted/decrypted/re-encrypted
+# by encryption threads fail to be FLUSH FOR EXPORT
+
+let MYSQLD_DATADIR = `SELECT @@datadir`;
+--let $number_of_records = 10000
+
+CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB;
+
+DELIMITER //;
+CREATE PROCEDURE innodb_insert_proc (repeat_count INT)
+BEGIN
+  DECLARE current_num INT;
+  SET current_num = 0;
+  WHILE current_num < repeat_count DO
+    INSERT INTO t1 VALUES (current_num,repeat('foobar',42));
+    INSERT INTO t2 VALUES (current_num,repeat('foobar',42));
+    SET current_num = current_num + 1;
+  END WHILE;
+END//
+DELIMITER ;//
+COMMIT;
+
+SET autocommit=0;
+eval call innodb_insert_proc($number_of_records);
+COMMIT;
+SET autocommit=1;
+
+# Make sure encryption is disabled
+--let $assert_text= Make sure encryption is disabled
+--let $assert_cond= "[SELECT @@GLOBAL.default_table_encryption]" = 0
+--source include/assert.inc
+
+--let $assert_text= Make sure t1 is not encrypted
+--let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME=\\'test/t1\\']" = 0
+--source include/assert.inc
+
+--let $assert_text= Make sure t2 is not encrypted
+--let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME=\\'test/t1\\']" = 0
+--source include/assert.inc
+
+--echo # We want t1 to hang on starting rotation with one thread active on it.
+SET GLOBAL debug="+d,hang_on_t1_rotation";
+
+--echo # Start rotation to online keyring encrypted (tables do not have crypt data stored in page 0)
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+
+--echo # All tables should get encrypted. tables_count - 2 because temporary tablespace is not encrypted and t1 will hang
+--echo # on starting rotation with one thread active on it.
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = $tables_count - 2 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+--echo # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
+--echo # have been rotatted.
+--let $wait_timeout= 600
+--let $wait_condition=SELECT name = 'test/t1' FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND ROTATING_OR_FLUSHING = 1
+--source include/wait_condition.inc
+
+--let $assert_text= Make sure t1 is not encrypted
+--let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME=\\'test/t1\\']" = 0
+--source include/assert.inc
+
+--let $assert_text= Make sure t2 is encrypted
+--let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME=\\'test/t2\\']" = 8192
+--source include/assert.inc
+
+# should fail as t1 is not fully encrypted and there are still
+# threads running on it.
+
+--error ER_FLUSH_ENC_THREADS_RUNNING
+FLUSH TABLE t1 FOR EXPORT;
+
+# should pass as t2 is fully encyrpted and there are no threads
+# running on it.
+FLUSH TABLE t2 FOR EXPORT;
+
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_backup_tablespaces("test", "t2");
+EOF
+
+UNLOCK TABLES;
+
+# let t1 rotation complete
+SET GLOBAL debug="-d,hang_on_t1_rotation";
+
+--echo # Wait for t1 to be fully encrypted
+--let $wait_timeout= 600
+--let $wait_condition=SELECT MIN_KEY_VERSION = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name = 'test/t1'
+--source include/wait_condition.inc
+
+--let $assert_text= Make sure t1 is encrypted
+--let $assert_cond= "[SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME=\\'test/t1\\']" = 8192
+--source include/assert.inc
+
+# it now should be possible to export t1
+FLUSH TABLE t1 FOR EXPORT;
+
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_backup_tablespaces("test", "t1");
+EOF
+
+UNLOCK TABLES;
+
+# Check that tables were properly exported by importing them.
+
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t2 DISCARD TABLESPACE;
+--perl
+do "$ENV{MYSQL_TEST_DIR}/include/innodb-util.inc";
+ib_restore_tablespaces("test", "t1");
+ib_restore_tablespaces("test", "t2");
+EOF
+
+ALTER TABLE t1 IMPORT TABLESPACE;
+ALTER TABLE t2 IMPORT TABLESPACE;
+
+--let $assert_text= Make sure t1 is readable
+--let $assert_cond= "[SELECT COUNT(*) FROM t1]" = $number_of_records
+--source include/assert.inc
+
+--let $assert_text= Make sure t2 is readable
+--let $assert_cond= "[SELECT COUNT(*) FROM t2]" = $number_of_records
+--source include/assert.inc
+
+# cleanup
+DROP TABLE t1,t2;
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;
+DROP PROCEDURE innodb_insert_proc;
+--remove_file $MYSQLTEST_VARDIR/tmp/t1.cfg
+--remove_file $MYSQLTEST_VARDIR/tmp/t1.ibd
+--remove_file $MYSQLTEST_VARDIR/tmp/t2.cfg
+--remove_file $MYSQLTEST_VARDIR/tmp/t2.ibd

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change2-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change2-master.opt
@@ -1,0 +1,4 @@
+$KEYRING_PLUGIN_OPT
+--early-plugin-load="keyring_file=$KEYRING_PLUGIN"
+--loose-keyring_file_data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--innodb-stats-persistent=OFF

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
@@ -1,32 +1,18 @@
---skip
 #
 # MDEV-8750: Server crashes in page_cur_is_after_last on altering table using a wrong encryption key
 # MDEV-8769: Server crash at file btr0btr.ic line 122 when defragmenting encrypted table using incorrect keys
 # MDEV-8768: Server crash at file btr0btr.ic line 122 when checking encrypted table using incorrect keys
 # MDEV-8727: Server/InnoDB hangs on shutdown after trying to read an encrypted table with a wrong key
 #
-call mtr.add_suppression("InnoDB: The page \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\] in file '.*test.t1(new)?\\.ibd' cannot be decrypted\\.");
-call mtr.add_suppression("failed to read or decrypt \\[page id: space=[1-9][0-9]*, page number=[1-9][0-9]*\\]");
-# Suppression for builds where file_key_management plugin is linked statically
-call mtr.add_suppression("Couldn't load plugins from 'file_key_management");
-call mtr.add_suppression("InnoDB: Tablespace for table \`test\`.\`t1\` is set as discarded\\.");
 
-SET GLOBAL innodb_stats_persistent=OFF;
-
---replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
---let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
-#--let $restart_parameters=--plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys2.txt
---source include/restart_mysqld.inc
-
-SET GLOBAL innodb_stats_persistent=OFF;
-SET GLOBAL innodb_file_per_table = ON;
+call mtr.add_suppression("\\[InnoDB\\] Tablespace id [0-9]+ in file t1\.ibd is encrypted but keyring or used key_id 4 is not available\. Can't continue reading table\. Please provide the correct keyring\.");
+call mtr.add_suppression("\\[InnoDB\\] Table `test`\.`t1` does not have an \.ibd file in the database directory\.");
 
 CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(8)) ENGINE=InnoDB ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4;
 INSERT INTO t1 VALUES (1,'foo'),(2,'bar');
 
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
-##--let $restart_parameters=--plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys3.txt
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_stats_persistent=OFF;
@@ -61,15 +47,19 @@ ib_backup_tablespaces("test", "t1");
 EOF
 UNLOCK TABLES;
 
-#--die
-
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_stats_persistent=OFF;
-# Discard should pass even with incorrect keys
---replace_regex /(tablespace|key_id) [1-9][0-9]*/\1 /
+# Discard should not pass with incorrect keys
+--error ER_GET_ERRMSG
+ALTER TABLE t1 DISCARD TABLESPACE;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
+--source include/restart_mysqld.inc
+
 ALTER TABLE t1 DISCARD TABLESPACE;
 
 perl;
@@ -78,29 +68,25 @@ ib_discard_tablespaces("test", "t1");
 ib_restore_tablespaces("test", "t1");
 EOF
 
-
---replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
---let $restart_parameters=restart:--keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys2.txt
-#--let $restart_parameters=--plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys2.txt
---source include/restart_mysqld.inc
-
 SET GLOBAL innodb_stats_persistent=OFF;
 ALTER TABLE t1 IMPORT TABLESPACE;
 SHOW CREATE TABLE t1;
 
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
---let $restart_parameters=restart: --default-table-encryption --keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
-#--let $restart_parameters= --default-table-encryption --plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys3.txt
+--let $restart_parameters=restart: --keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_stats_persistent=OFF;
-# Rename table should pass even with incorrect keys
+--error ER_ERROR_ON_RENAME
 RENAME TABLE t1 TO t1new;
 --replace_regex /(tablespace|key_id) [1-9][0-9]*/\1 /
 
 # Alter table rename is not allowed with incorrect keys
---error ER_GET_ERRMSG
+--error ER_NO_SUCH_TABLE
 ALTER TABLE t1new RENAME TO t2new;
 # Drop should pass even with incorrect keys
 --replace_regex /(tablespace|key_id) [1-9][0-9]*/\1 /
+--error ER_BAD_TABLE_ERROR
 DROP TABLE t1new;
+
+DROP TABLE t1;

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change3.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change3.test
@@ -1,12 +1,9 @@
---skip #has import
 -- source include/not_valgrind.inc
 
-call mtr.add_suppression("cannot be decrypted. Are you using correct keyring that contain the");
-call mtr.add_suppression("InnoDB: Tablespace for table .* is set as discarded.");
-call mtr.add_suppression("InnoDB: Cannot calculate statistics for table .* because the .ibd file is missing. Please refer to .* for how to resolve the issue.");
-call mtr.add_suppression("InnoDB: Trying to access missing tablespace [0-9]+");
-call mtr.add_suppression("InnoDB: Cannot save statistics for table .* because the .ibd file is missing.");
-
+call mtr.add_suppression("\\[InnoDB\\] Tablespace id [0-9]+ in file t1\.ibd is encrypted but keyring or used key_id 4 is not available\. Can't continue reading table\. Please provide the correct keyring\.");
+call mtr.add_suppression("\\[InnoDB\\] Tablespace for table `test`\.`t1` is set as discarded\.");
+call mtr.add_suppression("\\[InnoDB\\] Cannot calculate statistics for table .* because the \.ibd file is missing\. Please refer to .* for how to resolve the issue\.");
+call mtr.add_suppression("\\[InnoDB\\] Encryption can't find tablespace key_id = 4");
 
 CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4;
 SHOW WARNINGS;
@@ -37,7 +34,7 @@ EOF
 --let MYSQLD_DATADIR =`SELECT @@datadir`
 --let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd
 
---error ER_GET_ERRMSG
+--error ER_IMPORT_TABLESPACE_MISSING_KEY
 ALTER TABLE t1 IMPORT TABLESPACE;
 SHOW CREATE TABLE t1;
 --error ER_TABLESPACE_DISCARDED

--- a/mysql-test/suite/encryption/t/innodb_encryption-page-compression.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption-page-compression.test
@@ -91,6 +91,12 @@ update innodb_page_compressed7 set c1 = c1 + 1;
 update innodb_page_compressed8 set c1 = c1 + 1;
 update innodb_page_compressed9 set c1 = c1 + 1;
 
+--echo # Wait max 10 min for key encryption threads to decrypt all spaces as it is
+--echo # impossible to flush pages if encryption threads are still working on them.
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+--source include/wait_condition.inc
+
 flush tables innodb_page_compressed1, innodb_page_compressed2,
 innodb_page_compressed3, innodb_page_compressed4,
 innodb_page_compressed5, innodb_page_compressed6,

--- a/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
@@ -1,9 +1,14 @@
---skip
 --source include/not_valgrind.inc
 
-call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table `[^`]+`.`[^`]+` is set as discarded\\.");
-call mtr.add_suppression("\\[Warning\\] InnoDB: Page [[:digit:]]+ at offset [[:digit:]]+ looks corrupted in file");
-call mtr.add_suppression("\\[ERROR\\] InnoDB: os_file_read\\(\\) failed");
+call mtr.add_suppression("\\[InnoDB\\] Tablespace id .* in file t[1-8]\.ibd is encrypted but keyring or used key_id [4-5] is not available\. Can't continue reading table\. Please provide the correct keyring\.");
+call mtr.add_suppression("\\[InnoDB\\] Tablespace for table `test`\.`t[1-8]` is set as discarded\.");
+call mtr.add_suppression("\\[InnoDB\\] Cannot calculate statistics for table .* because the \.ibd file is missing\. Please refer to .* for how to resolve the issue\.");
+call mtr.add_suppression("\\[InnoDB\\] Encryption can't find tablespace key_id = 5");
+
+CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
+
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
 
 --let $number_of_records = 10000
 --let MYSQLD_DATADIR = `SELECT @@datadir`
@@ -19,7 +24,6 @@ call mtr.add_suppression("\\[ERROR\\] InnoDB: os_file_read\\(\\) failed");
 --let $t8_ibd = $MYSQLD_DATADIR/$DB_NAME/t8.ibd
 
 CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='KEYRING';
-CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ENCRYPTION='Y';
 CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib" ENCRYPTION='KEYRING';
 CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB COMPRESSION="zlib";
 CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING';
@@ -52,14 +56,12 @@ eval CALL innodb_insert_proc($number_of_records);
 COMMIT;
 SET autocommit = 1;
 
---let $tables_count = `SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES`
+--let $tables_count=`SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES`
 
 --echo # Wait max 2 min for key encryption threads to encrypt all spaces
 --let $wait_timeout = 120
-# All tables should get encrypted. Exactly ($tables_count) because
-# INNODB_TABLESPACES_ENCRYPTION contains artificial 'innodb_system' (+1)
-# table and 't7' is unencrypted (-1).
---let $wait_condition = SELECT COUNT(*) = $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+# All tables should get encrypted. Apart from temporary tablespace and t7.
+--let $wait_condition = SELECT COUNT(*) = $tables_count - 2 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
 --source include/wait_condition.inc
 
 --let $assert_text = Make sure t7 is not encrypted
@@ -191,10 +193,17 @@ ALTER TABLE t8 IMPORT TABLESPACE;
 --source include/search_pattern_in_file.inc
 
 
-ALTER TABLE t1 ENGINE InnoDB;
-SHOW CREATE TABLE t1;
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption = OFF;
+
 ALTER TABLE t2 ENGINE InnoDB;
 SHOW CREATE TABLE t2;
+
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
+
+ALTER TABLE t1 ENGINE InnoDB;
+SHOW CREATE TABLE t1;
 ALTER TABLE t3 ENGINE InnoDB;
 SHOW CREATE TABLE t3;
 ALTER TABLE t4 ENGINE InnoDB;
@@ -209,6 +218,7 @@ ALTER TABLE t8 ENGINE InnoDB;
 SHOW CREATE TABLE t8;
 
 --echo # Restarting server
+--let $restart_hide_args=1
 --source include/restart_mysqld.inc
 --echo # Done restarting server
 
@@ -269,7 +279,7 @@ SHOW CREATE TABLE t8;
 
 
 --let $assert_text = Make sure all tables, apart from t7, are encrypted
---let $assert_cond = "[SELECT COUNT(*) = 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0]" = 1
+--let $assert_cond = "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0]" = 1
 --source include/assert.inc
 
 --list_files $MYSQLD_DATADIR/$DB_NAME
@@ -303,9 +313,9 @@ SET GLOBAL default_table_encryption = OFF;
 
 ALTER TABLE t1 IMPORT TABLESPACE;
 --let $assert_text = Make sure t1 has encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t1"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t1"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t1 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t1"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t1 is readable
@@ -314,9 +324,9 @@ ALTER TABLE t1 IMPORT TABLESPACE;
 
 ALTER TABLE t2 IMPORT TABLESPACE;
 --let $assert_text = Make sure t2 has encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t2"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t2"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t2 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t2"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t2 is readable
@@ -325,9 +335,9 @@ ALTER TABLE t2 IMPORT TABLESPACE;
 
 ALTER TABLE t3 IMPORT TABLESPACE;
 --let $assert_text = Make sure t3 has encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t3"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t3"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t3 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t3"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t3 is readable
@@ -336,9 +346,9 @@ ALTER TABLE t3 IMPORT TABLESPACE;
 
 ALTER TABLE t4 IMPORT TABLESPACE;
 --let $assert_text = Make sure t4 has encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t4"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t4"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t4 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t4"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t4 is readable
@@ -347,9 +357,9 @@ ALTER TABLE t4 IMPORT TABLESPACE;
 
 ALTER TABLE t5 IMPORT TABLESPACE;
 --let $assert_text = Make sure t5 has encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t5"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t5"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t5 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t5"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t5 is readable
@@ -358,9 +368,9 @@ ALTER TABLE t5 IMPORT TABLESPACE;
 
 ALTER TABLE t6 IMPORT TABLESPACE;
 --let $assert_text = Make sure t6 has encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t6"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t6"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t6 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t6"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t6 is readable
@@ -369,9 +379,9 @@ ALTER TABLE t6 IMPORT TABLESPACE;
 
 ALTER TABLE t7 IMPORT TABLESPACE;
 --let $assert_text = Make sure t7 does not have encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t7"] = 0
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t7"] = 0
 --source include/assert.inc
---let $assert_text = Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
+--let $assert_text = Make sure t7 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t7"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t7 is readable
@@ -380,9 +390,9 @@ ALTER TABLE t7 IMPORT TABLESPACE;
 
 ALTER TABLE t8 IMPORT TABLESPACE;
 --let $assert_text = Make sure t8 has encrypted flag set after importing
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t8"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t8"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t8 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t8"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t8 is readable
@@ -418,6 +428,7 @@ ALTER TABLE t8 IMPORT TABLESPACE;
 --let SEARCH_FILE = $t8_ibd
 --source include/search_pattern_in_file.inc
 
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 
 --echo # Wait max 2 min for key encryption threads to decrypt all spaces, apart from t1, t3 and t5
@@ -426,9 +437,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/wait_condition.inc
 
 --let $assert_text = Make sure t1 has encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t1"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t1"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t1 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t1 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t1"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t1 is readable
@@ -436,9 +447,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/assert.inc
 
 --let $assert_text = Make sure t2 does not have encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t2"] = 0
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t2"] = 0
 --source include/assert.inc
---let $assert_text = Make sure t2 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_text = Make sure t2 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t2"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t2 is readable
@@ -446,9 +457,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/assert.inc
 
 --let $assert_text = Make sure t3 has encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t3"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t3"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t3 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t3 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t3"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t3 is readable
@@ -456,9 +467,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/assert.inc
 
 --let $assert_text = Make sure t4 does not have encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t4"] = 0
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t4"] = 0
 --source include/assert.inc
---let $assert_text = Make sure t4 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_text = Make sure t4 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t4"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t4 is readable
@@ -466,9 +477,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/assert.inc
 
 --let $assert_text = Make sure t5 has encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t5"] = 8192
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t5"] = 8192
 --source include/assert.inc
---let $assert_text = Make sure t5 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 1
+--let $assert_text = Make sure t5 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 1
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1 AND NAME = "$DB_NAME/t5"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t5 is readable
@@ -476,9 +487,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/assert.inc
 
 --let $assert_text = Make sure t6 does not have encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t6"] = 0
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t6"] = 0
 --source include/assert.inc
---let $assert_text = Make sure t6 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_text = Make sure t6 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t6"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t6 is readable
@@ -486,9 +497,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/assert.inc
 
 --let $assert_text = Make sure t7 does not have encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t7"] = 0
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t7"] = 0
 --source include/assert.inc
---let $assert_text = Make sure t7 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
+--let $assert_text = Make sure t7 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0 (i.e. unencrypted)
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t7"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t7 is readable
@@ -496,9 +507,9 @@ SET GLOBAL innodb_encryption_threads = 4;
 --source include/assert.inc
 
 --let $assert_text = Make sure t8 does not have encrypted flag set
---let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_SYS_TABLESPACES WHERE NAME = "$DB_NAME/t8"] = 0
+--let $assert_cond = [SELECT FLAG & 8192 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = "$DB_NAME/t8"] = 0
 --source include/assert.inc
---let $assert_text = Make sure t8 is visible in INNODB_SYS_TABLESPACES with MIN_KEY_VERSION = 0
+--let $assert_text = Make sure t8 is visible in INNODB_TABLESPACES with MIN_KEY_VERSION = 0
 --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME = "$DB_NAME/t8"] = 1
 --source include/assert.inc
 --let $assert_text = Make sure t8 is readable
@@ -536,21 +547,24 @@ SET GLOBAL innodb_encryption_threads = 4;
 --let SEARCH_FILE = $t8_ibd
 --source include/search_pattern_in_file.inc
 
---echo # Now let's backup keyring file, change encryption key id of encrypt-able tables (all but t7) 
+--echo # Now let's backup keyring file, change encryption key id of encrypt-able tables (all but t7 and temporary)
 --echo # export and dicard them. Next restart the server with backuped keyring file and make sure that
---echo # server starts, but tables cannot be imported gracefully
+--echo # server starts, but tables cannot be imported gracefully.
 
+SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads = 4;
 
 --echo # Wait max 2 min for key encryption threads to encrypt all spaces
 --let $wait_timeout = 120
-# All tables should get encrypted. Exactly ($tables_count) because
-# INNODB_TABLESPACES_ENCRYPTION contains artificial 'innodb_system' (+1)
-# table and 't7' is unencrypted (-1).
---let $wait_condition = SELECT COUNT(*) = $tables_count FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+# All tables should get encrypted. Apart from temporary tablespace and t7.
+--let $wait_condition = SELECT COUNT(*) = $tables_count - 2 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
 --source include/wait_condition.inc
 
---copy_file $MYSQLTEST_VARDIR/tmp/mysecret_keyring $MYSQLTEST_VARDIR/tmp/mysecret_keyring_backup
+SET GLOBAL innodb_encryption_threads = 0;
+SET GLOBAL default_table_encryption = OFF;
+
+--copy_file $MYSQL_TMP_DIR/mysecret_keyring $MYSQL_TMP_DIR/mysecret_keyring_backup
 
 ALTER TABLE t1 encryption_key_id = 5;
 ALTER TABLE t2 encryption_key_id = 5;
@@ -585,24 +599,23 @@ ib_restore_tablespaces("$ENV{DB_NAME}", "t1", "t2", "t3", "t4", "t5", "t6", "t8"
 EOF
 
 --let $restart_parameters = restart:--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring_backup
+--let $restart_hide_args=1
 --source include/restart_mysqld.inc
 
---error ER_INTERNAL_ERROR
+--error ER_IMPORT_TABLESPACE_MISSING_KEY
 ALTER TABLE t1 IMPORT TABLESPACE;
 #--error ER_INTERNAL_ERROR
 ALTER TABLE t2 IMPORT TABLESPACE;
---error ER_INTERNAL_ERROR
+--error ER_IMPORT_TABLESPACE_MISSING_KEY
 ALTER TABLE t3 IMPORT TABLESPACE;
---error ER_INTERNAL_ERROR
 ALTER TABLE t4 IMPORT TABLESPACE;
---error ER_INTERNAL_ERROR
+--error ER_IMPORT_TABLESPACE_MISSING_KEY
 ALTER TABLE t5 IMPORT TABLESPACE;
---error ER_INTERNAL_ERROR
 ALTER TABLE t6 IMPORT TABLESPACE;
---error ER_INTERNAL_ERROR
 ALTER TABLE t8 IMPORT TABLESPACE;
 
---let $restart_parameters = restart:--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+--let $restart_parameters = restart:--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring --default-table-encryption=OFF --innodb-encryption-threads=4
+--let $restart_hide_args=1
 --source include/restart_mysqld.inc
 
 DROP PROCEDURE innodb_insert_proc;

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -9412,6 +9412,18 @@ ER_SYSTEM_KEY_ROTATION_CANT_GENERATE_NEW_VERSION
 ER_DTE_ENCRYPTION_THREADS_ACTIVE
   eng "In order to change default_table_encryption, disable encryption threads. Please set number of innodb_encryption_threads to 0."
 
+ER_FLUSH_ENC_THREADS_RUNNING
+  eng "Tablespace %s cannot be flushed for export as tablespace is being currently encrypted/decrypted by encryption threads."
+
+ER_IMPORT_TABLESPACE_MISSING_KEY
+  eng "You are importing table that is encrypted but keyring or used key is not available. Can't continue importing this table. Please provide the correct keyring.";
+
+ER_IMPORT_TABLESPACE_ENCRYPTION_MISSING_KEY_VERSIONS
+  eng "You are importing table that is encrypted. Although server managed to find key in keyring to decrypt it, some versions of this key, that are needed to decrypt this space, are missing. Maybe you are using an old keyring? Can't continue impoting this table. Please provide the correct keyring."
+
+ER_IMPORT_TABLESPACE_ENCRYPTION_CORRUPTED_KEYS
+  eng "You are importing table id %u that is encrypted. Although server managed to find all needed versions of key in keyring to decrypt it, the provided versions are either incorrect or corrupted. Can't continue importing this table. Please provide the correct keyring."
+
 #
 # End of Percona Server 8.0 client messages
 #

--- a/storage/innobase/api/api0api.cc
+++ b/storage/innobase/api/api0api.cc
@@ -2981,7 +2981,8 @@ dberr_t ib_sdi_set(uint32_t tablespace_id, const ib_sdi_key_t *ib_sdi_key,
                                   << " Error returned: " << err
                                   << " by trx->id: " << trx->id;);
 
-    ut_ad(err == DB_SUCCESS || trx_is_interrupted(trx) || !"sdi_insert_failed");
+    ut_ad(err == DB_SUCCESS || err == DB_IO_DECRYPT_FAIL ||
+          trx_is_interrupted(trx) || !"sdi_insert_failed");
   }
 
   ib_tuple_delete(new_tuple);

--- a/storage/innobase/api/api0misc.cc
+++ b/storage/innobase/api/api0misc.cc
@@ -87,6 +87,7 @@ handle_new_error:
     case DB_CANNOT_ADD_CONSTRAINT:
     case DB_TOO_MANY_CONCURRENT_TRXS:
     case DB_OUT_OF_FILE_SPACE:
+    case DB_IO_DECRYPT_FAIL:
       if (savept) {
         /* Roll back the latest, possibly incomplete
         insertion or update */

--- a/storage/innobase/buf/checksum.cc
+++ b/storage/innobase/buf/checksum.cc
@@ -325,10 +325,10 @@ bool BlockReporter::is_corrupted() const {
       if ((i < FIL_PAGE_FILE_FLUSH_LSN ||
            i >= FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID) &&
           m_read_buf[i] != 0) {
-        if (i >= FIL_PAGE_ENCRYPTION_KEY_VERSION &&
-            i <= FIL_PAGE_ENCRYPTION_KEY_VERSION +
-                     3)  // those four bytes might not be 0 for keyring
-                         // encryption
+        if (i >= FIL_PAGE_ORIGINAL_TYPE_V1 &&
+            i <= FIL_PAGE_ENCRYPTION_KEY_VERSION + 3)  // those four bytes might
+                                                       // not be 0 for keyring
+                                                       // encryption
           continue;
         empty = false;
         break;
@@ -572,7 +572,11 @@ bool BlockReporter::verify_zip_checksum() const {
     ulint i;
     bool empty = true;
     for (i = 0; i < m_page_size.physical(); i++) {
-      if (*((const char *)m_read_buf + i) != 0) {
+      if (*((const char *)m_read_buf + i) != 0 &&
+          (i < FIL_PAGE_ORIGINAL_TYPE_V1 ||
+           i > FIL_PAGE_ENCRYPTION_KEY_VERSION +
+                   3)  // those four bytes might not be 0 for keyring encryption
+      ) {
         empty = false;
         break;
       }

--- a/storage/innobase/dict/dict0dd.cc
+++ b/storage/innobase/dict/dict0dd.cc
@@ -1143,7 +1143,6 @@ dberr_t dd_tablespace_rename(dd::Object_id dd_space_id, bool is_system_cs,
   }
 
   bool fail = client->update(new_space);
-  ut_ad(!fail);
   dd::rename_tablespace_mdl_hook(thd, src_ticket, dst_ticket);
 
   return fail ? DB_ERROR : DB_SUCCESS;

--- a/storage/innobase/dict/dict0sdi.cc
+++ b/storage/innobase/dict/dict0sdi.cc
@@ -403,8 +403,12 @@ bool dict_sdi_set(handlerton *hton, const dd::Tablespace &tablespace,
                         << " is interrupted";);
     return (true);
   } else if (err != DB_SUCCESS) {
-    ut_ad(0);
-    dict_sdi_report_error(operation, table, tablespace);
+    ut_ad(err == DB_IO_DECRYPT_FAIL);
+    if (err == DB_IO_DECRYPT_FAIL) {
+      my_error(ER_XB_MSG_4, MYF(0), tablespace.name().c_str());
+    } else {
+      dict_sdi_report_error(operation, table, tablespace);
+    }
     return (true);
   } else {
     return (false);

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -8887,7 +8887,6 @@ struct Fil_page_iterator {
   /** Encruption iv */
   byte *m_encryption_iv;
 
-  uint m_encryption_key_version;
   uint m_encryption_key_id;
   fil_space_crypt_t *m_crypt_data; /*!< Crypt data (if encrypted) */
 };
@@ -8968,13 +8967,16 @@ static dberr_t fil_iterate(const Fil_page_iterator &iter, buf_block_t *block,
     if ((iter.m_encryption_key != NULL || encrypted_with_keyring) &&
         offset != 0) {
       read_request.encryption_key(
-          encrypted_with_keyring ? iter.m_crypt_data->tablespace_key
-                                 : iter.m_encryption_key,
+          encrypted_with_keyring
+              ? iter.m_crypt_data
+                    ->local_keys_cache[iter.m_crypt_data->min_key_version]
+              : iter.m_encryption_key,
           Encryption::KEY_LEN,
           encrypted_with_keyring ? iter.m_crypt_data->iv : iter.m_encryption_iv,
           0, iter.m_encryption_key_id,
           encrypted_with_keyring ? iter.m_crypt_data->tablespace_key : nullptr,
-          encrypted_with_keyring ? iter.m_crypt_data->uuid : nullptr, nullptr);
+          encrypted_with_keyring ? iter.m_crypt_data->uuid : nullptr,
+          &iter.m_crypt_data->local_keys_cache);
 
       read_request.encryption_algorithm(iter.m_crypt_data ? Encryption::KEYRING
                                                           : Encryption::AES);
@@ -9026,17 +9028,25 @@ static dberr_t fil_iterate(const Fil_page_iterator &iter, buf_block_t *block,
     if (iter.m_encryption_key != NULL && offset != 0 &&
         iter.m_crypt_data == NULL) {
       write_request.encryption_key(
-          iter.m_encryption_key, Encryption::KEY_LEN, iter.m_encryption_iv,
-          iter.m_encryption_key_version, iter.m_encryption_key_id, nullptr,
-          nullptr, nullptr);
+          iter.m_encryption_key, Encryption::KEY_LEN, iter.m_encryption_iv, 0,
+          iter.m_encryption_key_id, nullptr, nullptr, nullptr);
       write_request.encryption_algorithm(Encryption::AES);
-    } else if (offset != 0 && iter.m_crypt_data) {
+      write_request.encryption_rotation(Encryption_rotation::NO_ROTATION);
+    } else if (offset != 0 && iter.m_crypt_data &&
+               iter.m_crypt_data->type != CRYPT_SCHEME_UNENCRYPTED) {
+      ut_ad(iter.m_crypt_data
+                ->local_keys_cache[iter.m_crypt_data->max_key_version] !=
+            nullptr);
       write_request.encryption_key(
-          iter.m_encryption_key, Encryption::KEY_LEN, iter.m_encryption_iv,
-          iter.m_encryption_key_version, iter.m_crypt_data->key_id, nullptr,
-          iter.m_crypt_data->uuid, nullptr);
+          iter.m_crypt_data
+              ->local_keys_cache[iter.m_crypt_data->max_key_version],
+          Encryption::KEY_LEN, iter.m_crypt_data->iv,
+          iter.m_crypt_data->max_key_version, iter.m_crypt_data->key_id,
+          nullptr, iter.m_crypt_data->uuid,
+          &iter.m_crypt_data->local_keys_cache);
 
       write_request.encryption_algorithm(Encryption::KEYRING);
+      write_request.encryption_rotation(iter.m_crypt_data->encryption_rotation);
 
       if (callback.get_page_size().is_compressed()) {
         write_request.mark_page_zip_compressed();
@@ -9263,20 +9273,38 @@ dberr_t fil_tablespace_iterate(dict_table_t *table, ulint n_io_buffers,
     /* read (optional) crypt data */
     if (iter.m_crypt_data &&
         iter.m_crypt_data->type != CRYPT_SCHEME_UNENCRYPTED) {
-      ut_ad(FSP_FLAGS_GET_ENCRYPTION(space_flags));
+      // when importing half encrypted tablespace the encrypted
+      // flag will not be set
+      ut_ad(DBUG_EVALUATE_IF("importing_half_encrypted", true, false) ||
+            FSP_FLAGS_GET_ENCRYPTION(space_flags));
       iter.m_encryption_key_id = iter.m_crypt_data->key_id;
 
-      Encryption::get_latest_tablespace_key(
-          iter.m_crypt_data->key_id, iter.m_crypt_data->uuid,
-          &iter.m_encryption_key_version, &iter.m_encryption_key);
-      if (iter.m_encryption_key == NULL) err = DB_IO_DECRYPT_FAIL;
+      iter.m_encryption_iv = iter.m_crypt_data->iv;
+
+      if (iter.m_crypt_data->type != CRYPT_SCHEME_UNENCRYPTED &&
+          iter.m_crypt_data->private_version == 3) {
+        // for versions 1,2 and encrypted table we will fail the upgrade.
+        Validation_key_verions_result valid_result{
+            iter.m_crypt_data->key_found
+                ? iter.m_crypt_data->validate_encryption_key_versions()
+                : Validation_key_verions_result::MISSING_KEY_VERSIONS};
+        if (!iter.m_crypt_data->key_found ||
+            valid_result != Validation_key_verions_result::SUCCESS) {
+          err =
+              !iter.m_crypt_data->key_found
+                  ? DB_IO_IMPORT_ENCRYPTION_MISSING_KEY
+                  : (valid_result ==
+                             Validation_key_verions_result::MISSING_KEY_VERSIONS
+                         ? DB_IO_IMPORT_ENCRYPTION_MISSING_KEY_VERSIONS
+                         : DB_IO_IMPORT_ENCRYPTION_CORRUPTED_KEYS);
+        }
+
+        // iter.m_crypt_data->load_keys_to_local_cache();
+      }
     } else {
       /* Set encryption info. */
       iter.m_encryption_key = table->encryption_key;
       iter.m_encryption_iv = table->encryption_iv;
-      iter.m_encryption_key_version = ~0;  // TODO:Robert:flipping bits so to
-                                           // make this a marker that tablespace
-                                           // key id used
     }
 
     /* Check encryption is matched or not. */
@@ -9287,7 +9315,7 @@ dberr_t fil_tablespace_iterate(dict_table_t *table, ulint n_io_buffers,
                                     " is an encrypted tablespace";
 
         err = DB_IO_NO_ENCRYPT_TABLESPACE;
-      } else {
+      } else if (!iter.m_crypt_data) {
         /* encryption_key must have been populated while reading CFP file. */
         ut_ad(table->encryption_key != nullptr &&
               table->encryption_iv != nullptr);
@@ -9323,7 +9351,6 @@ dberr_t fil_tablespace_iterate(dict_table_t *table, ulint n_io_buffers,
 
     if (iter.m_crypt_data) {
       fil_space_destroy_crypt_data(&iter.m_crypt_data);
-      if (iter.m_encryption_key != NULL) my_free(iter.m_encryption_key);
     }
   }
 

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -755,7 +755,7 @@ Datafile::ValidateOutput Datafile::validate_first_page(space_id_t space_id,
   }
 
   if (crypt_data != nullptr) {
-    if (crypt_data->type != CRYPT_SCHEME_UNENCRYPTED && !for_import &&
+    if (crypt_data->type != CRYPT_SCHEME_UNENCRYPTED &&
         crypt_data->private_version == 3) {
       // for versions 1,2 and encrypted table we will fail the upgrade.
       Validation_key_verions_result valid_result{

--- a/storage/innobase/include/db0err.h
+++ b/storage/innobase/include/db0err.h
@@ -165,6 +165,13 @@ enum dberr_t {
   DB_IO_DECRYPT_FAIL,
   /** The tablespace doesn't support encrypt */
   DB_IO_NO_ENCRYPT_TABLESPACE,
+
+  DB_IO_IMPORT_ENCRYPTION_MISSING_KEY_VERSIONS,
+
+  DB_IO_IMPORT_ENCRYPTION_CORRUPTED_KEYS,
+
+  DB_IO_IMPORT_ENCRYPTION_MISSING_KEY,
+
   /** Partial IO request failed */
   DB_IO_PARTIAL_FAILED,
   /** Transaction was forced to rollback by a higher priority transaction */

--- a/storage/innobase/include/row0quiesce.h
+++ b/storage/innobase/include/row0quiesce.h
@@ -52,12 +52,13 @@ struct trx_t;
 #define IB_EXPORT_CFG_VERSION_V5 5
 /** Future version used to test that the correct error message is returned. */
 #define IB_EXPORT_CFG_VERSION_V99 99
-#define IB_EXPORT_CFG_VERSION_V1_WITH_RK 0xFFFFFFFF
+#define IB_EXPORT_CFG_VERSION_V1_WITH_KEYRING 0xFFFFFFFF
+#define IB_EXPORT_CFG_VERSION_V3_WITH_KEYRING 0xFFFFFFFD
 
 /** Quiesce the tablespace that the table resides in. */
 void row_quiesce_table_start(dict_table_t *table, /*!< in: quiesce this table */
-                             trx_t *trx); /*!< in/out: transaction/session */
-
+                             trx_t *trx, /*!< in/out: transaction/session */
+                             std::tuple<bool, bool> keyring_info);
 /** Set a table's quiesce state.
  @return DB_SUCCESS or errro code. */
 dberr_t row_quiesce_set_state(
@@ -69,6 +70,7 @@ dberr_t row_quiesce_set_state(
 /** Cleanup after table quiesce. */
 void row_quiesce_table_complete(
     dict_table_t *table, /*!< in: quiesce this table */
-    trx_t *trx);         /*!< in/out: transaction/session */
+    trx_t *trx,          /*!< in/out: transaction/session */
+    bool has_crypt_data);
 
 #endif /* row0quiesce_h */

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -469,6 +469,12 @@ const char *ut_strerr(dberr_t num) {
       return ("Punch hole not supported by the tablespace");
     case DB_IO_NO_ENCRYPT_TABLESPACE:
       return ("Page encryption not supported by the tablespace");
+    case DB_IO_IMPORT_ENCRYPTION_MISSING_KEY:
+      return ("Encryption key missing for table being imported");
+    case DB_IO_IMPORT_ENCRYPTION_MISSING_KEY_VERSIONS:
+      return ("Versions of encryption key missing for table being imported");
+    case DB_IO_IMPORT_ENCRYPTION_CORRUPTED_KEYS:
+      return ("Corrupted encryption key for table being imported");
     case DB_IO_DECRYPT_FAIL:
       return ("Page decryption failed after reading from disk");
     case DB_IO_PARTIAL_FAILED:


### PR DESCRIPTION
Introduced IB_EXPORT_CFG_VERSION_V3_WITH_RK for marking tablespaces
exported with keyring encryption. Please note that V2(IB_EXPORT_CFG_VERSION_V2)
was skipped because when V2 was added by upstream the import/export
with keyring encryption was not functional. Thus it is not possible
for keyring encrypted tablespaces to be exported with V2.

The error handling was improved, but not all paths were covered and some
decryption errors can manifest as "missing tablespace" range of errors.
Please have a look at diff for innodb-bad-key-change2.test.
The keyring encryption error handling becomes a big part of every
upstream merge. To mitigate this problem an improvement PS-5635 was
proposed.