### PR TITLE
8.0 PS-6751 - innodb.table_encrypt_debug is failing

### DIFF
--- a/mysql-test/include/table_encrypt_debug.inc
+++ b/mysql-test/include/table_encrypt_debug.inc
@@ -26,6 +26,8 @@ call mtr.add_suppression("Cannot open table tde_db/.* from the internal data dic
 call mtr.add_suppression("\\[Warning\\] InnoDB: Tablespace for table `tde_db`.`t1` is set as discarded");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: The table .* doesn't have a corresponding tablespace, it was discarded.");
 call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot calculate statistics for table .* because the \.ibd file is missing");
+call mtr.add_suppression("InnoDB: Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("\\[Warning\\] InnoDB: Cannot save statistics for table .* because the \.ibd file is missing");
 --enable_query_log
 
 let $innodb_file_per_table = `SELECT @@innodb_file_per_table`;

--- a/mysql-test/include/table_encrypt_debug.inc
+++ b/mysql-test/include/table_encrypt_debug.inc
@@ -23,6 +23,9 @@ call mtr.add_suppression("Cannot open table tde_db/.* from the internal data dic
 call mtr.add_suppression("\\[Warning\\] .* Tablespace for table `tde_db`.`t1` is set as discarded");
 call mtr.add_suppression("\\[Warning\\] .* Database page corruption or a failed file read of page");
 call mtr.add_suppression("\\[Warning\\] .* Cannot calculate statistics for table .* because the \.ibd file is missing");
+call mtr.add_suppression("\\[Warning\\] .* Cannot calculate statistics for table .* because file .*\.ibd cannot be decrypted");
+call mtr.add_suppression("\\[Warning\\] .* Trying to access missing tablespace [0-9]+");
+call mtr.add_suppression("\\[Warning\\] .* Cannot save statistics for table .* because the \.ibd file is missing");
 call mtr.add_suppression("\\[ERROR\\] .* The table .* doesn't have a corresponding tablespace, it was discarded.");
 call mtr.add_suppression("\\[ERROR\\] .* Encryption can't find master key, please check the keyring plugin is loaded.");
 call mtr.add_suppression("\\[ERROR\\] .* Encryption algorithm support missing:");

--- a/mysql-test/suite/innodb/t/sdi.test
+++ b/mysql-test/suite/innodb/t/sdi.test
@@ -464,6 +464,7 @@ call mtr.add_suppression("Operating system error number 2 in a file operation.")
 call mtr.add_suppression("The error means the system cannot find the path specified.");
 call mtr.add_suppression("Cannot open datafile for read-only:");
 call mtr.add_suppression("Cannot calculate statistics for table .* because the \.ibd file is missing");
+call mtr.add_suppression("\\[Warning\\] .* Trying to access missing tablespace [0-9]+");
 call mtr.add_suppression("Tablespace .*, name 'ts1', file 'ts1.ibd' is missing!");
 call mtr.add_suppression("Cannot find tablespace for 'ts1' in the tablespace memory cache");
 

--- a/mysql-test/t/bug95923.test
+++ b/mysql-test/t/bug95923.test
@@ -1,5 +1,7 @@
 --disable_query_log
 call mtr.add_suppression("Cannot delete tablespace");
+call mtr.add_suppression("\\[Warning\\] .* Cannot calculate statistics for table .* because the \.ibd file is missing");
+call mtr.add_suppression("\\[Warning\\] .* Trying to access missing tablespace [0-9]+");
 --enable_query_log
 
 SET @old_table_open_cache= @@global.table_open_cache;

--- a/mysql-test/t/schema.test
+++ b/mysql-test/t/schema.test
@@ -318,6 +318,7 @@ CALL mtr.add_suppression("Failed to find tablespace");
 CALL mtr.add_suppression("Ignoring tablespace");
 CALL mtr.add_suppression("Cannot rename");
 CALL mtr.add_suppression("Cannot calculate");
+call mtr.add_suppression("\\[Warning\\] .* Trying to access missing tablespace [0-9]+");
 CALL mtr.add_suppression("Cannot open datafile");
 CALL mtr.add_suppression("The error means the system cannot find");
 CALL mtr.add_suppression("File ./s/t_innodb.ibd");


### PR DESCRIPTION
This is a regression introduced by PS-5325 at [1]. A few tests were
missing add_suppression on new warnings thrown by the fix.

[1]:

commit 1daddaf870c94b7297ac49619100f8b511f3b546
Author: Marcelo Altmann <altmannmarcelo@gmail.com>
Date:   Wed Jul 17 08:54:28 2019 -0300

    PS-5325 Conditional jump or move depends on uninitialised value on innodb_zip.wl5522_zip and innodb.alter_missing_tablespace

    Problem:
    As part of DISCARD TABLESPACE, MySQL deinitialize table statistics.
    Later if we need to access the table (MySQL allows DDL)
    those variables won't have been initialized again. This is a regression
    introduced by PS-3829 at [1].

    Solution:
    Call dict_stats_init even if the table has been discarded.
    This will result in dict_stats_report_error been called, which as
    part of the error handling will init empty table statistics.
    As part of the fix, we need to suppress warnings that will be generated
    by dict_stats_report_error on related tests.