### PR TITLE
Fix PS-5746 (Code review fixes from 8.0: userstat)

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2563,28 +2563,6 @@ void THD::shutdown_active_vio()
 }
 #endif
 
-char *THD::get_client_host_port(THD *client)
-{
-  Security_context *client_sctx= client->security_ctx;
-  char *client_host= NULL;
-
-  if (client->peer_port && (client_sctx->get_host()->length()
-                            || client_sctx->get_ip()->length()) &&
-      security_ctx->host_or_ip[0])
-  {
-    if ((client_host= (char *) this->alloc(LIST_PROCESS_HOST_LEN+1)))
-      my_snprintf((char *) client_host, LIST_PROCESS_HOST_LEN,
-                  "%s:%u", client_sctx->host_or_ip, client->peer_port);
-  }
-  else
-    client_host= this->strdup(client_sctx->host_or_ip[0] ?
-                              client_sctx->host_or_ip :
-                              client_sctx->get_host()->length() ?
-                              client_sctx->get_host()->ptr() : "");
-
-  return client_host;
-}
-
 const char *get_client_host(THD *client)
 {
   return client->security_ctx->host_or_ip[0] ?

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4221,15 +4221,6 @@ public:
   }
   thd_scheduler event_scheduler;
 
-  /* Returns string as 'IP:port' for the client-side
-     of the connnection represented
-     by 'client' as displayed by SHOW PROCESSLIST.
-     Allocates memory from the heap of
-     this THD and that is not reclaimed
-     immediately, so use sparingly. May return NULL.
-  */
-  char *get_client_host_port(THD *client);
-
 public:
   inline Internal_error_handler *get_internal_handler()
   { return m_internal_handler; }

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -133,54 +133,50 @@ end:
 
 }
 
-extern "C" uchar *get_key_user_stats(USER_STATS *user_stats, size_t *length,
-                         my_bool not_used MY_ATTRIBUTE((unused)))
+static uchar *get_key_user_stats(USER_STATS *user_stats, size_t *length,
+                                 my_bool not_used MY_ATTRIBUTE((unused)))
 {
   *length= user_stats->user_len;
   return (uchar*) user_stats->user;
 }
 
-extern "C" uchar *get_key_thread_stats(THREAD_STATS *thread_stats, size_t *length,
-                         my_bool not_used MY_ATTRIBUTE((unused)))
+/* Lookup function for my_hash tables with THREAD_STATS entries */
+static uchar *get_key_thread_stats(THREAD_STATS *thread_stats,
+                                   size_t *length,
+                                   my_bool not_used MY_ATTRIBUTE((unused)))
 {
   *length= sizeof(my_thread_id);
   return (uchar *) &(thread_stats->id);
 }
 
-void free_user_stats(USER_STATS* user_stats)
+static void free_user_stats(USER_STATS* user_stats)
 {
   my_free((char *) user_stats);
 }
 
-void free_thread_stats(THREAD_STATS* thread_stats)
+static void free_thread_stats(THREAD_STATS* thread_stats)
 {
   my_free((char *) thread_stats);
 }
 
-void init_user_stats(USER_STATS *user_stats,
-                     const char *user,
-                     const char *priv_user,
-                     uint total_connections,
-                     uint total_ssl_connections,
-                     uint concurrent_connections,
-                     time_t connected_time,
-                     double busy_time,
-                     double cpu_time,
-                     ulonglong bytes_received,
-                     ulonglong bytes_sent,
-                     ulonglong binlog_bytes_written,
-                     ha_rows rows_fetched,
-                     ha_rows rows_updated,
-                     ha_rows rows_read,
-                     ulonglong select_commands,
-                     ulonglong update_commands,
-                     ulonglong other_commands,
-                     ulonglong commit_trans,
-                     ulonglong rollback_trans,
-                     ulonglong denied_connections,
-                     ulonglong lost_connections,
-                     ulonglong access_denied_errors,
-                     ulonglong empty_queries)
+/* Intialize an instance of USER_STATS */
+static void init_user_stats(USER_STATS *user_stats, const char *user,
+                            const char *priv_user, uint total_connections,
+                            uint total_ssl_connections,
+                            uint concurrent_connections,
+                            time_t connected_time, double busy_time,
+                            double cpu_time, ulonglong bytes_received,
+                            ulonglong bytes_sent,
+                            ulonglong binlog_bytes_written,
+                            ha_rows rows_fetched, ha_rows rows_updated,
+                            ha_rows rows_read, ulonglong select_commands,
+                            ulonglong update_commands,
+                            ulonglong other_commands,
+                            ulonglong commit_trans, ulonglong rollback_trans,
+                            ulonglong denied_connections,
+                            ulonglong lost_connections,
+                            ulonglong access_denied_errors,
+                            ulonglong empty_queries)
 {
   DBUG_ENTER("init_user_stats");
   DBUG_PRINT("info",
@@ -216,29 +212,25 @@ void init_user_stats(USER_STATS *user_stats,
   DBUG_VOID_RETURN;
 }
 
-void init_thread_stats(THREAD_STATS *thread_stats,
-                     my_thread_id id,
-                     uint total_connections,
-                     uint total_ssl_connections,
-                     uint concurrent_connections,
-                     time_t connected_time,
-                     double busy_time,
-                     double cpu_time,
-                     ulonglong bytes_received,
-                     ulonglong bytes_sent,
-                     ulonglong binlog_bytes_written,
-                     ha_rows rows_fetched,
-                     ha_rows rows_updated,
-                     ha_rows rows_read,
-                     ulonglong select_commands,
-                     ulonglong update_commands,
-                     ulonglong other_commands,
-                     ulonglong commit_trans,
-                     ulonglong rollback_trans,
-                     ulonglong denied_connections,
-                     ulonglong lost_connections,
-                     ulonglong access_denied_errors,
-                     ulonglong empty_queries)
+/* Intialize an instance of THREAD_STATS */
+static void init_thread_stats(THREAD_STATS *thread_stats, my_thread_id id,
+                              uint total_connections,
+                              uint total_ssl_connections,
+                              uint concurrent_connections,
+                              time_t connected_time,
+                              double busy_time, double cpu_time,
+                              ulonglong bytes_received,
+                              ulonglong bytes_sent,
+                              ulonglong binlog_bytes_written,
+                              ha_rows rows_fetched, ha_rows rows_updated,
+                              ha_rows rows_read, ulonglong select_commands,
+                              ulonglong update_commands,
+                              ulonglong other_commands, ulonglong commit_trans,
+                              ulonglong rollback_trans,
+                              ulonglong denied_connections,
+                              ulonglong lost_connections,
+                              ulonglong access_denied_errors,
+                              ulonglong empty_queries)
 {
   DBUG_ENTER("init_thread_stats");
   DBUG_PRINT("info",
@@ -296,19 +288,19 @@ void init_global_thread_stats(void)
                 0, 0, (my_hash_get_key) get_key_thread_stats,
                 (my_hash_free_key) free_thread_stats, 0))
   {
-    sql_print_error("Initializing global_client_stats failed.");
+    sql_print_error("Initializing global_thread_stats failed.");
     exit(1);
   }
 }
 
-extern "C" uchar *get_key_table_stats(TABLE_STATS *table_stats, size_t *length,
-                                     my_bool not_used MY_ATTRIBUTE((unused)))
+static uchar *get_key_table_stats(TABLE_STATS *table_stats, size_t *length,
+                                  my_bool not_used MY_ATTRIBUTE((unused)))
 {
   *length= table_stats->table_len;
   return (uchar*) table_stats->table;
 }
 
-extern "C" void free_table_stats(TABLE_STATS* table_stats)
+static void free_table_stats(TABLE_STATS* table_stats)
 {
   my_free((char*) table_stats);
 }
@@ -323,14 +315,14 @@ void init_global_table_stats(void)
   }
 }
 
-extern "C" uchar *get_key_index_stats(INDEX_STATS *index_stats, size_t *length,
-                                     my_bool not_used MY_ATTRIBUTE((unused)))
+static uchar *get_key_index_stats(INDEX_STATS *index_stats, size_t *length,
+                                  my_bool not_used MY_ATTRIBUTE((unused)))
 {
   *length= index_stats->index_len;
   return (uchar*) index_stats->index;
 }
 
-extern "C" void free_index_stats(INDEX_STATS* index_stats)
+static void free_index_stats(INDEX_STATS* index_stats)
 {
   my_free((char*) index_stats);
 }

--- a/sql/structs.h
+++ b/sql/structs.h
@@ -266,40 +266,6 @@ typedef struct st_user_stats {
   ulonglong empty_queries;
 } USER_STATS;
 
-/* Lookup function for my_hash tables with USER_STATS entries */
-extern "C" uchar *get_key_user_stats(USER_STATS *user_stats, size_t *length,
-                                my_bool not_used MY_ATTRIBUTE((unused)));
-
-/* Free all memory for a my_hash table with USER_STATS entries */
-extern void free_user_stats(USER_STATS* user_stats);
-
-/* Intialize an instance of USER_STATS */
-extern void
-init_user_stats(USER_STATS *user_stats,
-                const char *user,
-                const char *priv_user,
-                uint total_connections,
-                uint total_ssl_connections,
-                uint concurrent_connections,
-                time_t connected_time,
-                double busy_time,
-                double cpu_time,
-                ulonglong bytes_received,
-                ulonglong bytes_sent,
-                ulonglong binlog_bytes_written,
-                ha_rows rows_fetched,
-                ha_rows rows_updated,
-                ha_rows rows_read,
-                ulonglong select_commands,
-                ulonglong update_commands,
-                ulonglong other_commands,
-                ulonglong commit_trans,
-                ulonglong rollback_trans,
-                ulonglong denied_connections,
-                ulonglong lost_connections,
-                ulonglong access_denied_errors,
-                ulonglong empty_queries);
-
 typedef struct st_thread_stats {
   my_thread_id id;
   uint total_connections;
@@ -318,39 +284,6 @@ typedef struct st_thread_stats {
   ulonglong access_denied_errors;
   ulonglong empty_queries;
 } THREAD_STATS;
-
-/* Lookup function for my_hash tables with THREAD_STATS entries */
-extern "C" uchar *get_key_thread_stats(THREAD_STATS *thread_stats, size_t *length,
-                                my_bool not_used MY_ATTRIBUTE((unused)));
-
-/* Free all memory for a my_hash table with THREAD_STATS entries */
-extern void free_thread_stats(THREAD_STATS* thread_stats);
-
-/* Intialize an instance of THREAD_STATS */
-extern void
-init_thread_stats(THREAD_STATS *thread_stats,
-                my_thread_id id,
-                uint total_connections,
-                uint total_ssl_connections,
-                uint concurrent_connections,
-                time_t connected_time,
-                double busy_time,
-                double cpu_time,
-                ulonglong bytes_received,
-                ulonglong bytes_sent,
-                ulonglong binlog_bytes_written,
-                ha_rows rows_fetched,
-                ha_rows rows_updated,
-                ha_rows rows_read,
-                ulonglong select_commands,
-                ulonglong update_commands,
-                ulonglong other_commands,
-                ulonglong commit_trans,
-                ulonglong rollback_trans,
-                ulonglong denied_connections,
-                ulonglong lost_connections,
-                ulonglong access_denied_errors,
-                ulonglong empty_queries);
 
 typedef struct st_table_stats {
   char table[NAME_LEN * 2 + 2];  // [db] + '.' + [table] + '\0'


### PR DESCRIPTION
- get_key_user_stats, free_user_stats, init_user_stats,
  get_key_thread_stats, free_thread_stats, init_thread_stats,
  free_table_stats, get_key_index_stats, free_index_stats made static
  to sql_connect.cc;
- get_key_user_stats, get_key_thread_stats, get_key_table_stats,
  get_key_index_stats, free_index_stats no longer made extern "C";
- fixed init_global_thread_stats referencing client_stats in the error
  message;
- removed not longer used THD::get_client_host_port.

https://ps56.cd.percona.com/job/percona-server-5.6-param/17/