### PR TITLE
PS-5932: Implementing --tokudb-force-recovery=6 to skip reading the logs

### DIFF
--- a/mysql-test/suite/tokudb/r/recovery.result
+++ b/mysql-test/suite/tokudb/r/recovery.result
@@ -1,0 +1,28 @@
+create table t (a int, b int, primary key (a)) engine=tokudb;
+insert into t values (1,2),(2,4),(3,8);
+optimize table t;
+Table	Op	Msg_type	Msg_text
+test.t	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t	optimize	status	OK
+insert into t values (4,9),(10,11),(12,13);
+select * from t;
+a	b
+1	2
+2	4
+3	8
+4	9
+10	11
+12	13
+# Kill the server
+# restart:--tokudb-force-recovery=6 --read-only --super-read-only
+select * from t;
+a	b
+1	2
+2	4
+3	8
+select * from t;
+a	b
+1	2
+2	4
+3	8
+drop table t;

--- a/mysql-test/suite/tokudb/t/recovery.test
+++ b/mysql-test/suite/tokudb/t/recovery.test
@@ -1,0 +1,46 @@
+--source include/have_tokudb.inc
+
+# verify that delete from table leaves the table empty
+create table t (a int, b int, primary key (a)) engine=tokudb;
+insert into t values (1,2),(2,4),(3,8);
+
+--let $MYSQLD_DATADIR= `select @@datadir`
+
+optimize table t;
+
+--source include/restart_mysqld.inc
+
+insert into t values (4,9),(10,11),(12,13);
+
+select * from t;
+
+--source include/kill_mysqld.inc
+
+--exec mv $MYSQLD_DATADIR/tokudb.rollback $MYSQLD_DATADIR/rollback.backup
+# Create an empty rollback file that tokudb can't interpret
+--exec echo "" > $MYSQLD_DATADIR/tokudb.rollback
+# Make everything read only - to make sure the server can't write these files
+--exec find $MYSQLD_DATADIR -type f -name "*toku*" | xargs chmod u-w
+
+--let $restart_parameters= restart:--tokudb-force-recovery=6 --read-only --super-read-only
+--source include/start_mysqld.inc
+
+select * from t;
+
+--let $restart_parameters= restart:--tokudb-force-recovery=6 --read-only --super-read-only
+--source include/restart_mysqld.inc
+
+select * from t;
+
+--source include/shutdown_mysqld.inc
+# Restore rollback & RW permissions
+--exec find $MYSQLD_DATADIR -type f -name "*toku*" | xargs chmod u+w
+--exec rm $MYSQLD_DATADIR/tokudb.rollback
+--exec mv $MYSQLD_DATADIR/rollback.backup $MYSQLD_DATADIR/tokudb.rollback
+--let $restart_parameters= 
+--source include/start_mysqld.inc
+
+# Cleanup recovery files
+--exec rm $MYSQLD_DATADIR/tokudb.rollback2
+--exec rm $MYSQLD_DATADIR/tokudb.environment2
+drop table t;

--- a/storage/tokudb/tokudb_status.h
+++ b/storage/tokudb/tokudb_status.h
@@ -212,6 +212,11 @@ int create(
     return error;
 }
 
+extern "C" {
+  extern uint         force_recovery;
+}
+
+
 int open(
     DB_ENV* env,
     DB** status_db_ptr,
@@ -230,7 +235,7 @@ int open(
                 NULL,
                 DB_BTREE,
                 DB_THREAD,
-                S_IWUSR);
+                force_recovery ? 0 : S_IWUSR);
     }
     if (error == 0) {
         uint32_t pagesize = 0;

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -97,6 +97,18 @@ static MYSQL_SYSVAR_ULONGLONG(
     0);
 
 static MYSQL_SYSVAR_UINT(
+    force_recovery,
+    force_recovery,
+    PLUGIN_VAR_READONLY,
+    "force recovery. Set to 6 to skip reading the logs",
+    NULL,
+    NULL,
+    0,
+    0,
+    0,
+    0);
+
+static MYSQL_SYSVAR_UINT(
     cachetable_pool_threads,
     cachetable_pool_threads,
     PLUGIN_VAR_READONLY,
@@ -997,6 +1009,7 @@ static int dir_cmd_check(THD* thd,
 st_mysql_sys_var* system_variables[] = {
     // global vars
     MYSQL_SYSVAR(cache_size),
+    MYSQL_SYSVAR(force_recovery),
     MYSQL_SYSVAR(checkpoint_on_flush_logs),
     MYSQL_SYSVAR(cachetable_pool_threads),
     MYSQL_SYSVAR(cardinality_scale_percent),

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -26,6 +26,11 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #ifndef _TOKUDB_SYSVARS_H
 #define _TOKUDB_SYSVARS_H
 
+
+extern "C" {
+extern uint         force_recovery;
+}
+
 namespace tokudb {
 namespace sysvars {
 
@@ -56,7 +61,6 @@ enum row_format_t {
 #define DEFAULT_TOKUDB_CLEANER_PERIOD 1
 #define DEFAULT_TOKUDB_KILLED_TIME 4000     // milliseconds
 #define DEFAULT_TOKUDB_LOCK_TIMEOUT 4000    // milliseconds
-
 
 // globals
 extern ulonglong    cache_size;


### PR DESCRIPTION
This could be useful when the server crashed with a corrupted rollback file,
and is unable to start up. Specifying --tokudb--force-recovery=6 --super-read-only
should start it up in a read-only, but usable state. Some data may be lost and
unrecoverable.

Starting the server without the read only option is NOT supported.

(this is a backport from 5.7, including all bugfixes)