### PR TITLE
Fix PS-5716 (innodb.percona_extended_innodb_status does not remove a …

### DIFF
--- a/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
+++ b/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
@@ -65,4 +65,4 @@ DROP TABLE t;
 --let SEARCH_PATTERN=Buffer pool size, bytes 25149440
 --echo Grepping InnoDB status for $SEARCH_PATTERN
 --source include/search_pattern_in_file.inc
-
+--remove_file $innodb_status


### PR DESCRIPTION
…temp file)

A merge regression from 5.6. Fix trivially.

https://ps57.cd.percona.com/job/percona-server-5.7-param/61/