### PR TITLE
JEN-957 (8.0 trunk testing implementation): reduce default trunk test

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -211,9 +211,8 @@ our $opt_xml_report;
 our $opt_gterm;
 
 our $DEFAULT_SUITES =
-"main,sys_vars,binlog,binlog_gtid,binlog_nogtid,binlog_57_decryption,encryption,rpl_encryption,federated,gis,rpl,rpl_gtid,rpl_nogtid,innodb,innodb_gis,innodb_fts,innodb_zip,innodb_undo,perfschema,funcs_1,opt_trace,parts,auth_sec,query_rewrite_plugins,gcol,sysschema,test_service_sql_api,json,connection_control,test_services,collations,service_udf_registration,service_sys_var_registration,service_status_var_registration,x,secondary_engine,"
-  ."funcs_2,jp,stress,engines/iuds,engines/funcs,group_replication,audit_null,"
-  ."interactive_utilities,"
+"main,sys_vars,binlog,binlog_gtid,binlog_nogtid,binlog_57_decryption,encryption,rpl_encryption,rpl,rpl_gtid,rpl_nogtid,innodb,innodb_gis,innodb_fts,innodb_zip,innodb_undo,perfschema,funcs_1,opt_trace,parts,auth_sec,collations,"
+  ."audit_null,"
   ."audit_log,"
   ."tokudb.add_index,tokudb.alter_table,tokudb,tokudb.bugs,tokudb.parts,"
   ."tokudb.rpl,tokudb.perfschema,"


### PR DESCRIPTION
Now that CI has implemented testing second tier MTR suites - where
Percona patches are light or nonexistent - separately, remove them
from the default MTR suite list.

Tested locally