### PR TITLE
PS-6148: If ANALYZE TABLE with transient statistics runs more than 600 seconds diagnostic query may crash server

### DIFF
--- a/mysql-test/suite/innodb/r/analyze_index.result
+++ b/mysql-test/suite/innodb/r/analyze_index.result
@@ -10,4 +10,15 @@ SET DEBUG_SYNC='now SIGNAL analyze.finish';
 Table	Op	Msg_type	Msg_text
 test.t1	analyze	status	OK
 SET DEBUG_SYNC= 'RESET';
+ALTER TABLE t1 STATS_PERSISTENT=0;
+SET DEBUG_SYNC='innodb_dict_stats_update_transient SIGNAL analyze.running WAIT_FOR analyze.finish';
+ANALYZE TABLE t1;
+SET DEBUG_SYNC='now WAIT_FOR analyze.running';
+SELECT ENGINE,SUM(DATA_LENGTH+INDEX_LENGTH),COUNT(ENGINE),SUM(DATA_LENGTH),SUM(INDEX_LENGTH) FROM information_schema.TABLES WHERE TABLE_SCHEMA NOT IN ('information_schema', 'performance_schema', 'mysql') AND ENGINE='InnoDB';
+ENGINE	SUM(DATA_LENGTH+INDEX_LENGTH)	COUNT(ENGINE)	SUM(DATA_LENGTH)	SUM(INDEX_LENGTH)
+InnoDB	49152	2	32768	16384
+SET DEBUG_SYNC='now SIGNAL analyze.finish';
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+SET DEBUG_SYNC= 'RESET';
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/analyze_index.test
+++ b/mysql-test/suite/innodb/t/analyze_index.test
@@ -1,11 +1,16 @@
 #
 # Bug #97828
 # PS-6113: If ANALYZE TABLE runs more than 600 seconds diagnostic query may crash server
+# PS-6148: If ANALYZE TABLE with transient statistics runs more than 600 seconds diagnostic query may crash server	
 #
 
 --source include/have_innodb.inc
 --source include/have_debug_sync.inc
 --source include/count_sessions.inc
+
+#
+# Test STATS_PERSISTENT=1 (it is by default)
+#
 
 CREATE TABLE t1(a int, index inda(a)) ENGINE=INNODB;
 INSERT INTO t1 VALUES(1);
@@ -22,10 +27,36 @@ SELECT ENGINE,SUM(DATA_LENGTH+INDEX_LENGTH),COUNT(ENGINE),SUM(DATA_LENGTH),SUM(I
 
 # let the ANALYZE TABLE to finish
 SET DEBUG_SYNC='now SIGNAL analyze.finish';
+
+--connection default
+--reap
+SET DEBUG_SYNC= 'RESET';
+
+
+#
+# Test STATS_PERSISTENT=0
+#
+
+ALTER TABLE t1 STATS_PERSISTENT=0;
+
+SET DEBUG_SYNC='innodb_dict_stats_update_transient SIGNAL analyze.running WAIT_FOR analyze.finish';
+--send ANALYZE TABLE t1
+
+# ANALYZE TABLE is running. Query for stats.
+
+--connection con1
+SET DEBUG_SYNC='now WAIT_FOR analyze.running';
+
+SELECT ENGINE,SUM(DATA_LENGTH+INDEX_LENGTH),COUNT(ENGINE),SUM(DATA_LENGTH),SUM(INDEX_LENGTH) FROM information_schema.TABLES WHERE TABLE_SCHEMA NOT IN ('information_schema', 'performance_schema', 'mysql') AND ENGINE='InnoDB';
+
+# let the ANALYZE TABLE to finish
+SET DEBUG_SYNC='now SIGNAL analyze.finish';
 --disconnect con1
 
 --connection default
 --reap
+
+#cleanup
 SET DEBUG_SYNC= 'RESET';
 DROP TABLE t1;
 

--- a/storage/innobase/dict/dict0stats.cc
+++ b/storage/innobase/dict/dict0stats.cc
@@ -819,6 +819,10 @@ dict_stats_update_transient_for_index(
 /*==================================*/
 	dict_index_t*	index)	/*!< in/out: index */
 {
+	/* stats_latch is created on 1st lock. */
+	ut_ad(!(index->table->stats_latch_created) ||
+		!rw_lock_own(index->table->stats_latch, RW_X_LATCH));
+
 	if (srv_force_recovery >= SRV_FORCE_NO_TRX_UNDO
 	    && (srv_force_recovery >= SRV_FORCE_NO_LOG_REDO
 		|| !dict_index_is_clust(index))) {
@@ -889,6 +893,10 @@ dict_stats_update_transient(
 	dict_index_t*	index;
 	ulint		sum_of_index_sizes	= 0;
 
+	dict_table_analyze_index_lock(table);
+
+	DEBUG_SYNC_C("innodb_dict_stats_update_transient");
+
 	/* Find out the sizes of the indexes and how many different values
 	for the key they approximately have */
 
@@ -897,6 +905,7 @@ dict_stats_update_transient(
 	if (dict_table_is_discarded(table)) {
 		/* Nothing to do. */
 		dict_stats_empty_table(table);
+		dict_table_analyze_index_unlock(table);
 		return;
 	} else if (index == NULL) {
 		/* Table definition is corrupt */
@@ -904,6 +913,7 @@ dict_stats_update_transient(
 		ib::warn() << "Table " << table->name
 			<< " has no indexes. Cannot calculate statistics.";
 		dict_stats_empty_table(table);
+		dict_table_analyze_index_unlock(table);
 		return;
 	}
 
@@ -934,6 +944,8 @@ dict_stats_update_transient(
 
 	index = dict_table_get_first_index(table);
 
+	dict_table_stats_lock(table, RW_X_LATCH);
+
 	table->stat_n_rows = index->stat_n_diff_key_vals[
 		dict_index_get_n_unique(index) - 1];
 
@@ -947,6 +959,9 @@ dict_stats_update_transient(
 	table->stat_modified_counter = 0;
 
 	table->stat_initialized = TRUE;
+
+	dict_table_stats_unlock(index->table, RW_X_LATCH);
+	dict_table_analyze_index_unlock(table);
 }
 
 /* @{ Pseudo code about the relation between the following functions
@@ -3119,9 +3134,9 @@ dict_stats_update_for_index(
 			" corrupted. Using transient stats instead.";
 	}
 
-	dict_table_stats_lock(index->table, RW_X_LATCH);
+	dict_table_analyze_index_lock(index->table);
 	dict_stats_update_transient_for_index(index);
-	dict_table_stats_unlock(index->table, RW_X_LATCH);
+	dict_table_analyze_index_unlock(index->table);
 
 	DBUG_VOID_RETURN;
 }
@@ -3324,11 +3339,7 @@ dict_stats_update(
 
 transient:
 
-	dict_table_stats_lock(table, RW_X_LATCH);
-
 	dict_stats_update_transient(table);
-
-	dict_table_stats_unlock(table, RW_X_LATCH);
 
 	return(DB_SUCCESS);
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-6148

Locking of table statistics limited to the time when statistics related table members are changed. While calculation is done, statistics are not locked, so can be queried.

Index analysis protected by analyze_index_mutex (the same which protects index when analysis is done for persistent statistics)

Fix applied on top of 5.7 trunk (not GCA) because GCA does not contain changes needed for this fix.