### PR TITLE
Implement PS-5742 (Code review fixes from 8.0 work: threadpool):

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8394,7 +8394,8 @@ show_ssl_get_server_not_after(THD *thd, SHOW_VAR *var, char *buff)
 #endif /* HAVE_OPENSSL && !EMBEDDED_LIBRARY */
 
 #ifdef HAVE_POOL_OF_THREADS
-int show_threadpool_idle_threads(THD *thd, SHOW_VAR *var, char *buff)
+static int
+show_threadpool_idle_threads(THD *thd, SHOW_VAR *var, char *buff)
 {
   var->type= SHOW_INT;
   var->value= buff;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -5719,8 +5719,6 @@ inline bool add_group_to_list(THD *thd, Item *item, bool asc)
   return thd->lex->current_select->add_group_to_list(thd, item, asc);
 }
 
-extern pthread_attr_t *get_connection_attrib(void);
-
 #endif /* MYSQL_SERVER */
 
 /**

--- a/sql/threadpool.h
+++ b/sql/threadpool.h
@@ -72,5 +72,3 @@ extern void tp_set_threadpool_stall_limit(uint val);
 
 /* Activate threadpool scheduler */
 extern void tp_scheduler(void);
-
-extern int show_threadpool_idle_threads(THD *thd, SHOW_VAR *var, char *buff);

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -188,7 +188,6 @@ static int  create_worker(thread_group_t *thread_group);
 static void *worker_main(void *param);
 static void check_stall(thread_group_t *thread_group);
 static void connection_abort(connection_t *connection);
-void tp_post_kill_notification(THD *thd);
 static void set_wait_timeout(connection_t *connection);
 static void set_next_timeout_check(ulonglong abstime);
 static void print_pool_blocked_message(bool);


### PR DESCRIPTION
- show_threadpool_idle_threads in mysqld.cc made static, its
  declaration in threadpool.h removed;
- get_connection_attrib declaration in sql_class.h removed;
- converted struct Worker_thread_context to a scope guard class
  Worker_thread_context, made method "save" its constructor and
  "restore" the destructor, added missing HAVE_PSI_THREAD_INTERFACE
  blocks;
- removed tp_post_kill_notification declaration from
  threadpool_unix.cc.

https://ps56.cd.percona.com/job/percona-server-5.6-param/13/