### PR TITLE
PS-5875: Innodb_redo_log_encrpt can't be set to NULL (5.7)

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_encrypt_tables_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_encrypt_tables_basic.result
@@ -20,6 +20,8 @@ SET GLOBAL innodb_encrypt_tables=1.1;
 ERROR 42000: Incorrect argument type to variable 'innodb_encrypt_tables'
 SET GLOBAL innodb_encrypt_tables=1e1;
 ERROR 42000: Incorrect argument type to variable 'innodb_encrypt_tables'
+SET GLOBAL innodb_encrypt_tables=NULL;
+ERROR 42000: Variable 'innodb_encrypt_tables' can't be set to the value of 'NULL'
 SET GLOBAL innodb_encrypt_tables='foo';
 ERROR 42000: Variable 'innodb_encrypt_tables' can't be set to the value of 'foo'
 SELECT @@GLOBAL.innodb_encrypt_tables;

--- a/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_redo_log_encrypt_basic.result
@@ -50,6 +50,8 @@ set session innodb_redo_log_encrypt='some';
 ERROR HY000: Variable 'innodb_redo_log_encrypt' is a GLOBAL variable and should be set with SET GLOBAL
 set @@session.innodb_redo_log_encrypt='some';
 ERROR HY000: Variable 'innodb_redo_log_encrypt' is a GLOBAL variable and should be set with SET GLOBAL
+set global innodb_redo_log_encrypt=NULL;
+ERROR 42000: Variable 'innodb_redo_log_encrypt' can't be set to the value of 'NULL'
 set global innodb_redo_log_encrypt=1.1;
 ERROR 42000: Incorrect argument type to variable 'innodb_redo_log_encrypt'
 set global innodb_redo_log_encrypt='foo';

--- a/mysql-test/suite/sys_vars/t/innodb_encrypt_tables_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_encrypt_tables_basic.test
@@ -19,6 +19,8 @@ SET GLOBAL innodb_encrypt_tables=1.1;
 --error ER_WRONG_TYPE_FOR_VAR
 SET GLOBAL innodb_encrypt_tables=1e1;
 --error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_encrypt_tables=NULL;
+--error ER_WRONG_VALUE_FOR_VAR
 SET GLOBAL innodb_encrypt_tables='foo';
 
 SELECT @@GLOBAL.innodb_encrypt_tables;

--- a/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_redo_log_encrypt_basic.test
@@ -46,6 +46,8 @@ set @@session.innodb_redo_log_encrypt='some';
 #
 # incorrect types
 #
+--error ER_WRONG_VALUE_FOR_VAR
+set global innodb_redo_log_encrypt=NULL;
 --error ER_WRONG_TYPE_FOR_VAR
 set global innodb_redo_log_encrypt=1.1;
 --error ER_WRONG_VALUE_FOR_VAR

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -24004,7 +24004,7 @@ innodb_encrypt_tables_validate(
 	bool legit_value= false;
 	uint use = 0;
 	for (;
-	    use < array_elements(srv_encrypt_tables_names);
+	    use < array_elements(srv_encrypt_tables_names) - 1;
 	    use++) {
 		if (!innobase_strcasecmp(
 		    innodb_encrypt_tables_input,
@@ -24045,7 +24045,7 @@ innodb_redo_log_encrypt_validate(
 
 	bool legit_value = false;
 	uint use = 0;
-	for (; use < array_elements(redo_log_encrypt_names); use++) {
+	for (; use < array_elements(redo_log_encrypt_names) - 1; use++) {
 		if (innobase_strcasecmp(redo_log_encrypt_input,
 					redo_log_encrypt_names[use]) == 0) {
 			legit_value = true;


### PR DESCRIPTION
Issue: the array of names ends with NULL, and validation function incorrectly
allowed it.

Same issue was also present for innodb_encrypt_tables validation, also fixed
by this commit.