### PR TITLE
PS-5839: Fix memory leak in keyring_key redo log encryption (8.0)

### DIFF
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -2997,6 +2997,9 @@ redo_log_key *redo_log_keys::load_latest_key(THD *thd, bool generate) {
 
   if (it != m_keys.end() && it->second.present) {
     ut_ad(memcmp(it->second.key, rkey2, ENCRYPTION_KEY_LEN) == 0);
+    my_free(rkey);
+    my_free(rkey2);
+    my_free(key_type);
     return &it->second;
   }
 


### PR DESCRIPTION
(cherry picked from commit 643bafe9bc882bf4c6495a00b311eeb953e6c0fc)