### PR TITLE
PS-6824 Debian/Ubuntu installation - add gnupg2

### DIFF
--- a/doc/source/installation/apt_repo.rst
+++ b/doc/source/installation/apt_repo.rst
@@ -45,7 +45,13 @@ The ``libperconaserverclient18.1`` package contains the client shared library. T
 Installing |Percona Server| from Percona ``apt`` repository
 ===========================================================
 
-1. Fetch the repository packages from Percona web: 
+1. Install ``GnuPG``, the GNU Privacy Guard:
+
+   .. code-block:: bash
+
+      $ sudo apt-get install gnupg2
+   
+2. Fetch the repository packages from Percona web: 
 
    .. code-block:: bash
 


### PR DESCRIPTION
modified file:
added the step to install gnupg2 to the Installing Percona Server for MySQL from Percona apt repository section