### PR TITLE
PS-6051: After 8.0.17 has been merged encryption mtr tests started to

### DIFF
--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -263,7 +263,7 @@ extern uint srv_fil_crypt_rotate_key_age;
 extern ib_mutex_t fil_crypt_threads_mutex;
 extern ib_mutex_t fil_crypt_list_mutex;
 
-extern uint srv_n_fil_crypt_threads;
+extern uint srv_n_fil_crypt_threads_requested;
 
 enum fil_load_status {
   /** The tablespace file(s) were found and valid. */
@@ -2447,7 +2447,7 @@ dberr_t Fil_shard::get_file_size(fil_node_t *file, bool read_only_mode) {
         space->crypt_data->min_key_version != 0)) &&
       FSP_FLAGS_GET_ENCRYPTION(fil_space_flags) !=
           FSP_FLAGS_GET_ENCRYPTION(header_fsp_flags)) {
-    if (srv_n_fil_crypt_threads == 0) {
+    if (srv_n_fil_crypt_threads_requested == 0) {
       ib::warn() << "Table encryption flag is "
                  << (FSP_FLAGS_GET_ENCRYPTION(fil_space_flags) ? "ON" : "OFF")
                  << " in the data dictionary but the encryption flag in file "

--- a/storage/innobase/fsp/fsp0file.cc
+++ b/storage/innobase/fsp/fsp0file.cc
@@ -419,7 +419,7 @@ Datafile::ValidateOutput Datafile::validate_to_dd(space_id_t space_id,
         output.keyring_encryption_info.keyring_encryption_min_key_version !=
             0)) &&
       FSP_FLAGS_GET_ENCRYPTION(flags) != FSP_FLAGS_GET_ENCRYPTION(m_flags)) {
-    if (srv_n_fil_crypt_threads == 0) {
+    if (srv_n_fil_crypt_threads_requested == 0) {
       ib::warn() << "In file '" << m_filepath
                  << "' (tablespace id = " << m_space_id
                  << ") encryption flag is "

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -5290,7 +5290,7 @@ static int innodb_init(void *p) {
   }
 
   // We are starting encryption threads, we must lock the keyring plugins
-  if (srv_n_fil_crypt_threads > 0) {
+  if (srv_n_fil_crypt_threads_requested > 0) {
     uint number_of_keyring_locked = lock_keyrings(NULL);
 
     if (number_of_keyring_locked == 0) {
@@ -22542,7 +22542,7 @@ static int innodb_encryption_threads_validate(
     DBUG_RETURN(1);
   }
 
-  if (srv_n_fil_crypt_threads == 0 &&
+  if (srv_n_fil_crypt_threads_requested == 0 &&
       intbuf > 0) {  // We are starting encryption threads, we must lock
                      // the keyring plugins
     uint number_of_keyrings_locked = lock_keyrings(NULL);
@@ -22563,9 +22563,9 @@ static int innodb_encryption_threads_validate(
       unlock_keyrings(NULL);
       DBUG_RETURN(1);
     }
-  } else if (intbuf == 0 &&
-             srv_n_fil_crypt_threads > 0) {  // We are disabling encryption
-                                             // threads, unlock the keyrings
+  } else if (intbuf == 0 && srv_n_fil_crypt_threads_requested >
+                                0) {  // We are disabling encryption
+                                      // threads, unlock the keyrings
     unlock_keyrings(NULL);
   }
 
@@ -24071,11 +24071,11 @@ static MYSQL_SYSVAR_BOOL(encrypt_online_alter_logs,
                          "Encrypt online alter logs.", nullptr, nullptr, false);
 
 static MYSQL_SYSVAR_UINT(
-    encryption_threads, srv_n_fil_crypt_threads, PLUGIN_VAR_RQCMDARG,
+    encryption_threads, srv_n_fil_crypt_threads_requested, PLUGIN_VAR_RQCMDARG,
     "Number of threads performing background key rotation and "
     "scrubbing",
     innodb_encryption_threads_validate, innodb_encryption_threads_update,
-    srv_n_fil_crypt_threads, 0, UINT_MAX32, 0);
+    srv_n_fil_crypt_threads_requested, 0, UINT_MAX32, 0);
 
 static MYSQL_SYSVAR_UINT(encryption_rotate_key_age,
                          srv_fil_crypt_rotate_key_age, PLUGIN_VAR_RQCMDARG,

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -127,7 +127,7 @@ struct Cached_key {
 extern enum_default_table_encryption srv_default_table_encryption;
 
 struct fil_space_rotate_state_t {
-  fil_space_rotate_state_t() : trx(NULL), flush_observer(NULL) {}
+  fil_space_rotate_state_t() : trx(nullptr), flush_observer(nullptr) {}
 
   time_t start_time;          /*!< time when rotation started */
   ulint active_threads;       /*!< active threads in space */

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -282,8 +282,8 @@ struct Srv_threads {
   /** true if tablespace alter encrypt thread is created */
   bool m_ts_alter_encrypt_thread_active;
 
-  /** true if there is keyring encryption thread running */
-  bool m_encryption_threads_active;
+  /** No of key rotation threads started */
+  size_t m_crypt_threads_n = 0;
 };
 
 /** Check if given thread is still active. */
@@ -433,8 +433,7 @@ extern ulong srv_rollback_segments;
 /** Maximum size of undo tablespace. */
 extern unsigned long long srv_max_undo_tablespace_size;
 
-extern uint srv_n_fil_crypt_threads;
-extern uint srv_n_fil_crypt_threads_started;
+extern uint srv_n_fil_crypt_threads_requested;
 
 /** Rate at which UNDO records should be purged. */
 extern ulong srv_purge_rseg_truncate_frequency;

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -1797,7 +1797,7 @@ void srv_shutdown_all_bg_threads() {
         os_event_set(log_scrub_event);
       }
 
-      if (srv_n_fil_crypt_threads_started) {
+      if (srv_threads.m_crypt_threads_n) {
         os_event_set(fil_crypt_threads_event);
       }
     }
@@ -3363,7 +3363,7 @@ void srv_pre_dd_shutdown() {
       }
     }
 
-    if (srv_threads.m_encryption_threads_active) {
+    if (srv_threads.m_crypt_threads_n > 0) {
       wait = true;
       if ((count % 600) == 0) {
         ib::info(ER_XB_MSG_WAIT_FOR_KEYRING_ENCRYPT_THREAD)


### PR DESCRIPTION
fail.

All transaction related objects should be freed before thread is marked
as inactive. It means calling destroy_thd (where transaction object
associated with THD is freed) before setting srv_threads.m_encryption_threads_active
to false (marking thread as inactive).