### PR TITLE
PS-4653 Extended mysqlbinlog doc page should only discuss --compress

### DIFF
--- a/doc/source/flexibility/extended_mysqlbinlog.rst
+++ b/doc/source/flexibility/extended_mysqlbinlog.rst
@@ -4,30 +4,21 @@
 Extended ``mysqlbinlog``
 ========================
 
-|Percona Server| has implemented compression support for
-:command:`mysqlbinlog`. This is similar to support that both ``mysql`` and
-``mysqldump`` programs include (the ``-C``, ``--compress`` options "Use
-compression in server/client protocol"). Using the compressed protocol helps
-reduce the bandwidth use and speed up transfers. 
+|Percona Server| has implemented protocol compression support for the
+:command:`mysqlbinlog` command. 
 
-|Percona Server| has also implemented support for ``SSL``.
-:command:`mysqlbinlog` now accepts the ``SSL`` connection options as all the
-other client programs. This feature can be useful with
-``--read-from-remote-server`` option. Following ``SSL`` options are now
-available:
+You can request protocol compression when connecting to a remote server to
+transfer binary log files. The protocol compression helps reduce the
+bandwidth use and improves the transfer speed.
 
- * :option:`--ssl` - Enable SSL for connection (automatically enabled with
-   other flags).
- * :option:`--ssl-ca=name` - CA file in PEM format (check OpenSSL docs,
-   implies --ssl).
- * :option:`--ssl-capath=name` - CA directory (check OpenSSL docs, implies
-   --ssl).
- * :option:`--ssl-cert=name` - X509 cert in PEM format (implies --ssl).
- * :option:`--ssl-cipher=name` - SSL cipher to use (implies --ssl).
- * :option:`--ssl-key=name` - X509 key in PEM format (implies --ssl).
- * :option:`--ssl-verify-server-cert` - Verify server's "Common Name" in its
-   cert against hostname used when connecting. This option is disabled by
-   default.
+In the `mysqlbinlog utility
+<https://dev.mysql.com/doc/refman/5.7/en/mysqlbinlog.html>`__ add either the
+``--compress`` or ``-C`` flag to the command-line options.
+
+.. code-block:: MySQL
+
+    $ mysqlbinlog [--compress|-C] --remote-server
+
 
 Version Specific Information
 ============================


### PR DESCRIPTION
Removed ssl information from extended_mysqlbinlog
Rewrote the compression paragraphs.
Added example