### PR TITLE
PS-5629:Fixed handling of persisted bool and enum variables set as integer with persist_only option.

### DIFF
--- a/mysql-test/r/percona_persist_only_bool_enum.result
+++ b/mysql-test/r/percona_persist_only_bool_enum.result
@@ -1,0 +1,161 @@
+#
+# Changing values
+#
+SET PERSIST_ONLY super_read_only = OFF;
+SET PERSIST_ONLY binlog_row_image = FULL;
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+FULL
+# restart
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+FULL
+#
+# Changing values
+#
+SET PERSIST_ONLY super_read_only = ON;
+SET PERSIST_ONLY binlog_row_image = NOBLOB;
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+FULL
+# restart
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+NOBLOB
+#
+# Changing values
+#
+SET PERSIST_ONLY super_read_only = off;
+SET PERSIST_ONLY binlog_row_image = minimal;
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	NOBLOB
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+NOBLOB
+# restart
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+MINIMAL
+#
+# Changing values
+#
+SET PERSIST_ONLY super_read_only = on;
+SET PERSIST_ONLY binlog_row_image = full;
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+MINIMAL
+# restart
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+FULL
+#
+# Changing values
+#
+SET PERSIST_ONLY super_read_only = 0;
+SET PERSIST_ONLY binlog_row_image = 0;
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+FULL
+# restart
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+MINIMAL
+#
+# Changing values
+#
+SET PERSIST_ONLY super_read_only = 1;
+SET PERSIST_ONLY binlog_row_image = 2;
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	MINIMAL
+super_read_only	OFF
+SELECT @@global.super_read_only;
+@@global.super_read_only
+0
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+MINIMAL
+# restart
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+Variable_name	Value
+binlog_row_image	FULL
+super_read_only	ON
+SELECT @@global.super_read_only;
+@@global.super_read_only
+1
+SELECT @@global.binlog_row_image;
+@@global.binlog_row_image
+FULL
+#
+# Cleanup
+#
+# Restart server with defaults
+# restart

--- a/mysql-test/t/percona_persist_only_bool_enum.test
+++ b/mysql-test/t/percona_persist_only_bool_enum.test
@@ -1,0 +1,103 @@
+--let $MYSQL_DATA_DIR=`select @@datadir`
+
+# Test dynamic bool variable super_read_only
+# Test readonly enum variable binlog_row_image
+
+--echo #
+--echo # Changing values
+--echo #
+SET PERSIST_ONLY super_read_only = OFF;
+SET PERSIST_ONLY binlog_row_image = FULL;
+
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+--source include/restart_mysqld.inc
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+
+################################################################################################
+--echo #
+--echo # Changing values
+--echo #
+SET PERSIST_ONLY super_read_only = ON;
+SET PERSIST_ONLY binlog_row_image = NOBLOB;
+
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+--source include/restart_mysqld.inc
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+
+################################################################################################
+--echo #
+--echo # Changing values
+--echo #
+SET PERSIST_ONLY super_read_only = off;
+SET PERSIST_ONLY binlog_row_image = minimal;
+
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+--source include/restart_mysqld.inc
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+
+################################################################################################
+--echo #
+--echo # Changing values
+--echo #
+SET PERSIST_ONLY super_read_only = on;
+SET PERSIST_ONLY binlog_row_image = full;
+
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+--source include/restart_mysqld.inc
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+
+################################################################################################
+--echo #
+--echo # Changing values
+--echo #
+SET PERSIST_ONLY super_read_only = 0;
+SET PERSIST_ONLY binlog_row_image = 0;
+
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+--source include/restart_mysqld.inc
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+
+################################################################################################
+--echo #
+--echo # Changing values
+--echo #
+SET PERSIST_ONLY super_read_only = 1;
+SET PERSIST_ONLY binlog_row_image = 2;
+
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+--source include/restart_mysqld.inc
+SHOW VARIABLES WHERE Variable_name LIKE 'super_read_only' OR Variable_name LIKE 'binlog_row_image';
+SELECT @@global.super_read_only;
+SELECT @@global.binlog_row_image;
+
+################################################################################################
+# Cleanup
+--echo #
+--echo # Cleanup
+--echo #
+--remove_file $MYSQL_DATA_DIR/mysqld-auto.cnf
+--echo # Restart server with defaults
+--source include/restart_mysqld.inc
+

--- a/sql/persisted_variable.h
+++ b/sql/persisted_variable.h
@@ -40,6 +40,7 @@ class Json_dom;
 class THD;
 class set_var;
 class sys_var;
+class Item;
 struct MYSQL_FILE;
 
 /**
@@ -156,6 +157,8 @@ class Persisted_variables_cache {
   /* Helper function to extract variables from json formatted string */
   bool extract_variables_from_json(const Json_dom *dom,
                                    bool is_read_only = false);
+  /* Helper function to create value item depending on provided content */
+  Item *create_item(THD *thd, const std::string &str);
 
  private:
   /* Helper functions for file IO */


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5629

If the user sets bool/enum value providing alias iteger value, it is stored in mysqld-auto.cnf file. Then when value is read on server start, it was considered to be string literal and validated against allowed bool/enum string literals which caused value rejection and server not to start.