### PR TITLE
PS-5783: New thread variables: innodb_(force_index_)records_in_range (5.7)

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_force_index_records_in_range_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_force_index_records_in_range_basic.result
@@ -1,0 +1,67 @@
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+0
+0 Expected
+SET @@GLOBAL.innodb_force_index_records_in_range=100;
+1 Expected
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+100
+100 Expected
+SET @@GLOBAL.innodb_force_index_records_in_range=DEFAULT;
+1 Expected
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+0
+0 Expected
+SELECT @@GLOBAL.innodb_force_index_records_in_range = VARIABLE_VALUE
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+@@GLOBAL.innodb_force_index_records_in_range = VARIABLE_VALUE
+1
+1 Expected
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+0
+0 Expected
+SELECT VARIABLE_VALUE
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+VARIABLE_VALUE
+0
+0 Expected
+SELECT @@innodb_force_index_records_in_range = VARIABLE_VALUE
+FROM performance_schema.session_variables
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+@@innodb_force_index_records_in_range = VARIABLE_VALUE
+1
+1 Expected
+SELECT VARIABLE_VALUE
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+VARIABLE_VALUE
+0
+0 Expected
+SELECT @@innodb_force_index_records_in_range = @@GLOBAL.innodb_force_index_records_in_range;
+@@innodb_force_index_records_in_range = @@GLOBAL.innodb_force_index_records_in_range
+1
+1 Expected
+SELECT @@innodb_force_index_records_in_range;
+@@innodb_force_index_records_in_range
+0
+0 Expected
+SELECT @@local.innodb_force_index_records_in_range;
+@@local.innodb_force_index_records_in_range
+0
+0 Expected
+SELECT @@SESSION.innodb_force_index_records_in_range;
+@@SESSION.innodb_force_index_records_in_range
+0
+0 Expected
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+@@GLOBAL.innodb_force_index_records_in_range
+0
+0 Expected
+SELECT innodb_force_index_records_in_range;
+ERROR 42S22: Unknown column 'innodb_force_index_records_in_range' in 'field list'
+Expected error 'Unknow column in field list'

--- a/mysql-test/suite/sys_vars/r/innodb_records_in_range_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_records_in_range_basic.result
@@ -1,0 +1,67 @@
+SELECT @@GLOBAL.innodb_records_in_range;
+@@GLOBAL.innodb_records_in_range
+0
+0 Expected
+SET @@GLOBAL.innodb_records_in_range=100;
+1 Expected
+SELECT @@GLOBAL.innodb_records_in_range;
+@@GLOBAL.innodb_records_in_range
+100
+100 Expected
+SET @@GLOBAL.innodb_records_in_range=DEFAULT;
+1 Expected
+SELECT @@GLOBAL.innodb_records_in_range;
+@@GLOBAL.innodb_records_in_range
+0
+0 Expected
+SELECT @@GLOBAL.innodb_records_in_range = VARIABLE_VALUE
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='innodb_records_in_range';
+@@GLOBAL.innodb_records_in_range = VARIABLE_VALUE
+1
+1 Expected
+SELECT @@GLOBAL.innodb_records_in_range;
+@@GLOBAL.innodb_records_in_range
+0
+0 Expected
+SELECT VARIABLE_VALUE
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='innodb_records_in_range';
+VARIABLE_VALUE
+0
+0 Expected
+SELECT @@innodb_records_in_range = VARIABLE_VALUE
+FROM performance_schema.session_variables
+WHERE VARIABLE_NAME='innodb_records_in_range';
+@@innodb_records_in_range = VARIABLE_VALUE
+1
+1 Expected
+SELECT VARIABLE_VALUE
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='innodb_records_in_range';
+VARIABLE_VALUE
+0
+0 Expected
+SELECT @@innodb_records_in_range = @@GLOBAL.innodb_records_in_range;
+@@innodb_records_in_range = @@GLOBAL.innodb_records_in_range
+1
+1 Expected
+SELECT @@innodb_records_in_range;
+@@innodb_records_in_range
+0
+0 Expected
+SELECT @@local.innodb_records_in_range;
+@@local.innodb_records_in_range
+0
+0 Expected
+SELECT @@SESSION.innodb_records_in_range;
+@@SESSION.innodb_records_in_range
+0
+0 Expected
+SELECT @@GLOBAL.innodb_records_in_range;
+@@GLOBAL.innodb_records_in_range
+0
+0 Expected
+SELECT innodb_records_in_range;
+ERROR 42S22: Unknown column 'innodb_records_in_range' in 'field list'
+Expected error 'Unknow column in field list'

--- a/mysql-test/suite/sys_vars/t/innodb_force_index_records_in_range_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_force_index_records_in_range_basic.test
@@ -1,0 +1,63 @@
+--source include/have_innodb.inc
+
+# Display default value
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+--echo 0 Expected
+
+# Check if value can be set
+SET @@GLOBAL.innodb_force_index_records_in_range=100;
+--echo 1 Expected
+
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+--echo 100 Expected
+
+SET @@GLOBAL.innodb_force_index_records_in_range=DEFAULT;
+--echo 1 Expected
+
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+--echo 0 Expected
+
+# Check if the value in GLOBAL TABLE matches value in variable
+SELECT @@GLOBAL.innodb_force_index_records_in_range = VARIABLE_VALUE
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+--echo 1 Expected
+
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+--echo 0 Expected
+
+SELECT VARIABLE_VALUE
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+--echo 0 Expected
+
+SELECT @@innodb_force_index_records_in_range = VARIABLE_VALUE
+FROM performance_schema.session_variables
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+--echo 1 Expected
+
+SELECT VARIABLE_VALUE
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='innodb_force_index_records_in_range';
+--echo 0 Expected
+
+# Check if accessing variable with and without GLOBAL point to same variable
+SELECT @@innodb_force_index_records_in_range = @@GLOBAL.innodb_force_index_records_in_range;
+--echo 1 Expected
+
+# Check if innodb_force_index_records_in_range can be accessed with and without @@ sign
+SELECT @@innodb_force_index_records_in_range;
+--echo 0 Expected
+
+SELECT @@local.innodb_force_index_records_in_range;
+--echo 0 Expected
+
+SELECT @@SESSION.innodb_force_index_records_in_range;
+--echo 0 Expected
+
+SELECT @@GLOBAL.innodb_force_index_records_in_range;
+--echo 0 Expected
+
+--Error ER_BAD_FIELD_ERROR
+SELECT innodb_force_index_records_in_range;
+--echo Expected error 'Unknow column in field list'

--- a/mysql-test/suite/sys_vars/t/innodb_records_in_range_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_records_in_range_basic.test
@@ -1,0 +1,63 @@
+--source include/have_innodb.inc
+
+# Display default value
+SELECT @@GLOBAL.innodb_records_in_range;
+--echo 0 Expected
+
+# Check if value can be set
+SET @@GLOBAL.innodb_records_in_range=100;
+--echo 1 Expected
+
+SELECT @@GLOBAL.innodb_records_in_range;
+--echo 100 Expected
+
+SET @@GLOBAL.innodb_records_in_range=DEFAULT;
+--echo 1 Expected
+
+SELECT @@GLOBAL.innodb_records_in_range;
+--echo 0 Expected
+
+# Check if the value in GLOBAL TABLE matches value in variable
+SELECT @@GLOBAL.innodb_records_in_range = VARIABLE_VALUE
+FROM performance_schema.global_variables
+WHERE VARIABLE_NAME='innodb_records_in_range';
+--echo 1 Expected
+
+SELECT @@GLOBAL.innodb_records_in_range;
+--echo 0 Expected
+
+SELECT VARIABLE_VALUE
+FROM performance_schema.global_variables 
+WHERE VARIABLE_NAME='innodb_records_in_range';
+--echo 0 Expected
+
+SELECT @@innodb_records_in_range = VARIABLE_VALUE
+FROM performance_schema.session_variables
+WHERE VARIABLE_NAME='innodb_records_in_range';
+--echo 1 Expected
+
+SELECT VARIABLE_VALUE
+FROM performance_schema.session_variables 
+WHERE VARIABLE_NAME='innodb_records_in_range';
+--echo 0 Expected
+
+# Check if accessing variable with and without GLOBAL point to same variable
+SELECT @@innodb_records_in_range = @@GLOBAL.innodb_records_in_range;
+--echo 1 Expected
+
+# Check if innodb_records_in_range can be accessed with and without @@ sign
+SELECT @@innodb_records_in_range;
+--echo 0 Expected
+
+SELECT @@local.innodb_records_in_range;
+--echo 0 Expected
+
+SELECT @@SESSION.innodb_records_in_range;
+--echo 0 Expected
+
+SELECT @@GLOBAL.innodb_records_in_range;
+--echo 0 Expected
+
+--Error ER_BAD_FIELD_ERROR
+SELECT innodb_records_in_range;
+--echo Expected error 'Unknow column in field list'

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -636,6 +636,26 @@ uint get_global_default_encryption_key_id_value()
 	return THDVAR(NULL, default_encryption_key_id);
 }
 
+static MYSQL_THDVAR_UINT(records_in_range, PLUGIN_VAR_RQCMDARG,
+                         "Used to override the result of records_in_range(). "
+                         "Set to a positive number to override",
+                         NULL, NULL, 0,
+                         /* min */ 0, /* max */ INT_MAX, 0);
+
+static MYSQL_THDVAR_UINT(force_index_records_in_range, PLUGIN_VAR_RQCMDARG,
+                         "Used to override the result of records_in_range() "
+                         "when FORCE INDEX is used.",
+                         NULL, NULL, 0,
+                         /* min */ 0, /* max */ INT_MAX, 0);
+
+uint innodb_force_index_records_in_range(THD* thd) {
+	return THDVAR(thd, force_index_records_in_range);
+}
+
+uint innodb_records_in_range(THD* thd) {
+	return THDVAR(thd, records_in_range);
+}
+
 /** Set up InnoDB API callback function array */
 ib_cb_t innodb_api_cb[] = {
 	(ib_cb_t) ib_cursor_open_table,
@@ -22931,6 +22951,8 @@ static struct st_mysql_sys_var* innobase_system_variables[]= {
   MYSQL_SYSVAR(background_scrub_data_compressed),
   MYSQL_SYSVAR(background_scrub_data_interval),
   MYSQL_SYSVAR(background_scrub_data_check_interval),
+  MYSQL_SYSVAR(records_in_range),
+  MYSQL_SYSVAR(force_index_records_in_range),
   NULL
 };
 

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -1197,3 +1197,6 @@ innobase_create_zip_dict_references(
 /** Free InnoDB session specific data.
 @param[in,out]	thd	MySQL thread handler. */
 void thd_free_innodb_session(THD* thd);
+
+uint innodb_force_index_records_in_range(THD* thd);
+uint innodb_records_in_range(THD* thd);

--- a/storage/innobase/handler/ha_innopart.cc
+++ b/storage/innobase/handler/ha_innopart.cc
@@ -3302,6 +3302,17 @@ ha_innopart::records_in_range(
 	DBUG_ENTER("ha_innopart::records_in_range");
 	DBUG_PRINT("info", ("keynr %u min %p max %p", keynr, min_key, max_key));
 
+	ha_rows ret = innodb_records_in_range(ha_thd());
+	if (ret) {
+		DBUG_RETURN(ret);
+	}
+	if (table->force_index) {
+		const ha_rows force_rows = innodb_force_index_records_in_range(ha_thd());
+		if (force_rows) {
+			DBUG_RETURN(force_rows);
+		}
+	}
+
 	ut_a(m_prebuilt->trx == thd_to_trx(ha_thd()));
 
 	m_prebuilt->trx->op_info = (char*)"estimating records in index range";


### PR DESCRIPTION
These variables make it possible to override reconds_in_range, effectively
skipping its computation. This could be useful in some cases where reconds_in_range
takes up most of the query cost.