### PR TITLE
PS-6013: Prevented ICP for keys that cannot be decoded (backported PS-5024 fix) (5.7)

### DIFF
--- a/mysql-test/suite/rocksdb/r/PS-5024.result
+++ b/mysql-test/suite/rocksdb/r/PS-5024.result
@@ -1,0 +1,37 @@
+#
+# PS-5024: Query returns incorrect result for table with no PK and non-unique CHAR utf8mb4 SK
+#
+CREATE TABLE t1 (cola char(3) not null, colb char(3) not null, filler char(200), key ka(cola), key kb(colb)) default charset utf8mb4 engine=rocksdb;
+INSERT INTO t1(cola,colb,filler) VALUES('aaa','aaa', 'Z1'), ('aaa','aaa', 'Z2'), ('aaa','aaa', 'Z3'), ('bbb','bbb', 'Z4');
+SELECT * FROM t1 WHERE cola <> 'aaa';
+cola	colb	filler
+bbb	bbb	Z4
+SELECT * FROM t1 WHERE colb <> 'aaa';
+cola	colb	filler
+bbb	bbb	Z4
+SELECT * FROM t1 FORCE INDEX(kb) WHERE cola <> 'aaa';
+cola	colb	filler
+bbb	bbb	Z4
+SELECT * FROM t1 WHERE cola = 'aaa';
+cola	colb	filler
+aaa	aaa	Z1
+aaa	aaa	Z2
+aaa	aaa	Z3
+SELECT * FROM t1 WHERE colb = 'aaa';
+cola	colb	filler
+aaa	aaa	Z1
+aaa	aaa	Z2
+aaa	aaa	Z3
+CREATE TABLE t2 (pk VARCHAR(16) not null PRIMARY KEY, key1 VARCHAR(16) not null, col1 VARCHAR(16) not null, KEY(key1)) ENGINE=rocksdb;
+INSERT INTO t2 VALUES ('row1', 'row1-key', 'row1-data'), ('row2', 'row2-key', 'row2-data'), ('row3', 'row3-key', 'row3-data'), ('row4', 'row4-key', 'row4-data'), ('row5', 'row5-key', 'row5-data');
+SELECT * FROM t2 WHERE key1 <='row3-key';
+pk	key1	col1
+row1	row1-key	row1-data
+row2	row2-key	row2-data
+row3	row3-key	row3-data
+SELECT * FROM t2 WHERE key1 > 'row1-key' AND key1 < 'row4-key';
+pk	key1	col1
+row2	row2-key	row2-data
+row3	row3-key	row3-data
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/t/PS-5024.test
+++ b/mysql-test/suite/rocksdb/t/PS-5024.test
@@ -1,0 +1,21 @@
+--source include/have_rocksdb.inc
+
+--echo #
+--echo # PS-5024: Query returns incorrect result for table with no PK and non-unique CHAR utf8mb4 SK
+--echo #
+
+CREATE TABLE t1 (cola char(3) not null, colb char(3) not null, filler char(200), key ka(cola), key kb(colb)) default charset utf8mb4 engine=rocksdb;
+INSERT INTO t1(cola,colb,filler) VALUES('aaa','aaa', 'Z1'), ('aaa','aaa', 'Z2'), ('aaa','aaa', 'Z3'), ('bbb','bbb', 'Z4');
+SELECT * FROM t1 WHERE cola <> 'aaa';
+SELECT * FROM t1 WHERE colb <> 'aaa';
+SELECT * FROM t1 FORCE INDEX(kb) WHERE cola <> 'aaa';
+SELECT * FROM t1 WHERE cola = 'aaa';
+SELECT * FROM t1 WHERE colb = 'aaa';
+
+CREATE TABLE t2 (pk VARCHAR(16) not null PRIMARY KEY, key1 VARCHAR(16) not null, col1 VARCHAR(16) not null, KEY(key1)) ENGINE=rocksdb;
+INSERT INTO t2 VALUES ('row1', 'row1-key', 'row1-data'), ('row2', 'row2-key', 'row2-data'), ('row3', 'row3-key', 'row3-data'), ('row4', 'row4-key', 'row4-data'), ('row5', 'row5-key', 'row5-data');
+SELECT * FROM t2 WHERE key1 <='row3-key';
+SELECT * FROM t2 WHERE key1 > 'row1-key' AND key1 < 'row4-key';
+
+DROP TABLE t1;
+DROP TABLE t2;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7420,8 +7420,9 @@ ulong ha_rocksdb::index_flags(bool &pk_can_be_decoded,
   ulong base_flags = HA_READ_NEXT | // doesn't seem to be used
                      HA_READ_ORDER | HA_READ_RANGE | HA_READ_PREV;
 
-  if (check_keyread_allowed(pk_can_be_decoded, table_share, inx, part,
-                            all_parts))
+  bool res = check_keyread_allowed(pk_can_be_decoded, table_share, inx, part,
+                                   all_parts);
+  if (res)
     base_flags |= HA_KEYREAD_ONLY;
 
   if (inx == table_share->primary_key) {
@@ -7431,7 +7432,8 @@ ulong ha_rocksdb::index_flags(bool &pk_can_be_decoded,
       plans.
     */
     base_flags |= HA_KEYREAD_ONLY;
-  } else {
+  } else if (res) {
+    /* We can do ICP only if we are able to decode the key (res == true) */
     /*
       We can Index Condition Pushdown any key except the primary. With primary
       key, we get (pk, record) pair immediately, there is no place to put the


### PR DESCRIPTION
https://jira.percona.com/browse/PS-6013

Note that PS-5024 problem was not visible in 5.7. For detailed explanation see
https://jira.percona.com/browse/PS-5024