### PR TITLE
Fix PS-5798 (rocksdb.cons_snapshot_read_committed testcase failed sometimes)

### DIFF
--- a/mysql-test/suite/rocksdb/t/commit_in_the_middle_ddl.test
+++ b/mysql-test/suite/rocksdb/t/commit_in_the_middle_ddl.test
@@ -21,3 +21,4 @@ select count(*) from a force index(v);
 
 DROP TABLE a;
 
+--source suite/rocksdb/include/drop_table_sync.inc


### PR DESCRIPTION
cons_snapshot_read_committed follow the commit_in_the_middle_ddl,
which may cause the new snapshot in the backend thread Rdb_drop_index_thread.