### PR TITLE
PS-5776: Report undo encryption errors to the user (8.0)

### DIFF
--- a/mysql-test/suite/innodb/r/log_encrypt_kill.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_kill.result
@@ -6,6 +6,8 @@ SET GLOBAL innodb_redo_log_encrypt = 1;
 Warnings:
 Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 SET GLOBAL innodb_undo_log_encrypt = 1;
+Warnings:
+Warning	49015	InnoDB: Undo log can't be encrypted if the keyring plugin is not loaded.
 UNINSTALL PLUGIN keyring_file;
 ERROR 42000: PLUGIN keyring_file does not exist
 CREATE TABLE tne_1(c1 INT, c2 varchar(2000)) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/undo_encrypt_basic.result
+++ b/mysql-test/suite/innodb/r/undo_encrypt_basic.result
@@ -3,6 +3,8 @@
 # Run the bootstrap command with keyring
 # Start the DB server with undo log encryption disabled, and no keyring plugin.
 SET GLOBAL innodb_undo_log_encrypt = ON;
+Warnings:
+Warning	49015	InnoDB: Undo log can't be encrypted if the keyring plugin is not loaded.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 # Start the DB server with undo log encryption disabled and keyring plugin loaded. It should success.

--- a/mysql-test/suite/innodb/t/log_encrypt_kill.test
+++ b/mysql-test/suite/innodb/t/log_encrypt_kill.test
@@ -7,6 +7,8 @@
 
 --disable_query_log
 call mtr.add_suppression('Error in Log_event::read_log_event()');
+call mtr.add_suppression("Undo log can't be encrypted if the keyring plugin is not loaded.");
+call mtr.add_suppression("Check keyring plugin fail, please check the keyring plugin is loaded.");
 --enable_query_log
 
 # Create a table with encryption, should fail since keyring is not

--- a/mysql-test/suite/innodb/t/undo_encrypt_basic.test
+++ b/mysql-test/suite/innodb/t/undo_encrypt_basic.test
@@ -15,6 +15,8 @@ call mtr.add_suppression("\\[ERROR\\] .* The error means the system cannot find 
 call mtr.add_suppression("\\[ERROR\\] .* Could not find a valid tablespace file for");
 call mtr.add_suppression("\\[ERROR\\] .* If you are installing InnoDB, remember that you must create directories yourself, InnoDB does not create them.");
 call mtr.add_suppression("\\[ERROR\\] .* Can't set undo tablespace 'innodb_undo_001' to be encrypted");
+call mtr.add_suppression("Undo log can't be encrypted if the keyring plugin is not loaded.");
+call mtr.add_suppression("Check keyring plugin fail, please check the keyring plugin is loaded.");
 --enable_query_log
 
 let $MYSQLD_BASEDIR= `select @@basedir`;

--- a/mysql-test/suite/sys_vars/r/innodb_undo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_undo_log_encrypt_basic.result
@@ -23,6 +23,8 @@ select * from performance_schema.session_variables where variable_name='innodb_u
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_undo_log_encrypt	OFF
 set global innodb_undo_log_encrypt=1;
+Warnings:
+Warning	49015	InnoDB: Undo log can't be encrypted if the keyring plugin is not loaded.
 select @@global.innodb_undo_log_encrypt;
 @@global.innodb_undo_log_encrypt
 0
@@ -51,6 +53,8 @@ ERROR 42000: Incorrect argument type to variable 'innodb_undo_log_encrypt'
 set global innodb_undo_log_encrypt='foo';
 ERROR 42000: Variable 'innodb_undo_log_encrypt' can't be set to the value of 'foo'
 set global innodb_undo_log_encrypt=-2;
+Warnings:
+Warning	49015	InnoDB: Undo log can't be encrypted if the keyring plugin is not loaded.
 set global innodb_undo_log_encrypt=1e1;
 ERROR 42000: Incorrect argument type to variable 'innodb_undo_log_encrypt'
 set global innodb_undo_log_encrypt=2;

--- a/mysql-test/suite/sys_vars/t/innodb_undo_log_encrypt_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_undo_log_encrypt_basic.test
@@ -1,6 +1,8 @@
 --disable_query_log
 call mtr.add_suppression("\\[ERROR\\] .* Encryption can't find master key, please check the keyring plugin is loaded.");
 call mtr.add_suppression("\\[ERROR\\] .* Can't set undo tablespace 'innodb_undo_001' to be encrypted");
+call mtr.add_suppression("Undo log can't be encrypted if the keyring plugin is not loaded.");
+call mtr.add_suppression("Check keyring plugin fail, please check the keyring plugin is loaded.");
 --enable_query_log
 
 SET @start_global_value = @@global.innodb_undo_log_encrypt;

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -19324,6 +19324,9 @@ ER_REDO_ENCRYPTION_CANT_PARSE_KEY
 ER_REDO_ENCRYPTION_KEYRING
   eng "Redo log cannot be encrypted if the keyring plugin is not loaded."
 
+ER_UNDO_NO_KEYRING
+  eng "Undo log can't be encrypted if the keyring plugin is not loaded."
+
 #
 # End of Percona Server 8.0 error messages
 #

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1057,7 +1057,7 @@ void undo_rotate_default_master_key();
                         case, default master key will be used which will be
                         rotated later with actual master key from kyering.
 @return false for success, true otherwise. */
-bool srv_enable_undo_encryption(bool is_boot);
+bool srv_enable_undo_encryption(THD *thd, bool is_boot);
 
 /** Get count of tasks in the queue.
  @return number of tasks in queue */

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1341,7 +1341,7 @@ static dberr_t srv_undo_tablespaces_construct(bool create_new_db) {
   }
 
   if (srv_undo_log_encrypt) {
-    srv_enable_undo_encryption(false);
+    srv_enable_undo_encryption(nullptr, false);
   }
 
   return (DB_SUCCESS);


### PR DESCRIPTION
If we can't set the undo tablespace to be encrypted, and it was requested in a
MySQL session, errors should be also reported to the sessior requesting encryption.

If encryption fails because there is no keyring plugin loaded, this should be
mentioned in the error message.