### PR TITLE
Bug #94747: 4GB Limit on large_pages shared memory set-up (5.7)

### DIFF
--- a/storage/innobase/include/os0proc.h
+++ b/storage/innobase/include/os0proc.h
@@ -45,7 +45,7 @@ extern ulint	os_total_large_mem_allocated;
 extern my_bool	os_use_large_pages;
 
 /** Large page size. This may be a boot-time option on some platforms */
-extern uint	os_large_page_size;
+extern ulint	os_large_page_size;
 
 /** Converts the current process id to a number.
 @return process id as a number */

--- a/storage/innobase/os/os0proc.cc
+++ b/storage/innobase/os/os0proc.cc
@@ -64,7 +64,7 @@ ulint	os_total_large_mem_allocated = 0;
 my_bool	os_use_large_pages;
 
 /** Large page size. This may be a boot-time option on some platforms */
-uint	os_large_page_size;
+ulint	os_large_page_size;
 
 
 /****************************************************************//**


### PR DESCRIPTION
mysqld --large-pages --innodb_buffer_pool_chunk_size=4G result in 1G chunk allocations instead of 4G.

This patch was originally provided by Daniel Black at https://bugs.mysql.com/bug.php?id=94747

No testcase provided: the server setup requires a specific environment.