### PR TITLE
PS-5785: MTR issues with changed page tracking tests (8.0)

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -429,6 +429,8 @@ sub main {
 
   mtr_report("Collecting tests...");
   my $tests= collect_test_cases($opt_reorder, $opt_suites, \@opt_cases, \@opt_skip_test_list);
+  my $all_tests;
+  @$all_tests = @$tests;
   mark_time_used('collect');
 
   if ( $opt_report_features ) {
@@ -586,19 +588,23 @@ sub main {
     mtr_error("Test suite aborted");
   }
 
-  if ( @$completed != $num_tests){
-
-    if ($opt_force){
-      # All test should have been run, print any that are still in $tests
-      #foreach my $test ( @$tests ){
-      #  $test->print_test();
-      #}
-    }
-
-    # Not all tests completed, failure
+  if (@$completed != $num_tests) {
+    # Not all tests completed
     mtr_report();
     mtr_report("Only ", int(@$completed), " of $num_tests completed.");
-    mtr_error("Not all tests completed");
+    mtr_report("Not all tests completed. This means that a test scheduled for a worker did not report anything, the worker most likely crashed.");
+
+    my %comp;
+
+    foreach ( @$completed ) {
+      $comp{$_->{name}} = 1;
+    }
+    for (my $i = 0 ; $i <= @$all_tests ; $i++) {
+      my $t = $all_tests->[$i];
+      if (exists $t->{name} && !exists $comp{$t->{name}}) {
+        mtr_report("Missing result for testcase: ", $t->{name});
+      }
+    }
   }
 
   mark_time_used('init');

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -388,6 +388,8 @@ sub main {
 
   mtr_report("Collecting tests...");
   my $tests= collect_test_cases($opt_reorder, $opt_suites, \@opt_cases, \@opt_skip_test_list);
+  my $all_tests;
+  @$all_tests = @$tests;
   mark_time_used('collect');
 
   if ( $opt_report_features ) {
@@ -517,19 +519,23 @@ sub main {
     mtr_error("Test suite aborted");
   }
 
-  if ( @$completed != $num_tests){
-
-    if ($opt_force){
-      # All test should have been run, print any that are still in $tests
-      #foreach my $test ( @$tests ){
-      #  $test->print_test();
-      #}
-    }
-
-    # Not all tests completed, failure
+  if (@$completed != $num_tests) {
+    # Not all tests completed
     mtr_report();
     mtr_report("Only ", int(@$completed), " of $num_tests completed.");
-    mtr_error("Not all tests completed");
+    mtr_report("Not all tests completed. This means that a test scheduled for a worker did not report anything, the worker most likely crashed.");
+
+    my %comp;
+
+    foreach ( @$completed ) {
+      $comp{$_->{name}} = 1;
+    }
+    for (my $i = 0 ; $i <= @$all_tests ; $i++) {
+      my $t = $all_tests->[$i];
+      if (exists $t->{name} && !exists $comp{$t->{name}}) {
+        mtr_report("Missing result for testcase: ", $t->{name});
+      }
+    }
   }
 
   mark_time_used('init');

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -541,6 +541,8 @@ sub main {
   mtr_report("Collecting tests");
   my $tests = collect_test_cases($opt_reorder, $opt_suites,
                                  \@opt_cases,  $opt_skip_test_list);
+  my $all_tests;
+  @$all_tests = @$tests;
   mark_time_used('collect');
 
   check_secondary_engine_option($tests) if $secondary_engine_support;
@@ -706,10 +708,23 @@ sub main {
   }
 
   if (@$completed != $num_tests) {
-    # Not all tests completed, failure
+    # Not all tests completed
     mtr_report();
     mtr_report("Only ", int(@$completed), " of $num_tests completed.");
-    mtr_error("Not all tests completed");
+    mtr_report("Not all tests completed. This means that a test scheduled for a worker did not report anything, the worker most likely crashed.");
+
+    my %comp;
+
+    foreach ( @$completed ) {
+      $comp{$_->{name}} = 1;
+    }
+    for (my $i = 0 ; $i <= @$all_tests ; $i++) {
+      my $t = $all_tests->[$i];
+      if (exists $t->{name} && !exists $comp{$t->{name}}) {
+        mtr_report("Missing result for testcase: ", $t->{name});
+      }
+    }
+
   }
 
   mark_time_used('init');

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
@@ -27,7 +27,7 @@ ib_modified_log_1_0.xdb
 # restart
 include/assert.inc [There should not be a hole in the tracked LSN range]
 2nd restart
-# restart:-#d,crash_before_bitmap_write
+# restart:--debug=+d,crash_before_bitmap_write
 INSERT INTO t1 SELECT x FROM t1;
 ERROR HY000: Lost connection to MySQL server during query
 include/assert.inc [There should not be a hole in the tracked LSN range]

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_crash.result
@@ -26,7 +26,7 @@ SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 # restart
 include/assert.inc [There should not be a hole in the tracked LSN range]
 2nd restart
-# restart:-#d,crash_before_bitmap_write
+# restart:--debug=+d,crash_before_bitmap_write
 INSERT INTO t1 SELECT x FROM t1;
 ERROR HY000: Lost connection to MySQL server during query
 include/assert.inc [There should not be a hole in the tracked LSN range]

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_debug.result
@@ -6,7 +6,7 @@ call mtr.add_suppression("last tracked LSN in");
 RESET CHANGED_PAGE_BITMAPS;
 CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 2nd restart
-# restart:-#d,bitmap_page_write_error
+# restart:--debug=+d,bitmap_page_write_error
 INSERT INTO t1 VALUES (1);
 SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
@@ -38,7 +38,7 @@ RESET CHANGED_PAGE_BITMAPS;
 4th restart
 # restart
 5th restart
-# restart:-#d,bitmap_page_2_write_error
+# restart:--debug=+d,bitmap_page_2_write_error
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
 SET DEBUG_SYNC="i_s_innodb_changed_pages_range_ready SIGNAL ready WAIT_FOR finish";
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_CHANGED_PAGES;
@@ -66,7 +66,7 @@ CREATE TABLE t1 (a INT) ENGINE=InnoDB STATS_PERSISTENT=0;
 SET GLOBAL innodb_file_per_table=ON;
 CREATE TABLE t2 (a INT) ENGINE=InnoDB;
 # 6th restart
-# restart:-#d,bitmap_page_2_write_error
+# restart:--debug=+d,bitmap_page_2_write_error
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
 INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
@@ -105,7 +105,7 @@ RESET CHANGED_PAGE_BITMAPS;
 #
 CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 9th restart
-# restart:-#d,bitmap_page_write_error
+# restart:--debug=+d,bitmap_page_write_error
 # connection con2
 SET DEBUG_SYNC="log_online_follow_redo_log SIGNAL flush_ready WAIT_FOR finish_flush";
 FLUSH CHANGED_PAGE_BITMAPS;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -53,7 +53,7 @@ list_files $MYSQLD_DATADIR ib_modified_log*;
 #
 
 --echo 2nd restart
---let $restart_parameters=restart:-#d,crash_before_bitmap_write
+--let $restart_parameters=restart:--debug="+d,crash_before_bitmap_write"
 --source include/restart_mysqld.inc
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --error CR_SERVER_LOST

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -51,7 +51,7 @@ SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 #
 
 --echo 2nd restart
---let $restart_parameters=restart:-#d,crash_before_bitmap_write
+--let $restart_parameters=restart:--debug="+d,crash_before_bitmap_write"
 --source include/restart_mysqld.inc
 --exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
 --error 2013

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash.test
@@ -50,7 +50,7 @@ SET GLOBAL INNODB_FAST_SHUTDOWN=2;
 # Test crash right before writing of new bitmap data
 #
 
---let $restart_parameters= restart:-#d,crash_before_bitmap_write
+--let $restart_parameters=restart:--debug="+d,crash_before_bitmap_write"
 --echo 2nd restart
 --source include/restart_mysqld.inc
 

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -20,7 +20,7 @@ CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 
 # Setup an error on bitmap write
 --echo 2nd restart
---let $restart_parameters= restart:-#d,bitmap_page_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_write_error"
 --source include/restart_mysqld.inc
 
 # Generate some log data
@@ -127,7 +127,7 @@ RESET CHANGED_PAGE_BITMAPS;
 
 # Setup an error on the 2nd bitmap page write, so that bitmap contains an incomplete run
 --echo 5th restart
---let $restart_parameters= restart:-#d,bitmap_page_2_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_2_write_error"
 --source include/restart_mysqld.inc
 
 --connect(con2,localhost,root,,)
@@ -191,7 +191,7 @@ SET GLOBAL innodb_file_per_table=ON;
 CREATE TABLE t2 (a INT) ENGINE=InnoDB;
 
 --echo # 6th restart
---let $restart_parameters= restart:-#d,bitmap_page_2_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_2_write_error"
 --source include/restart_mysqld.inc
 
 # Generate log data that is larger than the log capacity
@@ -254,7 +254,7 @@ RESET CHANGED_PAGE_BITMAPS;
 CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 
 --echo 9th restart
---let $restart_parameters= restart:-#d,bitmap_page_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_write_error"
 --source include/restart_mysqld.inc
 
 --connect(con2,localhost,root,,)

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_debug.test
@@ -22,7 +22,7 @@ CREATE TABLE t1 (x INT) ENGINE=InnoDB;
 
 # Setup an error on bitmap write
 --echo 2nd restart
---let $restart_parameters= restart:-#d,bitmap_page_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_write_error"
 --source include/restart_mysqld.inc
 
 # Generate some log data
@@ -129,7 +129,7 @@ RESET CHANGED_PAGE_BITMAPS;
 
 # Setup an error on the 2nd bitmap page write, so that bitmap contains an incomplete run
 --echo 5th restart
---let $restart_parameters= restart:-#d,bitmap_page_2_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_2_write_error"
 --source include/restart_mysqld.inc
 
 --connect(con2,localhost,root,,)
@@ -193,7 +193,7 @@ SET GLOBAL innodb_file_per_table=ON;
 CREATE TABLE t2 (a INT) ENGINE=InnoDB;
 
 --echo # 6th restart
---let $restart_parameters= restart:-#d,bitmap_page_2_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_2_write_error"
 --source include/restart_mysqld.inc
 
 # Generate log data that is larger than the log capacity
@@ -256,7 +256,7 @@ RESET CHANGED_PAGE_BITMAPS;
 CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 
 --echo 9th restart
---let $restart_parameters= restart:-#d,bitmap_page_write_error
+--let $restart_parameters= restart:--debug="+d,bitmap_page_write_error"
 --source include/restart_mysqld.inc
 
 --connect(con2,localhost,root,,)


### PR DESCRIPTION
I've added this as two commits to keep the mysql test run change separate (and easily upstreamable).

#### PS-5785: Fix MTR error reporting when a worker dies.
Previously if for some reason an MTR worker crashed, MTR would continue, but it wouldn't summarize the failures at the end. Checking which checks failed could only be done by analyzing the output, if it was saved.

This change modifies mysql-test-run so:

reporting continues even if not all tests were completed (a worker crashed, for example because the die call in split_options during a server restart)
the tests without a status set will be reported at the end. One line per missing testcase, with the format: "Missing result for testcase: "

#### PS-5785: Fix incorrect restart parameters in changed page tests