### PR TITLE
PS-5736 - Make innodb_temp_tablespace_encrypt truly dynamic

### DIFF
--- a/mysql-test/suite/innodb/include/temp_table_encrypt.inc
+++ b/mysql-test/suite/innodb/include/temp_table_encrypt.inc
@@ -17,11 +17,10 @@ INSERT INTO t01 VALUES ('Lorem ipsum dolor sit amet, consectetur adipiscing elit
 --source include/wait_condition.inc
 
 # make sure ibtmp1 is not encrypted
-
---let $grep_pattern= Lorem ipsum dolor sit amet
---let $grep_file= $MYSQL_DATA_DIR/ibtmp1
---let $grep_output= boolean
---source include/grep_pattern.inc
+--let SEARCH_PATTERN= Lorem ipsum dolor sit amet
+--let SEARCH_FILE= $MYSQL_DATA_DIR/ibtmp1
+--let ABORT_ON= NOT_FOUND
+--source include/search_pattern_in_file.inc
 
 
 # this table created in separate file per table tablespace, make sure it not
@@ -36,21 +35,14 @@ INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 --let $t04_fn= `SELECT CONCAT(@@tmpdir, '/', NAME, '.ibd') FROM INFORMATION_SCHEMA.INNODB_TEMP_TABLE_INFO WHERE NAME LIKE '#%';`
 
 # make sure t04 is not encrypted
-
---let $grep_pattern= Praesent tristique eros a tempus fringilla
---let $grep_file= $t04_fn
---let $grep_output= boolean
---source include/grep_pattern.inc
+--let SEARCH_PATTERN= Praesent tristique eros a tempus fringilla
+--let SEARCH_FILE= $t04_fn
+--let ABORT_ON= NOT_FOUND
+--source include/search_pattern_in_file.inc
 
 DROP TABLE t04;
 
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
-
---let $innodb_master_loops= `SELECT SUM(VARIABLE_VALUE) FROM performance_schema.global_status WHERE VARIABLE_NAME LIKE 'innodb_master%loops'`
-
-# wait for couple of master thread turnarounds
---let $wait_condition= SELECT SUM(VARIABLE_VALUE) > $innodb_master_loops + 2 FROM performance_schema.global_status WHERE VARIABLE_NAME LIKE 'innodb_master%loops'
---source include/wait_condition.inc
 
 CREATE TEMPORARY TABLE t02 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 
@@ -62,11 +54,10 @@ INSERT INTO t03 VALUES ('Curabitur laoreet, velit non interdum venenatis');
 --source include/wait_condition.inc
 
 # make sure ibtmp1 is encrypted now
-
---let $grep_pattern= Curabitur laoreet, velit non interdum venenatis
---let $grep_file= $MYSQL_DATA_DIR/ibtmp1
---let $grep_output= boolean
---source include/grep_pattern.inc
+--let SEARCH_PATTERN= Curabitur laoreet, velit non interdum venenatis
+--let SEARCH_FILE= $MYSQL_DATA_DIR/ibtmp1
+--let ABORT_ON= FOUND
+--source include/search_pattern_in_file.inc
 
 # this table created in separate file per table tablespace, make sure it is
 # encrypted as well
@@ -82,25 +73,47 @@ INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
 --let $t04_fn= `SELECT CONCAT(@@tmpdir, '/', NAME, '.ibd') FROM INFORMATION_SCHEMA.INNODB_TEMP_TABLE_INFO WHERE NAME LIKE '#%';`
 
 # make sure t04 is encrypted
+--let SEARCH_PATTERN= Praesent tristique eros a tempus fringilla
+--let SEARCH_FILE= $t04_fn
+--let ABORT_ON= FOUND
+--source include/search_pattern_in_file.inc
 
---let $grep_pattern= Praesent tristique eros a tempus fringilla
---let $grep_file= $t04_fn
---let $grep_output= boolean
---source include/grep_pattern.inc
+DROP TABLE t04;
 
-CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
-INSERT INTO t05 VALUES (1), (2), (3);
+CREATE TEMPORARY TABLE t05 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+INSERT INTO t05 VALUES ('Quisque malesuada placerat nisl');
 
---error ER_ILLEGAL_HA_CREATE_OPTION
-CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let SEARCH_PATTERN= Quisque malesuada placerat nisl
+--let SEARCH_FILE= `SELECT CONCAT(@@tmpdir, '/', NAME, '.ibd') FROM INFORMATION_SCHEMA.INNODB_TEMP_TABLE_INFO WHERE NAME LIKE '#%';`
+--let ABORT_ON= FOUND
+--source include/search_pattern_in_file.inc
+
+DROP TABLE t05;
+
+CREATE TEMPORARY TABLE t06 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+INSERT INTO t06 VALUES ('Sed in libero ut nibh placerat accumsan');
+
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let SEARCH_PATTERN= Sed in libero ut nibh placerat accumsan
+--let SEARCH_FILE= `SELECT CONCAT(@@tmpdir, '/', NAME, '.ibd') FROM INFORMATION_SCHEMA.INNODB_TEMP_TABLE_INFO WHERE NAME LIKE '#%';`
+--let ABORT_ON= NOT_FOUND
+--source include/search_pattern_in_file.inc
+
+DROP TABLE t06;
 
 # test that we can turn encryption OFF and ON
 
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
 
-# Setting OFF after encryption doesn't make it decrypted. So temp tablespace
-# is still encrypted.
+# Setting OFF after encryption allows to create unencrypted tables.
+--error ER_ILLEGAL_HA_CREATE_OPTION
 CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
 INSERT INTO t07 VALUES (1), (2), (3);
 
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
@@ -181,3 +194,60 @@ INSERT INTO t1 VALUES (3);
 SET big_tables=1;
 SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
 DROP TABLE t1;
+
+#
+# PS-5736: Make innodb_temp_tablespace_encrypt truly dynamic
+#
+
+--echo # innodb temp table encrypt is ON:
+--error ER_ILLEGAL_HA_CREATE_OPTION
+CREATE TEMPORARY TABLE t1 (a INT);
+
+CREATE TEMPORARY TABLE tmp1 (a TEXT) ENCRYPTION='y';
+INSERT INTO tmp1 VALUES ('Maecenas condimentum leo eu lorem aliquam malesuada');
+CREATE TEMPORARY TABLE tmp2 (a TEXT) ENCRYPTION='y';
+
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let SEARCH_PATTERN= Maecenas condimentum leo eu lorem aliquam malesuada
+--let SEARCH_FILE= $MYSQL_DATA_DIR/ibtmp1
+--let ABORT_ON= FOUND
+--source include/search_pattern_in_file.inc
+
+# file-per-table temporary tables do not obey 'innodb_temp_tablespace_encrypt'
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='n';
+DROP TABLE t1;
+
+SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+
+--error ER_ILLEGAL_HA_CREATE_OPTION
+CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='y';
+
+INSERT INTO tmp2 VALUES ('Nam vestibulum mauris massa');
+
+CREATE TEMPORARY TABLE tmp3 (a TEXT);
+INSERT INTO tmp3 VALUES ('Sed sodales ligula sed enim condimentum');
+
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+--let SEARCH_PATTERN= Nam vestibulum mauris massa
+--let SEARCH_FILE= $MYSQL_DATA_DIR/ibtmp1
+--let ABORT_ON= NOT_FOUND
+--source include/search_pattern_in_file.inc
+
+--let SEARCH_PATTERN= Sed sodales ligula sed enim condimentum
+--let SEARCH_FILE= $MYSQL_DATA_DIR/ibtmp1
+--let ABORT_ON= NOT_FOUND
+--source include/search_pattern_in_file.inc
+
+# file-per-table temporary tables do not obey 'innodb_temp_tablespace_encrypt'
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+DROP TABLE t1;
+
+SET GLOBAL innodb_temp_tablespace_encrypt = ON;

--- a/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
+++ b/mysql-test/suite/innodb/r/temp_table_encrypt_keyring_file.result
@@ -2,27 +2,28 @@ call mtr.add_suppression("\\[Error\\] InnoDB: Encryption can't find master key, 
 # restart:<hidden args>
 CREATE TEMPORARY TABLE t01 (a TEXT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES ('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
-Pattern found.
 CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
-Pattern found.
 DROP TABLE t04;
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TEMPORARY TABLE t02 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 CREATE TEMPORARY TABLE t03 (a TEXT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t03 VALUES ('Curabitur laoreet, velit non interdum venenatis');
-Pattern not found.
 SET GLOBAL innodb_encrypt_tables=ON;
 CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
-Pattern not found.
-CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
-INSERT INTO t05 VALUES (1), (2), (3);
-CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
-ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+DROP TABLE t04;
+CREATE TEMPORARY TABLE t05 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+INSERT INTO t05 VALUES ('Quisque malesuada placerat nisl');
+DROP TABLE t05;
+CREATE TEMPORARY TABLE t06 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+INSERT INTO t06 VALUES ('Sed in libero ut nibh placerat accumsan');
+DROP TABLE t06;
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
 CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
 INSERT INTO t07 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TABLE t10 (a INT AUTO_INCREMENT PRIMARY KEY, b INT);
@@ -66,3 +67,24 @@ SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
 a
 11061
 DROP TABLE t1;
+# innodb temp table encrypt is ON:
+CREATE TEMPORARY TABLE t1 (a INT);
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+CREATE TEMPORARY TABLE tmp1 (a TEXT) ENCRYPTION='y';
+INSERT INTO tmp1 VALUES ('Maecenas condimentum leo eu lorem aliquam malesuada');
+CREATE TEMPORARY TABLE tmp2 (a TEXT) ENCRYPTION='y';
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+INSERT INTO tmp2 VALUES ('Nam vestibulum mauris massa');
+CREATE TEMPORARY TABLE tmp3 (a TEXT);
+INSERT INTO tmp3 VALUES ('Sed sodales ligula sed enim condimentum');
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = ON;

--- a/plugin/keyring_vault/tests/mtr/temp_table_encrypt_keyring_vault.result
+++ b/plugin/keyring_vault/tests/mtr/temp_table_encrypt_keyring_vault.result
@@ -5,27 +5,28 @@ call mtr.add_suppression("\\[Error\\] InnoDB: Encryption can't find master key, 
 # restart:<hidden args>
 CREATE TEMPORARY TABLE t01 (a TEXT) ENGINE=InnoDB;
 INSERT INTO t01 VALUES ('Lorem ipsum dolor sit amet, consectetur adipiscing elit');
-Pattern found.
 CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
-Pattern found.
 DROP TABLE t04;
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TEMPORARY TABLE t02 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
 CREATE TEMPORARY TABLE t03 (a TEXT) ENGINE=InnoDB ENCRYPTION='Y';
 INSERT INTO t03 VALUES ('Curabitur laoreet, velit non interdum venenatis');
-Pattern not found.
 SET GLOBAL innodb_encrypt_tables=ON;
 CREATE TEMPORARY TABLE t04 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED;
 SET GLOBAL innodb_encrypt_tables=OFF;
 INSERT INTO t04 VALUES ('Praesent tristique eros a tempus fringilla');
-Pattern not found.
-CREATE TEMPORARY TABLE t05 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
-INSERT INTO t05 VALUES (1), (2), (3);
-CREATE TEMPORARY TABLE t06 (a INT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
-ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+DROP TABLE t04;
+CREATE TEMPORARY TABLE t05 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+INSERT INTO t05 VALUES ('Quisque malesuada placerat nisl');
+DROP TABLE t05;
+CREATE TEMPORARY TABLE t06 (a TEXT) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+INSERT INTO t06 VALUES ('Sed in libero ut nibh placerat accumsan');
+DROP TABLE t06;
 SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
 CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB ENCRYPTION='Y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+CREATE TEMPORARY TABLE t07 (a INT) ENGINE=InnoDB;
 INSERT INTO t07 VALUES (1), (2), (3);
 SET GLOBAL innodb_temp_tablespace_encrypt = ON;
 CREATE TABLE t10 (a INT AUTO_INCREMENT PRIMARY KEY, b INT);
@@ -69,3 +70,24 @@ SELECT * FROM t1 WHERE a IN(SELECT MAX(a) FROM t1);
 a
 11061
 DROP TABLE t1;
+# innodb temp table encrypt is ON:
+CREATE TEMPORARY TABLE t1 (a INT);
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` can contain only an ENCRYPTED tables.
+CREATE TEMPORARY TABLE tmp1 (a TEXT) ENCRYPTION='y';
+INSERT INTO tmp1 VALUES ('Maecenas condimentum leo eu lorem aliquam malesuada');
+CREATE TEMPORARY TABLE tmp2 (a TEXT) ENCRYPTION='y';
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) KEY_BLOCK_SIZE=8 ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = OFF;
+CREATE TEMPORARY TABLE t1 (a INT) ENCRYPTION='y';
+ERROR HY000: InnoDB: Tablespace `innodb_temporary` cannot contain an ENCRYPTED table.
+INSERT INTO tmp2 VALUES ('Nam vestibulum mauris massa');
+CREATE TEMPORARY TABLE tmp3 (a TEXT);
+INSERT INTO tmp3 VALUES ('Sed sodales ligula sed enim condimentum');
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='y';
+DROP TABLE t1;
+CREATE TEMPORARY TABLE t1 (a INT) ROW_FORMAT=COMPRESSED ENCRYPTION='n';
+DROP TABLE t1;
+SET GLOBAL innodb_temp_tablespace_encrypt = ON;

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -506,8 +506,7 @@ dict_build_tablespace_for_table(
 
 		/* Determine the tablespace flags. */
 		bool	is_temp = dict_table_is_temporary(table);
-		bool	is_encrypted = (srv_tmp_tablespace_encrypt && is_temp)
-					|| dict_table_is_encrypted(table);
+		bool	is_encrypted = dict_table_is_encrypted(table);
 		bool	has_data_dir = DICT_TF_HAS_DATA_DIR(table->flags);
 		ulint	fsp_flags = dict_tf_to_fsp_flags(table->flags,
 							 is_temp,

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -7948,11 +7948,20 @@ fil_set_encryption(
 
 /** Enable encryption of temporary tablespace
 @param[in,out]	space	tablespace object
+@param[in]	enable	true to enable encryption, false to disable
 @return DB_SUCCESS on success, DB_ERROR on failure */
 dberr_t
 fil_temp_update_encryption(
-	fil_space_t*	space)
+	fil_space_t*	space,
+	bool		enable)
 {
+	if (!enable || FSP_FLAGS_GET_ENCRYPTION(space->flags)) {
+		/* Do nothing when asked to disable encryption. Because
+		existing tables in the temporary tablespace may be
+		encrypted we need to keep existing keys */
+
+		return(DB_SUCCESS);
+	}
 	/* Make sure the keyring is loaded. */
 	if (!Encryption::check_keyring()) {
 		ib::error() << "Can't set temporary tablespace"

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -1854,11 +1854,13 @@ fil_names_clear(
 
 /** Enable encryption of temporary tablespace
 @param[in,out]	space	tablespace object
+@param[in]	enable	true to enable encryption, false to disable
 @return DB_SUCCESS on success, DB_ERROR on failure */
 MY_NODISCARD
 dberr_t
 fil_temp_update_encryption(
-	fil_space_t*	space);
+	fil_space_t*	space,
+	bool		enable);
 
 #if !defined(NO_FALLOCATE) && defined(UNIV_LINUX)
 /**

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2774,29 +2774,15 @@ srv_temp_encryption_update(bool enable)
 
 	ut_ad(fsp_is_system_temporary(space->id));
 
-	if (enable) {
-
-		if (is_encrypted) {
-			/* Encryption already enabled */
-			return(DB_SUCCESS);
-		} else {
-			/* Enable encryption now */
-			dberr_t err = fil_temp_update_encryption(space);
-			if (err == DB_SUCCESS) {
-				srv_tmp_space.set_flags(space->flags);
-			}
-			return(err);
+	if (enable != is_encrypted) {
+		/* Toggle encryption */
+		dberr_t err = fil_temp_update_encryption(space, enable);
+		if (err == DB_SUCCESS) {
+			srv_tmp_space.set_flags(space->flags);
 		}
-
-	} else {
-		if (!is_encrypted) {
-			/* Encryption already disabled */
-			return(DB_SUCCESS);
-		} else {
-			// TODO: Disabling encryption is not allowed yet
-			return(DB_SUCCESS);
-		}
+		return (err);
 	}
+	return (DB_SUCCESS);
 }
 
 /*********************************************************************//**


### PR DESCRIPTION
PS-5734 - Disabling temp tablespace encryption at runtime does
not create un-encrypted file-per-table temp tables

Problem:

  innodb_temp_tablespace_encrypt behavior is confusing in two ways:

  1. User can turn it ON dynamically, but cannot turn it off
  2. File-per-table temporary tables obey the setting for system
     temporary tablespace

Fix:

  Make innodb_temp_tablespace_encrypt dynamic. It means that:

  1. User can turn it ON and OFF any time.
  2. Once turned ON, it generates the encryption key for system
     temporary tablespace and starts encrypting all pages written into
     system temporary tablespace.
  3. Once turned OFF, all pages are written to system temporary
     tablespace without encryption. Tablespace keys are not erased so
     that already encrypted pages can be decrypted.
  4. Changing innodb_temp_tablespace_encrypt affects CREATE TEMPORARY
     TABLE:
     - when ON: CREATE TEMPORARY TABLE t ENCRYPTION='n' fails
     - when ON: CREATE TEMPORARY TABLE t fails
     - when OFF: CREATE TEMPORARY TABLE t ENCRYPTION='y' fails
  5. Changing innodb_temp_tablespace_encrypt does not affect
     - CREATE TEMPORARY TABLE t ROW_FORMAT=COMPRESSED
     - CREATE TEMPORARY TABLE t KEY_BLOCK_SIZE=n
     File-per-table temporary tables will be encrypted when
     ENCRYPTION='y' is specified.