### PR TITLE
PS-5736 - Make innodb_temp_tablespace_encrypt truly dynamic

### DIFF
--- a/mysql-test/suite/innodb/include/temp_table_encrypt.inc
+++ b/mysql-test/suite/innodb/include/temp_table_encrypt.inc
@@ -88,19 +88,42 @@ INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 --let $grep_output= boolean
 --source include/grep_pattern.inc
 
-CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
-INSERT INTO t05 VALUES (1), (2), (3);
+DROP TABLE t04;
 
---error ER_ILLEGAL_HA_CREATE_OPTION
-CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+CREATE TEMPORARY TABLE t05 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+INSERT INTO t05 VALUES ('Quisque malesuada placerat nisl');
+
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let $grep_pattern= Quisque malesuada placerat nisl
+--let $grep_file= `SELECT CONCAT(@@tmpdir, '/', NAME, '.ibd') FROM INFORMATION_SCHEMA.INNODB_TEMP_TABLE_INFO WHERE NAME LIKE '#%';`
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+DROP TABLE t05;
+
+CREATE TEMPORARY TABLE t06 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+INSERT INTO t06 VALUES ('Sed in libero ut nibh placerat accumsan');
+
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let $grep_pattern= Sed in libero ut nibh placerat accumsan
+--let $grep_file= `SELECT CONCAT(@@tmpdir, '/', NAME, '.ibd') FROM INFORMATION_SCHEMA.INNODB_TEMP_TABLE_INFO WHERE NAME LIKE '#%';`
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+DROP TABLE t06;
 
 # test that we can turn encryption OFF and ON
 
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
 
-# Setting OFF after encryption doesn't make it decrypted. So temp tablespace
-# is still encrypted.
+# Setting OFF after encryption allows to create unencrypted tables.
+--error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
 INSERT INTO t07 VALUES (1), (2), (3);
 
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
@@ -181,3 +204,60 @@ INSERT INTO t1 VALUES (3);
 SET big_tables=1;
 SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
 DROP TABLE t1;
+
+#
+# PS-5736: Make innodb_temp_tablespace_encrypt truly dynamic
+#
+
+--echo # innodb temp table encrypt is ON:
+--error ER_ILLEGAL_HA_CREATE_OPTION
+CREATE TEMPORARY TABLE t1 (a INT);
+
+CREATE TEMPORARY TABLE tmp1 (a TEXT) ENCRYPTION='y';
+INSERT INTO tmp1 VALUES ('Maecenas condimentum leo eu lorem aliquam malesuada');
+CREATE TEMPORARY TABLE tmp2 (a TEXT) ENCRYPTION='y';
+
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let $grep_pattern= Maecenas condimentum leo eu lorem aliquam malesuada
+--let $grep_file= $MYSQL_DATA_DIR/ibtmp1
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+# file-per-table temporary tables do not obey 'innodb_temp_tablespace_encrypt'
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='n';
+DROP TABLE t1;
+
+SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+
+--error ER_ILLEGAL_HA_CREATE_OPTION
+CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='y';
+
+INSERT INTO tmp2 VALUES ('Nam vestibulum mauris massa');
+
+CREATE TEMPORARY TABLE tmp3 (a TEXT);
+INSERT INTO tmp3 VALUES ('Sed sodales ligula sed enim condimentum');
+
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let $grep_pattern= Nam vestibulum mauris massa
+--let $grep_file= $MYSQL_DATA_DIR/ibtmp1
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+--let $grep_pattern= Sed sodales ligula sed enim condimentum
+--let $grep_file= $MYSQL_DATA_DIR/ibtmp1
+--let $grep_output= boolean
+--source include/grep_pattern.inc
+
+# file-per-table temporary tables do not obey 'innodb_temp_tablespace_encrypt'
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+DROP TABLE t1;
+
+SET GLOBAL innodb_temp_tablespace_encrypt = ON;

--- a/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
@@ -17,12 +17,19 @@ CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 Pattern not found.
-CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
-INSERT INTO t05 VALUES (1), (2), (3);
-CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
-ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+DROP TABLE t04;
+CREATE TEMPORARY TABLE t05 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+INSERT INTO t05 VALUES ('Quisque malesuada placerat nisl');
+Pattern not found.
+DROP TABLE t05;
+CREATE TEMPORARY TABLE t06 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+INSERT INTO t06 VALUES ('Sed in libero ut nibh placerat accumsan');
+Pattern found.
+DROP TABLE t06;
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
 CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
 INSERT INTO t07 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TABLE t10 (a INT AUTO_INCREMENT PRIMARY KEY, b INT);
@@ -66,3 +73,27 @@ SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
 a
 11061
 DROP TABLE t1;
+# innodb temp table encrypt is ON:
+CREATE TEMPORARY TABLE t1 (a INT);
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+CREATE TEMPORARY TABLE tmp1 (a TEXT) ENCRYPTION='y';
+INSERT INTO tmp1 VALUES ('Maecenas condimentum leo eu lorem aliquam malesuada');
+CREATE TEMPORARY TABLE tmp2 (a TEXT) ENCRYPTION='y';
+Pattern not found.
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+INSERT INTO tmp2 VALUES ('Nam vestibulum mauris massa');
+CREATE TEMPORARY TABLE tmp3 (a TEXT);
+INSERT INTO tmp3 VALUES ('Sed sodales ligula sed enim condimentum');
+Pattern found.
+Pattern found.
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = ON;

--- a/plugin/keyring_vault/tests/mtr/temp_table_encrypt_keyring_vault.result
+++ b/plugin/keyring_vault/tests/mtr/temp_table_encrypt_keyring_vault.result
@@ -20,12 +20,19 @@ CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 Pattern not found.
-CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
-INSERT INTO t05 VALUES (1), (2), (3);
-CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
-ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+DROP TABLE t04;
+CREATE TEMPORARY TABLE t05 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+INSERT INTO t05 VALUES ('Quisque malesuada placerat nisl');
+Pattern not found.
+DROP TABLE t05;
+CREATE TEMPORARY TABLE t06 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+INSERT INTO t06 VALUES ('Sed in libero ut nibh placerat accumsan');
+Pattern found.
+DROP TABLE t06;
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
 CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
 INSERT INTO t07 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TABLE t10 (a INT AUTO_INCREMENT PRIMARY KEY, b INT);
@@ -69,3 +76,27 @@ SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
 a
 11061
 DROP TABLE t1;
+# innodb temp table encrypt is ON:
+CREATE TEMPORARY TABLE t1 (a INT);
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+CREATE TEMPORARY TABLE tmp1 (a TEXT) ENCRYPTION='y';
+INSERT INTO tmp1 VALUES ('Maecenas condimentum leo eu lorem aliquam malesuada');
+CREATE TEMPORARY TABLE tmp2 (a TEXT) ENCRYPTION='y';
+Pattern not found.
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+INSERT INTO tmp2 VALUES ('Nam vestibulum mauris massa');
+CREATE TEMPORARY TABLE tmp3 (a TEXT);
+INSERT INTO tmp3 VALUES ('Sed sodales ligula sed enim condimentum');
+Pattern found.
+Pattern found.
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = ON;

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -506,8 +506,7 @@ dict_build_tablespace_for_table(
 
 		/* Determine the tablespace flags. */
 		bool	is_temp = dict_table_is_temporary(table);
-		bool	is_encrypted = (srv_tmp_tablespace_encrypt && is_temp)
-					|| dict_table_is_encrypted(table);
+		bool	is_encrypted = dict_table_is_encrypted(table);
 		bool	has_data_dir = DICT_TF_HAS_DATA_DIR(table->flags);
 		ulint	fsp_flags = dict_tf_to_fsp_flags(table->flags,
 							 is_temp,

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1854,11 +1854,13 @@ fil_names_clear(
 
 /** Enable encryption of temporary tablespace
 @param[in,out]	space	tablespace object
+@param[in]	enable	true to enable encryption, false to disable
 @return DB_SUCCESS on success, DB_ERROR on failure */
 MY_NODISCARD
 dberr_t
 fil_temp_update_encryption(
-	fil_space_t*	space);
+	fil_space_t*	space,
+	bool		enable);
 
 #if !defined(NO_FALLOCATE) && defined(UNIV_LINUX)
 /**

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2774,29 +2774,15 @@ srv_temp_encryption_update(bool enable)
 
 	ut_ad(fsp_is_system_temporary(space->id));
 
-	if (enable) {
-
-		if (is_encrypted) {
-			/* Encryption already enabled */
-			return(DB_SUCCESS);
-		} else {
-			/* Enable encryption now */
-			dberr_t err = fil_temp_update_encryption(space);
-			if (err == DB_SUCCESS) {
-				srv_tmp_space.set_flags(space->flags);
-			}
-			return(err);
+	if (enable != is_encrypted) {
+		/* Toggle encryption */
+		dberr_t err = fil_temp_update_encryption(space, enable);
+		if (err == DB_SUCCESS) {
+			srv_tmp_space.set_flags(space->flags);
 		}
-
-	} else {
-		if (!is_encrypted) {
-			/* Encryption already disabled */
-			return(DB_SUCCESS);
-		} else {
-			// TODO: Disabling encryption is not allowed yet
-			return(DB_SUCCESS);
-		}
+		return (err);
 	}
+	return (DB_SUCCESS);
 }
 
 /*********************************************************************//**


### PR DESCRIPTION
PS-5734 - Disabling temp tablespace encryption at runtime does
not create un-encrypted file-per-table temp tables

Problem:

  innodb_temp_tablespace_encrypt behavior is confusing in two ways:

  1. User can turn it ON dynamically, but cannot turn it off
  2. File-per-table temporary tables obey the setting for system
     temporary tablespace

Fix:

  Make innodb_temp_tablespace_encrypt dynamic. It means that:

  1. User can turn it ON and OFF any time.
  2. Once turned ON, it generates the encryption key for system
     temporary tablespace and starts encrypting all pages written into
     system temporary tablespace.
  3. Once turned OFF, all pages are written to system temporary
     tablespace without encryption. Tablespace keys are not erased so
     that already encrypted pages can be decrypted.
  4. Changing innodb_temp_tablespace_encrypt affects CREATE TEMPORARY
     TABLE:
     - when ON: CREATE TEMPORARY TABLE t ENCRYPTION='n' fails
     - when ON: CREATE TEMPORARY TABLE t fails
     - when OFF: CREATE TEMPORARY TABLE t ENCRYPTION='n' fails
  5. Changing innodb_temp_tablespace_encrypt does not affect
     - CREATE TEMPORARY TABLE t ROW_FORMAT=COMPRESSED
     - CREATE TEMPORARY TABLE t KEY_BLOCK_SIZE=n
     File-per-table temporary tables will be encrypted when
     ENCRYPTION='y' is specified.