### PR TITLE
PS-6093 Unhandled mutex in Aggregate StatsProblem:

### DIFF
--- a/storage/innobase/include/sync0policy.ic
+++ b/storage/innobase/include/sync0policy.ic
@@ -45,6 +45,7 @@ std::string AggregateMutexStatsPolicy<Mutex>::to_string() const
 	switch (m_id) {
 
 	case LATCH_ID_BUF_BLOCK_MUTEX:
+	case LATCH_ID_BUF_POOL_ZIP:
 		/* I don't think it makes sense to keep track of the file name
 		and line number for each block mutex. Too much of overhead.
 		Use the latch id to figure out the location from the source. */


### PR DESCRIPTION
Problem
----
This is a regression from PS-5639.
Aggregate type mutexes were assumed to be used only by two mutexes
BUF_BLOCK_MUTEX and AUTO INC.
BUF_POOL_ZIP mutex was not considered as aggregate mutex
and Latch ID to name conversion didn't handle BUF_POOL_ZIP mutex.
Fix:
----
Handle LATCH_ID_BUF_POOL_ZIP in AggregateMutexStatsPolicy ID to name conversion