### PR TITLE
Fix PS-5715 (MyEncryptionCTX_nopad::init: do not call memcpy with NUL…

### DIFF
--- a/mysys_ssl/my_crypt.cc
+++ b/mysys_ssl/my_crypt.cc
@@ -149,8 +149,12 @@ public:
     this->key= key;
     this->klen= klen;
     this->buf_len= 0;
-    memcpy(oiv, iv, ivlen);
-    DBUG_ASSERT(ivlen == 0 || ivlen == sizeof(oiv));
+    if (iv) {
+      memcpy(oiv, iv, ivlen);
+      DBUG_ASSERT(ivlen == sizeof(oiv));
+    } else {
+      DBUG_ASSERT(ivlen == 0);
+    }
 
     int res= MyEncryptionCTX::init(mode, encrypt, key, klen, iv, ivlen);
     if (res == MY_AES_OK)


### PR DESCRIPTION
…L arg even if len == 0)

Backport from 8.0: avoid calling memcpy in MyEncryptionCTX_nopad::init
with NULL source argument.

https://ps57.cd.percona.com/job/percona-server-5.7-param/62/