### PR TITLE
PS-5686: improve innodb_redo_log_encrypt validation and formatting (5.7)

### DIFF
--- a/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
@@ -19,7 +19,7 @@ USE tde_db;
 # Starting server with keyring plugin
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 ERROR HY000: Function 'keyring_file' already exists
 UNINSTALL PLUGIN keyring_file;
@@ -27,17 +27,17 @@ UNINSTALL PLUGIN keyring_file;
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 ERROR HY000: Function 'keyring_file' already exists
 UNINSTALL PLUGIN keyring_file;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -52,7 +52,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -80,7 +80,7 @@ a	LEFT(b,10)
 DROP TABLE tde_db.t1,tde_db.t2,tde_db.t3,tde_db.t4;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 CREATE TABLE tde_db.t2 (a BIGINT PRIMARY KEY, b LONGBLOB)
 ENCRYPTION='Y' ENGINE=InnoDB;
@@ -112,7 +112,7 @@ START TRANSACTION;
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -154,7 +154,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 SELECT a,LEFT(b,10) FROM tde_db.t1;
 a	LEFT(b,10)
@@ -171,7 +171,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 SELECT a,LEFT(b,10) FROM tde_db.t1;
 a	LEFT(b,10)
@@ -191,17 +191,17 @@ FLUSH PRIVILEGES;
 # In connection 1 - with encryptnonprivuser
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 SET GLOBAL innodb_redo_log_encrypt = 0;
 ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 # In connection default
 UNINSTALL PLUGIN keyring_file;
 DROP TABLE tde_db.t1,tde_db.t2,tde_db.t3,tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
@@ -19,7 +19,7 @@ USE tde_db;
 # Starting server with keyring plugin
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 ERROR HY000: Function 'keyring_file' already exists
 UNINSTALL PLUGIN keyring_file;
@@ -27,17 +27,17 @@ UNINSTALL PLUGIN keyring_file;
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 ERROR HY000: Function 'keyring_file' already exists
 UNINSTALL PLUGIN keyring_file;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -52,7 +52,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -80,7 +80,7 @@ a	LEFT(b,10)
 DROP TABLE tde_db.t1,tde_db.t2,tde_db.t3,tde_db.t4;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 CREATE TABLE tde_db.t2 (a BIGINT PRIMARY KEY, b LONGBLOB)
 ENCRYPTION='Y' ENGINE=InnoDB;
@@ -112,7 +112,7 @@ START TRANSACTION;
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -154,7 +154,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 SELECT a,LEFT(b,10) FROM tde_db.t1;
 a	LEFT(b,10)
@@ -171,7 +171,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 ALTER INSTANCE ROTATE INNODB MASTER KEY;
 SELECT a,LEFT(b,10) FROM tde_db.t1;
 a	LEFT(b,10)
@@ -191,17 +191,17 @@ FLUSH PRIVILEGES;
 # In connection 1 - with encryptnonprivuser
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 SET GLOBAL innodb_redo_log_encrypt = 0;
 ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) for this operation
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 # In connection default
 UNINSTALL PLUGIN keyring_file;
 DROP TABLE tde_db.t1,tde_db.t2,tde_db.t3,tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_4_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_4_mk.result
@@ -4,7 +4,7 @@
 # Start the DB server with datadir1
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 USE test;
 CREATE TABLE tab1(c1 INT, c2 VARCHAR(30));
 INSERT INTO tab1 VALUES(1, 'Test consistency undo*');
@@ -24,7 +24,7 @@ DROP TABLE tab1,tab2;
 # Start the DB server with datadir2
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 USE test;
 CREATE TABLE tab1(c1 INT, c2 VARCHAR(30));
 INSERT INTO tab1 VALUES(1, 'Test consistency undo*');
@@ -43,7 +43,7 @@ DROP TABLE tab1,tab2;
 # Start the DB server with datadir3 and keyring loaded.
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 USE test;
 CREATE TABLE tab1(c1 INT, c2 VARCHAR(30));
 INSERT INTO tab1 VALUES(1, 'Test consistency undo*');

--- a/mysql-test/suite/innodb/r/log_encrypt_4_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_4_rk.result
@@ -4,7 +4,7 @@
 # Start the DB server with datadir1
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 USE test;
 CREATE TABLE tab1(c1 INT, c2 VARCHAR(30));
 INSERT INTO tab1 VALUES(1, 'Test consistency undo*');
@@ -24,7 +24,7 @@ DROP TABLE tab1,tab2;
 # Start the DB server with datadir2
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 USE test;
 CREATE TABLE tab1(c1 INT, c2 VARCHAR(30));
 INSERT INTO tab1 VALUES(1, 'Test consistency undo*');
@@ -43,7 +43,7 @@ DROP TABLE tab1,tab2;
 # Start the DB server with datadir3 and keyring loaded.
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 USE test;
 CREATE TABLE tab1(c1 INT, c2 VARCHAR(30));
 INSERT INTO tab1 VALUES(1, 'Test consistency undo*');

--- a/mysql-test/suite/innodb/r/log_encrypt_5_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_5_mk.result
@@ -14,7 +14,7 @@ keyring_file	ACTIVE	KEYRING
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -29,7 +29,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -44,7 +44,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/innodb/r/log_encrypt_5_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_5_rk.result
@@ -14,7 +14,7 @@ keyring_file	ACTIVE	KEYRING
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -29,7 +29,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -44,7 +44,7 @@ a	LEFT(b,10)
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/innodb/r/log_encrypt_6_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_6_mk.result
@@ -7,10 +7,10 @@ USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -24,7 +24,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -38,7 +38,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/innodb/r/log_encrypt_6_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_6_rk.result
@@ -7,10 +7,10 @@ USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 CREATE TABLE tde_db.t1 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t1 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t1;
@@ -24,7 +24,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 CREATE TABLE tde_db.t3 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t3 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t3;
@@ -38,7 +38,7 @@ a	LEFT(b,10)
 1	aaaaaaaaaa
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 CREATE TABLE tde_db.t5 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t5 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t5;

--- a/mysql-test/suite/innodb/r/log_encrypt_kill.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_kill.result
@@ -1,7 +1,7 @@
 # restart: --no-console --log-error=ERROR_LOG_FILE
 SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 UNINSTALL PLUGIN keyring_file;
 ERROR 42000: PLUGIN keyring_file does not exist
@@ -21,14 +21,14 @@ Pattern "Can\'t set redo log tablespace to be encrypted" found
 # Starting server with keyring plugin
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 ERROR HY000: Function 'keyring_file' already exists
 SET GLOBAL innodb_redo_log_encrypt = 0;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 ERROR HY000: Function 'keyring_file' already exists
 CREATE DATABASE tde_db;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_change_mk.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_change_mk.result
@@ -1,23 +1,23 @@
 call mtr.add_suppression("Redo log encryption mode can't be switched without stopping the server and recreating the redo logs");
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 SET GLOBAL innodb_redo_log_encrypt=KEYRING_KEY;
 Warnings:
 Warning	1210	 Redo log encryption mode can't be switched without stopping the server and recreating the redo logs. Current mode is master_key, requested keyring_key.
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 SET GLOBAL innodb_redo_log_encrypt=OFF;
 SET GLOBAL innodb_redo_log_encrypt=KEYRING_KEY;
 Warnings:
 Warning	1210	 Redo log encryption mode can't be switched without stopping the server and recreating the redo logs. Current mode is master_key, requested keyring_key.
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-off
+OFF
 include/assert_grep.inc [Check that there is a warning in the error log]
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-master_key
+MASTER_KEY
 include/assert_grep.inc [Check that there is a warning in the error log]
 SET GLOBAL innodb_redo_log_encrypt=MASTER_KEY;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_change_rk.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_change_rk.result
@@ -1,23 +1,23 @@
 call mtr.add_suppression("Redo log encryption mode can't be switched without stopping the server and recreating the redo logs");
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 SET GLOBAL innodb_redo_log_encrypt=MASTER_KEY;
 Warnings:
 Warning	1210	 Redo log encryption mode can't be switched without stopping the server and recreating the redo logs. Current mode is keyring_key, requested master_key.
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 SET GLOBAL innodb_redo_log_encrypt=OFF;
 SET GLOBAL innodb_redo_log_encrypt=MASTER_KEY;
 Warnings:
 Warning	1210	 Redo log encryption mode can't be switched without stopping the server and recreating the redo logs. Current mode is keyring_key, requested master_key.
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-off
+OFF
 include/assert_grep.inc [Check that there is a warning in the error log]
 SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-keyring_key
+KEYRING_KEY
 include/assert_grep.inc [Check that there is a warning in the error log]
 SET GLOBAL innodb_redo_log_encrypt=KEYRING_KEY;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_failure.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_failure.result
@@ -2,6 +2,6 @@ call mtr.add_suppression("Encryption can't find master key, please check the key
 call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
 select @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
-off
+OFF
 Pattern "Can't set redo log tablespace to be encrypted." found
 Pattern "Encryption can't find master key, please check the keyring plugin is loaded." found

--- a/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
@@ -1,47 +1,47 @@
 SET @start_global_value = @@global.innodb_redo_log_encrypt;
 SELECT @start_global_value;
 @start_global_value
-off
+OFF
 select @@global.innodb_redo_log_encrypt in (0, 1);
 @@global.innodb_redo_log_encrypt in (0, 1)
 1
 Warnings:
-Warning	1292	Truncated incorrect DOUBLE value: 'off'
+Warning	1292	Truncated incorrect DOUBLE value: 'OFF'
 select @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 select @@session.innodb_redo_log_encrypt;
 ERROR HY000: Variable 'innodb_redo_log_encrypt' is a GLOBAL variable
 show global variables like 'innodb_redo_log_encrypt';
 Variable_name	Value
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 show session variables like 'innodb_redo_log_encrypt';
 Variable_name	Value
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 select * from performance_schema.global_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 select * from performance_schema.session_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 set global innodb_redo_log_encrypt='MASTER_KEY';
 set global innodb_redo_log_encrypt='KEYRING_KEY';
 select * from performance_schema.global_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 select * from performance_schema.session_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 set @@global.innodb_redo_log_encrypt=0;
 select @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF
 select * from performance_schema.global_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 select * from performance_schema.session_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
-innodb_redo_log_encrypt	off
+innodb_redo_log_encrypt	OFF
 set session innodb_redo_log_encrypt='some';
 ERROR HY000: Variable 'innodb_redo_log_encrypt' is a GLOBAL variable and should be set with SET GLOBAL
 set @@session.innodb_redo_log_encrypt='some';
@@ -50,6 +50,8 @@ set global innodb_redo_log_encrypt=1.1;
 ERROR 42000: Incorrect argument type to variable 'innodb_redo_log_encrypt'
 set global innodb_redo_log_encrypt='foo';
 ERROR 42000: Variable 'innodb_redo_log_encrypt' can't be set to the value of 'foo'
+set global innodb_redo_log_encrypt=3;
+ERROR 42000: Variable 'innodb_redo_log_encrypt' can't be set to the value of '3'
 set global innodb_redo_log_encrypt=-2;
 ERROR 42000: Variable 'innodb_redo_log_encrypt' can't be set to the value of '-2'
 set global innodb_redo_log_encrypt=1e1;
@@ -59,4 +61,4 @@ ERROR 42000: Variable 'innodb_redo_log_encrypt' can't be set to the value of '5'
 SET @@global.innodb_redo_log_encrypt = @start_global_value;
 SELECT @@global.innodb_redo_log_encrypt;
 @@global.innodb_redo_log_encrypt
-off
+OFF

--- a/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
@@ -51,6 +51,8 @@ set global innodb_redo_log_encrypt=1.1;
 --error ER_WRONG_VALUE_FOR_VAR
 set global innodb_redo_log_encrypt='foo';
 --error ER_WRONG_VALUE_FOR_VAR
+set global innodb_redo_log_encrypt=3;
+--error ER_WRONG_VALUE_FOR_VAR
 set global innodb_redo_log_encrypt=-2;
 --error ER_WRONG_TYPE_FOR_VAR
 set global innodb_redo_log_encrypt=1e1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -346,9 +346,9 @@ static TYPELIB innodb_default_row_format_typelib = {
 };
 
 static const char* redo_log_encrypt_names[] = {
-	"off",
-	"master_key",
-	"keyring_key",
+	"OFF",
+	"MASTER_KEY",
+	"KEYRING_KEY",
 	NullS
 };
 
@@ -945,6 +945,19 @@ innodb_encrypt_tables_validate(
 	void*				save,	/*!< out: immediate result
 						for update function */
 	struct st_mysql_value*		value);	/*!< in: incoming string */
+
+/** Validates the possible innodb_redo_log_encrypt_values.
+@param[in]	thd	current session
+@param[in]	var	the system variable innodb_support_xa
+@param[in,out]	var_ptr	the contents of the variable
+@param[in]	save	the to-be-updated value */
+static
+int
+innodb_redo_log_encrypt_validate(
+	THD *		     	thd,
+	struct st_mysql_sys_var *var,
+	void *		     	save,
+	struct st_mysql_value   *value);
 
 
 /** Update the session variable innodb_support_xa.
@@ -22599,7 +22612,7 @@ static MYSQL_SYSVAR_ENUM(default_row_format, innodb_default_row_format,
 static MYSQL_SYSVAR_ENUM(redo_log_encrypt, srv_redo_log_encrypt,
   PLUGIN_VAR_OPCMDARG,
   "Enable or disable Encryption of REDO tablespace. Possible values: OFF, MASTER_KEY, KEYRING_KEY.",
-  NULL, update_innodb_redo_log_encrypt, REDO_LOG_ENCRYPT_OFF, &redo_log_encrypt_typelib);
+  innodb_redo_log_encrypt_validate, update_innodb_redo_log_encrypt, REDO_LOG_ENCRYPT_OFF, &redo_log_encrypt_typelib);
 
 #ifdef UNIV_DEBUG
 static MYSQL_SYSVAR_UINT(trx_rseg_n_slots_debug, trx_rseg_n_slots_debug,
@@ -23995,6 +24008,65 @@ innodb_encrypt_tables_validate(
 	if (legit_value == false)
 		return 1;
 	*static_cast<ulong*>(save)= use;
+
+	return 0;
+}
+
+/** Validates the possible innodb_redo_log_encrypt_values.
+@param[in]	thd	current session
+@param[in]	var	the system variable innodb_support_xa
+@param[in,out]	var_ptr	the contents of the variable
+@param[in]	save	the to-be-updated value */
+static
+int
+innodb_redo_log_encrypt_validate(
+	THD *		     	thd,
+	struct st_mysql_sys_var *var,
+	void *		     	save,
+	struct st_mysql_value   *value)
+{
+	const char	*redo_log_encrypt_input;
+	char		buff[STRING_BUFFER_USUAL_SIZE];
+	int		len = sizeof(buff);
+
+	ut_a(save != NULL);
+	ut_a(value != NULL);
+
+	redo_log_encrypt_input = value->val_str(value, buff, &len);
+
+	bool legit_value = false;
+	uint use = 0;
+	for (; use < array_elements(redo_log_encrypt_names); use++) {
+		if (innobase_strcasecmp(redo_log_encrypt_input,
+					redo_log_encrypt_names[use]) == 0) {
+			legit_value = true;
+			break;
+		}
+	}
+
+	if (innobase_strcasecmp(redo_log_encrypt_input, "0") == 0) {
+		use = 0;
+		legit_value = true;
+	}
+
+	if (innobase_strcasecmp(redo_log_encrypt_input, "false") == 0) {
+		use = 0;
+		legit_value = true;
+	}
+
+	if (innobase_strcasecmp(redo_log_encrypt_input, "1") == 0) {
+		use = 1;
+		legit_value = true;
+	}
+
+	if (innobase_strcasecmp(redo_log_encrypt_input, "true") == 0) {
+		use = 1;
+		legit_value = true;
+	}
+
+	if (!legit_value)
+		return 1;
+	*static_cast<ulong *>(save) = use;
 
 	return 0;
 }


### PR DESCRIPTION
* Variable no longer accepts 2 and 3 as valid values
* Value is dispayed in upcase as with other variables