### PR TITLE
PS-5844 Memory leak after 'innodb.alter_crash' - in 'prepare_inplace_…

### DIFF
--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -4338,6 +4338,11 @@ row_merge_create_index(
 		this index, to ensure read consistency. */
 		ut_ad(index->trx_id == trx->id);
 	} else {
+		/* In case we were unable to assign an undo record for this index
+		we won't free index memory object */
+		if (err == DB_TOO_MANY_CONCURRENT_TRXS) {
+			dict_mem_index_free(index);
+		}
 		index = NULL;
 	}
 


### PR DESCRIPTION
…alter_table_dict()'

The problem
If online alter fails to allocate undo log, heap memory allocated to
index object won't be freed. This can be simulated by using debug point
'ib_create_table_fail_too_many_trx' prior to an alter table.

Solution
If we fail to allocate undo log, prior to set index pointer to null,
call dict_mem_index_free to correctly free memory objects allocated
by the index.