### PR TITLE
PS-5966: Fixed drifting status variables values (5.7)

### DIFF
--- a/storage/perfschema/pfs_visitor.cc
+++ b/storage/perfschema/pfs_visitor.cc
@@ -1390,7 +1390,9 @@ void PFS_connection_status_visitor::visit_thread(PFS_thread *pfs)
 
 void PFS_connection_status_visitor::visit_THD(THD *thd)
 {
-  add_to_status(m_status_vars, &thd->status_var, false);
+  if (!thd->status_var_aggregated) {
+    add_to_status(m_status_vars, &thd->status_var, false);
+  }
 }
 
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5966

Fixing by skipping already aggregated thread status variables when query for global status variables is invoked.
Variables may be already aggregated, but thread can be still alive after aggregation in sql_class.cc THD::release_resources()