### PR TITLE
PS-5997: Add LLVM/clang-9 to Travis CI (5.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,45 +43,49 @@ matrix:
       os: osx
     # 2
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=8    BUILD=RelWithDebInfo
+      env: VERSION=9    BUILD=RelWithDebInfo
       compiler: clang
     # 3
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=Debug
+      env: VERSION=8    BUILD=Debug
       compiler: clang
     # 4
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6.0  BUILD=Debug
+      env: VERSION=7    BUILD=Debug
       compiler: clang
     # 5
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5.0  BUILD=Debug
+      env: VERSION=6.0  BUILD=Debug
       compiler: clang
     # 6
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=4.0  BUILD=Debug
+      env: VERSION=5.0  BUILD=Debug
       compiler: clang
     # 7
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=9    BUILD=Debug
-      compiler: gcc
+      env: VERSION=4.0  BUILD=Debug
+      compiler: clang
     # 8
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=8    BUILD=Debug
+      env: VERSION=9    BUILD=Debug
       compiler: gcc
     # 9
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=Debug
+      env: VERSION=8    BUILD=Debug
       compiler: gcc
     # 10
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=Debug
+      env: VERSION=7    BUILD=Debug
       compiler: gcc
     # 11
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=Debug
+      env: VERSION=6    BUILD=Debug
       compiler: gcc
     # 12
+    - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=Debug
+      compiler: gcc
+    # 13
     - if: repo != percona/percona-server OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=Debug
       compiler: gcc
@@ -95,45 +99,49 @@ matrix:
       os: osx
     # 2
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=8    BUILD=Debug
+      env: VERSION=9    BUILD=Debug
       compiler: clang
     # 3
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo
+      env: VERSION=8    BUILD=RelWithDebInfo
       compiler: clang
     # 4
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=6.0  BUILD=RelWithDebInfo
+      env: VERSION=7    BUILD=RelWithDebInfo
       compiler: clang
     # 5
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=5.0  BUILD=RelWithDebInfo
+      env: VERSION=6.0  BUILD=RelWithDebInfo
       compiler: clang
     # 6
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=4.0  BUILD=RelWithDebInfo
+      env: VERSION=5.0  BUILD=RelWithDebInfo
       compiler: clang
     # 7
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=9    BUILD=RelWithDebInfo
-      compiler: gcc
+      env: VERSION=4.0  BUILD=RelWithDebInfo
+      compiler: clang
     # 8
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=8    BUILD=RelWithDebInfo
+      env: VERSION=9    BUILD=RelWithDebInfo
       compiler: gcc
     # 9
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo
+      env: VERSION=8    BUILD=RelWithDebInfo
       compiler: gcc
     # 10
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo
+      env: VERSION=7    BUILD=RelWithDebInfo
       compiler: gcc
     # 11
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo
+      env: VERSION=6    BUILD=RelWithDebInfo
       compiler: gcc
     # 12
+    - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo
+      compiler: gcc
+    # 13
     - if: branch =~ fullci OR repo = percona/percona-server AND type IN (push, pull_request, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo
       compiler: gcc
@@ -142,45 +150,49 @@ matrix:
     # Configurations to be run after merging a pull request for percona/percona-server
     # 1
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=9    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 2
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 3
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6.0  BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 4
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5.0  BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=6.0  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 5
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=4.0  BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=5.0  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: clang
     # 6
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=9    BUILD=RelWithDebInfo  INVERTED=ON
-      compiler: gcc
+      env: VERSION=4.0  BUILD=RelWithDebInfo  INVERTED=ON
+      compiler: clang
     # 7
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=9    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 8
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=8    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 9
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=7    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 10
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
-      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      env: VERSION=6    BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
     # 11
+    - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
+      env: VERSION=5    BUILD=RelWithDebInfo  INVERTED=ON
+      compiler: gcc
+    # 12
     - if: branch =~ extraci OR repo = percona/percona-server AND type IN (push, cron)
       env: VERSION=4.8  BUILD=RelWithDebInfo  INVERTED=ON
       compiler: gcc
@@ -193,7 +205,7 @@ script:
     echo --- JOB_NUMBER=$JOB_NUMBER TRAVIS_COMMIT=$TRAVIS_COMMIT TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG TRAVIS_BRANCH=$TRAVIS_BRANCH TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST TRAVIS_PULL_REQUEST_BRANCH=$TRAVIS_PULL_REQUEST_BRANCH
 
   - echo --- Perform all Travis jobs or only jobs that are included in ENV_VAR_JOB_NUMBERS list if it is defined;
-    JOB_NUMBERS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36";
+    JOB_NUMBERS="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39";
     if [[ "$ENV_VAR_JOB_NUMBERS" != "" ]]; then
        JOB_NUMBERS=$ENV_VAR_JOB_NUMBERS;
     fi;
@@ -245,13 +257,13 @@ script:
        CC=$CC-$VERSION;
        CXX=$CXX-$VERSION;
        sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
-       sudo -E apt-get -yq --no-install-suggests --no-install-recommends install $CXX $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libssl-dev libevent-dev libmecab-dev libprotobuf-dev protobuf-compiler liblz4-dev libnuma-dev || travis_terminate 1;
+       sudo -E apt-get -yq --allow-unauthenticated --no-install-suggests --no-install-recommends install $CXX $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libssl-dev libevent-dev libmecab-dev libprotobuf-dev protobuf-compiler liblz4-dev libnuma-dev || travis_terminate 1;
        sudo ln -s $(which ccache) /usr/lib/ccache/$CC;
        sudo ln -s $(which ccache) /usr/lib/ccache/$CXX || echo;
     else
        TIMEOUT_CMD=gtimeout;
        brew update;
-       brew install ccache protobuf@3.1; `# protobuf 3.6+ uses C++11 features`;
+       brew install ccache;
        brew link ccache;
        export PATH="/usr/local/opt/ccache/libexec:$PATH";
     fi;
@@ -280,13 +292,9 @@ script:
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       CMAKE_OPT+="
         -DMYSQL_MAINTAINER_MODE=OFF
-        -DWITH_PROTOBUF=system
+        -DWITH_PROTOBUF=bundled
         -DWITH_TOKUDB=OFF
         -DWITH_ROCKSDB=OFF
-        -DPROTOBUF_LIBRARY=/usr/local/opt/protobuf@3.1/lib/libprotobuf.dylib
-        -DPROTOBUF_INCLUDE_DIR=/usr/local/opt/protobuf@3.1/include
-        -DPROTOBUF_PROTOC_EXECUTABLE=/usr/local/opt/protobuf@3.1/bin/protoc
-        -DPROTOBUF_PROTOC_LIBRARY=/usr/local/opt/protobuf@3.1/lib/libprotoc.dylib 
       ";
     else
       CMAKE_OPT+="


### PR DESCRIPTION
This patch also fixes macOS issues with protobuf:
```
protobuf@3.1 was deleted from homebrew/core in commit 4b0eeba74:
  protobuf@3.1: remove
  Closes https://github.com/Homebrew/homebrew-core/issues/45042.
  Signed-off-by: FX Coudert <fxcoudert@gmail.com>
```