### PR TITLE
PS-5744 : innodb.innodb_wl6501_crash_2 test fails

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -2472,7 +2472,9 @@ fil_recreate_table(
 	/* Step-1: Scan for active indexes from REDO logs and drop
 	all the indexes using low level function that take root_page_no
 	and space-id. */
+	mutex_enter(&dict_sys->mutex);
 	truncate.drop_indexes(space_id);
+	mutex_exit(&dict_sys->mutex);
 
 	/* Step-2: Scan for active indexes and re-create them. */
 	err = truncate.create_indexes(


### PR DESCRIPTION
Problem:
--------
The tests fails with assert that says dict_sys mutex
is not acquired.

After crash during truncate, next startup, there are
truncate actions to recreate indexes.

This path doesn't acquire dict_sys mutex.

Fix:
----
Add dict_sys mutex acquisition for drop of indexes as
part of index recreation at startup (after a truncate crash).

Since it is single threaded at this stage, extra mutex acquisition
doesn't have any impact.