### PR TITLE
PS-6860 : Innodb_buffer_pool_pages_LRU_flushed doesn't work

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -495,6 +495,9 @@ buf_get_total_stat(
 
 		tot_stat->n_pages_not_made_young +=
 			buf_stat->n_pages_not_made_young;
+
+		tot_stat->buf_lru_flush_page_count +=
+		    buf_stat->buf_lru_flush_page_count;
 	}
 }
 


### PR DESCRIPTION
- Simple fix to merge buf_lru_flush_page_count from individual pool instances
  into total stats.