### PR TITLE
PS-5521 tokudb_cache_size missing from documentation

### DIFF
--- a/doc/source/tokudb/tokudb_variables.rst
+++ b/doc/source/tokudb/tokudb_variables.rst
@@ -110,6 +110,11 @@ TokuDB Server Variables
      - Yes
      - Session, Global
      - Yes
+   * - :variable:`tokudb_cache_size`
+     - Yes
+     - Yes
+     - Global
+     - No
    * - :variable:`tokudb_cachetable_pool_threads`
      - Yes
      - Yes


### PR DESCRIPTION
Added tokudb_cache_size to the list of variables
Verified link