### PR TITLE
PS-5697: Improve redo log encryption error reporting (8.0)

### DIFF
--- a/mysql-test/include/log_encrypt_6.inc
+++ b/mysql-test/include/log_encrypt_6.inc
@@ -85,7 +85,7 @@ DROP DATABASE tde_db;
 
 --echo # Try starting without keyring : Error
 let NEW_CMD = $MYSQLD --no-defaults --innodb_dedicated_server=OFF --innodb_page_size=$START_PAGE_SIZE --innodb_log_file_size=$LOG_FILE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1  --secure-file-priv="" --console </dev/null>>$MYSQL_TMP_DIR/wl9290.err 2>&1;
---error 1
+--error 2
 --exec $NEW_CMD
 
 --echo # Restart without keyring plugin possible if redo files removed
@@ -102,9 +102,6 @@ let NEW_CMD = $MYSQLD --no-defaults --innodb_dedicated_server=OFF --innodb_page_
 let SEARCH_FILE= $MYSQL_TMP_DIR/wl9290.err;
 let SEARCH_PATTERN=  Redo log was encrypted, but keyring plugin is not loaded;
 --source include/search_pattern.inc
-let SEARCH_PATTERN= Aborting;
---source include/search_pattern.inc
-
 
 # shutdown server
 --let $_server_id= `SELECT @@server_id`

--- a/mysql-test/include/percona_log_encrypt_change.inc
+++ b/mysql-test/include/percona_log_encrypt_change.inc
@@ -24,19 +24,47 @@ SELECT @@innodb_redo_log_encrypt;
 
 # Test: using a different parameter during restart
 
---let $restart_parameters = restart: $KEYRING_PARAMS --innodb-redo_log_encrypt=$LOG_ENCRYPT_OTHER_TYPE
---replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT --plugin-dir=KEYRING_PLUGIN_PATH
---replace_regex /\.dll/.so/
---source include/restart_mysqld_no_echo.inc
+--let MYSQLD_DATADIR = `SELECT @@datadir`
+--let MYSQLD_LOG = $MYSQL_TMP_DIR/server.log
 
-SELECT @@innodb_redo_log_encrypt;
+--source include/shutdown_mysqld.inc
+
+--let NEW_CMD = $MYSQLD $extra_args $KEYRING_PARAMS --datadir=$MYSQLD_DATADIR --innodb_redo_log_encrypt=$LOG_ENCRYPT_OTHER_TYPE >$MYSQLD_LOG 2>&1;
+--error 2
+--exec $NEW_CMD
+
+# Test: crash the server AND restart with a different parameter
+--source include/start_mysqld_no_echo.inc
+
+--let $assert_text = Check that there is a warning in the error log
+--let $assert_select = Redo log encryption mode can't be switched without stopping the server and recreating the redo logs
+--let $assert_file = $MYSQLD_LOG
+--let $assert_count = 1
+--source include/assert_grep.inc
+
+--remove_file $MYSQLD_LOG
+
+CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "aaaaa");
+INSERT INTO t1 VALUES(1, "bbbbb");
+INSERT INTO t1 VALUES(2, "ccccc");
+
+--source include/kill_mysqld.inc
+
+--let NEW_CMD = $MYSQLD $extra_args $KEYRING_PARAMS --datadir=$MYSQLD_DATADIR --innodb_redo_log_encrypt=$LOG_ENCRYPT_OTHER_TYPE >$MYSQLD_LOG 2>&1;
+--error 2
+--exec $NEW_CMD
+
+--source include/start_mysqld_no_echo.inc
 
 --let $assert_text=Check that there is a warning in the error log
 --let $assert_select=Redo log encryption mode can't be switched without stopping the server and recreating the redo logs
---let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
---let $assert_count=3
+--let $assert_file=$MYSQLD_LOG
+--let $assert_count=1
 --let $assert_only_after=CURRENT_TEST: innodb.percona_log_encrypt_change_$LOG_ENCRYPT_TEST_END
 --source include/assert_grep.inc
 
 # Cleanup
+DROP TABLE t1;
 --eval SET GLOBAL innodb_redo_log_encrypt=$LOG_ENCRYPT_TYPE
+--remove_file $MYSQLD_LOG

--- a/mysql-test/suite/innodb/r/log_encrypt_1_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_1_mk.result
@@ -1,4 +1,6 @@
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
+Warnings:
+Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/log_encrypt_1_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_1_rk.result
@@ -1,4 +1,6 @@
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
+Warnings:
+Warning	49009	InnoDB: Redo log key generation failed.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
@@ -5,8 +5,11 @@ call mtr.add_suppression("Redo log key generation failed.");
 CREATE DATABASE tde_db;
 USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
+Warnings:
+Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
 SHOW WARNINGS;
 Level	Code	Message
+Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
 CREATE TABLE tde_db.t4 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
@@ -5,8 +5,11 @@ call mtr.add_suppression("Redo log key generation failed.");
 CREATE DATABASE tde_db;
 USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
+Warnings:
+Warning	49009	InnoDB: Redo log key generation failed.
 SHOW WARNINGS;
 Level	Code	Message
+Warning	49009	InnoDB: Redo log key generation failed.
 CREATE TABLE tde_db.t4 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_6_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_6_mk.result
@@ -57,7 +57,6 @@ DROP DATABASE tde_db;
 # Start the DB server with datadir1
 # Search for error message
 Pattern "Redo log was encrypted, but keyring plugin is not loaded" found
-Pattern "Aborting" found
 # Try starting without keyring and  --innodb_force_recovery=SRV_FORCE_NO_LOG_REDO.
 # Start the DB server with datadir1
 SELECT 1;

--- a/mysql-test/suite/innodb/r/log_encrypt_6_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_6_rk.result
@@ -57,7 +57,6 @@ DROP DATABASE tde_db;
 # Start the DB server with datadir1
 # Search for error message
 Pattern "Redo log was encrypted, but keyring plugin is not loaded" found
-Pattern "Aborting" found
 # Try starting without keyring and  --innodb_force_recovery=SRV_FORCE_NO_LOG_REDO.
 # Start the DB server with datadir1
 SELECT 1;

--- a/mysql-test/suite/innodb/r/log_encrypt_kill.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_kill.result
@@ -3,6 +3,8 @@ SELECT @@global.innodb_redo_log_encrypt ;
 @@global.innodb_redo_log_encrypt
 OFF
 SET GLOBAL innodb_redo_log_encrypt = 1;
+Warnings:
+Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
 SET GLOBAL innodb_undo_log_encrypt = 1;
 UNINSTALL PLUGIN keyring_file;
 ERROR 42000: PLUGIN keyring_file does not exist

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_change_mk.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_change_mk.result
@@ -16,8 +16,12 @@ SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
 OFF
 include/assert_grep.inc [Check that there is a warning in the error log]
-SELECT @@innodb_redo_log_encrypt;
-@@innodb_redo_log_encrypt
-MASTER_KEY
 include/assert_grep.inc [Check that there is a warning in the error log]
+CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "aaaaa");
+INSERT INTO t1 VALUES(1, "bbbbb");
+INSERT INTO t1 VALUES(2, "ccccc");
+# Kill the server
+include/assert_grep.inc [Check that there is a warning in the error log]
+DROP TABLE t1;
 SET GLOBAL innodb_redo_log_encrypt=MASTER_KEY;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_change_rk.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_change_rk.result
@@ -16,8 +16,12 @@ SELECT @@innodb_redo_log_encrypt;
 @@innodb_redo_log_encrypt
 OFF
 include/assert_grep.inc [Check that there is a warning in the error log]
-SELECT @@innodb_redo_log_encrypt;
-@@innodb_redo_log_encrypt
-KEYRING_KEY
 include/assert_grep.inc [Check that there is a warning in the error log]
+CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
+INSERT INTO t1 VALUES(0, "aaaaa");
+INSERT INTO t1 VALUES(1, "bbbbb");
+INSERT INTO t1 VALUES(2, "ccccc");
+# Kill the server
+include/assert_grep.inc [Check that there is a warning in the error log]
+DROP TABLE t1;
 SET GLOBAL innodb_redo_log_encrypt=KEYRING_KEY;

--- a/mysql-test/suite/innodb/r/percona_log_encrypt_failure.result
+++ b/mysql-test/suite/innodb/r/percona_log_encrypt_failure.result
@@ -1,7 +1,2 @@
-call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
-select @@innodb_redo_log_encrypt;
-@@innodb_redo_log_encrypt
-OFF
-Pattern "Can't set redo log tablespace to be encrypted." found
-Pattern "Encryption can't find master key, please check the keyring plugin is loaded." found
+Pattern "keyring plugin fail" found
+# restart

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_failure-master.opt
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_failure-master.opt
@@ -1,1 +1,0 @@
---innodb-redo-log-encrypt=MASTER_KEY

--- a/mysql-test/suite/innodb/t/percona_log_encrypt_failure.test
+++ b/mysql-test/suite/innodb/t/percona_log_encrypt_failure.test
@@ -1,11 +1,16 @@
-call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
-select @@innodb_redo_log_encrypt;
+--let MYSQLD_DATADIR=`SELECT @@datadir`
+--let MYSQLD_LOG=$MYSQL_TMP_DIR/server.log
+
+--source include/shutdown_mysqld.inc
+
+--let NEW_CMD=$MYSQLD $extra_args $KEYRING_PARAMS --datadir=$MYSQLD_DATADIR --innodb_redo_log_encrypt=MASTER_KEY >$MYSQLD_LOG 2>&1;
+--error 1
+--exec $NEW_CMD
 
 
---let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err
---let SEARCH_PATTERN=Can't set redo log tablespace to be encrypted.
+--let SEARCH_FILE=$MYSQLD_LOG
+--let SEARCH_PATTERN=keyring plugin fail
 --source include/search_pattern.inc
---let SEARCH_PATTERN=Encryption can't find master key, please check the keyring plugin is loaded.
---source include/search_pattern.inc
 
+--source include/start_mysqld.inc
+--remove_file $MYSQLD_LOG

--- a/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
@@ -25,6 +25,8 @@ select * from performance_schema.session_variables where variable_name='innodb_r
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_redo_log_encrypt	OFF
 set global innodb_redo_log_encrypt=1;
+Warnings:
+Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
 select * from performance_schema.global_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_redo_log_encrypt	OFF

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -19306,6 +19306,21 @@ ER_COMPRESSION_DICTIONARY_IS_REFERENCED
 ER_REDO_ENCRYPTION_CANT_BE_CHANGED
   eng "Redo log encryption mode can't be switched without stopping the server and recreating the redo logs. Current mode is %s, requested %s."
 
+ER_REDO_ENCRYPTION_CANT_GENERATE_KEY
+  eng "Redo log key generation failed."
+
+ER_REDO_ENCRYPTION_FAILED
+  eng "Failed to encrypt redo log tablespace."
+
+ER_REDO_ENCRYPTION_CANT_LOAD_KEY_VERSION
+  eng "Failed to load redo key version %u"
+
+ER_REDO_ENCRYPTION_CANT_FETCH_KEY
+  eng "Couldn't fetch newly generated redo key."
+
+ER_REDO_ENCRYPTION_CANT_PARSE_KEY
+  eng "Couldn't parse system key: %s"
+
 #
 # End of Percona Server 8.0 error messages
 #

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4062,7 +4062,7 @@ static void innobase_post_recover() {
       srv_redo_log_encrypt = false;
     } else {
       /* Enable encryption for REDO log */
-      if (srv_enable_redo_encryption()) {
+      if (srv_enable_redo_encryption(nullptr)) {
         ut_ad(false);
         srv_redo_log_encrypt = false;
       }
@@ -4382,7 +4382,7 @@ bool innobase_fix_tablespaces_empty_uuid() {
        server run. These functions are also called later, when the master key is
        correctly set up, later in this function.
      */
-    if (srv_enable_redo_encryption()) {
+    if (srv_enable_redo_encryption(nullptr)) {
       srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
     } else {
       log_rotate_default_key();
@@ -4422,7 +4422,7 @@ bool innobase_fix_tablespaces_empty_uuid() {
     return (true);
   }
 
-  if (srv_enable_redo_encryption()) {
+  if (srv_enable_redo_encryption(nullptr)) {
     srv_redo_log_encrypt = REDO_LOG_ENCRYPT_OFF;
   } else {
     log_rotate_default_key();
@@ -22104,9 +22104,9 @@ static void update_innodb_redo_log_encrypt(THD *thd, SYS_VAR *var,
       existing_redo_encryption_mode != target &&
       !(existing_redo_encryption_mode == REDO_LOG_ENCRYPT_MK &&
         target == REDO_LOG_ENCRYPT_ON)) {
-    ib::warn(ER_REDO_ENCRYPTION_CANT_BE_CHANGED,
-             log_encrypt_name(existing_redo_encryption_mode),
-             log_encrypt_name(static_cast<redo_log_encrypt_enum>(target)));
+    ib::error(ER_REDO_ENCRYPTION_CANT_BE_CHANGED,
+              log_encrypt_name(existing_redo_encryption_mode),
+              log_encrypt_name(static_cast<redo_log_encrypt_enum>(target)));
     ib_senderrf(thd, IB_LOG_LEVEL_WARN, ER_REDO_ENCRYPTION_CANT_BE_CHANGED,
                 log_encrypt_name(existing_redo_encryption_mode),
                 log_encrypt_name(static_cast<redo_log_encrypt_enum>(target)));
@@ -22114,15 +22114,14 @@ static void update_innodb_redo_log_encrypt(THD *thd, SYS_VAR *var,
   }
 
   if (srv_read_only_mode) {
-    push_warning_printf(thd, Sql_condition::SL_WARNING, ER_WRONG_ARGUMENTS,
-                        " Redo log cannot be"
-                        " encrypted in innodb_read_only mode");
+    ib::error(ER_IB_MSG_1242);
+    ib_senderrf(thd, IB_LOG_LEVEL_WARN, ER_IB_MSG_1242);
     return;
   }
 
   if (target == REDO_LOG_ENCRYPT_MK || target == REDO_LOG_ENCRYPT_ON) {
     ut_ad(strlen(server_uuid) > 0);
-    if (srv_enable_redo_encryption_mk()) {
+    if (srv_enable_redo_encryption_mk(thd)) {
       return;
     }
     srv_redo_log_encrypt = target;
@@ -22131,7 +22130,7 @@ static void update_innodb_redo_log_encrypt(THD *thd, SYS_VAR *var,
 
   if (target == REDO_LOG_ENCRYPT_RK) {
     ut_ad(strlen(server_uuid) > 0);
-    if (srv_enable_redo_encryption_rk()) {
+    if (srv_enable_redo_encryption_rk(thd)) {
       return;
     }
 

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -354,12 +354,12 @@ class redo_log_keys final {
   @param[in]	generate If true, a key is generated if an existing key can't
   be loaded. */
   MY_NODISCARD
-  redo_log_key *load_latest_key(bool generate);
+  redo_log_key *load_latest_key(THD *thd, bool generate);
   MY_NODISCARD
-  redo_log_key *load_key_version(uint version);
+  redo_log_key *load_key_version(THD *thd, uint version);
 
   MY_NODISCARD
-  redo_log_key *generate_and_store_new_key();
+  redo_log_key *generate_and_store_new_key(THD *thd);
 
   /** These two methods are used during bootstrap encryption, when wo do not yet
   have an uuid */

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1117,15 +1117,15 @@ void undo_spaces_deinit();
 /** Enables master key redo encryption.
  * Doesn't depend on the srv_redo_log_encrypt variable, used by
  * SET innodb_redo_log_encrypt = MK. */
-bool srv_enable_redo_encryption_mk();
+bool srv_enable_redo_encryption_mk(THD *thd);
 
 /** Enables master key redo encryption.
  * Doesn't depend on the srv_redo_log_encrypt variable, used by
  * SET innodb_redo_log_encrypt = RK. */
-bool srv_enable_redo_encryption_rk();
+bool srv_enable_redo_encryption_rk(THD *thd);
 
 /** Enables redo log encryption based on srv_redo_log_encrypt. */
-bool srv_enable_redo_encryption();
+bool srv_enable_redo_encryption(THD *thd);
 
 #ifdef UNIV_DEBUG
 struct SYS_VAR;

--- a/storage/innobase/include/ut0ut.h
+++ b/storage/innobase/include/ut0ut.h
@@ -705,7 +705,8 @@ class fatal : public logger {
   @param[in]	err		Error code from errmsg-*.txt.
   @param[in]	args		Variable length argument list */
   template <class... Args>
-  explicit fatal(int err, Args &&... args) : logger(ERROR_LEVEL, err) {
+  explicit fatal(int err, Args &&... args) : logger(ERROR_LEVEL) {
+    m_err = err;
     m_oss << "[FATAL] ";
 
     m_oss << msg(err, std::forward<Args>(args)...);

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -9635,7 +9635,8 @@ dberr_t Encryption::decrypt_log_block(const IORequest &type, byte *src,
 
       if (m_key_version != enc_key_version &&
           enc_key_version != REDO_LOG_ENCRYPT_NO_VERSION) {
-        redo_log_key *mkey = redo_log_key_mgr.load_key_version(enc_key_version);
+        redo_log_key *mkey =
+            redo_log_key_mgr.load_key_version(nullptr, enc_key_version);
         m_key_version = mkey->version;
         m_key = reinterpret_cast<unsigned char *>(mkey->key);
       }

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -427,6 +427,11 @@ static dberr_t create_log_files(char *logfilename, size_t dirnamelen, lsn_t lsn,
     fsp_flags_set_encryption(log_space->flags);
     err = fil_set_encryption(log_space->id, alg,
                              reinterpret_cast<byte *>(mkey->key), nullptr);
+    if (err != DB_SUCCESS) {
+      ib::error(ER_REDO_ENCRYPTION_FAILED);
+
+      return (DB_ERROR);
+    }
     log_space->encryption_redo_key = mkey;
     log_space->encryption_key_version = REDO_LOG_ENCRYPT_NO_VERSION;
 


### PR DESCRIPTION
* If encryption can't be turned on during startup, the server will abort
* If encryption can't be turned on when it's requested in a connection,
  an error message will be returned to the client.

This results in a different behavior than MySQL 8.0, which silently
ignores these scenarios.