### PR TITLE
PS-5552: Assertion `m_idx >= 0' failed in plan_idx QEP_share d::idx() const

### DIFF
--- a/mysql-test/suite/opt_trace/r/semijoin_off.result
+++ b/mysql-test/suite/opt_trace/r/semijoin_off.result
@@ -1,0 +1,36 @@
+CREATE TABLE t1(name VARCHAR(64), type TEXT) ENGINE=innodb;
+INSERT INTO t1(name, type) VALUES ("t1", "table");
+INSERT INTO t1(name, type) VALUES ("t2", "table");
+INSERT INTO t1(name, type) VALUES ("t3", "table");
+INSERT INTO t1(name, type) VALUES ("t4", "table");
+INSERT INTO t1(name, type) VALUES ("t5", "table");
+INSERT INTO t1(name, type) VALUES ("t6", "table");
+INSERT INTO t1(name, type) VALUES ("t7", "table");
+INSERT INTO t1(name, type) VALUES ("t8", "table");
+INSERT INTO t1(name, type) VALUES ("t9", "table");
+INSERT INTO t1(name, type) VALUES ("t10", "table");
+INSERT INTO t1(name, type) VALUES ("t11", "table");
+CREATE TABLE t2(name VARCHAR(64), data TEXT) ENGINE=innodb;
+INSERT INTO t2(name, data) VALUES("t1", "data");
+INSERT INTO t2(name, data) VALUES("t2", "data");
+INSERT INTO t2(name, data) VALUES("t3", "data");
+INSERT INTO t2(name, data) VALUES("t4", "data");
+INSERT INTO t2(name, data) VALUES("t5", "data");
+INSERT INTO t2(name, data) VALUES("t6", "data");
+INSERT INTO t2(name, data) VALUES("t7", "data");
+INSERT INTO t2(name, data) VALUES("t8", "data");
+SET SESSION internal_tmp_mem_storage_engine=MEMORY;
+SET @@session.optimizer_trace="enabled=on";
+SET @@session.tmp_table_size = 1024;
+SET @@optimizer_switch="semijoin=off";
+SELECT name, data FROM t2 WHERE name IN ( SELECT name FROM t1 WHERE type='table');
+name	data
+t1	data
+t2	data
+t3	data
+t4	data
+t5	data
+t6	data
+t7	data
+t8	data
+DROP TABLE t1, t2;

--- a/mysql-test/suite/opt_trace/t/semijoin_off.test
+++ b/mysql-test/suite/opt_trace/t/semijoin_off.test
@@ -1,0 +1,33 @@
+--source include/have_optimizer_trace.inc
+
+CREATE TABLE t1(name VARCHAR(64), type TEXT) ENGINE=innodb;
+INSERT INTO t1(name, type) VALUES ("t1", "table");
+INSERT INTO t1(name, type) VALUES ("t2", "table");
+INSERT INTO t1(name, type) VALUES ("t3", "table");
+INSERT INTO t1(name, type) VALUES ("t4", "table");
+INSERT INTO t1(name, type) VALUES ("t5", "table");
+INSERT INTO t1(name, type) VALUES ("t6", "table");
+INSERT INTO t1(name, type) VALUES ("t7", "table");
+INSERT INTO t1(name, type) VALUES ("t8", "table");
+INSERT INTO t1(name, type) VALUES ("t9", "table");
+INSERT INTO t1(name, type) VALUES ("t10", "table");
+INSERT INTO t1(name, type) VALUES ("t11", "table");
+
+CREATE TABLE t2(name VARCHAR(64), data TEXT) ENGINE=innodb;
+INSERT INTO t2(name, data) VALUES("t1", "data");
+INSERT INTO t2(name, data) VALUES("t2", "data");
+INSERT INTO t2(name, data) VALUES("t3", "data");
+INSERT INTO t2(name, data) VALUES("t4", "data");
+INSERT INTO t2(name, data) VALUES("t5", "data");
+INSERT INTO t2(name, data) VALUES("t6", "data");
+INSERT INTO t2(name, data) VALUES("t7", "data");
+INSERT INTO t2(name, data) VALUES("t8", "data");
+
+SET SESSION internal_tmp_mem_storage_engine=MEMORY;
+SET @@session.optimizer_trace="enabled=on";
+SET @@session.tmp_table_size = 1024;
+SET @@optimizer_switch="semijoin=off";
+
+SELECT name, data FROM t2 WHERE name IN ( SELECT name FROM t1 WHERE type='table');
+
+DROP TABLE t1, t2;

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -3352,6 +3352,7 @@ bool subselect_hash_sj_engine::setup(THD *thd, List<Item> *tmp_columns) {
   if (tmp_tab_st == NULL) return true;
   tab = &tmp_tab_st->as_QEP_TAB();
   tab->set_table(tmp_table);
+  tab->set_idx(0);
   tab->ref().key = 0; /* The only temp table index. */
   tab->ref().key_length = tmp_key->key_length;
   tab->set_type((tmp_table->key_info[0].flags & HA_NOSAME) ? JT_EQ_REF


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5552

Note: This issue affected only debug build as it was caught by assert, without having side effects in release build.

When subselect_hash_sj_engine is created it creates its internal temporary table where IN subquery is materialized. Temporary table related objects are initialized only partially.
(introduced by commit e0a309bd92f12b344c9995511d47fd7aee07fd70)

Then if the result does not fit into heap tmp table, the tmp table switches to on-disk table and trace for new table is added. This uses idx member from QEP_TAB which is not initialized.
(introduced by commit 68151294e444692fb2d639e8b557cbb3f0730b47)

The fix is to initialize idx member to value 0. It is not used anyway, but assertion does not complain.