### PR TITLE
PS-5639 : Slow shutdown with many tables

### DIFF
--- a/storage/innobase/include/sync0types.h
+++ b/storage/innobase/include/sync0types.h
@@ -677,19 +677,7 @@ public:
 
 	/** Deregister a single instance counter
 	@param[in]	count		The count instance to deregister */
-	void single_deregister(Count* count)
-		UNIV_NOTHROW
-	{
-		m_mutex.enter();
-
-		m_counters.erase(
-			std::remove(
-				m_counters.begin(),
-				m_counters.end(), count),
-			m_counters.end());
-
-		m_mutex.exit();
-	}
+	void single_deregister(Count* count) UNIV_NOTHROW;
 
 	/** Iterate over the counters */
 	template <typename Callback>


### PR DESCRIPTION
Problem:
--------
On a database with 2M tables and with buffer pool size of 20GB or more,
shutdown takes approximately 12mins.

Lot of tables should have auto-inc mutexes.

Analysis:
---------
Perf data collected during shutdown revealead about 82% of time is spent in
mutex_destroy().

With a debug instrumentation patch, it is observed that the mutexes destroyed
are AUTOINC and Buffer pool Block Mutexes

Still if all tables with AUTOINC mutex are accessed, there would be cached table
objects (dict_table_t). With good amount of 'table_definition_cache',
'table_open_cache_instances' and 'open_files_limit', many tables could remain
in the cache.

Also with such big buffer pool, there can be many pages(blocks) in the buffer
pool.

The important observation here is about 1.6Million tables in cache and
1.3 Million blocks are in buffer pool. Count one mutex per each of those.

So total of 2.9 Million mutexes are destroyed during shutdown. Still why ~ 10mins
(82% of time) for destruction of these 2.6 Million mutexes?

These are custom mutexes. Implemented by InnoDB and not pthread_mutexes.

For these mutexes, to collect statistics, a Counter is created for each mutex.
Counter has information about spins, waits, calls. One counter is created for
every mutex instance. So for AUTOINC Mutex type, there is one vector which
will hold all Counters.

For AUTOINC, the vector would hold 1.6Million Count elements. Similary for
buffer block->mutex type, there is another vector that would 1.3 Million elements.

During shutdown, each mutex is destroyed and so that removes the stat object(count)
from the huge vector. This is one-by-one removal.

Lets see the complexity of removal of an element from vector of size N. To remove
one element, it is O(N). And to remove N elements, it is ~ O(N^2). Lets calculate
this for 1.6Million. So it would be O(1.6Million ^ 2) = 2.5Trillion operations.

Now we know why it took 82% of shutdown time :)

Fix:
----
Since we know the counters are anyway going to be destroyed during shutdown, there is
no point in doing one-by-one removal of Counter element from vector

After shutdown is initiated, clear the entire vector in one-go. The remains requests
to remove elements would be no-op as the vector is already empty.