### PR TITLE
PS-5775: Improve redo log encryption error messages (5.7)

### DIFF
--- a/mysql-test/include/log_encrypt_1.inc
+++ b/mysql-test/include/log_encrypt_1.inc
@@ -8,7 +8,8 @@
 
 --disable_query_log
 call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+call mtr.add_suppression("Redo log cannot be encrypted, if the keyring plugin is not loaded.");
+call mtr.add_suppression("keyring error: please check that a keyring plugin is loaded.");
 call mtr.add_suppression("Redo log key generation failed.");
 --enable_query_log
 

--- a/mysql-test/include/log_encrypt_3.inc
+++ b/mysql-test/include/log_encrypt_3.inc
@@ -7,7 +7,8 @@
 
 --disable_query_log
 call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+call mtr.add_suppression("Redo log cannot be encrypted, if the keyring plugin is not loaded.");
+call mtr.add_suppression("keyring error: please check that a keyring plugin is loaded.");
 call mtr.add_suppression("Redo log key generation failed.");
 --enable_query_log
 

--- a/mysql-test/include/log_encrypt_6.inc
+++ b/mysql-test/include/log_encrypt_6.inc
@@ -87,7 +87,7 @@ DROP DATABASE tde_db;
 
 --echo # Try starting without keyring : Error
 let NEW_CMD = $MYSQLD --no-defaults --innodb_undo_tablespaces=2 --innodb_page_size=$START_PAGE_SIZE --innodb_log_file_size=$LOG_FILE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1  --secure-file-priv="" --console </dev/null>>$MYSQL_TMP_DIR/wl9290.err 2>&1;
---error 2
+--error 1
 --exec $NEW_CMD
 
 --echo # Search for error message

--- a/mysql-test/include/percona_log_encrypt_change.inc
+++ b/mysql-test/include/percona_log_encrypt_change.inc
@@ -32,7 +32,7 @@ SELECT @@innodb_redo_log_encrypt;
 --source include/shutdown_mysqld.inc
 
 --let NEW_CMD = $MYSQLD $extra_args $KEYRING_PARAMS --datadir=$MYSQLD_DATADIR --innodb_redo_log_encrypt=$LOG_ENCRYPT_OTHER_TYPE >$MYSQLD_LOG 2>&1;
---error 2
+--error 1
 --exec $NEW_CMD
 
 # Test: crash the server AND restart with a different parameter
@@ -54,7 +54,7 @@ INSERT INTO t1 VALUES(2, "ccccc");
 --source include/kill_mysqld.inc
 
 --let NEW_CMD = $MYSQLD $extra_args $KEYRING_PARAMS --datadir=$MYSQLD_DATADIR --innodb_redo_log_encrypt=$LOG_ENCRYPT_OTHER_TYPE >$MYSQLD_LOG 2>&1;
---error 2
+--error 1
 --exec $NEW_CMD
 
 --source include/start_mysqld_no_echo.inc

--- a/mysql-test/suite/innodb/r/log_encrypt_1_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_1_mk.result
@@ -1,6 +1,6 @@
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 Warnings:
-Warning	3236	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	3236	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/log_encrypt_1_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_1_rk.result
@@ -1,6 +1,6 @@
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 Warnings:
-Warning	3236	InnoDB: Redo log key generation failed.
+Warning	3236	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
@@ -2,10 +2,10 @@ CREATE DATABASE tde_db;
 USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 Warnings:
-Warning	3236	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	3236	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 SHOW WARNINGS;
 Level	Code	Message
-Warning	3236	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	3236	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE tde_db.t4 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
@@ -2,10 +2,10 @@ CREATE DATABASE tde_db;
 USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 Warnings:
-Warning	3236	InnoDB: Redo log key generation failed.
+Warning	3236	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 SHOW WARNINGS;
 Level	Code	Message
-Warning	3236	InnoDB: Redo log key generation failed.
+Warning	3236	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE tde_db.t4 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_kill.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_kill.result
@@ -4,7 +4,7 @@ SELECT @@global.innodb_redo_log_encrypt ;
 OFF
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 Warnings:
-Warning	3236	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	3236	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 UNINSTALL PLUGIN keyring_file;
 ERROR 42000: PLUGIN keyring_file does not exist
 CREATE TABLE tne_1(c1 INT, c2 varchar(2000)) ENGINE = InnoDB;
@@ -16,7 +16,7 @@ c1	LEFT(c2,10)
 100	cccccccccc
 DROP TABLE tne_1;
 # Stop the MTR default DB server
-Pattern "Can\'t set redo log tablespace to be encrypted" found
+Pattern "Redo log cannot be encrypted if the keyring plugin is not loaded." not found
 # create bootstrap file
 # Prepare new datadir
 # Run the bootstrap command with keyring

--- a/mysql-test/suite/innodb/t/log_encrypt_kill.test
+++ b/mysql-test/suite/innodb/t/log_encrypt_kill.test
@@ -40,7 +40,7 @@ DROP TABLE tne_1;
 --source include/shutdown_mysqld.inc
 
 # Grep for message in server error log
-let SEARCH_PATTERN=Can\'t set redo log tablespace to be encrypted;
+let SEARCH_PATTERN=Redo log cannot be encrypted if the keyring plugin is not loaded.;
 --source include/search_pattern.inc
 
 # Create path for ibdata* & undo* files both DBs

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -21528,11 +21528,20 @@ update_innodb_redo_log_encrypt(
 		return;
 	}
 
-	byte iv[ENCRYPTION_KEY_LEN];
-	Encryption::random_value(iv);
+	ut_ad(strlen(server_uuid) > 0);
+
+	if (!Encryption::check_keyring()) {
+		ib_senderrf(
+			thd, IB_LOG_LEVEL_WARN,
+			ER_REDO_ENCRYPTION_ERROR,
+			"Redo log cannot be encrypted"
+			" if the keyring plugin is not loaded.");
+		ib::error() << "Redo log cannot be encrypted,"
+			<< " if the keyring plugin is not loaded.";
+		return;
+	}
 
 	if (target == REDO_LOG_ENCRYPT_MK) {
-		ut_ad(strlen(server_uuid) > 0);
 		if (srv_enable_redo_encryption_mk(thd)) {
 			return;
 		}
@@ -21542,7 +21551,6 @@ update_innodb_redo_log_encrypt(
 	}
 
 	if (target == REDO_LOG_ENCRYPT_RK) {
-		ut_ad(strlen(server_uuid) > 0);
 		if (srv_enable_redo_encryption_rk(thd)) {
 			return;
 		}

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -1143,7 +1143,7 @@ log_read_encryption() {
 		/* Make sure the keyring is loaded. */
 		if (!Encryption::check_keyring()) {
 			ut_free(log_block_buf_ptr);
-			ib::fatal() << "Redo log was encrypted,"
+			ib::error() << "Redo log was encrypted,"
 				    << " but keyring plugin is not loaded.";
 			return(false);
 		}
@@ -1177,7 +1177,7 @@ log_read_encryption() {
 
 		/* Make sure the keyring is loaded. */
 		if (!Encryption::check_keyring()) {
-			ib::fatal() << "Redo log was encrypted,"
+			ib::error() << "Redo log was encrypted,"
 				    << " but keyring plugin is not loaded.";
 		} else if (Encryption::decode_encryption_info(
 			       key, iv,
@@ -1189,7 +1189,7 @@ log_read_encryption() {
 	if (encrypted_log) {
 		if (existing_redo_encryption_mode != srv_redo_log_encrypt &&
 		    srv_redo_log_encrypt != REDO_LOG_ENCRYPT_OFF) {
-			ib::fatal() <<
+			ib::error() <<
 				" Redo log encryption mode"
 				" can't be switched without stopping the server and"
 				" recreating the redo logs. Current mode is "
@@ -1226,7 +1226,7 @@ log_read_encryption() {
 		}
 	} else if (encryption_magic) {
 		ut_free(log_block_buf_ptr);
-		ib::fatal() << "Cannot read the encryption"
+		ib::error() << "Cannot read the encryption"
 			       " information in log file header, please"
 			       " check if keyring plugin loaded and"
 			       " the key file exists.";


### PR DESCRIPTION
If redo log encryption fails becasuse a keyring errors, this should be
reported to the user instead of a generic error message.