### PR TITLE
PS-5.6-5941

### DIFF
--- a/doc/source/installation/apt_repo.rst
+++ b/doc/source/installation/apt_repo.rst
@@ -10,16 +10,12 @@ Supported Releases:
 
 * Debian:
 
- * 7.0 (wheezy)
  * 8.0 (jessie)
  * 9.0 (stretch)
 
 * Ubuntu:
 
- * 14.04LTS (trusty)
  * 16.04LTS (xenial) 
- * 17.04 (zesty)
- * 17.10 (artful)
  * 18.04 (bionic)
 
 Supported Platforms:


### PR DESCRIPTION
Updated apt_repo.rst - removed wheezy, trusty, zesty, and artful