### PR TITLE
PS-5827: Assertion failure: buf0lru.cc:672:err == DB_INTERRUPTED || e…

### DIFF
--- a/storage/innobase/buf/buf0lru.cc
+++ b/storage/innobase/buf/buf0lru.cc
@@ -668,9 +668,6 @@ static void buf_flush_dirty_pages(buf_pool_t *buf_pool, space_id_t id,
 
     err = buf_flush_or_remove_pages(buf_pool, id, observer, flush, trx);
 
-    ut_ad(err == DB_INTERRUPTED || err == DB_FAIL ||
-          buf_pool_get_dirty_pages_count(buf_pool, id, observer) == 0);
-
     mutex_exit(&buf_pool->LRU_list_mutex);
 
     ut_ad(buf_flush_validate(buf_pool));
@@ -692,6 +689,9 @@ static void buf_flush_dirty_pages(buf_pool_t *buf_pool, space_id_t id,
     ut_ad(buf_flush_validate(buf_pool));
 
   } while (err == DB_FAIL);
+
+  ut_ad(err == DB_INTERRUPTED || !strict ||
+        buf_pool_get_dirty_pages_count(buf_pool, id, observer) == 0);
 }
 
 /** Remove all pages that belong to a given tablespace inside a specific


### PR DESCRIPTION
…rr == DB_FAIL || buf_pool_get_dirty_pages_count(buf_pool, id, observer) == 0

The assertion is changed from upstream assertion doesn't handle the "strict" flag introduced.
This strict flag is introduced to handle ALTER TABLESPACE ENCRYPT=Y/N

It is changed in Percona Server for encryption threads purpose to handle unloading of keyring
when there are pages from encrypted tablespace.

Fix:
----
Move the assert after the entire buf_flush_or_remove_pages() is done (after while loop).
The assert is now same as upstream which handles the strict flag.