### PR TITLE
PS-5738: Decrease size of KEYRING encryption information on page0

### DIFF
--- a/mysql-test/suite/encryption/r/upgrade_crypt_data_57_v1.result
+++ b/mysql-test/suite/encryption/r/upgrade_crypt_data_57_v1.result
@@ -1,0 +1,35 @@
+# Set different paths for --datadir
+# Check that the file exists in the working folder.
+# Unzip the zip file.
+# Stop DB server which was created by MTR default
+# Start the 8.0.18 server on 5.7 datadir that contains tables with crypt_data v1
+# restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=MYSQLD_DATADIR1 --keyring_file_data=MYSQL_TMP_DIR/data_57_crypt_v1/mysecret_keyring KEYRING_PLUGIN_OPT KEYRING_PLUGIN_EARLY_LOAD
+# Now we will check if the encryption will finish off correctly on the tables with crypt_data v1
+# and if the tables are readable. The tables were created in 5.7 as:
+#CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='Y';
+#CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='KEYRING';
+#CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION_KEY_ID=4;
+#CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='N';
+include/assert.inc [table t4 should have excluded set to Y]
+SET GLOBAL innodb_encryption_threads = 4;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+30000
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+30000
+SELECT COUNT(*) FROM t3;
+COUNT(*)
+30000
+SELECT COUNT(*) FROM t4;
+COUNT(*)
+30000
+# restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=MYSQLD_DATADIR1 --keyring_file_data=MYSQL_TMP_DIR/data_57_crypt_v1/mysecret_keyring KEYRING_PLUGIN_OPT KEYRING_PLUGIN_EARLY_LOAD
+# Remove copied files
+# Restart the server with default options.
+# restart
+SELECT 1;
+1
+1

--- a/mysql-test/suite/encryption/r/upgrade_crypt_data_v1.result
+++ b/mysql-test/suite/encryption/r/upgrade_crypt_data_v1.result
@@ -1,0 +1,38 @@
+# Set different paths for --datadir
+# Check that the file exists in the working folder.
+# Unzip the zip file.
+# Stop DB server which was created by MTR default
+# Restart the server on 8.0.16 directory with tables with crypt data v1. The tables were created as:
+# CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='Y';
+# CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='KEYRING';
+# CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255));
+# CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION_KEY_ID=4;
+# CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='N';
+# CREATE TABLE t6 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION_KEY_ID=4;
+# Table t1 is the only table because of which the upgrade is not possible. This is because it is only partially re-encrypted
+# from master key encryption to online keyring encryption.
+# Remove the problematic tablespace and re-try the upgrade. It should pass.
+# Start the 8.0.18 server on 8.0.16 datadir
+# restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=MYSQLD_DATADIR1 --keyring_file_data=MYSQL_TMP_DIR/data_8016_crypt_v1/mysecret_keyring KEYRING_PLUGIN_OPT KEYRING_PLUGIN_EARLY_LOAD
+SET GLOBAL innodb_encryption_threads = 4;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+SELECT COUNT(*) FROM t2;
+COUNT(*)
+30000
+SELECT COUNT(*) FROM t3;
+COUNT(*)
+30000
+SELECT COUNT(*) FROM t4;
+COUNT(*)
+30000
+SELECT COUNT(*) FROM t5;
+COUNT(*)
+30000
+SELECT COUNT(*) FROM t6;
+COUNT(*)
+30000
+# restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=MYSQLD_DATADIR1 --keyring_file_data=MYSQL_TMP_DIR/data_8016_crypt_v1/mysecret_keyring KEYRING_PLUGIN_OPT KEYRING_PLUGIN_EARLY_LOAD
+# Remove copied files
+# Restart the server with default options.
+# restart

--- a/mysql-test/suite/encryption/t/upgrade_crypt_data_57_v1-master.opt
+++ b/mysql-test/suite/encryption/t/upgrade_crypt_data_57_v1-master.opt
@@ -1,0 +1,1 @@
+--initialize --innodb_page_size=16k

--- a/mysql-test/suite/encryption/t/upgrade_crypt_data_57_v1.test
+++ b/mysql-test/suite/encryption/t/upgrade_crypt_data_57_v1.test
@@ -1,0 +1,114 @@
+# This test contains keyring file created on 64bit which is not
+# portable
+--source include/have_64bit.inc
+--source include/no_valgrind_without_big.inc
+--source include/have_util_unzip.inc
+--source include/have_debug.inc
+
+--disable_query_log
+call mtr.add_suppression("Resizing redo log from");
+call mtr.add_suppression("Upgrading redo log");
+call mtr.add_suppression("Starting to delete and rewrite log files");
+call mtr.add_suppression("New log files created");
+call mtr.add_suppression("Unknown system variable 'show_compatibility_56'");
+call mtr.add_suppression("You need to use --log-bin to make --binlog-format work");
+call mtr.add_suppression("Creating routine without parsing routine body");
+call mtr.add_suppression("Resolving dependency for the view");
+call mtr.add_suppression("references invalid");
+call mtr.add_suppression("doesn't exist");
+call mtr.add_suppression("information_schema");
+call mtr.add_suppression("Storage engine '.*' does not support system tables. \\[mysql.*\\]");
+call mtr.add_suppression("Table 'mysql.component' doesn't exist");
+call mtr.add_suppression("is expected to be transactional");
+call mtr.add_suppression("table is missing or has an incorrect definition");
+call mtr.add_suppression("ACL DDLs will not work unless mysql_upgrade is executed");
+call mtr.add_suppression("Native table .* has the wrong structure");
+call mtr.add_suppression("Column count of mysql.* is wrong");
+call mtr.add_suppression("Cannot open table mysql/version from the internal data dictionary of InnoDB though the .frm file for the table exists");
+call mtr.add_suppression("Column count of performance_schema.events_statements_summary_by_digest is wrong");
+call mtr.add_suppression("The privilege system failed to initialize correctly");
+call mtr.add_suppression("Missing system table mysql.global_grants");
+# InnoDB reports "Lock wait timeout" warnings when it tries to drop persistent
+# statistics while persistent statistics table is altered during upgrade.
+# This issue doesn't seem to cause any further trouble (as there is no persistent
+# stats for persistent stats table anyway), so we ignore these warnings here.
+call mtr.add_suppression("Unable to delete statistics for table mysql.");
+# new fields were added to these tables
+call mtr.add_suppression("Column count of performance_schema.replication_group_members is wrong. Expected 7, found 5");
+call mtr.add_suppression("Column count of performance_schema.replication_group_member_stats is wrong. Expected 13, found 9");
+call mtr.add_suppression("Column count of performance_schema.threads is wrong. Expected 18, found 17");
+call mtr.add_suppression("ACL table mysql.[a-zA-Z_]* missing. Some operations may fail.");
+call mtr.add_suppression("Info table is not ready to be used. Table 'mysql.slave_master_info' cannot be opened");
+call mtr.add_suppression("Error in checking mysql.slave_master_info repository info type of TABLE");
+call mtr.add_suppression("Error creating master info: Error checking repositories.");
+call mtr.add_suppression("Slave: Failed to initialize the master info structure for channel");
+call mtr.add_suppression("Failed to create or recover replication info repositories.");
+call mtr.add_suppression("db.opt file not found for test database. Using default Character set");
+call mtr.add_suppression("Skip re-populating collations and character sets tables in InnoDB read-only mode");
+call mtr.add_suppression("Skipped updating resource group metadata in InnoDB read only mode");
+--enable_query_log
+
+--echo # Set different paths for --datadir
+let $MYSQLD_DATADIR1 = $MYSQL_TMP_DIR/data_57_crypt_v1/data;
+
+--copy_file $MYSQLTEST_VARDIR/std_data/data_57_crypt_v1.zip $MYSQL_TMP_DIR/data_57_crypt_v1.zip
+
+--echo # Check that the file exists in the working folder.
+--file_exists $MYSQL_TMP_DIR/data_57_crypt_v1.zip
+
+--echo # Unzip the zip file.
+--exec unzip -qo $MYSQL_TMP_DIR/data_57_crypt_v1.zip -d $MYSQL_TMP_DIR
+
+--let $MYSQLD_DATADIR=`SELECT @@datadir`
+
+--echo # Stop DB server which was created by MTR default
+--source include/shutdown_mysqld.inc
+
+--echo # Start the 8.0.18 server on 5.7 datadir that contains tables with crypt_data v1
+--let $restart_parameters = "restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=$MYSQLD_DATADIR1 --keyring_file_data=$MYSQL_TMP_DIR/data_57_crypt_v1/mysecret_keyring $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD"
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1 $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD KEYRING_PLUGIN_EARLY_LOAD
+--source include/start_mysqld.inc
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+
+--echo # Now we will check if the encryption will finish off correctly on the tables with crypt_data v1
+--echo # and if the tables are readable. The tables were created in 5.7 as:
+--echo #CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='Y';
+--echo #CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='KEYRING';
+--echo #CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION_KEY_ID=4;
+--echo #CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='N';
+
+--let $assert_text= table t4 should have excluded set to Y
+--let $assert_cond= "[SELECT EXCLUDED FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t4\\']" = "Y"
+--source include/assert.inc
+
+SET GLOBAL innodb_encryption_threads = 4;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+# All tables should get encrypted. tables_count - 2 because temporary tablespace, t4 are not encrypted and.
+--let $wait_condition=SELECT COUNT(*) = $tables_count - 2 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+SELECT COUNT(*) FROM t1;
+SELECT COUNT(*) FROM t2;
+SELECT COUNT(*) FROM t3;
+SELECT COUNT(*) FROM t4;
+
+# Check if server restarts correctly
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1 $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD KEYRING_PLUGIN_EARLY_LOAD
+--source include/restart_mysqld.inc
+
+--source include/shutdown_mysqld.inc
+
+--echo # Remove copied files
+--remove_file $MYSQL_TMP_DIR/data_57_crypt_v1.zip
+
+--force-rmdir $MYSQL_TMP_DIR/data_57_crypt_v1
+
+--echo # Restart the server with default options.
+--let $restart_parameters=
+--source include/start_mysqld.inc
+
+SELECT 1;

--- a/mysql-test/suite/encryption/t/upgrade_crypt_data_v1-master.opt
+++ b/mysql-test/suite/encryption/t/upgrade_crypt_data_v1-master.opt
@@ -1,0 +1,1 @@
+--initialize --innodb_page_size=16k

--- a/mysql-test/suite/encryption/t/upgrade_crypt_data_v1.test
+++ b/mysql-test/suite/encryption/t/upgrade_crypt_data_v1.test
@@ -1,0 +1,128 @@
+# This test contains keyring file created on 64bit which is not
+# portable
+--source include/have_64bit.inc
+--source include/no_valgrind_without_big.inc
+--source include/have_util_unzip.inc
+--source include/have_debug.inc
+
+--disable_query_log
+call mtr.add_suppression("Resizing redo log from");
+call mtr.add_suppression("Upgrading redo log");
+call mtr.add_suppression("Starting to delete and rewrite log files");
+call mtr.add_suppression("New log files created");
+call mtr.add_suppression("Unknown system variable 'show_compatibility_56'");
+call mtr.add_suppression("You need to use --log-bin to make --binlog-format work");
+call mtr.add_suppression("Creating routine without parsing routine body");
+call mtr.add_suppression("Resolving dependency for the view");
+call mtr.add_suppression("references invalid");
+call mtr.add_suppression("doesn't exist");
+call mtr.add_suppression("information_schema");
+call mtr.add_suppression("Storage engine '.*' does not support system tables. \\[mysql.*\\]");
+call mtr.add_suppression("Table 'mysql.component' doesn't exist");
+call mtr.add_suppression("is expected to be transactional");
+call mtr.add_suppression("table is missing or has an incorrect definition");
+call mtr.add_suppression("ACL DDLs will not work unless mysql_upgrade is executed");
+call mtr.add_suppression("Native table .* has the wrong structure");
+call mtr.add_suppression("Column count of mysql.* is wrong");
+call mtr.add_suppression("Cannot open table mysql/version from the internal data dictionary of InnoDB though the .frm file for the table exists");
+call mtr.add_suppression("Column count of performance_schema.events_statements_summary_by_digest is wrong");
+call mtr.add_suppression("The privilege system failed to initialize correctly");
+call mtr.add_suppression("Missing system table mysql.global_grants");
+# InnoDB reports "Lock wait timeout" warnings when it tries to drop persistent
+# statistics while persistent statistics table is altered during upgrade.
+# This issue doesn't seem to cause any further trouble (as there is no persistent
+# stats for persistent stats table anyway), so we ignore these warnings here.
+call mtr.add_suppression("Unable to delete statistics for table mysql.");
+# new fields were added to these tables
+call mtr.add_suppression("Column count of performance_schema.replication_group_members is wrong. Expected 7, found 5");
+call mtr.add_suppression("Column count of performance_schema.replication_group_member_stats is wrong. Expected 13, found 9");
+call mtr.add_suppression("Column count of performance_schema.threads is wrong. Expected 18, found 17");
+call mtr.add_suppression("ACL table mysql.[a-zA-Z_]* missing. Some operations may fail.");
+call mtr.add_suppression("Info table is not ready to be used. Table 'mysql.slave_master_info' cannot be opened");
+call mtr.add_suppression("Error in checking mysql.slave_master_info repository info type of TABLE");
+call mtr.add_suppression("Error creating master info: Error checking repositories.");
+call mtr.add_suppression("Slave: Failed to initialize the master info structure for channel");
+call mtr.add_suppression("Failed to create or recover replication info repositories.");
+call mtr.add_suppression("db.opt file not found for test database. Using default Character set");
+call mtr.add_suppression("Skip re-populating collations and character sets tables in InnoDB read-only mode");
+call mtr.add_suppression("Skipped updating resource group metadata in InnoDB read only mode");
+call mtr.add_suppression("file './test/t1.ibd' is missing!");
+#TODO : This warning is caused by bug#
+call mtr.add_suppression("Table encryption flag is OFF in the data dictionary but the encryption flag in file ./test/t6.ibd is ON.");
+--enable_query_log
+
+--echo # Set different paths for --datadir
+let $MYSQLD_DATADIR1 = $MYSQL_TMP_DIR/data_8016_crypt_v1/data;
+
+--copy_file $MYSQLTEST_VARDIR/std_data/data_8016_crypt_v1.zip $MYSQL_TMP_DIR/data_8016_crypt_v1.zip
+
+--echo # Check that the file exists in the working folder.
+--file_exists $MYSQL_TMP_DIR/data_8016_crypt_v1.zip
+
+--echo # Unzip the zip file.
+--exec unzip -qo $MYSQL_TMP_DIR/data_8016_crypt_v1.zip -d $MYSQL_TMP_DIR
+
+--let $MYSQLD_DATADIR=`SELECT @@datadir`
+
+--echo # Stop DB server which was created by MTR default
+--source include/shutdown_mysqld.inc
+
+let $MYSQLD_LOG= $MYSQLTEST_VARDIR/log/update_crypt_data_v1.log;
+
+--echo # Restart the server on 8.0.16 directory with tables with crypt data v1. The tables were created as:
+--echo # CREATE TABLE t1 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='Y';
+--echo # CREATE TABLE t2 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='KEYRING';
+--echo # CREATE TABLE t3 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255));
+--echo # CREATE TABLE t4 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION_KEY_ID=4;
+--echo # CREATE TABLE t5 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION='N';
+--echo # CREATE TABLE t6 (id INT NOT NULL PRIMARY KEY, a VARCHAR(255)) ENCRYPTION_KEY_ID=4;
+--echo # Table t1 is the only table because of which the upgrade is not possible. This is because it is only partially re-encrypted
+--echo # from master key encryption to online keyring encryption.
+
+--error 1
+--exec $MYSQLD_CMD --log-error=$MYSQLD_LOG --loose-skip-log-bin --skip-log-slave-updates --datadir=$MYSQLD_DATADIR1 --keyring_file_data=$MYSQL_TMP_DIR/data_8016_crypt_v1/mysecret_keyring $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD
+
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$MYSQLD_LOG
+--let SEARCH_PATTERN=Upgrade is not possible as there are tables for which re-encryption from master key encryption to online keyring encryption was not finished\. Please either finish off the re-encryption or decrypt the tables\. This feature is experimental in the version you are upgrading from\.
+--source include/search_pattern_in_file.inc
+
+--echo # Remove the problematic tablespace and re-try the upgrade. It should pass.
+--remove_file $MYSQLD_DATADIR1/test/t1.ibd
+
+--echo # Start the 8.0.18 server on 8.0.16 datadir
+--let $restart_parameters = "restart: --loose-skip-log-bin --skip-log-slave-updates --datadir=$MYSQLD_DATADIR1 --keyring_file_data=$MYSQL_TMP_DIR/data_8016_crypt_v1/mysecret_keyring $KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD"
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1 $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD KEYRING_PLUGIN_EARLY_LOAD
+--source include/start_mysqld.inc
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+
+SET GLOBAL innodb_encryption_threads = 4;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+# All tables should get encrypted. tables_count - 3 because temporary tablespace, t5 are not encrypted and t1 is missing, because we have
+# deleted it.
+--let $wait_condition=SELECT COUNT(*) = $tables_count - 3 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+SELECT COUNT(*) FROM t2;
+SELECT COUNT(*) FROM t3;
+SELECT COUNT(*) FROM t4;
+SELECT COUNT(*) FROM t5;
+SELECT COUNT(*) FROM t6;
+
+# Check if server restarts correctly
+--replace_result $MYSQLD_DATADIR1 MYSQLD_DATADIR1 $MYSQL_TMP_DIR MYSQL_TMP_DIR $KEYRING_PLUGIN_OPT KEYRING_PLUGIN_OPT $KEYRING_PLUGIN_EARLY_LOAD KEYRING_PLUGIN_EARLY_LOAD
+--source include/restart_mysqld.inc
+
+--source include/shutdown_mysqld.inc
+
+--echo # Remove copied files
+--remove_file $MYSQL_TMP_DIR/data_8016_crypt_v1.zip
+--force-rmdir $MYSQL_TMP_DIR/data_8016_crypt_v1
+
+--echo # Restart the server with default options.
+--let $restart_parameters=
+--source include/start_mysqld.inc

--- a/share/errmsg-utf8.txt
+++ b/share/errmsg-utf8.txt
@@ -19903,6 +19903,9 @@ ER_XB_MSG_6
 ER_XB_UNDO_DELETE_FAILURE
   eng "Deletion of 5.7 undo tablespace %s failed"
 
+ER_UPGRADE_MK_TO_KEYRING_ROTATION
+  eng "Upgrade is not possible as there are tables for which re-encryption from master key encryption to online keyring encryption was not finished. Please either finish off the re-encryption or decrypt the tables. This feature is experimental in the version you are upgrading from."
+
 ER_REDO_ENCRYPTION_CANT_BE_CHANGED
   eng "Redo log encryption mode can't be switched without stopping the server and recreating the redo logs. Current mode is %s, requested %s."
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1481,6 +1481,8 @@ enum class Tablespace_type {
   SPACE_TYPE_IMPLICIT
 };
 
+using is_there_mk_to_keyring_rotation_t = bool (*)();
+
 /**
   Get the tablespace type from the SE.
 
@@ -2383,6 +2385,7 @@ struct handlerton {
   upgrade_space_version_t upgrade_space_version;
   get_tablespace_type_t get_tablespace_type;
   get_tablespace_type_by_name_t get_tablespace_type_by_name;
+  is_there_mk_to_keyring_rotation_t is_there_mk_to_keyring_rotation;
   upgrade_logs_t upgrade_logs;
   finish_upgrade_t finish_upgrade;
   fill_is_table_t fill_is_table;

--- a/storage/innobase/fil/fil0crypt.cc
+++ b/storage/innobase/fil/fil0crypt.cc
@@ -116,6 +116,16 @@ EncryptionKeyId get_global_default_encryption_key_id_value();
 #define DEBUG_KEYROTATION_THROTTLING 0
 
 static constexpr uint KERYING_ENCRYPTION_INFO_MAX_SIZE =
+    ENCRYPTION_MAGIC_SIZE + 1  // type
+    + 4                        // min_key_version
+    + 4                        // key_id
+    + 1                        // encryption
+    + CRYPT_SCHEME_1_IV_LEN    // iv (16 bytes)
+    + 1                        // encryption rotation type
+    + ENCRYPTION_KEY_LEN       // tablespace key
+    + ENCRYPTION_KEY_LEN;      // tablespace iv
+
+static constexpr uint KERYING_ENCRYPTION_INFO_MAX_SIZE_V1 =
     ENCRYPTION_MAGIC_SIZE + 2  // length of iv
     + 4                        // space id
     + 2                        // offset
@@ -211,12 +221,12 @@ void fil_space_crypt_cleanup() {
   mutex_free(&crypt_stat_mutex);
 }
 
-fil_space_crypt_t::fil_space_crypt_t(
-    uint new_type, uint new_min_key_version, uint new_key_id,
-    fil_encryption_t new_encryption, Crypt_key_operation key_operation,
-    Encryption::Encryption_rotation encryption_rotation)
+fil_space_crypt_t::fil_space_crypt_t(uint new_type, uint new_min_key_version,
+                                     uint new_key_id,
+                                     fil_encryption_t new_encryption,
+                                     Crypt_key_operation key_operation,
+                                     Encryption_rotation encryption_rotation)
     : min_key_version(new_min_key_version),
-      page0_offset(0),
       encryption(new_encryption),
       key_found(false),
       rotate_state(),
@@ -411,22 +421,19 @@ static ulint fsp_header_get_keyring_encryption_offset(
   return offset;
 }
 
-fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
-                                             const byte *page) {
-  ulint bytes_read = 0;
+static fil_space_crypt_t *fil_space_read_crypt_data_v1(
+    const page_size_t &page_size, const byte *page) {
+  const ulint offset{fsp_header_get_keyring_encryption_offset(page_size)};
 
-  const ulint offset = fsp_header_get_keyring_encryption_offset(page_size);
+  ut_ad(memcmp(page + offset, ENCRYPTION_KEY_MAGIC_PS_V1,
+               ENCRYPTION_MAGIC_SIZE) == 0);
 
-  if (memcmp(page + offset, ENCRYPTION_KEY_MAGIC_PS_V1,
-             ENCRYPTION_MAGIC_SIZE) != 0) {
-    /* Crypt data is not stored. */
-    return NULL;
-  }
-
-  bytes_read += ENCRYPTION_MAGIC_SIZE;
+  ulint bytes_read{ENCRYPTION_MAGIC_SIZE};
 
   uint8_t iv_length = mach_read_from_2(page + offset + bytes_read);
+  ut_ad(iv_length == CRYPT_SCHEME_1_IV_LEN);
   bytes_read += 2;
+
   bytes_read += 4;  // skip space_id
   bytes_read += 2;  // skip offset
 
@@ -435,16 +442,16 @@ fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
 
   fil_space_crypt_t *crypt_data;
 
-  if (!(type == CRYPT_SCHEME_UNENCRYPTED || type == CRYPT_SCHEME_1) ||
-      iv_length != sizeof crypt_data->iv) {
-    ib::error() << "Found non sensible crypt scheme: " << type << ","
-                << iv_length << " for space: " << page_get_space_id(page)
+  if ((type != CRYPT_SCHEME_UNENCRYPTED && type != CRYPT_SCHEME_1) ||
+      iv_length != CRYPT_SCHEME_1_IV_LEN) {
+    ib::error() << "Found non sensible crypt scheme: " << type
+                << " for space: " << page_get_space_id(page)
                 << " offset: " << offset << " bytes: ["
                 << page[offset + 2 + ENCRYPTION_MAGIC_SIZE]
                 << page[offset + 3 + ENCRYPTION_MAGIC_SIZE]
                 << page[offset + 4 + ENCRYPTION_MAGIC_SIZE]
                 << page[offset + 5 + ENCRYPTION_MAGIC_SIZE] << "].";
-    return NULL;
+    return nullptr;
   }
 
   uint min_key_version = mach_read_from_4(page + offset + bytes_read);
@@ -467,14 +474,12 @@ fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
   crypt_data->type = type;
   crypt_data->min_key_version = min_key_version;
   crypt_data->encrypting_with_key_version = min_key_version;
-  crypt_data->page0_offset = offset;
-  memcpy(crypt_data->iv, page + offset + bytes_read, iv_length);
+  crypt_data->private_version = 1;
+  memcpy(crypt_data->iv, page + offset + bytes_read, CRYPT_SCHEME_1_IV_LEN);
+  bytes_read += CRYPT_SCHEME_1_IV_LEN;
 
-  bytes_read += iv_length;
-
-  crypt_data->encryption_rotation =
-      (Encryption::Encryption_rotation)mach_read_from_4(page + offset +
-                                                        bytes_read);
+  crypt_data->encryption_rotation = static_cast<Encryption_rotation>(
+      mach_read_from_4(page + offset + bytes_read));
   bytes_read += 4;
 
   uchar tablespace_key[ENCRYPTION_KEY_LEN];
@@ -486,22 +491,110 @@ fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
                     0) ==
       tablespace_key) {  // tablespace_key is all zeroes which means there is no
                          // tablepsace in mtr log
-    crypt_data->set_tablespace_key(NULL);
-    crypt_data->set_tablespace_iv(NULL);  // No tablespace_key => no iv
+    crypt_data->set_tablespace_key(nullptr);
   } else {
-    ut_ad(tablespace_key != NULL);
-    crypt_data->set_tablespace_key(tablespace_key);  // Since there is
-                                                     // tablespace_key present -
-                                                     // we also need to read
-                                                     // tablespace_iv
-    uchar tablespace_iv[ENCRYPTION_KEY_LEN];
-    ut_ad(tablespace_iv != NULL);
-    memcpy(tablespace_iv, page + offset + bytes_read, ENCRYPTION_KEY_LEN);
-    bytes_read += ENCRYPTION_KEY_LEN;
-    crypt_data->set_tablespace_iv(tablespace_iv);
+    crypt_data->set_tablespace_key(
+        tablespace_key);  // We are using the same iv for both
+                          // MK encryption and KEYRING encryption
   }
 
   return crypt_data;
+}
+
+static fil_space_crypt_t *fil_space_read_crypt_data_v2(
+    const page_size_t &page_size, const byte *page) {
+  const ulint offset = fsp_header_get_keyring_encryption_offset(page_size);
+
+  if (memcmp(page + offset, ENCRYPTION_KEY_MAGIC_PS_V2,
+             ENCRYPTION_MAGIC_SIZE) != 0) {
+    /* Crypt data is not stored. */
+    return nullptr;
+  }
+
+  ulint bytes_read{ENCRYPTION_MAGIC_SIZE};
+
+  uint8_t type = mach_read_from_1(page + offset + bytes_read);
+
+  ut_a(type == CRYPT_SCHEME_UNENCRYPTED ||
+       type == CRYPT_SCHEME_1);  // only supported
+
+  bytes_read += 1;
+
+  fil_space_crypt_t *crypt_data;
+
+  if (!(type == CRYPT_SCHEME_UNENCRYPTED || type == CRYPT_SCHEME_1)) {
+    ib::error() << "Found non sensible crypt scheme: " << type
+                << " for space: " << page_get_space_id(page)
+                << " offset: " << offset << " bytes: ["
+                << page[offset + 2 + ENCRYPTION_MAGIC_SIZE]
+                << page[offset + 3 + ENCRYPTION_MAGIC_SIZE]
+                << page[offset + 4 + ENCRYPTION_MAGIC_SIZE]
+                << page[offset + 5 + ENCRYPTION_MAGIC_SIZE] << "].";
+    return nullptr;
+  }
+
+  uint min_key_version = mach_read_from_4(page + offset + bytes_read);
+  bytes_read += 4;
+
+  uint key_id = mach_read_from_4(page + offset + bytes_read);
+  bytes_read += 4;
+
+  ut_ad(key_id != (uint)(~0));
+
+  fil_encryption_t encryption =
+      (fil_encryption_t)mach_read_from_1(page + offset + bytes_read);
+  bytes_read += 1;
+
+  crypt_data = fil_space_create_crypt_data(encryption, key_id,
+                                           Crypt_key_operation::FETCH_KEY);
+
+  /* We need to overwrite these as above function will initialize
+  members */
+  crypt_data->type = type;
+  crypt_data->min_key_version = min_key_version;
+  crypt_data->encrypting_with_key_version = min_key_version;
+  memcpy(crypt_data->iv, page + offset + bytes_read, CRYPT_SCHEME_1_IV_LEN);
+  bytes_read += CRYPT_SCHEME_1_IV_LEN;
+
+  crypt_data->encryption_rotation = static_cast<Encryption_rotation>(
+      mach_read_from_1(page + offset + bytes_read));
+  bytes_read += 1;
+
+  uchar tablespace_key[ENCRYPTION_KEY_LEN];
+  memcpy(tablespace_key, page + offset + bytes_read, ENCRYPTION_KEY_LEN);
+  bytes_read += ENCRYPTION_KEY_LEN;
+
+  if (std::search_n(tablespace_key, tablespace_key + ENCRYPTION_KEY_LEN,
+                    ENCRYPTION_KEY_LEN,
+                    0) ==
+      tablespace_key) {  // tablespace_key is all zeroes which means there is no
+                         // tablepsace in mtr log
+    crypt_data->set_tablespace_key(nullptr);
+  } else {
+    crypt_data->set_tablespace_key(
+        tablespace_key);  // We are using the same iv for both
+                          // MK encryption and KEYRING encryption
+  }
+
+  return crypt_data;
+}
+
+fil_space_crypt_t *fil_space_read_crypt_data(const page_size_t &page_size,
+                                             const byte *page) {
+  const ulint offset{fsp_header_get_keyring_encryption_offset(page_size)};
+
+  if (memcmp(page + offset, ENCRYPTION_KEY_MAGIC_PS_V1,
+             ENCRYPTION_MAGIC_SIZE) == 0) {
+    return fil_space_read_crypt_data_v1(page_size, page);
+  }
+
+  if (memcmp(page + offset, ENCRYPTION_KEY_MAGIC_PS_V2,
+             ENCRYPTION_MAGIC_SIZE) == 0) {
+    return fil_space_read_crypt_data_v2(page_size, page);
+  }
+
+  /* Crypt data is not stored. */
+  return nullptr;
 }
 
 /******************************************************************
@@ -542,11 +635,10 @@ Write crypt data to a page (0)
 // TODO: Should be marked as const when PS-5738 is implemented
 void fil_space_crypt_t::write_page0(
     const fil_space_t *space, byte *page, mtr_t *mtr, uint a_min_key_version,
-    uint a_type, Encryption::Encryption_rotation current_encryption_rotation) {
+    uint a_type, Encryption_rotation current_encryption_rotation) {
   ut_ad(this == space->crypt_data);
   const ulint offset =
       fsp_header_get_keyring_encryption_offset(page_size_t(space->flags));
-  page0_offset = offset;
 
   byte *encrypt_info = new byte[KERYING_ENCRYPTION_INFO_MAX_SIZE];
   byte *encrypt_info_ptr = encrypt_info;
@@ -554,15 +646,8 @@ void fil_space_crypt_t::write_page0(
   mlog_write_ulint(page + FSP_HEADER_OFFSET + FSP_SPACE_FLAGS, space->flags,
                    MLOG_4BYTES, mtr);  // done
 
-  memcpy(encrypt_info_ptr, ENCRYPTION_KEY_MAGIC_PS_V1, ENCRYPTION_MAGIC_SIZE);
+  memcpy(encrypt_info_ptr, ENCRYPTION_KEY_MAGIC_PS_V2, ENCRYPTION_MAGIC_SIZE);
   encrypt_info_ptr += ENCRYPTION_MAGIC_SIZE;
-  mach_write_to_2(encrypt_info_ptr, CRYPT_SCHEME_1_IV_LEN);
-  encrypt_info_ptr += 2;
-
-  mach_write_to_4(encrypt_info_ptr, space->id);
-  encrypt_info_ptr += 4;
-  mach_write_to_2(encrypt_info_ptr, offset);
-  encrypt_info_ptr += 2;
 
   mach_write_to_1(encrypt_info_ptr, a_type);
   encrypt_info_ptr += 1;
@@ -577,20 +662,15 @@ void fil_space_crypt_t::write_page0(
   memcpy(encrypt_info_ptr, iv, CRYPT_SCHEME_1_IV_LEN);
   encrypt_info_ptr += CRYPT_SCHEME_1_IV_LEN;
 
-  mach_write_to_4(encrypt_info_ptr, current_encryption_rotation);
-  encrypt_info_ptr += 4;
+  mach_write_to_1(encrypt_info_ptr,
+                  static_cast<byte>(current_encryption_rotation));
+  encrypt_info_ptr += 1;
 
-  if (tablespace_key == NULL) {
-    ut_ad(tablespace_iv == NULL);
-    memset(encrypt_info_ptr, 0, ENCRYPTION_KEY_LEN);
-    encrypt_info_ptr += ENCRYPTION_KEY_LEN;
+  if (tablespace_key == nullptr) {
     memset(encrypt_info_ptr, 0, ENCRYPTION_KEY_LEN);
     encrypt_info_ptr += ENCRYPTION_KEY_LEN;
   } else {
-    ut_ad(tablespace_iv != NULL);
     memcpy(encrypt_info_ptr, tablespace_key, ENCRYPTION_KEY_LEN);
-    encrypt_info_ptr += ENCRYPTION_KEY_LEN;
-    memcpy(encrypt_info_ptr, tablespace_iv, ENCRYPTION_KEY_LEN);
     encrypt_info_ptr += ENCRYPTION_KEY_LEN;
   }
 
@@ -634,38 +714,28 @@ static fil_space_crypt_t *fil_space_set_crypt_data(
   return ret_crypt_data;
 }
 
-/******************************************************************
-Parse a MLOG_FILE_WRITE_CRYPT_DATA log entry
-@param[in]	ptr		Log entry start
-@param[in]	end_ptr		Log entry end
-@param[in]	block		buffer block
+/** Parse a MLOG_FILE_WRITE_CRYPT_DATA log entry
+@param[in]  space_id  id of space that this log entry refers to
+@param[in]  ptr  Log entry start
+@param[in]  end_ptr  Log entry end
+@param[in]  len  Log entry length
 @return position on log buffer */
-
-byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
-                                 const buf_block_t *block, ulint len) {
+byte *fil_parse_write_crypt_data_v2(space_id_t space_id, byte *ptr,
+                                    const byte *end_ptr, ulint len) {
   ptr += 4;  // skip offset and len
-  const uint iv_len = mach_read_from_2(ptr + ENCRYPTION_MAGIC_SIZE);
-  ut_a(iv_len == CRYPT_SCHEME_1_IV_LEN);  // only supported
 
   if (len != KERYING_ENCRYPTION_INFO_MAX_SIZE) {
     recv_sys->set_corrupt_log();
-    return NULL;
+    return nullptr;
   }
 
   if (ptr + KERYING_ENCRYPTION_INFO_MAX_SIZE > end_ptr) {
-    return NULL;
+    return nullptr;
   }
 
-  // We should only enter this function if ENCRYPTION_KEY_MAGIC_PS_V1 is set
-  ut_ad((memcmp(ptr, ENCRYPTION_KEY_MAGIC_PS_V1, ENCRYPTION_MAGIC_SIZE) == 0));
+  // We should only enter this function if ENCRYPTION_KEY_MAGIC_PS_V2 is set
+  ut_ad((memcmp(ptr, ENCRYPTION_KEY_MAGIC_PS_V2, ENCRYPTION_MAGIC_SIZE) == 0));
   ptr += ENCRYPTION_MAGIC_SIZE;
-
-  ptr += 2;  // length of iv has been already read
-
-  space_id_t space_id = mach_read_from_4(ptr);
-  ptr += 4;
-  uint offset = mach_read_from_2(ptr);
-  ptr += 2;
 
   uint type = mach_read_from_1(ptr);
   ptr += 1;
@@ -685,14 +755,99 @@ byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
   fil_space_crypt_t *crypt_data = fil_space_create_crypt_data(
       encryption, key_id, Crypt_key_operation::FETCH_OR_GENERATE_KEY);
   /* Need to overwrite these as above will initialize fields. */
-  crypt_data->page0_offset = offset;
   DBUG_ASSERT(min_key_version != ENCRYPTION_KEY_VERSION_INVALID);
   crypt_data->min_key_version = min_key_version;
   crypt_data->encryption = encryption;
-  memcpy(crypt_data->iv, ptr, iv_len);
-  ptr += iv_len;
+  memcpy(crypt_data->iv, ptr, CRYPT_SCHEME_1_IV_LEN);
+  ptr += CRYPT_SCHEME_1_IV_LEN;
   crypt_data->encryption_rotation =
-      (Encryption::Encryption_rotation)mach_read_from_4(ptr);
+      static_cast<Encryption_rotation>(mach_read_from_1(ptr));
+  ptr += 1;
+  uchar tablespace_key[ENCRYPTION_KEY_LEN];
+  memcpy(tablespace_key, ptr, ENCRYPTION_KEY_LEN);
+  ptr += ENCRYPTION_KEY_LEN;
+
+  if (std::search_n(tablespace_key, tablespace_key + ENCRYPTION_KEY_LEN,
+                    ENCRYPTION_KEY_LEN,
+                    0) ==
+      tablespace_key) {  // tablespace_key is all zeroes which means there is no
+                         // tablepsace in mtr log
+    crypt_data->set_tablespace_key(nullptr);
+    ptr += ENCRYPTION_KEY_LEN;
+  } else {
+    crypt_data->set_tablespace_key(tablespace_key);
+  }
+
+  /* Check is used key found from encryption plugin */
+  if (crypt_data->should_encrypt() && !crypt_data->is_key_found()) {
+    ib::error() << "Key cannot be read for space id = " << space_id;
+    recv_sys->set_corrupt_log();
+  }
+
+  /* update fil_space memory cache with crypt_data */
+  fil_space_t *space = fil_space_acquire_silent(space_id);
+  if (space != nullptr) {
+    crypt_data = fil_space_set_crypt_data(space, crypt_data);
+    fil_space_release(space);
+  } else {
+    fil_space_destroy_crypt_data(&crypt_data);
+  }
+
+  return ptr;
+}
+/** Parse a MLOG_FILE_WRITE_CRYPT_DATA log entry
+@param[in]  space_id  id of space that this log entry refers to
+@param[in]  ptr  Log entry start
+@param[in]  end_ptr  Log entry end
+@param[in]  len  Log entry length
+@return position on log buffer */
+byte *fil_parse_write_crypt_data_v1(space_id_t space_id, byte *ptr,
+                                    const byte *end_ptr, ulint len) {
+  ptr += 4;  // skip offset and len
+  ptr += 2;  // skip iv_length
+
+  if (len != KERYING_ENCRYPTION_INFO_MAX_SIZE_V1) {
+    recv_sys->set_corrupt_log();
+    return nullptr;
+  }
+
+  if (ptr + KERYING_ENCRYPTION_INFO_MAX_SIZE_V1 > end_ptr) {
+    return nullptr;
+  }
+
+  // We should only enter this function if ENCRYPTION_KEY_MAGIC_PS_V1 is set
+  ut_ad((memcmp(ptr, ENCRYPTION_KEY_MAGIC_PS_V1, ENCRYPTION_MAGIC_SIZE) == 0));
+  ptr += ENCRYPTION_MAGIC_SIZE;
+
+  ptr += 4;  // skip space_id
+  ptr += 2;  // skip offset
+
+  uint type = mach_read_from_1(ptr);
+  ptr += 1;
+
+  ut_a(type == CRYPT_SCHEME_UNENCRYPTED ||
+       type == CRYPT_SCHEME_1);  // only supported
+
+  uint min_key_version = mach_read_from_4(ptr);
+  ptr += 4;
+
+  uint key_id = mach_read_from_4(ptr);
+  ptr += 4;
+
+  fil_encryption_t encryption = (fil_encryption_t)mach_read_from_1(ptr);
+  ptr += 1;
+
+  fil_space_crypt_t *crypt_data = fil_space_create_crypt_data(
+      encryption, key_id, Crypt_key_operation::FETCH_OR_GENERATE_KEY);
+  /* Need to overwrite these as above will initialize fields. */
+  DBUG_ASSERT(min_key_version != ENCRYPTION_KEY_VERSION_INVALID);
+  crypt_data->min_key_version = min_key_version;
+  crypt_data->encryption = encryption;
+  crypt_data->private_version = 1;
+  memcpy(crypt_data->iv, ptr, CRYPT_SCHEME_1_IV_LEN);
+  ptr += CRYPT_SCHEME_1_IV_LEN;
+  crypt_data->encryption_rotation =
+      static_cast<Encryption_rotation>(mach_read_from_4(ptr));
   ptr += 4;
   uchar tablespace_key[ENCRYPTION_KEY_LEN];
   memcpy(tablespace_key, ptr, ENCRYPTION_KEY_LEN);
@@ -703,21 +858,30 @@ byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
                     0) ==
       tablespace_key) {  // tablespace_key is all zeroes which means there is no
                          // tablepsace in mtr log
-    crypt_data->set_tablespace_key(NULL);
-    crypt_data->set_tablespace_iv(NULL);  // No tablespace_key => no iv
-    ptr += ENCRYPTION_KEY_LEN;
+    crypt_data->set_tablespace_key(nullptr);
+    ptr += ENCRYPTION_KEY_LEN;  // skip tablespace iv
   } else {
     crypt_data->set_tablespace_key(tablespace_key);
-    uchar tablespace_iv[ENCRYPTION_KEY_LEN];
-    memcpy(tablespace_iv, ptr, ENCRYPTION_KEY_LEN);
-    ptr += ENCRYPTION_KEY_LEN;
-    crypt_data->set_tablespace_iv(tablespace_iv);
+    ptr += ENCRYPTION_KEY_LEN;  // skip tablespace iv
+  }
+
+  if (crypt_data->encryption_rotation ==
+      Encryption_rotation::MASTER_KEY_TO_KEYRING) {
+    ib::error()
+        << "There is a redo record that would start master key to keyring "
+           "re-encryption "
+        << "for space = " << space_id
+        << ". Such record cannot be proceed by upgrade. "
+        << "Please finish off the re-encryption and try again. Re-encryption "
+           "is an "
+        << "experimental feature in the server version you are upgrading from.";
+    recv_sys->set_corrupt_log();
+    return ptr;
   }
 
   /* Check is used key found from encryption plugin */
   if (crypt_data->should_encrypt() && !crypt_data->is_key_found()) {
-    ib::error() << "Key cannot be read for space id = "
-                << space_id;  // TODO: To jest zmienione w MariaDB - zmienić!
+    ib::error() << "Key cannot be read for space id = " << space_id;
     recv_sys->set_corrupt_log();
   }
 
@@ -942,13 +1106,13 @@ static bool fil_crypt_start_encrypting_space(fil_space_t *space) {
                                                     // space from MK encryption
                                                     // to RK encryption
     // TODO: assert that space->encryption_key is all zeroes here
-    crypt_data->encryption_rotation = Encryption::MASTER_KEY_TO_KEYRING;
+    crypt_data->encryption_rotation =
+        Encryption_rotation::MASTER_KEY_TO_KEYRING;
     crypt_data->set_tablespace_key(space->encryption_key);
-    crypt_data->set_tablespace_iv(space->encryption_iv);  // space key and
-                                                          // encryption are
-                                                          // always initalized
-                                                          // for MK encrypted
-                                                          // tables
+    crypt_data->set_iv(
+        space->encryption_iv);  // using the same iv for reading MK encrypted
+                                // pages and encrypting KEYRING encrypted
+                                // pages
   }
 
   crypt_data->encrypting_with_key_version =
@@ -1738,7 +1902,7 @@ static void fil_crypt_rotate_page(const key_state_t *key_state,
     //
     // We will rotate the pages from the begining if there was a crash
     uint kv = space->crypt_data->encryption_rotation ==
-                      Encryption::MASTER_KEY_TO_KEYRING
+                      Encryption_rotation::MASTER_KEY_TO_KEYRING
                   ? ENCRYPTION_KEY_VERSION_NOT_ENCRYPTED
                   : mach_read_from_4(frame + FIL_PAGE_ENCRYPTION_KEY_VERSION);
 
@@ -2442,7 +2606,7 @@ static dberr_t fil_crypt_flush_space(rotate_thread_t *state) {
     // mtr.set_named_space(space);
     crypt_data->write_page0(space, block->frame, &mtr,
                             crypt_data->rotate_state.min_key_version_found,
-                            current_type, Encryption::NO_ROTATION);
+                            current_type, Encryption_rotation::NO_ROTATION);
   }
 
   mtr.commit();
@@ -2508,9 +2672,8 @@ static void fil_crypt_complete_rotate_space(const key_state_t *key_state,
       /* we're the last active thread */
       ut_ad(crypt_data->rotate_state.flushing == false);
       crypt_data->rotate_state.flushing = true;
-      crypt_data->set_tablespace_iv(NULL);
       crypt_data->set_tablespace_key(NULL);
-      crypt_data->encryption_rotation = Encryption::NO_ROTATION;
+      crypt_data->encryption_rotation = Encryption_rotation::NO_ROTATION;
     }
 
     DBUG_EXECUTE_IF(

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -165,15 +165,14 @@ struct fil_space_crypt_t {
   fil_space_crypt_t(uint new_type, uint new_min_key_version, uint new_key_id,
                     fil_encryption_t new_encryption,
                     Crypt_key_operation key_operation,
-                    Encryption::Encryption_rotation encryption_rotation =
-                        Encryption::NO_ROTATION);
+                    Encryption_rotation encryption_rotation =
+                        Encryption_rotation::NO_ROTATION);
 
   /** Destructor */
   ~fil_space_crypt_t() {
     mutex_free(&mutex);
     mutex_free(&start_rotate_mutex);
-    if (tablespace_key != NULL) ut_free(tablespace_key);
-    if (tablespace_iv != NULL) ut_free(tablespace_iv);
+    if (tablespace_key != nullptr) ut_free(tablespace_key);
 
     for (std::list<byte *>::iterator iter = fetched_keys.begin();
          iter != fetched_keys.end(); iter++) {
@@ -220,7 +219,7 @@ struct fil_space_crypt_t {
   @param[in,out]	mtr	mini-transaction */
   void write_page0(const fil_space_t *space, byte *page0, mtr_t *mtr,
                    uint a_min_key_version, uint a_type,
-                   Encryption::Encryption_rotation current_encryption_rotation);
+                   Encryption_rotation current_encryption_rotation);
 
   void set_tablespace_key(const uchar *tablespace_key) {
     if (tablespace_key == NULL) {
@@ -233,24 +232,13 @@ struct fil_space_crypt_t {
     }
   }
 
-  void set_tablespace_iv(const uchar *tablespace_iv) {
-    if (tablespace_iv == NULL) {
-      if (this->tablespace_iv != NULL) ut_free(this->tablespace_iv);
-      this->tablespace_iv = NULL;
-    } else {
-      if (this->tablespace_iv == NULL)
-        this->tablespace_iv = (byte *)ut_malloc_nokey(ENCRYPTION_KEY_LEN);
-      memcpy(this->tablespace_iv, tablespace_iv, ENCRYPTION_KEY_LEN);
-    }
-  }
+  void set_iv(const uchar *iv) { memcpy(this->iv, iv, CRYPT_SCHEME_1_IV_LEN); }
 
   bool load_needed_keys_into_local_cache();
   uchar *get_min_key_version_key();
   uchar *get_key_currently_used_for_encryption();
 
-  uint min_key_version;  // min key version for this space
-  ulint page0_offset;  // byte offset on page 0 for crypt data //TODO:Robert: po
-                       // co to ?
+  uint min_key_version;         // min key version for this space
   fil_encryption_t encryption;  // Encryption setup
 
   // key being used for encryption
@@ -275,15 +263,17 @@ struct fil_space_crypt_t {
 
   fil_space_rotate_state_t rotate_state;
 
-  Encryption::Encryption_rotation encryption_rotation;
+  Encryption_rotation encryption_rotation;
 
   uchar *tablespace_key;  // TODO:Make it private ?
-  // In Oracle's tablespace encryption is ENCRYPTION_KEY_LEN long,
-  // which is incorrect value - it should be always 128 bits,
-  // nevertheless we need ENCRYPTION_KEY_LEN tablespace_iv
-  // to be able to store this IV.
-  uchar *tablespace_iv;
 
+  // In Oracle's tablespace encryption iv is ENCRYPTION_KEY_LEN long,
+  // which is incorrect value - it should be always 128 bits.
+  // In case of MK to KEYRING re-encryption we re-use MK iv for
+  // Keyring encryption. Since only 128 bits is really used
+  // by AES we only store the needed 128 bits of this iv.
+  // During re-encryption we use this iv to decrypt MK encrypted
+  // pages and encrypt pages with KEYRING.
   unsigned char iv[CRYPT_SCHEME_1_IV_LEN];
 
   uint encrypting_with_key_version;
@@ -292,6 +282,11 @@ struct fil_space_crypt_t {
   unsigned int type;
 
   std::list<byte *> fetched_keys;  // TODO: temp for test
+
+  // Internally we have two versions of crypt_data written to page 0.
+  // One starting with magic PSA and the second one starting with PSB.
+  // Here we store which magic we read : 1 - PSA, 2 - PSB.
+  size_t private_version{2};
 };
 
 /** Status info about encryption */
@@ -434,15 +429,24 @@ Free a crypt data object
 @param[in,out] crypt_data	crypt data to be freed */
 void fil_space_destroy_crypt_data(fil_space_crypt_t **crypt_data);
 
-/******************************************************************
-Parse a MLOG_FILE_WRITE_CRYPT_DATA log entry
-@param[in]	ptr		Log entry start
-@param[in]	end_ptr		Log entry end
-@param[in]	block		buffer block
-@param[out]	err		DB_SUCCESS or DB_IO_DECRYPT_FAIL
+/** Parse a MLOG_FILE_WRITE_CRYPT_DATA log entry
+@param[in]  space_id  id of space that this log entry refers to
+@param[in]  ptr  Log entry start
+@param[in]  end_ptr  Log entry end
+@param[in]  len  Log entry length
 @return position on log buffer */
-byte *fil_parse_write_crypt_data(byte *ptr, const byte *end_ptr,
-                                 const buf_block_t *block, ulint len)
+byte *fil_parse_write_crypt_data_v1(space_id_t space_id, byte *ptr,
+                                    const byte *end_ptr, ulint len)
+    MY_ATTRIBUTE((warn_unused_result));
+
+/** Parse a MLOG_FILE_WRITE_CRYPT_DATA log entry
+@param[in]  space_id  id of space that this log entry refers to
+@param[in]  ptr  Log entry start
+@param[in]  end_ptr  Log entry end
+@param[in]  len  Log entry length
+@return position on log buffer */
+byte *fil_parse_write_crypt_data_v2(space_id_t space_id, byte *ptr,
+                                    const byte *end_ptr, ulint len)
     MY_ATTRIBUTE((warn_unused_result));
 
 /**

--- a/storage/innobase/include/fil0rkinfo.h
+++ b/storage/innobase/include/fil0rkinfo.h
@@ -6,23 +6,18 @@
 #define CRYPT_SCHEME_UNENCRYPTED 0
 #define CRYPT_SCHEME_1 1
 
-struct Keyring_encryption_info
-{
-   Keyring_encryption_info()
-     : keyring_encryption_key_is_missing(false)
-     , page0_has_crypt_data(false)
-     , keyring_encryption_min_key_version(0)
-     , type(CRYPT_SCHEME_UNENCRYPTED)
-   {}
-   bool keyring_encryption_key_is_missing; // initlialized in dict_mem_table_create
-   bool page0_has_crypt_data;
-   uint keyring_encryption_min_key_version;
-   uint type;
+struct Keyring_encryption_info {
+  bool keyring_encryption_key_is_missing{
+      false};  // initlialized in dict_mem_table_create
+  bool page0_has_crypt_data{false};
+  uint keyring_encryption_min_key_version{0};
+  uint type{CRYPT_SCHEME_UNENCRYPTED};
+  bool is_mk_to_keyring_rotation{false};
 
-   bool is_encryption_in_progress()
-   {
-     return keyring_encryption_min_key_version == 0 && type != CRYPT_SCHEME_UNENCRYPTED;
-   }
+  bool is_encryption_in_progress() {
+    return keyring_encryption_min_key_version == 0 &&
+           type != CRYPT_SCHEME_UNENCRYPTED;
+  }
 };
 
 //#endif // UNIV_INNOCHECKSUM

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -278,6 +278,8 @@ static const char ENCRYPTION_KEY_MAGIC_RK[] = "lRK";
 
 static const char ENCRYPTION_KEY_MAGIC_PS_V1[] = "PSA";
 
+static const char ENCRYPTION_KEY_MAGIC_PS_V2[] = "PSB";
+
 /** Encryption master key prifix */
 static const char ENCRYPTION_MASTER_KEY_PRIFIX[] = "INNODBKey";
 
@@ -331,6 +333,11 @@ static const uint ENCRYPTION_PROGRESS_INFO_SIZE = sizeof(uint);
 
 class IORequest;
 
+enum class Encryption_rotation : std::uint8_t {
+  NO_ROTATION,
+  MASTER_KEY_TO_KEYRING
+};
+
 /** Encryption algorithm. */
 struct Encryption {
   /** Algorithm types supported */
@@ -344,8 +351,6 @@ struct Encryption {
 
     KEYRING = 2
   };
-
-  enum Encryption_rotation { NO_ROTATION, MASTER_KEY_TO_KEYRING };
 
   /** Encryption information format version */
   enum Version {
@@ -367,27 +372,25 @@ struct Encryption {
         m_klen(0),
         m_key_allocated(false),
         m_iv(nullptr),
-        m_tablespace_iv(nullptr),
         m_tablespace_key(nullptr),
         m_key_version(0),
         m_key_id(0),
         m_checksum(0),
-        m_encryption_rotation(NO_ROTATION) {}
+        m_encryption_rotation(Encryption_rotation::NO_ROTATION) {}
 
   /** Specific constructor
   @param[in]	type		Algorithm type */
   explicit Encryption(Type type)
       : m_type(type),
-        m_key(NULL),
+        m_key(nullptr),
         m_klen(0),
         m_key_allocated(false),
-        m_iv(NULL),
-        m_tablespace_iv(NULL),
-        m_tablespace_key(NULL),
+        m_iv(nullptr),
+        m_tablespace_key(nullptr),
         m_key_version(0),
         m_key_id(0),
         m_checksum(0),
-        m_encryption_rotation(NO_ROTATION) {
+        m_encryption_rotation(Encryption_rotation::NO_ROTATION) {
 #ifdef UNIV_DEBUG
     switch (m_type) {
       case NONE:
@@ -414,7 +417,6 @@ struct Encryption {
     std::swap(m_klen, other.m_klen);
     std::swap(m_key_allocated, other.m_key_allocated);
     std::swap(m_iv, other.m_iv);
-    std::swap(m_tablespace_iv, other.m_tablespace_iv);
     std::swap(m_tablespace_key, other.m_tablespace_key);
     std::swap(m_key_version, other.m_key_version);
     std::swap(m_key_id, other.m_key_id);
@@ -657,12 +659,6 @@ struct Encryption {
 
   /** Encrypt initial vector */
   byte *m_iv;
-
-  // We decide as the last step in decrypt (after reading the page)
-  // when re_encryption_type is MK_TO_RK whether page is
-  // encrypted with MK or RK => thus we do not know which tablespace_iv we are
-  // going to use RK or MK
-  byte *m_tablespace_iv;
 
   byte *m_tablespace_key;
 
@@ -922,18 +918,15 @@ class IORequest {
   @param[in] key_len	length of the encryption key
   @param[in] iv		The encryption iv to use */
   void encryption_key(byte *key, ulint key_len, bool key_allocated, byte *iv,
-                      uint key_version, uint key_id, byte *tablespace_iv,
-                      byte *tablespace_key) {
+                      uint key_version, uint key_id, byte *tablespace_key) {
     m_encryption.set_key(key, key_len, key_allocated);
     m_encryption.m_iv = iv;
     m_encryption.m_key_version = key_version;
     m_encryption.m_key_id = key_id;
-    m_encryption.m_tablespace_iv = tablespace_iv;
     m_encryption.m_tablespace_key = tablespace_key;
   }
 
-  void encryption_rotation(
-      Encryption::Encryption_rotation encryption_rotation) {
+  void encryption_rotation(Encryption_rotation encryption_rotation) {
     m_encryption.m_encryption_rotation = encryption_rotation;
   }
 
@@ -960,13 +953,12 @@ class IORequest {
 
   /** Clear all encryption related flags */
   void clear_encrypted() {
-    m_encryption.set_key(NULL, 0, false);
-    m_encryption.m_iv = NULL;
+    m_encryption.set_key(nullptr, 0, false);
+    m_encryption.m_iv = nullptr;
     m_encryption.m_type = Encryption::NONE;
-    m_encryption.m_encryption_rotation = Encryption::NO_ROTATION;
-    m_encryption.m_tablespace_iv = NULL;
+    m_encryption.m_encryption_rotation = Encryption_rotation::NO_ROTATION;
     m_encryption.m_key_id = 0;
-    m_encryption.m_tablespace_key = NULL;
+    m_encryption.m_tablespace_key = nullptr;
   }
 
   void mark_page_zip_compressed() { m_is_page_zip_compressed = true; }

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -316,6 +316,7 @@ extern Log_DDL *log_ddl;
 extern bool srv_is_upgrade_mode;
 extern bool srv_downgrade_logs;
 extern bool srv_upgrade_old_undo_found;
+extern bool srv_has_crypt_data_v1_rotating_from_mk;
 #endif /* INNODB_DD_TABLE */
 
 #ifdef UNIV_DEBUG

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1646,7 +1646,11 @@ static byte *recv_parse_or_apply_log_rec_body(mlog_id_t type, byte *ptr,
           } else if (memcmp(ptr_copy, ENCRYPTION_KEY_MAGIC_PS_V1,
                             ENCRYPTION_MAGIC_SIZE) == 0 &&
                      apply) {
-            return (fil_parse_write_crypt_data(ptr, end_ptr, block, len));
+            return (fil_parse_write_crypt_data_v1(space_id, ptr, end_ptr, len));
+          } else if (memcmp(ptr_copy, ENCRYPTION_KEY_MAGIC_PS_V2,
+                            ENCRYPTION_MAGIC_SIZE) == 0 &&
+                     apply) {
+            return (fil_parse_write_crypt_data_v2(space_id, ptr, end_ptr, len));
           }
         }
         break;
@@ -3997,7 +4001,7 @@ void recv_dblwr_t::decrypt_sys_dblwr_pages() {
   IORequest decrypt_request;
 
   decrypt_request.encryption_key(space->encryption_key, space->encryption_klen,
-                                 false, space->encryption_iv, 0, 0, NULL, NULL);
+                                 false, space->encryption_iv, 0, 0, nullptr);
   decrypt_request.encryption_algorithm(Encryption::AES);
 
   Encryption encryption(decrypt_request.encryption_algorithm());

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -1720,7 +1720,7 @@ static dberr_t verify_post_encryption_checksum(const IORequest &type,
           encryption.is_encrypted_and_compressed(buf));
     }
 
-    if (encryption.m_encryption_rotation == Encryption::NO_ROTATION &&
+    if (encryption.m_encryption_rotation == Encryption_rotation::NO_ROTATION &&
         !is_crypt_checksum_correct) {  // There is no re-encryption going on
       const auto space_id =
           mach_read_from_4(buf + FIL_PAGE_ARCH_LOG_NO_OR_SPACE_ID);
@@ -1733,7 +1733,8 @@ static dberr_t verify_post_encryption_checksum(const IORequest &type,
   }
 
   if (encryption.m_encryption_rotation ==
-      Encryption::MASTER_KEY_TO_KEYRING) {  // There is re-encryption going on
+      Encryption_rotation::MASTER_KEY_TO_KEYRING) {  // There is re-encryption
+                                                     // going on
     encryption.m_type =
         is_crypt_checksum_correct
             ? Encryption::KEYRING  // assume page is RK encrypted
@@ -1798,16 +1799,13 @@ static bool load_key_needed_for_decryption(const IORequest &type,
     encryption.m_key_version = key_version_read_from_page;
   } else {
     ut_ad(encryption.m_type == Encryption::AES);
-    if (encryption.m_encryption_rotation == Encryption::NO_ROTATION)
+    if (encryption.m_encryption_rotation == Encryption_rotation::NO_ROTATION)
       return true;  // we are all set - needed key was alread loaded into
                     // encryption module
 
     ut_ad(encryption.m_encryption_rotation ==
-          Encryption::MASTER_KEY_TO_KEYRING);
-    ut_ad(encryption.m_tablespace_iv != NULL);
-    encryption.m_iv = encryption.m_tablespace_iv;  // iv comes from tablespace
-                                                   // header for MK encryption
-    ut_ad(encryption.m_tablespace_key != NULL);
+              Encryption_rotation::MASTER_KEY_TO_KEYRING &&
+          encryption.m_tablespace_key != nullptr);
     encryption.set_key(encryption.m_tablespace_key, ENCRYPTION_KEY_LEN, false);
   }
 
@@ -8390,7 +8388,6 @@ Encryption::Encryption(const Encryption &other) noexcept
       m_klen(other.m_klen),
       m_key_allocated(other.m_key_allocated),
       m_iv(other.m_iv),
-      m_tablespace_iv(other.m_tablespace_iv),
       m_tablespace_key(other.m_tablespace_key),
       m_key_version(other.m_key_version),
       m_key_id(other.m_key_id),
@@ -10183,7 +10180,7 @@ bool os_dblwr_encrypt_page(fil_space_t *space, page_t *in_page,
 
   IORequest write_request(IORequest::WRITE);
   write_request.encryption_key(space->encryption_key, space->encryption_klen,
-                               false, space->encryption_iv, 0, 0, NULL, NULL);
+                               false, space->encryption_iv, 0, 0, nullptr);
 
   write_request.encryption_algorithm(Encryption::AES);
 
@@ -10228,7 +10225,7 @@ dberr_t os_dblwr_decrypt_page(fil_space_t *space, page_t *page) {
   IORequest decrypt_request;
 
   decrypt_request.encryption_key(space->encryption_key, space->encryption_klen,
-                                 false, space->encryption_iv, 0, 0, NULL, NULL);
+                                 false, space->encryption_iv, 0, 0, nullptr);
 
   decrypt_request.encryption_algorithm(Encryption::AES);
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -112,6 +112,7 @@ Srv_cpu_usage srv_cpu_usage;
 bool srv_is_upgrade_mode = false;
 bool srv_downgrade_logs = false;
 bool srv_upgrade_old_undo_found = false;
+bool srv_has_crypt_data_v1_rotating_from_mk{false};
 #endif /* INNODB_DD_TABLE */
 
 #ifdef UNIV_DEBUG


### PR DESCRIPTION
Decreased Keyring encryption information stored on page0 of KEYRING
encrypted tables.

Removed:
 - space_id (4 bytes)
 - offset (2 bytes)
 - tablespace_iv (32 bytes)
Shrank the size of encryption_rotation from 4 bytes to 1 byte
(currently this can have only one of two values: NO_ROTATION or
MASTER_KEY_TO_KEYRING)

tablespace_iv was only used when there was MASTER_KEY_TO_KEYRING
rotation taking place. We would have two IVs then - one for KEYRING
encryption and the second one for MK decryption. However, those IVs do
not need to be different as long as the key used is different - which is
the case here. So instead of generating new IV for KEYRING encryption we
reuse the MK encryption IV when re-encrypting from MK to KEYRING.

This change introduces upgrade problem. When table is in the middle of
MK to KEYRING rotation it cannot be upgraded to this new schema as we do
not have place to store tablespace_iv. We could introduce this field in
the crypt_data in-memory structure to support this rotation. However,
since this feature is experimental we chose to ask user to finish off
the rotation before the upgrade and abort the upgrade if there is table
for which this rotation has not been finished. It also helps to clean up
the code, because we have to care only about one iv, instead of
two (and tablespace_iv being used in very rare cases).

The table which is being re-encrypted from MK to KEYRING has it first
page always validated (since encrypted flag is set for this table). We
chose to check if it is in the middle of MK to KEYRING re-encryption
there.