### PR TITLE
PS-1673 LP #1520467:ps_tokudb_admin cannot install tokudb remotely

### DIFF
--- a/doc/source/tokudb/tokudb_installation.rst
+++ b/doc/source/tokudb/tokudb_installation.rst
@@ -87,7 +87,7 @@ Once the |TokuDB| server package has been installed following output will be sho
 
      * See http://www.percona.com/doc/percona-server/5.6/tokudb/tokudb_intro.html for an introduction to TokuDB
 
-|Percona Server| :rn:`5.6.22-72.0` has implemented ``ps_tokudb_admin`` script to make the enabling the |TokuDB| storage engine easier. This script will automatically disable Transparent huge pages, if they're enabled, and install and enable the |TokuDB| storage engine with all the required plugins. You need to run this script as root or with :program:`sudo`. After you run the script with required parameters:
+|Percona Server| :rn:`5.6.22-72.0` has implemented ``ps_tokudb_admin`` script to make the enabling the |TokuDB| storage engine easier. This script will automatically disable Transparent huge pages, if they're enabled, and install and enable the |TokuDB| storage engine with all the required plugins. You need to run this script as root or with :program:`sudo`. The script should only be used for local installations and should not be used to install TokuDB to a remote server. After you run the script with required parameters:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Added sentence to the ps_tokudb_admin description that emphasizes the script should only be run locally and cannot be used for remote installs