### PR TITLE
PS-5818: Re-enable encryption threads tests that were disabled due to

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -172,61 +172,9 @@ tokudb.rpl.rpl_deadlock_tokudb : BUG#0 temporarily disabled until properly debug
 tokudb.rpl.rpl_partition_tokudb : BUG#0 exchange partition is not supported
 
 # encryption suite tests
-encryption.innodb-bad-key-change2 : BUG#5772 percona fix after https://jira.percona.com/browse/PS-5772
-encryption.alter_rename_table : BUG#5772 8.0.16 encryption reconciliation
-encryption.create_or_replace : BUG#5772 8.0.16 encryption reconciliation
-encryption.encrypt_and_grep : BUG#5772 8.0.16 encryption reconciliation
-encryption.encryption_force : BUG#5772 8.0.16 encryption reconciliation
-encryption.encryption_rotation : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_aborted_flush : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_alter_mk_to_rk : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_alters : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-bad-key-change2 : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-bad-key-change3 : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-bad-key-change4 : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-bad-key-change : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-corrupt-row-compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_default_key : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_key_rotation_mk_page_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_key_rotation_mk_row_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_key_rotation_mk : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_key_rotation_page_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_key_rotation_row_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_key_rotation : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_rotation_mk_page_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_rotation_mk_row_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_rotation_mk : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_rotation_page_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_rotation_row_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_aborted_rotation : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-encryption-alter : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_discard_import : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption-page-compression : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_row_compressed_big_table : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_row_compressed_corrupted : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_row_compressed : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption_tables : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encryption : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_encrypt_tables_var : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-first-page-read : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-force-corrupt : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-key-rotation-disable : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-key-rotation : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_lotoftables : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-missing-key : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_onlinealter_encryption : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-page_encryption-32k : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-page_encryption_compression : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_page_encryption_key_change : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-page_encryption : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-read-only : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-redo-nokeys2_debug : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-redo-nokeys2_release : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-redo-nokeys : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-redo-wrongkey : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_rotation_mk_to_rk_post_enc_checksum_fail : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb_rotation_mk_to_rk : BUG#5772 8.0.16 encryption reconciliation
-encryption.innodb-spatial-index : BUG#5772 8.0.16 encryption reconciliation
-encryption.percona_system_key_rotation : BUG#5772 8.0.16 encryption reconciliation
-encryption.rename_table : BUG#5772 8.0.16 encryption reconciliation
-encryption.uninstall_keyring : BUG#5772 8.0.16 encryption reconciliation
+encryption.encryption_force : BUG#5817 Align Keyring encryption and default_table_encryption
+encryption.innodb_lotoftables : BUG#5817 Align Keyring encryption and default_table_encryption
+encryption.innodb-bad-key-change2 : BUG#5322 Keyring encrypted tablespace import/export is broken
+encryption.innodb-bad-key-change3 : BUG#5322 Keyring encrypted tablespace import/export is broken
+encryption.innodb_encryption_discard_import : BUG#5322 Keyring encrypted tablespace import/export is broken
+encryption.innodb-redo-wrongkey : BUG#5635 Intoduce crypt_schema 2 for better error checking in encryption threads

--- a/mysql-test/suite/encryption/r/create_or_replace.result
+++ b/mysql-test/suite/encryption/r/create_or_replace.result
@@ -12,10 +12,10 @@ INSERT IGNORE INTO `table0_int_autoinc` ( `col_int_key` ) VALUES ( 1 ), ( 3 ), (
 INSERT IGNORE INTO `table1_int_autoinc` ( `col_int` ) VALUES ( 1 ), ( 0 ), ( 7 ), ( 9 );
 INSERT IGNORE INTO `table10_int_autoinc` ( `col_int` ) VALUES ( 6 ), ( 2 ), ( 3 ), ( 6 );
 drop table if exists create_or_replace_t, table1_int_autoinc, table0_int_autoinc, table10_int_autoinc;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Wait max 10 min for key encryption threads to decrypt all spaces
 # Success!
 SET GLOBAL innodb_encryption_threads = 0;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # restart

--- a/mysql-test/suite/encryption/r/default_table_encryption_var.result
+++ b/mysql-test/suite/encryption/r/default_table_encryption_var.result
@@ -1,0 +1,40 @@
+call mtr.add_suppression("Plugin keyring_file reported: 'File .*keyring' not found .*");
+call mtr.add_suppression("keyring_file initialization failure. Please check if the keyring_file_data points to readable keyring file or keyring file can be created in the specified location. The keyring_file will stay unusable until correct path to the keyring file gets provided");
+SET GLOBAL innodb_file_per_table = ON;
+INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
+SET GLOBAL keyring_file_data="MYSQL_TMP_DIR/mysecret_keyring";
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+create table t1 (a varchar(255)) engine=innodb;
+create table t2 (a varchar(255)) engine=innodb;
+create table t3 (a varchar(255)) engine=innodb;
+create table t4 (a varchar(255)) engine=innodb;
+insert t1 values (repeat('foobarsecret', 12));
+insert t2 values (repeat('tempsecret', 12));
+insert t3 values (repeat('dummysecret', 12));
+insert t4 values (repeat('verysecret', 12));
+# Wait max 10 min for key encryption threads to encrypt all spaces, apart from temp tablespace
+SET GLOBAL default_table_encryption = OFF;
+include/assert.inc [Make sure all tables stay encrypted, apart from temporary tablespace]
+SET GLOBAL default_table_encryption = ON;
+include/assert.inc [Make sure all tables stay encrypted, apart from temporary tablespace]
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+include/assert.inc [Make sure all tables stay encrypted, apart from temporary tablespace]
+SET GLOBAL default_table_encryption = OFF;
+include/assert.inc [Successful rotation of percona_innodb-0 to version 2]
+SET GLOBAL default_table_encryption = ON;
+include/assert.inc [Successful rotation of percona_innodb-0 to version 3]
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
+include/assert.inc [Successful rotation of percona_innodb-0 to version 4]
+include/assert.inc [Successful rotation of percona_innodb-0 to version 5]
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+include/assert.inc [Successful rotation of percona_innodb-0 to version 6]
+# Wait max 10 min for key encryption threads to decrypt all spaces
+SET GLOBAL default_table_encryption = OFF;
+include/assert.inc [Make sure all tables stay decrypted]
+SET GLOBAL default_table_encryption = ON;
+include/assert.inc [Make sure all tables stay decrypted]
+DROP TABLES t1,t2,t3,t4;
+SET GLOBAL default_table_encryption = OFF;
+SET GLOBAL innodb_encryption_threads=0;
+UNINSTALL PLUGIN keyring_file;

--- a/mysql-test/suite/encryption/r/encrypt_and_grep.result
+++ b/mysql-test/suite/encryption/r/encrypt_and_grep.result
@@ -50,9 +50,9 @@ include/assert.inc [All encrypted tables should have encrypted flag set, apart f
 # t4 no  on expecting NOT FOUND
 # ibdata1 expecting NOT FOUND
 # ts_encrypted expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 # Now turn off encryption and wait for threads to decrypt everything
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Only three tables should stayed encrypted - the ones with explicite encryption
 include/assert.inc [Three tables should stayed encrypted - the ones with explicite encryption t1, t4 and t6]
 # t1 yes on expecting NOT FOUND
@@ -60,9 +60,9 @@ include/assert.inc [Three tables should stayed encrypted - the ones with explici
 # t3 no  on expecting FOUND
 # t1 yes on expecting NOT FOUND
 # ibdata1 expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Now turn on encryption and wait for threads to encrypt all spaces
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 include/assert.inc [Only two tablespaces should stay unencrypted i.e. t3 and temporary tablespace]
 # t1 yes on expecting NOT FOUND
@@ -70,7 +70,7 @@ include/assert.inc [Only two tablespaces should stay unencrypted i.e. t3 and tem
 # t3 no  on expecting FOUND
 # t1 yes on expecting NOT FOUND
 # ibdata1 expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 alter table t1 encryption='n';
 alter table t4 encryption='n';
 # Wait max 10 min for key encryption threads to encrypt all spaces (apart from t1,t3 and t4)
@@ -80,11 +80,11 @@ include/assert.inc [All spaces apart from t1, t3, t4 and temporary tablespace sh
 # t3 no  on expecting FOUND
 # t4 no  on expecting FOUND
 # ibdata1 expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 drop table t1, t2, t3, t4, t5, t6;
 drop tablespace ts_encrypted;
 drop tablespace ts_rk_encrypted;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb-encryption-alter.result
+++ b/mysql-test/suite/encryption/r/innodb-encryption-alter.result
@@ -1,4 +1,4 @@
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads = 4;
 CREATE TABLE t1 (pk INT PRIMARY KEY AUTO_INCREMENT, c VARCHAR(256)) ENGINE=INNODB encryption='N' ENCRYPTION_KEY_ID=4;
 Warnings:
@@ -34,7 +34,7 @@ SHOW WARNINGS;
 Level	Code	Message
 set innodb_default_encryption_key_id = 1;
 drop table t1,t2;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 SET GLOBAL innodb_encryption_threads = 0;

--- a/mysql-test/suite/encryption/r/innodb-first-page-read.result
+++ b/mysql-test/suite/encryption/r/innodb-first-page-read.result
@@ -1,4 +1,4 @@
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_file_per_table = ON;
 create database innodb_test;
 use innodb_test;
@@ -54,7 +54,7 @@ commit;
 # restart
 include/assert.inc [number of page 0 should be greater than 0]
 include/assert.inc [number of page 0 read should be less than number of tables in both innodb_test and mysql databases]
-set global innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+set global default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # wait until tables are decrypted
 include/assert.inc [number of page 0 read should be less than number of tables in both innodb_test and mysql databases]
 # restart and see number of pages 0 read
@@ -69,5 +69,5 @@ c1	b
 include/assert.inc [innodb_pages0_read should be increased only by one]
 drop database innodb_test;
 include/assert.inc [All the tables should to be unencrypted]
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=4;

--- a/mysql-test/suite/encryption/r/innodb-key-rotation-disable.result
+++ b/mysql-test/suite/encryption/r/innodb-key-rotation-disable.result
@@ -39,8 +39,8 @@ enctests/t4	1	0
 enctests/t5	1	0
 enctests/t6	1	0
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # t1 default on expecting NOT FOUND
 # t2 default on expecting NOT FOUND
 # t3 default on expecting NOT FOUND
@@ -53,7 +53,7 @@ SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
 # restart
 drop database enctests;
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb-key-rotation.result
+++ b/mysql-test/suite/encryption/r/innodb-key-rotation.result
@@ -57,15 +57,15 @@ include/assert.inc [table t6 should be marked as unencrypted]
 # restart:--innodb-encryption-threads=4
 # Now turn off the encryption. Only one table should remain encrypted - the one with explicite encryption
 # ie. t1
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 include/assert.inc [table t1 should stay encrypted with version 4 of key 0]
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 include/assert.inc [table t6 should be marked as unencrypted]
 # Create table t7 encrypted with an existing key 5. It should have its latest
 # key_version assigned, i.e. 5
 create table t7 (a varchar(255)) engine=innodb encryption='KEYRING' ENCRYPTION_KEY_ID=5;
 include/assert.inc [table t7 should be encrypted with latest version of percona_innodb-5, i.e. version 5]
 drop table t1, t2, t3, t4, t5, t6, t7;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb-missing-key.result
+++ b/mysql-test/suite/encryption/r/innodb-missing-key.result
@@ -551,8 +551,8 @@ SELECT COUNT(1) FROM t4;
 COUNT(1)
 0
 DROP TABLE t1, t2, t3, t4;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 # Wait max 10 min for encryption threads to decrypt all tables
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb-page_encryption_compression.result
+++ b/mysql-test/suite/encryption/r/innodb-page_encryption_compression.result
@@ -34,7 +34,7 @@ call innodb_insert_proc(2000);
 insert into innodb_compact select * from innodb_normal;
 insert into innodb_dynamic select * from innodb_normal;
 commit;
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 select * from innodb_compact;
 c1	b
 0	

--- a/mysql-test/suite/encryption/r/innodb-read-only.result
+++ b/mysql-test/suite/encryption/r/innodb-read-only.result
@@ -1,15 +1,15 @@
 call mtr.add_suppression(".* in InnoDB read only mode");
 call mtr.add_suppression(".* in InnoDB read-only mode");
 call mtr.add_suppression("Plugin \'keyring_file\' has ref_count=1 after shutdown");
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=4;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Success!
-# restart:--innodb-read-only=1 --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-threads=4
+# restart:--innodb-read-only=1 --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-threads=4
 # All done
 # cleanup
-# restart:--innodb-read-only=0 --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=4
+# restart:--innodb-read-only=0 --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=4
 # All done
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb-spatial-index.result
+++ b/mysql-test/suite/encryption/r/innodb-spatial-index.result
@@ -43,7 +43,7 @@ Warnings:
 Warning	3674	The spatial index on column 'coordinate' will not be used by the query optimizer since the column does not have an SRID attribute. Consider adding an SRID attribute to the column.
 INSERT INTO t1 values(1, 'secret', ST_GeomFromText('POINT(903994614 180726515)'));
 INSERT INTO t2 values(1, 'secret', ST_GeomFromText('POINT(903994614 180726515)'));
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 #Wait for all tables to get encrypted (apart from temporary)
 # Success!
 SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION > 0;
@@ -60,5 +60,5 @@ test/t2
 SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0;
 NAME
 DROP TABLE t1, t2;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/r/innodb_aborted_flush.result
+++ b/mysql-test/suite/encryption/r/innodb_aborted_flush.result
@@ -13,7 +13,7 @@ SET GLOBAL debug="+d,fail_encryption_flag_update_on_t3";
 # Enable encryption
 SET GLOBAL innodb_encryption_rotate_key_age=15;
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 # Wait for all tables to get encrypted
 include/assert.inc [Make sure only t3's encryption flag is not set (ignore temporary tablepsace, which is never encrypted with keyring)]
 # Disable encryption
@@ -36,11 +36,11 @@ SELECT * FROM t4;
 a
 verysecretverysecretverysecretverysecretverysecretverysecretverysecretverysecretverysecretverysecretverysecretverysecret
 include/assert.inc [Make sure only t3's encryption flag is not set (ignore temporary tablespace)]
-# restart:--innodb-encryption-threads=4 --innodb-encrypt-tables=ONLINE_TO_KEYRING
+# restart:--innodb-encryption-threads=4 --default-table-encryption=ONLINE_TO_KEYRING
 # Wait for all tables to get encrypted
 include/assert.inc [Make sure all tablespaces have encryption flag set (ignore temporary tablespace)]
 DROP TABLE t1,t2,t3,t4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/r/innodb_alters.result
+++ b/mysql-test/suite/encryption/r/innodb_alters.result
@@ -166,8 +166,8 @@ Table	Create Table
 t_alter_to_rk	CREATE TABLE `t_alter_to_rk` (
   `a` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=0
-# Testing alters with innodb-encrypt-tables ONLINE_TO_KEYRING
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# Testing alters with default-table-encryption ONLINE_TO_KEYRING
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Check that tables' definitions are correct after the reset
 SHOW CREATE TABLE t1;
 Table	Create Table
@@ -217,7 +217,7 @@ t3	CREATE TABLE `t3` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION_KEY_ID=4
 include/assert.inc [Table t3 should appear in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERSION (1) ENCRYPTED KEY_ID =4]
 # Now decrypt t3. It should it should still be possible to change the ENCRYPTION_KEY_ID.
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 #Wait for all tables to get decrypted (apart from t2, t_rk_with_encryption_key_id, t_alter_to_rk)
 # Alter ENCRYPTION_KEY_ID of unencrypted table. The key_id 5 should be used during encryption with encryption
 # threads. However note that t3 was already encrypted with rotated threads.
@@ -229,7 +229,7 @@ t3	CREATE TABLE `t3` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION_KEY_ID=5
 include/assert.inc [Table t3 should appear in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERSION (0 => UNECRYPTED) AND ENCRYPTED KEY_ID=5]
 # After the re-encryption t3 should get encrypted with key 5
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 #Wait for all tables to get encrypted (apart from t1 and temporary)
 include/assert.inc [Table t3 should appear in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERSION (1) ENCRYPTED KEY_ID =5]
 SHOW CREATE TABLE t3;
@@ -241,7 +241,7 @@ t3	CREATE TABLE `t3` (
 # i.e. on plain innodb tables.
 # Turn off encryption threads and encryption
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 CREATE TABLE t4 (a varchar(255)) engine=innodb;
 SHOW CREATE TABLE t4;
 Table	Create Table
@@ -259,10 +259,10 @@ t4	CREATE TABLE `t4` (
 include/assert.inc [Table t4 should appear in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERSION (0 => UNENCRYPTED) AND ENCRYPTION_KEY_ID =6]
 # Encrypt all tables and check if t4 got encrypted with ENCRYPTION KEY 6
 SET GLOBAL innodb_encryption_threads=4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 #Wait for all tables to get encrypted (apart from t1 and temporary)
 include/assert.inc [Table t4 should appear in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERSION (1 => ENCRYPTED) AND ENCRYPTION_KEY_ID =6]
 drop table t1,t2,t3,t4,t_rk_with_encryption_key_id,t_alter_to_rk,t_alter_encryption_key_id;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = OFF;
 SET GLOBAL innodb_encryption_threads = 0;

--- a/mysql-test/suite/encryption/r/innodb_default_key.result
+++ b/mysql-test/suite/encryption/r/innodb_default_key.result
@@ -1,5 +1,5 @@
 SET GLOBAL innodb_file_per_table = ON;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads= 0;
 # Encryption disabled, innodb_default_encryption_key_id set default. Create table KEYRING should assign ENCRYPION_KEY_ID=0
 CREATE TABLE t1 (a varchar(255)) ENCRYPTION="KEYRING" ENGINE=innodb;
@@ -39,7 +39,7 @@ CREATE TABLE t3 (a varchar(255)) ENGINE=innodb;
 CREATE TABLE t4 (a varchar(255)) ENCRYPTION="Y" ENGINE=innodb;
 SET GLOBAL innodb_default_encryption_key_id = 8;
 # Turn on encryption. t3 and t4 should get encrypted with key 8.
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads= 4;
 #Wait for all tables to get encrypted (without temporary tablespace)
 include/assert.inc [Table t3 should be included in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERION 1 (encrypted) and CURRENT_KEY_ID = 8]
@@ -65,7 +65,7 @@ t5	CREATE TABLE `t5` (
 include/assert.inc [Table t5 should be included in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERION 1 (encrypted) and CURRENT_KEY_ID = 5]
 # Turn off encryption, create table t6 (unencrypted), create table t7 with MK encryption, restart server with innodb_default_key = 6 and encryption enabled. t6 and t7 should get encrypted with key 6.
 SET GLOBAL innodb_encryption_threads= 0;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 CREATE TABLE t6 (a varchar(255)) ENGINE=innodb;
 SHOW CREATE TABLE t6;
 Table	Create Table
@@ -79,7 +79,7 @@ t7	CREATE TABLE `t7` (
   `a` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
 include/assert.inc [Table t6 and t7 should NOT be included in INNODB_TABLESPACES_ENCRYPTION]
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=6
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=6
 #Wait for all tables to get encrypted (without temporary tablespace)
 include/assert.inc [Table t6 should be included in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERION 1 (encrypted) and CURRENT_KEY_ID = 6]
 # Both statements should produce warnings
@@ -91,7 +91,7 @@ Warnings:
 Warning	140	InnoDB: Ignored ENCRYPTION_KEY_ID 5 when encryption is disabled.
 include/assert.inc [Table t7 should be included in INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERION 1 (encrypted) and CURRENT_KEY_ID = 6]
 drop table t1,t2,t3,t4,t5,t6,t7,t8,t9;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Wait for all tables to get decrypted encrypted
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 SET GLOBAL innodb_encryption_threads = 0;

--- a/mysql-test/suite/encryption/r/innodb_encryption-page-compression.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption-page-compression.result
@@ -121,7 +121,7 @@ unlock tables;
 # Wait until dirty pages are compressed and encrypted
 # restart
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 update innodb_page_compressed1 set c1 = c1 + 1;
 update innodb_page_compressed2 set c1 = c1 + 1;
 update innodb_page_compressed3 set c1 = c1 + 1;
@@ -148,4 +148,4 @@ drop table innodb_page_compressed6;
 drop table innodb_page_compressed7;
 drop table innodb_page_compressed8;
 drop table innodb_page_compressed9;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;

--- a/mysql-test/suite/encryption/r/innodb_encryption.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption.result
@@ -1,37 +1,35 @@
 SHOW VARIABLES LIKE 'innodb_encrypt%';
 Variable_name	Value
 innodb_encrypt_online_alter_logs	OFF
-innodb_encrypt_tables	OFF
 innodb_encryption_rotate_key_age	15
 innodb_encryption_rotation_iops	100
 innodb_encryption_threads	4
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces, apart from temporary tablespace
 # Success!
 # Now turn off encryption and wait for threads to decrypt everything
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Wait max 10 min for key encryption threads to decrypt all spaces
 # Success!
 # Shutdown innodb_encryption_threads
 SET GLOBAL innodb_encryption_threads=0;
 # Turn on encryption
 # since threads are off tables should remain unencrypted
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 # Wait 15s to check that nothing gets encrypted
 # Success!
 # Startup innodb_encryption_threads
 SET GLOBAL innodb_encryption_threads=4;
 # Wait max 10 min for key encryption threads to encrypt all spaces (apart from temporary tablespace)
 # Success!
-# restart:--innodb-encryption-threads=0 --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+# restart:--innodb-encryption-threads=0 --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 SHOW VARIABLES LIKE 'innodb_encrypt%';
 Variable_name	Value
 innodb_encrypt_online_alter_logs	OFF
-innodb_encrypt_tables	ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 innodb_encryption_rotate_key_age	15
 innodb_encryption_rotation_iops	100
 innodb_encryption_threads	0
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 # Wait max 10 min for key encryption threads to decrypt all spaces
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation.result
@@ -31,9 +31,9 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # restart:--innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace is not encrypted
 # Make sure t1 is encrypted
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # All tables should get decrypted, apart from t1.
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_mk.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_mk.result
@@ -31,9 +31,9 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # restart:--innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace is not encrypted
 # Make sure t1 is encrypted
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # All tables should get decrypted, apart from t1.
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_mk_page_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_mk_page_compressed.result
@@ -31,9 +31,9 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # restart:--innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace is not encrypted
 # Make sure t1 is encrypted
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # All tables should get decrypted, apart from t1.
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_mk_row_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_mk_row_compressed.result
@@ -31,9 +31,9 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # restart:--innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace is not encrypted
 # Make sure t1 is encrypted
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # All tables should get decrypted, apart from t1.
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_page_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_page_compressed.result
@@ -31,9 +31,9 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # restart:--innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace is not encrypted
 # Make sure t1 is encrypted
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # All tables should get decrypted, apart from t1.
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_row_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_key_rotation_row_compressed.result
@@ -31,9 +31,9 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # restart:--innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace is not encrypted
 # Make sure t1 is encrypted
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # All tables should get decrypted, apart from t1.
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation.result
@@ -21,7 +21,7 @@ include/assert.inc [Make sure t1 is unencrypted]
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 # Start rotation unnencrypted => encrypted (tables do not have crypt data stored in page 0)
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
@@ -33,14 +33,14 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # unless originaly table was compressed or MK encrypted - then it does not
 # make sense to check the table as table will not contain plaintext
 # t1 is only half rotatted, now we will check if the encryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace should remain unencrypted
 # innodb_system
 # Make sure t1 is encrypted
 # Now we try rotation encrypted => unencrypted
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Table t1 should have min_key_version = 1 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -49,12 +49,12 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only decrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 contains foobar - as it is decrypted
 # Now we try rotation => unencrypted => encrypted (now tables have crypt data in page 0)
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Table t1 should have min_key_version = 0 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -63,7 +63,7 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only encrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 does not contain foobar - as it is encrypted
 # After table has been rotated there is update to DD and after that
 # there is update to page0 of the table. When a crash occures after DD update we will go out of sync with table's
@@ -73,7 +73,7 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # In order to check this behavior we will first rotate encrypted=>unencrypted and we will make server commit suicide
 # after DD update and before page 0 update.
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
 # t1 will be opened without validating idb file to DD.
@@ -87,14 +87,14 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0 --log-error=MYSQL_TMP_DIR/my_restart.err
 SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Now we need to test the rotation unencrypted=>encrypted, when we get a crash after all pages
 # got rotated and DD was updated but before updating page 0
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
@@ -110,9 +110,9 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk.result
@@ -21,7 +21,7 @@ include/assert.inc [Make sure t1 is encrypted]
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 # Start rotation unnencrypted => encrypted (tables do not have crypt data stored in page 0)
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
@@ -33,14 +33,14 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # unless originaly table was compressed or MK encrypted - then it does not
 # make sense to check the table as table will not contain plaintext
 # t1 is only half rotatted, now we will check if the encryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace should remain unencrypted
 # innodb_system
 # Make sure t1 is encrypted
 # Now we try rotation encrypted => unencrypted
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Table t1 should have min_key_version = 1 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -49,12 +49,12 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only decrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 contains foobar - as it is decrypted
 # Now we try rotation => unencrypted => encrypted (now tables have crypt data in page 0)
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Table t1 should have min_key_version = 0 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -63,7 +63,7 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only encrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 does not contain foobar - as it is encrypted
 # After table has been rotated there is update to DD and after that
 # there is update to page0 of the table. When a crash occures after DD update we will go out of sync with table's
@@ -73,7 +73,7 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # In order to check this behavior we will first rotate encrypted=>unencrypted and we will make server commit suicide
 # after DD update and before page 0 update.
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
 # t1 will be opened without validating idb file to DD.
@@ -87,14 +87,14 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0 --log-error=MYSQL_TMP_DIR/my_restart.err
 SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Now we need to test the rotation unencrypted=>encrypted, when we get a crash after all pages
 # got rotated and DD was updated but before updating page 0
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
@@ -110,9 +110,9 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_page_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_page_compressed.result
@@ -21,7 +21,7 @@ include/assert.inc [Make sure t1 is encrypted]
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 # Start rotation unnencrypted => encrypted (tables do not have crypt data stored in page 0)
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
@@ -33,14 +33,14 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # unless originaly table was compressed or MK encrypted - then it does not
 # make sense to check the table as table will not contain plaintext
 # t1 is only half rotatted, now we will check if the encryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace should remain unencrypted
 # innodb_system
 # Make sure t1 is encrypted
 # Now we try rotation encrypted => unencrypted
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Table t1 should have min_key_version = 1 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -49,12 +49,12 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only decrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 contains foobar - as it is decrypted
 # Now we try rotation => unencrypted => encrypted (now tables have crypt data in page 0)
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Table t1 should have min_key_version = 0 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -63,7 +63,7 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only encrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 does not contain foobar - as it is encrypted
 # After table has been rotated there is update to DD and after that
 # there is update to page0 of the table. When a crash occures after DD update we will go out of sync with table's
@@ -73,7 +73,7 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # In order to check this behavior we will first rotate encrypted=>unencrypted and we will make server commit suicide
 # after DD update and before page 0 update.
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
 # t1 will be opened without validating idb file to DD.
@@ -87,14 +87,14 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0 --log-error=MYSQL_TMP_DIR/my_restart.err
 SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Now we need to test the rotation unencrypted=>encrypted, when we get a crash after all pages
 # got rotated and DD was updated but before updating page 0
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
@@ -110,9 +110,9 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_row_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_row_compressed.result
@@ -21,7 +21,7 @@ include/assert.inc [Make sure t1 is encrypted]
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 # Start rotation unnencrypted => encrypted (tables do not have crypt data stored in page 0)
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
@@ -33,14 +33,14 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # unless originaly table was compressed or MK encrypted - then it does not
 # make sense to check the table as table will not contain plaintext
 # t1 is only half rotatted, now we will check if the encryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace should remain unencrypted
 # innodb_system
 # Make sure t1 is encrypted
 # Now we try rotation encrypted => unencrypted
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Table t1 should have min_key_version = 1 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -49,12 +49,12 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only decrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 contains foobar - as it is decrypted
 # Now we try rotation => unencrypted => encrypted (now tables have crypt data in page 0)
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Table t1 should have min_key_version = 0 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -63,7 +63,7 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only encrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 does not contain foobar - as it is encrypted
 # After table has been rotated there is update to DD and after that
 # there is update to page0 of the table. When a crash occures after DD update we will go out of sync with table's
@@ -73,7 +73,7 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # In order to check this behavior we will first rotate encrypted=>unencrypted and we will make server commit suicide
 # after DD update and before page 0 update.
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
 # t1 will be opened without validating idb file to DD.
@@ -87,14 +87,14 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0 --log-error=MYSQL_TMP_DIR/my_restart.err
 SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Now we need to test the rotation unencrypted=>encrypted, when we get a crash after all pages
 # got rotated and DD was updated but before updating page 0
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
@@ -110,9 +110,9 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_page_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_page_compressed.result
@@ -21,7 +21,7 @@ include/assert.inc [Make sure t1 is unencrypted]
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 # Start rotation unnencrypted => encrypted (tables do not have crypt data stored in page 0)
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
@@ -33,14 +33,14 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # unless originaly table was compressed or MK encrypted - then it does not
 # make sense to check the table as table will not contain plaintext
 # t1 is only half rotatted, now we will check if the encryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace should remain unencrypted
 # innodb_system
 # Make sure t1 is encrypted
 # Now we try rotation encrypted => unencrypted
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Table t1 should have min_key_version = 1 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -49,12 +49,12 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only decrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 contains foobar - as it is decrypted
 # Now we try rotation => unencrypted => encrypted (now tables have crypt data in page 0)
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Table t1 should have min_key_version = 0 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -63,7 +63,7 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only encrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 does not contain foobar - as it is encrypted
 # After table has been rotated there is update to DD and after that
 # there is update to page0 of the table. When a crash occures after DD update we will go out of sync with table's
@@ -73,7 +73,7 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # In order to check this behavior we will first rotate encrypted=>unencrypted and we will make server commit suicide
 # after DD update and before page 0 update.
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
 # t1 will be opened without validating idb file to DD.
@@ -87,14 +87,14 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0 --log-error=MYSQL_TMP_DIR/my_restart.err
 SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Now we need to test the rotation unencrypted=>encrypted, when we get a crash after all pages
 # got rotated and DD was updated but before updating page 0
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
@@ -110,9 +110,9 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_row_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_row_compressed.result
@@ -21,7 +21,7 @@ include/assert.inc [Make sure t1 is unencrypted]
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 # Start rotation unnencrypted => encrypted (tables do not have crypt data stored in page 0)
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 # Table t1 should have min_key_version = 0 assigned and ROTATIONG_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
@@ -33,14 +33,14 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # unless originaly table was compressed or MK encrypted - then it does not
 # make sense to check the table as table will not contain plaintext
 # t1 is only half rotatted, now we will check if the encryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # All tables should get encrypted. tables_count - 1 because temporary tablespace should remain unencrypted
 # innodb_system
 # Make sure t1 is encrypted
 # Now we try rotation encrypted => unencrypted
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Table t1 should have min_key_version = 1 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -49,12 +49,12 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only decrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 contains foobar - as it is decrypted
 # Now we try rotation => unencrypted => encrypted (now tables have crypt data in page 0)
 # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 # Table t1 should have min_key_version = 0 assigned and ROTATING_OR_FLUSHING=1 <= this means that only 100 pages
 # have been rotatted.
 # Disable rotation threads
@@ -63,7 +63,7 @@ SET GLOBAL innodb_encryption_threads = 0;
 SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # Make sure that t1 contains foobar - as it is only encrypted in half
 # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Make sure that t1 does not contain foobar - as it is encrypted
 # After table has been rotated there is update to DD and after that
 # there is update to page0 of the table. When a crash occures after DD update we will go out of sync with table's
@@ -73,7 +73,7 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 # In order to check this behavior we will first rotate encrypted=>unencrypted and we will make server commit suicide
 # after DD update and before page 0 update.
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
 # t1 will be opened without validating idb file to DD.
@@ -87,14 +87,14 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0 --log-error=MYSQL_TMP_DIR/my_restart.err
 SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Now we need to test the rotation unencrypted=>encrypted, when we get a crash after all pages
 # got rotated and DD was updated but before updating page 0
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
@@ -110,9 +110,9 @@ SELECT COUNT(1) FROM t1;
 COUNT(1)
 30000
 # Restart and finish up the rotation
-# restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/r/innodb_encryption_tables.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_tables.result
@@ -135,6 +135,6 @@ drop table innodb_compact;
 drop table innodb_dynamic;
 drop table innodb_compressed;
 drop table innodb_redundant;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;

--- a/mysql-test/suite/encryption/r/innodb_onlinealter_encryption.result
+++ b/mysql-test/suite/encryption/r/innodb_onlinealter_encryption.result
@@ -122,8 +122,8 @@ t7	CREATE TABLE `t7` (
 # t5 ... on expecting NOT FOUND
 # t6 ... on expecting NOT FOUND
 # t7 ... on expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=KEYRING_PLUGIN --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--early-plugin-load=keyring_file=KEYRING_PLUGIN --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 DROP PROCEDURE innodb_insert_proc;
 DROP TABLE t1, t2, t3, t4, t5, t6, t7;
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;

--- a/mysql-test/suite/encryption/r/innodb_rotation_mk_to_rk.result
+++ b/mysql-test/suite/encryption/r/innodb_rotation_mk_to_rk.result
@@ -2,29 +2,29 @@ SET @@global.keyring_file_data="MYSQL_TMP_DIR/mysecret_keyring";
 SET GLOBAL innodb_file_per_table = ON;
 create table t1 (a varchar(255)) engine=innodb encryption='Y';
 insert t1 values (repeat('foobarsecret', 12));
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 include/assert.inc [All encrypted tables should have encrypted flag set apart from temporary tablespace]
 include/assert.inc [Make sure t1 is present in INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION with MIN_KEY_VERSION = 1]
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 # Now turn off encryption and wait for threads to decrypt everything
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 include/assert.inc [There should be no encrypted tables left]
 # t1 yes on expecting NOT FOUND
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 # Now turn on encryption and wait for threads to encrypt all spaces
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 # Wait max 10 min for key encryption threads to encrypt all spaces
 include/assert.inc [All tables should have been encrypted, apart from temporary tablepsace]
 include/assert.inc [temprorary tablespace should be the only one left unencrypted]
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 alter table t1 encryption='n';
 # Wait max 10 min for key encryption to decrypt t1
 include/assert.inc [t1 should got decrypted]
 include/assert.inc [also temporary tablespace should stay unenecrypted]
 include/assert.inc [t1 and temporary should be the only unencrypted tables]
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 drop table t1;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Wait max 10 min for encryption threads to decrypt all tables
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;

--- a/mysql-test/suite/encryption/r/innodb_rotation_mk_to_rk_post_enc_checksum_fail.result
+++ b/mysql-test/suite/encryption/r/innodb_rotation_mk_to_rk_post_enc_checksum_fail.result
@@ -8,20 +8,20 @@ create table t1 (a TEXT) engine=innodb encryption='Y';
 BEGIN;
 INSERT INTO t1 (a) VALUES ('foobarsecret');
 COMMIT;
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 # Wait max 10 min for key encryption threads to encrypt all spaces (apart from temporary)
 include/assert.inc [All encrypted tables should have encrypted flag set apart from temporary tablespace]
 # Backup t1 before corrupting
 # Corrupt t1
 # Now restart server with encryption from keyring to unencrypted and wait for threads to decrypt everything
 # Apart from t1 which is corrupted and it should not be possible to decrypt this table
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 include/assert.inc [Table t1 should stayed encrypted as some of its pages were corrupted]
 include/assert.inc [Table t1 should be the only one with encrypted flag set]
 SELECT * FROM t1;
 ERROR HY000: Got error 500 'Table encrypted but decryption failed. Seems that the encryption key fetched from keyring is not the correct one. Are you using the correct keyring?' from InnoDB
 # Restore the original t1
-# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+# restart:--early-plugin-load=keyring_file=keyring_file.so --loose-keyring_file_data=MYSQL_TMP_DIR/mysecret_keyring KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SELECT COUNT(*) FROM t1;
 COUNT(*)
 101

--- a/mysql-test/suite/encryption/t/create_or_replace.test
+++ b/mysql-test/suite/encryption/t/create_or_replace.test
@@ -12,14 +12,14 @@ CREATE TABLE t2 AS SELECT * FROM t1;
 let $i = 40;
 while ($i)
 {
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads = 1;
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1 AS SELECT * FROM t2;
 DROP TABLE IF EXISTS t2;
 CREATE TABLE t2 AS SELECT * FROM t1;
 SET GLOBAL innodb_encryption_rotation_iops = 100;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 DROP TABLE IF EXISTS t2;
 CREATE TABLE t2 AS SELECT * FROM t1;
 DROP TABLE IF EXISTS t1;
@@ -58,7 +58,7 @@ let $i = 100;
 while ($i)
 {
 connection con1;
-send SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+send SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 connection default;
 DROP TABLE IF EXISTS create_or_replace_t;
 CREATE TABLE IF NOT EXISTS create_or_replace_t AS SELECT * FROM table1_int_autoinc;
@@ -70,7 +70,7 @@ DROP TABLE IF EXISTS create_or_replace_t;
 send CREATE TABLE IF NOT EXISTS create_or_replace_t AS SELECT * FROM table0_int_autoinc;
 connection con1;
 --reap;
-send SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+send SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 connection con2;
 --reap;
 connection default;
@@ -82,7 +82,7 @@ DROP TABLE IF EXISTS create_or_replace_t;
 send CREATE TABLE IF NOT EXISTS create_or_replace_t AS SELECT * FROM table10_int_autoinc;
 connection con1;
 --reap;
-send SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+send SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 connection default;
 --reap;
 DROP TABLE IF EXISTS create_or_replace_t;
@@ -108,7 +108,7 @@ drop table if exists create_or_replace_t, table1_int_autoinc, table0_int_autoinc
 --enable_abort_on_error
 --enable_warnings
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 
 --echo # Wait max 10 min for key encryption threads to decrypt all spaces
@@ -135,7 +135,7 @@ if (!$success)
 --echo # Success!
 
 SET GLOBAL innodb_encryption_threads = 0;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 # Make sure that all dirty pages are flushed
 

--- a/mysql-test/suite/encryption/t/default_table_encryption_var-master.opt
+++ b/mysql-test/suite/encryption/t/default_table_encryption_var-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-rotate-key-age=1
 --innodb-encryption-threads=0
 --loose-keyring-file-data=$MYSQL_TMP_DIR/mydummy_key

--- a/mysql-test/suite/encryption/t/default_table_encryption_var.test
+++ b/mysql-test/suite/encryption/t/default_table_encryption_var.test
@@ -8,7 +8,7 @@ INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET GLOBAL keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=4;
 
 create table t1 (a varchar(255)) engine=innodb;
@@ -30,33 +30,33 @@ insert t4 values (repeat('verysecret', 12));
 --let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
 --source include/wait_condition.inc
 
-# Now all the tables are encrypted - need to check if other values of innodb_encrypt_tables than
+# Now all the tables are encrypted - need to check if other values of default_table_encryption than
 # ONLINE_FROM_KEYRING_TO_UNENCRYPTED do not start decrypting the tables
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 --sleep 10
 
 --let $assert_text= Make sure all tables stay encrypted, apart from temporary tablespace
 --let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1]" = $tables_count - 1
 --source include/assert.inc
 
-SET GLOBAL innodb_encrypt_tables = ON;
+SET GLOBAL default_table_encryption = ON;
 --sleep 10
 
 --let $assert_text= Make sure all tables stay encrypted, apart from temporary tablespace
 --let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1]" = $tables_count - 1
 --source include/assert.inc
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING_FORCE;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 --sleep 10
 
 --let $assert_text= Make sure all tables stay encrypted, apart from temporary tablespace
 --let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1]" = $tables_count - 1
 --source include/assert.inc
 
-# Now check key rotation works with different values of innodb_encrypt_tables and encryption
+# Now check key rotation works with different values of default_table_encryption and encryption
 # threads running
 
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 
 --let $assert_text= Successful rotation of percona_innodb-0 to version 2
 --let $assert_cond= "[SELECT rotate_system_key\\(\\"percona_innodb-0\\"\\) = 1]" = 1
@@ -69,7 +69,7 @@ SET GLOBAL innodb_encrypt_tables = OFF;
 --let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 2
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = ON;
+SET GLOBAL default_table_encryption = ON;
 
 --let $assert_text= Successful rotation of percona_innodb-0 to version 3
 --let $assert_cond= "[SELECT rotate_system_key\\(\\"percona_innodb-0\\"\\) = 1]" = 1
@@ -80,7 +80,7 @@ SET GLOBAL innodb_encrypt_tables = ON;
 --let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 3
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --let $assert_text= Successful rotation of percona_innodb-0 to version 4
 --let $assert_cond= "[SELECT rotate_system_key\\(\\"percona_innodb-0\\"\\) = 1]" = 1
@@ -91,8 +91,6 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
 --let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 4
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = FORCE;
-
 --let $assert_text= Successful rotation of percona_innodb-0 to version 5
 --let $assert_cond= "[SELECT rotate_system_key\\(\\"percona_innodb-0\\"\\) = 1]" = 1
 --source include/assert.inc
@@ -102,14 +100,14 @@ SET GLOBAL innodb_encrypt_tables = FORCE;
 --let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 5
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $assert_text= Successful rotation of percona_innodb-0 to version 6
 --let $assert_cond= "[SELECT rotate_system_key\\(\\"percona_innodb-0\\"\\) = 1]" = 1
 --source include/assert.inc
 
 # Even though the key was rotated - all the tables should be decrypted as
-# innodb_encrypt_tables is set to ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+# default_table_encryption is set to ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 
 --echo # Wait max 10 min for key encryption threads to decrypt all spaces
 --let $wait_timeout= 600
@@ -118,14 +116,14 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 # Now all the tables are decrypted - need to check if other values than
 # ONLINE_TO_KEYRING do not start encrypting the tables
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 --sleep 10
 
 --let $assert_text= Make sure all tables stay decrypted
 --let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0]" = 0
 --source include/assert.inc
 
-SET GLOBAL innodb_encrypt_tables = ON;
+SET GLOBAL default_table_encryption = ON;
 --sleep 10
 
 --let $assert_text= Make sure all tables stay decrypted
@@ -134,7 +132,7 @@ SET GLOBAL innodb_encrypt_tables = ON;
 
 # cleanup
 DROP TABLES t1,t2,t3,t4;
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 SET GLOBAL innodb_encryption_threads=0;
 
 UNINSTALL PLUGIN keyring_file;

--- a/mysql-test/suite/encryption/t/encrypt_and_grep-master.opt
+++ b/mysql-test/suite/encryption/t/encrypt_and_grep-master.opt
@@ -1,6 +1,6 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/encrypt_and_grep.test
+++ b/mysql-test/suite/encryption/t/encrypt_and_grep.test
@@ -114,12 +114,12 @@ ALTER TABLE t6 ENCRYPTION='KEYRING', ALGORITHM=INPLACE;
 
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 -- source include/start_mysqld.inc
 
 --echo # Now turn off encryption and wait for threads to decrypt everything
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --echo # Only three tables should stayed encrypted - the ones with explicite encryption
 --let $wait_timeout= 600
@@ -163,13 +163,13 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --let SEARCH_PATTERN=moresecret
 --source include/search_pattern_in_file.inc
 
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT
 -- source include/start_mysqld.inc
 
 --echo # Now turn on encryption and wait for threads to encrypt all spaces
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --echo # Wait max 10 min for key encryption threads to encrypt all spaces
 --let $wait_timeout= 600
@@ -267,13 +267,13 @@ drop table t1, t2, t3, t4, t5, t6;
 drop tablespace ts_encrypted;
 drop tablespace ts_rk_encrypted;
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;
 

--- a/mysql-test/suite/encryption/t/encryption_force.test
+++ b/mysql-test/suite/encryption/t/encryption_force.test
@@ -1,8 +1,8 @@
-let $innodb_encrypt_tables_orig=`SELECT @@innodb_encrypt_tables`;
+let $default_table_encryption_orig=`SELECT @@default_table_encryption`;
 
 # Need to restart the server with KEYRING_FORCE to check how it behaves as a command line option.
 --let $restart_hide_args=1 
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=KEYRING_FORCE
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=KEYRING_FORCE
 --source include/restart_mysqld.inc
 
 create table t1 (a int) engine=innodb encryption='KEYRING';
@@ -14,9 +14,9 @@ create table t4 (a int) engine=innodb encryption='KEYRING' partition by hash(a) 
 --error ER_INVALID_ENCRYPTION_OPTION
 create table t5 (a int) engine=innodb encryption='N' partition by hash(a) partitions 2;
 
-set global innodb_encrypt_tables='KEYRING_ON';
+set global default_table_encryption='KEYRING_ON';
 create table t3 (a int) engine=innodb encryption='N';
-set global innodb_encrypt_tables='KEYRING_FORCE';
+set global default_table_encryption='KEYRING_FORCE';
 
 show create table t1;
 show create table t2;
@@ -55,4 +55,4 @@ drop table t3;
 drop table t4;
 
 UNINSTALL PLUGIN keyring_file;
-EVAL SET GLOBAL innodb_encrypt_tables = $innodb_encrypt_tables_orig;
+EVAL SET GLOBAL default_table_encryption = $default_table_encryption_orig;

--- a/mysql-test/suite/encryption/t/encryption_rotation-master.opt
+++ b/mysql-test/suite/encryption/t/encryption_rotation-master.opt
@@ -1,4 +1,4 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change2.test
@@ -89,8 +89,8 @@ ALTER TABLE t1 IMPORT TABLESPACE;
 SHOW CREATE TABLE t1;
 
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
---let $restart_parameters=restart: --innodb-encrypt-tables --keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
-#--let $restart_parameters= --innodb-encrypt-tables --plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys3.txt
+--let $restart_parameters=restart: --default-table-encryption --keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt
+#--let $restart_parameters= --default-table-encryption --plugin-load-add=file_key_management.so --file-key-management --file-key-management-filename=$MYSQLTEST_VARDIR/std_data/keys3.txt
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_stats_persistent=OFF;

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change3-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change3-master.opt
@@ -1,4 +1,4 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQLTEST_VARDIR/keys1.txt
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change4-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change4-master.opt
@@ -1,7 +1,7 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 --loose-innodb-buffer-pool-stats
 --loose-innodb-buffer-page
 --loose-innodb-buffer-page-lru

--- a/mysql-test/suite/encryption/t/innodb-encryption-alter-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-encryption-alter-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-encryption-alter.test
+++ b/mysql-test/suite/encryption/t/innodb-encryption-alter.test
@@ -1,7 +1,7 @@
 #
 # MDEV-8817: Failing assertion: new_state->key_version != ENCRYPTION_KEY_VERSION_INVALID
 #
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads = 4;
 
 CREATE TABLE t1 (pk INT PRIMARY KEY AUTO_INCREMENT, c VARCHAR(256)) ENGINE=INNODB encryption='N' ENCRYPTION_KEY_ID=4;
@@ -79,12 +79,12 @@ connection default;
 drop table t1,t2;
 
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 SET GLOBAL innodb_encryption_threads = 0;

--- a/mysql-test/suite/encryption/t/innodb-first-page-read-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-first-page-read-master.opt
@@ -1,6 +1,6 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=4

--- a/mysql-test/suite/encryption/t/innodb-first-page-read.test
+++ b/mysql-test/suite/encryption/t/innodb-first-page-read.test
@@ -1,4 +1,4 @@
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 
 --disable_warnings
 SET GLOBAL innodb_file_per_table = ON;
@@ -75,7 +75,7 @@ commit;
 --let $assert_cond= "[SELECT VARIABLE_VALUE FROM performance_schema.global_status WHERE VARIABLE_NAME = \\'innodb_pages0_read\\']" <= $number_of_tables_that_could_be_opened
 --source include/assert.inc
 
-set global innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+set global default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --echo # wait until tables are decrypted
 --let $wait_timeout= 600
@@ -115,5 +115,5 @@ drop database innodb_test;
 --let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0]" = 0
 --source include/assert.inc
 
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=4;

--- a/mysql-test/suite/encryption/t/innodb-key-rotation-disable-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-key-rotation-disable-master.opt
@@ -1,6 +1,6 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-rotate-key-age=0
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-key-rotation-disable.test
+++ b/mysql-test/suite/encryption/t/innodb-key-rotation-disable.test
@@ -5,7 +5,7 @@ SET GLOBAL innodb_encryption_threads=4;
 
 --disable_query_log
 --disable_warnings
-let $encryption = `SELECT @@innodb_encrypt_tables`;
+let $encryption = `SELECT @@default_table_encryption`;
 SET GLOBAL innodb_file_per_table = ON;
 --enable_warnings
 --enable_query_log
@@ -43,8 +43,8 @@ SELECT NAME,ENCRYPTION_SCHEME,CURRENT_KEY_ID FROM INFORMATION_SCHEMA.INNODB_TABL
 
 # Check if changing encrypt variable is still possible even though key rotation is disabled
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 
 --let $MYSQLD_DATADIR=`select @@datadir`
 
@@ -90,12 +90,12 @@ SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
 drop database enctests;
 
 --echo # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/t/innodb-key-rotation-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-key-rotation-master.opt
@@ -3,4 +3,4 @@ $KEYRING_PLUGIN_OPT
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=2
 --innodb-encryption-threads=0
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING

--- a/mysql-test/suite/encryption/t/innodb-key-rotation.test
+++ b/mysql-test/suite/encryption/t/innodb-key-rotation.test
@@ -174,7 +174,7 @@ alter table t6 encryption='N';
 --echo # Now turn off the encryption. Only one table should remain encrypted - the one with explicite encryption
 --echo # ie. t1
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $wait_timeout= 600
 # We should have $tables_count - 2 tables unencrypted (table t1 should stay encrypted with version 4 of key 0 and temporary is never encrypted)
@@ -187,7 +187,7 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --source include/assert.inc
 
 # t6 has been marked as unencrypted - turn on the encryption - it should stay unencrypted
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --let $wait_timeout= 600
 # Encrypted tables count should be equal $tables_count - 2 as t6 and temporary should stays unencrypted
@@ -212,12 +212,12 @@ drop table t1, t2, t3, t4, t5, t6, t7;
 # cleanup
 
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;
 # The backup file might be a leftover after calling generate key on existing key
 --error 0,1

--- a/mysql-test/suite/encryption/t/innodb-missing-key-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-missing-key-master.opt
@@ -1,6 +1,6 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQLTEST_VARDIR/std_data/keys2.txt
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-missing-key.test
+++ b/mysql-test/suite/encryption/t/innodb-missing-key.test
@@ -65,7 +65,7 @@ SELECT COUNT(1) FROM t4;
 DROP TABLE t1, t2, t3, t4;
 
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 
 --echo # Wait max 10 min for encryption threads to decrypt all tables
@@ -73,5 +73,5 @@ SET GLOBAL innodb_encryption_threads=4;
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/t/innodb-page_encryption-32k-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption-32k-master.opt
@@ -5,4 +5,4 @@ $KEYRING_PLUGIN_OPT
 --innodb-buffer-pool-size=24M
 --initialize
 --innodb_page_size=32K
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF

--- a/mysql-test/suite/encryption/t/innodb-page_encryption-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-page_encryption_compression-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption_compression-master.opt
@@ -1,4 +1,4 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED

--- a/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
+++ b/mysql-test/suite/encryption/t/innodb-page_encryption_compression.test
@@ -32,7 +32,7 @@ commit;
 #let $wait_condition= select variable_value > 0 from information_schema.global_status where variable_name = 'INNODB_NUM_PAGES_PAGE_COMPRESSED';
 #--source include/wait_condition.inc
 
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 --source include/restart_mysqld.inc
 
 select * from innodb_compact;

--- a/mysql-test/suite/encryption/t/innodb-read-only-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-read-only-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-read-only.test
+++ b/mysql-test/suite/encryption/t/innodb-read-only.test
@@ -2,7 +2,7 @@ call mtr.add_suppression(".* in InnoDB read only mode");
 call mtr.add_suppression(".* in InnoDB read-only mode");
 call mtr.add_suppression("Plugin \'keyring_file\' has ref_count=1 after shutdown"); #TODO: Needs fixing 
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=4;
 
 #We do not encrypt temporary tablespace
@@ -18,13 +18,13 @@ SET GLOBAL innodb_encryption_threads=4;
 # MDEV-11835: InnoDB: Failing assertion: free_slot != NULL on
 # restarting server with encryption and read-only
 #
---let $restart_parameters=restart:--innodb-read-only=1 --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-threads=4
+--let $restart_parameters=restart:--innodb-read-only=1 --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-threads=4
 --source include/restart_mysqld.inc
 --echo # All done
 
 --echo # cleanup
 
---let $restart_parameters=restart:--innodb-read-only=0 --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=4
+--let $restart_parameters=restart:--innodb-read-only=0 --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=4
 --source include/restart_mysqld.inc
 --echo # All done
 
@@ -33,5 +33,5 @@ SET GLOBAL innodb_encryption_threads=4;
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/t/innodb-redo-nokeys-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-redo-nokeys-master.opt
@@ -2,6 +2,6 @@ $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQLTEST_VARDIR/std_data/keys2.txt
 --innodb-change-buffering=none
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-default-encryption-key-id=20
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-redo-nokeys2_debug-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-redo-nokeys2_debug-master.opt
@@ -2,6 +2,6 @@ $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQLTEST_VARDIR/std_data/keys2.txt
 --innodb-change-buffering=none
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-default-encryption-key-id=20
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-redo-nokeys2_release-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-redo-nokeys2_release-master.opt
@@ -2,6 +2,6 @@ $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQLTEST_VARDIR/std_data/keys2.txt
 --innodb-change-buffering=none
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-default-encryption-key-id=20
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb-redo-nokeys2_release.test
+++ b/mysql-test/suite/encryption/t/innodb-redo-nokeys2_release.test
@@ -59,7 +59,7 @@ let $cleanup= drop table t1,t2,t3,t4;
 
 --echo # Start the server without keyring loaded
 --let $restart_hide_args=1
---let $restart_parameters=restart:--early-plugin-load="" --log-error=$error_log --innodb-encrypt-tables=OFF
+--let $restart_parameters=restart:--early-plugin-load="" --log-error=$error_log --default-table-encryption=OFF
 --source include/start_mysqld.inc
 
 --source include/shutdown_mysqld.inc

--- a/mysql-test/suite/encryption/t/innodb-redo-wrongkey.test
+++ b/mysql-test/suite/encryption/t/innodb-redo-wrongkey.test
@@ -5,7 +5,7 @@
 # should fail to apply redo logs to those tables since the tables will be garbage, as incorrect key was
 # used.
 SET GLOBAL innodb_file_per_table = ON;
-SET GLOBAL innodb_encrypt_tables = KEYRING_ON;
+SET GLOBAL default_table_encryption = KEYRING_ON;
 
 create table t1(a int not null primary key, c char(200), b blob, index(b(10))) engine=innodb row_format=compressed ENCRYPTION='KEYRING' encryption_key_id=2;
 create table t2(a int not null primary key, c char(200), b blob, index(b(10))) engine=innodb row_format=compressed;
@@ -62,7 +62,7 @@ let $cleanup= drop table t1,t2,t3,t4;
 # and then encrypted with keys from keys3.txt. Making it impossible to decrypt for subsequentail restart with
 # correct keyring file, i.e. keys2.txt
 --error 1
---exec $MYSQLD_CMD --core-file --log-error=$error_log --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=OFF --innodb-doublewrite=0
+--exec $MYSQLD_CMD --core-file --log-error=$error_log --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --keyring-file-data=$MYSQLTEST_VARDIR/std_data/keys3.txt $KEYRING_PLUGIN_OPT --default-table-encryption=OFF --innodb-doublewrite=0
 
 # We should get error in error log as it should not be possible to apply redo logs
 # to encrypted tables
@@ -90,4 +90,4 @@ let $cleanup= drop table t1,t2,t3,t4;
 drop table t1,t2,t3,t4;
 --remove_file $error_log
 
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/t/innodb-spatial-index-master.opt
+++ b/mysql-test/suite/encryption/t/innodb-spatial-index-master.opt
@@ -2,5 +2,5 @@ $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=15
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=4

--- a/mysql-test/suite/encryption/t/innodb-spatial-index.test
+++ b/mysql-test/suite/encryption/t/innodb-spatial-index.test
@@ -51,7 +51,7 @@ INSERT INTO t1 values(1, 'secret', ST_GeomFromText('POINT(903994614 180726515)')
 INSERT INTO t2 values(1, 'secret', ST_GeomFromText('POINT(903994614 180726515)'));
 
 --let $tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 --echo #Wait for all tables to get encrypted (apart from temporary)
 --let $wait_timeout=600
 --let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
@@ -66,10 +66,10 @@ SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_
 
 DROP TABLE t1, t2;
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $wait_timeout=600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/t/innodb_aborted_flush-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_aborted_flush-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_aborted_flush.test
+++ b/mysql-test/suite/encryption/t/innodb_aborted_flush.test
@@ -27,7 +27,7 @@ SET GLOBAL debug="+d,fail_encryption_flag_update_on_t3";
 --echo # Enable encryption
 SET GLOBAL innodb_encryption_rotate_key_age=15;
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --echo # Wait for all tables to get encrypted
 --let $tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
@@ -77,7 +77,7 @@ SELECT * FROM t4;
 
 --remove_file $error_log
 
---let $restart_parameters=restart:--innodb-encryption-threads=4 --innodb-encrypt-tables=ONLINE_TO_KEYRING
+--let $restart_parameters=restart:--innodb-encryption-threads=4 --default-table-encryption=ONLINE_TO_KEYRING
 --source include/start_mysqld.inc
 
 --echo # Wait for all tables to get encrypted
@@ -95,7 +95,7 @@ SELECT * FROM t4;
 DROP TABLE t1,t2,t3,t4;
 
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 
 --let $wait_timeout= 600
@@ -103,4 +103,4 @@ SET GLOBAL innodb_encryption_threads=4;
 --source include/wait_condition.inc
 
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/t/innodb_alters.test
+++ b/mysql-test/suite/encryption/t/innodb_alters.test
@@ -1,4 +1,4 @@
-let $innodb_encrypt_tables_orig = `SELECT @@innodb_encrypt_tables`;
+let $default_table_encryption_orig = `SELECT @@default_table_encryption`;
 let $innodb_encryption_threads_orig = `SELECT @@innodb_encryption_threads`;
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
@@ -151,8 +151,8 @@ ALTER TABLE t_alter_encryption_key_id ENCRYPTION_KEY_ID = 6;
 SHOW CREATE TABLE t_alter_encryption_key_id;
 SHOW CREATE TABLE t_alter_to_rk;
 
---echo # Testing alters with innodb-encrypt-tables ONLINE_TO_KEYRING
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--echo # Testing alters with default-table-encryption ONLINE_TO_KEYRING
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/restart_mysqld.inc
 
 --echo # Check that tables' definitions are correct after the reset
@@ -187,7 +187,7 @@ SHOW CREATE TABLE t3;
 
 --echo # Now decrypt t3. It should it should still be possible to change the ENCRYPTION_KEY_ID.
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --echo #Wait for all tables to get decrypted (apart from t2, t_rk_with_encryption_key_id, t_alter_to_rk)
 --let $wait_timeout= 600
@@ -205,7 +205,7 @@ SHOW CREATE TABLE t3;
 
 --echo # After the re-encryption t3 should get encrypted with key 5
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 
 --echo #Wait for all tables to get encrypted (apart from t1 and temporary)
 --let $wait_timeout= 600
@@ -223,7 +223,7 @@ SHOW CREATE TABLE t3;
 
 --echo # Turn off encryption threads and encryption
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 CREATE TABLE t4 (a varchar(255)) engine=innodb;
 SHOW CREATE TABLE t4;
@@ -243,7 +243,7 @@ SHOW CREATE TABLE t4;
 
 --echo # Encrypt all tables and check if t4 got encrypted with ENCRYPTION KEY 6
 SET GLOBAL innodb_encryption_threads=4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 
 --let encrypted_tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
 --echo #Wait for all tables to get encrypted (apart from t1 and temporary)
@@ -257,11 +257,11 @@ SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
 
 drop table t1,t2,t3,t4,t_rk_with_encryption_key_id,t_alter_to_rk,t_alter_encryption_key_id;
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-EVAL SET GLOBAL innodb_encrypt_tables = $innodb_encrypt_tables_orig;
+EVAL SET GLOBAL default_table_encryption = $default_table_encryption_orig;
 EVAL SET GLOBAL innodb_encryption_threads = $innodb_encryption_threads_orig;

--- a/mysql-test/suite/encryption/t/innodb_default_key.test
+++ b/mysql-test/suite/encryption/t/innodb_default_key.test
@@ -1,9 +1,9 @@
-let $innodb_encrypt_tables_orig = `SELECT @@innodb_encrypt_tables`;
+let $default_table_encryption_orig = `SELECT @@default_table_encryption`;
 let $innodb_encryption_threads_orig = `SELECT @@innodb_encryption_threads`;
 
 --disable_warnings
 SET GLOBAL innodb_file_per_table = ON;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads= 0;
 --enable_warnings
 
@@ -39,7 +39,7 @@ SET GLOBAL innodb_default_encryption_key_id = 8;
 
 --echo # Turn on encryption. t3 and t4 should get encrypted with key 8.
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads= 4;
 
 --let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
@@ -70,7 +70,7 @@ SHOW CREATE TABLE t5;
 --echo # Turn off encryption, create table t6 (unencrypted), create table t7 with MK encryption, restart server with innodb_default_key = 6 and encryption enabled. t6 and t7 should get encrypted with key 6.
 
 SET GLOBAL innodb_encryption_threads= 0;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 CREATE TABLE t6 (a varchar(255)) ENGINE=innodb;
 SHOW CREATE TABLE t6;
 CREATE TABLE t7 (a varchar(255)) ENCRYPTION="Y" ENGINE=innodb;
@@ -80,7 +80,7 @@ SHOW CREATE TABLE t7;
 --let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE NAME = \\"test/t6\\" OR NAME = \\"test/t7\\" ]" = 0
 --source include/assert.inc
 
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=6
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=6
 --source include/restart_mysqld.inc
 
 --let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
@@ -103,12 +103,12 @@ CREATE TABLE t9 (a varchar(255)) ENCRYPTION="N" ENCRYPTION_KEY_ID=5 ENGINE=innod
 
 drop table t1,t2,t3,t4,t5,t6,t7,t8,t9;
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --echo # Wait for all tables to get decrypted encrypted
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-EVAL SET GLOBAL innodb_encrypt_tables = $innodb_encrypt_tables_orig;
+EVAL SET GLOBAL default_table_encryption = $default_table_encryption_orig;
 EVAL SET GLOBAL innodb_encryption_threads = $innodb_encryption_threads_orig;

--- a/mysql-test/suite/encryption/t/innodb_encryption-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption-master.opt
@@ -1,6 +1,6 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=4

--- a/mysql-test/suite/encryption/t/innodb_encryption-page-compression-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption-page-compression-master.opt
@@ -1,7 +1,7 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=0
 --innodb-monitor-enable=module_encryption

--- a/mysql-test/suite/encryption/t/innodb_encryption-page-compression.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption-page-compression.test
@@ -1,5 +1,5 @@
 --disable_query_log
-let $innodb_encrypt_tables_orig = `SELECT @@innodb_encrypt_tables`;
+let $default_table_encryption_orig = `SELECT @@default_table_encryption`;
 let $innodb_encryption_threads_orig = `SELECT @@innodb_encryption_threads`;
 --enable_query_log
 
@@ -79,7 +79,7 @@ let $wait_condition= select count > 0 from information_schema.innodb_metrics WHE
 --source include/restart_mysqld.inc
 
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 update innodb_page_compressed1 set c1 = c1 + 1;
 update innodb_page_compressed2 set c1 = c1 + 1;
@@ -117,13 +117,13 @@ drop table innodb_page_compressed8;
 drop table innodb_page_compressed9;
 
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
 # reset system
 --disable_query_log
-EVAL SET GLOBAL innodb_encrypt_tables = $innodb_encrypt_tables_orig;
+EVAL SET GLOBAL default_table_encryption = $default_table_encryption_orig;
 EVAL SET GLOBAL innodb_encryption_threads = $innodb_encryption_threads_orig;
 --enable_query_log

--- a/mysql-test/suite/encryption/t/innodb_encryption.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption.test
@@ -1,6 +1,6 @@
 SHOW VARIABLES LIKE 'innodb_encrypt%';
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 # We do not encrypt temporary tablespace
 --let encrypted_tables_count=`select count(*) - 1 from INFORMATION_SCHEMA.INNODB_TABLESPACES`
@@ -13,7 +13,7 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
 --echo # Success!
 
 --echo # Now turn off encryption and wait for threads to decrypt everything
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --echo # Wait max 10 min for key encryption threads to decrypt all spaces
 --let $wait_timeout= 600
@@ -27,7 +27,7 @@ SET GLOBAL innodb_encryption_threads=0;
 
 --echo # Turn on encryption
 --echo # since threads are off tables should remain unencrypted
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --echo # Wait 15s to check that nothing gets encrypted
 
@@ -51,14 +51,14 @@ SET GLOBAL innodb_encryption_threads=4;
 
 --source include/shutdown_mysqld.inc
 
---let $restart_parameters=restart:--innodb-encryption-threads=0 --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+--let $restart_parameters=restart:--innodb-encryption-threads=0 --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 --source include/start_mysqld.inc
 
 SHOW VARIABLES LIKE 'innodb_encrypt%';
 
 # cleanup
 #
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 
 --echo # Wait max 10 min for key encryption threads to decrypt all spaces
@@ -66,4 +66,4 @@ SET GLOBAL innodb_encryption_threads=4;
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0;
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation-master.opt
@@ -3,4 +3,4 @@ $KEYRING_PLUGIN_OPT
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=1
 --innodb-encryption-threads=0
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation.inc
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation.inc
@@ -100,7 +100,7 @@ SET GLOBAL debug="-d,rotate_only_first_100_pages_from_t1";
 --let SEARCH_FILE=$t1_IBD
 --source include/search_pattern_in_file.inc
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $wait_timeout= 600
 --echo # All tables should get decrypted, apart from t1.
@@ -110,7 +110,7 @@ SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 #Cleanup
 
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 
 DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_mk-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_mk-master.opt
@@ -3,4 +3,4 @@ $KEYRING_PLUGIN_OPT
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=1
 --innodb-encryption-threads=0
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_mk_page_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_mk_page_compressed-master.opt
@@ -3,4 +3,4 @@ $KEYRING_PLUGIN_OPT
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=1
 --innodb-encryption-threads=0
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_mk_row_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_mk_row_compressed-master.opt
@@ -3,4 +3,4 @@ $KEYRING_PLUGIN_OPT
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=1
 --innodb-encryption-threads=0
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_page_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_page_compressed-master.opt
@@ -3,4 +3,4 @@ $KEYRING_PLUGIN_OPT
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=1
 --innodb-encryption-threads=0
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_row_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_key_rotation_row_compressed-master.opt
@@ -3,4 +3,4 @@ $KEYRING_PLUGIN_OPT
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-rotate-key-age=1
 --innodb-encryption-threads=0
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation.inc
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation.inc
@@ -41,7 +41,7 @@ set autocommit=1;
 
 # Make sure encryption is disabled
 --let $assert_text= Make sure encryption is disabled
---let $assert_cond= "[SELECT @@GLOBAL.innodb_encrypt_tables]" = 0
+--let $assert_cond= "[SELECT @@GLOBAL.default_table_encryption]" = 0
 --source include/assert.inc
 
 if ($is_mk_encrypted)
@@ -61,7 +61,7 @@ SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 
 --echo # Start rotation unnencrypted => encrypted (tables do not have crypt data stored in page 0)
 SET GLOBAL innodb_encryption_threads = 4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 
 --let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
 
@@ -99,7 +99,7 @@ if ($grep_log)
 }
 
 --echo # t1 is only half rotatted, now we will check if the encryption can be completed after the restart
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/start_mysqld.inc
 
 --let $wait_timeout= 600
@@ -121,7 +121,7 @@ if (!$is_t1_compressed)
 --echo # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $wait_timeout= 600
 # All tables should get unencrypted, apart from t1. tables_count - 2 - because t1 will only have half of the pages unencrypted =>
@@ -152,7 +152,7 @@ if (!$is_t1_compressed)
 }
 
 --echo # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/start_mysqld.inc
 
 --let $wait_timeout= 600
@@ -173,7 +173,7 @@ if (!$is_t1_compressed)
 --echo # Enable rotation of only first 100 pages
 SET GLOBAL debug="+d,rotate_only_first_100_pages_from_t1";
 
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 
 --let $wait_timeout= 600
 # All tables should get unencrypted, apart from t1 and temporary tablespace.
@@ -206,7 +206,7 @@ if (!$is_t1_compressed)
 }
 
 --echo # t1 is only half rotatted, now we will check if the decryption can be completed after the restart
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/start_mysqld.inc
 
 --let $wait_timeout= 600
@@ -235,7 +235,7 @@ if (!$is_t1_compressed)
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 
 --source include/expect_crash.inc
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --source include/wait_until_disconnected.inc
 
 # The server crashed after but t1's pages have been flushed to disk by encryption thread
@@ -277,7 +277,7 @@ SELECT COUNT(1) FROM t1;
 --remove_file $error_log
 
 --echo # Restart and finish up the rotation
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/start_mysqld.inc
 
 --let $wait_timeout= 600
@@ -302,7 +302,7 @@ SELECT COUNT(1) FROM t1;
 --echo # Now we need to test the rotation unencrypted=>encrypted, when we get a crash after all pages
 --echo # got rotated and DD was updated but before updating page 0
 
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
 --source include/start_mysqld.inc
 
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
@@ -351,7 +351,7 @@ SELECT COUNT(1) FROM t1;
 --remove_file $error_log
 
 --echo # Restart and finish up the rotation
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/start_mysqld.inc
 
 --let $wait_timeout= 600
@@ -364,11 +364,11 @@ DROP TABLE t1;
 DROP PROCEDURE innodb_insert_proc;
 
 # decrypt all the tables
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables=OFF;
+SET GLOBAL default_table_encryption=OFF;
 SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_mk-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_mk-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_mk_page_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_mk_page_compressed-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_mk_row_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_mk_row_compressed-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_page_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_page_compressed-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_row_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation_row_compressed-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_encryption_discard_import-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_discard_import-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-threads=4

--- a/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_discard_import.test
@@ -299,7 +299,7 @@ EOF
 
 --echo # Disable rotation threads
 SET GLOBAL innodb_encryption_threads = 0;
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 
 ALTER TABLE t1 IMPORT TABLESPACE;
 --let $assert_text = Make sure t1 has encrypted flag set after importing
@@ -540,7 +540,7 @@ SET GLOBAL innodb_encryption_threads = 4;
 --echo # export and dicard them. Next restart the server with backuped keyring file and make sure that
 --echo # server starts, but tables cannot be imported gracefully
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --echo # Wait max 2 min for key encryption threads to encrypt all spaces
 --let $wait_timeout = 120

--- a/mysql-test/suite/encryption/t/innodb_encryption_row_compressed-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_row_compressed-master.opt
@@ -2,4 +2,4 @@ $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-threads=4
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF

--- a/mysql-test/suite/encryption/t/innodb_encryption_tables-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_encryption_tables-master.opt
@@ -1,7 +1,7 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=0
 --innodb-monitor-enable=module_encryption

--- a/mysql-test/suite/encryption/t/innodb_encryption_tables.test
+++ b/mysql-test/suite/encryption/t/innodb_encryption_tables.test
@@ -94,10 +94,10 @@ drop table innodb_compressed;
 drop table innodb_redundant;
 
 # Decrypt all tables
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;

--- a/mysql-test/suite/encryption/t/innodb_lotoftables-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_lotoftables-master.opt
@@ -1,5 +1,5 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_lotoftables.test
+++ b/mysql-test/suite/encryption/t/innodb_lotoftables.test
@@ -131,7 +131,7 @@ show status like 'innodb_pages0_read%';
 use test;
 show status like 'innodb_pages0_read%';
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=4;
 
 --echo #tables in innodb_encrypted_1 and innodb_encrypted_2 should be encrypted
@@ -156,8 +156,8 @@ SET GLOBAL innodb_encryption_threads=4;
 --source include/assert.inc
 
 --echo # Success!
---echo # Restart mysqld --innodb_encrypt_tables=0 --innodb_encryption_threads=0
--- let $restart_parameters=restart:--innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb_encryption_threads=0
+--echo # Restart mysqld --default_table_encryption=0 --innodb_encryption_threads=0
+-- let $restart_parameters=restart:--default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb_encryption_threads=0
 -- source include/restart_mysqld.inc
 
 --echo # Restart Success!
@@ -232,7 +232,7 @@ show status like 'innodb_pages0_read%';
 --let $assert_cond="[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0 AND NAME LIKE \\'innodb_encrypted_3%\\']" = 100
 --source include/assert.inc
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads=4;
 
 --let $wait_timeout= 600

--- a/mysql-test/suite/encryption/t/innodb_onlinealter_encryption-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_onlinealter_encryption-master.opt
@@ -1,6 +1,6 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/innodb_onlinealter_encryption.test
+++ b/mysql-test/suite/encryption/t/innodb_onlinealter_encryption.test
@@ -131,7 +131,7 @@ SHOW CREATE TABLE t7;
 -- source include/search_pattern_in_file.inc
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN KEYRING_PLUGIN $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/start_mysqld.inc
 
 DROP PROCEDURE innodb_insert_proc;
@@ -144,4 +144,4 @@ DROP TABLE t1, t2, t3, t4, t5, t6, t7;
 --source include/wait_condition.inc
 
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;

--- a/mysql-test/suite/encryption/t/innodb_page_encryption_key_change-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_page_encryption_key_change-master.opt
@@ -1,4 +1,4 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED

--- a/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk-master.opt
@@ -2,4 +2,4 @@ $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-threads=4
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF

--- a/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk.test
+++ b/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk.test
@@ -12,7 +12,7 @@ create table t1 (a varchar(255)) engine=innodb encryption='Y';
 
 insert t1 values (repeat('foobarsecret', 12));
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
 --echo # Wait max 10 min for key encryption threads to encrypt all spaces
@@ -37,12 +37,12 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
 --source include/search_pattern_in_file.inc
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 --source include/start_mysqld.inc
 
 --echo # Now turn off encryption and wait for threads to decrypt everything
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
@@ -61,11 +61,11 @@ SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 --source include/search_pattern_in_file.inc
 
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ON --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4
 --source include/start_mysqld.inc
 
 --echo # Now turn on encryption and wait for threads to encrypt all spaces
-SET GLOBAL innodb_encrypt_tables = ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption = ONLINE_TO_KEYRING;
 
 --echo # Wait max 10 min for key encryption threads to encrypt all spaces
 --let $wait_timeout= 600
@@ -120,12 +120,12 @@ alter table t1 encryption='n';
 # cleanup
 drop table t1;
 
-SET GLOBAL innodb_encrypt_tables = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --echo # Wait max 10 min for encryption threads to decrypt all tables
 --let $wait_timeout= 600
 --let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
 --source include/wait_condition.inc
 
-SET GLOBAL innodb_encrypt_tables = OFF;
+SET GLOBAL default_table_encryption = OFF;
 

--- a/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk_post_enc_checksum_fail-master.opt
+++ b/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk_post_enc_checksum_fail-master.opt
@@ -2,4 +2,4 @@ $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
 --innodb-encryption-threads=4
---innodb-encrypt-tables=OFF
+--default-table-encryption=OFF

--- a/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk_post_enc_checksum_fail.test
+++ b/mysql-test/suite/encryption/t/innodb_rotation_mk_to_rk_post_enc_checksum_fail.test
@@ -41,7 +41,7 @@ COMMIT;
 --copy_file $MYSQLD_DATADIR/test/t1.ibd $MYSQLD_DATADIR/test/t1.ibd.MK
 
 --replace_result $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 --source include/start_mysqld.inc
 
 --let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
@@ -82,7 +82,7 @@ EOF
 --echo # Apart from t1 which is corrupted and it should not be possible to decrypt this table
 
 --replace_result $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $MYSQL_TMP_DIR MYSQL_TMP_DIR
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 --source include/start_mysqld.inc
 
 --let $wait_timeout= 600

--- a/mysql-test/suite/encryption/t/uninstall_keyring-master.opt
+++ b/mysql-test/suite/encryption/t/uninstall_keyring-master.opt
@@ -1,6 +1,6 @@
 $KEYRING_PLUGIN_OPT
 --early-plugin-load="keyring_file=$KEYRING_PLUGIN"
 --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
---innodb-encrypt-tables=ONLINE_TO_KEYRING
+--default-table-encryption=ONLINE_TO_KEYRING
 --innodb-encryption-rotate-key-age=15
 --innodb-encryption-threads=3

--- a/mysql-test/suite/encryption/t/uninstall_keyring.test
+++ b/mysql-test/suite/encryption/t/uninstall_keyring.test
@@ -37,7 +37,7 @@ CREATE table t_mk (a varchar(255)) engine=innodb;
 
 --echo # Turn off encryption threads, uninstall keyring. Check CREATE, ALTER etc.
 SET GLOBAL innodb_encryption_threads=0;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 UNINSTALL PLUGIN keyring_file;
 
 --error ER_ILLEGAL_HA_CREATE_OPTION
@@ -52,7 +52,7 @@ ALTER TABLE t_mk ENCRYPTION='KEYRING';
 --echo # any system tables left encrypted with KEYRING
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 SET GLOBAL innodb_encryption_threads=4;
-SET GLOBAL innodb_encrypt_tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 
 --echo # Wait max 10 min for key encryption threads to decrypt all spaces
 --let $wait_timeout= 600
@@ -100,7 +100,7 @@ UNINSTALL PLUGIN keyring_file;
 
 --echo # Start with keyring plugin installed but not functional (impossible keyring file path). Enabling encryption threads should not be possible as well as creating tables encrypted with KEYRING.
 
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=/homeless/root/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=$error_log --innodb-encrypt-tables=OFF
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=/homeless/root/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0 --log-error=$error_log --default-table-encryption=OFF
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT
 --source include/start_mysqld.inc
 #--source include/restart_mysqld.inc
@@ -144,7 +144,7 @@ INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 eval SET @@global.keyring_file_data= '$MYSQL_TMP_DIR/mysecret_keyring';
 
 --replace_result $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT
---let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=/homeless/root/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0
+--let $restart_parameters=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=/homeless/root/mysecret_keyring $KEYRING_PLUGIN_OPT --default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0
 --source include/restart_mysqld.inc
 
 --remove_file $error_log
@@ -170,14 +170,14 @@ INSERT t6 VALUES (repeat('foobarsecret', 12));
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval SET @@global.keyring_file_data= '$MYSQL_TMP_DIR/mysecret_keyring';
 SET GLOBAL innodb_encryption_threads=3;
-SET GLOBAL innodb_encrypt_tables=ONLINE_TO_KEYRING;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 CREATE TABLE t7 (a varchar(255)) engine=innodb;
 INSERT t7 VALUES (repeat('foobarsecret', 12));
 
 SET GLOBAL innodb_encryption_threads=0;
 UNINSTALL PLUGIN keyring_file;
 
---let $restart_parameters=restart:--innodb-encrypt-tables=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED --innodb-encryption-threads=0
 --source include/restart_mysqld.inc
 
 DROP TABLE t1,t2,t3,t4,t5,t6,t7;


### PR DESCRIPTION
PS-5772

Made the innodb-encrypt-tables to default_table_encryption switch and
re-enabled tests that were disabled due to PS-5772.

The tests that are still disabled have PS ticket assigned to them.