### PR TITLE
PS-5629: Fixed handling of persisted bool variables set as integer with persist_only option.

### DIFF
--- a/mysql-test/r/percona_persisted_bool_variable_as_int.result
+++ b/mysql-test/r/percona_persisted_bool_variable_as_int.result
@@ -1,0 +1,58 @@
+SET PERSIST_ONLY super_read_only = OFF;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SET PERSIST_ONLY super_read_only = ON;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+SET PERSIST_ONLY super_read_only = 0;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SET PERSIST_ONLY super_read_only = 1;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+# Restart server with defaults
+# restart

--- a/mysql-test/t/percona_persisted_bool_variable_as_int.test
+++ b/mysql-test/t/percona_persisted_bool_variable_as_int.test
@@ -1,0 +1,35 @@
+--let $MYSQL_DATA_DIR=`select @@datadir`
+
+SET PERSIST_ONLY super_read_only = OFF;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+SET PERSIST_ONLY super_read_only = ON;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+SET PERSIST_ONLY super_read_only = 0;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+SET PERSIST_ONLY super_read_only = 1;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+# Cleanup
+--remove_file $MYSQL_DATA_DIR/mysqld-auto.cnf
+--echo # Restart server with defaults
+--source include/restart_mysqld.inc
+


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5629

Fixed handling of integer passed as persisted variable value with persist_only option. Such value was handled as string literal for bool and rejected because only allowed string literals are ON/OFF.