### PR TITLE
5.7 PS-6796 test percona_changed_page_bmp_shutdown_thread is unstable

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_shutdown_thread.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_shutdown_thread.result
@@ -1,3 +1,4 @@
+call mtr.add_suppression("Last tracked LSN in \'\.\/ib_modified_log_[0-9_]+.xdb\' is [0-9]+, but the last checkpoint LSN is [0-9]+.  This might be due to a server crash or a very fast shutdown");
 SELECT 1;
 1
 1

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_shutdown_thread.test
@@ -5,6 +5,7 @@
 --source include/have_debug.inc
 --source include/not_embedded.inc
 
+call mtr.add_suppression("Last tracked LSN in \'\.\/ib_modified_log_[0-9_]+.xdb\' is [0-9]+, but the last checkpoint LSN is [0-9]+.  This might be due to a server crash or a very fast shutdown");
 SELECT 1;
 --source include/shutdown_mysqld.inc
 --error 1


### PR DESCRIPTION
Test test percona_changed_page_bmp_shutdown_thread is unstable because
it sometimes thrown a warning that was not suppressed.

Not a GCA revision, will be cherry-picked to the higher versions.