### PR TITLE
PS-6897: Tests main.udf_myisam and main.transactional_acl_tables fail on

### DIFF
--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -2122,7 +2122,12 @@ static bool fill_dd_table_from_create_info(
   // (ENCRYPTION clause was used with CREATE)).
   if ((create_info->used_fields & HA_CREATE_USED_ENCRYPT) ||
       create_info->explicit_encryption) {
-    table_options->set("explicit_encryption", true);
+    // clear explicit encryption if SE does not support encryption
+    if (!(hton->flags & HTON_SUPPORTS_TABLE_ENCRYPTION)) {
+      table_options->set("explicit_encryption", false);
+    } else {
+      table_options->set("explicit_encryption", true);
+    }
   } else {
     table_options->set("explicit_encryption", false);
   }


### PR DESCRIPTION
trunk.

Failure scenario:
CREATE TABLE t1 ENCYRYPTION='N'; -- explicit encryption set in DD
ALTER TABLE t1 ENGINE=MYISAM; -- explicit encryption remains set in DD
ALTER TABLE t1 ENGINE=INNODB; -- explicit encryption remains set in DD,
however the ENCRYPTION clause is empty.

This triggered the assertion as we do not expect in InnoDB
explicit_encryption with empty ENCRYPTION clasue.

The resolution:
DD option explicit_encryption is only set for storage engines that
support encryption.