### PR TITLE
PS-5776: Backport 8.0 undo encryption changes and report errors to the users (5.7)

### DIFF
--- a/mysql-test/suite/innodb/r/undo_encrypt_basic.result
+++ b/mysql-test/suite/innodb/r/undo_encrypt_basic.result
@@ -2,7 +2,7 @@
 # Stop the MTR default DB server
 # Run the bootstrap command with keyring
 # Search for particular string of encryption metadata, should success since it's encrypted.
-Pattern "lCB" found
+Pattern "lCC" found
 # Start the DB server with undo log encryption disabled and keyring plugin loaded. It should success.
 INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
 ERROR HY000: Function 'keyring_file' already exists
@@ -27,5 +27,5 @@ c1	c2
 400	bbbbb
 UNINSTALL PLUGIN keyring_file;
 DROP TABLE tab1;
-Pattern "lCB" found
-Pattern "lCB" found
+Pattern "lCC" found
+Pattern "lCC" found

--- a/mysql-test/suite/innodb/t/undo_encrypt_basic.test
+++ b/mysql-test/suite/innodb/t/undo_encrypt_basic.test
@@ -56,7 +56,7 @@ let NEW_CMD = $MYSQLD --no-defaults --initialize-insecure --innodb_log_file_size
 
 --echo # Search for particular string of encryption metadata, should success since it's encrypted.
 let SEARCH_FILE= $MYSQLD_UNDO_DATADIR/undo001;
-let SEARCH_PATTERN= lCB;
+let SEARCH_PATTERN= lCC;
 --source include/search_pattern.inc
 
 --echo # Start the DB server with undo log encryption disabled and keyring plugin loaded. It should success.
@@ -91,11 +91,11 @@ DROP TABLE tab1;
 # stored.
 --sleep 2
 let SEARCH_FILE= $MYSQLD_UNDO_DATADIR/undo001;
-let SEARCH_PATTERN= lCB;
+let SEARCH_PATTERN= lCC;
 --source include/search_pattern.inc
 
 let SEARCH_FILE= $MYSQLD_UNDO_DATADIR/undo002;
-let SEARCH_PATTERN= lCB;
+let SEARCH_PATTERN= lCC;
 --source include/search_pattern.inc
 
 # restart the server with MTR default
@@ -106,6 +106,6 @@ let SEARCH_PATTERN= lCB;
 --remove_file $BOOTSTRAP_SQL
 
 # Remove residue files
---force-rmdir $MYSQL_TMP_DIR/datadir
---force-rmdir $MYSQL_TMP_DIR/innodb_data_home_dir
---force-rmdir $MYSQL_TMP_DIR/innodb_undo_data_dir
+#--force-rmdir $MYSQL_TMP_DIR/datadir
+#--force-rmdir $MYSQL_TMP_DIR/innodb_data_home_dir
+#--force-rmdir $MYSQL_TMP_DIR/innodb_undo_data_dir

--- a/mysql-test/suite/sys_vars/r/innodb_undo_log_encrypt_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_undo_log_encrypt_basic.result
@@ -22,17 +22,13 @@ innodb_undo_log_encrypt	OFF
 select * from performance_schema.session_variables where variable_name='innodb_undo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_undo_log_encrypt	OFF
-set global innodb_undo_log_encrypt=1;
-select @@global.innodb_undo_log_encrypt;
-@@global.innodb_undo_log_encrypt
-0
+set global innodb_undo_log_encrypt=0;
 select * from performance_schema.global_variables where variable_name='innodb_undo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_undo_log_encrypt	OFF
 select * from performance_schema.session_variables where variable_name='innodb_undo_log_encrypt';
 VARIABLE_NAME	VARIABLE_VALUE
 innodb_undo_log_encrypt	OFF
-set @@global.innodb_undo_log_encrypt=0;
 select @@global.innodb_undo_log_encrypt;
 @@global.innodb_undo_log_encrypt
 0
@@ -51,6 +47,7 @@ ERROR 42000: Incorrect argument type to variable 'innodb_undo_log_encrypt'
 set global innodb_undo_log_encrypt='foo';
 ERROR 42000: Variable 'innodb_undo_log_encrypt' can't be set to the value of 'foo'
 set global innodb_undo_log_encrypt=-2;
+ERROR 42000: Variable 'innodb_undo_log_encrypt' can't be set to the value of '-2'
 set global innodb_undo_log_encrypt=1e1;
 ERROR 42000: Incorrect argument type to variable 'innodb_undo_log_encrypt'
 set global innodb_undo_log_encrypt=2;

--- a/mysql-test/suite/sys_vars/t/innodb_undo_log_encrypt_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_undo_log_encrypt_basic.test
@@ -4,6 +4,8 @@
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Encryption can't find master key, please check the keyring plugin is loaded.");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Can't set undo tablespaces to be encrypted, since innodb_undo_tablespaces=0");
 call mtr.add_suppression("\\[ERROR\\] InnoDB: Can't set undo tablespace number 1 to be encrypted");
+call mtr.add_suppression("Undo log cannot be encrypted");
+call mtr.add_suppression("keyring error:");
 --enable_query_log
 
 SET @start_global_value = @@global.innodb_undo_log_encrypt;
@@ -25,15 +27,13 @@ select * from performance_schema.session_variables where variable_name='innodb_u
 
 #
 # show that it's writable
+# "writing" 0, as it can't be turned on without a keyring
 #
-set global innodb_undo_log_encrypt=1;
---sleep 2
-select @@global.innodb_undo_log_encrypt;
+set global innodb_undo_log_encrypt=0;
 --disable_warnings
 select * from performance_schema.global_variables where variable_name='innodb_undo_log_encrypt';
 select * from performance_schema.session_variables where variable_name='innodb_undo_log_encrypt';
 --enable_warnings
-set @@global.innodb_undo_log_encrypt=0;
 select @@global.innodb_undo_log_encrypt;
 --disable_warnings
 select * from performance_schema.global_variables where variable_name='innodb_undo_log_encrypt';
@@ -51,6 +51,7 @@ set @@session.innodb_undo_log_encrypt='some';
 set global innodb_undo_log_encrypt=1.1;
 --error ER_WRONG_VALUE_FOR_VAR
 set global innodb_undo_log_encrypt='foo';
+--error ER_WRONG_VALUE_FOR_VAR
 set global innodb_undo_log_encrypt=-2;
 --error ER_WRONG_TYPE_FOR_VAR
 set global innodb_undo_log_encrypt=1e1;

--- a/sql/share/errmsg-utf8.txt
+++ b/sql/share/errmsg-utf8.txt
@@ -7824,6 +7824,9 @@ ER_REDO_ENCRYPTION_ERROR
 ER_REDO_ENCRYPTION_CANT_BE_CHANGED
   eng "Redo log encryption mode can't be switched without stopping the server and recreating the redo logs. Current mode is %s, requested %s."
 
+ER_UNDO_ENCRYPTION_ERROR
+  eng "%s"
+
 #
 # End of Percona Server 5.7 error messages
 #

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -2636,8 +2636,8 @@ typedef DECLARE_MYSQL_THDVAR_SIMPLE(thdvar_double_t, double);
   default variable data check and update functions
 ****************************************************************************/
 
-static int check_func_bool(THD *thd, st_mysql_sys_var *var,
-                           void *save, st_mysql_value *value)
+int check_func_bool(THD *thd, st_mysql_sys_var *var,
+                    void *save, st_mysql_value *value)
 {
   char buff[STRING_BUFFER_USUAL_SIZE];
   const char *str;

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1057,6 +1057,10 @@ Doesn't depend on the srv_redo_log_encrypt variable, used by
 SET innodb_redo_log_encrypt = MK. */
 bool srv_enable_redo_encryption_mk(THD* thd);
 
+bool srv_enable_undo_encryption(THD* thd);
+
+bool srv_rotate_undo_encryption();
+
 /** Enables keyring key redo encryption. 
 Doesn't depend on the srv_redo_log_encrypt variable, used by 
 SET innodb_redo_log_encrypt = RK. */


### PR DESCRIPTION
…e user

* Updates the testcase to test for the V3 format
* Undo encryption setter blocks until the change is applied, instead of
  checking periodically in the master thread
* Errors are reported to the user, not just into the error log