### PR TITLE
Fix PS-5722 (rocksdb.ttl_primary testcase sometimes failed)

### DIFF
--- a/mysql-test/suite/rocksdb/r/ttl_primary.result
+++ b/mysql-test/suite/rocksdb/r/ttl_primary.result
@@ -448,6 +448,8 @@ set global rocksdb_force_flush_memtable_now=1;
 set global rocksdb_compact_cf='default';
 SELECT a FROM t1;
 a
+1
+3
 DROP TABLE t1;
 CREATE TABLE t1 (
 a bigint(20) NOT NULL,

--- a/mysql-test/suite/rocksdb/t/ttl_primary.test
+++ b/mysql-test/suite/rocksdb/t/ttl_primary.test
@@ -487,6 +487,9 @@ INSERT INTO t1 values (3, UNIX_TIMESTAMP());
 INSERT INTO t1 values (5, UNIX_TIMESTAMP());
 INSERT INTO t1 values (7, UNIX_TIMESTAMP());
 
+# wait for unix timestamp value changed to make sure ttl column b update
+let $wait_condition= SELECT UNIX_TIMESTAMP() != max(b) FROM t1;
+--source include/wait_condition.inc
 set global rocksdb_debug_ttl_rec_ts = 300;
 UPDATE t1 SET b=UNIX_TIMESTAMP() WHERE a < 4;
 set global rocksdb_debug_ttl_rec_ts = 0;


### PR DESCRIPTION
update ttl column may be ignored if the ttl column value not changed.