### PR TITLE
PS-5842 - Memory leak after 'rocksdb.sys_vars.rocksdb_update_cf_optio…

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -13111,7 +13111,8 @@ static void rocksdb_set_update_cf_options(
   // Reset the pointers regardless of how much success we had with updating
   // the CF options. This will results in consistent behavior and avoids
   // dealing with cases when only a subset of CF-s was successfully updated.
-  *reinterpret_cast<char **>(var_ptr) = my_strdup(0, val, MYF(0));
+  *static_cast<const char **>(var_ptr) =
+      *static_cast<const char *const *>(save);
 
   // Do the real work of applying the changes.
   Rdb_cf_options::Name_to_config_t option_map;


### PR DESCRIPTION
…ns_basic' - in 'sys_var_pluginvar::global_update()'

MyRocks uses update_cf_options option to trigger updates of cf options
using functions like SetOptions. While setting the value of var_ptr
we were copying the value of val leaking the old value of the pointer.
update_cf_options variable is declared with PLUGIN_VAR_MEMALLOC flag,
which will call my_free on previously used resources.

The solution is to use a static cast of save pointer and let
plugin_var_memalloc_global_update take care of freeing allocated
resources.