### PR TITLE
8.0 PS-5642 - page tracker thread won't exist if startup fails

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_shutdown_thread.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_shutdown_thread.result
@@ -1,0 +1,7 @@
+SELECT 1;
+1
+1
+# Asserting that the error was not thrown.
+[log_grep.inc] file:  pattern: threads created by InnoDB had not exited at shutdown
+[log_grep.inc] lines:   0
+# restart

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread-master.opt
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread-master.opt
@@ -1,0 +1,1 @@
+--innodb_track_changed_pages=TRUE

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread.test
@@ -1,0 +1,19 @@
+#
+# PS-5642 - page tracker thread won't exist if startup fails
+#
+
+--source include/have_debug.inc
+
+SELECT 1;
+--source include/shutdown_mysqld.inc
+--error 1
+--exec $MYSQLD_CMD --innodb_track_changed_pages=TRUE --debug=d,ib_dic_boot_error --log-error=$MYSQLTEST_VARDIR/tmp/percona_changed_page_bmp_shutdown_thread.err
+
+--echo # Asserting that the error was not thrown.
+--let log_file_full_path=$MYSQLTEST_VARDIR/tmp/percona_changed_page_bmp_shutdown_thread.err
+--let grep_pattern=threads created by InnoDB had not exited at shutdown
+--let log_expected_matches=0
+--source include/log_grep.inc
+
+--source include/start_mysqld.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/percona_changed_page_bmp_shutdown_thread.err


### PR DESCRIPTION
If page tracker is enabled and InnoDB fail to start,
srv_shutdown_all_bg_threads won't signal page tracker thread to exit.

This fix ensure srv_threads.m_changed_page_tracker will be signaled.

This is a fix for previously reverted PR - https://github.com/percona/percona-server/pull/3195 https://github.com/percona/percona-server/pull/3510. 8.0.17 changed background threads API.