### PR TITLE
PS-6023: Percona server crashes after a Kerberos password change

### DIFF
--- a/plugin/percona-pam-for-mysql/src/auth_pam_common.c
+++ b/plugin/percona-pam-for-mysql/src/auth_pam_common.c
@@ -93,7 +93,7 @@ static int vio_server_conv (int num_msg, const struct pam_message **msg,
       return PAM_CONV_ERR;
     }
 
-    error= auth_pam_talk_perform(msg[i], resp[i], data, talk_data);
+    error= auth_pam_talk_perform(msg[i], &(*resp)[i], data, talk_data);
     if (error != PAM_SUCCESS)
     {
       auth_pam_client_talk_finalize(talk_data);


### PR DESCRIPTION
response

Problem:

Issue comes when PAM plugin needs to perform dialog consisting of more
than one request/response actions. Response buffer address passed to
auth_pam_talk_perform is invalid for second and subsequent responses.

Fix:

Pass correct response buffer address to auth_pam_talk_perform.