### PR TITLE
PS-5979: Redo log encryption initialization error during recovery

### DIFF
--- a/mysql-test/suite/innodb/r/log_encrypt_kill2.result
+++ b/mysql-test/suite/innodb/r/log_encrypt_kill2.result
@@ -1,0 +1,20 @@
+SET GLOBAL innodb_log_checkpoint_now = 1;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = 1;
+CREATE TABLE tne_1(c1 INT, c2 varchar(2000)) ENGINE = InnoDB;
+INSERT INTO tne_1 VALUES (1,REPEAT('a',1990)),(2,REPEAT('b',1990)),(100,REPEAT('c',1990));
+SELECT c1,LEFT(c2,10) FROM tne_1;
+c1	LEFT(c2,10)
+1	aaaaaaaaaa
+2	bbbbbbbbbb
+100	cccccccccc
+# Kill the server
+# Starting server with keyring plugin
+SELECT @@global.innodb_redo_log_encrypt;
+@@global.innodb_redo_log_encrypt
+ON
+#
+# Cleanup
+#
+SET GLOBAL innodb_redo_log_encrypt=OFF;
+DROP TABLE tne_1;

--- a/mysql-test/suite/innodb/t/log_encrypt_kill2.test
+++ b/mysql-test/suite/innodb/t/log_encrypt_kill2.test
@@ -1,0 +1,29 @@
+--source include/have_debug.inc
+
+SET GLOBAL innodb_log_checkpoint_now = 1;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = 1;
+CREATE TABLE tne_1(c1 INT, c2 varchar(2000)) ENGINE = InnoDB;
+INSERT INTO tne_1 VALUES (1,REPEAT('a',1990)),(2,REPEAT('b',1990)),(100,REPEAT('c',1990));
+SELECT c1,LEFT(c2,10) FROM tne_1;
+--source include/kill_mysqld.inc
+
+--echo # Starting server with keyring plugin
+--let $restart_parameters=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT --innodb_redo_log_encrypt=ON
+--replace_regex /\.dll/.so/
+--source include/start_mysqld_no_echo.inc
+
+SELECT @@global.innodb_redo_log_encrypt;
+
+--let $MYSQLD_DATADIR=`select @@datadir`
+--let SEARCH_PATTERN=lCC
+--let SEARCH_FILE=$MYSQLD_DATADIR/ib_logfile0
+--let ABORT_ON=NOT_FOUND
+--source include/search_pattern_in_file.inc
+
+--echo #
+--echo # Cleanup
+--echo #
+--remove_file $MYSQL_TMP_DIR/mysecret_keyring
+SET GLOBAL innodb_redo_log_encrypt=OFF;
+DROP TABLE tne_1;

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2712,12 +2712,12 @@ void undo_rotate_default_master_key() {
 }
 
 bool srv_enable_redo_encryption(THD *thd) {
-  if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_MK) {
-    return srv_enable_redo_encryption_mk(thd);
-  }
-
-  if (srv_redo_log_encrypt == REDO_LOG_ENCRYPT_RK) {
-    return srv_enable_redo_encryption_rk(thd);
+  switch (srv_redo_log_encrypt) {
+    case REDO_LOG_ENCRYPT_ON:
+    case REDO_LOG_ENCRYPT_MK:
+      return srv_enable_redo_encryption_mk(thd);
+    case REDO_LOG_ENCRYPT_RK:
+      return srv_enable_redo_encryption_rk(thd);
   }
 
   return false;


### PR DESCRIPTION
Issue: If redo log encryption was first turned on during crash recovery,
and the "ON" option was used, redo log encryption wasn't initialized
properly.

Fix: handling all options during encryption initialization