### PR TITLE
PS-5216: Fix utility user invisibility issues, and document limitations (5.6)

### DIFF
--- a/mysql-test/r/percona_utility_user.result
+++ b/mysql-test/r/percona_utility_user.result
@@ -1,10 +1,8 @@
-DROP DATABASE IF EXISTS mysqltest;
 call mtr.add_suppression("Did not write failed .* ");
 SELECT user FROM mysql.user WHERE user LIKE 'frank';
 user
 CREATE USER 'frank'@'localhost' IDENTIFIED BY 'password';
 ERROR HY000: Operation CREATE USER failed for 'frank'@'localhost'
-FLUSH PRIVILEGES;
 CREATE USER 'frank'@'%' IDENTIFIED BY 'password';
 ERROR HY000: Operation CREATE USER failed for 'frank'@'%'
 SET PASSWORD FOR 'frank'@'localhost' = PASSWORD('');
@@ -93,5 +91,42 @@ xx	root			1		xx
 xx	root			1		xx
 xx	root	%	frank	0	root@localhost	xx
 xx	plug	%	frank	0	root@localhost	xx
+REVOKE PROXY ON frank FROM plug;
 ERROR 28000: Access denied for user 'plug'@'localhost' (using password: YES)
 DROP USER plug;
+SHOW GLOBAL STATUS LIKE "Connections";
+Variable_name	Value
+Connections	2
+SHOW GLOBAL STATUS LIKE "Threads%";
+Variable_name	Value
+Threads_cached	0
+Threads_connected	1
+Threads_created	1
+Threads_running	1
+SHOW GLOBAL STATUS LIKE "Connections";
+Variable_name	Value
+Connections	3
+SHOW GLOBAL STATUS LIKE "Threads%";
+Variable_name	Value
+Threads_cached	0
+Threads_connected	2
+Threads_created	2
+Threads_running	1
+SHOW PROCESSLIST;
+Id	User	Host	db	Command	Time	State	Info	Rows_sent	Rows_examined
+SELECT * FROM performance_schema.users WHERE USER="frank";
+USER	CURRENT_CONNECTIONS	TOTAL_CONNECTIONS
+SELECT COUNT(*) from performance_schema.events_statements_current WHERE SQL_TEXT LIKE "%performance_schema.event_statements%";
+COUNT(*)
+0
+SELECT CURRENT_CONNECTIONS, TOTAL_CONNECTIONS FROM performance_schema.hosts WHERE HOST="localhost";
+CURRENT_CONNECTIONS	TOTAL_CONNECTIONS
+1	1
+SELECT * FROM performance_schema.accounts WHERE USER="frank";
+USER	HOST	CURRENT_CONNECTIONS	TOTAL_CONNECTIONS
+SELECT * FROM performance_schema.session_account_connect_attrs;
+PROCESSLIST_ID	ATTR_NAME	ATTR_VALUE	ORDINAL_POSITION
+SELECT COUNT(DISTINCT PROCESSLIST_ID) FROM performance_schema.session_connect_attrs;
+COUNT(DISTINCT PROCESSLIST_ID)
+1
+REVOKE PROXY ON 'frank'@'%' FROM 'root'@'localhost';

--- a/mysql-test/t/percona_utility_user-master.opt
+++ b/mysql-test/t/percona_utility_user-master.opt
@@ -1,1 +1,1 @@
---utility_user=frank@% --utility_user_password=password --utility_user_schema_access=mysql,performance_schema --utility-user-privileges="CREATE,DROP,SHOW DATABASES" $PLUGIN_AUTH_OPT $PLUGIN_AUTH_LOAD
+--utility_user=frank@% --utility_user_password=password --utility_user_schema_access=mysql,b,performance_schema,,other --utility-user-privileges="CREATE,DROP,SHOW DATABASES" $PLUGIN_AUTH_OPT $PLUGIN_AUTH_LOAD

--- a/mysql-test/t/percona_utility_user.test
+++ b/mysql-test/t/percona_utility_user.test
@@ -1,9 +1,6 @@
 --source include/have_plugin_auth.inc
 --source include/not_embedded.inc
-
---disable_warnings
-DROP DATABASE IF EXISTS mysqltest;
---enable_warnings
+--source include/count_sessions.inc
 
 call mtr.add_suppression("Did not write failed .* ");
 
@@ -11,7 +8,6 @@ SELECT user FROM mysql.user WHERE user LIKE 'frank';
 
 --error ER_CANNOT_USER 
 CREATE USER 'frank'@'localhost' IDENTIFIED BY 'password';
-FLUSH PRIVILEGES;
 
 connect (frank,localhost,frank,password,mysql);
 disconnect frank;
@@ -71,7 +67,6 @@ DROP USER 'frank'@'%';
 CREATE USER 'mysqltest_1'@'localhost';
 
 connect (frank,localhost,frank,password,mysql);
-connection frank;
 
 SELECT user FROM mysql.user WHERE user LIKE 'frank';
 
@@ -91,28 +86,28 @@ SET PASSWORD FOR 'frankjr'@'localhost' = PASSWORD('');
 
 DROP USER 'frankjr'@'localhost';
 
-# Allowed because --utility-user-priviliges has CREATE
+# Allowed because --utility-user-privileges has CREATE
 CREATE DATABASE mysqltest;
 
-# Allowed because --utility-user-priviliges has CREATE
+# Allowed because --utility-user-privileges has CREATE
 CREATE TABLE mysqltest.t1 (a INT, b INT);
 
-# Allowed because --utility-user-priviliges has SHOW DATABASES
+# Allowed because --utility-user-privileges has SHOW DATABASES
 SHOW TABLES IN mysqltest;
 
-# NOT allowed because --utility-user-priviliges does not have INSERT
+# NOT allowed because --utility-user-privileges does not have INSERT
 --error ER_TABLEACCESS_DENIED_ERROR
 INSERT INTO mysqltest.t1(a, b) VALUES (1, 1);
 
-# NOT allowed because --utility-user-priviliges does not have SELECT
+# NOT allowed because --utility-user-privileges does not have SELECT
 --error ER_TABLEACCESS_DENIED_ERROR
 SELECT * FROM mysqltest.t1;
 
-# NOT allowed because --utility-user-priviliges does not have ALTER
+# NOT allowed because --utility-user-privileges does not have ALTER
 --error ER_TABLEACCESS_DENIED_ERROR
 ALTER TABLE mysqltest.t1 DROP COLUMN b;
 
-# Allowed because --utility-user-priviliges has DROP
+# Allowed because --utility-user-privileges has DROP
 DROP DATABASE mysqltest;
 
 SET PASSWORD FOR 'mysqltest_1'@'localhost' = PASSWORD('newpass');
@@ -149,6 +144,8 @@ GRANT PROXY ON frank TO plug;
 --replace_column 1 xx 7 xx
 SELECT * FROM mysql.proxies_priv;
 
+REVOKE PROXY ON frank FROM plug;
+
 --disable_query_log
 --error ER_ACCESS_DENIED_ERROR : this should fail : no grant
 connect(plug_con,localhost,plug,frank);
@@ -157,3 +154,39 @@ connect(plug_con,localhost,plug,frank);
 connection default;
 
 DROP USER plug;
+
+# Ensure invisibility of the utility user
+
+# Restart to reset the global counters
+--source include/restart_mysqld.inc
+
+SHOW GLOBAL STATUS LIKE "Connections";
+SHOW GLOBAL STATUS LIKE "Threads%";
+
+connect (frank,localhost,frank,password,mysql);
+
+# Invisibility issue: this is the thread_id, will increase with each connection
+SHOW GLOBAL STATUS LIKE "Connections";
+# Invisibility issue: Threads_connected includes the utility user too
+# This is kept as is because this counter is used for logic within thread pool handling
+# E.g. fixing this would cause issues in threadpool_unix
+# Other Thread_ counters are fine.
+SHOW GLOBAL STATUS LIKE "Threads%";
+
+SHOW PROCESSLIST;
+
+SELECT * FROM performance_schema.users WHERE USER="frank";
+
+SELECT COUNT(*) from performance_schema.events_statements_current WHERE SQL_TEXT LIKE "%performance_schema.event_statements%";
+
+SELECT CURRENT_CONNECTIONS, TOTAL_CONNECTIONS FROM performance_schema.hosts WHERE HOST="localhost";
+SELECT * FROM performance_schema.accounts WHERE USER="frank";
+SELECT * FROM performance_schema.session_account_connect_attrs;
+SELECT COUNT(DISTINCT PROCESSLIST_ID) FROM performance_schema.session_connect_attrs;
+
+connection default;
+disconnect frank;
+
+REVOKE PROXY ON 'frank'@'%' FROM 'root'@'localhost';
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_acl.cc
+++ b/sql/sql_acl.cc
@@ -2100,10 +2100,13 @@ acl_init_utility_user(my_bool check_no_resolve)
     {
       if (*cur_pos == ',' || *cur_pos == '\0')
       {
-        char *dbname= my_strndup(cur_db, cur_pos-cur_db, MYF(MY_FAE));
-        (void) push_dynamic(&acl_utility_user_schema_access, (uchar*) &dbname);
+	if (cur_pos - cur_db > 0)
+        {
+          char *dbname= my_strndup(cur_db, cur_pos-cur_db, MYF(MY_FAE));
+          (void) push_dynamic(&acl_utility_user_schema_access, (uchar*) &dbname);
+	}
         cur_db= cur_pos+1;
-        if(*cur_pos == '\0')
+        if (*cur_pos == '\0')
           break;
       }
       cur_pos++;

--- a/storage/perfschema/unittest/pfs_server_stubs.cc
+++ b/storage/perfschema/unittest/pfs_server_stubs.cc
@@ -34,3 +34,8 @@ void compute_digest_md5(const sql_digest_storage *, unsigned char *)
 {
 }
 
+my_bool
+acl_is_utility_user(const char *, const char *, const char *)
+{
+  return FALSE;
+}


### PR DESCRIPTION
* The utility user and anything related to its sessions is no longer
appears in any performance_schema tables.
* Documented the limitation of the utility user increasing some
connection counters in the related mtr test