### PR TITLE
(8.0) PS-5747 : Remove AHI overhead for DDLs when AHI is disabled

### DIFF
--- a/mysql-test/suite/innodb/r/percona_ddl_ahi.result
+++ b/mysql-test/suite/innodb/r/percona_ddl_ahi.result
@@ -1,0 +1,40 @@
+CREATE TABLE t1(a INT, b INT, KEY k1(b));
+INSERT INTO t1 VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+CREATE TABLE t2 AS SELECT * FROM t1;
+FLUSH TABLES;
+SET GLOBAL innodb_limit_optimistic_insert_debug=2;
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1280
+SET DEBUG='+d, simulate_long_ahi';
+SET DEBUG_SYNC = 'replay_free_tree_log SIGNAL drop_index_started WAIT_FOR resume_drop_index';
+ALTER TABLE t1 DROP INDEX k1;;
+#connection con1
+SET DEBUG_SYNC = 'now WAIT_FOR drop_index_started';
+SET DEBUG_SYNC = 'ha_innobase_open SIGNAL resume_drop_index';
+SET @t_start:=unix_timestamp(now(6));
+SELECT * FROM t2;
+a	b
+1	1
+2	2
+3	3
+4	4
+5	5
+SET @t_end:=unix_timestamp(now(6));
+SET @duration:=@t_end-@t_start;
+include/assert.inc [The time taken for SELECT should be less than 5 seconds]
+# connection default
+SET DEBUG_SYNC = 'RESET';
+DROP TABLE t1;
+DROP TABLE t2;
+SET GLOBAL innodb_limit_optimistic_insert_debug=default;
+SET GLOBAL innodb_adaptive_hash_index = default;

--- a/mysql-test/suite/innodb/t/percona_ddl_ahi.test
+++ b/mysql-test/suite/innodb/t/percona_ddl_ahi.test
@@ -1,0 +1,51 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+CREATE TABLE t1(a INT, b INT, KEY k1(b));
+INSERT INTO t1 VALUES (1,1),(2,2),(3,3),(4,4),(5,5);
+CREATE TABLE t2 AS SELECT * FROM t1;
+FLUSH TABLES;
+
+SET GLOBAL innodb_limit_optimistic_insert_debug=2;
+SET GLOBAL innodb_adaptive_hash_index = OFF;
+
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+SELECT COUNT(*) FROM t1;
+
+SET DEBUG='+d, simulate_long_ahi';
+SET DEBUG_SYNC = 'replay_free_tree_log SIGNAL drop_index_started WAIT_FOR resume_drop_index';
+--send ALTER TABLE t1 DROP INDEX k1;
+
+connect (con1,localhost,root,,);
+--connection con1
+--echo #connection con1
+SET DEBUG_SYNC = 'now WAIT_FOR drop_index_started';
+SET DEBUG_SYNC = 'ha_innobase_open SIGNAL resume_drop_index';
+SET @t_start:=unix_timestamp(now(6));
+SELECT * FROM t2;
+SET @t_end:=unix_timestamp(now(6));
+SET @duration:=@t_end-@t_start;
+
+--let $assert_text= The time taken for SELECT should be less than 5 seconds
+--let $assert_cond= [SELECT @duration] < 5
+--source include/assert.inc
+
+--connection default
+--echo # connection default
+--reap
+SET DEBUG_SYNC = 'RESET';
+--disconnect con1
+
+DROP TABLE t1;
+DROP TABLE t2;
+SET GLOBAL innodb_limit_optimistic_insert_debug=default;
+SET GLOBAL innodb_adaptive_hash_index = default;
+--source include/wait_until_count_sessions.inc

--- a/storage/innobase/btr/btr0btr.cc
+++ b/storage/innobase/btr/btr0btr.cc
@@ -1027,12 +1027,23 @@ ulint btr_create(ulint type, space_id_t space, const page_size_t &page_size,
 /** Free a B-tree except the root page. The root page MUST be freed after
 this by calling btr_free_root.
 @param[in,out]	block		root page
-@param[in]	log_mode	mtr logging mode */
-static void btr_free_but_not_root(buf_block_t *block, mtr_log_t log_mode) {
+@param[in]	log_mode	mtr logging mode
+@param[in]	is_ahi_allowed	false for intrinsic tables because AHI
+                                is disallowed. See dict_index_t->disable_ahi,
+                                true for other tables */
+static void btr_free_but_not_root(buf_block_t *block, mtr_log_t log_mode,
+                                  bool is_ahi_allowed) {
   ibool finished;
   mtr_t mtr;
 
   ut_ad(page_is_root(block->frame));
+
+  bool ahi = false;
+  if (is_ahi_allowed) {
+    ut_ad(mutex_own(&dict_sys->mutex));
+    ahi = btr_search_enabled;
+  }
+
 leaf_loop:
   mtr_start(&mtr);
   mtr_set_log_mode(&mtr, log_mode);
@@ -1054,7 +1065,7 @@ leaf_loop:
   /* NOTE: page hash indexes are dropped when a page is freed inside
   fsp0fsp. */
 
-  finished = fseg_free_step(root + PAGE_HEADER + PAGE_BTR_SEG_LEAF, true, &mtr);
+  finished = fseg_free_step(root + PAGE_HEADER + PAGE_BTR_SEG_LEAF, ahi, &mtr);
   mtr_commit(&mtr);
 
   if (!finished) {
@@ -1077,7 +1088,7 @@ top_loop:
 #endif /* UNIV_BTR_DEBUG */
 
   finished = fseg_free_step_not_header(root + PAGE_HEADER + PAGE_BTR_SEG_TOP,
-                                       true, &mtr);
+                                       ahi, &mtr);
   mtr_commit(&mtr);
 
   if (!finished) {
@@ -1098,15 +1109,17 @@ void btr_free_if_exists(const page_id_t &page_id, const page_size_t &page_size,
     return;
   }
 
-  btr_free_but_not_root(root, mtr->get_log_mode());
+  btr_free_but_not_root(root, mtr->get_log_mode(), true);
   btr_free_root(root, mtr);
   btr_free_root_invalidate(root, mtr);
 }
 
 /** Free an index tree in a temporary tablespace.
 @param[in]	page_id		root page id
-@param[in]	page_size	page size */
-void btr_free(const page_id_t &page_id, const page_size_t &page_size) {
+@param[in]	page_size	page size
+@param[in]	is_intrinsic	true for intrinsic tables else false */
+void btr_free(const page_id_t &page_id, const page_size_t &page_size,
+              bool is_intrinsic) {
   mtr_t mtr;
   mtr.start();
   mtr.set_log_mode(MTR_LOG_NO_REDO);
@@ -1115,7 +1128,7 @@ void btr_free(const page_id_t &page_id, const page_size_t &page_size) {
 
   ut_ad(page_is_root(block->frame));
 
-  btr_free_but_not_root(block, MTR_LOG_NO_REDO);
+  btr_free_but_not_root(block, MTR_LOG_NO_REDO, !is_intrinsic);
   btr_free_root(block, &mtr);
   mtr.commit();
 }
@@ -1164,7 +1177,7 @@ void btr_truncate(const dict_index_t *index) {
   block = buf_page_get(page_id, page_size, RW_X_LATCH, &mtr);
 
   /* Free all except the root, we don't want to change it. */
-  btr_free_but_not_root(block, MTR_LOG_ALL);
+  btr_free_but_not_root(block, MTR_LOG_ALL, false);
 
   /* Reset the mark saying that we have finished the truncate.
   The PAGE_MAX_TRX_ID would be reset here. */

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2457,7 +2457,7 @@ withdraw_retry:
 
   /* enable AHI if needed */
   if (btr_search_disabled) {
-    btr_search_enable();
+    btr_search_enable(true);
     ib::info(ER_IB_MSG_70) << "Re-enabled adaptive hash index.";
   }
 

--- a/storage/innobase/dict/dict0crea.cc
+++ b/storage/innobase/dict/dict0crea.cc
@@ -523,7 +523,8 @@ void dict_drop_temporary_table_index(const dict_index_t *index,
   tablespace and the .ibd file is missing do nothing,
   else free the all the pages */
   if (root_page_no != FIL_NULL && found) {
-    btr_free(page_id_t(space, root_page_no), page_size);
+    btr_free(page_id_t(space, root_page_no), page_size,
+             index->table->is_intrinsic());
   }
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7420,6 +7420,8 @@ int ha_innobase::open(const char *name, int, uint open_flags,
   ib_table = thd_to_innodb_session(thd)->lookup_table_handler(norm_name);
 
   if (ib_table == NULL) {
+    DEBUG_SYNC_C("ha_innobase_open");
+
     mutex_enter(&dict_sys->mutex);
     ib_table = dict_table_check_if_in_cache_low(norm_name);
     if (ib_table != nullptr) {
@@ -20497,7 +20499,7 @@ static void innodb_adaptive_hash_index_update(
                       from check function */
 {
   if (*(bool *)save) {
-    btr_search_enable();
+    btr_search_enable(true);
   } else {
     btr_search_disable(true);
   }

--- a/storage/innobase/include/btr0btr.h
+++ b/storage/innobase/include/btr0btr.h
@@ -275,8 +275,10 @@ void btr_free_if_exists(const page_id_t &page_id, const page_size_t &page_size,
 
 /** Free an index tree in a temporary tablespace.
 @param[in]	page_id		root page id
-@param[in]	page_size	page size */
-void btr_free(const page_id_t &page_id, const page_size_t &page_size);
+@param[in]	page_size	page size
+@param[in]	is_intrinsic	true for intrinsic tables else false */
+void btr_free(const page_id_t &page_id, const page_size_t &page_size,
+              bool is_intrinsic);
 
 /** Truncate an index tree. We just free all except the root.
 Currently, this function is only specific for clustered indexes and the only

--- a/storage/innobase/include/btr0sea.h
+++ b/storage/innobase/include/btr0sea.h
@@ -55,8 +55,10 @@ void btr_search_sys_free();
 /** Disable the adaptive hash search system and empty the index.
 @param  need_mutex      need to acquire dict_sys->mutex */
 void btr_search_disable(bool need_mutex);
-/** Enable the adaptive hash search system. */
-void btr_search_enable();
+/** Enable the adaptive hash search system
+@param[in]	need_dict_mutex	if true mutex is acquired and released
+                                by function */
+void btr_search_enable(bool need_dict_mutex);
 
 /** Returns search info for an index.
  @return search info; search mutex reserved */

--- a/storage/innobase/log/log0ddl.cc
+++ b/storage/innobase/log/log0ddl.cc
@@ -1560,6 +1560,8 @@ void Log_DDL::replay_free_tree_log(space_id_t space_id, page_no_t page_no,
   /* This is required by dropping hash index afterwards. */
   mutex_enter(&dict_sys->mutex);
 
+  DEBUG_SYNC_C("replay_free_tree_log");
+
   mtr_t mtr;
   mtr_start(&mtr);
 

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -2946,7 +2946,7 @@ void row_delete_all_rows(dict_table_t *table) {
        index = UT_LIST_GET_NEXT(indexes, index)) {
     ut_ad(index->space == table->space);
     const page_id_t root(index->space, index->page);
-    btr_free(root, page_size);
+    btr_free(root, page_size, table->is_intrinsic());
 
     mtr_t mtr;
 


### PR DESCRIPTION
Problem:
--------
Even when AHI is disabled, there is overhead because of AHI.
This is because of checks required for AHI to delete hash entries
of pages being dropped.

These checks are not necessary if we know for sure that AHI is already
disabled.

Fix:
----
1. Take extra dict_sys mutex when enabling AHI (btr_search_enable()). This
   is now similar to AHI disable (btr_search_disable())

2. btr_search_enabled variable read under dict_sys mutex is now accurate
   and can be used to know if AHI is disabled for sure and can't be enabled
   currently.

Fix is similar to PS-5576 - Server stalls because ALTER TABLE on partitioned
                             table holds dict mutex

This fix is more generic and should cover DROP TABLE, DROP INDEX also (apart
from TRUNCATE)

(cherry picked from commit 496cde45f0c33d0dd69ed43c3d79936e9b1b13e9)