### PR TITLE
Post-push PS-5492 fix: assertion during temp tablespace initialization

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1687,7 +1687,7 @@ static dberr_t srv_open_tmp_tablespace(bool create_new_db,
       mtr_start(&mtr);
       mtr_set_log_mode(&mtr, MTR_LOG_NO_REDO);
 
-      fsp_header_init(tmp_space->space_id(), size, &mtr, false);
+      fsp_header_init(tmp_space->space_id(), size, &mtr, true);
 
       mtr_commit(&mtr);
     } else {


### PR DESCRIPTION
This caused crashes when a temporary tablespace was used after
srv_is_uuid_ready was set, but Encryption::s_uuid wasn't yet
initialized.

Fix: set srv_is_uuid_ready to true only after s_uuid is set based
on server_uuid