### PR TITLE
PS-6811: Crash in ACL_PROXY_USER::check_validity with --skip-name-resolve=1 (5.7)

### DIFF
--- a/mysql-test/r/skip_name_resolve.result
+++ b/mysql-test/r/skip_name_resolve.result
@@ -66,4 +66,18 @@ FLUSH PRIVILEGES;
 # must not find the pattern
 Pattern "'user' entry 'b20438524@localhost' ignored in --skip-name-resolve mode" not found
 DELETE FROM mysql.user WHERE user='b20438524';
+#
+# Bug #98908: Crash in ACL_PROXY_USER::check_validity with --skip-name-resolve=1
+#             https://bugs.mysql.com/bug.php?id=98908
+#
+CREATE USER IF NOT EXISTS ''@'';
+CREATE USER IF NOT EXISTS dba@'localhost' IDENTIFIED BY 'pass';
+GRANT PROXY ON dba@'localhost' TO ''@'';
+Warnings:
+Warning	1285	MySQL is started in --skip-name-resolve mode; you must restart it without this switch for this grant to work
+# restart:--skip-name-resolve=1
+Grants for dba@localhost
+GRANT USAGE ON *.* TO 'dba'@'localhost'
+DROP USER dba@'localhost';
+DROP USER ''@'';
 End of 5.7 tests

--- a/mysql-test/t/skip_name_resolve.test
+++ b/mysql-test/t/skip_name_resolve.test
@@ -91,5 +91,24 @@ source include/search_pattern.inc;
 
 DELETE FROM mysql.user WHERE user='b20438524';
 
+
+--echo #
+--echo # Bug #98908: Crash in ACL_PROXY_USER::check_validity with --skip-name-resolve=1
+--echo #             https://bugs.mysql.com/bug.php?id=98908
+--echo #
+
+CREATE USER IF NOT EXISTS ''@'';
+CREATE USER IF NOT EXISTS dba@'localhost' IDENTIFIED BY 'pass';
+GRANT PROXY ON dba@'localhost' TO ''@'';
+
+--let $restart_parameters=restart:--skip-name-resolve=1
+--source include/restart_mysqld.inc
+
+--exec $MYSQL $AUTH_PAM_OPT -udba -ppass -e "SHOW GRANTS;"
+
+DROP USER dba@'localhost';
+DROP USER ''@'';
+
+
 --echo End of 5.7 tests
 

--- a/sql/auth/sql_auth_cache.cc
+++ b/sql/auth/sql_auth_cache.cc
@@ -100,6 +100,21 @@ static void acl_free_utility_user();
 #endif /* NO_EMBEDDED_ACCESS_CHECKS */
 
 /**
+  Check if the given host name is equal to "localhost".
+
+  @return a flag telling if the given host name is equal to "localhost".
+  @retval TRUE the given host name is equal to "localhost".
+  @retval FALSE the given host name is not equal to "localhost".
+}
+*/
+static bool is_localhost_string(const char *hostname)
+{
+  if (!hostname) return false;
+
+  return !strcmp(hostname, "localhost");
+}
+
+/**
   Add an internal schema to the registry.
   @param name the schema name
   @param access the schema ACL specific rules
@@ -280,7 +295,7 @@ ACL_PROXY_USER::check_validity(bool check_no_resolve)
   if (check_no_resolve && 
       (hostname_requires_resolving(host.get_host()) ||
        hostname_requires_resolving(proxied_host.get_host())) &&
-      strcmp(host.get_host(), "localhost") != 0) {
+       !is_localhost_string(host.get_host())) {
     sql_print_warning("'proxies_priv' entry '%s@%s %s@%s' "
                       "ignored in --skip-name-resolve mode.",
                       proxied_user ? proxied_user : "",
@@ -1776,7 +1791,7 @@ static my_bool acl_load(THD *thd, TABLE_LIST *tables)
     user.user= get_field(&global_acl_memory,
                          table->field[table_schema->user_idx()]);
   if (check_no_resolve && hostname_requires_resolving(user.host.get_host()) &&
-      strcmp(user.host.get_host(), "localhost") != 0) {
+      !is_localhost_string(user.host.get_host())) {
       sql_print_warning("'user' entry '%s@%s' "
                         "ignored in --skip-name-resolve mode.",
                         user.user ? user.user : "",
@@ -2154,7 +2169,7 @@ static my_bool acl_load(THD *thd, TABLE_LIST *tables)
     }
     db.user=get_field(&global_acl_memory, table->field[MYSQL_DB_FIELD_USER]);
     if (check_no_resolve && hostname_requires_resolving(db.host.get_host()) &&
-        strcmp(db.host.get_host(), "localhost") != 0) {
+        !is_localhost_string(db.host.get_host())) {
       sql_print_warning("'db' entry '%s %s@%s' "
                         "ignored in --skip-name-resolve mode.",
                         db.db,
@@ -2700,7 +2715,7 @@ static my_bool grant_load(THD *thd, TABLE_LIST *tables)
       if (check_no_resolve)
       {
         if (hostname_requires_resolving(mem_check->host.get_host()) &&
-            strcmp(mem_check->host.get_host(), "localhost") != 0) {
+            !is_localhost_string(mem_check->host.get_host())) {
           sql_print_warning("'tables_priv' entry '%s %s@%s' "
                             "ignored in --skip-name-resolve mode.",
                             mem_check->tname,


### PR DESCRIPTION
This patch fixes the issue when `host.get_host()` returns `nullptr`.
It also expands `main.skip_name_resolve` with additional tests.

The bug was introduced with https://github.com/mysql/mysql-server/commit/93b813a3ca44