### PR TITLE
5.7 PS-5642 - page tracker thread won't exist if startup fails

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_shutdown_thread.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_shutdown_thread.result
@@ -1,0 +1,6 @@
+SELECT 1;
+1
+1
+# Asserting that the error was not thrown.
+[log_grep.inc] file:  pattern: threads created by InnoDB had not exited at shutdown
+[log_grep.inc] lines:   0

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread-master.opt
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread-master.opt
@@ -1,0 +1,1 @@
+--innodb_track_changed_pages=TRUE

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread.test
@@ -1,0 +1,20 @@
+#
+# PS-5642 - page tracker thread won't exist if startup fails
+#
+
+--source include/have_debug.inc
+--source include/not_embedded.inc
+
+SELECT 1;
+--source include/shutdown_mysqld.inc
+--error 1
+--exec $MYSQLD_CMD --innodb_track_changed_pages=TRUE --debug=d,ib_dic_boot_error --log-error=$MYSQLTEST_VARDIR/tmp/percona_changed_page_bmp_shutdown_thread.err
+
+--echo # Asserting that the error was not thrown.
+--let log_file_full_path=$MYSQLTEST_VARDIR/tmp/percona_changed_page_bmp_shutdown_thread.err
+--let grep_pattern=threads created by InnoDB had not exited at shutdown
+--let log_expected_matches=0
+--source include/log_grep.inc
+
+--source include/start_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/percona_changed_page_bmp_shutdown_thread.err

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2506,7 +2506,8 @@ files_checked:
 		works for space 0. */
 
 		err = dict_boot();
-
+		DBUG_EXECUTE_IF("ib_dic_boot_error",
+				err = DB_ERROR;);
 		if (err != DB_SUCCESS) {
 			return(err);
 		}


### PR DESCRIPTION
If page tracker is enabled and innodb fail to start,
shutdown process won't signal page tracker thread to exit.

This fix ensure those threads will be proper signaled and exit.