### PR TITLE
PS-5921 - Detect memory leaks on stage of bootstrap if PS was built w…

### DIFF
--- a/sql/dd/impl/bootstrap/bootstrapper.cc
+++ b/sql/dd/impl/bootstrap/bootstrapper.cc
@@ -768,6 +768,7 @@ bool DDSE_dict_init(THD *thd, dict_init_mode_t dict_init_mode, uint version) {
       // From now on all DD tables will be created with encryption='y'
     }
   }
+  delete p;
 
   /*
     Iterate over the table definitions and add them to the System_tables


### PR DESCRIPTION
…ith '-DWITH_ASAN'

Problem:
As part of boostrap process, DDSE_dict_init reads proprieties from
the first table in the data dictionary to decide whatever or not
the next tables will be created with encryption. The object that
stores the proprieties of the first table is never destroyed.

Solution:
Call delete on dd::Properties *p object.