### PR TITLE
PS-5820: Crashes with the slow query log enabled (8.0)

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10507,6 +10507,7 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_RELAYLOG_LOCK_xids, "MYSQL_RELAY_LOG::LOCK_xids", 0, 0, PSI_DOCUMENT_ME},
   { &key_hash_filo_lock, "hash_filo::lock", 0, 0, PSI_DOCUMENT_ME},
   { &Gtid_set::key_gtid_executed_free_intervals_mutex, "Gtid_set::gtid_executed::free_intervals_mutex", 0, 0, PSI_DOCUMENT_ME},
+  { &key_LOCK_bloom_filter, "Bloom_filter", 0, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_crypt, "LOCK_crypt", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_error_log, "LOCK_error_log", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_global_system_variables, "LOCK_global_system_variables", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -100,6 +100,7 @@ bool opt_log_slow_admin_statements = false;
 ulong opt_log_slow_sp_statements = 0;
 
 ulong kill_idle_transaction_timeout = 0;
+PSI_mutex_key key_LOCK_bloom_filter;
 
 /*
   The following is used to initialise Table_ident with a internal


### PR DESCRIPTION
Issue: there is a race condition between different threads calling
Bloom_filter::clear and Bloom_filter::test_and_set.
Before the fix for PS-5581, races always resulted in test_and_set
returning false. After the fix, clear is no longer a single pointer
change, and test_and_set could also return true in these situations.

Root cause: PS-5581, 715f78f

Workaround: restore the previous behavior by switching the single
MEM_ROOT allocated Bitset a per THD locked raw pointer. The race is
still there, but the results should be the same as before PS-5581.

(cherry-picked from commit bde9bf2)