### PR TITLE
PS-5867: Re-enable keyring_vault tests on Jenkins.

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -218,7 +218,7 @@ our $DEFAULT_SUITES =
   ."tokudb.add_index,tokudb.alter_table,tokudb,tokudb.bugs,tokudb.parts,"
   ."tokudb.rpl,tokudb.perfschema,"
   ."rocksdb,rocksdb.rpl,rocksdb.sys_vars,"
-  ."percona-pam-for-mysql";
+  ."keyring_vault,percona-pam-for-mysql";
 
 our $opt_big_test                  = 0;
 our $opt_check_testcases           = 1;


### PR DESCRIPTION
After PS-5772 and PS-5790 are completed it is safe now to re-add
keyring_vault to default test suite. They were removed by PS-5102.