### PR TITLE
Implement PS-5749 (Code review fixes from 8.0 work: misc)

### DIFF
--- a/include/mysql/psi/mysql_file.h
+++ b/include/mysql/psi/mysql_file.h
@@ -315,7 +315,7 @@
   @c mysql_unix_socket_connect connects to the unix domain socket.
 */
 #ifndef __WIN__
-#ifdef HAVE_PSI_INTERFACE
+#ifdef HAVE_PSI_FILE_INTERFACE
   #define mysql_unix_socket_connect(K, N, F) \
     inline_mysql_unix_socket_connect(K, __FILE__, __LINE__, N, F)
 #else
@@ -1072,28 +1072,27 @@ inline_mysql_file_open(
 #ifndef __WIN__
 static inline File
 inline_mysql_unix_socket_connect(
-#ifdef HAVE_PSI_INTERFACE
+#ifdef HAVE_PSI_FILE_INTERFACE
   PSI_file_key key, const char *src_file, uint src_line,
 #endif
   const char *filename, myf myFlags)
 {
   File file;
-#ifdef HAVE_PSI_INTERFACE
-  struct PSI_file_locker *locker= NULL;
+#ifdef HAVE_PSI_FILE_INTERFACE
+  struct PSI_file_locker *locker;
   PSI_file_locker_state state;
-  if (likely(PSI_server != NULL))
+  locker= PSI_FILE_CALL(get_thread_file_name_locker)
+    (&state, key, PSI_FILE_OPEN, filename, &locker);
+  if (likely(locker != NULL))
   {
-    locker= PSI_server->get_thread_file_name_locker(&state, key, PSI_FILE_OPEN,
-                                                    filename, &locker);
-    if (likely(locker != NULL))
-      PSI_server->start_file_open_wait(locker, src_file, src_line);
+    PSI_FILE_CALL(start_file_open_wait)(locker, src_file, src_line);
+    file= my_unix_socket_connect(filename, myFlags);
+    PSI_FILE_CALL(end_file_open_wait_and_bind_to_descriptor)(locker, file);
+    return file;
   }
 #endif
-  file = my_unix_socket_connect(filename, myFlags);
-#ifdef HAVE_PSI_INTERFACE
-  if (likely(locker != NULL))
-    PSI_server->end_file_open_wait_and_bind_to_descriptor(locker, file);
-#endif
+
+  file= my_unix_socket_connect(filename, myFlags);
   return file;
 }
 #endif

--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -49,20 +49,20 @@ typedef void (*escape_buf_func_t)(const char *, size_t *, char *, size_t *);
 static audit_handler_t *log_handler= NULL;
 static ulonglong record_id= 0;
 static time_t log_file_time= 0;
-char *audit_log_file;
-char default_audit_log_file[]= "audit.log";
-ulong audit_log_policy= ALL;
-ulong audit_log_strategy= ASYNCHRONOUS;
-ulonglong audit_log_buffer_size= 1048576;
-ulonglong audit_log_rotate_on_size= 0;
-ulonglong audit_log_rotations= 0;
-char audit_log_flush= FALSE;
-ulong audit_log_format= OLD;
-ulong audit_log_handler= HANDLER_FILE;
-char *audit_log_syslog_ident;
-char default_audit_log_syslog_ident[] = "percona-audit";
-ulong audit_log_syslog_facility= 0;
-ulong audit_log_syslog_priority= 0;
+static char *audit_log_file;
+static const char default_audit_log_file[]= "audit.log";
+static ulong audit_log_policy= ALL;
+static ulong audit_log_strategy= ASYNCHRONOUS;
+static ulonglong audit_log_buffer_size= 1048576;
+static ulonglong audit_log_rotate_on_size= 0;
+static ulonglong audit_log_rotations= 0;
+static char audit_log_flush= FALSE;
+static ulong audit_log_format= OLD;
+static ulong audit_log_handler= HANDLER_FILE;
+static char *audit_log_syslog_ident;
+static const char default_audit_log_syslog_ident[] = "percona-audit";
+static ulong audit_log_syslog_facility= 0;
+static ulong audit_log_syslog_priority= 0;
 static char *audit_log_exclude_accounts= NULL;
 static char *audit_log_include_accounts= NULL;
 static char *audit_log_exclude_commands= NULL;
@@ -1670,8 +1670,9 @@ static struct st_mysql_sys_var* audit_log_system_variables[] =
   NULL
 };
 
-char thd_local_init_buf[sizeof(audit_log_thd_local)];
+static char thd_local_init_buf[sizeof(audit_log_thd_local)];
 
+static
 void MY_ATTRIBUTE((constructor)) audit_log_so_init()
 {
   memset(thd_local_init_buf, 1, sizeof(thd_local_init_buf) - 1);

--- a/plugin/audit_log/audit_syslog.c
+++ b/plugin/audit_log/audit_syslog.c
@@ -28,10 +28,10 @@ struct audit_handler_syslog_data_struct
   logger_epilog_func_t footer;
 };
 
-int audit_handler_syslog_write(audit_handler_t *handler,
-                               const char *buf, size_t len);
-int audit_handler_syslog_flush(audit_handler_t *handler);
-int audit_handler_syslog_close(audit_handler_t *handler);
+static int audit_handler_syslog_write(audit_handler_t *handler,
+                                      const char *buf, size_t len);
+static int audit_handler_syslog_flush(audit_handler_t *handler);
+static int audit_handler_syslog_close(audit_handler_t *handler);
 
 
 audit_handler_t *audit_handler_syslog_open(audit_handler_syslog_config_t *opts)
@@ -59,6 +59,7 @@ audit_handler_t *audit_handler_syslog_open(audit_handler_syslog_config_t *opts)
   return handler;
 }
 
+static
 int audit_handler_syslog_write(audit_handler_t *handler,
                                const char *buf, size_t len)
 {
@@ -69,6 +70,7 @@ int audit_handler_syslog_write(audit_handler_t *handler,
   return len;
 }
 
+static
 int audit_handler_syslog_flush(audit_handler_t *handler)
 {
   audit_handler_syslog_data_t *data=
@@ -80,6 +82,7 @@ int audit_handler_syslog_flush(audit_handler_t *handler)
   return 0;
 }
 
+static
 int audit_handler_syslog_close(audit_handler_t *handler)
 {
   audit_handler_syslog_data_t *data=

--- a/plugin/audit_log/filter.c
+++ b/plugin/audit_log/filter.c
@@ -56,8 +56,8 @@ static PSI_rwlock_info all_rwlock_list[]=
 
 #endif
 
-mysql_rwlock_t LOCK_account_list;
-mysql_rwlock_t LOCK_command_list;
+static mysql_rwlock_t LOCK_account_list;
+static mysql_rwlock_t LOCK_command_list;
 
 /*
   Initialize account
@@ -93,6 +93,7 @@ account *account_create(const char *user, size_t user_length,
 /*
   Get account key
 */
+static
 uchar *account_get_key(const account *acc, size_t *length,
                        my_bool not_used MY_ATTRIBUTE((unused)))
 {
@@ -130,6 +131,7 @@ command *command_create(const char *name, size_t length)
 /*
   Get command key
 */
+static
 uchar *command_get_key(const command *acc, size_t *length,
                        my_bool not_used MY_ATTRIBUTE((unused)))
 {

--- a/plugin/audit_log/logger.h
+++ b/plugin/audit_log/logger.h
@@ -33,15 +33,10 @@
   So that one can open the log with logger_open(), specifying
   the limit on the logfile size and the rotations number.
 
-  Then it's possible to write messages to the log with
-  logger_printf or logger_vprintf functions.
-
   As the size of the logfile grows over the specified limit,
   it is renamed to 'logfile.1'. The former 'logfile.1' becomes
   'logfile.2', etc. The file 'logfile.rotations' is removed.
   That's how the rotation works.
-
-  The rotation can be forced with the logger_rotate() call.
 
   Finally the log should be closed with logger_close().
 
@@ -74,11 +69,8 @@ LOGGER_HANDLE *logger_open(const char *path,
                            int thread_safe,
                            logger_prolog_func_t header);
 int logger_close(LOGGER_HANDLE *log, logger_epilog_func_t footer);
-int logger_vprintf(LOGGER_HANDLE *log, const char *fmt, va_list argptr);
-int logger_printf(LOGGER_HANDLE *log, const char *fmt, ...);
 int logger_write(LOGGER_HANDLE *log, const char *buffer, size_t size,
                  log_record_state_t state);
-int logger_rotate(LOGGER_HANDLE *log); 
 int logger_sync(LOGGER_HANDLE *log);
 int logger_reopen(LOGGER_HANDLE *log, logger_prolog_func_t header,
                   logger_epilog_func_t footer);

--- a/sql/lock.cc
+++ b/sql/lock.cc
@@ -1119,8 +1119,8 @@ bool Global_backup_lock::acquire(THD *thd)
 
   DBUG_ENTER("Global_backup_lock::acquire");
 
-  DBUG_ASSERT(m_lock == NULL &&
-              !thd->mdl_context.is_lock_owner(m_namespace, "", "",
+  DBUG_ASSERT(m_lock == NULL);
+  DBUG_ASSERT(!thd->mdl_context.is_lock_owner(m_namespace, "", "",
                                               MDL_SHARED));
 
   mdl_request.init(m_namespace, "", "", MDL_SHARED, MDL_EXPLICIT);
@@ -1144,8 +1144,8 @@ void Global_backup_lock::release(THD *thd)
 {
   DBUG_ENTER("Global_backup_lock::release");
 
-  DBUG_ASSERT(m_lock != NULL &&
-              thd->mdl_context.is_lock_owner(m_namespace, "", "",
+  DBUG_ASSERT(m_lock != NULL);
+  DBUG_ASSERT(thd->mdl_context.is_lock_owner(m_namespace, "", "",
                                              MDL_SHARED));
 
   thd->mdl_context.release_lock(m_lock);
@@ -1246,8 +1246,8 @@ void Global_backup_lock::release_protection(THD *thd)
 {
   DBUG_ENTER("Global_backup_lock::release_protection");
 
-  DBUG_ASSERT(m_prot_lock != NULL &&
-              thd->mdl_context.is_lock_owner(m_namespace, "", "",
+  DBUG_ASSERT(m_prot_lock != NULL);
+  DBUG_ASSERT(thd->mdl_context.is_lock_owner(m_namespace, "", "",
                                              MDL_INTENTION_EXCLUSIVE));
 
   thd->mdl_context.release_lock(m_prot_lock);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9380,11 +9380,6 @@ static void option_error_reporter(enum loglevel level, const char *format, ...)
 
 C_MODE_END
 
-/* defined in sys_vars.cc */
-extern void init_log_slow_verbosity();
-extern void init_slow_query_log_use_global_control();
-extern void init_log_slow_sp_statements();
-
 /**
   Get server options from the command line,
   and perform related server initializations.

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -378,5 +378,9 @@ int sys_var_init();
 int sys_var_add_options(std::vector<my_option> *long_options, int parse_flags);
 void sys_var_end(void);
 
+extern void init_log_slow_verbosity();
+extern void init_slow_query_log_use_global_control();
+extern void init_log_slow_sp_statements();
+
 #endif
 

--- a/sql/sql_profile.cc
+++ b/sql/sql_profile.cc
@@ -553,7 +553,8 @@ static void my_b_print_status(IO_CACHE *log_file, const char *status,
                               PROF_MEASUREMENT *start, PROF_MEASUREMENT *stop)
 {
   DBUG_ENTER("my_b_print_status");
-  DBUG_ASSERT(log_file != NULL && status != NULL);
+  DBUG_ASSERT(log_file != NULL);
+  DBUG_ASSERT(status != NULL);
   char query_time_buff[22+7];
   const char *tmp;
 

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2831,6 +2831,7 @@ end:
      0 - OK
      1 - error
 */
+static
 int send_user_stats(THD* thd, HASH *all_user_stats, TABLE *table)
 {
   DBUG_ENTER("send_user_stats");
@@ -2870,6 +2871,7 @@ int send_user_stats(THD* thd, HASH *all_user_stats, TABLE *table)
   DBUG_RETURN(0);
 }
 
+static
 int send_thread_stats(THD* thd, HASH *all_thread_stats, TABLE *table)
 {
   DBUG_ENTER("send_thread_stats");
@@ -2923,7 +2925,7 @@ int send_thread_stats(THD* thd, HASH *all_thread_stats, TABLE *table)
      1 - error
 */
 
-
+static
 int fill_schema_user_stats(THD* thd, TABLE_LIST* tables, Item* cond)
 {
   TABLE *table= tables->table;
@@ -2963,7 +2965,7 @@ int fill_schema_user_stats(THD* thd, TABLE_LIST* tables, Item* cond)
      1 - error
 */
 
-
+static
 int fill_schema_client_stats(THD* thd, TABLE_LIST* tables, Item* cond)
 {
   TABLE *table= tables->table;
@@ -2990,6 +2992,7 @@ int fill_schema_client_stats(THD* thd, TABLE_LIST* tables, Item* cond)
   DBUG_RETURN(1);
 }
 
+static
 int fill_schema_thread_stats(THD* thd, TABLE_LIST* tables, Item* cond)
 {
   TABLE *table= tables->table;
@@ -3016,6 +3019,7 @@ int fill_schema_thread_stats(THD* thd, TABLE_LIST* tables, Item* cond)
 }
 
 // Sends the global table stats back to the client.
+static
 int fill_schema_table_stats(THD* thd, TABLE_LIST* tables, Item* cond)
 {
   TABLE *table= tables->table;
@@ -3060,6 +3064,7 @@ int fill_schema_table_stats(THD* thd, TABLE_LIST* tables, Item* cond)
 }
 
 // Sends the global index stats back to the client.
+static
 int fill_schema_index_stats(THD* thd, TABLE_LIST* tables, Item* cond)
 {
   TABLE *table= tables->table;
@@ -4110,6 +4115,7 @@ uint get_table_open_method(TABLE_LIST *tables,
     @retval       0                        success
     @retval       1                        error
 */
+static
 int make_temporary_tables_old_format(THD *thd, ST_SCHEMA_TABLE *schema_table)
 {
   char tmp[128];
@@ -4331,7 +4337,7 @@ static int fill_global_temporary_tables(THD *thd, TABLE_LIST *tables, Item *cond
     @retval       0                        success
     @retval       1                        error
 */
-
+static
 int fill_temporary_tables(THD *thd, TABLE_LIST *tables, Item *cond)
 {
   DBUG_ENTER("fill_temporary_tables");
@@ -8257,7 +8263,7 @@ ST_FIELD_INFO tables_fields_info[]=
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, SKIP_OPEN_TABLE}
 };
 
-ST_FIELD_INFO temporary_table_fields_info[]=
+static ST_FIELD_INFO temporary_table_fields_info[]=
 {
   {"SESSION_ID", 4, MYSQL_TYPE_LONGLONG, 0, 0, "Session", SKIP_OPEN_TABLE},
   {"TABLE_SCHEMA", NAME_CHAR_LEN, MYSQL_TYPE_STRING, 0, 0, "Db", SKIP_OPEN_TABLE},
@@ -8692,7 +8698,7 @@ ST_FIELD_INFO variables_fields_info[]=
 };
 
 
-ST_FIELD_INFO user_stats_fields_info[]=
+static ST_FIELD_INFO user_stats_fields_info[]=
 {
   {"USER", USERNAME_LENGTH, MYSQL_TYPE_STRING, 0, 0, "User", SKIP_OPEN_TABLE},
   {"TOTAL_CONNECTIONS", MY_INT64_NUM_DECIMAL_DIGITS, MYSQL_TYPE_LONGLONG, 0,
@@ -8740,7 +8746,7 @@ ST_FIELD_INFO user_stats_fields_info[]=
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, 0}
 };
 
-ST_FIELD_INFO client_stats_fields_info[]=
+static ST_FIELD_INFO client_stats_fields_info[]=
 {
   {"CLIENT", LIST_PROCESS_HOST_LEN, MYSQL_TYPE_STRING, 0, 0, "Client",
    SKIP_OPEN_TABLE},
@@ -8789,7 +8795,7 @@ ST_FIELD_INFO client_stats_fields_info[]=
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, 0}
 };
 
-ST_FIELD_INFO thread_stats_fields_info[]=
+static ST_FIELD_INFO thread_stats_fields_info[]=
 {
   {"THREAD_ID", MY_INT64_NUM_DECIMAL_DIGITS, MYSQL_TYPE_LONGLONG, 0,
    MY_I_S_UNSIGNED, "Thread_id", SKIP_OPEN_TABLE},
@@ -8838,7 +8844,7 @@ ST_FIELD_INFO thread_stats_fields_info[]=
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, 0}
 };
 
-ST_FIELD_INFO table_stats_fields_info[]=
+static ST_FIELD_INFO table_stats_fields_info[]=
 {
   {"TABLE_SCHEMA", NAME_LEN, MYSQL_TYPE_STRING, 0, 0, "Table_schema",
    SKIP_OPEN_TABLE},
@@ -8853,7 +8859,7 @@ ST_FIELD_INFO table_stats_fields_info[]=
   {0, 0, MYSQL_TYPE_STRING, 0, 0, 0, 0}
 };
 
-ST_FIELD_INFO index_stats_fields_info[]=
+static ST_FIELD_INFO index_stats_fields_info[]=
 {
   {"TABLE_SCHEMA", NAME_LEN, MYSQL_TYPE_STRING, 0, 0, "Table_schema",
    SKIP_OPEN_TABLE},

--- a/sql/sql_timer.cc
+++ b/sql/sql_timer.cc
@@ -157,7 +157,8 @@ thd_timer_set(THD *thd, thd_timer_t *ttp, unsigned long time)
   if (ttp == NULL && (ttp= thd_timer_create()) == NULL)
     DBUG_RETURN(NULL);
 
-  DBUG_ASSERT(!ttp->destroy && !ttp->thd);
+  DBUG_ASSERT(!ttp->destroy);
+  DBUG_ASSERT(!ttp->thd);
 
   /* Mark the notification as pending. */
   ttp->thd= thd;

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -75,7 +75,8 @@ _increment_page_get_statistics(buf_block_t* block, trx_t* trx)
 	byte            block_hash_offset;
 
 	ut_ad(block);
-	ut_ad(trx && trx->take_stats);
+	ut_ad(trx);
+	ut_ad(trx->take_stats);
 
 	if (!trx->distinct_page_access_hash) {
 		trx->distinct_page_access_hash

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -5837,7 +5837,8 @@ dict_table_set_corrupt_by_space(
 	dict_table_t*	table;
 	ibool		found = FALSE;
 
-	ut_a(space_id != 0 && space_id < SRV_LOG_SPACE_FIRST_ID);
+	ut_a(space_id != 0);
+	ut_a(space_id < SRV_LOG_SPACE_FIRST_ID);
 
 	if (need_mutex)
 		mutex_enter(&(dict_sys->mutex));

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1795,9 +1795,9 @@ UNIV_INTERN
 ulong
 thd_flush_log_at_trx_commit(
 /*================================*/
-	void*	thd)
+	THD*	thd)
 {
-	return(THDVAR((THD*) thd, flush_log_at_trx_commit));
+	return(THDVAR(thd, flush_log_at_trx_commit));
 }
 
 /******************************************************************//**
@@ -17183,7 +17183,7 @@ innodb_sched_priority_master_update(
 		push_warning_printf(thd, Sql_condition::WARN_LEVEL_WARN,
 				    ER_WRONG_ARGUMENTS,
 				    "Failed to set the master thread "
-				    "priority to %lu,  "
+				    "priority to %lu, "
 				    "the current priority is %lu", priority,
 				    actual_priority);
 	} else {
@@ -18787,14 +18787,14 @@ static MYSQL_SYSVAR_ULONG(saved_page_number_debug,
   NULL, innodb_save_page_no, 0, 0, UINT_MAX32, 0);
 #endif /* UNIV_DEBUG */
 
-const char *corrupt_table_action_names[]=
+static const char *corrupt_table_action_names[]=
 {
   "assert", /* 0 */
   "warn", /* 1 */
   "salvage", /* 2 */
   NullS
 };
-TYPELIB corrupt_table_action_typelib=
+static TYPELIB corrupt_table_action_typelib=
 {
   array_elements(corrupt_table_action_names) - 1, "corrupt_table_action_typelib",
   corrupt_table_action_names, NULL

--- a/storage/innobase/include/btr0sea.ic
+++ b/storage/innobase/include/btr0sea.ic
@@ -106,8 +106,8 @@ btr_search_get_latch(
 	const dict_index_t*	index)	/*!< in: index */
 {
 	ut_ad(index);
-	ut_ad(index->search_latch >= btr_search_latch_arr &&
-	      index->search_latch < btr_search_latch_arr +
+	ut_ad(index->search_latch >= btr_search_latch_arr);
+	ut_ad(index->search_latch < btr_search_latch_arr +
 	      btr_search_index_num);
 
 	return(index->search_latch);

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -387,7 +387,7 @@ innobase_get_table_cache_size(void);
 ulong
 thd_flush_log_at_trx_commit(
 /*================================*/
-	void*	thd);
+	THD*	thd);
 
 /**********************************************************************//**
 Get the current setting of the lower_case_table_names global parameter from

--- a/storage/innobase/include/sync0rw.ic
+++ b/storage/innobase/include/sync0rw.ic
@@ -447,7 +447,8 @@ rw_lock_higher_prio_waiters_exist(
 		return(false);
 	}
 
-	ut_ad(priority_lock && !high_priority);
+	ut_ad(priority_lock);
+	ut_ad(!high_priority);
 
 	prio_rw_lock_t *prio_rw_lock = (prio_rw_lock_t *) lock;
 	return prio_rw_lock->high_priority_wait_ex_waiter > 0

--- a/storage/innobase/lock/lock0wait.cc
+++ b/storage/innobase/lock/lock0wait.cc
@@ -204,6 +204,7 @@ functions to get some info from THD.
 @param[in]	trx	requested trx
 @param[in]	blocking	blocking info array
 @param[in]	blocking_count	blocking info array size */
+static
 void
 print_lock_wait_timeout(
 	const trx_t &trx,

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -417,7 +417,7 @@ column_zip_free(
 }
 
 /** Configure the zlib allocator to use the given memory heap. */
-UNIV_INTERN
+static
 void
 column_zip_set_alloc(
 	void*		stream,	/*!< in/out: zlib stream */
@@ -660,7 +660,8 @@ row_decompress_column(
 
 	err = inflate(&d_stream, Z_FINISH);
 	if (err == Z_NEED_DICT) {
-		ut_a(dict_data != 0 && dict_data_len != 0);
+		ut_a(dict_data != NULL);
+		ut_a(dict_data_len != 0);
 		err = inflateSetDictionary(&d_stream, dict_data,
 			dict_data_len);
 		ut_a(err == Z_OK);

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -39,7 +39,6 @@ Created 5/11/1994 Heikki Tuuri
 #include <ctype.h>
 
 #ifndef UNIV_HOTBACKUP
-# include "btr0types.h"
 # include "trx0trx.h"
 # include "ha_prototypes.h"
 # include "mysql_com.h" /* NAME_LEN */

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -1075,7 +1075,8 @@ static inline int tokudb_generate_row(DB* dest_db,
         }
 
         buff = (uchar *)dest_key->data;
-        assert_always(buff != NULL && max_key_len > 0);
+        assert_always(buff != nullptr);
+        assert_always(max_key_len > 0);
     } else {
         assert_unreachable();
     }

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -387,7 +387,8 @@ inline void TOKUDB_SHARE::init_cardinality_counts(
 
     assert_debug(_mutex.is_owned_by_me());
     // can not change number of keys live
-    assert_always(_rec_per_key == NULL && _rec_per_keys == 0);
+    assert_always(_rec_per_key == nullptr);
+    assert_always(_rec_per_keys == 0);
     _rec_per_keys = rec_per_keys;
     _rec_per_key = rec_per_key;
 }

--- a/storage/tokudb/hatoku_cmp.cc
+++ b/storage/tokudb/hatoku_cmp.cc
@@ -954,9 +954,8 @@ static inline int tokudb_compare_two_hidden_keys(
     const void*  saved_key_data,
     const uint32_t saved_key_size
     ) {
-    assert_always(
-        (new_key_size >= TOKUDB_HIDDEN_PRIMARY_KEY_LENGTH) &&
-        (saved_key_size >= TOKUDB_HIDDEN_PRIMARY_KEY_LENGTH));
+    assert_always(new_key_size >= TOKUDB_HIDDEN_PRIMARY_KEY_LENGTH);
+    assert_always(saved_key_size >= TOKUDB_HIDDEN_PRIMARY_KEY_LENGTH);
     ulonglong a = hpk_char_to_num((uchar *) new_key_data);
     ulonglong b = hpk_char_to_num((uchar *) saved_key_data);
     return a < b ? -1 : (a > b ? 1 : 0);
@@ -2534,7 +2533,8 @@ static uint32_t create_toku_secondary_key_pack_descriptor (
         bool is_col_in_pk = false;
 
         if (bitmap_is_set(&kc_info->key_filters[pk_index],field_index)) {
-            assert_always(!has_hpk && prim_key != NULL);
+            assert_always(!has_hpk);
+            assert_always(prim_key != nullptr);
             is_col_in_pk = true;
         }
         else {

--- a/storage/tokudb/tests/math_test_int.cc
+++ b/storage/tokudb/tests/math_test_int.cc
@@ -54,16 +54,20 @@ static void test_int8() {
                 assert(over);
             else if (m < -max)
                 assert(over);
-            else
-                assert(!over && n == m);
+            else {
+                assert(!over);
+                assert(n == m);
+            }
             n = int_sub(x, y, 8, &over);
             m = x - y;
             if (m > max-1)
                 assert(over);
             else if (m < -max)
                 assert(over);
-            else
-                assert(!over && n == m);
+            else {
+                assert(!over);
+                asset(n == m);
+            }
         }
     }
 }
@@ -82,16 +86,20 @@ static void test_int16() {
                 assert(over);
             else if (m < -max)
                 assert(over);
-            else
-                assert(!over && n == m);
+            else {
+                assert(!over);
+                assert(n == m);
+            }
             n = int_sub(x, y, 16, &over);
             m = x - y;
             if (m > max-1)
                 assert(over);
             else if (m < -max)
                 assert(over);
-            else
-                assert(!over && n == m);
+            else {
+                assert(!over);
+                assert(n == m);
+            }
         }
     }
 }
@@ -104,20 +112,42 @@ static void test_int24() {
 
     s = int_add(1, (1ULL<<23)-1, 24, &over); assert(over);
     s = int_add((1ULL<<23)-1, 1, 24, &over); assert(over);
-    s = int_sub(-1, (1ULL<<23), 24, &over); assert(!over && s == (1ULL<<23)-1);
+    s = int_sub(-1, (1ULL<<23), 24, &over);
+    assert(!over);
+    assert(s == (1ULL<<23)-1);
     s = int_sub((1ULL<<23), 1, 24, &over); assert(over);
 
-    s = int_add(0, 0, 24, &over); assert(!over && s == 0);
-    s = int_sub(0, 0, 24, &over); assert(!over && s == 0);
-    s = int_add(0, -1, 24, &over); assert(!over && s == -1);
-    s = int_sub(0, 1, 24, &over); assert(!over && s == -1);
-    s = int_add(0, (1ULL<<23), 24, &over); assert(!over && (s & ((1ULL<<24)-1)) == (1ULL<<23));
-    s = int_sub(0, (1ULL<<23)-1, 24, &over); assert(!over && (s & ((1ULL<<24)-1)) == (1ULL<<23)+1);
+    s = int_add(0, 0, 24, &over);
+    assert(!over);
+    assert(s == 0);
+    s = int_sub(0, 0, 24, &over);
+    assert(!over);
+    assert(s == 0);
+    s = int_add(0, -1, 24, &over);
+    assert(!over);
+    assert(s == -1);
+    s = int_sub(0, 1, 24, &over);
+    assert(!over);
+    assert(s == -1);
+    s = int_add(0, (1ULL<<23), 24, &over);
+    assert(!over);
+    assert((s & ((1ULL<<24)-1)) == (1ULL<<23));
+    s = int_sub(0, (1ULL<<23)-1, 24, &over);
+    assert(!over);
+    assert((s & ((1ULL<<24)-1)) == (1ULL<<23)+1);
 
-    s = int_add(-1, 0, 24, &over); assert(!over && s == -1);
-    s = int_add(-1, 1, 24, &over); assert(!over && s == 0);
-    s = int_sub(-1, -1, 24, &over); assert(!over && s == 0);
-    s = int_sub(-1, (1ULL<<23)-1, 24, &over); assert(!over && (s & ((1ULL<<24)-1)) == (1ULL<<23));
+    s = int_add(-1, 0, 24, &over);
+    assert(!over);
+    assert(s == -1);
+    s = int_add(-1, 1, 24, &over);
+    assert(!over);
+    assert(s == 0);
+    s = int_sub(-1, -1, 24, &over);
+    assert(!over);
+    assert(s == 0);
+    s = int_sub(-1, (1ULL<<23)-1, 24, &over);
+    assert(!over);
+    assert((s & ((1ULL<<24)-1)) == (1ULL<<23));
 }
 
 static void test_int32() {
@@ -128,20 +158,42 @@ static void test_int32() {
 
     s = int_add(1, (1ULL<<31)-1, 32, &over); assert(over);
     s = int_add((1ULL<<31)-1, 1, 32, &over); assert(over);
-    s = int_sub(-1, (1ULL<<31), 32, &over); assert(s == (1ULL<<31)-1 && !over);
+    s = int_sub(-1, (1ULL<<31), 32, &over);
+    assert(s == (1ULL<<31)-1);
+    assert(!over);
     s = int_sub((1ULL<<31), 1, 32, &over); assert(over);
 
-    s = int_add(0, 0, 32, &over); assert(s == 0 && !over);
-    s = int_sub(0, 0, 32, &over); assert(s == 0 && !over);
-    s = int_add(0, -1, 32, &over); assert(s == -1 && !over);
-    s = int_sub(0, 1, 32, &over); assert(s == -1 && !over);
-    s = int_add(0, (1ULL<<31), 32, &over); assert((s & ((1ULL<<32)-1)) == (1ULL<<31) && !over);
-    s = int_sub(0, (1ULL<<31)-1, 32, &over); assert((s & ((1ULL<<32)-1)) == (1ULL<<31)+1 && !over);
+    s = int_add(0, 0, 32, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_sub(0, 0, 32, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_add(0, -1, 32, &over);
+    assert(s == -1);
+    assert(!over);
+    s = int_sub(0, 1, 32, &over);
+    assert(s == -1);
+    assert(!over);
+    s = int_add(0, (1ULL<<31), 32, &over);
+    assert((s & ((1ULL<<32)-1)) == (1ULL<<31));
+    assert(!over);
+    s = int_sub(0, (1ULL<<31)-1, 32, &over);
+    assert((s & ((1ULL<<32)-1)) == (1ULL<<31)+1);
+    assert(!over);
 
-    s = int_add(-1, 0, 32, &over); assert(s == -1 && !over);
-    s = int_add(-1, 1, 32, &over); assert(s == 0 && !over);
-    s = int_sub(-1, -1, 32, &over); assert(s == 0 && !over);
-    s = int_sub(-1, (1ULL<<31)-1, 32, &over); assert((s & ((1ULL<<32)-1)) == (1ULL<<31) && !over);
+    s = int_add(-1, 0, 32, &over);
+    assert(s == -1);
+    assert(!over);
+    s = int_add(-1, 1, 32, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_sub(-1, -1, 32, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_sub(-1, (1ULL<<31)-1, 32, &over);
+    assert((s & ((1ULL<<32)-1)) == (1ULL<<31));
+    assert(!over);
 }
 
 static void test_int64() {
@@ -152,20 +204,42 @@ static void test_int64() {
 
     s = int_add(1, (1ULL<<63)-1, 64, &over); assert(over);
     s = int_add((1ULL<<63)-1, 1, 64, &over); assert(over);
-    s = int_sub(-1, (1ULL<<63), 64, &over); assert(s == (1ULL<<63)-1 && !over);
+    s = int_sub(-1, (1ULL<<63), 64, &over);
+    assert(s == (1ULL<<63)-1);
+    assert(!over);
     s = int_sub((1ULL<<63), 1, 64, &over); assert(over);
 
-    s = int_add(0, 0, 64, &over); assert(s == 0 && !over);
-    s = int_sub(0, 0, 64, &over); assert(s == 0 && !over);
-    s = int_add(0, -1, 64, &over); assert(s == -1 && !over);
-    s = int_sub(0, 1, 64, &over); assert(s == -1 && !over);
-    s = int_add(0, (1ULL<<63), 64, &over); assert(s == (int64_t)(1ULL<<63) && !over);
-    s = int_sub(0, (1ULL<<63)-1, 64, &over); assert(s == (int64_t)((1ULL<<63)+1) && !over);
+    s = int_add(0, 0, 64, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_sub(0, 0, 64, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_add(0, -1, 64, &over);
+    assert(s == -1);
+    assert(!over);
+    s = int_sub(0, 1, 64, &over);
+    assert(s == -1);
+    assert(!over);
+    s = int_add(0, (1ULL<<63), 64, &over);
+    assert(s == (int64_t)(1ULL<<63));
+    assert(!over);
+    s = int_sub(0, (1ULL<<63)-1, 64, &over);
+    assert(s == (int64_t)((1ULL<<63)+1));
+    assert(!over);
 
-    s = int_add(-1, 0, 64, &over); assert(s == -1 && !over);
-    s = int_add(-1, 1, 64, &over); assert(s == 0 && !over);
-    s = int_sub(-1, -1, 64, &over); assert(s == 0 && !over);
-    s = int_sub(-1, (1ULL<<63)-1, 64, &over); assert(s == (int64_t)(1ULL<<63) && !over);
+    s = int_add(-1, 0, 64, &over);
+    assert(s == -1);
+    assert(!over);
+    s = int_add(-1, 1, 64, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_sub(-1, -1, 64, &over);
+    assert(s == 0);
+    assert(!over);
+    s = int_sub(-1, (1ULL<<63)-1, 64, &over);
+    assert(s == (int64_t)(1ULL<<63));
+    assert(!over);
 }
 
 static void test_int_sign(uint length_bits) {

--- a/storage/tokudb/tests/math_test_uint.cc
+++ b/storage/tokudb/tests/math_test_uint.cc
@@ -51,14 +51,18 @@ static void test_uint8() {
             m = x + y;
             if (m > (1ULL<<8)-1)
                 assert(over);
-            else 
-                assert(!over && n == (m % 256));
+            else {
+                assert(!over);
+                assert(n == (m % 256));
+            }
             n = uint_sub(x, y, 8, &over);
             m = x - y;
             if (m > x)
                 assert(over);
-            else
-                assert(!over && n == (m % 256));
+            else {
+                assert(!over);
+                assert(n == (m % 256));
+            }
         }
     }
 }
@@ -75,14 +79,18 @@ static void test_uint16() {
             m = x + y;
             if (m > (1ULL<<16)-1)
                 assert(over);
-            else
-                assert(!over && n == (m % (1ULL<<16)));
+            else {
+                assert(!over);
+                assert(n == (m % (1ULL<<16)));
+            }
             n = uint_sub(x, y, 16, &over);
             m = x - y;
             if (m > x)
                 assert(over);
-            else
-                assert(!over && n == (m % (1ULL<<16)));
+            else {
+                assert(!over);
+                assert(n == (m % (1ULL<<16)));
+            }
         }
     }
 }
@@ -95,13 +103,23 @@ static void test_uint24() {
 
     s = uint_add((1ULL<<24)-1, (1ULL<<24)-1, 24, &over); assert(over);
     s = uint_add((1ULL<<24)-1, 1, 24, &over); assert(over);
-    s = uint_add((1ULL<<24)-1, 0, 24, &over); assert(!over && s == (1ULL<<24)-1);
-    s = uint_add(0, 1, 24, &over); assert(!over && s == 1);
-    s = uint_add(0, 0, 24, &over); assert(!over && s == 0);
-    s = uint_sub(0, 0, 24, &over); assert(!over && s == 0);
+    s = uint_add((1ULL<<24)-1, 0, 24, &over);
+    assert(!over);
+    assert(s == (1ULL<<24)-1);
+    s = uint_add(0, 1, 24, &over);
+    assert(!over);
+    assert(s == 1);
+    s = uint_add(0, 0, 24, &over);
+    assert(!over);
+    assert(s == 0);
+    s = uint_sub(0, 0, 24, &over);
+    assert(!over);
+    assert(s == 0);
     s = uint_sub(0, 1, 24, &over); assert(over);
     s = uint_sub(0, (1ULL<<24)-1, 24, &over); assert(over);
-    s = uint_sub((1ULL<<24)-1, (1ULL<<24)-1, 24, &over); assert(!over && s == 0);
+    s = uint_sub((1ULL<<24)-1, (1ULL<<24)-1, 24, &over);
+    assert(!over);
+    assert(s == 0);
 }
 
 static void test_uint32() {
@@ -112,13 +130,23 @@ static void test_uint32() {
 
     s = uint_add((1ULL<<32)-1, (1ULL<<32)-1, 32, &over); assert(over);
     s = uint_add((1ULL<<32)-1, 1, 32, &over); assert(over);
-    s = uint_add((1ULL<<32)-1, 0, 32, &over); assert(!over && s == (1ULL<<32)-1);
-    s = uint_add(0, 1, 32, &over); assert(!over && s == 1);
-    s = uint_add(0, 0, 32, &over); assert(!over && s == 0);
-    s = uint_sub(0, 0, 32, &over); assert(!over && s == 0);
+    s = uint_add((1ULL<<32)-1, 0, 32, &over);
+    assert(!over);
+    assert(s == (1ULL<<32)-1);
+    s = uint_add(0, 1, 32, &over);
+    assert(!over);
+    assert(s == 1);
+    s = uint_add(0, 0, 32, &over);
+    assert(!over);
+    assert(s == 0);
+    s = uint_sub(0, 0, 32, &over);
+    assert(!over);
+    assert(s == 0);
     s = uint_sub(0, 1, 32, &over); assert(over);
     s = uint_sub(0, (1ULL<<32)-1, 32, &over); assert(over);
-    s = uint_sub((1ULL<<32)-1, (1ULL<<32)-1, 32, &over); assert(!over && s == 0);
+    s = uint_sub((1ULL<<32)-1, (1ULL<<32)-1, 32, &over);
+    assert(!over);
+    assert(s == 0);
 }
 
 static void test_uint64() {
@@ -129,13 +157,23 @@ static void test_uint64() {
 
     s = uint_add(~0ULL, ~0ULL, 64, &over); assert(over);
     s = uint_add(~0ULL, 1, 64, &over); assert(over);
-    s = uint_add(~0ULL, 0, 64, &over); assert(!over && s == ~0ULL);
-    s = uint_add(0, 1, 64, &over); assert(!over && s == 1);
-    s = uint_add(0, 0, 64, &over); assert(!over && s == 0);
-    s = uint_sub(0, 0, 64, &over); assert(!over && s == 0);
+    s = uint_add(~0ULL, 0, 64, &over);
+    assert(!over);
+    assert(s == ~0ULL);
+    s = uint_add(0, 1, 64, &over);
+    assert(!over);
+    assert(s == 1);
+    s = uint_add(0, 0, 64, &over);
+    assert(!over);
+    assert(s == 0);
+    s = uint_sub(0, 0, 64, &over);
+    assert(!over);
+    assert(s == 0);
     s = uint_sub(0, 1, 64, &over); assert(over);
     s = uint_sub(0, ~0ULL, 64, &over); assert(over);
-    s = uint_sub(~0ULL, ~0ULL, 64, &over); assert(!over && s == 0);
+    s = uint_sub(~0ULL, ~0ULL, 64, &over);
+    assert(!over);
+    assert(s == 0);
 }
 
 int main() {

--- a/storage/tokudb/tests/sint_test.cc
+++ b/storage/tokudb/tests/sint_test.cc
@@ -27,7 +27,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdint.h>
 #include <inttypes.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <sys/types.h>
 
 #include <tokudb_math.h>

--- a/storage/tokudb/tests/tokudb_buffer_test.cc
+++ b/storage/tokudb/tests/tokudb_buffer_test.cc
@@ -32,9 +32,13 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 static void test_null() {
     tokudb::buffer b;
-    assert(b.data() == NULL && b.size() == 0 && b.limit() == 0);
+    assert(b.data() == nullptr);
+    assert(b.size() == 0);
+    assert(b.limit() == 0);
     b.append(NULL, 0);
-    assert(b.data() == NULL && b.size() == 0 && b.limit() == 0);
+    assert(b.data() == nullptr);
+    assert(b.size() == 0);
+    assert(b.limit() == 0);
 }
 
 static void append_az(tokudb::buffer &b) {
@@ -132,7 +136,8 @@ static void test_replace_grow() {
     }
     for (size_t i = 0; i < a.size()/2; i++) {
         unsigned char *cp = (unsigned char *) a.data() + 2*i;
-        assert(cp[0] == 'a'+i && cp[1] == 'a'+i);
+        assert(cp[0] == 'a'+i);
+        assert(cp[1] == 'a'+i);
     }
 }
 

--- a/storage/tokudb/tests/uint_test.cc
+++ b/storage/tokudb/tests/uint_test.cc
@@ -27,7 +27,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdint.h>
 #include <inttypes.h>
 #include <stdlib.h>
-#include <assert.h>
 #include <sys/types.h>
 
 #include <tokudb_math.h>

--- a/storage/tokudb/tests/vlq_test.cc
+++ b/storage/tokudb/tests/vlq_test.cc
@@ -52,7 +52,8 @@ static void test_vlq_uint32_error(void) {
     in_s = tokudb::vlq_decode_ui<uint32_t>(&n, b, 1);
     assert(in_s == 0);
     in_s = tokudb::vlq_decode_ui<uint32_t>(&n, b, 2);
-    assert(in_s == 2 && n == 128);
+    assert(in_s == 2);
+    assert(n == 128);
 }
 
 static void test_80000000(void) {
@@ -63,7 +64,8 @@ static void test_80000000(void) {
     out_s = tokudb::vlq_encode_ui<uint64_t>(v, b, sizeof b);
     assert(out_s == 5);
     in_s = tokudb::vlq_decode_ui<uint64_t>(&n, b, out_s);
-    assert(in_s == 5 && n == v);
+    assert(in_s == 5);
+    assert(n == v);
 }
 
 static void test_100000000(void) {
@@ -74,7 +76,8 @@ static void test_100000000(void) {
     out_s = tokudb::vlq_encode_ui<uint64_t>(v, b, sizeof b);
     assert(out_s == 5);
     in_s = tokudb::vlq_decode_ui<uint64_t>(&n, b, out_s);
-    assert(in_s == 5 && n == v);
+    assert(in_s == 5);
+    assert(n == v);
 }   
 
 int main(void) {

--- a/storage/tokudb/tests/vlq_test_uint32.cc
+++ b/storage/tokudb/tests/vlq_test_uint32.cc
@@ -44,7 +44,8 @@ static void test_vlq_uint32(void) {
         assert(out_s == 1);
         uint32_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint32_t>(&n, b, out_s);
-        assert(in_s == 1 && n == v);
+        assert(in_s == 1);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<7);
@@ -54,7 +55,8 @@ static void test_vlq_uint32(void) {
         assert(out_s == 2);
         uint32_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint32_t>(&n, b, out_s);
-        assert(in_s == 2 && n == v);
+        assert(in_s == 2);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<14);
@@ -64,7 +66,8 @@ static void test_vlq_uint32(void) {
         assert(out_s == 3);
         uint32_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint32_t>(&n, b, out_s);
-        assert(in_s == 3 && n == v);
+        assert(in_s == 3);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<21);
@@ -74,7 +77,8 @@ static void test_vlq_uint32(void) {
         assert(out_s == 4);
         uint32_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint32_t>(&n, b, out_s);
-        assert(in_s == 4 && n == v);
+        assert(in_s == 4);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<28);
@@ -84,7 +88,8 @@ static void test_vlq_uint32(void) {
         assert(out_s == 5);
         uint32_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint32_t>(&n, b, out_s);
-        assert(in_s == 5 && n == v);
+        assert(in_s == 5);
+        assert(n == v);
     }
 }
 

--- a/storage/tokudb/tests/vlq_test_uint64.cc
+++ b/storage/tokudb/tests/vlq_test_uint64.cc
@@ -46,7 +46,8 @@ static void test_vlq_uint64(uint64_t start, uint64_t stride) {
         assert(out_s == 1);
         uint64_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint64_t>(&n, b, out_s);
-        assert(in_s == 1 && n == v);
+        assert(in_s == 1);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<7);
@@ -56,7 +57,8 @@ static void test_vlq_uint64(uint64_t start, uint64_t stride) {
         assert(out_s == 2);
         uint64_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint64_t>(&n, b, out_s);
-        assert(in_s == 2 && n == v);
+        assert(in_s == 2);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<14);
@@ -66,7 +68,8 @@ static void test_vlq_uint64(uint64_t start, uint64_t stride) {
         assert(out_s == 3);
         uint64_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint64_t>(&n, b, out_s);
-        assert(in_s == 3 && n == v);
+        assert(in_s == 3);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<21);
@@ -76,7 +79,8 @@ static void test_vlq_uint64(uint64_t start, uint64_t stride) {
         assert(out_s == 4);
         uint64_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint64_t>(&n, b, out_s);
-        assert(in_s == 4 && n == v);
+        assert(in_s == 4);
+        assert(n == v);
     }
 
     printf("%u\n", 1<<28);
@@ -90,7 +94,8 @@ static void test_vlq_uint64(uint64_t start, uint64_t stride) {
         assert(out_s == 5);
         uint64_t n;
         size_t in_s = tokudb::vlq_decode_ui<uint64_t>(&n, b, out_s);
-        assert(in_s == 5 && n == v);
+        assert(in_s == 5);
+        assert(n == v);
     }
 }
 

--- a/storage/tokudb/tokudb_buffer.h
+++ b/storage/tokudb/tokudb_buffer.h
@@ -134,8 +134,8 @@ public:
         char* data_offset = (char*)m_data + offset;
         if (new_s != old_s) {
             size_t n = m_size - (offset + old_s);
-            assert_always(
-                offset + new_s + n <= m_limit && offset + old_s + n <= m_limit);
+            assert_always(offset + new_s + n <= m_limit);
+            assert_always(offset + old_s + n <= m_limit);
             memmove(data_offset + new_s, data_offset + old_s, n);
             if (new_s > old_s)
                 m_size += new_s - old_s;

--- a/storage/tokudb/tokudb_math.h
+++ b/storage/tokudb/tokudb_math.h
@@ -59,7 +59,8 @@ TOKUDB_UNUSED(static uint64_t uint_add(
     bool* over));
 static uint64_t uint_add(uint64_t x, uint64_t y, uint length_bits, bool *over) {
     uint64_t mask = uint_mask(length_bits);
-    assert_always((x & ~mask) == 0 && (y & ~mask) == 0);
+    assert_always((x & ~mask) == 0);
+    assert_always((y & ~mask) == 0);
     uint64_t s = (x + y) & mask;
     *over = s < x;     // check for overflow
     return s;
@@ -75,7 +76,8 @@ TOKUDB_UNUSED(static uint64_t uint_sub(
     bool* over));
 static uint64_t uint_sub(uint64_t x, uint64_t y, uint length_bits, bool *over) {
     uint64_t mask = uint_mask(length_bits);
-    assert_always((x & ~mask) == 0 && (y & ~mask) == 0);
+    assert_always((x & ~mask) == 0);
+    assert_always((y & ~mask) == 0);
     uint64_t s = (x - y) & mask;
     *over = s > x;    // check for overflow
     return s;


### PR DESCRIPTION
Backport miscellaneous fixes from 8.0 work:
- thd_flush_log_at_trx_commit: replace void* arg with THD* one;
- split ut_a / ut_ad / DBUG_ASSERT / assert / assert_always /
  assert_debug logical conjunctions to separate asserts;
- remove extra space in innodb_sched_priority_master_update warning message;
- mark lock0wait.cc:print_lock_wait_timeout static;
- ut0ut.cc: do not include btr0types.h;
- mysql_unix_socket_connect: use HAVE_PSI_FILE_INTERFACE instead of
  HAVE_PSI_INTERFACE, replace PSI_server calls  with PSI_FILE_CALL
  macro, restructure the PFS annotation to match the common style
- audit_log plugin: mark a lot of variables and functions static,
  remove unused ones;
- mark Percona additions in sql_show.cc static;
- move extern void init_log_slow_verbosity,
  init_slow_query_log_use_global_control, init_log_slow_sp_statements
  declarations from mysqld.cc to set_var.h
- mark row0mysql.cc:column_zip_set_alloc static.

https://ps56.cd.percona.com/job/percona-server-5.6-param/26/