### PR TITLE
post push fix for PS-5838: Enabling ENCRYPTION_KEY_ID for tablespaces…

### DIFF
--- a/mysql-test/suite/encryption/r/encrypt_and_grep.result
+++ b/mysql-test/suite/encryption/r/encrypt_and_grep.result
@@ -55,7 +55,7 @@ include/assert.inc [All encrypted tables should have encrypted flag set, apart f
 # Now turn off encryption and wait for threads to decrypt everything
 SET GLOBAL default_table_encryption = ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 # Three tables should stay encrypted - the ones with explicit encryption
-include/assert.inc [Three tables should stay encrypted - the ones with explicit encryption t1, t4 and t6]
+include/assert.inc [Three tablespaces should stay encrypted - the ones with explicit encryption t1, t4 and t6]
 # t1 yes on expecting NOT FOUND
 # t2 ... default expecting FOUND
 # t3 no  on expecting FOUND

--- a/mysql-test/suite/encryption/r/tablespace_encryption.result
+++ b/mysql-test/suite/encryption/r/tablespace_encryption.result
@@ -18,10 +18,10 @@ SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
 SET GLOBAL innodb_encryption_threads=4;
 include/assert.inc [table ts4 should not be encrypted]
 include/assert.inc [Successful rotation of percona_innodb-0 to version 2]
-include/assert.inc [None of the tablespaces should get re-encrypted with version 2]
+include/assert.inc [None of the tablespaces should get re-encrypted with version 2 as innodb_encryption_rotate_key_age is 2]
 include/assert.inc [Successful rotation of percona_innodb-0 to version 3]
 include/assert.inc [Table ts1 should not get re-encrypted as key 3 is still in version 1]
-include/assert.inc [Tablespace ts2 should not get re-encrypted as key 3 is still in version 1]
+include/assert.inc [Tablespace ts2 should not get re-encrypted as key 5 is still in version 1]
 include/assert.inc [Table ts4 should stay unencrypted]
 # Now, let's rotate key 5 twice
 include/assert.inc [Successful rotation of percona_innodb-5 to version 2]


### PR DESCRIPTION
… and disable ENCRYPTION='KEYRING' - re-recorded results for encrypt_and_grep and tablespace_encryption tests.