### PR TITLE
PS-5803, PS-5804: innodb_redo_log_encrypt shouldn't be persisted

### DIFF
--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -45,7 +45,7 @@ include/assert.inc ['Expect 625 variables in the table. Due to open Bugs, we are
 
 # Test SET PERSIST
 
-include/assert.inc [Expect 437 persisted variables in the table. Due to open Bugs, we are checking for 426]
+include/assert.inc [Expect 436 persisted variables in the table. Due to open Bugs, we are checking for 425]
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -53,9 +53,9 @@ include/assert.inc [Expect 437 persisted variables in the table. Due to open Bug
 ************************************************************
 # restart
 
-include/assert.inc [Expect 426 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 426 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 426 persisted variables with matching peristed and global values.]
+include/assert.inc [Expect 425 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 425 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 425 persisted variables with matching peristed and global values.]
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
@@ -24,6 +24,10 @@ innodb_redo_log_encrypt	OFF
 select * from performance_schema.session_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_redo_log_encrypt	OFF
+set persist innodb_redo_log_encrypt=1;
+ERROR HY000: Variable 'innodb_redo_log_encrypt' is a non persistent variable
+set persist_only innodb_redo_log_encrypt=1;
+ERROR HY000: Variable 'innodb_redo_log_encrypt' is a non persistent variable
 set global innodb_redo_log_encrypt=1;
 Warnings:
 Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.

--- a/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
@@ -20,6 +20,12 @@ select * from performance_schema.global_variables where variable_name='innodb_re
 select * from performance_schema.session_variables where variable_name='innodb_redo_log_encrypt';
 --enable_warnings
 
+# Can't be persisted
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set persist innodb_redo_log_encrypt=1;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set persist_only innodb_redo_log_encrypt=1;
+
 #
 # show that it's writable
 #

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -41,7 +41,7 @@
 call mtr.add_suppression("Failed to set up SSL because of the following SSL library error");
 
 let $total_global_vars=`SELECT COUNT(*) FROM performance_schema.global_variables where variable_name NOT LIKE 'ndb_%'`;
-let $total_persistent_vars=437;
+let $total_persistent_vars=436;
 
 --echo ***************************************************************
 --echo * 0. Verify that variables present in performance_schema.global

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -23289,7 +23289,7 @@ static MYSQL_SYSVAR_ENUM(
     NULL, NULL, DEFAULT_ROW_FORMAT_DYNAMIC, &innodb_default_row_format_typelib);
 
 static MYSQL_SYSVAR_ENUM(redo_log_encrypt, srv_redo_log_encrypt,
-                         PLUGIN_VAR_OPCMDARG,
+                         PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_NOPERSIST,
                          "Enable or disable Encryption of REDO tablespace."
                          "Possible values: OFF, ON, MASTER_KEY, KEYRING_KEY.",
                          innodb_redo_log_encrypt_validate,


### PR DESCRIPTION
    Persisted variables are handled differently (after the redo log is already opened),
    and startup continues even with incorrect values, resulting in encryption turning off
    and writing a message to the error log.

    This caused the following issues:

    * PS-5803: changing encryption mode with set persist fails, but we do persist the current
    value
    * PS-5804: changing encryption mode with set persist_only succeeds, and we silently turn
    off encryption at next startup

    As a workaround, we disable persisting this variable.
