### PR TITLE
PS-5546

### DIFF
--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_with_dictionaries.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_with_dictionaries.test
@@ -75,6 +75,9 @@ SET @longer_dictionary_data = CONCAT(@long_dictionary_data, 'a');
 --error ER_COMPRESSION_DICTIONARY_DATA_TOO_LONG
 CREATE COMPRESSION_DICTIONARY d14(@longer_dictionary_data);
 
+--error ER_COMPRESSION_DICTIONARY_DATA_ZERO_LEN
+CREATE COMPRESSION_DICTIONARY d15('');
+
 # we use MD5() function here to get rid of NUL characters in the output
 SELECT id, name, MD5(zip_dict), LENGTH(zip_dict)
   FROM information_schema.xtradb_zip_dict

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -712,6 +712,7 @@ enum handler_create_zip_dict_result
                                           exists */
   HA_CREATE_ZIP_DICT_NAME_TOO_LONG,  /*!< zip dict name is too long */
   HA_CREATE_ZIP_DICT_DATA_TOO_LONG,  /*!< zip dict data is too long */
+  HA_CREATE_ZIP_DICT_DATA_ZERO_LEN,  /*!< zip dict data is zero len */
   HA_CREATE_ZIP_DICT_READ_ONLY,      /*!< cannot create in read-only mode */
   HA_CREATE_ZIP_DICT_OUT_OF_MEMORY,  /*!< out of memory */
   HA_CREATE_ZIP_DICT_OUT_OF_FILE_SPACE,

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7792,6 +7792,9 @@ ER_COMPRESSION_DICTIONARY_NAME_TOO_LONG
 ER_COMPRESSION_DICTIONARY_DATA_TOO_LONG
   eng "Data for compression dictionary '%-.192s' is too long (max length = %lu)"
 
+ER_COMPRESSION_DICTIONARY_DATA_ZERO_LEN
+  eng "Data for compression dictionary can't be of zero lenght"
+
 ER_COMPRESSION_DICTIONARY_IS_REFERENCED
   eng "Compression dictionary '%-.192s' is in use"
 

--- a/sql/sql_zip_dict.cc
+++ b/sql/sql_zip_dict.cc
@@ -38,6 +38,7 @@ Creates a new compression dictionary with the specified data.
                                                 compression dictionaries
 @retval ER_COMPRESSION_DICTIONARY_NAME_TOO_LONG Dictionary name is too long
 @retval ER_COMPRESSION_DICTIONARY_DATA_TOO_LONG Dictionary data is too long
+@retval ER_COMPRESSION_DICTIONARY_DATA_ZERO_LEN Dictionary data is zero len
 @retval ER_COMPRESSION_DICTIONARY_EXISTS        Dictionary with such name
                                                 already exists
 @retval ER_READ_ONLY_MODE                       Forbidden in read-only mode
@@ -76,6 +77,10 @@ int mysql_create_zip_dict(THD* thd, const char* name, ulong name_len,
       case HA_CREATE_ZIP_DICT_NAME_TOO_LONG:
         error= ER_COMPRESSION_DICTIONARY_NAME_TOO_LONG;
         my_error(error, MYF(0), name, local_name_len);
+        break;
+      case HA_CREATE_ZIP_DICT_DATA_ZERO_LEN:
+        error= ER_COMPRESSION_DICTIONARY_DATA_ZERO_LEN;
+        my_error(error, MYF(0), name, local_data_len);
         break;
       case HA_CREATE_ZIP_DICT_DATA_TOO_LONG:
         error= ER_COMPRESSION_DICTIONARY_DATA_TOO_LONG;

--- a/sql/sql_zip_dict.h
+++ b/sql/sql_zip_dict.h
@@ -39,6 +39,7 @@ class THD;
                                                   compression dictionaries
   @retval ER_COMPRESSION_DICTIONARY_NAME_TOO_LONG Dictionary name is too long
   @retval ER_COMPRESSION_DICTIONARY_DATA_TOO_LONG Dictionary data is too long
+  @retval ER_COMPRESSION_DICTIONARY_DATA_ZERO_LEN Dictionary data is zero len
   @retval ER_COMPRESSION_DICTIONARY_EXISTS        Dictionary with such name
                                                   already exists
   @retval ER_READ_ONLY_MODE                       Forbidden in read-only mode

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4953,6 +4953,10 @@ innobase_create_zip_dict(
 		DBUG_RETURN(HA_CREATE_ZIP_DICT_DATA_TOO_LONG);
 	}
 
+	if (UNIV_UNLIKELY(*data_len == 0)) {
+		DBUG_RETURN(HA_CREATE_ZIP_DICT_DATA_ZERO_LEN);
+	}
+
 	switch (dict_create_zip_dict(name, *name_len, data, *data_len)) {
 		case DB_SUCCESS:
 			result = HA_CREATE_ZIP_DICT_OK;


### PR DESCRIPTION
Empty compression dictionaries should be disallowed

CREATE COMPRESSION_DICTIONARY numbers ('');
This should be disallowed because we cannot later update
the compression dictionary to a valid text.