### PR TITLE
PS-1469: MEMORY table "is full" flag stuck when should not be (8.0)

### DIFF
--- a/mysql-test/r/percona_heap_bug_ps1469.result
+++ b/mysql-test/r/percona_heap_bug_ps1469.result
@@ -1,0 +1,18 @@
+CALL mtr.add_suppression("The table 't1' is full");
+SET @@session.max_heap_table_size = 10485760;
+CREATE TABLE t1 (inmem VARCHAR(8192)) ENGINE=MEMORY;
+CREATE PROCEDURE load_test() 
+BEGIN 
+DECLARE v_iterations int default 0; 
+TRUNCATE TABLE t1; 
+WHILE v_iterations < 8192 DO 
+INSERT INTO t1 (inmem) VALUES (REPEAT("a", 8192)); 
+SET v_iterations=v_iterations+1; 
+END WHILE;
+END//
+CALL load_test;
+ERROR HY000: The table 't1' is full
+DELETE FROM t1 LIMIT 100;
+INSERT INTO t1 VALUES (REPEAT("a", 8192));
+DROP PROCEDURE load_test;
+DROP TABLE t1;

--- a/mysql-test/t/percona_heap_bug_ps1469.test
+++ b/mysql-test/t/percona_heap_bug_ps1469.test
@@ -1,0 +1,34 @@
+#
+# PS-1469: MEMORY table "is full" flag stuck when should not be
+#
+
+CALL mtr.add_suppression("The table 't1' is full");
+
+SET @@session.max_heap_table_size = 10485760;
+
+CREATE TABLE t1 (inmem VARCHAR(8192)) ENGINE=MEMORY;
+
+DELIMITER //;
+
+CREATE PROCEDURE load_test() 
+  BEGIN 
+    DECLARE v_iterations int default 0; 
+    TRUNCATE TABLE t1; 
+    WHILE v_iterations < 8192 DO 
+      INSERT INTO t1 (inmem) VALUES (REPEAT("a", 8192)); 
+      SET v_iterations=v_iterations+1; 
+    END WHILE;
+  END//
+
+DELIMITER ;//
+
+--error ER_RECORD_FILE_FULL
+CALL load_test;
+
+DELETE FROM t1 LIMIT 100;
+
+INSERT INTO t1 VALUES (REPEAT("a", 8192));
+
+# cleanup
+DROP PROCEDURE load_test;
+DROP TABLE t1;

--- a/storage/heap/hp_write.c
+++ b/storage/heap/hp_write.c
@@ -44,15 +44,21 @@ int heap_write(HP_INFO *info, const uchar *record)
   }
 #endif
 
-  if ((share->records >= share->max_records && share->max_records) ||
-      (share->recordspace.total_data_length + share->index_length >=
-       share->max_table_size))
+  if (share->records >= share->max_records && share->max_records)
   {
     my_errno= HA_ERR_RECORD_FILE_FULL;
     DBUG_RETURN(my_errno);
   }
 
   hp_get_encoded_data_length(share, record, &chunk_count);
+
+  if ((share->recordspace.del_chunk_count < chunk_count) &&
+      (share->recordspace.total_data_length + share->index_length >=
+       share->max_table_size))
+  {
+    my_errno= HA_ERR_RECORD_FILE_FULL;
+    DBUG_RETURN(my_errno);
+  }
 
   if (!(pos= hp_allocate_chunkset(&share->recordspace, chunk_count)))
     DBUG_RETURN(my_errno);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-1469

Fixed wrong condition detecting out of space for memory storage engine. When all chunks were allocated, but some of them were unused (deleted rows) engine still reported that there is no room for new records. In such case there is space that can be reused. Free chunks are kept in HP_DATASPACE::del_link list.