### PR TITLE
PS-5689: Add an MTR testcase to test encryption of temporary tables c…

### DIFF
--- a/mysql-test/include/innodb_row_log_encryption.inc
+++ b/mysql-test/include/innodb_row_log_encryption.inc
@@ -79,4 +79,54 @@ DROP TABLE t1;
 
 SET DEBUG_SYNC= 'RESET';
 
+# PS-5689: Add an MTR testcase to test encryption of temporary tables created during online alter
+
+let MYSQLD_DATADIR=`SELECT @@datadir`;
+
+CREATE TABLE t (a INT, b TEXT) ENGINE=InnoDB ENCRYPTION='y';
+
+let $i=1000;
+
+--disable_query_log
+while ($i) {
+eval INSERT INTO t (a, b) VALUES ($i, UUID());
+dec $i;
+}
+--enable_query_log
+
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL paused WAIT_FOR unpause';
+
+send ALTER TABLE t ADD PRIMARY KEY (a);
+
+connect (con1,localhost,root,,);
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+
+perl;
+opendir(my $dh, "$ENV{'MYSQLD_DATADIR'}/test");
+@files = grep(/^#sql.*ibd$/, readdir($dh));
+closedir($dh);
+
+die "temp table is not found" unless scalar(@files) > 0;
+
+foreach $file (@files) {
+  open(my $fh, '<:raw', "$ENV{'MYSQLD_DATADIR'}/test/$file") || die "unable to open $file";
+  seek($fh, 38 + 16, 0) || die "unable to seek $file";
+  read($fh, my $bytes, 4) || die "unable to read $file";
+  my $flags = unpack("N*", $bytes);
+  die "temp table $file is not encrypted" unless $flags & 8192 == 8192;
+  close($fh);
+}
+EOF
+
+SET DEBUG_SYNC= 'now SIGNAL unpause';
+disconnect con1;
+
+connection default;
+
+reap;
+
+DROP TABLE t;
+
+SET DEBUG_SYNC= 'RESET';
+
 -- source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/innodb/r/innodb_row_log_encryption.result
+++ b/mysql-test/suite/innodb/r/innodb_row_log_encryption.result
@@ -34,3 +34,10 @@ variable_value > 0
 1
 DROP TABLE t1;
 SET DEBUG_SYNC= 'RESET';
+CREATE TABLE t (a INT, b TEXT) ENGINE=InnoDB ENCRYPTION='y';
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL paused WAIT_FOR unpause';
+ALTER TABLE t ADD PRIMARY KEY (a);
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+SET DEBUG_SYNC= 'now SIGNAL unpause';
+DROP TABLE t;
+SET DEBUG_SYNC= 'RESET';

--- a/plugin/keyring_vault/tests/mtr/innodb_row_log_encryption.result
+++ b/plugin/keyring_vault/tests/mtr/innodb_row_log_encryption.result
@@ -35,3 +35,10 @@ variable_value > 0
 1
 DROP TABLE t1;
 SET DEBUG_SYNC= 'RESET';
+CREATE TABLE t (a INT, b TEXT) ENGINE=InnoDB ENCRYPTION='y';
+SET DEBUG_SYNC = 'row_log_table_apply1_before SIGNAL paused WAIT_FOR unpause';
+ALTER TABLE t ADD PRIMARY KEY (a);
+SET DEBUG_SYNC= 'now WAIT_FOR paused';
+SET DEBUG_SYNC= 'now SIGNAL unpause';
+DROP TABLE t;
+SET DEBUG_SYNC= 'RESET';


### PR DESCRIPTION
…reated during online alter

Added test which produce temporary table during online ALTER and
checks that table is encrypted by looking at tablespace flags.