### PR TITLE
PS-5724: Travis-CI: 8.0.16 MySQL Router does not build cleanly with clang 4 & 5 (8.0)

### DIFF
--- a/router/CMakeLists.txt
+++ b/router/CMakeLists.txt
@@ -71,6 +71,12 @@ IF(SOLARIS)
   ENDIF()
 ENDIF()
 
+# Clang 5 and older: disable "suggest braces around initialization of subobject" warnings
+IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_LESS "6.0")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-braces")
+ENDIF()
+
 IF(WIN32)
   # 'identifier' : class 'type' needs to have dll-interface to be used by clients of class 'type2'
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")


### PR DESCRIPTION
Turn off warnings for MySQL Router for clang-4 and clang-5 using the `-Wno-missing-braces` compiler flag.