### PR TITLE
PS-5966: Fixed drifting status variables values (8.0)

### DIFF
--- a/storage/perfschema/pfs_visitor.cc
+++ b/storage/perfschema/pfs_visitor.cc
@@ -1390,7 +1390,9 @@ void PFS_connection_status_visitor::visit_thread(PFS_thread *pfs)
 
 void PFS_connection_status_visitor::visit_THD(THD *thd)
 {
-  add_to_status(m_status_vars, &thd->status_var, false);
+  if (!thd->status_var_aggregated) {
+    add_to_status(m_status_vars, &thd->status_var, false);
+  }
 }
 
 


### PR DESCRIPTION
https://ps80.cd.percona.com/job/percona-server-8.0-param/354/