### PR TITLE
PS-5938 8.0.19 post-merge fix: re-recorded rocksdb.add_index_inplace_sstfilewriter

### DIFF
--- a/mysql-test/suite/rocksdb/r/add_index_inplace_sstfilewriter.result
+++ b/mysql-test/suite/rocksdb/r/add_index_inplace_sstfilewriter.result
@@ -61,8 +61,8 @@ ALTER TABLE t1 ADD INDEX kb(b) comment 'cfname=rev:cf1', ALGORITHM=INPLACE;
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (
-  `a` int(11) NOT NULL,
-  `b` int(11) DEFAULT NULL,
+  `a` int NOT NULL,
+  `b` int DEFAULT NULL,
   PRIMARY KEY (`a`),
   KEY `kb` (`b`) COMMENT 'cfname=rev:cf1'
 ) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5938

Re-recorded 'rocksdb.add_index_inplace_sstfilewriter' MTR test case because of the
removed integer width specifiers.