### PR TITLE
PS-5425 MyRocks - Write Ahead Log (WAL) is not archived unless rocksd…

### DIFF
--- a/doc/source/myrocks/variables.rst
+++ b/doc/source/myrocks/variables.rst
@@ -2385,7 +2385,7 @@ Allowed range is up to ``9223372036854775807``.
   :default: ``0``
 
 Specifies the timeout in seconds before deleting archived WAL files.
-Default is ``0`` (archived WAL files are never deleted).
+Default is ``0`` (WAL files are not archived).
 Allowed range is up to ``9223372036854775807``.
 
 .. variable:: rocksdb_whole_key_filtering


### PR DESCRIPTION
…b_wal_ttl_seconds is set to non-zero value

Added a note to the variable