### PR TITLE
PS-6751 - innodb.table_encrypt_debug is failing

### DIFF
--- a/mysql-test/include/table_encrypt_debug.inc
+++ b/mysql-test/include/table_encrypt_debug.inc
@@ -26,6 +26,8 @@ call mtr.add_suppression("Cannot open table tde_db/.* from the internal data dic
 call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table `tde_db`.`t1` is set as discarded");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: The table .* doesn't have a corresponding tablespace, it was discarded.");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot calculate statistics for table .* because the \.ibd file is missing");
+call mtr.add_suppression("InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table .* because the \.ibd file is missing");
 --enable_query_log
 
 let $innodb_file_per_table = `SELECT @@innodb_file_per_table`;


### PR DESCRIPTION
This is a regression introduced by PS-5325 at [1]. A few tests were
missing add_suppression on new warnings thrown by the fix.

[1]:

commit 1daddaf870c94b7297ac49619100f8b511f3b546
Author: Marcelo Altmann <altmannmarcelo@gmail.com>
Date:   Wed Jul 17 08:54:28 2019 -0300

    PS-5325 Conditional jump or move depends on uninitialised value on innodb_zip.wl5522_zip and innodb.alter_missing_tablespace

    Problem:
    As part of DISCARD TABLESPACE, MySQL deinitialize table statistics.
    Later if we need to access the table (MySQL allows DDL)
    those variables won't have been initialized again. This is a regression
    introduced by PS-3829 at [1].

    Solution:
    Call dict_stats_init even if the table has been discarded.
    This will result in dict_stats_report_error been called, which as
    part of the error handling will init empty table statistics.
    As part of the fix, we need to suppress warnings that will be generated
    by dict_stats_report_error on related tests.