### PR TITLE
PS-6739 : Allow inplace tablespace encryption with ALTER for file per…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_fpt_tablespace_encrypt_2.result
+++ b/mysql-test/suite/innodb/r/percona_fpt_tablespace_encrypt_2.result
@@ -1,0 +1,405 @@
+#########################################################################
+# START : WITHOUT KEYRING PLUGIN
+#########################################################################
+
+#########
+# SETUP #
+#########
+CREATE TABLE t1(c1 char(100)) ENGINE=InnoDB ENCRYPTION="N";
+SET GLOBAL innodb_buf_flush_list_now = 1;
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	N
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
+#############################################################
+# TEST 1 : CRASH DURING ALTER ENCRYPT A TABLESPACE.
+#############################################################
+
+#########################################################################
+# RESTART 1 : WITH KEYRING PLUGIN
+#########################################################################
+############################################################
+# ALTER TABLESPACE 1 :    Unencrypted => Encrypted         #
+#                         (crash at page 10)               #
+############################################################
+# Set Encryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+# Encrypt the tablespace. It will cause crash.
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+# Restart after crash
+# Wait for Encryption processing to finish in background thread
+SET GLOBAL innodb_buf_flush_list_now = 1;
+# After restart/recovery, check that Encryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	Y
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+#########################################################################
+# RESTART 2 : WITHOUT KEYRING PLUGIN
+#########################################################################
+SELECT * FROM t1 LIMIT 10;
+ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
+#########################################################################
+# RESTART 3 : WITH KEYRING PLUGIN
+#########################################################################
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	Y
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+############################################################
+# ALTER TABLESPACE 2 :    Encrypted => Unencrypted         #
+#                         (crash at page 10)               #
+############################################################
+# Set Unencryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+# Unencrypt the tablespace. It will cause crash.
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+# Restart after crash
+# Wait for Unencryption processing to finish in background thread
+SET GLOBAL innodb_buf_flush_list_now = 1;
+# After restart/recovery, check that Unencryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	N
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+#########################################################################
+# RESTART 4 : WITHOUT KEYRING PLUGIN
+#########################################################################
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	N
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+####################################################################
+# TEST 2 : CRASH DURING ALTER ENCRYPT A TABLESPACE (Compressed).
+####################################################################
+
+CREATE TABLE t2(c1 char(100)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+SET GLOBAL innodb_buf_flush_list_now = 1;
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE NAME='test/t2';
+NAME	ENCRYPTION
+test/t2	N
+SELECT * FROM t2 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+#########################################################################
+# RESTART 5 : WITH KEYRING PLUGIN
+#########################################################################
+############################################################
+# ALTER TABLESPACE 1 :    Unencrypted => Encrypted         #
+#                         (crash at page 10)               #
+############################################################
+# Set Encryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+# Encrypt the tablespace. It will cause crash.
+ALTER TABLESPACE `test/t2` ENCRYPTION='Y';
+# Restart after crash
+# Wait for Encryption processing to finish in background thread
+SET GLOBAL innodb_buf_flush_list_now = 1;
+# After restart/recovery, check that Encryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE NAME='test/t2';
+NAME	ENCRYPTION
+test/t2	Y
+SELECT * FROM t2 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+#########################################################################
+# RESTART 6 : WITHOUT KEYRING PLUGIN
+#########################################################################
+SELECT * FROM t2 LIMIT 10;
+ERROR HY000: Can't find master key from keyring, please check in the server log if a keyring plugin is loaded and initialized successfully.
+#########################################################################
+# RESTART 7 WITH KEYRING PLUGIN
+#########################################################################
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE NAME='test/t2';
+NAME	ENCRYPTION
+test/t2	Y
+SELECT * FROM t2 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+############################################################
+# ALTER TABLESPACE 2 :    Encrypted => Unencrypted         #
+#                         (crash at page 10)               #
+############################################################
+# Set Unencryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+# Unencrypt the tablespace. It will cause crash.
+ALTER TABLESPACE `test/t2` ENCRYPTION='N';
+# Restart after crash
+# Wait for Unencryption processing to finish in background thread
+SET GLOBAL innodb_buf_flush_list_now = 1;
+# After restart/recovery, check that Unencryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE NAME='test/t2';
+NAME	ENCRYPTION
+test/t2	N
+SELECT * FROM t2 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+#########################################################################
+# RESTART 8 : WITHOUT KEYRING PLUGIN
+#########################################################################
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	N
+SELECT * FROM t2 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+DROP TABLE t2;
+#############################################################
+# TEST 3 : CRASH BEFORE/AFTER ENCRYPTION PROCESSING.
+#############################################################
+
+#########################################################################
+# RESTART 9 : WITH KEYRING PLUGIN
+#########################################################################
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+# Set server to crash just before encryption processing starts
+SET SESSION debug="+d,alter_encrypt_tablespace_crash_before_processing";
+# Unencrypt the tablespace. It will cause crash.
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+# Restart after crash
+# Wait for Unencryption processing to finish in background thread
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	Y
+# Set server to crash just after encryption processing finishes
+SET SESSION debug="-d,alter_encrypt_tablespace_crash_before_processing";
+SET SESSION debug="+d,alter_encrypt_tablespace_crash_after_processing";
+# Unencrypt the tablespace. It will cause crash.
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+# Restart after crash
+# Wait for Unencryption processing to finish in background thread
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+NAME	ENCRYPTION
+test/t1	N
+#############################################################
+# TEST 4 : CRASH DURING KEY ROTATION.
+#############################################################
+
+#########################################################################
+# RESTART 10 : WITH KEYRING PLUGIN
+#########################################################################
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+# Set server to crash while rotating encryption
+SET SESSION debug="+d,ib_crash_during_rotation_for_encryption";
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+# Restart after crash
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SET SESSION debug="-d,ib_crash_during_rotation_for_encryption";
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+SELECT * FROM t1 LIMIT 10;
+c1
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+SOME VALUES
+###############################################################
+# TEST 5 : CRASH DURING CREATING AN ENCRYPTED TABLESPACE
+###############################################################
+# Not Applicable as we create via tablespace via CREATE TABLE
+# (implicit)
+###############################################################
+# TEST 6 : DMLs ALLOWED AND DDLs BLOCKED TEST
+###############################################################
+SELECT ENABLED FROM performance_schema.setup_instruments
+WHERE NAME='wait/lock/metadata/sql/mdl';
+ENABLED
+YES
+SET DEBUG_SYNC = 'innodb_alter_encrypt_tablespace SIGNAL s1 WAIT_FOR s2';
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';;
+# Session 2
+SET DEBUG_SYNC = 'now WAIT_FOR s1';
+OBJECT_TYPE	OBJECT_NAME	LOCK_TYPE	LOCK_DURATION	LOCK_STATUS
+TABLESPACE	test/t1	EXCLUSIVE	TRANSACTION	GRANTED
+DESCRIBE t1;
+Field	Type	Null	Key	Default	Extra
+c1	char(100)	YES		NULL	
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` char(100) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+4096
+INSERT INTO t1 VALUES ("SOME VALUES");
+SELECT COUNT(*) from t1;
+COUNT(*)
+4097
+ALTER TABLE t1 ADD COLUMN (c2 int);;
+# Monitoring session
+OBJECT_TYPE	OBJECT_NAME	LOCK_TYPE	LOCK_DURATION	LOCK_STATUS
+TABLESPACE	test/t1	EXCLUSIVE	TRANSACTION	GRANTED
+# Wait for MDL request by con2 to appear in metadata_locks table.
+OBJECT_TYPE	OBJECT_NAME	LOCK_TYPE	LOCK_DURATION	LOCK_STATUS
+TABLE	t1	SHARED_UPGRADABLE	TRANSACTION	PENDING
+SET DEBUG_SYNC = 'now SIGNAL s2';
+# Connection default
+# Connection con2
+# Connection default
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+WHERE NAME LIKE "%test/t1%";
+NAME	ENCRYPTION
+test/t1	N
+DESCRIBE t1;
+Field	Type	Null	Key	Default	Extra
+c1	char(100)	YES		NULL	
+c2	int(11)	YES		NULL	
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `c1` char(100) DEFAULT NULL,
+  `c2` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+###########
+# Cleanup #
+###########
+DROP TABLE t1;
+# Restarting server without keyring to restore server state
+# restart

--- a/mysql-test/suite/innodb/r/percona_fpt_tablespace_encrypt_5.result
+++ b/mysql-test/suite/innodb/r/percona_fpt_tablespace_encrypt_5.result
@@ -1,0 +1,84 @@
+#########
+# SETUP #
+#########
+
+#########################################################################
+# RESTART 1 : WITH KEYRING PLUGIN
+#########################################################################
+# Create a new 'unencrypted' tablespace 'encrypt_ts'
+SELECT NAME, FLAG, SPACE_TYPE FROM information_schema.INNODB_TABLESPACES
+WHERE NAME="test/t1";
+NAME	FLAG	SPACE_TYPE
+# Create a table test.t1 in 'encrypt_ts' tablespace and insert some records.
+CREATE TABLE test.t1 (c char(20)) encryption='n';
+INSERT INTO test.t1 values ("samplerecord");
+SET GLOBAL innodb_buf_flush_list_now = 1;
+#############################################################
+# INITIAL SETUP : Tablespace is created as unencrypted      #
+#                 A table is created and rows are inserted  #
+#############################################################
+# Check that tablespace file is not encrypted yet
+# Print result
+table space is Unencrypted.
+############################################################
+# ALTER TABLESPACE 1 :    Unencrypted => Encrypted         #
+############################################################
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+SET GLOBAL innodb_buf_flush_list_now = 1;
+# Check that tablespace file is encrypted now
+# Print result
+table space is Encrypted.
+############################################################
+# ALTER TABLESPACE 2 :    Encrypted => Unencrypted         #
+############################################################
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+SET GLOBAL innodb_buf_flush_list_now = 1;
+# Check that tablespace file is not encrypted now
+# Print result
+table space is Unencrypted.
+
+################# CRASH/RECOVERY TESTING ###################
+
+############################################################
+# ALTER TABLESPACE 3 :    Unencrypted => Encrypted         #
+#                         (crash at page 10)               #
+############################################################
+SELECT COUNT(*) FROM test.t1;
+COUNT(*)
+4096
+SET GLOBAL innodb_buf_flush_list_now = 1;
+# Check that tablespace file is still unencrypted
+# Print result
+table space is Unencrypted.
+# Set Encryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+# Wait for Encryption processing to finish in background thread
+# After restart/recovery, check that Encryption was roll-forward and
+# tablespace file is encrypted now
+# Print result
+table space is Encrypted.
+############################################################
+# ALTER TABLESPACE 4 :    Encrypted => Unencrypted         #
+#                         (crash at page 10)               #
+############################################################
+SELECT COUNT(*) FROM test.t1;
+COUNT(*)
+4096
+# Check that tablespace file is Encrypted
+# Print result
+table space is Encrypted.
+# Set Encryption process to crash after page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+# Wait for Unencryption processing to finish in background thread
+# After restart/recovery, check that Unencryption was roll-forward and
+# tablespace file is Unencrypted now
+# Print result
+table space is Unencrypted.
+###########
+# CLEANUP #
+###########
+DROP TABLE test.t1;
+# Restarting server without keyring to restore server state
+# restart: 

--- a/mysql-test/suite/innodb/r/percona_fpt_tablespace_encrypt_debug.result
+++ b/mysql-test/suite/innodb/r/percona_fpt_tablespace_encrypt_debug.result
@@ -1,0 +1,28 @@
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci ENCRYPTION='Y'
+SET DEBUG='+d, skip_dd_table_access_check';
+include/assert.inc [t1 dd::Table should have encryption attribute set as 'Y']
+include/assert.inc [t1 dd::Tablespace should have encryption attribute set as 'Y']
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `a` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+include/assert.inc [t1 dd::Table should have encryption attribute set as 'N']
+include/assert.inc [t1 dd::Tablespace should have encryption attribute set as 'N']
+ALTER TABLESPACE `test/t1` RENAME TO `test/t2`;
+ERROR 42000: InnoDB: A general tablespace name cannot contain '/'.
+ALTER TABLESPACE `test/t1` RENAME TO `ts2`;
+ERROR 42000: InnoDB: A general tablespace name cannot contain '/'.
+CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd';
+ALTER TABLESPACE ts1 RENAME TO `test/t2`;
+ERROR 42000: InnoDB: A general tablespace name cannot contain '/'.
+DROP TABLESPACE ts1;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_2-master.opt
+++ b/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_2-master.opt
@@ -1,0 +1,1 @@
+--initialize --innodb_page_size=16k

--- a/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_2.test
+++ b/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_2.test
@@ -1,0 +1,464 @@
+################################################################################
+# InnoDB transparent tablespace data encryption for general shared tablespace.
+# This test case will test
+#    - Crash during altering an encrypted tablespace
+#        - encryption='y' to encryption='n'
+#        - encryption='n' to encryption='y'
+#    - Crash during altering an encrypted tablespace (Compressed)
+#        - encryption='y' to encryption='n'
+#        - encryption='n' to encryption='y'
+#    - Crash
+#        - just before encryption processing starts
+#        - just after encryption processing finishes
+#    - Crash during master key rotation
+#    - Crash during creating an encrypted tablespace
+#    - During alter tablespace encryption, DMLs are allowed and DDLs are blocked
+################################################################################
+
+--source include/big_test.inc
+--source include/have_debug.inc
+# --source include/no_valgrind_without_big.inc
+# Disable in valgrind because of timeout, cf. Bug#22760145
+--source include/not_valgrind.inc
+# Waiting time when (re)starting the server
+--let $explicit_default_wait_counter=10000;
+
+--disable_query_log
+call mtr.add_suppression("ibd can't be decrypted, please confirm the keyfile is match and keyring plugin is loaded.");
+call mtr.add_suppression("\\[Error\\] \\[[^]]*\\] \\[[^]]*\\] Encryption can't find master key, please check the keyring plugin is loaded.");
+call mtr.add_suppression("\\[ERROR\\] \\[[^]]*\\] \\[[^]]*\\] Check keyring plugin fail, please check the keyring plugin is loaded.");
+--enable_query_log
+
+--echo #########################################################################
+--echo # START : WITHOUT KEYRING PLUGIN
+--echo #########################################################################
+--echo
+--echo #########
+--echo # SETUP #
+--echo #########
+
+CREATE TABLE t1(c1 char(100)) ENGINE=InnoDB ENCRYPTION="N";
+# Insert few rows in table
+--disable_query_log
+INSERT INTO t1 VALUES ("SOME VALUES");
+let $counter=12;
+while ($counter>0)
+{
+  INSERT INTO test.t1 SELECT * FROM test.t1;
+  dec $counter;
+}
+--enable_query_log
+
+# Make sure ts file is updated with new records in table
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+SELECT * FROM t1 LIMIT 10;
+
+# Try to alter tablespace to be encrypted. Should fail as keyring is not laoded.
+--error ER_CANNOT_FIND_KEY_IN_KEYRING
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+
+--echo #############################################################
+--echo # TEST 1 : CRASH DURING ALTER ENCRYPT A TABLESPACE.
+--echo #############################################################
+--echo
+--echo #########################################################################
+--echo # RESTART 1 : WITH KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart: --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 1 :    Unencrypted => Encrypted         #
+--echo #                         (crash at page 10)               #
+--echo ############################################################
+--echo # Set Encryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+
+--echo # Encrypt the tablespace. It will cause crash.
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+--echo # Restart after crash
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Encryption processing to finish in background thread
+let $wait_condition = SELECT ENCRYPTION = 'Y'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='test/t1';
+--source include/wait_condition.inc
+
+# Make sure ts file is updated with new records in table
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo # After restart/recovery, check that Encryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+SELECT * FROM t1 LIMIT 10;
+
+--echo #########################################################################
+--echo # RESTART 2 : WITHOUT KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart:;
+--source include/restart_mysqld_no_echo.inc
+
+# We shouldn't be able to read t1 records as it is encrypted now and keyring
+# plugin is not loaded.
+--error ER_CANNOT_FIND_KEY_IN_KEYRING
+SELECT * FROM t1 LIMIT 10;
+
+--echo #########################################################################
+--echo # RESTART 3 : WITH KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart: --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+SELECT * FROM t1 LIMIT 10;
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 2 :    Encrypted => Unencrypted         #
+--echo #                         (crash at page 10)               #
+--echo ############################################################
+--echo # Set Unencryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+
+--echo # Unencrypt the tablespace. It will cause crash.
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+--echo # Restart after crash
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Unencryption processing to finish in background thread
+let $wait_condition = SELECT ENCRYPTION = 'N'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='test/t1';
+--source include/wait_condition.inc
+
+# Make sure ts file is updated with new records in table
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo # After restart/recovery, check that Unencryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+SELECT * FROM t1 LIMIT 10;
+
+--echo #########################################################################
+--echo # RESTART 4 : WITHOUT KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart:;
+--source include/restart_mysqld_no_echo.inc
+
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+# We should be able to read t1 records even without OKV keyring plugin as it should
+# be unencrypted now.
+SELECT * FROM t1 LIMIT 10;
+
+--echo ####################################################################
+--echo # TEST 2 : CRASH DURING ALTER ENCRYPT A TABLESPACE (Compressed).
+--echo ####################################################################
+--echo
+# Create an Unencrypted compressed tablespace
+# Create an unencrypted table in tablespace
+CREATE TABLE t2(c1 char(100)) ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8;
+# Insert few rows in table
+--disable_query_log
+INSERT INTO t2 VALUES ("SOME VALUES");
+let $counter=12;
+while ($counter>0)
+{
+  INSERT INTO test.t2 SELECT * FROM test.t1;
+  dec $counter;
+}
+--enable_query_log
+
+# Make sure ts file is updated with new records in table
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+	WHERE NAME='test/t2';
+SELECT * FROM t2 LIMIT 10;
+
+--echo #########################################################################
+--echo # RESTART 5 : WITH KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart: --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 1 :    Unencrypted => Encrypted         #
+--echo #                         (crash at page 10)               #
+--echo ############################################################
+--echo # Set Encryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+
+--echo # Encrypt the tablespace. It will cause crash.
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t2` ENCRYPTION='Y';
+--echo # Restart after crash
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Encryption processing to finish in background thread
+let $wait_condition = SELECT ENCRYPTION = 'Y'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='test/t2';
+--source include/wait_condition.inc
+
+# Make sure ts file is updated with new records in table
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo # After restart/recovery, check that Encryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+	WHERE NAME='test/t2';
+SELECT * FROM t2 LIMIT 10;
+
+--echo #########################################################################
+--echo # RESTART 6 : WITHOUT KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart:;
+--source include/restart_mysqld_no_echo.inc
+
+# We shouldn't be able to read t2 records as it is encrypted now and keyring
+# plugin is not loaded.
+--error ER_CANNOT_FIND_KEY_IN_KEYRING
+SELECT * FROM t2 LIMIT 10;
+
+--echo #########################################################################
+--echo # RESTART 7 WITH KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart: --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+	WHERE NAME='test/t2';
+SELECT * FROM t2 LIMIT 10;
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 2 :    Encrypted => Unencrypted         #
+--echo #                         (crash at page 10)               #
+--echo ############################################################
+--echo # Set Unencryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+
+--echo # Unencrypt the tablespace. It will cause crash.
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t2` ENCRYPTION='N';
+--echo # Restart after crash
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Unencryption processing to finish in background thread
+let $wait_condition = SELECT ENCRYPTION = 'N'
+        FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+        WHERE NAME='test/t2';
+--source include/wait_condition.inc
+
+# Make sure ts file is updated with new records in table
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo # After restart/recovery, check that Unencryption was roll-forward
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+	WHERE NAME='test/t2';
+SELECT * FROM t2 LIMIT 10;
+
+--echo #########################################################################
+--echo # RESTART 8 : WITHOUT KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart:;
+--source include/restart_mysqld_no_echo.inc
+
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+# We should be able to read t1 records even without keyring plugin as it should
+# be unencrypted now.
+SELECT * FROM t2 LIMIT 10;
+
+DROP TABLE t2;
+
+--echo #############################################################
+--echo # TEST 3 : CRASH BEFORE/AFTER ENCRYPTION PROCESSING.
+--echo #############################################################
+--echo
+--echo #########################################################################
+--echo # RESTART 9 : WITH KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart: --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+# Encrypt tablespace
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+# Read rows from table
+SELECT * FROM t1 LIMIT 10;
+
+--echo # Set server to crash just before encryption processing starts
+SET SESSION debug="+d,alter_encrypt_tablespace_crash_before_processing";
+
+--echo # Unencrypt the tablespace. It will cause crash.
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+--echo # Restart after crash
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Unencryption processing to finish in background thread
+let $wait_condition = select count(*) = 0
+        from performance_schema.events_stages_current
+        where EVENT_NAME='stage/innodb/alter tablespace (encryption)';
+--source include/wait_condition.inc
+
+# Encrytion property of tablespace shouldn't have changed i.e. it should still
+# be encrypted.
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+
+
+--echo # Set server to crash just after encryption processing finishes
+SET SESSION debug="-d,alter_encrypt_tablespace_crash_before_processing";
+SET SESSION debug="+d,alter_encrypt_tablespace_crash_after_processing";
+
+--echo # Unencrypt the tablespace. It will cause crash.
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+--echo # Restart after crash
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Unencryption processing to finish in background thread
+let $wait_condition = select count(*) = 0
+        from performance_schema.events_stages_current
+        where EVENT_NAME='stage/innodb/alter tablespace (encryption)';
+--source include/wait_condition.inc
+
+# Encrytion property of tablespace should have changed i.e. it should be
+# unencrypted now.
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES WHERE NAME='test/t1';
+
+--echo #############################################################
+--echo # TEST 4 : CRASH DURING KEY ROTATION.
+--echo #############################################################
+--echo
+--echo #########################################################################
+--echo # RESTART 10 : WITH KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart: --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+# Encrypt tablespace
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+# Read rows from table
+SELECT * FROM t1 LIMIT 10;
+
+--echo # Set server to crash while rotating encryption
+SET SESSION debug="+d,ib_crash_during_rotation_for_encryption";
+
+# Rotate the key. It will cause server to crash.
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+--echo # Restart after crash
+--source include/start_mysqld_no_echo.inc
+# Read rows from table
+SELECT * FROM t1 LIMIT 10;
+
+# Rotate the key.
+SET SESSION debug="-d,ib_crash_during_rotation_for_encryption";
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+# Read rows from table
+SELECT * FROM t1 LIMIT 10;
+
+--echo ###############################################################
+--echo # TEST 5 : CRASH DURING CREATING AN ENCRYPTED TABLESPACE
+--echo ###############################################################
+--echo # Not Applicable as we create via tablespace via CREATE TABLE
+--echo # (implicit)
+
+--echo ###############################################################
+--echo # TEST 6 : DMLs ALLOWED AND DDLs BLOCKED TEST
+--echo ###############################################################
+
+# Make sure metadata locks instrumentation is enabled
+SELECT ENABLED FROM performance_schema.setup_instruments
+	WHERE NAME='wait/lock/metadata/sql/mdl';
+
+let $con_default_thread_id= `SELECT THREAD_ID FROM performance_schema.threads
+				WHERE PROCESSLIST_ID = connection_id()`;
+
+SET DEBUG_SYNC = 'innodb_alter_encrypt_tablespace SIGNAL s1 WAIT_FOR s2';
+--send ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+
+--echo # Session 2
+connect(con2, localhost, root,,);
+--connection con2
+let $con2_thread_id= `SELECT THREAD_ID FROM performance_schema.threads
+			WHERE PROCESSLIST_ID = connection_id()`;
+SET DEBUG_SYNC = 'now WAIT_FOR s1';
+# Make sure MDL on tablespace is GRANTED to 'default connection' thread.
+--disable_query_log
+eval SELECT OBJECT_TYPE, OBJECT_NAME, LOCK_TYPE, LOCK_DURATION, LOCK_STATUS
+	FROM performance_schema.metadata_locks
+	WHERE OBJECT_NAME='test/t1' AND
+	OWNER_THREAD_ID = $con_default_thread_id;
+--enable_query_log
+# Try to run some DMLs. Should be allowed.
+DESCRIBE t1;
+SHOW CREATE TABLE t1;
+SELECT COUNT(*) FROM t1;
+INSERT INTO t1 VALUES ("SOME VALUES");
+SELECT COUNT(*) from t1;
+# Try to run a DDL. Should be blocked.
+--send ALTER TABLE t1 ADD COLUMN (c2 int);
+
+--echo # Monitoring session
+connect(conmon, localhost, root,,);
+--connection conmon
+# Make sure 'connection default' thread has MDL request GRANTED.
+--disable_query_log
+eval SELECT OBJECT_TYPE, OBJECT_NAME, LOCK_TYPE, LOCK_DURATION, LOCK_STATUS
+	FROM performance_schema.metadata_locks
+	WHERE OBJECT_NAME='test/t1' AND
+	OWNER_THREAD_ID = $con_default_thread_id;
+--echo # Wait for MDL request by con2 to appear in metadata_locks table.
+let $wait_condition = SELECT LOCK_STATUS = 'PENDING'
+        FROM performance_schema.metadata_locks
+        WHERE OBJECT_NAME='t1' AND
+        OWNER_THREAD_ID = $con2_thread_id;
+--source include/wait_condition.inc
+# Make sure con2 thread has MDL request in PENDING state.
+eval SELECT OBJECT_TYPE, OBJECT_NAME, LOCK_TYPE, LOCK_DURATION, LOCK_STATUS
+	FROM performance_schema.metadata_locks
+	WHERE OBJECT_NAME='t1' AND
+	OWNER_THREAD_ID = $con2_thread_id;
+--enable_query_log
+
+# Allow 'default connection' thread to proceed
+SET DEBUG_SYNC = 'now SIGNAL s2';
+
+--echo # Connection default
+--connection default
+--reap
+
+--echo # Connection con2
+--connection con2
+--reap
+
+--echo # Connection default
+--connection default
+# Make sure Tablespace 'unencryption' is done.
+SELECT NAME, ENCRYPTION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES
+	WHERE NAME LIKE "%test/t1%";
+# Make sure table DDL is done.
+DESCRIBE t1;
+SHOW CREATE TABLE t1;
+
+--echo ###########
+--echo # Cleanup #
+--echo ###########
+--disconnect con2
+--disconnect conmon
+
+DROP TABLE t1;
+remove_file $MYSQL_TMP_DIR/mysecret_keyring;
+
+--echo # Restarting server without keyring to restore server state
+let $restart_parameters = ;
+--source include/restart_mysqld.inc

--- a/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_5-master.opt
+++ b/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_5-master.opt
@@ -1,0 +1,1 @@
+--initialize --innodb_page_size=16k

--- a/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_5.test
+++ b/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_5.test
@@ -1,0 +1,154 @@
+################################################################################
+# InnoDB transparent tablespace data encryption for general shared tablespace.
+# This test case will test
+#    - Crash during altering an encrypted tablespace
+#        - encryption='y' to encryption='n'
+#        - encryption='n' to encryption='y'
+# This test checks physical ibd file to see if unencrypted string is present
+# in any of the pages in tablespace file.
+################################################################################
+--source include/have_debug.inc
+--source include/big_test.inc
+# --source include/no_valgrind_without_big.inc
+# Disable in valgrind because of timeout, cf. Bug#22760145
+--source include/not_valgrind.inc
+# Waiting time when (re)starting the server
+--let $explicit_default_wait_counter=10000;
+
+--echo #########
+--echo # SETUP #
+--echo #########
+--echo
+let datadir=`SELECT @@datadir`;
+let search_pattern=samplerecord;
+let ts_name=test/t1.ibd;
+
+--echo #########################################################################
+--echo # RESTART 1 : WITH KEYRING PLUGIN
+--echo #########################################################################
+let $restart_parameters = restart: --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT;
+--source include/restart_mysqld_no_echo.inc
+
+--echo # Create a new 'unencrypted' tablespace 'encrypt_ts'
+SELECT NAME, FLAG, SPACE_TYPE FROM information_schema.INNODB_TABLESPACES
+	 WHERE NAME="test/t1";
+
+--echo # Create a table test.t1 in 'encrypt_ts' tablespace and insert some records.
+CREATE TABLE test.t1 (c char(20)) encryption='n';
+INSERT INTO test.t1 values ("samplerecord");
+
+# Make sure ts file is updated
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo #############################################################
+--echo # INITIAL SETUP : Tablespace is created as unencrypted      #
+--echo #                 A table is created and rows are inserted  #
+--echo #############################################################
+
+--echo # Check that tablespace file is not encrypted yet
+--source include/if_encrypted.inc
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 1 :    Unencrypted => Encrypted         #
+--echo ############################################################
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+
+# Make sure all pages are flushed
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo # Check that tablespace file is encrypted now
+--source include/if_encrypted.inc
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 2 :    Encrypted => Unencrypted         #
+--echo ############################################################
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+
+# Make sure all pages are flushed
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo # Check that tablespace file is not encrypted now
+--source include/if_encrypted.inc
+
+--echo
+--echo ################# CRASH/RECOVERY TESTING ###################
+--echo
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 3 :    Unencrypted => Encrypted         #
+--echo #                         (crash at page 10)               #
+--echo ############################################################
+# Insert few records in table
+--disable_query_log
+let $counter=12;
+while ($counter>0)
+{
+  INSERT INTO test.t1 SELECT * FROM test.t1;
+  dec $counter;
+}
+--enable_query_log
+
+SELECT COUNT(*) FROM test.t1;
+
+# Make sure ts file is updated with new records in table
+SET GLOBAL innodb_buf_flush_list_now = 1;
+
+--echo # Check that tablespace file is still unencrypted
+--source include/if_encrypted.inc
+
+--echo # Set Encryption process to crash at page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Encryption processing to finish in background thread
+let $wait_condition = select count(*) = 0
+	from performance_schema.events_stages_current
+	where EVENT_NAME='stage/innodb/alter tablespace (encryption)';
+--source include/wait_condition.inc
+
+--echo # After restart/recovery, check that Encryption was roll-forward and
+--echo # tablespace file is encrypted now
+--source include/if_encrypted.inc
+
+--echo ############################################################
+--echo # ALTER TABLESPACE 4 :    Encrypted => Unencrypted         #
+--echo #                         (crash at page 10)               #
+--echo ############################################################
+
+SELECT COUNT(*) FROM test.t1;
+
+--echo # Check that tablespace file is Encrypted
+--source include/if_encrypted.inc
+
+--echo # Set Encryption process to crash after page 10
+SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
+
+--source include/expect_crash.inc
+--error 0,CR_SERVER_LOST,ER_INTERNAL_ERROR
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+--source include/start_mysqld_no_echo.inc
+
+--echo # Wait for Unencryption processing to finish in background thread
+let $wait_condition = select count(*) = 0
+	from performance_schema.events_stages_current
+	where EVENT_NAME='stage/innodb/alter tablespace (encryption)';
+--source include/wait_condition.inc
+
+--echo # After restart/recovery, check that Unencryption was roll-forward and
+--echo # tablespace file is Unencrypted now
+--source include/if_encrypted.inc
+
+--echo ###########
+--echo # CLEANUP #
+--echo ###########
+DROP TABLE test.t1;
+remove_file $MYSQLTEST_VARDIR/tmpfile.txt;
+remove_file $MYSQL_TMP_DIR/mysecret_keyring;
+
+--echo # Restarting server without keyring to restore server state
+let $restart_parameters = restart: ;
+--source include/restart_mysqld.inc

--- a/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_debug-master.opt
+++ b/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_debug-master.opt
@@ -1,0 +1,4 @@
+$KEYRING_PLUGIN_OPT
+$KEYRING_PLUGIN_EARLY_LOAD
+--keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring
+

--- a/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_debug.test
+++ b/mysql-test/suite/innodb/t/percona_fpt_tablespace_encrypt_debug.test
@@ -1,0 +1,43 @@
+--source include/have_debug.inc
+
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+
+ALTER TABLESPACE `test/t1` ENCRYPTION='Y';
+
+SHOW CREATE TABLE t1;
+
+SET DEBUG='+d, skip_dd_table_access_check';
+
+--let $assert_text = t1 dd::Table should have encryption attribute set as 'Y'
+--let $assert_cond= "[SELECT COUNT(*) FROM mysql.tables WHERE NAME=\'t1\' AND options LIKE \'%encrypt_type=Y%\']" = 1
+--source include/assert.inc
+
+--let $assert_text = t1 dd::Tablespace should have encryption attribute set as 'Y'
+--let $assert_cond= "[SELECT COUNT(*) FROM mysql.tablespaces WHERE NAME=\'test/t1\' AND options LIKE \'%encryption=Y%\']" = 1
+--source include/assert.inc
+
+ALTER TABLESPACE `test/t1` ENCRYPTION='N';
+SHOW CREATE TABLE t1;
+
+--let $assert_text = t1 dd::Table should have encryption attribute set as 'N'
+--let $assert_cond= "[SELECT COUNT(*) FROM mysql.tables WHERE NAME=\'t1\' AND options LIKE \'%encrypt_type=N%\']" = 1
+--source include/assert.inc
+
+--let $assert_text = t1 dd::Tablespace should have encryption attribute set as 'N'
+--let $assert_cond= "[SELECT COUNT(*) FROM mysql.tablespaces WHERE NAME=\'test/t1\' AND options LIKE \'%encryption=N%\']" = 1
+--source include/assert.inc
+
+--error ER_WRONG_TABLESPACE_NAME
+ALTER TABLESPACE `test/t1` RENAME TO `test/t2`;
+
+--error ER_WRONG_TABLESPACE_NAME
+ALTER TABLESPACE `test/t1` RENAME TO `ts2`;
+
+CREATE TABLESPACE ts1 ADD DATAFILE 'ts1.ibd';
+
+--error ER_WRONG_TABLESPACE_NAME
+ALTER TABLESPACE ts1 RENAME TO `test/t2`;
+DROP TABLESPACE ts1;
+
+DROP TABLE t1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12553,7 +12553,8 @@ static int validate_tablespace_name(ts_command_type ts_command,
   }
 
   /* The tablespace name cannot contain a '/'. */
-  if (memchr(name, '/', strlen(name)) != NULL) {
+  if (ts_command != ALTER_TABLESPACE &&
+      memchr(name, '/', strlen(name)) != NULL) {
     my_printf_error(ER_WRONG_TABLESPACE_NAME,
                     "InnoDB: A general tablespace name cannot"
                     " contain '/'.",


### PR DESCRIPTION
… table tablespaces

Since 8.0, conversion of tablespace from unencrypted to encrypted and vice-versa can be done INPLACE.
It is restricted only to general tablespaces via the ALTER TABLESPACE SQL.

INPLACE here means there is no need create another tablespace (like the COPY algorithm does).

Underlying mechanism is to dirty pages with encryption headers written and handle recovery.

Fix:
----
Remove restrictions on file_per_tablespace with ALTER TABLESPACE syntax.

ALTER TABLESPACE `test/t1` ENCRYPTION='Y' is now allowed.