### PR TITLE
PS-5952, PS-5956: Fix utility user bugs (5.7)

### DIFF
--- a/mysql-test/r/percona_utility_user.result
+++ b/mysql-test/r/percona_utility_user.result
@@ -168,4 +168,9 @@ PROCESSLIST_ID	ATTR_NAME	ATTR_VALUE	ORDINAL_POSITION
 SELECT COUNT(DISTINCT PROCESSLIST_ID) FROM performance_schema.session_connect_attrs;
 COUNT(DISTINCT PROCESSLIST_ID)
 1
+SELECT COUNT(*) from performance_schema.threads where type='FOREGROUND';
+COUNT(*)
+2
+KILL 3;
+ERROR HY000: You are not owner of thread 3
 REVOKE PROXY ON 'frank'@'%' FROM 'root'@'localhost';

--- a/mysql-test/t/percona_utility_user.test
+++ b/mysql-test/t/percona_utility_user.test
@@ -234,7 +234,18 @@ SELECT * FROM performance_schema.accounts WHERE USER="frank";
 SELECT * FROM performance_schema.session_account_connect_attrs;
 SELECT COUNT(DISTINCT PROCESSLIST_ID) FROM performance_schema.session_connect_attrs;
 
+# PS-5952: Utility user visible in performance_schema.threads
+SELECT COUNT(*) from performance_schema.threads where type='FOREGROUND';
+
+
+# PS-5956: Root session must not be allowed to kill Utility user session
+--let conn_id=`select connection_id()`
+
 connection default;
+
+--error ER_KILL_DENIED_ERROR
+--eval KILL $conn_id
+
 disconnect frank;
 
 REVOKE PROXY ON 'frank'@'%' FROM 'root'@'localhost';

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6818,7 +6818,12 @@ static uint kill_one_thread(THD *thd, my_thread_id id, bool only_kill_query)
       slayage if both are string-equal.
     */
 
-    if ((thd->security_context()->check_access(SUPER_ACL)) ||
+    const bool is_utility_connection =
+        acl_is_utility_user(tmp->m_security_ctx->user().str,
+                            tmp->m_security_ctx->host().str,
+                            tmp->m_security_ctx->ip().str);
+
+    if (((thd->security_context()->check_access(SUPER_ACL)) && !is_utility_connection) ||
         thd->security_context()->user_matches(tmp->security_context()))
     {
       /* process the kill only if thread is not already undergoing any kill

--- a/storage/perfschema/pfs.cc
+++ b/storage/perfschema/pfs.cc
@@ -2396,6 +2396,7 @@ void pfs_set_thread_account_v1(const char *user, int user_len,
     so we keep this pfs session dirty. This fixes many, but not all tables.
     The remaining seems to honor m_enabled, so we also set that to false. */
     pfs->m_enabled= false;
+    pfs->m_disable_instrumentation = true;
     return;
   }
 

--- a/storage/perfschema/pfs_instr.cc
+++ b/storage/perfschema/pfs_instr.cc
@@ -525,6 +525,7 @@ PFS_thread* create_thread(PFS_thread_class *klass, const void *identity,
     pfs->m_stmt_lock.set_allocated();
     pfs->m_session_lock.set_allocated();
     pfs->set_enabled(true);
+    pfs->m_disable_instrumentation= false;
     pfs->set_history(true);
     pfs->m_class= klass;
     pfs->m_events_waits_current= & pfs->m_events_waits_stack[WAIT_STACK_BOTTOM];

--- a/storage/perfschema/pfs_instr.h
+++ b/storage/perfschema/pfs_instr.h
@@ -344,6 +344,7 @@ struct PFS_ALIGNED PFS_thread : PFS_connection_slice
 
   /** Thread instrumentation flag. */
   bool m_enabled;
+  bool m_disable_instrumentation;
   /** Thread history instrumentation flag. */
   bool m_history;
 

--- a/storage/perfschema/table_threads.cc
+++ b/storage/perfschema/table_threads.cc
@@ -242,12 +242,15 @@ void table_threads::make_row(PFS_thread *pfs)
   m_row.m_connection_type = pfs->m_connection_type;
 
 
-  m_row.m_enabled= pfs->m_enabled;
+  m_row.m_enabled= !pfs->m_disable_instrumentation && pfs->m_enabled;
   m_row.m_history= pfs->m_history;
   m_row.m_psi= pfs;
 
   if (pfs->m_lock.end_optimistic_lock(& lock))
     m_row_exists= true;
+
+  if(pfs->m_disable_instrumentation)
+    m_row_exists= false;
 }
 
 int table_threads::read_row_values(TABLE *table,


### PR DESCRIPTION
PS-5952: Utility user visible in performance_schema.threads
PS-5956: Root session must not be allowed to kill Utility user session

(cherry picked from commit c6ac4db9d10be35526ff755aa7963c863bafa643)