### PR TITLE
PS-5938 8.0.19 post-merge fix: reverted previous fix for innodb.bug64663

### DIFF
--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -17865,8 +17865,6 @@ bool mysql_trans_commit_alter_copy_data(THD *thd) {
   bool error = false;
   DBUG_TRACE;
 
-  DBUG_EXECUTE_IF("crash_innodb_add_index_after", DBUG_SUICIDE(););
-
   /*
     Ensure that ha_commit_trans() which is implicitly called by
     ha_enable_transaction() doesn't update GTID and slave info states.

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -5002,6 +5002,8 @@ static MY_ATTRIBUTE((warn_unused_result)) bool prepare_inplace_alter_table_dict(
     }
   }
 
+  DBUG_EXECUTE_IF("crash_innodb_add_index_after", DBUG_SUICIDE(););
+
 error_handling:
 
   if (build_fts_common || fts_index) {


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5938

After properly fixing PS-6903
"Creating a `temporary table like` with expand_fast_index_creation enabled can lead to a crash"
(https://jira.percona.com/browse/PS-6903)
(commit 85d097a)
commit e53708c "PS-5938: Post push fix, for bug64663 testcase" is no longer needed.