### PR TITLE
WIP PS-4464: Expose last GTID executed for CONSISTENT SNAPSHOT

### DIFF
--- a/mysql-test/suite/binlog/r/percona_binlog_consistent_debug.result
+++ b/mysql-test/suite/binlog/r/percona_binlog_consistent_debug.result
@@ -19,6 +19,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	POSITION
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SET DEBUG_SYNC="now SIGNAL finish_commit";
 # connection con1
 # connection default
@@ -51,5 +52,6 @@ Warning	1868	file ./binlog.000002 was not purged because it is the active log fi
 VARIABLE_NAME	VARIABLE_VALUE
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	POSITION
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 # connection con3
 # connection default

--- a/mysql-test/suite/binlog/r/percona_binlog_consistent_mixed.result
+++ b/mysql-test/suite/binlog/r/percona_binlog_consistent_mixed.result
@@ -8,6 +8,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	392
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 BEGIN;
 INSERT INTO t1 VALUES (0, "");
 # Connection con1
@@ -39,6 +40,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	1213
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000001	1829			
@@ -61,6 +63,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	1213
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	155			
@@ -69,6 +72,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	155
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	155			
@@ -79,6 +83,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	438			
@@ -95,6 +100,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	741
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	741			
@@ -106,6 +112,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	741
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	741			
@@ -117,6 +124,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	741			
@@ -126,6 +134,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000003
 Binlog_snapshot_position	155
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			
@@ -134,6 +143,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			
@@ -143,6 +153,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			

--- a/mysql-test/suite/binlog/r/percona_binlog_consistent_row.result
+++ b/mysql-test/suite/binlog/r/percona_binlog_consistent_row.result
@@ -8,6 +8,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	392
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 BEGIN;
 INSERT INTO t1 VALUES (0, "");
 # Connection con1
@@ -39,6 +40,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	1198
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000001	1799			
@@ -61,6 +63,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	1198
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	155			
@@ -69,6 +72,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	155
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	155			
@@ -79,6 +83,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	484
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	484			
@@ -95,6 +100,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	772
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	772			
@@ -106,6 +112,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	772
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	772			
@@ -117,6 +124,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	484
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	772			
@@ -126,6 +134,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000003
 Binlog_snapshot_position	155
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			
@@ -134,6 +143,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	484
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			
@@ -143,6 +153,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	484
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			

--- a/mysql-test/suite/binlog/r/percona_binlog_consistent_stmt.result
+++ b/mysql-test/suite/binlog/r/percona_binlog_consistent_stmt.result
@@ -9,6 +9,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	392
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 BEGIN;
 INSERT INTO t1 VALUES (0, "");
 # Connection con1
@@ -44,6 +45,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	895
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000001	1193			
@@ -66,6 +68,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000001
 Binlog_snapshot_position	895
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	155			
@@ -74,6 +77,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	155
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	155			
@@ -84,6 +88,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	438			
@@ -100,6 +105,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	741
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	741			
@@ -111,6 +117,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	741
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	741			
@@ -122,6 +129,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000002	741			
@@ -131,6 +139,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000003
 Binlog_snapshot_position	155
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			
@@ -139,6 +148,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			
@@ -148,6 +158,7 @@ SHOW STATUS LIKE 'binlog_snapshot_%';
 Variable_name	Value
 Binlog_snapshot_file	binlog.000002
 Binlog_snapshot_position	438
+Binlog_snapshot_gtid_last_executed	not-in-consistent-snapshot
 SHOW MASTER STATUS;
 File	Position	Binlog_Do_DB	Binlog_Ignore_DB	Executed_Gtid_Set
 binlog.000003	155			

--- a/mysql-test/suite/binlog_gtid/r/percona_binlog_snapshot_gtid_last_executed.result
+++ b/mysql-test/suite/binlog_gtid/r/percona_binlog_snapshot_gtid_last_executed.result
@@ -1,0 +1,25 @@
+SET @session.autocommit = 0;
+CREATE TABLE t1 (a INT);
+COMMIT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:1]
+INSERT INTO t1 VALUES(1);
+COMMIT;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1-2 and Binlog_snapshot_gtid_last_executed=not-in-consistent-snapshot]
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1-2 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:2]
+INSERT INTO t1 VALUES(2);
+COMMIT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1-3 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:3]
+# Test START TRANSACTION WITH CONSISTENT SNAPSHOT FROM SESSION
+SET @session.autocommit = 0;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1-3 and Binlog_snapshot_gtid_last_executed=not-in-consistent-snapshot]
+INSERT INTO t1 VALUES(3);
+COMMIT;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1-4 and Binlog_snapshot_gtid_last_executed=not-in-consistent-snapshot]
+START TRANSACTION WITH CONSISTENT SNAPSHOT FROM SESSION $donor_id;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1-4 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:3]
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+include/assert.inc [@@GTID_EXECUTED=MASTER_UUID:1-4 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:4]
+DROP TABLE t1;

--- a/mysql-test/suite/binlog_gtid/t/percona_binlog_snapshot_gtid_last_executed.test
+++ b/mysql-test/suite/binlog_gtid/t/percona_binlog_snapshot_gtid_last_executed.test
@@ -1,0 +1,81 @@
+--source include/assert_gtid_mode_on.inc
+
+--let $master_uuid= `SELECT @@GLOBAL.SERVER_UUID`
+--source include/count_sessions.inc
+
+SET @session.autocommit = 0;
+CREATE TABLE t1 (a INT);
+COMMIT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:1
+--let $assert_cond= "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$gtid_last_executed"
+--source include/assert.inc
+
+INSERT INTO t1 VALUES(1);
+COMMIT;
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1-2 and Binlog_snapshot_gtid_last_executed=not-in-consistent-snapshot
+--let $assert_cond= "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-2" AND "$gtid_last_executed" = "not-in-consistent-snapshot"
+--source include/assert.inc
+
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1-2 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:2
+--let $assert_cond= "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-2" AND "$gtid_last_executed" = "$master_uuid:2"
+--source include/assert.inc
+
+INSERT INTO t1 VALUES(2);
+COMMIT;
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1-3 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:3
+--let $assert_cond= "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-3" AND "$gtid_last_executed" = "$master_uuid:3"
+--source include/assert.inc
+
+
+--echo # Test START TRANSACTION WITH CONSISTENT SNAPSHOT FROM SESSION
+--let $donor_id=`SELECT CONNECTION_ID()`
+
+--connect(con1,localhost,root,,)
+SET @session.autocommit = 0;
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1-3 and Binlog_snapshot_gtid_last_executed=not-in-consistent-snapshot
+--let $assert_cond= "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-3" AND "$gtid_last_executed" = "not-in-consistent-snapshot"
+--source include/assert.inc
+
+INSERT INTO t1 VALUES(3);
+COMMIT;
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1-4 and Binlog_snapshot_gtid_last_executed=not-in-consistent-snapshot
+--let $assert_cond= "[SELECT COUNT(*) FROM t1]" = "3" AND "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-4" AND "$gtid_last_executed" = "not-in-consistent-snapshot"
+--source include/assert.inc
+
+--disable_query_log
+--eval START TRANSACTION WITH CONSISTENT SNAPSHOT FROM SESSION $donor_id
+--echo START TRANSACTION WITH CONSISTENT SNAPSHOT FROM SESSION \$donor_id;
+--enable_query_log
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1-4 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:3
+--let $assert_cond= "[SELECT COUNT(*) FROM t1]" = "2" AND "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-4" AND "$gtid_last_executed" = "$master_uuid:3"
+--source include/assert.inc
+
+START TRANSACTION WITH CONSISTENT SNAPSHOT;
+
+--let $gtid_last_executed = query_get_value(SHOW STATUS LIKE "Binlog_snapshot_gtid_last_executed", Value, 1)
+--let $assert_text= @@GTID_EXECUTED=MASTER_UUID:1-4 and Binlog_snapshot_gtid_last_executed=MASTER_UUID:4
+--let $assert_cond= "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-4" AND "$gtid_last_executed" = "$master_uuid:4"
+--source include/assert.inc
+
+--disconnect con1
+--connection default
+DROP TABLE t1;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/rpl_gtid.h
+++ b/sql/rpl_gtid.h
@@ -3182,7 +3182,15 @@ class Gtid_state {
   int warn_or_err_on_modify_gtid_table(THD *thd, TABLE_LIST *table);
 #endif
 
+  /* Allow to snapshot last executed GTID */
+  void get_snapshot_last_executed_gtid(Gtid &snapshot_last_executed_gtid,
+                                       rpl_sid &snapshot_last_executed_sid);
+
  private:
+  /* Track last executed GTID */
+  Gtid last_executed_gtid;
+  rpl_sid last_executed_sid;
+
   /**
     Remove the GTID owned by thread from owned GTIDs.
 

--- a/sql/rpl_gtid_state.cc
+++ b/sql/rpl_gtid_state.cc
@@ -150,6 +150,14 @@ void Gtid_state::broadcast_owned_sidnos(const THD *thd) {
   }
 }
 
+void Gtid_state::get_snapshot_last_executed_gtid(
+    Gtid &snapshot_last_executed_gtid, rpl_sid &snapshot_last_executed_sid) {
+  global_sid_lock->wrlock();
+  snapshot_last_executed_gtid = last_executed_gtid;
+  snapshot_last_executed_sid = last_executed_sid;
+  global_sid_lock->unlock();
+}
+
 void Gtid_state::update_commit_group(THD *first_thd) {
   DBUG_TRACE;
 
@@ -858,6 +866,9 @@ void Gtid_state::update_gtids_impl_own_gtid(THD *thd, bool is_commit) {
       into global executed_gtids, lost_gtids and gtids_only_in_table.
     */
     executed_gtids._add_gtid(thd->owned_gtid);
+    last_executed_gtid = thd->owned_gtid;
+    last_executed_sid = thd->owned_sid;
+
     thd->rpl_thd_ctx.session_gtids_ctx().notify_after_gtid_executed_update(thd);
     if (thd->slave_thread && opt_bin_log && !opt_log_slave_updates) {
       lost_gtids._add_gtid(thd->owned_gtid);


### PR DESCRIPTION
This patch adds a status variable `Binlog_snapshot_gtid_last_executed` with the following changes:
1. Add tracking of last executed GTID in `Gtid_state::last_executed_gtid`
2. Add function to snapshot last executed GTID with `Gtid_state::get_snapshot_last_executed_gtid()`
3. Add a status variable `Binlog_snapshot_gtid_last_executed`