### PR TITLE
8.0 PS-5325 Conditional jump or move depends on uninitialised value

### DIFF
--- a/mysql-test/suite/encryption/r/innodb-bad-key-change3.result
+++ b/mysql-test/suite/encryption/r/innodb-bad-key-change3.result
@@ -1,6 +1,8 @@
 call mtr.add_suppression("cannot be decrypted. Are you using correct keyring that contain the");
 call mtr.add_suppression("InnoDB: Tablespace for table .* is set as discarded.");
 call mtr.add_suppression("InnoDB: Cannot calculate statistics for table .* because the .ibd file is missing. Please refer to .* for how to resolve the issue.");
+call mtr.add_suppression("InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("InnoDB: Cannot save statistics for table .* because the .ibd file is missing.");
 CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4;
 SHOW WARNINGS;
 Level	Code	Message

--- a/mysql-test/suite/encryption/t/innodb-bad-key-change3.test
+++ b/mysql-test/suite/encryption/t/innodb-bad-key-change3.test
@@ -6,6 +6,8 @@
 call mtr.add_suppression("cannot be decrypted. Are you using correct keyring that contain the");
 call mtr.add_suppression("InnoDB: Tablespace for table .* is set as discarded.");
 call mtr.add_suppression("InnoDB: Cannot calculate statistics for table .* because the .ibd file is missing. Please refer to .* for how to resolve the issue.");
+call mtr.add_suppression("InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("InnoDB: Cannot save statistics for table .* because the .ibd file is missing.");
 
 
 CREATE TABLE t1 (pk INT PRIMARY KEY, f VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED ENCRYPTION='KEYRING' ENCRYPTION_KEY_ID=4;

--- a/mysql-test/suite/innodb/t/alter_kill.test
+++ b/mysql-test/suite/innodb/t/alter_kill.test
@@ -11,6 +11,7 @@ call mtr.add_suppression("InnoDB: Tablespace open failed for.*bug16720368");
 call mtr.add_suppression("InnoDB: Failed to find tablespace.*bug16720368");
 call mtr.add_suppression("InnoDB: Header page contains inconsistent data in .*bug16720368.ibd");
 call mtr.add_suppression("InnoDB: Could not find.*test/bug16720368");
+call mtr.add_suppression("Trying to access missing tablespace [0-9]+");
 call mtr.add_suppression("Found 1 prepared XA transactions");
 call mtr.add_suppression("InnoDB: .*test.*bug16720368.*missing");
 call mtr.add_suppression("InnoDB: Operating system error.*in a file operation");

--- a/mysql-test/suite/innodb/t/alter_missing_tablespace.test
+++ b/mysql-test/suite/innodb/t/alter_missing_tablespace.test
@@ -24,6 +24,8 @@ EOF
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot calculate statistics for table `test`\.`t` because the \.ibd file is missing");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot delete tablespace [0-9]+ in DISCARD TABLESPACE: Tablespace not found");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Ignoring tablespace .* because it could not be opened");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table `test`\.`t` because the .ibd file is missing.");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Cannot delete tablespace [0-9]+ because it is not found in the tablespace memory cache");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Cannot open datafile for read-only:");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Could not find a valid tablespace file for");
@@ -67,6 +69,7 @@ INSERT INTO `x..d` (a) VALUES (1),(2),(3),(4),(5),(6),(7),(8);
 --disable_query_log
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Failed to find tablespace for table `test`\.`x\.\.d` in the cache");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot calculate statistics for table `test`\.`x\.\.d` because the .ibd file is missing.");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table `test`\.`x\.\.d` because the .ibd file is missing.");
 --enable_query_log
 
 --error ER_TABLESPACE_MISSING

--- a/mysql-test/suite/innodb/t/innodb-multiple-tablespaces.test
+++ b/mysql-test/suite/innodb/t/innodb-multiple-tablespaces.test
@@ -45,6 +45,8 @@ call mtr.add_suppression("\\[ERROR\\] InnoDB: The error means the system cannot 
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Will not open tablespace `test/.*`");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot calculate statistics for table `test`\.`.*` because the \.ibd file is missing");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Ignoring tablespace `test/.*` because it could not be opened.");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table `test`\.`.*` because the \.ibd file is missing.");
 --enable_query_log
 
 --echo #

--- a/mysql-test/suite/innodb/t/innodb-wl5980-discard.test
+++ b/mysql-test/suite/innodb/t/innodb-wl5980-discard.test
@@ -701,5 +701,7 @@ call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot calculate statistics for 
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot delete tablespace .+ in DISCARD TABLESPACE. Tablespace not found");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Ignoring tablespace .* because it could not be opened");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table .* is set as discarded");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table .* because the \.ibd file is missing.");
 -- enable_query_log
 

--- a/mysql-test/suite/innodb/t/missing_tablespaces.test
+++ b/mysql-test/suite/innodb/t/missing_tablespaces.test
@@ -30,6 +30,8 @@ call mtr.add_suppression("\\[ERROR\\] InnoDB: Cannot open datafile for read-only
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Could not find a valid tablespace file for");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Ignoring tablespace .* because it could not be opened");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot calculate statistics for table `\.\.*`\.`\.\.*` because the \.ibd file is missing");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table `\.\.*`\.`\.\.*` because the \.ibd file is missing.");
 --enable_query_log
 
 --error ER_TABLESPACE_MISSING

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -7019,11 +7019,7 @@ ha_innobase::open(
 
 	innobase_copy_frm_flags_from_table_share(ib_table, table->s);
 
-	if (ib_table->is_readable()) {
-		dict_stats_init(ib_table);
-	} else {
-		ib_table->stat_initialized = 1;
-	}
+	dict_stats_init(ib_table);
 
 	MONITOR_INC(MONITOR_TABLE_OPEN);
 


### PR DESCRIPTION
Problem:
As part of DISCARD TABLESPACE, MySQL deinitialize table statistics.
Later if we need to access the table (MySQL allows DDL)
those variables won't have been initialized again. This is a regression
introduced by PS-3829 at [1].

Solution:
Call dict_stats_init even if the table has been discarded.
This will result in dict_stats_report_error been called, which as
part of the error handling will init empty table statistics.
As part of the fix, we need to suppress warnings that will be generated
by dict_stats_report_error on related tests.

[1]:

commit c7f44ee
Author: Robert Golebiowski <robert.golebiowski@percona.com>
Date:   Thu Nov 16 17:53:11 2017 +0100

    PS-3829 : Innodb key rotation. ALPHA

    This PR implements Encryption threads for
    encryption/re-encryption/decryption of
    innodb tablespaces. It is based on MariaDB implementation ported from
    Google's
    patch. With this WL user can:

    1) Change default KEYRING encryption key
    2) Create a new table with KEYRING
    3) Encrypt offline already existing tables with KEYRING (with alter)
    4) Encrypt/re-encrypt online already existing tables with KEYRING (with
    innodb_online_encryption, innodb_online_encryption_rotate_key_age
    variables and innodb_online_encryption_threads) – including tables
    already encrypted with Master Key encryption.
    5) Re-encrypt online already encrypted tables with newer version of
    encryption key (with variables innodb_online_encryption variable,
    innodb_online_encryption_threads,
    innodb_online_encryption_rotate_key_age).

    This WL also fixed the following bugs reported to MariaDB:

    (MDEV-17231) Encryption threads keep re-encrypting/encrypting corrupted
    pages
    (MDEV-17235) Data dictonary is not updated with encryption flags
    (MDEV-17234) In memory crypt_data is updated before page0 is updated
    (MDEV-17233) Page 0 is updated more than once when encryption completes
    (MDEV-17230) encryption_key_id from alter is ignored by encryption
    threads
    (MDEV-17229) Encryption threads ignore innodb_default_encryption_key_id