### PR TITLE
PS-5813: Fixed handling of 'none' value for slow_query_log_use_global_control server variable (5.7)

### DIFF
--- a/mysql-test/suite/sys_vars/r/slow_query_log_use_global_control_basic.result
+++ b/mysql-test/suite/sys_vars/r/slow_query_log_use_global_control_basic.result
@@ -1,3 +1,31 @@
 SELECT @@global.slow_query_log_use_global_control;
 @@global.slow_query_log_use_global_control
 
+#
+# Bug PS-5813: Setting 'none' value for slow_query_log_use_global_control throwing error.
+#
+SET @saved_slow_query_log_use_global_control=@@GLOBAL.slow_query_log_use_global_control;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+Variable_name	Value
+slow_query_log_use_global_control	
+SET GLOBAL slow_query_log_use_global_control=none;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+Variable_name	Value
+slow_query_log_use_global_control	
+SET GLOBAL slow_query_log_use_global_control=log_slow_verbosity;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+Variable_name	Value
+slow_query_log_use_global_control	log_slow_verbosity
+SET GLOBAL slow_query_log_use_global_control=NONE;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+Variable_name	Value
+slow_query_log_use_global_control	
+SET GLOBAL slow_query_log_use_global_control=all;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+Variable_name	Value
+slow_query_log_use_global_control	log_slow_filter,log_slow_rate_limit,log_slow_verbosity,long_query_time,min_examined_row_limit
+SET GLOBAL slow_query_log_use_global_control='';
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+Variable_name	Value
+slow_query_log_use_global_control	
+SET GLOBAL slow_query_log_use_global_control=@saved_slow_query_log_use_global_control;

--- a/mysql-test/suite/sys_vars/t/slow_query_log_use_global_control_basic.test
+++ b/mysql-test/suite/sys_vars/t/slow_query_log_use_global_control_basic.test
@@ -1,1 +1,22 @@
 SELECT @@global.slow_query_log_use_global_control;
+
+--echo #
+--echo # Bug PS-5813: Setting 'none' value for slow_query_log_use_global_control throwing error.
+--echo #
+
+SET @saved_slow_query_log_use_global_control=@@GLOBAL.slow_query_log_use_global_control;
+
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+SET GLOBAL slow_query_log_use_global_control=none;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+SET GLOBAL slow_query_log_use_global_control=log_slow_verbosity;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+SET GLOBAL slow_query_log_use_global_control=NONE;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+SET GLOBAL slow_query_log_use_global_control=all;
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+SET GLOBAL slow_query_log_use_global_control='';
+SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
+
+SET GLOBAL slow_query_log_use_global_control=@saved_slow_query_log_use_global_control;
+

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -4414,7 +4414,45 @@ void init_log_slow_verbosity()
 {
   update_slow_query_log_use_global_control(0,0,OPT_GLOBAL);
 }
-static Sys_var_set Sys_slow_query_log_use_global_control(
+
+/**
+  Specialized class that handles "none" value of
+  slow_query_log_use_global_control_set variable.
+  When "none" only value is detected, it is rewriten to empty
+  causing set to be cleared.
+*/
+class Sys_var_set_none: public Sys_var_set {
+public:
+  Sys_var_set_none(const char *name_arg,
+        const char *comment, int flag_args, ptrdiff_t off, size_t size,
+        CMD_LINE getopt, const char *values[], ulonglong def_val, PolyLock *lock =
+        0, enum binlog_status_enum binlog_status_arg = VARIABLE_NOT_IN_BINLOG,
+        on_check_function on_check_func = 0,
+        on_update_function on_update_func = 0, const char *substitute = 0)
+    : Sys_var_set(name_arg, comment, flag_args, off, size, getopt, values,
+          def_val, lock, binlog_status_arg, on_check_func, on_update_func,
+          substitute)
+  {
+  }
+
+  virtual bool do_check(THD *thd, set_var *var)
+  {
+    if (var->value->result_type() == STRING_RESULT) {
+      char buff[STRING_BUFFER_USUAL_SIZE];
+      String str(buff, sizeof(buff), system_charset_info);
+
+      String *res = var->value->val_str(&str);
+      if (res
+          && (res->length() > 0)
+          && (0 == my_strcasecmp(system_charset_info, res->ptr(), "none"))) {
+        var->value = new Item_string("", 0, system_charset_info);
+      }
+    }
+    return Sys_var_set::do_check(thd, var);
+  }
+};
+
+static Sys_var_set_none Sys_slow_query_log_use_global_control(
        "slow_query_log_use_global_control",
        "Choose flags, wich always use the global variables. Multiple flags allowed in a comma-separated string. [none, log_slow_filter, log_slow_rate_limit, log_slow_verbosity, long_query_time, min_examined_row_limit, all]",
        GLOBAL_VAR(opt_slow_query_log_use_global_control), CMD_LINE(REQUIRED_ARG),


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5813

slow_query_log_use_global_control variable was implemented as Sys_var_set class. The purpose of 'none' value is to clear the set, but for Sys_var_set it is done by providing empty value. Specialized class implemented that detects 'none' literal.