### PR TITLE
Post push fix: PS-6150: MySQL crash - sync_mutex_to_string

### DIFF
--- a/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
+++ b/mysql-test/suite/innodb/r/percona_extended_innodb_status.result
@@ -81,5 +81,5 @@ SET DEBUG_SYNC='now WAIT_FOR autoinc_mutex_wait.locked';
 SHOW ENGINE INNODB STATUS;
 SET DEBUG_SYNC='now SIGNAL autoinc_lock.continue';
 SET SESSION debug="-d,catch_autoinc_mutex_os_lock";
-SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
+SET DEBUG_SYNC = 'RESET';

--- a/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
+++ b/mysql-test/suite/innodb/t/percona_extended_innodb_status.test
@@ -1,3 +1,4 @@
+--source include/have_debug_sync.inc
 --source include/count_sessions.inc
 
 # saving global variables which will be changed in this test
@@ -93,7 +94,6 @@ SHOW ENGINE INNODB STATUS;
 --connection default
 SET DEBUG_SYNC='now SIGNAL autoinc_lock.continue';
 SET SESSION debug="-d,catch_autoinc_mutex_os_lock";
-SET DEBUG_SYNC = 'RESET';
 
 --connection con1
 --reap
@@ -109,4 +109,5 @@ DROP TABLE t1;
 
 # wait until all additional connections close
 --source include/wait_until_count_sessions.inc
+SET DEBUG_SYNC = 'RESET';
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-6150

1. MTR test was failing on builds where DEBUG SYNC facility is not present.
Added proper MTR test guard.
2. Fixed MTR test stability