### PR TITLE
PS-5707: fixed filtering of audit_log against audit_log_exclude_accounts

### DIFF
--- a/mysql-test/r/audit_log_filter_users.result
+++ b/mysql-test/r/audit_log_filter_users.result
@@ -139,9 +139,9 @@ set global audit_log_flush= ON;
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= ''","root[root] @ localhost []","localhost","","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%,veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooongusername@veryveryveryveryveryveryveryveryveryveryveryveryveryveryveryloooooooooooooonghostname'","root[root] @ localhost []","localhost","","","test"
-"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
-"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user1'","user1[user1] @ localhost [127.0.0.1]","localhost","","127.0.0.1","test"
-"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'admin'","admin[admin] @ localhost [127.0.0.1]","localhost","","127.0.0.1","test"
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_include_accounts= NULL","root[root] @ localhost []","localhost","","","test"
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
@@ -163,6 +163,9 @@ set global audit_log_flush= ON;
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_accounts= 'user1@localhost,, user22@127.0.0.1,admin@%'","root[root] @ localhost []","localhost","","","test"
+"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
+"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user1'","user1[user1] @ localhost [127.0.0.1]","localhost","","127.0.0.1","test"
+"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user1","user1","","","localhost","127.0.0.1","test"
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user22'","user22[user22] @ localhost []","localhost","","","test"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","","test"
@@ -171,15 +174,52 @@ set global audit_log_flush= ON;
 "Change user","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","",""
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'user22'","user22[user22] @ localhost []","localhost","","",""
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"user22","user22","","","localhost","",""
-"Connect","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
-"Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'admin'","admin[admin] @ localhost [127.0.0.1]","localhost","","127.0.0.1","test"
-"Quit","<ID>","<DATETIME>","<CONN_ID>",0,"admin","admin","","","localhost","127.0.0.1","test"
 "Connect","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
 "Query","<ID>","<DATETIME>","select","<CONN_ID>",0,"SELECT 'us,er1'","us,er1[us,er1] @ localhost []","localhost","","","test"
 "Quit","<ID>","<DATETIME>","<CONN_ID>",0,"us,er1","us,er1","","","localhost","","test"
 *************************************************************
 "Query","<ID>","<DATETIME>","set_option","<CONN_ID>",0,"SET GLOBAL audit_log_exclude_accounts= NULL","root[root] @ localhost []","localhost","","","test"
 ===================================================================
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+Variable_name	Value
+audit_log_exclude_accounts	
+SET GLOBAL audit_log_exclude_accounts = 'user22@%';
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+Variable_name	Value
+audit_log_exclude_accounts	user22@%
+SET GLOBAL audit_log_flush = ON;
+SET GLOBAL audit_log_flush = ON;
+SELECT current_user();
+current_user()
+user22@%
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+Variable_name	Value
+audit_log_exclude_accounts	user22@%
+CREATE TABLE t1 (a text);
+INSERT INTO t1 VALUES("This shouldn't go to audit log");
+SELECT * FROM t1;
+a
+This shouldn't go to audit log
+DROP TABLE t1;
+SET GLOBAL audit_log_exclude_accounts = '';
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+Variable_name	Value
+audit_log_exclude_accounts	
+SELECT current_user();
+current_user()
+user22@%
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+Variable_name	Value
+audit_log_exclude_accounts	
+CREATE TABLE t1 (a text);
+INSERT INTO t1 VALUES("This should go to audit log");
+SELECT * FROM t1;
+a
+This should go to audit log
+DROP TABLE t1;
+SET GLOBAL audit_log_flush = ON;
+include/assert_grep.inc ["This should go to audit log"]
+include/assert_grep.inc ["This shouldn't go to audit log"]
 DROP USER 'user1'@'127.0.0.1';
 DROP USER 'user22'@'%';
 DROP USER '22user'@'localhost';

--- a/mysql-test/t/audit_log_filter_users.test
+++ b/mysql-test/t/audit_log_filter_users.test
@@ -73,9 +73,73 @@ SET GLOBAL audit_log_exclude_accounts= NULL;
 
 --source audit_log_echo.inc
 
+
+
+#
+# PS-5707: Audit log filtering by user is not working
+#
+
+--let $expected_text = "This should go to audit log"
+--let $not_expected_text = "This shouldn't go to audit log"
+
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+SET GLOBAL audit_log_exclude_accounts = 'user22@%';
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+
+SET GLOBAL audit_log_flush = ON;
+--remove_file $log_file
+SET GLOBAL audit_log_flush = ON;
+
+
+--connect (user_connection, 127.0.0.1, user22, password1, )
+--connection user_connection
+SELECT current_user();
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+
+CREATE TABLE t1 (a text);
+--eval INSERT INTO t1 VALUES($not_expected_text)
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--disconnect user_connection
+
+--connection default
+SET GLOBAL audit_log_exclude_accounts = '';
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+
+
+--connect (user_connection, 127.0.0.1, user22, password1, )
+--connection user_connection
+SELECT current_user();
+SHOW VARIABLES LIKE 'audit_log_exclude_accounts';
+
+CREATE TABLE t1 (a text);
+--eval INSERT INTO t1 VALUES($expected_text)
+SELECT * FROM t1;
+DROP TABLE t1;
+
+--disconnect user_connection
+
+--connection default
+SET GLOBAL audit_log_flush = ON;
+
+# Check that log is properly filtered
+--let $assert_file= $log_file
+--let $assert_count = 1
+--let $assert_select = $expected_text
+--let $assert_text = $expected_text
+--source include/assert_grep.inc
+
+--let $assert_count = 0
+--let $assert_select = $not_expected_text
+--let $assert_text = $not_expected_text
+--source include/assert_grep.inc
+
+
 # cleanup users
 DROP USER 'user1'@'127.0.0.1';
 DROP USER 'user22'@'%';
 DROP USER '22user'@'localhost';
 DROP USER 'admin'@'%';
 DROP USER 'us,er1'@'localhost';
+

--- a/mysql-test/t/percona_bug_ps3867.test
+++ b/mysql-test/t/percona_bug_ps3867.test
@@ -13,7 +13,7 @@ let $MYSQLD_DATADIR= `select @@datadir`;
 let $log_file=$MYSQLD_DATADIR/test_audit.log;
 
 
---let $restart_parameters="restart: $AUDIT_LOG_OPT $AUDIT_LOG_LOAD --audit_log_include_accounts='user1@localhost' --audit_log_file=test_audit.log --audit_log_policy=ALL --audit-log-format=CSV --audit_log_strategy=SYNCHRONOUS"
+--let $restart_parameters="restart: $AUDIT_LOG_OPT $AUDIT_LOG_LOAD --audit_log_include_accounts='user1@127.0.0.1' --audit_log_file=test_audit.log --audit_log_policy=ALL --audit-log-format=CSV --audit_log_strategy=SYNCHRONOUS"
 --source include/restart_mysqld.inc
 
 SET GLOBAL audit_log_flush=ON;

--- a/plugin/audit_log/CMakeLists.txt
+++ b/plugin/audit_log/CMakeLists.txt
@@ -14,5 +14,5 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
 
 MYSQL_ADD_PLUGIN(audit_log audit_log.c file_logger.c buffer.c audit_file.c
- audit_syslog.c filter.c
+ audit_syslog.c filter.c security_context_wrapper.cc
  MODULE_ONLY MODULE_OUTPUT_NAME "audit_log")

--- a/plugin/audit_log/security_context_wrapper.cc
+++ b/plugin/audit_log/security_context_wrapper.cc
@@ -1,0 +1,27 @@
+/* Copyright (c) 2019 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include "security_context_wrapper.h"
+
+#define MYSQL_SERVER  "We need security context"
+
+#include <sql_class.h>
+
+
+const char* get_priv_host(MYSQL_THD thd)
+{
+  return thd->security_ctx->priv_host_name();
+}

--- a/plugin/audit_log/security_context_wrapper.h
+++ b/plugin/audit_log/security_context_wrapper.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2019 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef AUDIT_LOG_SECURITY_CONTEXT_INCLUDED
+#define AUDIT_LOG_SECURITY_CONTEXT_INCLUDED
+
+#include <mysql/plugin.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+const char* get_priv_host(MYSQL_THD thd);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif /* AUDIT_LOG_SECURITY_CONTEXT_INCLUDED */


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5707

Filtering audit_og against audit_log_exclude_accounts used host instead of priv_host member of security context. Added security_context_wrapper class to be able to access security context from plugin context.