### PR TITLE
Post-push fix for upstream 5.7.13 merge: re-enable some tests for Val…

### DIFF
--- a/mysql-test/t/mysqlpump.test
+++ b/mysql-test/t/mysqlpump.test
@@ -2,9 +2,6 @@
 
 -- source include/not_embedded.inc
 --source include/big_test.inc
-# Disabled until https://bugs.mysql.com/bug.php?id=78224 is fixed.
--- source include/not_valgrind.inc
-
 --echo #
 --echo # WL#7755  mysqlpump: Extend mysqldump functionalities with mysqldump option.
 --echo #

--- a/mysql-test/t/mysqlpump_basic.test
+++ b/mysql-test/t/mysqlpump_basic.test
@@ -1,7 +1,5 @@
 
 -- source include/not_embedded.inc
-# Disabled until https://bugs.mysql.com/bug.php?id=78224 is fixed.
--- source include/not_valgrind.inc
 
 --echo #
 --echo # WL#7755  mysqlpump: Extend mysqldump functionalities

--- a/mysql-test/t/mysqlpump_charset.test
+++ b/mysql-test/t/mysqlpump_charset.test
@@ -1,7 +1,5 @@
 
 -- source include/not_embedded.inc
-# Disabled until https://bugs.mysql.com/bug.php?id=78224 is fixed.
--- source include/not_valgrind.inc
 
 --echo #
 --echo # WL#7755  mysqlpump: Extend mysqldump functionalities

--- a/mysql-test/t/mysqlpump_concurrency.test
+++ b/mysql-test/t/mysqlpump_concurrency.test
@@ -1,8 +1,6 @@
 # Created: 2015-05-15  Lalit Choudhary
 
 -- source include/not_embedded.inc
-# Disabled until https://bugs.mysql.com/bug.php?id=78224 is fixed.
--- source include/not_valgrind.inc
 
 --echo #
 --echo # WL#7755  mysqlpump: Extend mysqldump functionalities

--- a/mysql-test/t/mysqlpump_filters.test
+++ b/mysql-test/t/mysqlpump_filters.test
@@ -2,8 +2,6 @@
 
 -- source include/not_embedded.inc
 -- source include/big_test.inc
-# Disabled until https://bugs.mysql.com/bug.php?id=78224 is fixed.
--- source include/not_valgrind.inc
 
 --echo #
 --echo # WL#7755  mysqlpump: Extend mysqldump functionalities

--- a/mysql-test/t/mysqlpump_multi_thread.test
+++ b/mysql-test/t/mysqlpump_multi_thread.test
@@ -2,8 +2,6 @@
 
 -- source include/not_embedded.inc
 -- source include/big_test.inc
-# Disabled until https://bugs.mysql.com/bug.php?id=78224 is fixed.
--- source include/not_valgrind.inc
 
 --echo #
 --echo # WL#7755  mysqlpump: Extend mysqldump functionalities

--- a/mysql-test/t/mysqlpump_partial_bkp.test
+++ b/mysql-test/t/mysqlpump_partial_bkp.test
@@ -1,5 +1,4 @@
 --source include/not_embedded.inc
---source include/not_valgrind.inc
 
 --echo #
 --echo # Bug#26199978 - WRONG ERROR MESSAGE FOR PARTIAL BACKUPS WITH GTID_MODE = ON


### PR DESCRIPTION
…grind

MySQL 5.7.13 fixed https://bugs.mysql.com/bug.php?id=78224, which had
forced us to disable the affected tests for Valgrind. Re-enable them.

https://ps57.cd.percona.com/job/percona-server-5.7-param/77/