### PR TITLE
PS-5327 proxy protocol-related memory leak at shutdown

### DIFF
--- a/include/violite.h
+++ b/include/violite.h
@@ -89,6 +89,7 @@ Vio* vio_new_win32shared_memory(HANDLE handle_file_map,
 #endif /* __WIN__ */
 
 void vio_proxy_protocol_add(const struct st_vio_network *net);
+void vio_proxy_cleanup();
 void    vio_delete(Vio* vio);
 int vio_shutdown(Vio* vio, int how);
 int vio_cancel(Vio* vio, int how);

--- a/mysql-test/r/proxy_protocol.result
+++ b/mysql-test/r/proxy_protocol.result
@@ -3,3 +3,4 @@ SELECT @@proxy_protocol_networks;
 *
 # An unproxied client connection should be rejected if proxying enabled on the server
 Got one of the listed errors
+# PS-5327 proxy protocol-related memory leak at shutdown

--- a/mysql-test/t/proxy_protocol.test
+++ b/mysql-test/t/proxy_protocol.test
@@ -1,3 +1,4 @@
+--source include/not_embedded.inc
 SELECT @@proxy_protocol_networks;
 
 --echo # An unproxied client connection should be rejected if proxying enabled on the server
@@ -5,3 +6,7 @@ SELECT @@proxy_protocol_networks;
 --error ER_BAD_HOST_ERROR,2013
 connect (err,"127.0.0.1",root,,,$MASTER_MYPORT,);
 --enable_query_log
+
+--echo # PS-5327 proxy protocol-related memory leak at shutdown
+# Restart the server
+--source include/restart_mysqld.inc

--- a/vio/vio.c
+++ b/vio/vio.c
@@ -402,4 +402,5 @@ void vio_end(void)
   EVP_cleanup();
   CRYPTO_cleanup_all_ex_data();
 #endif
+  vio_proxy_cleanup();
 }

--- a/vio/viosocket.c
+++ b/vio/viosocket.c
@@ -687,6 +687,11 @@ void vio_proxy_protocol_add(const struct st_vio_network *net)
   memcpy(&vio_pp_networks[vio_pp_networks_nb - 1], net, sizeof(*net));
 }
 
+void vio_proxy_cleanup()
+{
+  my_free(vio_pp_networks);
+}
+
 /* Check whether a connection from this source address must provide the proxy
 protocol header */
 static my_bool vio_client_must_be_proxied(const struct sockaddr *addr)


### PR DESCRIPTION
The Problem:
When proxy protocol is enabled, MySQL won't cleanup
vio_pp_networks variable at shutdown.

Solution:
Cleanup allocated networks at shutdown.
Enhanced proxy_protocol test to cover this scenario.