### PR TITLE
PS-5932: Implementing --tokudb-force-recovery=6 to skip reading the logs (8.0)

### DIFF
--- a/mysql-test/suite/tokudb/r/recovery.result
+++ b/mysql-test/suite/tokudb/r/recovery.result
@@ -1,0 +1,28 @@
+create table t (a int, b int, primary key (a)) engine=tokudb;
+insert into t values (1,2),(2,4),(3,8);
+optimize table t;
+Table	Op	Msg_type	Msg_text
+test.t	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.t	optimize	status	OK
+insert into t values (4,9),(10,11),(12,13);
+select * from t;
+a	b
+1	2
+2	4
+3	8
+4	9
+10	11
+12	13
+# Kill the server
+# restart:--tokudb-force-recovery=6 --read-only --super-read-only
+select * from t;
+a	b
+1	2
+2	4
+3	8
+select * from t;
+a	b
+1	2
+2	4
+3	8
+drop table t;

--- a/mysql-test/suite/tokudb/t/recovery.test
+++ b/mysql-test/suite/tokudb/t/recovery.test
@@ -1,0 +1,46 @@
+--source include/have_tokudb.inc
+
+# verify that delete from table leaves the table empty
+create table t (a int, b int, primary key (a)) engine=tokudb;
+insert into t values (1,2),(2,4),(3,8);
+
+--let $MYSQLD_DATADIR= `select @@datadir`
+
+optimize table t;
+
+--source include/restart_mysqld.inc
+
+insert into t values (4,9),(10,11),(12,13);
+
+select * from t;
+
+--source include/kill_mysqld.inc
+
+--exec mv $MYSQLD_DATADIR/tokudb.rollback $MYSQLD_DATADIR/rollback.backup
+# Create an empty rollback file that tokudb can't interpret
+--exec echo "" > $MYSQLD_DATADIR/tokudb.rollback
+# Make everything read only - to make sure the server can't write these files
+--exec find $MYSQLD_DATADIR -type f -name "*toku*" | xargs chmod u-w
+
+--let $restart_parameters= restart:--tokudb-force-recovery=6 --read-only --super-read-only
+--source include/start_mysqld.inc
+
+select * from t;
+
+--let $restart_parameters= restart:--tokudb-force-recovery=6 --read-only --super-read-only
+--source include/restart_mysqld.inc
+
+select * from t;
+
+--source include/shutdown_mysqld.inc
+# Restore rollback & RW permissions
+--exec find $MYSQLD_DATADIR -type f -name "*toku*" | xargs chmod u+w
+--exec rm $MYSQLD_DATADIR/tokudb.rollback
+--exec mv $MYSQLD_DATADIR/rollback.backup $MYSQLD_DATADIR/tokudb.rollback
+--let $restart_parameters= 
+--source include/start_mysqld.inc
+
+# Cleanup recovery files
+--exec rm $MYSQLD_DATADIR/tokudb.rollback2
+--exec rm $MYSQLD_DATADIR/tokudb.environment2
+drop table t;

--- a/storage/tokudb/ha_tokudb.cc
+++ b/storage/tokudb/ha_tokudb.cc
@@ -1109,7 +1109,7 @@ int ha_tokudb::open_main_dictionary(const char *name, bool is_read_only,
   share->key_file[primary_key] = share->file;
 
   error = share->file->open(share->file, txn, newname, NULL, DB_BTREE,
-                            open_flags, 0);
+                            open_flags, is_read_only ? 0 : S_IWUSR);
   if (error) {
     goto exit;
   }
@@ -1160,7 +1160,8 @@ int ha_tokudb::open_secondary_dictionary(DB **ptr, KEY *key_info,
     goto cleanup;
   }
 
-  error = (*ptr)->open(*ptr, txn, newname, NULL, DB_BTREE, open_flags, 0);
+  error = (*ptr)->open(*ptr, txn, newname, NULL, DB_BTREE, open_flags,
+                       is_read_only ? 0 : S_IWUSR);
   if (error) {
     set_my_errno(error);
     goto cleanup;
@@ -1211,7 +1212,7 @@ int ha_tokudb::initialize_share(const char *name, int mode) {
   if (table->part_info == NULL) {
     error = verify_frm_data(table->s->path.str, txn);
     if (error) goto exit;
-  } else {
+  } else if (force_recovery == 0 && !read_only && !super_read_only) {
     // remove the frm data for partitions since we are not maintaining it
     error = remove_frm_data(share->status_block, txn);
     if (error) goto exit;
@@ -1617,6 +1618,8 @@ int ha_tokudb::write_frm_data(DB *db, DB_TXN *txn, const char *frm_name) {
   uchar *frm_data = NULL;
   size_t frm_len = 0;
   int error = 0;
+
+  if (force_recovery != 0 || read_only || super_read_only) goto cleanup;
 
   error = readfrm(frm_name, &frm_data, &frm_len);
   if (error) {

--- a/storage/tokudb/tokudb_status.h
+++ b/storage/tokudb/tokudb_status.h
@@ -161,12 +161,17 @@ int create(DB_ENV *env, DB **status_db_ptr, const char *name, DB_TXN *txn) {
   return error;
 }
 
+extern "C" {
+extern uint force_recovery;
+}
+
 int open(DB_ENV *env, DB **status_db_ptr, const char *name, DB_TXN *txn) {
   int error = 0;
   DB *status_db = NULL;
   error = db_create(&status_db, env, 0);
   if (error == 0) {
-    error = status_db->open(status_db, txn, name, NULL, DB_BTREE, DB_THREAD, 0);
+    error = status_db->open(status_db, txn, name, NULL, DB_BTREE, DB_THREAD,
+                            force_recovery ? 0 : S_IWUSR);
   }
   if (error == 0) {
     uint32_t pagesize = 0;

--- a/storage/tokudb/tokudb_sysvars.cc
+++ b/storage/tokudb/tokudb_sysvars.cc
@@ -491,6 +491,10 @@ static int dir_cmd_check(THD *thd, TOKUDB_UNUSED(struct SYS_VAR *var),
   return error;
 }
 
+static MYSQL_SYSVAR_UINT(force_recovery, force_recovery, PLUGIN_VAR_READONLY,
+                         "force recovery. Set to 6 to skip reading the logs",
+                         NULL, NULL, 0, 0, 0, 0);
+
 //******************************************************************************
 // all system variables
 //******************************************************************************
@@ -504,10 +508,11 @@ SYS_VAR *system_variables[] = {
     MYSQL_SYSVAR(client_pool_threads),
     MYSQL_SYSVAR(compress_buffers_before_eviction), MYSQL_SYSVAR(data_dir),
     MYSQL_SYSVAR(debug), MYSQL_SYSVAR(directio),
-    MYSQL_SYSVAR(enable_partial_eviction), MYSQL_SYSVAR(fs_reserve_percent),
-    MYSQL_SYSVAR(fsync_log_period), MYSQL_SYSVAR(log_dir),
-    MYSQL_SYSVAR(max_lock_memory), MYSQL_SYSVAR(read_status_frequency),
-    MYSQL_SYSVAR(strip_frm_data), MYSQL_SYSVAR(tmp_dir), MYSQL_SYSVAR(version),
+    MYSQL_SYSVAR(enable_partial_eviction), MYSQL_SYSVAR(force_recovery),
+    MYSQL_SYSVAR(fs_reserve_percent), MYSQL_SYSVAR(fsync_log_period),
+    MYSQL_SYSVAR(log_dir), MYSQL_SYSVAR(max_lock_memory),
+    MYSQL_SYSVAR(read_status_frequency), MYSQL_SYSVAR(strip_frm_data),
+    MYSQL_SYSVAR(tmp_dir), MYSQL_SYSVAR(version),
     MYSQL_SYSVAR(write_status_frequency), MYSQL_SYSVAR(dir_per_db),
     MYSQL_SYSVAR(check_jemalloc),
 

--- a/storage/tokudb/tokudb_sysvars.h
+++ b/storage/tokudb/tokudb_sysvars.h
@@ -27,6 +27,10 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #ifndef _TOKUDB_SYSVARS_H
 #define _TOKUDB_SYSVARS_H
 
+extern "C" {
+extern uint force_recovery;
+}
+
 namespace tokudb {
 namespace sysvars {
 


### PR DESCRIPTION
This could be useful when the server crashed with a corrupted rollback file,
and is unable to start up. Specifying --tokudb--force-recovery=6 --super-read-only
should start it up in a read-only, but usable state. Some data may be lost and
unrecoverable.

Starting the server without the read only option is NOT supported.

(this is a cherry pick from 5.6 & 5.7, including all previous
commits)