### PR TITLE
Implement PS-5743 (Code review fixes from 8.0 work: slow query log)

### DIFF
--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -3734,7 +3734,7 @@ public:
     PSI_THREAD_CALL(set_thread_start_time)(start_time.tv_sec);
 #endif
   }
-  void get_time(QUERY_START_TIME_INFO *time_info)
+  void get_time(QUERY_START_TIME_INFO *time_info) const
   {
     time_info->start_time= start_time;
     time_info->start_utime= start_utime;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -637,7 +637,6 @@ static Sys_var_int32 Sys_binlog_max_flush_queue_time(
        VALID_RANGE(0, 100000), DEFAULT(0), BLOCK_SIZE(1),
        NO_MUTEX_GUARD, NOT_IN_BINLOG);
 
-
 static bool check_has_super(sys_var *self, THD *thd, set_var *var)
 {
   DBUG_ASSERT(self->scope() != sys_var::GLOBAL);// don't abuse check_has_super()
@@ -4242,7 +4241,7 @@ static Sys_var_mybool Sys_slow_query_log(
        DEFAULT(FALSE), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
        ON_UPDATE(fix_log_state));
 
-const char *log_slow_filter_name[]= { "qc_miss", "full_scan", "full_join",
+static const char *log_slow_filter_name[]= { "qc_miss", "full_scan", "full_join",
                                       "tmp_table", "tmp_table_on_disk", "filesort", "filesort_on_disk", 0};
 static Sys_var_set Sys_log_slow_filter(
        "log_slow_filter",
@@ -4273,7 +4272,7 @@ static Sys_var_double sys_slow_query_log_always_write_time(
        VALID_RANGE(0, LONG_TIMEOUT), DEFAULT(10),
        NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
        ON_UPDATE(update_slow_query_log_always_write_time));
-const char* log_slow_verbosity_name[] = { 
+static const char* log_slow_verbosity_name[] = {
   "microtime", "query_plan", "innodb", 
   "profiling", "profiling_use_getrusage", 
   "minimal", "standard", "full", 0
@@ -4291,12 +4290,12 @@ static ulonglong update_log_slow_verbosity_replace(ulonglong value, ulonglong wh
 static void update_log_slow_verbosity(ulonglong* value_ptr)
 {
   ulonglong &value    = *value_ptr;
-  ulonglong microtime= ULL(1) << SLOG_V_MICROTIME;
-  ulonglong query_plan= ULL(1) << SLOG_V_QUERY_PLAN;
-  ulonglong innodb= ULL(1) << SLOG_V_INNODB;
-  ulonglong minimal= ULL(1) << SLOG_V_MINIMAL;
-  ulonglong standard= ULL(1) << SLOG_V_STANDARD;
-  ulonglong full= ULL(1) << SLOG_V_FULL;
+  static const ulonglong microtime= ULL(1) << SLOG_V_MICROTIME;
+  static const ulonglong query_plan= ULL(1) << SLOG_V_QUERY_PLAN;
+  static const ulonglong innodb= ULL(1) << SLOG_V_INNODB;
+  static const ulonglong minimal= ULL(1) << SLOG_V_MINIMAL;
+  static const ulonglong standard= ULL(1) << SLOG_V_STANDARD;
+  static const ulonglong full= ULL(1) << SLOG_V_FULL;
   value= update_log_slow_verbosity_replace(value,minimal,microtime);
   value= update_log_slow_verbosity_replace(value,standard,microtime | query_plan);
   value= update_log_slow_verbosity_replace(value,full,microtime | query_plan | innodb);
@@ -4357,7 +4356,7 @@ static Sys_var_mybool Sys_slow_query_log_timestamp_always(
        "Timestamp is printed for all records of the slow log even if they are same time.",
        GLOBAL_VAR(opt_slow_query_log_timestamp_always), CMD_LINE(OPT_ARG),
        DEFAULT(FALSE));
-const char *slow_query_log_use_global_control_name[]= { "log_slow_filter", "log_slow_rate_limit", "log_slow_verbosity", "long_query_time", "min_examined_row_limit", "all", 0};
+static const char *slow_query_log_use_global_control_name[]= { "log_slow_filter", "log_slow_rate_limit", "log_slow_verbosity", "long_query_time", "min_examined_row_limit", "all", 0};
 static bool update_slow_query_log_use_global_control(sys_var */*self*/, THD */*thd*/,
                                                enum_var_type /*type*/)
 {
@@ -4381,7 +4380,7 @@ static Sys_var_set Sys_slow_query_log_use_global_control(
        slow_query_log_use_global_control_name, DEFAULT(0),
         NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),
        ON_UPDATE(update_slow_query_log_use_global_control));
-const char *slow_query_log_timestamp_precision_name[]= { "second", "microsecond", 0 };
+static const char *slow_query_log_timestamp_precision_name[]= { "second", "microsecond", 0 };
 static Sys_var_enum Sys_slow_query_log_timestamp_precision(
        "slow_query_log_timestamp_precision",
        "Select the timestamp precision for use in the slow query log.  "
@@ -4389,7 +4388,7 @@ static Sys_var_enum Sys_slow_query_log_timestamp_precision(
        GLOBAL_VAR(opt_slow_query_log_timestamp_precision), CMD_LINE(REQUIRED_ARG),
        slow_query_log_timestamp_precision_name, DEFAULT(SLOG_SECOND));
 
-const char* slow_query_log_rate_name[]= {"session", "query", 0};
+static const char* slow_query_log_rate_name[]= {"session", "query", 0};
 static Sys_var_enum Sys_slow_query_log_rate_type(
        "log_slow_rate_type",
        "Choose the log_slow_rate_limit behavior: session or query. "


### PR DESCRIPTION
- Make THD::get_time method const;
- make log_slow_verbosity_name,
  slow_query_log_timestamp_precision_name, slow_query_log_rate_name,
  log_slow_filter_name, & slow_query_log_use_global_control_name in
  sys_vars.cc static;
- make constants in sys_vars.cc:update_low_slow_verbosity const
  static.

https://ps56.cd.percona.com/job/percona-server-5.6-param/14/