### PR TITLE
PS-5629: Fixed handling of persisted bool variables set as integer with persist_only option.

### DIFF
--- a/mysql-test/r/percona_persisted_bool_variable_as_int.result
+++ b/mysql-test/r/percona_persisted_bool_variable_as_int.result
@@ -1,0 +1,58 @@
+SET PERSIST_ONLY super_read_only = OFF;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SET PERSIST_ONLY super_read_only = ON;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+SET PERSIST_ONLY super_read_only = 0;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SET PERSIST_ONLY super_read_only = 1;
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+# restart
+SHOW VARIABLES LIKE 'super_read_only';
+Variable_name	Value
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+# Restart server with defaults
+# restart

--- a/mysql-test/r/persisted_variables_bugs.result
+++ b/mysql-test/r/persisted_variables_bugs.result
@@ -412,7 +412,7 @@ SELECT @@global.skip_name_resolve;
 0
 SELECT * FROM performance_schema.persisted_variables;
 VARIABLE_NAME	VARIABLE_VALUE
-skip_name_resolve	0
+skip_name_resolve	OFF
 RESET PERSIST;
 DROP USER 'bug28749668'@'%';
 # End of the 8.0 tests

--- a/mysql-test/r/read_only_persisted_plugin_variables.result
+++ b/mysql-test/r/read_only_persisted_plugin_variables.result
@@ -126,22 +126,22 @@ VARIABLE_NAME	VARIABLE_VALUE
 innodb_log_buffer_size	16777216
 slave_type_conversions	
 back_log	80
-binlog_gtid_simple_recovery	1
+binlog_gtid_simple_recovery	ON
 binlog_space_limit	134217728
 disabled_storage_engines	
-encrypt_tmp_files	1
+encrypt_tmp_files	ON
 enforce_storage_engine	MyISAM
 ft_max_word_len	84
 ft_min_word_len	4
 ft_query_expansion_limit	20
 innodb_adaptive_hash_index_parts	8
-innodb_api_disable_rowlock	0
-innodb_api_enable_binlog	0
-innodb_api_enable_mdl	0
+innodb_api_disable_rowlock	OFF
+innodb_api_enable_binlog	OFF
+innodb_api_enable_mdl	OFF
 innodb_autoinc_lock_mode	1
 innodb_buffer_pool_chunk_size	134217728
 innodb_buffer_pool_instances	1
-innodb_doublewrite	1
+innodb_doublewrite	ON
 innodb_force_recovery	0
 innodb_ft_cache_size	16777216
 innodb_ft_max_token_size	84
@@ -154,18 +154,18 @@ innodb_open_files	1
 innodb_page_cleaners	1
 innodb_purge_threads	4
 innodb_read_io_threads	4
-innodb_rollback_on_timeout	0
+innodb_rollback_on_timeout	OFF
 innodb_sort_buffer_size	1048576
 innodb_sync_array_size	1
-innodb_use_native_aio	1
+innodb_use_native_aio	ON
 innodb_write_io_threads	4
-log_slave_updates	0
+log_slave_updates	OFF
 max_digest_length	1024
 myisam_recover_options	OFF
 ngram_token_size	2
-old	0
+old	OFF
 open_files_limit	5000
-performance_schema	1
+performance_schema	ON
 performance_schema_accounts_size	-1
 performance_schema_digests_size	10000
 performance_schema_error_size	1986
@@ -209,14 +209,14 @@ performance_schema_setup_actors_size	-1
 performance_schema_setup_objects_size	-1
 performance_schema_users_size	-1
 proxy_protocol_networks	*
-relay_log_recovery	0
+relay_log_recovery	OFF
 relay_log_space_limit	0
 report_host	
 report_password	
 report_port	21000
 report_user	
-skip_name_resolve	0
-skip_show_database	0
+skip_name_resolve	OFF
+skip_show_database	OFF
 table_open_cache_instances	16
 thread_handling	one-thread-per-connection
 thread_stack	286720

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -135,7 +135,7 @@ include/assert.inc ['Expect 74 persisted variables in persisted_variables table.
 
 include/assert.inc ['Expect 74 persisted variables in persisted_variables table.']
 include/assert.inc ['Expect 74 persisted variables shown as PERSISTED in variables_info table.']
-include/assert.inc ['Expect 73 persisted variables with matching persisted and global values.']
+include/assert.inc ['Expect 74 persisted variables with matching persisted and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST. Verify persisted variable settings

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -110,10 +110,6 @@ while ( $varid <= $countvars )
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info WHERE variable_source="PERSISTED", count, 1] = $expected
 --source include/assert.inc
 
-# WL#10957 added binlog_encryption and as it is persisted as read only and
-# appended to command line parameter, its value is not converted from 0 to OFF.
-# The values at persisted_variables and global_variables tables differ: 0 != OFF.
---dec $expected
 --let $assert_text= 'Expect $expected persisted variables with matching persisted and global values.'
 --let $assert_cond= [SELECT COUNT(*) as count FROM performance_schema.variables_info vi JOIN performance_schema.persisted_variables pv JOIN performance_schema.global_variables gv ON vi.variable_name=pv.variable_name AND vi.variable_name=gv.variable_name AND pv.variable_value=gv.variable_value WHERE vi.variable_source="PERSISTED", count, 1] = $expected
 --source include/assert.inc

--- a/mysql-test/t/percona_persisted_bool_variable_as_int.test
+++ b/mysql-test/t/percona_persisted_bool_variable_as_int.test
@@ -1,0 +1,35 @@
+--let $MYSQL_DATA_DIR=`select @@datadir`
+
+SET PERSIST_ONLY super_read_only = OFF;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+SET PERSIST_ONLY super_read_only = ON;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+SET PERSIST_ONLY super_read_only = 0;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+SET PERSIST_ONLY super_read_only = 1;
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+--source include/restart_mysqld.inc
+SHOW VARIABLES LIKE 'super_read_only';
+SELECT @@global.super_read_only;
+
+# Cleanup
+--remove_file $MYSQL_DATA_DIR/mysqld-auto.cnf
+--echo # Restart server with defaults
+--source include/restart_mysqld.inc
+

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9475,7 +9475,8 @@ bool mysqld_get_one_option(int optid,
       opt_specialflag |= SPECIAL_NO_HOST_CACHE;
       break;
     case (int)OPT_SKIP_RESOLVE:
-      if (argument && argument[0] == '0')
+      if (argument && (argument[0] == '0' ||
+          native_strcasecmp(argument, "OFF") == 0))
         opt_skip_name_resolve = 0;
       else {
         opt_skip_name_resolve = 1;

--- a/sql/persisted_variable.cc
+++ b/sql/persisted_variable.cc
@@ -99,6 +99,8 @@ const string colon(" : ");
 const string comma(" , ");
 const string open_brace("{ ");
 const string close_brace(" }");
+const string on("ON");
+const string off("OFF");
 
 const int file_version = 1;
 
@@ -312,6 +314,18 @@ void Persisted_variables_cache::set_variable(THD *thd, set_var *setvar) {
       setvar->var->saved_value_to_string(thd, setvar, (char *)str.ptr());
       utf8_str.copy(str.ptr(), str.length(), str.charset(), tocs, &dummy_err);
       var_value = utf8_str.c_ptr_quick();
+    }
+
+    /* Fix bool variable. If was provided as integer, convert to ON/OFF literal. */
+    if(system_var->show_type() == SHOW_MY_BOOL || system_var->show_type() == SHOW_BOOL) {
+      int error;
+      const char *end = utf8_str.ptr() + utf8_str.length();
+      longlong value = tocs->cset->strtoll10(tocs, utf8_str.ptr(), &end, &error);
+      if(!error) {
+        const string &literal = value ? on : off;
+        utf8_str.copy(literal.c_str(), literal.length(), system_charset_info, tocs, &dummy_err);
+        var_value = utf8_str.c_ptr_quick();
+      }
     }
   } else {
     Persisted_variables_cache::get_variable_value(thd, system_var, &utf8_str,


### PR DESCRIPTION
This PR is optional to https://github.com/percona/percona-server/pull/3420.
It fixes handling of all bool values (also readonly). 
As the consequence some existing MTR tests had to be adjusted.