### PR TITLE
PS-3411: Prevent creation of xb_doublewrite file when innodb_doublewrite is disabled (8.0)

### DIFF
--- a/mysql-test/suite/innodb/r/percona_doublewrite.result
+++ b/mysql-test/suite/innodb/r/percona_doublewrite.result
@@ -39,5 +39,38 @@ SET GLOBAL innodb_fast_shutdown=2;
 # restart:--innodb-force-recovery=6
 # Test that --innodb_force_recovery=6 succeeds to start without the doublewrite file
 # restart:--innodb-force-recovery=6
+#
+# Bug PS-3411: Parallel doublewrite buffer file created when skip-innodb_doublewrite is set
+#
+# restart:<hidden args>
+CREATE TABLE t1 (a INT);
+SELECT * FROM t1 ORDER BY a DESC LIMIT 10;
+a
+1000
+999
+998
+997
+996
+995
+994
+993
+992
+991
+DROP TABLE t1;
+# restart:<hidden args>
+CREATE TABLE t1 (a INT);
+SELECT * FROM t1 ORDER BY a DESC LIMIT 10;
+a
+1000
+999
+998
+997
+996
+995
+994
+993
+992
+991
+DROP TABLE t1;
 # Cleanup
 # restart

--- a/mysql-test/suite/innodb/t/percona_doublewrite.test
+++ b/mysql-test/suite/innodb/t/percona_doublewrite.test
@@ -138,6 +138,62 @@ SET GLOBAL innodb_fast_shutdown=2;
 --let $restart_parameters=restart:--innodb-force-recovery=6
 --source include/start_mysqld.inc
 
+--echo #
+--echo # Bug PS-3411: Parallel doublewrite buffer file created when skip-innodb_doublewrite is set
+--echo #
+
+--let $restart_hide_args= 1
+--let $restart_parameters= restart:--innodb-parallel-doublewrite-path=$DOUBLEWRITE_FILE
+--source include/restart_mysqld.inc
+file_exists $DOUBLEWRITE_FILE;
+
+CREATE TABLE t1 (a INT);
+
+--let $i= 1000
+--disable_query_log
+START TRANSACTION;
+while($i)
+{
+    --eval INSERT INTO t1 VALUES ($i);
+    --dec $i
+}
+COMMIT;
+--enable_query_log
+
+# wait until pages flushed
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+SELECT * FROM t1 ORDER BY a DESC LIMIT 10;
+DROP TABLE t1;
+
+--let $restart_hide_args= 1
+--let $restart_parameters= "restart:--innodb-parallel-doublewrite-path=$DOUBLEWRITE_FILE --skip-innodb-doublewrite"
+--source include/restart_mysqld.inc
+--error 1
+--file_exists $DOUBLEWRITE_FILE;
+
+# check that it still works
+CREATE TABLE t1 (a INT);
+
+--let $i= 1000
+--disable_query_log
+START TRANSACTION;
+while($i)
+{
+    --eval INSERT INTO t1 VALUES ($i);
+    --dec $i
+}
+COMMIT;
+--enable_query_log
+
+# wait until pages flushed
+--let $wait_condition= SELECT variable_value = 0 FROM performance_schema.global_status WHERE LOWER(variable_name) = 'innodb_buffer_pool_pages_dirty'
+--source include/wait_condition.inc
+
+SELECT * FROM t1 ORDER BY a DESC LIMIT 10;
+DROP TABLE t1;
+
 --echo # Cleanup
 --let $restart_parameters=
 --source include/restart_mysqld.inc

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -1640,6 +1640,10 @@ the disk file.
 dberr_t
 buf_parallel_dblwr_create(void)
 {
+	if (!srv_use_doublewrite_buf) {
+		return(DB_SUCCESS);
+	}
+
 	if (!parallel_dblwr_buf.file.is_closed() || srv_read_only_mode) {
 
 		ut_ad(parallel_dblwr_buf.recovery_buf_unaligned == NULL);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-3411

Unnecessary xb_doublewrite file is no more created when innodb_doublewrite option is disabled.