### PR TITLE
5.7 PS-6773 - Conditional jump or move depends on uninitialised value(s) …

### DIFF
--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -2929,7 +2929,7 @@ static int sha256_password_authenticate(MYSQL_PLUGIN_VIO *vio,
   char stage2[CRYPT_MAX_PASSWORD_SIZE + 1];
   String scramble_response_packet;
   int cipher_length= 0;
-  unsigned char plain_text[MAX_CIPHER_LENGTH + 1];
+  unsigned char plain_text[MAX_CIPHER_LENGTH + 1]= "";
   RSA *private_key= NULL;
   RSA *public_key= NULL;
 


### PR DESCRIPTION
…in sha256_password_authenticate

The problem
Valgrind is complaining about an uninitialised value of plain_text at
sha256_password_authenticate.

Solution
Initialize plain_text with empty string.