### PR TITLE
PS-6123: Replace '>' with '-gt' (8.0)

### DIFF
--- a/build-ps/debian/percona-server-server-5.7.mysql.init
+++ b/build-ps/debian/percona-server-server-5.7.mysql.init
@@ -62,7 +62,7 @@ fix_thp_setting() {
 
 check_exit_status() {
         errcode=$1
-        if [ $errcode > 0 ];
+        if [ $errcode -gt 0 ];
         then
                 exit $errcode
         fi


### PR DESCRIPTION
Hello masters,
**I haven't found a way to file an issue. If this PR disturbs you please close it directly.**

I use Percona Server in Docker (image: Ubuntu 16.04).

It doesn't wait service started when I use `service mysql start`, but `service mysql stop` is worked. So I try to found the reason from source code(`/etc/init.d/mysql`).
I noticed that `[ $errcode > 0 ]` not work well with bash.

There are two ways can fix it:
1. Use `[[ $errcode > 0 ]]`
2. Use `[ $errcode -gt 0 ]`

I found the 2nd one is in your repo. So I fix it with `-gt`.