### PR TITLE
PS-5819: Information which tablespace is excluded from encryption

### DIFF
--- a/mysql-test/suite/encryption/r/encrypt_threads_skip_tablespace.result
+++ b/mysql-test/suite/encryption/r/encrypt_threads_skip_tablespace.result
@@ -1,0 +1,79 @@
+SET @@global.keyring_file_data="MYSQL_TMP_DIR/mysecret_keyring";
+CREATE TABLE t1 (a varchar(255)) ENCRYPTION='KEYRING';
+CREATE TABLE t2 (a varchar(255));
+CREATE TABLE t3 (a varchar(255)) ENCRYPTION='N';
+CREATE TABLE t4 (a varchar(255)) ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=5;
+CREATE TABLESPACE ts_encrypted ADD DATAFILE 'ts_encrypted.ibd' ENCRYPTION="Y";
+CREATE TABLE t5 (a varchar(255)) TABLESPACE ts_encrypted ENCRYPTION="Y";
+CREATE TABLESPACE ts_not_encrypted ADD DATAFILE 'ts_not_encrypted.ibd' ENCRYPTION="N";
+CREATE TABLE t6 (a varchar(255)) TABLESPACE ts_not_encrypted;
+CREATE TABLESPACE ts_with_encryption_key_id ADD DATAFILE 'ts_with_encryption_key_id.ibd'  ENCRYPTION_KEY_ID=2;
+CREATE TABLE t7 (a varchar(255)) TABLESPACE ts_with_encryption_key_id;
+CREATE TABLE t8 (a varchar(255)) ENCRYPTION_KEY_ID=3;
+include/assert.inc [TABLE t3 should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION]
+include/assert.inc [TABLE ts_not_encrypted should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION]
+include/assert.inc [All the other tablespaces should have EXCLUDED set to N]
+SET GLOBAL debug="+d,hang_on_ts_with_encryption_key_id_rotation";
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=1;
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='N';
+ERROR HY000: Tablespace ts_with_encryption_key_id cannot be excluded from encryption threads as it is being currently encrypted/decrypted by encryption threads. Please try again later.
+SET GLOBAL debug="-d,hang_on_ts_with_encryption_key_id_rotation";
+SET GLOBAL innodb_encryption_threads=4;
+insert t1 values (repeat('foobarsecret', 12));
+insert t2 values (repeat('tempsecret', 12));
+insert t3 values (repeat('dummysecret', 12));
+insert t4 values (repeat('verysecret', 12));
+insert t5 values (repeat('moresecret', 12));
+insert t6 values (repeat('sooosecret', 12));
+insert t7 values (repeat('notsosecret', 12));
+insert t8 values (repeat('uuuuusecret', 12));
+# Wait max 10 min for key encryption threads to encrypt all spaces
+include/assert.inc [TABLE ts3 should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION]
+include/assert.inc [TABLE ts_not_encrypted should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION]
+include/assert.inc [All the other tablespaces should have EXCLUDED set to N]
+ALTER TABLESPACE ts_encrypted ENCRYPTION='N';
+ERROR HY000: Tablespace ts_encrypted is encrypted by encryption threads and cannot be explicitly decrypted. Please use default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENECRYPTED to decypt the tablespace
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='N';
+ERROR HY000: Tablespace ts_with_encryption_key_id is encrypted by encryption threads and cannot be explicitly decrypted. Please use default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENECRYPTED to decypt the tablespace
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+# Wait max 10 min for key encryption threads to decrypt spaces
+include/assert.inc [TABLE t3 should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION]
+include/assert.inc [TABLE ts_not_encrypted should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION]
+include/assert.inc [All the other tablespaces should have EXCLUDED set to N]
+ALTER TABLE t1 ENCRYPTION='N';
+ALTER TABLE t2 ENCRYPTION='N';
+ALTER TABLE t3 ENCRYPTION='N';
+ALTER TABLE t4 ENCRYPTION='N';
+ALTER TABLESPACE ts_encrypted ENCRYPTION='N';
+ALTER TABLESPACE ts_not_encrypted ENCRYPTION='N';
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='N';
+ALTER TABLE t8 ENCRYPTION='N';
+include/assert.inc [All the ALTERed tables/tablespaces should have EXCLUDED set to Y (i.e. 8 tablespaces)]
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+include/assert.inc [All the ALTERed tables/tablespaces to ENCRYPTION='N' should have EXCLUDED set to Y (i.e. 8 tablespaces)]
+include/assert.inc [All EXCLUDED tablespaces should have MIN_KEY_VERSION = 0]
+include/assert.inc [All tablespace without EXCLUDED set should have MIN_KEY_VERSION = 1]
+# restart
+include/assert.inc [default_table_encryption should be OFF]
+include/assert.inc [encryption threads should be disable]
+include/assert.inc [All the tables/tablespaces with ENCRYPTION='N' should have EXCLUDED set to Y]
+ALTER TABLE t1 ENCRYPTION='KEYRING';
+ALTER TABLE t2 ENCRYPTION='KEYRING';
+ALTER TABLE t3 ENCRYPTION='KEYRING';
+ALTER TABLE t4 ENCRYPTION='KEYRING';
+ALTER TABLESPACE ts_encrypted ENCRYPTION='Y';
+ALTER TABLESPACE ts_not_encrypted ENCRYPTION='Y';
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='Y';
+ALTER TABLE t8 ENCRYPTION='Y';
+include/assert.inc [There should not be any table/tablespace with EXCLUDED=Y]
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8;
+DROP TABLESPACE ts_encrypted;
+DROP TABLESPACE ts_not_encrypted;
+DROP TABLESPACE ts_with_encryption_key_id;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+# Wait max 10 min for key encryption threads to decrypt all spaces
+SET GLOBAL default_table_encryption=OFF;
+SET GLOBAL innodb_encryption_threads=0;

--- a/mysql-test/suite/encryption/t/encrypt_threads_skip_tablespace-master.opt
+++ b/mysql-test/suite/encryption/t/encrypt_threads_skip_tablespace-master.opt
@@ -1,0 +1,6 @@
+$KEYRING_PLUGIN_OPT
+--early-plugin-load="keyring_file=$KEYRING_PLUGIN"
+--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+--default-table-encryption=OFF
+--innodb-encryption-rotate-key-age=15
+--innodb-encryption-threads=0

--- a/mysql-test/suite/encryption/t/encrypt_threads_skip_tablespace.test
+++ b/mysql-test/suite/encryption/t/encrypt_threads_skip_tablespace.test
@@ -1,0 +1,207 @@
+--source include/have_debug.inc
+
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+eval SET @@global.keyring_file_data="$MYSQL_TMP_DIR/mysecret_keyring";
+
+CREATE TABLE t1 (a varchar(255)) ENCRYPTION='KEYRING';
+CREATE TABLE t2 (a varchar(255));
+CREATE TABLE t3 (a varchar(255)) ENCRYPTION='N';
+CREATE TABLE t4 (a varchar(255)) ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=5;
+
+CREATE TABLESPACE ts_encrypted ADD DATAFILE 'ts_encrypted.ibd' ENCRYPTION="Y";
+CREATE TABLE t5 (a varchar(255)) TABLESPACE ts_encrypted ENCRYPTION="Y";
+
+CREATE TABLESPACE ts_not_encrypted ADD DATAFILE 'ts_not_encrypted.ibd' ENCRYPTION="N";
+CREATE TABLE t6 (a varchar(255)) TABLESPACE ts_not_encrypted;
+
+CREATE TABLESPACE ts_with_encryption_key_id ADD DATAFILE 'ts_with_encryption_key_id.ibd'  ENCRYPTION_KEY_ID=2;
+CREATE TABLE t7 (a varchar(255)) TABLESPACE ts_with_encryption_key_id;
+
+CREATE TABLE t8 (a varchar(255)) ENCRYPTION_KEY_ID=3;
+
+--let $assert_text= TABLE t3 should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION
+--let $assert_cond= "[SELECT EXCLUDED FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t3\\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text= TABLE ts_not_encrypted should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION
+--let $assert_cond= "[SELECT EXCLUDED FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'ts_not_encrypted\\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text=All the other tablespaces should have EXCLUDED set to N
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name NOT IN(\\'ts_not_encrypted\\',\\'test/t3\\') AND EXCLUDED = \\'Y\\']" = 0
+--source include/assert.inc
+
+# Try EXCLUDE t1 from rotation while encryption threads are running on it - should result in error
+SET GLOBAL debug="+d,hang_on_ts_with_encryption_key_id_rotation";
+
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+# CURRENT_KEY_ID=10 is a marker that we have reached the hang_on_ts_with_encryption_key_id_rotation
+# Can be only one encryption threads - in other case artifical CURRENT_KEY_ID=10 will cause asserts to fail
+SET GLOBAL innodb_encryption_threads=1;
+
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE CURRENT_KEY_ID=10
+--source include/wait_condition.inc
+
+# Now let's try to exlude ts_encrypted while there are encryption threads running on it.
+# It should fail.
+--error ER_EXCLUDE_ENCRYPTION_THREADS_RUNNING
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='N';
+
+SET GLOBAL debug="-d,hang_on_ts_with_encryption_key_id_rotation";
+
+# Wait for CURRENT_KEY_ID to be restored
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*)=0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE CURRENT_KEY_ID=10
+--source include/wait_condition.inc
+
+SET GLOBAL innodb_encryption_threads=4;
+
+insert t1 values (repeat('foobarsecret', 12));
+insert t2 values (repeat('tempsecret', 12));
+insert t3 values (repeat('dummysecret', 12));
+insert t4 values (repeat('verysecret', 12));
+insert t5 values (repeat('moresecret', 12));
+insert t6 values (repeat('sooosecret', 12));
+insert t7 values (repeat('notsosecret', 12));
+insert t8 values (repeat('uuuuusecret', 12));
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+# - 3 we do not encrypt t3, ts_not_encrypted and temporary tablespace
+--let $wait_condition=SELECT COUNT(*) = $tables_count - 3 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+# Make sure are EXLCUDED flags stays the same after encryption
+
+--let $assert_text= TABLE ts3 should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION
+--let $assert_cond= "[SELECT EXCLUDED FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t3\\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text= TABLE ts_not_encrypted should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION
+--let $assert_cond= "[SELECT EXCLUDED FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'ts_not_encrypted\\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text=All the other tablespaces should have EXCLUDED set to N
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name NOT IN(\\'ts_not_encrypted\\',\\'test/t3\\') AND EXCLUDED=\\'Y\\']" = 0
+--source include/assert.inc
+
+# It should not be possible to EXCLUDE tablespace encrypted by encryption threads
+--error ER_EXPLICIT_DECRYPTION_OF_ONLINE_ENCRYPTED_TABLESPACE
+ALTER TABLESPACE ts_encrypted ENCRYPTION='N';
+--error ER_EXPLICIT_DECRYPTION_OF_ONLINE_ENCRYPTED_TABLESPACE
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='N';
+
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+
+# Make sure that EXLCUDED flags stay the same after decryption
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+--echo # Wait max 10 min for key encryption threads to decrypt spaces
+--let $wait_timeout= 600
+# 2 - the ones with explicit KEYRING encryption: t1,t4 stay encrypted
+--let $wait_condition=SELECT COUNT(*) = 2 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+--let $assert_text= TABLE t3 should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION
+--let $assert_cond= "[SELECT EXCLUDED FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t3\\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text= TABLE ts_not_encrypted should have EXCLUDED set to Y in INNODB_TABLESPACES_ENCRYPTION
+--let $assert_cond= "[SELECT EXCLUDED FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'ts_not_encrypted\\']" = "Y"
+--source include/assert.inc
+
+--let $assert_text=All the other tablespaces should have EXCLUDED set to N
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name NOT IN(\\'ts_not_encrypted\\',\\'test/t3\\') AND EXCLUDED=\\'Y\\']" = 0
+--source include/assert.inc
+
+# Mark all tablespaces with ENCRYPTION='N'. Make sure all have EXCLUDE set to Y.
+
+ALTER TABLE t1 ENCRYPTION='N';
+ALTER TABLE t2 ENCRYPTION='N';
+ALTER TABLE t3 ENCRYPTION='N';
+ALTER TABLE t4 ENCRYPTION='N';
+
+ALTER TABLESPACE ts_encrypted ENCRYPTION='N';
+ALTER TABLESPACE ts_not_encrypted ENCRYPTION='N';
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='N';
+ALTER TABLE t8 ENCRYPTION='N';
+
+--let $assert_text=All the ALTERed tables/tablespaces should have EXCLUDED set to Y (i.e. 8 tablespaces)
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name IN (\\'test/t1\\', \\'test/t2\\',\\'test/t3\\',\\'test/t4\\',\\'test/t8\\',\\'ts_encrypted\\',\\'ts_not_encrypted\\',\\'ts_with_encryption_key_id\\') AND EXCLUDED=\\'Y\\']" = 8
+--source include/assert.inc
+
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+
+# Make sure all tablespaces with EXCLUDED set will not be encrypted and all tablespaces without EXCLUDED set
+# will be encrypted
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE EXCLUDED = 'N' AND MIN_KEY_VERSION = 0
+--source include/wait_condition.inc
+
+--let $assert_text=All the ALTERed tables/tablespaces to ENCRYPTION='N' should have EXCLUDED set to Y (i.e. 8 tablespaces)
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name IN (\\'test/t1\\', \\'test/t2\\',\\'test/t3\\',\\'test/t4\\',\\'test/t8\\',\\'ts_encrypted\\',\\'ts_not_encrypted\\',\\'ts_with_encryption_key_id\\') AND EXCLUDED=\\'Y\\']" = 8
+--source include/assert.inc
+
+--let $assert_text=All EXCLUDED tablespaces should have MIN_KEY_VERSION = 0
+--let $assert_cond= "[SELECT MAX(MIN_KEY_VERSION) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE EXCLUDED = \\'Y\\']" = 0
+--source include/assert.inc
+
+--let $assert_text=All tablespace without EXCLUDED set should have MIN_KEY_VERSION = 1
+--let $assert_cond= "[SELECT MIN(MIN_KEY_VERSION) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE EXCLUDED = \\'N\\']" = 1
+--source include/assert.inc
+
+# check that excluded flags stay the same after the restart
+
+--source include/restart_mysqld.inc
+
+--let $assert_text=default_table_encryption should be OFF
+--let $assert_cond= "[SELECT @@default_table_encryption]" = "OFF";
+--source include/assert.inc
+
+--let $assert_text=encryption threads should be disable
+--let $assert_cond= "[SELECT @@innodb_encryption_threads]" = 0;
+--source include/assert.inc
+
+--let $assert_text=All the tables/tablespaces with ENCRYPTION='N' should have EXCLUDED set to Y
+--let $assert_cond= "[SELECT COUNT(name) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name IN (\\'test/t1\\', \\'test/t2\\',\\'test/t3\\',\\'test/t4\\',\\'test/t8\\',\\'ts_encrypted\\',\\'ts_not_encrypted\\',\\'ts_with_encryption_key_id\\') AND EXCLUDED=\\'Y\\']" = 8
+--source include/assert.inc
+
+# remove exluded flag
+
+ALTER TABLE t1 ENCRYPTION='KEYRING';
+ALTER TABLE t2 ENCRYPTION='KEYRING';
+ALTER TABLE t3 ENCRYPTION='KEYRING';
+ALTER TABLE t4 ENCRYPTION='KEYRING';
+
+ALTER TABLESPACE ts_encrypted ENCRYPTION='Y';
+ALTER TABLESPACE ts_not_encrypted ENCRYPTION='Y';
+ALTER TABLESPACE ts_with_encryption_key_id ENCRYPTION='Y';
+ALTER TABLE t8 ENCRYPTION='Y';
+
+--let $assert_text=There should not be any table/tablespace with EXCLUDED=Y
+--let $assert_cond= "[SELECT COUNT(name) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE EXCLUDED=\\'Y\\']" = 0
+--source include/assert.inc
+
+# cleanup
+DROP TABLE t1,t2,t3,t4,t5,t6,t7,t8;
+DROP TABLESPACE ts_encrypted;
+DROP TABLESPACE ts_not_encrypted;
+DROP TABLESPACE ts_with_encryption_key_id;
+
+# Decrypt everything
+
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+
+--echo # Wait max 10 min for key encryption threads to decrypt all spaces
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0
+--source include/wait_condition.inc
+
+SET GLOBAL default_table_encryption=OFF;
+SET GLOBAL innodb_encryption_threads=0;

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -9198,6 +9198,11 @@ ER_DA_UNDO_NO_KEYRING
 ER_DA_ENCRYPTION_TABLE_CHECK_FAILED
   eng "Table %s is encrypted but decryption failed. Seems that the encryption key fetched from keyring is not the correct one. Are you using the correct keyring?";
 
+ER_EXCLUDE_ENCRYPTION_THREADS_RUNNING
+  eng "Tablespace %s cannot be excluded from encryption threads as it is being currently encrypted/decrypted by encryption threads. Please try again later."
+
+ER_EXPLICIT_DECRYPTION_OF_ONLINE_ENCRYPTED_TABLESPACE
+  eng "Tablespace %s is encrypted by encryption threads and cannot be explicitly decrypted. Please use default-table-encryption=ONLINE_FROM_KEYRING_TO_UNENECRYPTED to decypt the tablespace"
 
 #
 # End of Percona Server 8.0 client messages

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -643,11 +643,9 @@ static MY_ATTRIBUTE((warn_unused_result)) bool innobase_need_rebuild(
   Alter_inplace_info::HA_ALTER_FLAGS alter_inplace_flags =
       ha_alter_info->handler_flags & ~(INNOBASE_INPLACE_IGNORE);
 
-  if ((Encryption::none_explicitly_specified(
-           ha_alter_info->create_info->used_fields,
-           ha_alter_info->create_info->encrypt_type.str) &&
-       (Encryption::is_keyring(old_table->s->encrypt_type.str) ||
-        Encryption::is_empty(old_table->s->encrypt_type.str))) ||
+  if (Encryption::none_explicitly_specified(
+          ha_alter_info->create_info->used_fields,
+          ha_alter_info->create_info->encrypt_type.str) ||
       (Encryption::is_keyring(ha_alter_info->create_info->encrypt_type.str) &&
        !Encryption::is_keyring(old_table->s->encrypt_type.str)) ||
       ha_alter_info->create_info->encryption_key_id !=

--- a/storage/innobase/handler/i_s.cc
+++ b/storage/innobase/handler/i_s.cc
@@ -7560,56 +7560,62 @@ static ST_FIELD_INFO innodb_tablespaces_encryption_fields_info[] = {
      STRUCT_FLD(field_flags, MY_I_S_MAYBE_NULL), STRUCT_FLD(old_name, ""),
      STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_ENCRYPTION_SCHEME 2
+#define TABLESPACES_ENCRYPTION_EXCLUDED 2
+    {STRUCT_FLD(field_name, "EXCLUDED"), STRUCT_FLD(field_length, 1),
+     STRUCT_FLD(field_type, MYSQL_TYPE_STRING), STRUCT_FLD(value, 0),
+     STRUCT_FLD(field_flags, MY_I_S_MAYBE_NULL), STRUCT_FLD(old_name, ""),
+     STRUCT_FLD(open_method, 0)},
+
+#define TABLESPACES_ENCRYPTION_ENCRYPTION_SCHEME 3
     {STRUCT_FLD(field_name, "ENCRYPTION_SCHEME"),
      STRUCT_FLD(field_length, MY_INT32_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED), STRUCT_FLD(old_name, ""),
      STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_KEYSERVER_REQUESTS 3
+#define TABLESPACES_ENCRYPTION_KEYSERVER_REQUESTS 4
     {STRUCT_FLD(field_name, "KEYSERVER_REQUESTS"),
      STRUCT_FLD(field_length, MY_INT32_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED), STRUCT_FLD(old_name, ""),
      STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_MIN_KEY_VERSION 4
+#define TABLESPACES_ENCRYPTION_MIN_KEY_VERSION 5
     {STRUCT_FLD(field_name, "MIN_KEY_VERSION"),
      STRUCT_FLD(field_length, MY_INT32_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED), STRUCT_FLD(old_name, ""),
      STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_CURRENT_KEY_VERSION 5
+#define TABLESPACES_ENCRYPTION_CURRENT_KEY_VERSION 6
     {STRUCT_FLD(field_name, "CURRENT_KEY_VERSION"),
      STRUCT_FLD(field_length, MY_INT32_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED), STRUCT_FLD(old_name, ""),
      STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_KEY_ROTATION_PAGE_NUMBER 6
+#define TABLESPACES_ENCRYPTION_KEY_ROTATION_PAGE_NUMBER 7
     {STRUCT_FLD(field_name, "KEY_ROTATION_PAGE_NUMBER"),
      STRUCT_FLD(field_length, MY_INT64_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONGLONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED | MY_I_S_MAYBE_NULL),
      STRUCT_FLD(old_name, ""), STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_KEY_ROTATION_MAX_PAGE_NUMBER 7
+#define TABLESPACES_ENCRYPTION_KEY_ROTATION_MAX_PAGE_NUMBER 8
     {STRUCT_FLD(field_name, "KEY_ROTATION_MAX_PAGE_NUMBER"),
      STRUCT_FLD(field_length, MY_INT64_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONGLONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED | MY_I_S_MAYBE_NULL),
      STRUCT_FLD(old_name, ""), STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_CURRENT_KEY_ID 8
+#define TABLESPACES_ENCRYPTION_CURRENT_KEY_ID 9
     {STRUCT_FLD(field_name, "CURRENT_KEY_ID"),
      STRUCT_FLD(field_length, MY_INT32_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED), STRUCT_FLD(old_name, ""),
      STRUCT_FLD(open_method, 0)},
 
-#define TABLESPACES_ENCRYPTION_ROTATING_OR_FLUSHING 9
+#define TABLESPACES_ENCRYPTION_ROTATING_OR_FLUSHING 10
     {STRUCT_FLD(field_name, "ROTATING_OR_FLUSHING"),
      STRUCT_FLD(field_length, 1), STRUCT_FLD(field_type, MYSQL_TYPE_LONG),
      STRUCT_FLD(value, 0), STRUCT_FLD(field_flags, MY_I_S_UNSIGNED),
@@ -7644,6 +7650,10 @@ static int i_s_dict_fill_tablespaces_encryption(THD *thd, fil_space_t *space,
   OK(fields[TABLESPACES_ENCRYPTION_SPACE]->store(space->id, true));
 
   OK(field_store_string(fields[TABLESPACES_ENCRYPTION_NAME], space->name));
+
+  OK(field_store_string(
+      fields[TABLESPACES_ENCRYPTION_EXCLUDED],
+      space->crypt_data->is_encryption_disabled() ? "Y" : "N"));
 
   OK(fields[TABLESPACES_ENCRYPTION_ENCRYPTION_SCHEME]->store(status.scheme,
                                                              true));
@@ -7872,7 +7882,7 @@ static ST_FIELD_INFO innodb_tablespaces_scrubbing_fields_info[] = {
      STRUCT_FLD(field_type, MYSQL_TYPE_LONGLONG), STRUCT_FLD(value, 0),
      STRUCT_FLD(field_flags, MY_I_S_UNSIGNED), STRUCT_FLD(old_name, ""),
      STRUCT_FLD(open_method, 0)},
-#define TABLESPACES_ENCRYPTION_ROTATING_OR_FLUSHING 9
+#define TABLESPACES_ENCRYPTION_ROTATING_OR_FLUSHING 10
     {STRUCT_FLD(field_name, "ROTATING_OR_FLUSHING"),
      STRUCT_FLD(field_length, MY_INT32_NUM_DECIMAL_DIGITS),
      STRUCT_FLD(field_type, MYSQL_TYPE_LONG), STRUCT_FLD(value, 0),

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -380,6 +380,15 @@ class redo_log_keys final {
 
 extern redo_log_keys redo_log_key_mgr;
 
+/**
+Exclude tablespace from encryption threads rotation
+@param[in] space tablespace to exclude
+@return false tablespace cannot be excluded because there are encryption
+              threads currently operating on it.
+        true  success
+*/
+bool fil_crypt_exclude_tablespace_from_rotation(fil_space_t *space);
+
 /*********************************************************************
 Init space crypt */
 void fil_space_crypt_init();


### PR DESCRIPTION
threads should be visible via I_S.

Explicit ENCRYPTION='N' is still used to mark tablespace as to be
excluded from encryption threads. i.e. ALTER/CREATE TABLE/TABLESPACE
ENCRYPTION=N will mean that TABLE/TABLESPACE should be excluded from
encryption threads.

The information if TABLE/TABLESPACE is excluded from encryption
threads is visible through I_S table: INNODB_TABLESPACE_ENCRYPTION,
field EXCLUDED.
Due to changes in 8.0.16 we will no longer rely on
SHOW CREATE TABLE to check if ENCRYPTION=’N’ was explicitly
specified.