### PR TITLE
PS-5593: Assertion failure this == space->crypt_data in encryption

### DIFF
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -832,8 +832,11 @@ fil_crypt_read_crypt_data(fil_space_t* space) {
 					      page_size, RW_S_LATCH, &mtr)) {
 		mutex_enter(&fil_system->mutex);
 		if (!space->crypt_data) {
-			space->crypt_data = fil_space_read_crypt_data(
-				page_size, block->frame);
+			fil_space_crypt_t *crypt_data =
+				fil_space_read_crypt_data(page_size, block->frame);
+			if (crypt_data != NULL) {
+				space->crypt_data = crypt_data;
+			}
 		}
 		mutex_exit(&fil_system->mutex);
 	}


### PR DESCRIPTION
threads

With current design the invariant is that encryption threads can only add
crypt_data to page0, but never removed it (setting crypt_data to NULL is
not allowed). This can be done only with ALTER statement. This invariant
can be broken by function fil_crypt_read_crypt_data. Consider scenario:

Thread I: checks if space has crypt_data assigned. It is NULL, so
next it checks whether it might not have been yet read from page0.
It finds that crypt_data is not present in page0 either. It starts
encrypting space by calling function fil_crypt_start_encrypting_space.
It will generate crypt_data for this space.
Thread II: reads crypt_data from page0 and find it missing, it tries
to read it from page0.
Thread I: sets space->crypt_data to crypt_data it created.
Thread II: It unconditionally sets space->crypt_data to whatever was
found on page0 - could be NULL.
Thread I: expects that the crypt_data it assigned to page0 exists when
calling fil_space_crypt_t::write_page0 which is not the case as it was
overitten by Thread II and assert ut_ad(this == space->crypt_data) will
fail.

It is worth highlighting that there is a silent assumption that
crypt_data cannot be ever removed from tablespace by encryption threads.
It saves some locking, however makes design complicated to programmers
who tries to reason about this code.

To fix this problem, function fil_crypt_read_crypt_data was changed so
to only assign crypt_data read from page0 to space->crypt_data in case
it is not NULL.