### PR TITLE
Fix PS-5780 (The release build (5.6) does not work on Debian buster) (5.6)

### DIFF
--- a/client/mysql_upgrade.c
+++ b/client/mysql_upgrade.c
@@ -1004,7 +1004,7 @@ static int check_version_match(void)
 
 int main(int argc, char **argv)
 {
-  char self_name[FN_REFLEN];
+  char self_name[FN_REFLEN + 1];
 
   MY_INIT(argv[0]);
 

--- a/mysys/my_gethwaddr.c
+++ b/mysys/my_gethwaddr.c
@@ -108,7 +108,7 @@ my_bool my_gethwaddr(uchar *to)
     {
       /* Reset struct, copy interface name */
       memset(&ifr, 0, sizeof(ifr));
-      strncpy(ifr.ifr_name, ifri->ifr_name, sizeof(ifr.ifr_name));
+      memcpy(ifr.ifr_name, ifri->ifr_name, sizeof(ifr.ifr_name));
 
       /* Get HW address, break if not 0 */
       if (ioctl(fd, SIOCGIFHWADDR, &ifr) >= 0)

--- a/sql/sql_connect.cc
+++ b/sql/sql_connect.cc
@@ -186,11 +186,17 @@ void init_user_stats(USER_STATS *user_stats,
   DBUG_PRINT("info",
              ("Add user_stats entry for user %s - priv_user %s",
               user, priv_user));
-  strncpy(user_stats->user, user, sizeof(user_stats->user));
-  strncpy(user_stats->priv_user, priv_user, sizeof(user_stats->priv_user));
+  user_stats->user_len=               strlen(user);
+  if (user_stats->user_len >= sizeof(user_stats->user))
+    user_stats->user_len= sizeof(user_stats->user) - 1;
+  memcpy(user_stats->user, user, user_stats->user_len);
+  user_stats->user[user_stats->user_len]= '\0';
 
-  user_stats->user_len=               strlen(user_stats->user);
-  user_stats->priv_user_len=          strlen(user_stats->priv_user);
+  user_stats->priv_user_len=          strlen(priv_user);
+  if (user_stats->priv_user_len >= sizeof(user_stats->priv_user))
+    user_stats->priv_user_len= sizeof(user_stats->priv_user) - 1;
+  strncpy(user_stats->priv_user, priv_user, user_stats->priv_user_len);
+  user_stats->priv_user[user_stats->priv_user_len]= '\0';
 
   user_stats->total_connections=      total_connections;
   user_stats->total_ssl_connections=  total_ssl_connections;

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -1833,7 +1833,7 @@ dict_table_rename_in_cache(
 
 			ulint	db_len;
 			char*	old_id;
-			char    old_name_cs_filename[MAX_TABLE_NAME_LEN+20];
+			char    old_name_cs_filename[MAX_FULL_NAME_LEN + 1];
 			uint    errors = 0;
 
 			/* All table names are internally stored in charset
@@ -1850,7 +1850,7 @@ dict_table_rename_in_cache(
 			in old_name_cs_filename */
 
 			strncpy(old_name_cs_filename, old_name,
-				MAX_TABLE_NAME_LEN);
+				sizeof(old_name_cs_filename));
 			if (strstr(old_name, TEMP_TABLE_PATH_PREFIX) == NULL) {
 
 				innobase_convert_to_system_charset(
@@ -1872,7 +1872,7 @@ dict_table_rename_in_cache(
 					/* Old name already in
 					my_charset_filename */
 					strncpy(old_name_cs_filename, old_name,
-						MAX_TABLE_NAME_LEN);
+						sizeof(old_name_cs_filename));
 				}
 			}
 
@@ -1898,7 +1898,7 @@ dict_table_rename_in_cache(
 
 				/* This is a generated >= 4.0.18 format id */
 
-				char	table_name[MAX_TABLE_NAME_LEN] = "";
+				char	table_name[MAX_TABLE_NAME_LEN + 1] = "";
 				uint	errors = 0;
 
 				if (strlen(table->name) > strlen(old_name)) {

--- a/storage/innobase/include/dict0crea.ic
+++ b/storage/innobase/include/dict0crea.ic
@@ -65,7 +65,7 @@ dict_create_add_foreign_id(
 			sprintf(id, "%s_ibfk_%lu", name,
 				(ulong) (*id_nr)++);
 		} else {
-			char	table_name[MAX_TABLE_NAME_LEN + 20] = "";
+			char	table_name[MAX_TABLE_NAME_LEN + 20 + 1] = "";
 			uint	errors = 0;
 
 			strncpy(table_name, name,

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -1468,7 +1468,7 @@ log_online_setup_bitmap_file_range(
 		if (file_seq_num > bitmap_files->files[array_pos].seq_num) {
 
 			bitmap_files->files[array_pos].seq_num = file_seq_num;
-			strncpy(bitmap_files->files[array_pos].name,
+			memcpy(bitmap_files->files[array_pos].name,
 				bitmap_dir_file_info.name, FN_REFLEN);
 			bitmap_files->files[array_pos].name[FN_REFLEN - 1]
 				= '\0';

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -5551,8 +5551,8 @@ row_rename_table_for_mysql(
 
 	if (!new_is_tmp) {
 		/* Rename all constraints. */
-		char	new_table_name[MAX_TABLE_NAME_LEN] = "";
-		char	old_table_utf8[MAX_TABLE_NAME_LEN] = "";
+		char	new_table_name[MAX_TABLE_NAME_LEN + 1] = "";
+		char	old_table_utf8[MAX_TABLE_NAME_LEN + 1] = "";
 		uint	errors = 0;
 
 		strncpy(old_table_utf8, old_name, MAX_TABLE_NAME_LEN);

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -3318,7 +3318,7 @@ srv_get_meta_data_filename(
 	} else {
 		ut_ad(strncmp(suffix, ".ibd", suffix_len) == 0);
 
-		strncpy(filename, path, len - suffix_len);
+		strncpy(filename, path, max_len - suffix_len);
 		suffix = filename + (len - suffix_len);
 		strcpy(suffix, ".cfg");
 	}

--- a/storage/perfschema/pfs_instr.cc
+++ b/storage/perfschema/pfs_instr.cc
@@ -1341,7 +1341,7 @@ search:
         pfs->m_class= klass;
         pfs->m_enabled= klass->m_enabled && flag_global_instrumentation;
         pfs->m_timed= klass->m_timed;
-        strncpy(pfs->m_filename, normalized_filename, normalized_length);
+        memcpy(pfs->m_filename, normalized_filename, normalized_length);
         pfs->m_filename[normalized_length]= '\0';
         pfs->m_filename_length= normalized_length;
         pfs->m_file_stat.m_open_count= 1;

--- a/storage/perfschema/pfs_instr_class.cc
+++ b/storage/perfschema/pfs_instr_class.cc
@@ -611,7 +611,7 @@ static void init_instr_class(PFS_instr_class *klass,
 {
   DBUG_ASSERT(name_length <= PFS_MAX_INFO_NAME_LENGTH);
   memset(klass, 0, sizeof(PFS_instr_class));
-  strncpy(klass->m_name, name, name_length);
+  memcpy(klass->m_name, name, name_length);
   klass->m_name_length= name_length;
   klass->m_flags= flags;
   klass->m_enabled= true;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5780

Partially cherry-picked 5.7 upstream fixes for gcc-8 - releated warnings.
"Bug#27558169 BACKPORT TO 5.7 BUG #26826272: REMOVE GCC 8 WARNINGS [noclose]"
(commit mysql/mysql-server@1ffd796)
(commit mysql/mysql-server@a091d6b)

Fixed Percona-specific 'strncpy()'-releated
'output may be truncated copying NNN bytes from a string of length MMM [-Werror=stringop-truncation]'
warning inside 'log_online_setup_bitmap_file_range()' function in
'storage/innobase/log/log0online.cc'.
