### PR TITLE
PS-5925 PS-5926 : ut_dbg_assertion_failed (expr=0x55555b75a742 "strlen(srv_uu…

### DIFF
--- a/mysql-test/include/ibd_encryption_check.inc
+++ b/mysql-test/include/ibd_encryption_check.inc
@@ -1,0 +1,52 @@
+perl;
+use strict;
+use warnings;
+use Fcntl qw(SEEK_SET);
+
+my $ibd_file = $ENV{'IBD_FILE'};
+
+if (!$ibd_file) {
+  print "ENV variable IBD_FILE is not set. Use --let IBD_FILE=some_filename_here in test\n";
+  exit;
+}
+
+my $file_offset = 10390;
+
+open(FILE, "<", $ibd_file) or die "could not open $ibd_file: $!";
+binmode FILE;
+
+seek(FILE, $file_offset, SEEK_SET) or die "could not seek: $!";
+my $data;
+read FILE, $data, 3;
+my $error=0;
+if ($data ne "lCC") {
+   print "File:", $ibd_file, " Unexpected encryption magic: ", $data, " should be lCC\n";
+   $error=1;
+}
+
+
+$file_offset = 10390 + 3;
+seek(FILE, $file_offset, SEEK_SET) or die "could not seek: $!";
+read FILE, $data, 4;
+my $new_data = unpack "N", $data;
+if ($new_data eq "0") {
+   print "File:", $ibd_file, " Unexpected master key id: ", $new_data, " should be non-zero\n";
+   $error=1;
+}
+
+$file_offset = 10390 + 3 + 4;
+seek(FILE, $file_offset, SEEK_SET) or die "could not seek: $!";
+read FILE, $data, 36;
+$new_data = unpack("a*", $data);
+#print "UUID read: ", $new_data;
+
+if ($new_data !~ m/[a-zA-Z0-9]/ ) {
+   print "File:", $ibd_file, " Empty UUID: ", $data, " should be non-empty\n";
+   $error=1;
+}
+
+close FILE;
+if ($error == 1) {
+  die "File:", $ibd_file, " Encryption header is not proper\n";
+}
+EOF

--- a/mysql-test/suite/innodb/r/percona_encrypt_mysql_ibd.result
+++ b/mysql-test/suite/innodb/r/percona_encrypt_mysql_ibd.result
@@ -1,0 +1,8 @@
+# create bootstrap file
+# Bootstrap new instance with encrypted mysql.ibd
+# Check Encryption header of mysql.ibd
+# restart:<hidden args>
+include/assert.inc [Mysql.ibd should be encrypted]
+# Check Encryption header of mysql.ibd after shutdown
+# Start default MTR instance
+# restart

--- a/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
+++ b/mysql-test/suite/innodb/r/percona_sys_tablespace_encrypt.result
@@ -76,6 +76,7 @@ DROP TABLESPACE tb01;
 # start unencrypted system with --innodb-sys-tablespace-encrypt=ON
 Pattern found.
 # Bootstrap new instance with encrypted system tablespace
+# Check Encryption header of ibdata1
 # Start encrypted system with --innodb-sys-tablespace-encrypt=OFF
 Pattern found.
 # Start encrypted system without early-plugin-load and only --plugin-load

--- a/mysql-test/suite/innodb/t/percona_encrypt_mysql_ibd-master.opt
+++ b/mysql-test/suite/innodb/t/percona_encrypt_mysql_ibd-master.opt
@@ -1,0 +1,3 @@
+$KEYRING_PLUGIN_OPT
+$KEYRING_PLUGIN_EARLY_LOAD
+--keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring

--- a/mysql-test/suite/innodb/t/percona_encrypt_mysql_ibd.test
+++ b/mysql-test/suite/innodb/t/percona_encrypt_mysql_ibd.test
@@ -1,0 +1,45 @@
+let $MYSQLD_BASEDIR= `select @@basedir`;
+--mkdir $MYSQL_TMP_DIR/datadir1
+
+let $MYSQLD_DATADIR1 = $MYSQL_TMP_DIR/datadir1/data;
+--source include/shutdown_mysqld.inc
+
+--let BOOTSTRAP_SQL=$MYSQL_TMP_DIR/boot.sql
+--let KEYRING_DATA="--keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring"
+--let ERROR_LOG=$MYSQL_TMP_DIR/percona_encrypt_mysql_ibd_err.log
+
+--echo # create bootstrap file
+write_file $BOOTSTRAP_SQL;
+CREATE DATABASE test;
+EOF
+
+--let BOOTSTRAP_CMD = $MYSQLD_CMD --initialize-insecure --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1 --init-file=$BOOTSTRAP_SQL $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD $KEYRING_DATA > $ERROR_LOG --default_table_encryption=ON 2>&1
+
+--echo # Bootstrap new instance with encrypted mysql.ibd
+--exec $BOOTSTRAP_CMD
+
+--echo # Check Encryption header of mysql.ibd
+--let IBD_FILE=$MYSQLD_DATADIR1/mysql.ibd
+--source include/ibd_encryption_check.inc
+
+--let $restart_hide_args=1
+--let $restart_parameters="restart: --datadir=$MYSQLD_DATADIR1"
+--source include/start_mysqld.inc
+
+--let $assert_text = Mysql.ibd should be encrypted
+--let $assert_cond = "[SELECT ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME = \"mysql\"]" = "Y"
+--source include/assert.inc
+
+--echo # Check Encryption header of mysql.ibd after shutdown
+--source include/shutdown_mysqld.inc
+
+--let IBD_FILE=$MYSQLD_DATADIR1/mysql.ibd
+--source include/ibd_encryption_check.inc
+
+--echo # Start default MTR instance
+--let $restart_parameters=
+--source include/start_mysqld.inc
+
+--remove_file $BOOTSTRAP_SQL
+--force-rmdir $MYSQL_TMP_DIR/datadir1
+--remove_file $ERROR_LOG

--- a/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
+++ b/mysql-test/suite/innodb/t/percona_sys_tablespace_encrypt.test
@@ -139,6 +139,10 @@ EOF
 --echo # Bootstrap new instance with encrypted system tablespace
 --exec $BOOTSTRAP_CMD
 
+--echo # Check Encryption header of ibdata1
+--let IBD_FILE=$MYSQLD_DATADIR1/ibdata1
+--source include/ibd_encryption_check.inc
+
 --echo # Start encrypted system with --innodb-sys-tablespace-encrypt=OFF
 --error 1
 --exec $MYSQLD_CMD --datadir=$MYSQLD_DATADIR1 --innodb-sys-tablespace-encrypt=OFF $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD $KEYRING_DATA > $ERROR_LOG 2>&1

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4404,9 +4404,13 @@ bool innobase_fix_tablespaces_empty_uuid() {
   }
 
   /* We only need to handle the case when an encrypted tablespace
-  is created at startup. If it is 0, there is no encrypted tablespace,
-  If it is > 1, it means we already have fixed the UUID */
-  if (Encryption::s_master_key_id != 1) {
+  is created at startup. If it is > 1, it means we already have fixed
+  the UUID */
+  if (Encryption::s_master_key_id > 1) {
+    return (false);
+  }
+
+  if (!default_master_key_used) {
     return (false);
   }
 
@@ -4441,6 +4445,7 @@ bool innobase_fix_tablespaces_empty_uuid() {
 
   space_ids.push_back(srv_sys_space.space_id());
   space_ids.push_back(srv_tmp_space.space_id());
+  space_ids.push_back(dict_sys_t::s_space_id);
 
 #ifdef UNIV_DEBUG
   /* Currently all session temp tablespaces that use empty uuid

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -75,6 +75,11 @@ extern ulint os_n_pending_writes;
 /* Flush after each os_fsync_threshold bytes */
 extern unsigned long long os_fsync_threshold;
 
+/** Set to true when default master key is used. This variable
+main purpose is to avoid extra Encryption::get_master_key() when there
+are no encrypted tablespaces */
+extern bool default_master_key_used;
+
 /** File offset in bytes */
 typedef ib_uint64_t os_offset_t;
 

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -141,6 +141,11 @@ static const size_t MAX_BLOCKS = 128;
 /** Disk sector size of aligning write buffer for DIRECT_IO */
 static ulint os_io_ptr_align = UNIV_SECTOR_SIZE;
 
+/** Set to true when default master key is used. This variable
+main purpose is to avoid extra Encryption::get_master_key() when there
+are no encrypted tablespaces */
+bool default_master_key_used = false;
+
 /** Determine if O_DIRECT is supported
 @retval	true	if O_DIRECT is supported.
 @retval	false	if O_DIRECT is not supported. */
@@ -8813,6 +8818,7 @@ bool Encryption::fill_encryption_info(byte *key, byte *iv, byte *encrypt_info,
     ut_ad(ENCRYPTION_KEY_LEN >= sizeof(ENCRYPTION_DEFAULT_MASTER_KEY));
 
     strcpy(reinterpret_cast<char *>(master_key), ENCRYPTION_DEFAULT_MASTER_KEY);
+    default_master_key_used = true;
   } else {
     get_master_key(&master_key_id, &master_key);
 

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2492,7 +2492,7 @@ files_checked:
 
     mtr_start(&mtr);
 
-    bool ret = fsp_header_init(0, sum_of_new_sizes, &mtr, false);
+    bool ret = fsp_header_init(0, sum_of_new_sizes, &mtr, true);
 
     mtr_commit(&mtr);
 


### PR DESCRIPTION
…id) != 0")

PS-5926 : default_table_encryption=ON at bootstrap doesn't encrypt mysql.ibd

PS-5925 happens in very corner case as described below:

Problem:
--------

I could reproduce only with Robert's zip file (data_8015_dd_encrypted.zip) for PS-5874

The magic in his datadir is that there is crash recovery involved and there redo is only on "mysql.ibd"

So the steps are
1. Only mysql.ibd should be encrypted at initialize
2. Do some change only on mysql.ibd (how? insert into some non core tables in mysql tablespace)
3. Ensure that there will recovery only on mysql.ibd (disable page cleaners, log chekpointers etc)
4. Let the recovery proceed
5. Restart server
6. Boom! You will get strlen(srv_uuid) != 0 assert

There is rotation of tablespaces that is done during startup, just after recovery

And during recovery only mysql.ibd is opened which has master key_id and zero uuid
Rotation happens before uuid is intialized, it writes uses master key_id as 1 with zero uuid (the core issue)
After this all tablespaces are booted (from sys_config, the highest found master key id is 2)
Fix empty tablespaces uuid doesn't do anything as master key id is 2.

Fix:
----
Fix UUID of mysql.ibd in innobase_fix_tablespaces_uuid()

PS-5926 : default_table_encryption=ON at bootstrap doesn't encrypt mysql.ibd

Problem:
--------
This varaible is duplicated in InnoDB by srv_default_table_encryption.
srv_default_table_encryption is set using fix_default_table_encryption() handlerton API
This handlerton API is called only after InnoDB is initialized.

mysql.ibd encryption happens as part of InnoDB initialization and the srv_default_table_encryption doesn't
have the correct value.

Fix:
----
Use the server global structure value to decide if mysql.ibd should be encrypted or not at bootstrap