### PR TITLE
PS-5738: Decrease size of KEYRING encryption information on page0

### DIFF
--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -119,15 +119,12 @@ EncryptionKeyId get_global_default_encryption_key_id_value();
 #define DEBUG_KEYROTATION_THROTTLING 0
 
 static constexpr uint KERYING_ENCRYPTION_INFO_MAX_SIZE =
-    ENCRYPTION_MAGIC_SIZE + 2  // length of iv
-    + 4                        // space id
-    + 2                        // offset
-    + 1                        // type
+    ENCRYPTION_MAGIC_SIZE + 1  // type
     + 4                        // min_key_version
     + 4                        // key_id
     + 1                        // encryption
     + CRYPT_SCHEME_1_IV_LEN    // iv (16 bytes)
-    + 4                        // encryption rotation type
+    + 1                        // encryption rotation type
     + ENCRYPTION_KEY_LEN       // tablespace key
     + ENCRYPTION_KEY_LEN;      // tablespace iv
 
@@ -214,12 +211,12 @@ void fil_space_crypt_cleanup() {
   mutex_free(&crypt_stat_mutex);
 }
 
-fil_space_crypt_t::fil_space_crypt_t(
-    uint new_type, uint new_min_key_version, uint new_key_id,
-    fil_encryption_t new_encryption, Crypt_key_operation key_operation,
-    Encryption::Encryption_rotation encryption_rotation)
+fil_space_crypt_t::fil_space_crypt_t(uint new_type, uint new_min_key_version,
+                                     uint new_key_id,
+                                     fil_encryption_t new_encryption,
+                                     Crypt_key_operation key_operation,
+                                     Encryption_rotation encryption_rotation)
     : min_key_version(new_min_key_version),
-      page0_offset(0),
       encryption(new_encryption),
       key_found(false),
       rotate_state(),
@@ -424,20 +421,14 @@ fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
 
   bytes_read += ENCRYPTION_MAGIC_SIZE;
 
-  uint8_t iv_length = mach_read_from_2(page + offset + bytes_read);
-  bytes_read += 2;
-  bytes_read += 4;  // skip space_id
-  bytes_read += 2;  // skip offset
-
   uint8_t type = mach_read_from_1(page + offset + bytes_read);
   bytes_read += 1;
 
   fil_space_crypt_t *crypt_data;
 
-  if (!(type == CRYPT_SCHEME_UNENCRYPTED || type == CRYPT_SCHEME_1) ||
-      iv_length != sizeof crypt_data->iv) {
-    ib::error() << "Found non sensible crypt scheme: " << type << ","
-                << iv_length << " for space: " << page_get_space_id(page)
+  if (!(type == CRYPT_SCHEME_UNENCRYPTED || type == CRYPT_SCHEME_1)) {
+    ib::error() << "Found non sensible crypt scheme: " << type
+                << " for space: " << page_get_space_id(page)
                 << " offset: " << offset << " bytes: ["
                 << page[offset + 2 + ENCRYPTION_MAGIC_SIZE]
                 << page[offset + 3 + ENCRYPTION_MAGIC_SIZE]
@@ -466,15 +457,12 @@ fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
   crypt_data->type = type;
   crypt_data->min_key_version = min_key_version;
   crypt_data->encrypting_with_key_version = min_key_version;
-  crypt_data->page0_offset = offset;
-  memcpy(crypt_data->iv, page + offset + bytes_read, iv_length);
+  memcpy(crypt_data->iv, page + offset + bytes_read, CRYPT_SCHEME_1_IV_LEN);
+  bytes_read += CRYPT_SCHEME_1_IV_LEN;
 
-  bytes_read += iv_length;
-
-  crypt_data->encryption_rotation =
-      (Encryption::Encryption_rotation)mach_read_from_4(page + offset +
-                                                        bytes_read);
-  bytes_read += 4;
+  crypt_data->encryption_rotation = static_cast<Encryption_rotation>(
+      mach_read_from_1(page + offset + bytes_read));
+  bytes_read += 1;
 
   uchar tablespace_key[ENCRYPTION_KEY_LEN];
   memcpy(tablespace_key, page + offset + bytes_read, ENCRYPTION_KEY_LEN);
@@ -485,19 +473,11 @@ fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
                     0) ==
       tablespace_key) {  // tablespace_key is all zeroes which means there is no
                          // tablepsace in mtr log
-    crypt_data->set_tablespace_key(NULL);
-    crypt_data->set_tablespace_iv(NULL);  // No tablespace_key => no iv
+    crypt_data->set_tablespace_key(nullptr);
   } else {
-    ut_ad(tablespace_key != NULL);
-    crypt_data->set_tablespace_key(tablespace_key);  // Since there is
-                                                     // tablespace_key present -
-                                                     // we also need to read
-                                                     // tablespace_iv
-    uchar tablespace_iv[ENCRYPTION_KEY_LEN];
-    ut_ad(tablespace_iv != NULL);
-    memcpy(tablespace_iv, page + offset + bytes_read, ENCRYPTION_KEY_LEN);
-    bytes_read += ENCRYPTION_KEY_LEN;
-    crypt_data->set_tablespace_iv(tablespace_iv);
+    crypt_data->set_tablespace_key(
+        tablespace_key);  // We are using the same iv for both
+                          // MK encryption and KEYRING encryption
   }
 
   return crypt_data;
@@ -540,11 +520,10 @@ Write crypt data to a page (0)
 
 void fil_space_crypt_t::write_page0(
     const fil_space_t *space, byte *page, mtr_t *mtr, uint a_min_key_version,
-    uint a_type, Encryption::Encryption_rotation current_encryption_rotation) {
+    uint a_type, Encryption_rotation current_encryption_rotation) {
   ut_ad(this == space->crypt_data);
   const ulint offset =
       fsp_header_get_keyring_encryption_offset(page_size_t(space->flags));
-  page0_offset = offset;
 
   byte *encrypt_info = new byte[KERYING_ENCRYPTION_INFO_MAX_SIZE];
   byte *encrypt_info_ptr = encrypt_info;
@@ -554,13 +533,6 @@ void fil_space_crypt_t::write_page0(
 
   memcpy(encrypt_info_ptr, ENCRYPTION_KEY_MAGIC_PS_V1, ENCRYPTION_MAGIC_SIZE);
   encrypt_info_ptr += ENCRYPTION_MAGIC_SIZE;
-  mach_write_to_2(encrypt_info_ptr, CRYPT_SCHEME_1_IV_LEN);
-  encrypt_info_ptr += 2;
-
-  mach_write_to_4(encrypt_info_ptr, space->id);
-  encrypt_info_ptr += 4;
-  mach_write_to_2(encrypt_info_ptr, offset);
-  encrypt_info_ptr += 2;
 
   mach_write_to_1(encrypt_info_ptr, a_type);
   encrypt_info_ptr += 1;
@@ -575,20 +547,15 @@ void fil_space_crypt_t::write_page0(
   memcpy(encrypt_info_ptr, iv, CRYPT_SCHEME_1_IV_LEN);
   encrypt_info_ptr += CRYPT_SCHEME_1_IV_LEN;
 
-  mach_write_to_4(encrypt_info_ptr, current_encryption_rotation);
-  encrypt_info_ptr += 4;
+  mach_write_to_1(encrypt_info_ptr,
+                  static_cast<byte>(current_encryption_rotation));
+  encrypt_info_ptr += 1;
 
-  if (tablespace_key == NULL) {
-    ut_ad(tablespace_iv == NULL);
-    memset(encrypt_info_ptr, 0, ENCRYPTION_KEY_LEN);
-    encrypt_info_ptr += ENCRYPTION_KEY_LEN;
+  if (tablespace_key == nullptr) {
     memset(encrypt_info_ptr, 0, ENCRYPTION_KEY_LEN);
     encrypt_info_ptr += ENCRYPTION_KEY_LEN;
   } else {
-    ut_ad(tablespace_iv != NULL);
     memcpy(encrypt_info_ptr, tablespace_key, ENCRYPTION_KEY_LEN);
-    encrypt_info_ptr += ENCRYPTION_KEY_LEN;
-    memcpy(encrypt_info_ptr, tablespace_iv, ENCRYPTION_KEY_LEN);
     encrypt_info_ptr += ENCRYPTION_KEY_LEN;
   }
 
@@ -634,16 +601,15 @@ static fil_space_crypt_t *fil_space_set_crypt_data(
 
 /******************************************************************
 Parse a MLOG_FILE_WRITE_CRYPT_DATA log entry
-@param[in]	ptr		Log entry start
-@param[in]	end_ptr		Log entry end
-@param[in]	block		buffer block
+@param[in]  space_id  id of space that this log entry refers to
+@param[in]  ptr  Log entry start
+@param[in]  end_ptr  Log entry end
+@param[in]  len  Log entry length
 @return position on log buffer */
 
-byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
-                                 const buf_block_t *block, ulint len) {
+byte *fil_parse_write_crypt_data(space_id_t space_id, byte *ptr,
+                                 const byte *end_ptr, ulint len) {
   ptr += 4;  // skip offset and len
-  const uint iv_len = mach_read_from_2(ptr + ENCRYPTION_MAGIC_SIZE);
-  ut_a(iv_len == CRYPT_SCHEME_1_IV_LEN);  // only supported
 
   if (len != KERYING_ENCRYPTION_INFO_MAX_SIZE) {
     recv_sys->set_corrupt_log();
@@ -657,13 +623,6 @@ byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
   // We should only enter this function if ENCRYPTION_KEY_MAGIC_PS_V1 is set
   ut_ad((memcmp(ptr, ENCRYPTION_KEY_MAGIC_PS_V1, ENCRYPTION_MAGIC_SIZE) == 0));
   ptr += ENCRYPTION_MAGIC_SIZE;
-
-  ptr += 2;  // length of iv has been already read
-
-  space_id_t space_id = mach_read_from_4(ptr);
-  ptr += 4;
-  uint offset = mach_read_from_2(ptr);
-  ptr += 2;
 
   uint type = mach_read_from_1(ptr);
   ptr += 1;
@@ -683,15 +642,14 @@ byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
   fil_space_crypt_t *crypt_data = fil_space_create_crypt_data(
       encryption, key_id, Crypt_key_operation::FETCH_OR_GENERATE_KEY);
   /* Need to overwrite these as above will initialize fields. */
-  crypt_data->page0_offset = offset;
   DBUG_ASSERT(min_key_version != ENCRYPTION_KEY_VERSION_INVALID);
   crypt_data->min_key_version = min_key_version;
   crypt_data->encryption = encryption;
-  memcpy(crypt_data->iv, ptr, iv_len);
-  ptr += iv_len;
+  memcpy(crypt_data->iv, ptr, CRYPT_SCHEME_1_IV_LEN);
+  ptr += CRYPT_SCHEME_1_IV_LEN;
   crypt_data->encryption_rotation =
-      (Encryption::Encryption_rotation)mach_read_from_4(ptr);
-  ptr += 4;
+      static_cast<Encryption_rotation>(mach_read_from_1(ptr));
+  ptr += 1;
   uchar tablespace_key[ENCRYPTION_KEY_LEN];
   memcpy(tablespace_key, ptr, ENCRYPTION_KEY_LEN);
   ptr += ENCRYPTION_KEY_LEN;
@@ -701,21 +659,15 @@ byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
                     0) ==
       tablespace_key) {  // tablespace_key is all zeroes which means there is no
                          // tablepsace in mtr log
-    crypt_data->set_tablespace_key(NULL);
-    crypt_data->set_tablespace_iv(NULL);  // No tablespace_key => no iv
+    crypt_data->set_tablespace_key(nullptr);
     ptr += ENCRYPTION_KEY_LEN;
   } else {
     crypt_data->set_tablespace_key(tablespace_key);
-    uchar tablespace_iv[ENCRYPTION_KEY_LEN];
-    memcpy(tablespace_iv, ptr, ENCRYPTION_KEY_LEN);
-    ptr += ENCRYPTION_KEY_LEN;
-    crypt_data->set_tablespace_iv(tablespace_iv);
   }
 
   /* Check is used key found from encryption plugin */
   if (crypt_data->should_encrypt() && !crypt_data->is_key_found()) {
-    ib::error() << "Key cannot be read for space id = "
-                << space_id;  // TODO: To jest zmienione w MariaDB - zmienić!
+    ib::error() << "Key cannot be read for space id = " << space_id;
     recv_sys->set_corrupt_log();
   }
 
@@ -889,13 +841,13 @@ static bool fil_crypt_start_encrypting_space(fil_space_t *space) {
                                                     // space from MK encryption
                                                     // to RK encryption
     // TODO: assert that space->encryption_key is all zeroes here
-    crypt_data->encryption_rotation = Encryption::MASTER_KEY_TO_KEYRING;
+    crypt_data->encryption_rotation =
+        Encryption_rotation::MASTER_KEY_TO_KEYRING;
     crypt_data->set_tablespace_key(space->encryption_key);
-    crypt_data->set_tablespace_iv(space->encryption_iv);  // space key and
-                                                          // encryption are
-                                                          // always initalized
-                                                          // for MK encrypted
-                                                          // tables
+    crypt_data->set_iv(
+        space->encryption_iv);  // using the same iv for reading MK encrypted
+                                // pages and encrypting KEYRING encrypted
+                                // pages
   }
 
   crypt_data->encrypting_with_key_version =
@@ -1673,7 +1625,7 @@ static void fil_crypt_rotate_page(const key_state_t *key_state,
     //
     // We will rotate the pages from the begining if there was a crash
     uint kv = space->crypt_data->encryption_rotation ==
-                      Encryption::MASTER_KEY_TO_KEYRING
+                      Encryption_rotation::MASTER_KEY_TO_KEYRING
                   ? ENCRYPTION_KEY_VERSION_NOT_ENCRYPTED
                   : mach_read_from_4(frame + FIL_PAGE_ENCRYPTION_KEY_VERSION);
 
@@ -2375,7 +2327,7 @@ static dberr_t fil_crypt_flush_space(rotate_thread_t *state) {
     // mtr.set_named_space(space);
     crypt_data->write_page0(space, block->frame, &mtr,
                             crypt_data->rotate_state.min_key_version_found,
-                            current_type, Encryption::NO_ROTATION);
+                            current_type, Encryption_rotation::NO_ROTATION);
   }
 
   mtr.commit();
@@ -2440,9 +2392,8 @@ static void fil_crypt_complete_rotate_space(const key_state_t *key_state,
       /* we're the last active thread */
       ut_ad(crypt_data->rotate_state.flushing == false);
       crypt_data->rotate_state.flushing = true;
-      crypt_data->set_tablespace_iv(NULL);
       crypt_data->set_tablespace_key(NULL);
-      crypt_data->encryption_rotation = Encryption::NO_ROTATION;
+      crypt_data->encryption_rotation = Encryption_rotation::NO_ROTATION;
     }
 
     DBUG_EXECUTE_IF(

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -7497,7 +7497,6 @@ inline void fil_io_set_keyring_encryption(IORequest &req_type,
   byte *key = NULL;
   ulint key_len = 32;  // 32*8=256
   byte *iv = NULL;
-  byte *tablespace_iv = NULL;
   byte *tablespace_key = NULL;
   uint key_version = 0;
   uint key_id = FIL_DEFAULT_ENCRYPTION_KEY;
@@ -7522,11 +7521,10 @@ inline void fil_io_set_keyring_encryption(IORequest &req_type,
   }
 
   if (req_type.is_read()) {
-    tablespace_iv = space->crypt_data->tablespace_iv;
     tablespace_key = space->crypt_data->tablespace_key;
     ut_ad(space->crypt_data->encryption_rotation !=
-              Encryption::MASTER_KEY_TO_KEYRING ||
-          space->crypt_data->tablespace_key != NULL);
+              Encryption_rotation::MASTER_KEY_TO_KEYRING ||
+          space->crypt_data->tablespace_key != nullptr);
     // retrieve key with min_key_version from local cache. In normal situation
     // this is the key needed for decryption. In rare cases when re-encryption
     // was aborted - due to server crash or shutdown there can be one more key
@@ -7550,7 +7548,7 @@ inline void fil_io_set_keyring_encryption(IORequest &req_type,
   }
 
   req_type.encryption_key(key, key_len, false, iv, key_version, key_id,
-                          tablespace_iv, tablespace_key);
+                          tablespace_key);
 
   req_type.encryption_rotation(space->crypt_data->encryption_rotation);
 
@@ -7568,9 +7566,9 @@ static void fil_io_set_mk_encryption(IORequest &req_type, fil_space_t *space) {
                      ? space->encryption_redo_key->version
                      : space->encryption_key_version;
   req_type.encryption_key(key, 32, false, space->encryption_iv, version, 0,
-                          nullptr, nullptr);
+                          nullptr);
 
-  req_type.encryption_rotation(Encryption::NO_ROTATION);
+  req_type.encryption_rotation(Encryption_rotation::NO_ROTATION);
 }
 
 static bool fil_keyring_skip_encryption(const page_id_t &page_id) {
@@ -8822,7 +8820,6 @@ static dberr_t fil_iterate(const Fil_page_iterator &iter, buf_block_t *block,
           ENCRYPTION_KEY_LEN, false,
           encrypted_with_keyring ? iter.m_crypt_data->iv : iter.m_encryption_iv,
           0, iter.m_encryption_key_id,
-          encrypted_with_keyring ? iter.m_crypt_data->tablespace_iv : NULL,
           encrypted_with_keyring ? iter.m_crypt_data->tablespace_key : NULL);
 
       read_request.encryption_algorithm(iter.m_crypt_data ? Encryption::KEYRING
@@ -8831,7 +8828,7 @@ static dberr_t fil_iterate(const Fil_page_iterator &iter, buf_block_t *block,
         read_request.encryption_rotation(
             iter.m_crypt_data->encryption_rotation);
       } else
-        read_request.encryption_rotation(Encryption::NO_ROTATION);
+        read_request.encryption_rotation(Encryption_rotation::NO_ROTATION);
     }
 
     err = os_file_read(read_request, iter.m_file, io_buffer, offset,
@@ -8874,13 +8871,13 @@ static dberr_t fil_iterate(const Fil_page_iterator &iter, buf_block_t *block,
       write_request.encryption_key(iter.m_encryption_key, ENCRYPTION_KEY_LEN,
                                    false, iter.m_encryption_iv,
                                    iter.m_encryption_key_version,
-                                   iter.m_encryption_key_id, NULL, NULL);
+                                   iter.m_encryption_key_id, nullptr);
       write_request.encryption_algorithm(Encryption::AES);
     } else if (offset != 0 && iter.m_crypt_data) {
       write_request.encryption_key(iter.m_encryption_key, ENCRYPTION_KEY_LEN,
                                    false, iter.m_encryption_iv,
                                    iter.m_encryption_key_version,
-                                   iter.m_crypt_data->key_id, NULL, NULL);
+                                   iter.m_crypt_data->key_id, nullptr);
 
       write_request.encryption_algorithm(Encryption::KEYRING);
 

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -324,6 +324,11 @@ static const uint ENCRYPTION_PROGRESS_INFO_SIZE = sizeof(uint);
 
 class IORequest;
 
+enum class Encryption_rotation : std::uint8_t {
+  NO_ROTATION,
+  MASTER_KEY_TO_KEYRING
+};
+
 /** Encryption algorithm. */
 struct Encryption {
   /** Algorithm types supported */
@@ -337,8 +342,6 @@ struct Encryption {
 
     KEYRING = 2
   };
-
-  enum Encryption_rotation { NO_ROTATION, MASTER_KEY_TO_KEYRING };
 
   /** Encryption information format version */
   enum Version {
@@ -360,27 +363,25 @@ struct Encryption {
         m_klen(0),
         m_key_allocated(false),
         m_iv(nullptr),
-        m_tablespace_iv(nullptr),
         m_tablespace_key(nullptr),
         m_key_version(0),
         m_key_id(0),
         m_checksum(0),
-        m_encryption_rotation(NO_ROTATION) {}
+        m_encryption_rotation(Encryption_rotation::NO_ROTATION) {}
 
   /** Specific constructor
   @param[in]	type		Algorithm type */
   explicit Encryption(Type type)
       : m_type(type),
-        m_key(NULL),
+        m_key(nullptr),
         m_klen(0),
         m_key_allocated(false),
-        m_iv(NULL),
-        m_tablespace_iv(NULL),
-        m_tablespace_key(NULL),
+        m_iv(nullptr),
+        m_tablespace_key(nullptr),
         m_key_version(0),
         m_key_id(0),
         m_checksum(0),
-        m_encryption_rotation(NO_ROTATION) {
+        m_encryption_rotation(Encryption_rotation::NO_ROTATION) {
 #ifdef UNIV_DEBUG
     switch (m_type) {
       case NONE:
@@ -407,7 +408,6 @@ struct Encryption {
     std::swap(m_klen, other.m_klen);
     std::swap(m_key_allocated, other.m_key_allocated);
     std::swap(m_iv, other.m_iv);
-    std::swap(m_tablespace_iv, other.m_tablespace_iv);
     std::swap(m_tablespace_key, other.m_tablespace_key);
     std::swap(m_key_version, other.m_key_version);
     std::swap(m_key_id, other.m_key_id);
@@ -648,12 +648,6 @@ struct Encryption {
 
   /** Encrypt initial vector */
   byte *m_iv;
-
-  // We decide as the last step in decrypt (after reading the page)
-  // when re_encryption_type is MK_TO_RK whether page is
-  // encrypted with MK or RK => thus we do not know which tablespace_iv we are
-  // going to use RK or MK
-  byte *m_tablespace_iv;
 
   byte *m_tablespace_key;
 
@@ -913,18 +907,15 @@ class IORequest {
   @param[in] key_len	length of the encryption key
   @param[in] iv		The encryption iv to use */
   void encryption_key(byte *key, ulint key_len, bool key_allocated, byte *iv,
-                      uint key_version, uint key_id, byte *tablespace_iv,
-                      byte *tablespace_key) {
+                      uint key_version, uint key_id, byte *tablespace_key) {
     m_encryption.set_key(key, key_len, key_allocated);
     m_encryption.m_iv = iv;
     m_encryption.m_key_version = key_version;
     m_encryption.m_key_id = key_id;
-    m_encryption.m_tablespace_iv = tablespace_iv;
     m_encryption.m_tablespace_key = tablespace_key;
   }
 
-  void encryption_rotation(
-      Encryption::Encryption_rotation encryption_rotation) {
+  void encryption_rotation(Encryption_rotation encryption_rotation) {
     m_encryption.m_encryption_rotation = encryption_rotation;
   }
 
@@ -951,13 +942,12 @@ class IORequest {
 
   /** Clear all encryption related flags */
   void clear_encrypted() {
-    m_encryption.set_key(NULL, 0, false);
-    m_encryption.m_iv = NULL;
+    m_encryption.set_key(nullptr, 0, false);
+    m_encryption.m_iv = nullptr;
     m_encryption.m_type = Encryption::NONE;
-    m_encryption.m_encryption_rotation = Encryption::NO_ROTATION;
-    m_encryption.m_tablespace_iv = NULL;
+    m_encryption.m_encryption_rotation = Encryption_rotation::NO_ROTATION;
     m_encryption.m_key_id = 0;
-    m_encryption.m_tablespace_key = NULL;
+    m_encryption.m_tablespace_key = nullptr;
   }
 
   void mark_page_zip_compressed() { m_is_page_zip_compressed = true; }

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1604,7 +1604,7 @@ static byte *recv_parse_or_apply_log_rec_body(mlog_id_t type, byte *ptr,
           } else if (memcmp(ptr_copy, ENCRYPTION_KEY_MAGIC_PS_V1,
                             ENCRYPTION_MAGIC_SIZE) == 0 &&
                      apply) {
-            return (fil_parse_write_crypt_data(ptr, end_ptr, block, len));
+            return (fil_parse_write_crypt_data(space_id, ptr, end_ptr, len));
           }
         }
         break;
@@ -3790,7 +3790,7 @@ void recv_dblwr_t::decrypt_sys_dblwr_pages() {
   IORequest decrypt_request;
 
   decrypt_request.encryption_key(space->encryption_key, space->encryption_klen,
-                                 false, space->encryption_iv, 0, 0, NULL, NULL);
+                                 false, space->encryption_iv, 0, 0, nullptr);
   decrypt_request.encryption_algorithm(Encryption::AES);
 
   Encryption encryption(decrypt_request.encryption_algorithm());


### PR DESCRIPTION
Decreased Keyring encryption information stored on page0 of KEYRING
encrypted tables.

Removed:
 - space_id (4 bytes)
 - offset (2 bytes)
 - tablespace_iv (32 bytes)
Shrank the size of encryption_rotation from 4 bytes to 1 byte
(currently this can have only one of two values: NO_ROTATION or
MASTER_KEY_TO_KEYRING)

tablespace_iv was only used when there was MASTER_KEY_TO_KEYRING
rotation taking place. We would have two IVs then - one for KEYRING
encryption and the second one for MK decryption. However, those IVs do
not need to be different as long as the key used is different - which is
the case here. So instead of generating new IV for KEYRING encryption we
reuse the MK encryption IV when re-encrypting from MK to KEYRING.