### PR TITLE
Fixed PS-6899 (main.events_bugs and main.events_1 fail because 2020-01-01 is considered future) (5.6)

### DIFF
--- a/mysql-test/r/events_1.result
+++ b/mysql-test/r/events_1.result
@@ -49,7 +49,7 @@ SECOND	10	SELECT 1
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
 execute_at IS NULL	starts IS NULL	ends IS NULL	comment
 1	0	1	
-ALTER EVENT event_starts_test ON SCHEDULE AT '2020-02-02 20:00:02';
+ALTER EVENT event_starts_test ON SCHEDULE AT '2037-02-02 20:00:02';
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
 execute_at IS NULL	starts IS NULL	ends IS NULL	comment
 0	1	1	
@@ -62,7 +62,7 @@ SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.even
 execute_at IS NULL	starts IS NULL	ends IS NULL	comment
 0	1	1	
 DROP EVENT event_starts_test;
-CREATE EVENT event_starts_test ON SCHEDULE EVERY 20 SECOND STARTS '2020-02-02 20:00:02' ENDS '2022-02-02 20:00:02' DO SELECT 2;
+CREATE EVENT event_starts_test ON SCHEDULE EVERY 20 SECOND STARTS '2035-02-02 20:00:02' ENDS '2037-02-02 20:00:02' DO SELECT 2;
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
 execute_at IS NULL	starts IS NULL	ends IS NULL	comment
 1	0	0	

--- a/mysql-test/t/events_1.test
+++ b/mysql-test/t/events_1.test
@@ -67,7 +67,7 @@ drop event event2;
 CREATE EVENT event_starts_test ON SCHEDULE EVERY 10 SECOND COMMENT "" DO SELECT 1;
 SELECT interval_field, interval_value, body FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
-ALTER EVENT event_starts_test ON SCHEDULE AT '2020-02-02 20:00:02';
+ALTER EVENT event_starts_test ON SCHEDULE AT '2037-02-02 20:00:02';
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
 ALTER EVENT event_starts_test COMMENT "non-empty comment";
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
@@ -75,7 +75,7 @@ ALTER EVENT event_starts_test COMMENT "";
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
 DROP EVENT event_starts_test;
 
-CREATE EVENT event_starts_test ON SCHEDULE EVERY 20 SECOND STARTS '2020-02-02 20:00:02' ENDS '2022-02-02 20:00:02' DO SELECT 2;
+CREATE EVENT event_starts_test ON SCHEDULE EVERY 20 SECOND STARTS '2035-02-02 20:00:02' ENDS '2037-02-02 20:00:02' DO SELECT 2;
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';
 ALTER EVENT event_starts_test COMMENT "non-empty comment";
 SELECT execute_at IS NULL, starts IS NULL, ends IS NULL, comment FROM mysql.event WHERE db='events_test' AND name='event_starts_test';


### PR DESCRIPTION
https://jira.percona.com/browse/PS-6899

Fixed and re-recorded 'main.events_1' and 'main.events_bugs' MTR test cases
because 2020 is not a timestamp in future any more.