### PR TITLE
PS-5790: keyring_vault tests are failing on Jenkins

### DIFF
--- a/plugin/keyring_vault/tests/mtr/delete_secret_directory.inc
+++ b/plugin/keyring_vault/tests/mtr/delete_secret_directory.inc
@@ -50,7 +50,7 @@ let SERVER_UUID= query_get_value(SELECT @@SERVER_UUID, @@SERVER_UUID, 1);
     $vault_ca_cert_opt= "--cacert $vault_ca";
   }
 
-  system(qq#curl -L -H "X-Vault-Token: $token" -X LIST $vault_ca_cert_opt $vault_url/v1/$secret_mount_point > $vardir/tmp/curl_list_result#);
+  system(qq#curl --http1.1 -L -H "X-Vault-Token: $token" -X LIST $vault_ca_cert_opt $vault_url/v1/$secret_mount_point > $vardir/tmp/curl_list_result#);
 
   my $curl_conn_successful = 1;
   my $curl_response = 0;
@@ -107,7 +107,7 @@ let SERVER_UUID= query_get_value(SELECT @@SERVER_UUID, @@SERVER_UUID, 1);
         if ($_ =~ m/"(.*)"/)
         {
           print $help_file $1;
-          system(qq#curl -L -H "X-Vault-Token: $token" $vault_ca_cert_opt -X DELETE $vault_url/v1/$secret_mount_point/$1#);
+          system(qq#curl --http1.1 -L -H "X-Vault-Token: $token" $vault_ca_cert_opt -X DELETE $vault_url/v1/$secret_mount_point/$1#);
         }
       }
     }

--- a/plugin/keyring_vault/tests/mtr/is_vault_server_up.inc
+++ b/plugin/keyring_vault/tests/mtr/is_vault_server_up.inc
@@ -53,7 +53,7 @@ if (!$CURL_TIMEOUT)
     $vault_ca_cert_opt= "--cacert $vault_ca";
   }
 
-  system(qq#curl -L -H "X-Vault-Token: $token" -X GET --max-time $curl_timeout $vault_ca_cert_opt $vault_url/v1/cicd/test_info/readme > $vardir/tmp/curl_result#);
+  system(qq#curl --http1.1 -L -H "X-Vault-Token: $token" -X GET --max-time $curl_timeout $vault_ca_cert_opt $vault_url/v1/cicd/test_info/readme > $vardir/tmp/curl_result#);
 
   my $curl_conn_successful = 1;
   my $curl_response = 0;

--- a/plugin/keyring_vault/tests/mtr/mount_point_service.inc
+++ b/plugin/keyring_vault/tests/mtr/mount_point_service.inc
@@ -59,11 +59,11 @@ let MOUNT_POINT_SERVICE_OP=$MOUNT_POINT_SERVICE_OP;
 
   if ($mount_point_service_op eq 'CREATE')
   {
-    system(qq#curl -L -H "X-Vault-Token: $token" $vault_ca_cert_opt --data '{"type":"generic"}' --request POST $vault_url/v1/sys/mounts/$secret_mount_point#);
+    system(qq#curl --http1.1 -L -H "X-Vault-Token: $token" $vault_ca_cert_opt --data '{"type":"generic"}' --request POST $vault_url/v1/sys/mounts/$secret_mount_point#);
   }
   elsif ($mount_point_service_op eq 'DELETE')
   {
-    system(qq#curl -L -H "X-Vault-Token: $token" $vault_ca_cert_opt -X DELETE $vault_url/v1/sys/mounts/$secret_mount_point#);
+    system(qq#curl --http1.1 -L -H "X-Vault-Token: $token" $vault_ca_cert_opt -X DELETE $vault_url/v1/sys/mounts/$secret_mount_point#);
   }
   else
   {

--- a/plugin/keyring_vault/vault_curl.cc
+++ b/plugin/keyring_vault/vault_curl.cc
@@ -208,6 +208,9 @@ bool Vault_curl::setup_curl_session(CURL *curl)
       (curl_res= curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, timeout)) !=
           CURLE_OK ||
       (curl_res= curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout)) !=
+          CURLE_OK ||
+      (curl_res = curl_easy_setopt(curl, CURLOPT_HTTP_VERSION,
+                                   (long)CURL_HTTP_VERSION_1_1)) !=
           CURLE_OK)
   {
     logger->log(MY_ERROR_LEVEL, get_error_from_curl(curl_res).c_str());


### PR DESCRIPTION
There is a bug in curl on Debian and it seems to not support http v2.
Because of that we should fall back to HTTP 1.1 in keyring_vault.
We should check when new fixes come around on Debian and re-check the
problem. Re-enable HTTP v2 in keyring_vault when the problem goes away
on Debian. There should not be any negative consequences security-wise
as all communication happens over TLS.