### PR TITLE
PS-5909 : Rotating Innodb Master key post upgrade crashes the server

### DIFF
--- a/mysql-test/r/percona_dd_upgrade_undo_encrypted.result
+++ b/mysql-test/r/percona_dd_upgrade_undo_encrypted.result
@@ -16,6 +16,7 @@ c1	c2
 200	bbbbb
 300	aaaaa
 400	bbbbb
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
 # Now let's test what happens when encryption key is missing and we try to start 8.0 server on 5.7 directory
 # with encrypted undo tablespaces
 # Recreate the directories

--- a/mysql-test/t/percona_dd_upgrade_undo_encrypted.test
+++ b/mysql-test/t/percona_dd_upgrade_undo_encrypted.test
@@ -72,6 +72,8 @@ SET GLOBAL innodb_fast_shutdown=0;
 SHOW CREATE TABLE test.tab1;
 SELECT * FROM tab1;
 
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
 --source include/shutdown_mysqld.inc
 
 --echo # Now let's test what happens when encryption key is missing and we try to start 8.0 server on 5.7 directory

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -19271,6 +19271,9 @@ ER_PARALLEL_DOUBLEWRITE_WRITE_ERROR
 ER_XB_MSG_6
   eng "Key rotation of encrypted session temporary tablespace %s failed"
 
+ER_XB_UNDO_DELETE_FAILURE
+  eng "Deletion of 5.7 undo tablespace %s failed"
+
 #
 # End of Percona Server 8.0 server error log messages
 #


### PR DESCRIPTION
Problem:
--------
After upgrade from 5.7 server which has encrypted undo tablespaces,
8.0 crashes on ALTER INSTANCE ROTATE INNODB MASTER KEY.

This is because upgrade recreates undo tablespaces. During this process,
old 5.7 undo tablespaces are deleted. The in-memory tablespace object
for them are not deleted. These objects I refer them as orphan or zombie tablespaces

ALTER INSTANCE finds this orphan tablespaces, tries to access page 0 and
cannot get it.

Note that this problem doesn't happen after restart (because after restart
the orphan in-memory objects for undo tablespaces don't exist anymore)

Fix:
----
During upgrade, remove the in-memory tablespace object (fil_space_t) along with physical file
removal of 5.7 undo tablespace.