### PR TITLE
PS-5996: MTR test fails on platforms with OpenSSL 1.1.1

### DIFF
--- a/mysql-test/t/ssl_bug75311-master.opt
+++ b/mysql-test/t/ssl_bug75311-master.opt
@@ -1,1 +1,6 @@
---ssl-cipher=DHE-RSA-AES256-SHA
+# Let's make this test generic for servers linked with OpenSSL ver < 1.1.1 (without TLSv1.3) and >= 1.1.1 (with TLSv1.3)
+# --tls-ciphersuites=       - no default TLSv1.3 ciphers
+# --ssl-cipher=             - we need only this TLSv1.2 cipher
+# --tls-version=            - server accepts only TLSv1.2
+
+--ssl-cipher=DHE-RSA-AES256-SHA --tls-ciphersuites= --tls-version=TLSv1.2


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5996

Restricted list of available ciphers to common set on builds with OpenSSL ver < 1.1.1 and OpenSSL ver >= 1.1.1.
Restricted list of available TLS protocols to the common set as well.
Such restriction makes protocol negotiation to be the same on both build kinds which results with the same test outputs.