### PR TITLE
PS-5840 - Memory leak in after 'main.threadpool_debug' - in 'Thread_p…

### DIFF
--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1344,7 +1344,8 @@ bool Thread_pool_connection_handler::add_connection(Channel_info *channel_info)
 
   if (unlikely(!connection))
   {
-    thd->get_protocol_classic()->end_net();
+    // channel will be closed by send_error_and_close_channel()
+    thd->get_protocol_classic()->get_vio()->inactive= TRUE;
     delete thd;
     channel_info->send_error_and_close_channel(ER_OUT_OF_RESOURCES, 0, false);
     DBUG_RETURN(true);


### PR DESCRIPTION
…ool_connection_handler::add_connection()'

Problem
If threadpool failed to allocate a connection, vio component allocated
as part of channel_info->create_thd() won't be freed.

Solution
call vio_delete on allocated vio to free up memory.
vio_delete will also close the channel, which particularly in this case
will be handled by send_error_and_close_channel, thus we set
vio->inactive= TRUE in order to avoid it been closed at vio_delete.