### PR TITLE
PS-5952, PS-5956: Fix utility user bugs (8.0)

### DIFF
--- a/mysql-test/r/percona_utility_user.result
+++ b/mysql-test/r/percona_utility_user.result
@@ -163,4 +163,9 @@ PROCESSLIST_ID	ATTR_NAME	ATTR_VALUE	ORDINAL_POSITION
 SELECT COUNT(DISTINCT PROCESSLIST_ID) FROM performance_schema.session_connect_attrs;
 COUNT(DISTINCT PROCESSLIST_ID)
 1
+SELECT COUNT(*) from performance_schema.threads where type='FOREGROUND';
+COUNT(*)
+3
+KILL 9;
+ERROR HY000: You are not owner of thread 9
 REVOKE PROXY ON 'frank'@'%' FROM 'root'@'localhost';

--- a/mysql-test/t/percona_utility_user.test
+++ b/mysql-test/t/percona_utility_user.test
@@ -233,7 +233,18 @@ SELECT * FROM performance_schema.accounts WHERE USER="frank";
 SELECT * FROM performance_schema.session_account_connect_attrs;
 SELECT COUNT(DISTINCT PROCESSLIST_ID) FROM performance_schema.session_connect_attrs;
 
+# PS-5952: Utility user visible in performance_schema.threads
+SELECT COUNT(*) from performance_schema.threads where type='FOREGROUND';
+
+
+# PS-5956: Root session must not be allowed to kill Utility user session
+--let conn_id=`select connection_id()`
+
 connection default;
+
+--error ER_KILL_DENIED_ERROR
+--eval KILL $conn_id
+
 disconnect frank;
 
 REVOKE PROXY ON 'frank'@'%' FROM 'root'@'localhost';

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -6663,8 +6663,13 @@ static uint kill_one_thread(THD *thd, my_thread_id id, bool only_kill_query) {
       slayage if both are string-equal.
     */
 
-    if (sctx->check_access(SUPER_ACL) ||
-        sctx->has_global_grant(STRING_WITH_LEN("CONNECTION_ADMIN")).first ||
+    const bool is_utility_connection = acl_is_utility_user(
+        tmp->m_security_ctx->user().str, tmp->m_security_ctx->host().str,
+        tmp->m_security_ctx->ip().str);
+
+    if (((sctx->check_access(SUPER_ACL) ||
+          sctx->has_global_grant(STRING_WITH_LEN("CONNECTION_ADMIN")).first) &&
+         !is_utility_connection) ||
         sctx->user_matches(tmp->security_context())) {
       /*
         Process the kill:

--- a/storage/perfschema/pfs.cc
+++ b/storage/perfschema/pfs.cc
@@ -3091,6 +3091,7 @@ void pfs_set_thread_account_vc(const char *user, int user_len, const char *host,
     so we keep this pfs session dirty. This fixes many, but not all tables.
     The remaining seems to honor m_enabled, so we also set that to false. */
     pfs->m_enabled = false;
+    pfs->m_disable_instrumentation = true;
     return;
   }
 

--- a/storage/perfschema/pfs_instr.cc
+++ b/storage/perfschema/pfs_instr.cc
@@ -536,6 +536,7 @@ PFS_thread *create_thread(PFS_thread_class *klass,
     pfs->m_stmt_lock.set_allocated();
     pfs->m_session_lock.set_allocated();
     pfs->set_enabled(klass->m_enabled);
+    pfs->m_disable_instrumentation = false;
     pfs->set_history(klass->m_history);
     pfs->m_class = klass;
     pfs->m_events_waits_current = &pfs->m_events_waits_stack[WAIT_STACK_BOTTOM];

--- a/storage/perfschema/pfs_instr.h
+++ b/storage/perfschema/pfs_instr.h
@@ -343,6 +343,7 @@ struct PFS_ALIGNED PFS_thread : PFS_connection_slice {
 
   /** Thread instrumentation flag. */
   bool m_enabled;
+  bool m_disable_instrumentation;
   /** Thread history instrumentation flag. */
   bool m_history;
 

--- a/storage/perfschema/table_threads.cc
+++ b/storage/perfschema/table_threads.cc
@@ -224,6 +224,10 @@ int table_threads::make_row(PFS_thread *pfs) {
     return HA_ERR_RECORD_DELETED;
   }
 
+  if (pfs->m_disable_instrumentation) {
+    return HA_ERR_RECORD_DELETED;
+  }
+
   m_row.m_thread_internal_id = pfs->m_thread_internal_id;
   m_row.m_parent_thread_internal_id = pfs->m_parent_thread_internal_id;
   m_row.m_processlist_id = pfs->m_processlist_id;
@@ -334,7 +338,7 @@ int table_threads::make_row(PFS_thread *pfs) {
   }
   m_row.m_connection_type = pfs->m_connection_type;
 
-  m_row.m_enabled = pfs->m_enabled;
+  m_row.m_enabled = !pfs->m_disable_instrumentation && pfs->m_enabled;
   m_row.m_history = pfs->m_history;
   m_row.m_psi = pfs;
 


### PR DESCRIPTION
PS-5952: Utility user visible in performance_schema.threads
PS-5956: Root session must not be allowed to kill Utility user session

(cherry picked from commit c6ac4db9d10be35526ff755aa7963c863bafa643)
(cherry picked from commit 14718d380573a30c4e328dc06a3c7eb1bd16ad05)