### PR TITLE
PS-5775: Improve redo log encryption error messages (8.0)

### DIFF
--- a/mysql-test/include/log_encrypt_1.inc
+++ b/mysql-test/include/log_encrypt_1.inc
@@ -7,7 +7,8 @@
 --disable_query_log
 call mtr.add_suppression("Ignoring tablespace .* because it could not be opened");
 call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+call mtr.add_suppression("Redo log cannot be encrypted, if the keyring plugin is not loaded.");
+call mtr.add_suppression("keyring error: please check that a keyring plugin is loaded.");
 call mtr.add_suppression("Redo log key generation failed.");
 --enable_query_log
 

--- a/mysql-test/include/log_encrypt_3.inc
+++ b/mysql-test/include/log_encrypt_3.inc
@@ -5,7 +5,8 @@
 
 call mtr.add_suppression("ibd can't be decrypted, please confirm the keyfile is match and keyring plugin is loaded.");
 call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+call mtr.add_suppression("Redo log cannot be encrypted, if the keyring plugin is not loaded.");
+call mtr.add_suppression("keyring error: please check that a keyring plugin is loaded.");
 call mtr.add_suppression("Redo log key generation failed.");
 
 let $old_innodb_file_per_table = `SELECT @@innodb_file_per_table`;

--- a/mysql-test/include/log_encrypt_6.inc
+++ b/mysql-test/include/log_encrypt_6.inc
@@ -85,7 +85,7 @@ DROP DATABASE tde_db;
 
 --echo # Try starting without keyring : Error
 let NEW_CMD = $MYSQLD --no-defaults --innodb_dedicated_server=OFF --innodb_page_size=$START_PAGE_SIZE --innodb_log_file_size=$LOG_FILE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1  --secure-file-priv="" --console </dev/null>>$MYSQL_TMP_DIR/wl9290.err 2>&1;
---error 2
+--error 1
 --exec $NEW_CMD
 
 --echo # Restart without keyring plugin possible if redo files removed

--- a/mysql-test/include/percona_log_encrypt_change.inc
+++ b/mysql-test/include/percona_log_encrypt_change.inc
@@ -30,7 +30,7 @@ SELECT @@innodb_redo_log_encrypt;
 --source include/shutdown_mysqld.inc
 
 --let NEW_CMD = $MYSQLD $extra_args $KEYRING_PARAMS --datadir=$MYSQLD_DATADIR --innodb_redo_log_encrypt=$LOG_ENCRYPT_OTHER_TYPE >$MYSQLD_LOG 2>&1;
---error 2
+--error 1
 --exec $NEW_CMD
 
 # Test: crash the server AND restart with a different parameter
@@ -52,7 +52,7 @@ INSERT INTO t1 VALUES(2, "ccccc");
 --source include/kill_mysqld.inc
 
 --let NEW_CMD = $MYSQLD $extra_args $KEYRING_PARAMS --datadir=$MYSQLD_DATADIR --innodb_redo_log_encrypt=$LOG_ENCRYPT_OTHER_TYPE >$MYSQLD_LOG 2>&1;
---error 2
+--error 1
 --exec $NEW_CMD
 
 --source include/start_mysqld_no_echo.inc

--- a/mysql-test/suite/innodb/r/log_encrypt_1_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_1_mk.result
@@ -1,6 +1,6 @@
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 Warnings:
-Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/log_encrypt_1_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_1_rk.result
@@ -1,6 +1,6 @@
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 Warnings:
-Warning	49009	InnoDB: Redo log key generation failed.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENCRYPTION="Y" ENGINE = InnoDB;
 ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
 CREATE TABLE t1(c1 INT, c2 char(20)) ENGINE = InnoDB;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_mk.result
@@ -1,15 +1,16 @@
 call mtr.add_suppression("ibd can't be decrypted, please confirm the keyfile is match and keyring plugin is loaded.");
 call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+call mtr.add_suppression("Redo log cannot be encrypted, if the keyring plugin is not loaded.");
+call mtr.add_suppression("keyring error: please check that a keyring plugin is loaded.");
 call mtr.add_suppression("Redo log key generation failed.");
 CREATE DATABASE tde_db;
 USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = MASTER_KEY;
 Warnings:
-Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 SHOW WARNINGS;
 Level	Code	Message
-Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE tde_db.t4 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_3_rk.result
@@ -1,15 +1,16 @@
 call mtr.add_suppression("ibd can't be decrypted, please confirm the keyfile is match and keyring plugin is loaded.");
 call mtr.add_suppression("Encryption can't find master key, please check the keyring plugin is loaded.");
-call mtr.add_suppression("Can't set redo log tablespace to be encrypted.");
+call mtr.add_suppression("Redo log cannot be encrypted, if the keyring plugin is not loaded.");
+call mtr.add_suppression("keyring error: please check that a keyring plugin is loaded.");
 call mtr.add_suppression("Redo log key generation failed.");
 CREATE DATABASE tde_db;
 USE tde_db;
 SET GLOBAL innodb_redo_log_encrypt = KEYRING_KEY;
 Warnings:
-Warning	49009	InnoDB: Redo log key generation failed.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 SHOW WARNINGS;
 Level	Code	Message
-Warning	49009	InnoDB: Redo log key generation failed.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 CREATE TABLE tde_db.t4 (a BIGINT PRIMARY KEY, b LONGBLOB) ENGINE=InnoDB;
 INSERT INTO t4 (a, b) VALUES (1, REPEAT('a', 6*512*512));
 SELECT a,LEFT(b,10) FROM tde_db.t4;

--- a/mysql-test/suite/innodb/r/log_encrypt_kill.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_kill.result
@@ -4,7 +4,7 @@ SELECT @@global.innodb_redo_log_encrypt ;
 OFF
 SET GLOBAL innodb_redo_log_encrypt = 1;
 Warnings:
-Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 SET GLOBAL innodb_undo_log_encrypt = 1;
 UNINSTALL PLUGIN keyring_file;
 ERROR 42000: PLUGIN keyring_file does not exist
@@ -17,7 +17,7 @@ c1	LEFT(c2,10)
 100	cccccccccc
 DROP TABLE tne_1;
 # Stop the MTR default DB server
-Pattern "Can\'t set redo log tablespace to be encrypted" found
+Pattern "Redo log cannot be encrypted if the keyring plugin is not loaded." found
 # create bootstrap file
 # Prepare new datadir
 # Run the bootstrap command with keyring

--- a/mysql-test/suite/innodb/t/log_encrypt_kill.test
+++ b/mysql-test/suite/innodb/t/log_encrypt_kill.test
@@ -44,7 +44,7 @@ DROP TABLE tne_1;
 --source include/shutdown_mysqld.inc
 
 # Grep for message in server error log
-let SEARCH_PATTERN=Can\'t set redo log tablespace to be encrypted;
+let SEARCH_PATTERN=Redo log cannot be encrypted if the keyring plugin is not loaded.;
 --source include/search_pattern.inc
 
 # Create path for ibdata* & undo* files both DBs

--- a/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
@@ -26,7 +26,7 @@ VARIABLE_NAME	VARIABLE_VALUE
 innodb_redo_log_encrypt	OFF
 set global innodb_redo_log_encrypt=1;
 Warnings:
-Warning	13068	InnoDB: Can't set redo log tablespace to be encrypted.
+Warning	49014	InnoDB: Redo log cannot be encrypted if the keyring plugin is not loaded.
 select * from performance_schema.global_variables where variable_name='innodb_redo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_redo_log_encrypt	OFF

--- a/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
@@ -1,6 +1,8 @@
 --disable_query_log
 call mtr.add_suppression("\\[Error\\] .*MY-\\d+.* Encryption can't find master key, please check the keyring plugin is loaded.");
 call mtr.add_suppression("\\[ERROR\\] .*MY-\\d+.* Can't set redo log tablespace to be encrypted.");
+call mtr.add_suppression("Redo log cannot be encrypted if the keyring plugin is not loaded.");
+call mtr.add_suppression("Check keyring plugin fail, please check the keyring plugin is loaded.");
 --enable_query_log
 
 SET @start_global_value = @@global.innodb_redo_log_encrypt;

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -19321,6 +19321,9 @@ ER_REDO_ENCRYPTION_CANT_FETCH_KEY
 ER_REDO_ENCRYPTION_CANT_PARSE_KEY
   eng "Couldn't parse system key: %s"
 
+ER_REDO_ENCRYPTION_KEYRING
+  eng "Redo log cannot be encrypted if the keyring plugin is not loaded."
+
 #
 # End of Percona Server 8.0 error messages
 #

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -22040,8 +22040,15 @@ static void update_innodb_redo_log_encrypt(THD *thd, SYS_VAR *var,
     return;
   }
 
+  ut_ad(strlen(server_uuid) > 0);
+
+  if (!Encryption::check_keyring()) {
+    ib_senderrf(thd, IB_LOG_LEVEL_WARN, ER_REDO_ENCRYPTION_KEYRING);
+    ib::error(ER_REDO_ENCRYPTION_KEYRING);
+    return;
+  }
+
   if (target == REDO_LOG_ENCRYPT_MK || target == REDO_LOG_ENCRYPT_ON) {
-    ut_ad(strlen(server_uuid) > 0);
     if (srv_enable_redo_encryption_mk(thd)) {
       return;
     }

--- a/storage/innobase/log/log0write.cc
+++ b/storage/innobase/log/log0write.cc
@@ -2708,7 +2708,7 @@ bool log_read_encryption() {
     /* Make sure the keyring is loaded. */
     if (!Encryption::check_keyring()) {
       ut_free(log_block_buf_ptr);
-      ib::fatal() << "Redo log was encrypted,"
+      ib::error() << "Redo log was encrypted,"
                   << " but keyring plugin is not loaded.";
       return (false);
     }
@@ -2736,7 +2736,7 @@ bool log_read_encryption() {
     existing_redo_encryption_mode = REDO_LOG_ENCRYPT_MK;
     if (!Encryption::check_keyring()) {
       ut_free(log_block_buf_ptr);
-      ib::fatal(ER_IB_MSG_1238) << "Redo log was encrypted,"
+      ib::error(ER_IB_MSG_1238) << "Redo log was encrypted,"
                                 << " but keyring plugin is not loaded.";
       return (false);
     }
@@ -2751,7 +2751,7 @@ bool log_read_encryption() {
   if (encrypted_log) {
     if (existing_redo_encryption_mode != srv_redo_log_encrypt &&
         srv_redo_log_encrypt != REDO_LOG_ENCRYPT_OFF) {
-      ib::fatal(ER_REDO_ENCRYPTION_CANT_BE_CHANGED,
+      ib::error(ER_REDO_ENCRYPTION_CANT_BE_CHANGED,
                 log_encrypt_name(existing_redo_encryption_mode),
                 log_encrypt_name(
                     static_cast<redo_log_encrypt_enum>(srv_redo_log_encrypt)));
@@ -2777,13 +2777,13 @@ bool log_read_encryption() {
       return (true);
     } else {
       ut_free(log_block_buf_ptr);
-      ib::fatal() << "Can't set redo log tablespace"
+      ib::error() << "Can't set redo log tablespace"
                   << " encryption metadata.";
       return (false);
     }
   } else if (encryption_magic) {
     ut_free(log_block_buf_ptr);
-    ib::fatal() << "Cannot read the encryption"
+    ib::error() << "Cannot read the encryption"
                    " information in log file header, please"
                    " check if keyring plugin loaded and"
                    " the key file exists.";


### PR DESCRIPTION
* If redo log encryption fails becasuse a keyring errors, this should be
reported to the user instead of a generic error message.
* User facing errors are simple ib::errors now instead of ib::fatal, to
avoid the debug assertion there

(cherry picked from commit 1fd5c9def0b19489ef7e685b7aca771eadc53bc6)