### PR TITLE
PS-6094: Handler fails to trigger on Error 1049 or SQLSTATE 42000 or plain sqlexception

### DIFF
--- a/mysql-test/r/sp-bugs.result
+++ b/mysql-test/r/sp-bugs.result
@@ -464,3 +464,26 @@ Function	sql_mode	Create Function	character_set_client	collation_connection	Data
 очень_очень_очень_очень_очень_очень_очень_очень_длинная_строка_e	#	#	#	#	#
 DROP FUNCTION очень_очень_очень_очень_очень_очень_очень_очень_длинная_строка_é;
 SET NAMES default;
+#
+# Bug#97682 - Handler fails to trigger on Error 1049 or SQLSTATE 42000 or plain sqlexception
+#
+CREATE FUNCTION handler_func() RETURNS INTEGER
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION RETURN NULL;
+SELECT fake_col INTO @a FROM fake_table;
+RETURN 1;
+END|
+CREATE FUNCTION handler_func2() RETURNS INTEGER
+BEGIN
+DECLARE EXIT HANDLER FOR SQLEXCEPTION RETURN NULL;
+SELECT fake_col INTO @a FROM fake_db.fake_table;
+RETURN 1;
+END|
+SELECT handler_func();
+handler_func()
+NULL
+SELECT handler_func2();
+handler_func2()
+NULL
+DROP FUNCTION handler_func;
+DROP FUNCTION handler_func2;

--- a/mysql-test/t/sp-bugs.test
+++ b/mysql-test/t/sp-bugs.test
@@ -476,3 +476,31 @@ SHOW CREATE FUNCTION очень_очень_очень_очень_очень_оч
 DROP FUNCTION очень_очень_очень_очень_очень_очень_очень_очень_длинная_строка_é;
 
 SET NAMES default;
+
+--echo #
+--echo # Bug#97682 - Handler fails to trigger on Error 1049 or SQLSTATE 42000 or plain sqlexception
+--echo #
+
+DELIMITER |;
+
+CREATE FUNCTION handler_func() RETURNS INTEGER
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION RETURN NULL;
+  SELECT fake_col INTO @a FROM fake_table;
+RETURN 1;
+END|
+
+CREATE FUNCTION handler_func2() RETURNS INTEGER
+BEGIN
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION RETURN NULL;
+  SELECT fake_col INTO @a FROM fake_db.fake_table;
+RETURN 1;
+END|
+
+DELIMITER ;|
+
+SELECT handler_func();
+SELECT handler_func2();
+
+DROP FUNCTION handler_func;
+DROP FUNCTION handler_func2;

--- a/sql/error_handler.h
+++ b/sql/error_handler.h
@@ -209,7 +209,8 @@ class View_error_handler : public Internal_error_handler {
 };
 
 /**
-  This internal handler is used to trap ER_NO_SUCH_TABLE.
+  This internal handler is used to trap ER_NO_SUCH_TABLE and
+  ER_BAD_DB_ERROR.
 */
 
 class No_such_table_error_handler : public Internal_error_handler {
@@ -219,7 +220,7 @@ class No_such_table_error_handler : public Internal_error_handler {
   virtual bool handle_condition(THD *, uint sql_errno, const char *,
                                 Sql_condition::enum_severity_level *,
                                 const char *) {
-    if (sql_errno == ER_NO_SUCH_TABLE) {
+    if (sql_errno == ER_NO_SUCH_TABLE || sql_errno == ER_BAD_DB_ERROR) {
       m_handled_errors++;
       return true;
     }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-6094

No_such_table_error_handler modified to trap ER_BAD_DB_ERROR as well to handle the case when specified nonexistent table is located in nonexistent database.