### PR TITLE
PS-6065 : PS fails to recover with smaller buffer pool size with impr…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_recovery_backoff_algo.result
+++ b/mysql-test/suite/innodb/r/percona_recovery_backoff_algo.result
@@ -1,0 +1,11 @@
+SELECT @@global.innodb_empty_free_list_algorithm;
+@@global.innodb_empty_free_list_algorithm
+backoff
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 LONGBLOB) ENGINE=InnoDB;
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+# Kill and restart
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_recovery_backoff_algo-master.opt
+++ b/mysql-test/suite/innodb/t/percona_recovery_backoff_algo-master.opt
@@ -1,0 +1,1 @@
+--innodb_buffer_pool_size=24M --innodb_log_file_size=50331648

--- a/mysql-test/suite/innodb/t/percona_recovery_backoff_algo.test
+++ b/mysql-test/suite/innodb/t/percona_recovery_backoff_algo.test
@@ -1,0 +1,11 @@
+SELECT @@global.innodb_empty_free_list_algorithm;
+CREATE TABLE t1 (f1 INTEGER PRIMARY KEY AUTO_INCREMENT, f2 LONGBLOB) ENGINE=InnoDB;
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+INSERT INTO t1 (f2) VALUES (REPEAT('x', 1024 * 1024 * 10));
+
+--source include/kill_and_restart_mysqld.inc
+
+DROP TABLE t1;

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -2708,11 +2708,16 @@ files_checked:
       ib::warn(ER_IB_MSG_1140);
     }
 
+    srv_dict_metadata = recv_recovery_from_checkpoint_finish(*log_sys, false);
+
+    /* buf_flush_sync_all_buf_pools() cannot be used before
+    recv_recovery_from_checkpoint_finish() because before this, page cleaners
+    wait on recv_sys->flush_start event. This is signaled either during recovery
+    or at end, ie. recv_recovery_from_checkpoint_finish(). So this is the first
+    point where we can use buf_flush_sync_all_buf_pools() */
     if (!srv_force_recovery && !srv_read_only_mode) {
       buf_flush_sync_all_buf_pools();
     }
-
-    srv_dict_metadata = recv_recovery_from_checkpoint_finish(*log_sys, false);
 
     if (!srv_force_recovery && !recv_sys->found_corrupt_log &&
         (srv_log_file_size_requested != srv_log_file_size ||


### PR DESCRIPTION
…oved innodb_empty_free_list_algorithm=backoff

Probem:
-------
With small buffer pool size (such as 24M) and innodb_empty_free_list_algorithm=backoff,
recovery hangs looking for free blocks

With backoff, we rely on page cleaners to give free blocks. At recovery stage, page cleaners
wait for recovery flush events and not yet start flushing. The LRU flushers thread are also
idle and not doing anything because the minimum size they need to be active is 256.

At this hanging state, the LRU list length is less than 256 and so it remains idle.

Fix:
----
We remove the minimum length of LRU restriction for LRU flusher threads during recovery