### PR TITLE
Fix PS-5881 (innodb_empty_free_list_algorithm incorrect default)

### DIFF
--- a/mysql-test/r/persisted_variables.result
+++ b/mysql-test/r/persisted_variables.result
@@ -403,7 +403,7 @@ SELECT @@global.general_log, @@global.autocommit,
 SELECT @@global.innodb_buffer_pool_size;
 @@global.innodb_buffer_pool_size
 25165824
-SET PERSIST innodb_buffer_pool_size=10*1024*1024;
+SET PERSIST innodb_buffer_pool_size=20*1024*1024;
 Warnings:
 Warning	1210	InnoDB: Cannot resize buffer pool to lesser than chunk size of 25165824 bytes.
 SELECT @@global.innodb_buffer_pool_size;

--- a/mysql-test/suite/innodb/t/log_file_name_1-master.opt
+++ b/mysql-test/suite/innodb/t/log_file_name_1-master.opt
@@ -1,1 +1,2 @@
---initialize --innodb_data_file_path=ibdata1:15M;ibdata2:20M:autoextend
+--initialize --innodb_data_file_path=ibdata1:15M;ibdata2:20M:autoextend --innodb_empty_free_list_algorithm=legacy
+

--- a/mysql-test/suite/innodb/t/log_file_name_1.test
+++ b/mysql-test/suite/innodb/t/log_file_name_1.test
@@ -2,6 +2,8 @@
 
 SET GLOBAL innodb_limit_optimistic_insert_debug = 2;
 SET GLOBAL innodb_file_per_table = 0;
+# Apparently this testcase wants to do single-page flushing only. Accomodate
+# by setting innodb_empty_free_list_algorithm=legacy in the option file
 SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
 SET GLOBAL innodb_dict_stats_disabled_debug = 1;
 SET GLOBAL innodb_master_thread_disabled_debug = 1;

--- a/mysql-test/suite/sys_vars/r/innodb_empty_free_list_algorithm_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_empty_free_list_algorithm_basic.result
@@ -1,7 +1,7 @@
 SET @start_value = @@GLOBAL.innodb_empty_free_list_algorithm;
 SELECT @@GLOBAL.innodb_empty_free_list_algorithm;
 @@GLOBAL.innodb_empty_free_list_algorithm
-legacy
+backoff
 SELECT @@SESSION.innodb_empty_free_list_algorithm;
 ERROR HY000: Variable 'innodb_empty_free_list_algorithm' is a GLOBAL variable
 SET GLOBAL innodb_empty_free_list_algorithm='legacy';

--- a/mysql-test/t/persisted_variables.test
+++ b/mysql-test/t/persisted_variables.test
@@ -384,7 +384,9 @@ SELECT @@global.general_log, @@global.autocommit,
 
 SELECT @@global.innodb_buffer_pool_size;
 --remove_file $MYSQLD_DATADIR/mysqld-auto.cnf
-SET PERSIST innodb_buffer_pool_size=10*1024*1024;
+# In Percona Server, resize to 20MB instead of 10MB to stay compatible
+# with innodb_empty_free_list_algorithm=backoff
+SET PERSIST innodb_buffer_pool_size=20*1024*1024;
 SELECT @@global.innodb_buffer_pool_size;
 
 --echo # Restart server

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -22516,8 +22516,8 @@ static MYSQL_SYSVAR_ULONG(cleaner_max_flush_time, srv_cleaner_max_flush_time,
 static MYSQL_SYSVAR_ENUM(
     cleaner_lsn_age_factor, srv_cleaner_lsn_age_factor, PLUGIN_VAR_OPCMDARG,
     "The formula for LSN age factor for page cleaner adaptive flushing. "
-    "LEGACY: Original Oracle MySQL 5.6 formula. "
-    "HIGH_CHECKPOINT: (the default) Percona Server 5.6 formula.",
+    "LEGACY: Original Oracle MySQL formula. "
+    "HIGH_CHECKPOINT: (the default) Percona Server formula.",
     nullptr, nullptr, SRV_CLEANER_LSN_AGE_FACTOR_HIGH_CHECKPOINT,
     &innodb_cleaner_lsn_age_factor_typelib);
 
@@ -22525,16 +22525,10 @@ static MYSQL_SYSVAR_ENUM(
     empty_free_list_algorithm, srv_empty_free_list_algorithm,
     PLUGIN_VAR_OPCMDARG,
     "The algorithm to use for empty free list handling.  Allowed values: "
-    "LEGACY: (default) Original Oracle MySQL 5.6 handling with single page "
-    "flushes; "
-    "BACKOFF: Wait until cleaner produces a free page.",
-    innodb_srv_empty_free_list_algorithm_validate, NULL,
-    SRV_EMPTY_FREE_LIST_LEGACY,
-    // Default changed until separate LRU flusher is merged. With a single page
-    // cleaner otherwise it is possible to loop forever in a query
-    // thread while the cleaner is waiting for the page latch held by that
-    // thread. See sys_vars.log_slow_admin_statements_func in 5.7.5.
-    &innodb_empty_free_list_algorithm_typelib);
+    "LEGACY: Original Oracle MySQL handling with single page flushes; "
+    "BACKOFF: (the default) Wait until cleaner produces a free page.",
+    innodb_srv_empty_free_list_algorithm_validate, nullptr,
+    SRV_EMPTY_FREE_LIST_BACKOFF, &innodb_empty_free_list_algorithm_typelib);
 
 static MYSQL_SYSVAR_ULONG(buffer_pool_instances, srv_buf_pool_instances,
                           PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,


### PR DESCRIPTION
Change innodb_empty_free_list_algorithm default to backoff as it's
supposed to have been since the LRU manager threads had been ported to
8.0. Cleanup some option descriptions, adjust MTR: re-record affected
sys_vars.innodb_empty_free_list_algorithm_basic; switch
innodb.log_file_name_1 to legacy, tweak buffer pool resize in
main.persisted_variables to stay compatible with backoff.

https://ps80.cd.percona.com/job/percona-server-8.0-param/302/
& https://ps80.cd.percona.com/job/percona-server-8.0-param/305/