### PR TITLE
PS-6867: Merge fb-prod201905 (5.7)

### DIFF
--- a/mysql-test/suite/rocksdb/include/rocksdb_read_free_rpl_stress.inc
+++ b/mysql-test/suite/rocksdb/include/rocksdb_read_free_rpl_stress.inc
@@ -27,9 +27,9 @@ while ($iter < 10) {
   let $t = 1;
   while ($t <= 8) {
     eval update t$t set a = a + 10000 where a > 900; # update pk (if any)
-    eval update t$t set b = b + 10000 where b> 900; # update sk or unique (if any)
-    eval update t$t set c = c + 10000 where c> 900; # update sk or unique(if any)
-    eval update t$t set d = d + 10000 where d> 900; # update non key col
+    eval update t$t set b = b + 10000 where b > 900; # update sk or unique (if any)
+    eval update t$t set c = c + 10000 where c > 900; # update sk or unique(if any)
+    eval update t$t set d = d + 10000 where d > 900; # update non key col
 
     eval delete from t$t where a < 25;
     eval delete from t$t where b < 50;

--- a/mysql-test/suite/rocksdb/r/bloomfilter3.result
+++ b/mysql-test/suite/rocksdb/r/bloomfilter3.result
@@ -20,14 +20,14 @@ id1	id2	link_type	visibility	data	time	version
 100	100	1	1	100	100	100
 select case when variable_value-@c > 0 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
 case when variable_value-@c > 0 then 'true' else 'false' end
-true
+false
 select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
 select id1, id2, link_type, visibility, data, time, version from linktable FORCE INDEX(`id1_type2`)  where id1 = 100 and link_type = 1 and time >= 0 and time <= 9223372036854775807 order by time desc;
 id1	id2	link_type	visibility	data	time	version
 100	100	1	1	100	100	100
 select case when variable_value-@c > 0 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
 case when variable_value-@c > 0 then 'true' else 'false' end
-true
+false
 select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
 select id1, id2, link_type, visibility, data, time, version from linktable FORCE INDEX(`id1_type3`)  where id1 = 100 and time >= 0 and time <= 9223372036854775807 and visibility = 1 order by time desc;
 id1	id2	link_type	visibility	data	time	version
@@ -41,7 +41,7 @@ id1	id2	link_type	visibility	data	time	version
 100	100	1	1	100	100	100
 select case when variable_value-@c > 0 then 'true' else 'false' end from performance_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
 case when variable_value-@c > 0 then 'true' else 'false' end
-true
+false
 select variable_value into @c from performance_schema.global_status where variable_name='rocksdb_bloom_filter_prefix_checked';
 select id1, id2, link_type, visibility, data, time, version from linktable FORCE INDEX(`id1_type2`)  where id1 = 100 and link_type = 1 and time >= 0 order by time desc;
 id1	id2	link_type	visibility	data	time	version
@@ -104,7 +104,7 @@ insert into t1 values (21,2,2,0x12FFFFFFFFFF,1);
 explain 
 select * from t1 where kp0=1 and kp1=1 and kp2=0x12FFFFFFFFFF order by kp3 desc;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	index	kp12	kp12	28	NULL	#	100.00	Using where; Using index
+1	SIMPLE	t1	NULL	ref	kp12	kp12	20	const,const,const	#	100.00	Using where; Using index
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`kp0` AS `kp0`,`test`.`t1`.`kp1` AS `kp1`,`test`.`t1`.`kp2` AS `kp2`,`test`.`t1`.`kp3` AS `kp3` from `test`.`t1` where ((`test`.`t1`.`kp2` = 20890720927743) and (`test`.`t1`.`kp1` = 1) and (`test`.`t1`.`kp0` = 1)) order by `test`.`t1`.`kp3` desc
 show status like '%rocksdb_bloom_filter_prefix%';

--- a/mysql-test/suite/rocksdb/r/issue255.result
+++ b/mysql-test/suite/rocksdb/r/issue255.result
@@ -2,7 +2,7 @@ CREATE TABLE t1 (pk BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES (5);
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	1	#	#	#	#	#	6	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	6	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
 pk
@@ -10,7 +10,7 @@ pk
 6
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	2	#	#	#	#	#	7	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	7	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
 pk
@@ -19,7 +19,7 @@ pk
 7
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	3	#	#	#	#	#	8	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	8	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES (10);
 SELECT * FROM t1;
 pk
@@ -29,7 +29,7 @@ pk
 10
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	4	#	#	#	#	#	11	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	11	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
 pk
@@ -40,13 +40,13 @@ pk
 11
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	5	#	#	#	#	#	12	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	12	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 DROP TABLE t1;
 CREATE TABLE t1 (pk TINYINT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=ROCKSDB;
 INSERT INTO t1 VALUES (5);
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	1	#	#	#	#	#	6	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	6	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES (127);
 SELECT * FROM t1;
 pk
@@ -54,7 +54,7 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	2	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 ERROR 23000: Duplicate entry '127' for key 'PRIMARY'
 SELECT * FROM t1;
@@ -63,7 +63,7 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	2	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES(6);
 SELECT * FROM t1 ORDER BY pk;
 pk
@@ -72,7 +72,7 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	3	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 INSERT INTO t1 VALUES ();
 ERROR 23000: Duplicate entry '127' for key 'PRIMARY'
 SELECT * FROM t1;
@@ -82,5 +82,5 @@ pk
 127
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	#	Fixed	3	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	#	Fixed	#	#	#	#	#	#	127	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/rocksdb_checksums.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_checksums.result
@@ -95,7 +95,7 @@ set session debug= "-d,myrocks_simulate_bad_key_checksum1";
 explain 
 select a from t3 force index(a) where a<4;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t3	NULL	index	a	a	5	NULL	#	100.00	Using where; Using index
+1	SIMPLE	t3	NULL	range	a	a	5	NULL	#	100.00	Using where; Using index
 Warnings:
 Note	1003	/* select#1 */ select `rocksdb_checksums_test`.`t3`.`a` AS `a` from `rocksdb_checksums_test`.`t3` FORCE INDEX (`a`) where (`rocksdb_checksums_test`.`t3`.`a` < 4)
 select a from t3 force index(a) where a<4;

--- a/mysql-test/suite/rocksdb/r/show_table_status.result
+++ b/mysql-test/suite/rocksdb/r/show_table_status.result
@@ -6,12 +6,12 @@ set global rocksdb_force_flush_memtable_now = true;
 CREATE TABLE t3 (a INT, b CHAR(8), pk INT PRIMARY KEY) ENGINE=ROCKSDB CHARACTER SET utf8;
 SHOW TABLE STATUS WHERE name IN ( 't1', 't2', 't3' );
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t1	ROCKSDB	10	Fixed	2	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
-t2	ROCKSDB	10	Fixed	1	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t1	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 t3	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	utf8_general_ci	NULL		
 SHOW TABLE STATUS WHERE name LIKE 't2';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
-t2	ROCKSDB	10	Fixed	10000	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
+t2	ROCKSDB	10	Fixed	1000	#	#	0	0	0	NULL	NULL	NULL	NULL	latin1_swedish_ci	NULL		
 DROP TABLE t1, t2, t3;
 CREATE DATABASE `db_new..............................................end`;
 USE `db_new..............................................end`;

--- a/mysql-test/suite/rocksdb/r/statistics.result
+++ b/mysql-test/suite/rocksdb/r/statistics.result
@@ -26,9 +26,9 @@ true
 set global rocksdb_force_flush_memtable_now = true;
 SELECT table_name, table_rows FROM information_schema.tables WHERE table_schema = DATABASE();
 table_name	table_rows
-t1	100000
-t2	4999
-t3	4999
+t1	1000
+t2	1000
+t3	1000
 SELECT table_name, data_length>0, index_length>0 FROM information_schema.tables WHERE table_schema = DATABASE();
 table_name	data_length>0	index_length>0
 t1	1	1
@@ -37,9 +37,9 @@ t3	1	1
 # restart
 SELECT table_name, table_rows FROM information_schema.tables WHERE table_schema = DATABASE();
 table_name	table_rows
-t1	100000
-t2	4999
-t3	4999
+t1	1000
+t2	1000
+t3	1000
 SELECT table_name, data_length>0, index_length>0 FROM information_schema.tables WHERE table_schema = DATABASE();
 table_name	data_length>0	index_length>0
 t1	1	1
@@ -56,9 +56,9 @@ test.t5	analyze	Error	Table 'test.t5' doesn't exist
 test.t5	analyze	status	Operation failed
 SELECT table_name, table_rows FROM information_schema.tables WHERE table_schema = DATABASE();
 table_name	table_rows
-t1	100000
-t2	4999
-t3	4999
+t1	1000
+t2	1000
+t3	1000
 SELECT table_name, data_length>0, index_length>0 FROM information_schema.tables WHERE table_schema = DATABASE();
 table_name	data_length>0	index_length>0
 t1	1	1

--- a/mysql-test/suite/rocksdb/r/ttl_rows_examined.result
+++ b/mysql-test/suite/rocksdb/r/ttl_rows_examined.result
@@ -1,0 +1,47 @@
+set debug_sync='RESET';
+set @save.rocksdb_debug_ttl_read_filter_ts = @@global.rocksdb_debug_ttl_read_filter_ts;
+set global rocksdb_debug_ttl_read_filter_ts = -10;
+connect  conn1, localhost, root,,test;
+connect  conn2, localhost, root,,test;
+connection conn1;
+CREATE TABLE t_re (
+a INT, b INT, PRIMARY KEY (a)
+) ENGINE=RocksDB
+COMMENT 'ttl_duration=1';
+affected rows: 0
+set global rocksdb_debug_ttl_rec_ts = -13;
+affected rows: 0
+insert into t_re values (1,1);
+affected rows: 1
+insert into t_re values (2,2);
+affected rows: 1
+set global rocksdb_debug_ttl_rec_ts = 0;
+affected rows: 0
+commit;
+affected rows: 0
+set debug_sync='rocksdb.ttl_rows_examined SIGNAL parked WAIT_FOR go';
+affected rows: 0
+SELECT * FROM t_re;
+connection conn2;
+set debug_sync='now WAIT_FOR parked';
+affected rows: 0
+SHOW PROCESSLIST;
+Id	User	Host	db	Command	Time	State	Info	Rows_sent	Rows_examined
+###	###	###	###	Query	###	debug sync point: rocksdb.ttl_rows_examined	SELECT * FROM t_re	0	###
+###	###	###	###	Query	###	starting	SHOW PROCESSLIST	0	###
+###	###	###	###	Sleep	###		NULL	0	###
+affected rows: 3
+set debug_sync='now SIGNAL go';
+affected rows: 0
+connection conn1;
+a	b
+affected rows: 0
+connection default;
+set debug_sync='RESET';
+affected rows: 0
+set global rocksdb_debug_ttl_read_filter_ts = @save.rocksdb_debug_ttl_read_filter_ts;
+affected rows: 0
+drop table t_re;
+affected rows: 0
+disconnect conn1;
+disconnect conn2;

--- a/mysql-test/suite/rocksdb/r/type_decimal.result
+++ b/mysql-test/suite/rocksdb/r/type_decimal.result
@@ -38,7 +38,7 @@ Note	1003	/* select#1 */ select `test`.`t1`.`pk` AS `pk`,`test`.`t1`.`col1` AS `
 explain
 select col1, col2 from t1 where col1 between -8 and 8;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	key1	key1	3	NULL	#	100.00	Using where; Using index
+1	SIMPLE	t1	NULL	index	key1	key1	6	NULL	#	100.00	Using where; Using index
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,`test`.`t1`.`col2` AS `col2` from `test`.`t1` where (`test`.`t1`.`col1` between <cache>(-(8)) and 8)
 select col1, col2 from t1 where col1 between -8 and 8;
@@ -52,7 +52,7 @@ insert into t1 values (10, -8.4, NULL, 'row2-with-null');
 explain
 select col1, col2 from t1 force index(key1) where col1 is null or col1 < -7;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	key1	key1	3	NULL	#	100.00	Using where; Using index
+1	SIMPLE	t1	NULL	index	key1	key1	6	NULL	#	100.00	Using where; Using index
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,`test`.`t1`.`col2` AS `col2` from `test`.`t1` FORCE INDEX (`key1`) where (isnull(`test`.`t1`.`col1`) or (`test`.`t1`.`col1` < <cache>(-(7))))
 select col1, col2 from t1 force index(key1) where col1 is null or col1 < -7;
@@ -103,7 +103,7 @@ test.t1	analyze	status	OK
 explain
 select col1, col2 from t1 force index(key1) where col1 between -800 and 800;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t1	NULL	range	key1	key1	7	NULL	#	100.00	Using where; Using index
+1	SIMPLE	t1	NULL	index	key1	key1	14	NULL	#	100.00	Using where; Using index
 Warnings:
 Note	1003	/* select#1 */ select `test`.`t1`.`col1` AS `col1`,`test`.`t1`.`col2` AS `col2` from `test`.`t1` FORCE INDEX (`key1`) where (`test`.`t1`.`col1` between <cache>(-(800)) and 800)
 select col1, col2 from t1 force index(key1) where col1 between -800 and 800;

--- a/mysql-test/suite/rocksdb/t/issue255.test
+++ b/mysql-test/suite/rocksdb/t/issue255.test
@@ -3,27 +3,27 @@
 CREATE TABLE t1 (pk BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=ROCKSDB;
 
 INSERT INTO t1 VALUES (5);
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES (10);
 SELECT * FROM t1;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 DROP TABLE t1;
@@ -31,29 +31,29 @@ DROP TABLE t1;
 CREATE TABLE t1 (pk TINYINT NOT NULL PRIMARY KEY AUTO_INCREMENT) ENGINE=ROCKSDB;
 
 INSERT INTO t1 VALUES (5);
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES (127);
 SELECT * FROM t1;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 --error ER_DUP_ENTRY
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 INSERT INTO t1 VALUES(6);
 SELECT * FROM t1 ORDER BY pk;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 --error ER_DUP_ENTRY
 INSERT INTO t1 VALUES ();
 SELECT * FROM t1;
---replace_column 3 # 6 # 7 # 8 # 9 # 10 #
+--replace_column 3 # 5 # 6 # 7 # 8 # 9 # 10 #
 SHOW TABLE STATUS LIKE 't1';
 
 DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/ttl_rows_examined.test
+++ b/mysql-test/suite/rocksdb/t/ttl_rows_examined.test
@@ -1,0 +1,60 @@
+--source include/have_rocksdb.inc
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+####
+# Bump rows_examined count whenever MyRocks filters out a row due to expired TTL
+####
+
+# clean start
+set debug_sync='RESET';
+set @save.rocksdb_debug_ttl_read_filter_ts = @@global.rocksdb_debug_ttl_read_filter_ts;
+set global rocksdb_debug_ttl_read_filter_ts = -10;
+
+--enable_connect_log
+--enable_info
+
+--connect (conn1, localhost, root,,test)
+--connect (conn2, localhost, root,,test)
+
+--connection conn1
+
+# create table with TTL policy (1s)
+CREATE TABLE t_re (
+  a INT, b INT, PRIMARY KEY (a)
+) ENGINE=RocksDB
+COMMENT 'ttl_duration=1';
+
+# start with 2 rows, expired at the insertion time
+set global rocksdb_debug_ttl_rec_ts = -13;
+insert into t_re values (1,1);
+insert into t_re values (2,2);
+set global rocksdb_debug_ttl_rec_ts = 0;
+commit;
+
+# setup signal to stop in code where we skip expired records
+set debug_sync='rocksdb.ttl_rows_examined SIGNAL parked WAIT_FOR go';
+send SELECT * FROM t_re;
+
+--connection conn2
+set debug_sync='now WAIT_FOR parked';
+
+# display "Rows Examined" before returning from call
+--replace_column 1 ### 2 ### 3 ### 4 ### 6 ### 10 ### 11 ### 12 ###
+--sorted_result
+SHOW PROCESSLIST;
+
+set debug_sync='now SIGNAL go';
+
+--connection conn1
+reap;
+
+# tidy up
+--connection default
+set debug_sync='RESET';
+set global rocksdb_debug_ttl_read_filter_ts = @save.rocksdb_debug_ttl_read_filter_ts;
+drop table t_re;
+
+--disconnect conn1
+--disconnect conn2
+--source include/wait_until_count_sessions.inc

--- a/storage/rocksdb/.clang-format
+++ b/storage/rocksdb/.clang-format
@@ -1,26 +1,52 @@
----
+# Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is also distributed with certain software (including
+# but not limited to OpenSSL) that is licensed under separate terms,
+# as designated in a particular file or component or in included license
+# documentation.  The authors of MySQL hereby grant you an additional
+# permission to link the program and your derivative works with the
+# separately licensed software that they have included with MySQL.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+# This is the output of clang-format-5.0 --style=google --dump-config,
+# except for changes mentioned below. We lock the style so that any newer
+# version of clang-format will give the same result; as time goes, we may
+# update this list, requiring newer versions of clang-format.
+
 Language:        Cpp
-# BasedOnStyle:  LLVM
+# BasedOnStyle:  Google
 AccessModifierOffset: -1
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-AlignEscapedNewlinesLeft: false
+AlignEscapedNewlines: Left
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: All
-AllowShortIfStatementsOnASingleLine: false
-AllowShortLoopsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: false
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
 BinPackArguments: true
 BinPackParameters: true
-BraceWrapping:
+BraceWrapping:   
   AfterClass:      false
   AfterControlStatement: false
   AfterEnum:       false
@@ -32,51 +58,64 @@ BraceWrapping:
   BeforeCatch:     false
   BeforeElse:      false
   IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
-#BreakAfterJavaFieldAnnotations: false
-#BreakStringLiterals: true
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
 ColumnLimit:     80
 CommentPragmas:  '^ IWYU pragma:'
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
-ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
-IncludeCategories:
-  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority:        2
-  - Regex:           '^(<|"(gtest|isl|json)/)'
-    Priority:        3
-  - Regex:           '.*'
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
     Priority:        1
-#IncludeIsMainRegex: '$'
-IndentCaseLabels: false
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
-KeepEmptyLinesAtTheStartOfBlocks: true
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 2
 ObjCSpaceAfterProperty: false
-ObjCSpaceBeforeProtocolList: true
-PenaltyBreakBeforeFirstCallParameter: 19
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
-PointerAlignment: Right
+PenaltyReturnTypeOnItsOwnLine: 200
 ReflowComments:  true
 SortIncludes:    true
+SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
@@ -86,8 +125,13 @@ SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
-#JavaScriptQuotes: Leave
-...
+
+# We declare one specific pointer style since right alignment is dominant in
+# the MySQL code base (default --style=google has DerivePointerAlignment true).
+DerivePointerAlignment: false
+PointerAlignment: Right
+
+# MySQL source code is allowed to use C++11 features.
+Standard:        Cpp11

--- a/storage/rocksdb/event_listener.cc
+++ b/storage/rocksdb/event_listener.cc
@@ -32,9 +32,9 @@
 
 namespace myrocks {
 
-static std::vector<Rdb_index_stats>
-extract_index_stats(const std::vector<std::string> &files,
-                    const rocksdb::TablePropertiesCollection &props) {
+static std::vector<Rdb_index_stats> extract_index_stats(
+    const std::vector<std::string> &files,
+    const rocksdb::TablePropertiesCollection &props) {
   std::vector<Rdb_index_stats> ret;
   for (auto fn : files) {
     const auto it = props.find(fn);
@@ -91,4 +91,4 @@ void Rdb_event_listener::OnBackgroundError(
     abort();
   }
 }
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/event_listener.cc
+++ b/storage/rocksdb/event_listener.cc
@@ -85,6 +85,7 @@ void Rdb_event_listener::OnExternalFileIngested(
 void Rdb_event_listener::OnBackgroundError(
     rocksdb::BackgroundErrorReason reason, rocksdb::Status *status) {
   rdb_log_status_error(*status, "Error detected in background");
+  // NO_LINT_DEBUG
   sql_print_error("RocksDB: BackgroundErrorReason: %d", (int)reason);
   if (status->IsCorruption()) {
     rdb_persist_corruption_marker();

--- a/storage/rocksdb/event_listener.cc
+++ b/storage/rocksdb/event_listener.cc
@@ -36,7 +36,7 @@ static std::vector<Rdb_index_stats> extract_index_stats(
     const std::vector<std::string> &files,
     const rocksdb::TablePropertiesCollection &props) {
   std::vector<Rdb_index_stats> ret;
-  for (auto fn : files) {
+  for (const auto &fn : files) {
     const auto it = props.find(fn);
     DBUG_ASSERT(it != props.end());
     std::vector<Rdb_index_stats> stats;

--- a/storage/rocksdb/event_listener.h
+++ b/storage/rocksdb/event_listener.h
@@ -22,7 +22,7 @@ namespace myrocks {
 class Rdb_ddl_manager;
 
 class Rdb_event_listener : public rocksdb::EventListener {
-public:
+ public:
   Rdb_event_listener(const Rdb_event_listener &) = delete;
   Rdb_event_listener &operator=(const Rdb_event_listener &) = delete;
 
@@ -40,10 +40,10 @@ public:
   void OnBackgroundError(rocksdb::BackgroundErrorReason reason,
                          rocksdb::Status *status) override;
 
-private:
+ private:
   Rdb_ddl_manager *m_ddl_manager;
 
   void update_index_stats(const rocksdb::TableProperties &props);
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -189,11 +189,26 @@ static void rocksdb_flush_all_memtables() {
 namespace  // anonymous namespace = not visible outside this source file
 {
 
-struct Rdb_open_tables_map {
+class Rdb_open_tables_map {
+ private:
   /* Hash table used to track the handlers of open tables */
-  std::unordered_map<std::string, Rdb_table_handler *> m_hash;
+  std::unordered_map<std::string, Rdb_table_handler *> m_table_map;
+
   /* The mutex used to protect the hash table */
   mutable mysql_mutex_t m_mutex;
+
+ public:
+  void init() {
+    m_table_map.clear();
+    mysql_mutex_init(rdb_psi_open_tbls_mutex_key, &m_mutex, MY_MUTEX_INIT_FAST);
+  }
+
+  void free() {
+    m_table_map.clear();
+    mysql_mutex_destroy(&m_mutex);
+  }
+
+  size_t count() { return m_table_map.size(); }
 
   Rdb_table_handler *get_table_handler(const char *const table_name);
   void release_table_handler(Rdb_table_handler *const table_handler);
@@ -1950,6 +1965,8 @@ static int rocksdb_compact_column_family(THD *const thd,
   }
   return HA_EXIT_SUCCESS;
 }
+
+///////////////////////////////////////////////////////////////////////////////////////////
 
 /*
   Drop index thread's control
@@ -4321,8 +4338,10 @@ static int rocksdb_init_func(void *const p) {
   init_rocksdb_psi_keys();
 
   rocksdb_hton = (handlerton *)p;
-  mysql_mutex_init(rdb_psi_open_tbls_mutex_key, &rdb_open_tables.m_mutex,
-                   MY_MUTEX_INIT_FAST);
+
+  rdb_open_tables.init();
+  Ensure_cleanup rdb_open_tables_cleanup([]() { rdb_open_tables.free(); });
+
 #ifdef HAVE_PSI_INTERFACE
   rdb_bg_thread.init(rdb_signal_bg_psi_mutex_key, rdb_signal_bg_psi_cond_key);
   rdb_drop_idx_thread.init(rdb_signal_drop_idx_psi_mutex_key,
@@ -4779,7 +4798,14 @@ static int rocksdb_init_func(void *const p) {
   // succeeded, set the init status flag
   rdb_get_hton_init_state()->set_initialized(true);
 
-  sql_print_information("RocksDB instance opened");
+  // NO_LINT_DEBUG
+  sql_print_information(
+      "MyRocks storage engine plugin has been successfully "
+      "initialized.");
+
+  // Skip cleaning up rdb_open_tables as we've succeeded
+  rdb_open_tables_cleanup.skip();
+
   DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
@@ -4841,13 +4867,13 @@ static int rocksdb_done_func(void *const p) {
         "RocksDB: Couldn't stop the manual compaction thread: (errno=%d)", err);
   }
 
-  if (rdb_open_tables.m_hash.size()) {
+  if (rdb_open_tables.count()) {
     // Looks like we are getting unloaded and yet we have some open tables
     // left behind.
     error = 1;
   }
 
-  mysql_mutex_destroy(&rdb_open_tables.m_mutex);
+  rdb_open_tables.free();
   mysql_mutex_destroy(&rdb_sysvars_mutex);
   mysql_mutex_destroy(&rdb_block_cache_resize_mutex);
 
@@ -4951,28 +4977,31 @@ Rdb_table_handler *Rdb_open_tables_map::get_table_handler(
     const char *const table_name) {
   DBUG_ASSERT(table_name != nullptr);
 
-  const std::string s_table_name(table_name);
+  Rdb_table_handler *table_handler;
+
+  const std::string table_name_str(table_name);
 
   // First, look up the table in the hash map.
   RDB_MUTEX_LOCK_CHECK(m_mutex);
-  Rdb_table_handler *table_handler = nullptr;
-  const auto &it = m_hash.find(s_table_name);
-  if (it != m_hash.end()) {
+  const auto &it = m_table_map.find(table_name_str);
+  if (it != m_table_map.end()) {
+    // Found it
     table_handler = it->second;
   } else {
+    char *tmp_name;
+
     // Since we did not find it in the hash map, attempt to create and add it
     // to the hash map.
-    char *tmp_name;
 #ifdef HAVE_PSI_INTERFACE
-    if (!(table_handler = static_cast<Rdb_table_handler *>(
+    if (!(table_handler = reinterpret_cast<Rdb_table_handler *>(
               my_multi_malloc(rdb_handler_memory_key, MYF(MY_WME | MY_ZEROFILL),
                               &table_handler, sizeof(*table_handler), &tmp_name,
-                              s_table_name.length() + 1, NullS)))) {
+                              table_name_str.length() + 1, NullS)))) {
 #else
-    if (!(table_handler = static_cast<Rdb_table_handler *>(
+    if (!(table_handler = reinterpret_cast<Rdb_table_handler *>(
               my_multi_malloc(PSI_NOT_INSTRUMENTED, MYF(MY_WME | MY_ZEROFILL),
                               &table_handler, sizeof(*table_handler), &tmp_name,
-                              s_table_name.length() + 1, NullS)))) {
+                              table_name_str.length() + 1, NullS)))) {
 #endif
       // Allocating a new Rdb_table_handler and a new table name failed.
       RDB_MUTEX_UNLOCK_CHECK(m_mutex);
@@ -4980,11 +5009,11 @@ Rdb_table_handler *Rdb_open_tables_map::get_table_handler(
     }
 
     table_handler->m_ref_count = 0;
-    table_handler->m_table_name_length = s_table_name.length();
+    table_handler->m_table_name_length = table_name_str.length();
     table_handler->m_table_name = tmp_name;
-    my_stpmov(table_handler->m_table_name, s_table_name.c_str());
+    my_stpmov(table_handler->m_table_name, table_name_str.c_str());
 
-    m_hash.insert({s_table_name, table_handler});
+    m_table_map.emplace(table_name_str, table_handler);
 
     thr_lock_init(&table_handler->m_thr_lock);
     table_handler->m_io_perf_read.init();
@@ -5006,8 +5035,8 @@ std::vector<std::string> Rdb_open_tables_map::get_table_names(void) const {
   std::vector<std::string> names;
 
   RDB_MUTEX_LOCK_CHECK(m_mutex);
-  for (const auto &it : m_hash) {
-    table_handler = it.second;
+  for (const auto &kv : m_table_map) {
+    table_handler = kv.second;
     DBUG_ASSERT(table_handler != nullptr);
     names.push_back(table_handler->m_table_name);
   }
@@ -5284,8 +5313,8 @@ void Rdb_open_tables_map::release_table_handler(
   DBUG_ASSERT(table_handler->m_ref_count > 0);
   if (!--table_handler->m_ref_count) {
     const auto ret MY_ATTRIBUTE((__unused__)) =
-        m_hash.erase(std::string(table_handler->m_table_name));
-    DBUG_ASSERT(ret == 1);
+        m_table_map.erase(std::string(table_handler->m_table_name));
+    DBUG_ASSERT(ret == 1);  // the hash entry must actually be found and deleted
     my_core::thr_lock_delete(&table_handler->m_thr_lock);
     my_free(table_handler);
   }

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10879,7 +10879,7 @@ static int calculate_stats(
 
   // get RocksDB table properties for these ranges
   rocksdb::TablePropertiesCollection props;
-  for (auto it : ranges) {
+  for (const auto &it : ranges) {
     const auto old_size MY_ATTRIBUTE((__unused__)) = props.size();
     const auto status = rdb->GetPropertiesOfTablesInRange(
         it.first, &it.second[0], it.second.size(), &props);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -5421,6 +5421,11 @@ bool ha_rocksdb::should_hide_ttl_rec(const Rdb_key_def &kd,
       ts + kd.m_ttl_duration + read_filter_ts <= static_cast<uint64>(curr_ts);
   if (is_hide_ttl) {
     update_row_stats(ROWS_FILTERED);
+
+    /* increment examined row count when rows are skipped */
+    THD *thd = ha_thd();
+    thd->inc_examined_row_count(1);
+    DEBUG_SYNC(thd, "rocksdb.ttl_rows_examined");
   }
   return is_hide_ttl;
 }

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -112,10 +112,11 @@ static std::vector<GL_INDEX_ID> rdb_indexes_to_recalc;
 void ha_rocksdb::update_row_stats(const operation_type &type) {
   DBUG_ASSERT(type < ROWS_MAX);
   // Find if we are modifying system databases.
-  if (table->s && m_tbl_def->m_is_mysql_system_table)
+  if (table->s && m_tbl_def->m_is_mysql_system_table) {
     global_stats.system_rows[type].inc();
-  else
+  } else {
     global_stats.rows[type].inc();
+  }
 }
 
 void dbug_dump_database(rocksdb::DB *db);
@@ -2241,8 +2242,9 @@ class Rdb_transaction {
     if (m_is_tx_failed) {
       rollback();
       res = false;
-    } else
+    } else {
       res = commit();
+    }
     return res;
   }
 
@@ -2777,8 +2779,9 @@ class Rdb_transaction_impl : public Rdb_transaction {
 
  public:
   void set_lock_timeout(int timeout_sec_arg) override {
-    if (m_rocksdb_tx)
+    if (m_rocksdb_tx) {
       m_rocksdb_tx->SetLockTimeout(rdb_convert_sec_to_ms(m_timeout_sec));
+    }
   }
 
   void set_sync(bool sync) override {
@@ -2912,8 +2915,9 @@ class Rdb_transaction_impl : public Rdb_transaction {
                       const bool assume_tracked) override {
     ++m_write_count;
     ++m_lock_count;
-    if (m_write_count > m_max_row_locks || m_lock_count > m_max_row_locks)
+    if (m_write_count > m_max_row_locks || m_lock_count > m_max_row_locks) {
       return rocksdb::Status::Aborted(rocksdb::Status::kLockLimit);
+    }
     return m_rocksdb_tx->Put(column_family, key, value, assume_tracked);
   }
 
@@ -2922,8 +2926,9 @@ class Rdb_transaction_impl : public Rdb_transaction {
                              const bool assume_tracked) override {
     ++m_write_count;
     ++m_lock_count;
-    if (m_write_count > m_max_row_locks || m_lock_count > m_max_row_locks)
+    if (m_write_count > m_max_row_locks || m_lock_count > m_max_row_locks) {
       return rocksdb::Status::Aborted(rocksdb::Status::kLockLimit);
+    }
     return m_rocksdb_tx->Delete(column_family, key, assume_tracked);
   }
 
@@ -2932,8 +2937,9 @@ class Rdb_transaction_impl : public Rdb_transaction {
       const rocksdb::Slice &key, const bool assume_tracked) override {
     ++m_write_count;
     ++m_lock_count;
-    if (m_write_count > m_max_row_locks || m_lock_count > m_max_row_locks)
+    if (m_write_count > m_max_row_locks || m_lock_count > m_max_row_locks) {
       return rocksdb::Status::Aborted(rocksdb::Status::kLockLimit);
+    }
     return m_rocksdb_tx->SingleDelete(column_family, key, assume_tracked);
   }
 
@@ -2971,8 +2977,9 @@ class Rdb_transaction_impl : public Rdb_transaction {
       rocksdb::ColumnFamilyHandle *const column_family,
       const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
       bool exclusive, const bool do_validate) override {
-    if (++m_lock_count > m_max_row_locks)
+    if (++m_lock_count > m_max_row_locks) {
       return rocksdb::Status::Aborted(rocksdb::Status::kLockLimit);
+    }
 
     if (value != nullptr) {
       value->Reset();
@@ -3077,10 +3084,11 @@ class Rdb_transaction_impl : public Rdb_transaction {
         if (org_snapshot != nullptr) m_snapshot_timestamp = 0;
 
         m_read_opts.snapshot = cur_snapshot;
-        if (cur_snapshot != nullptr)
+        if (cur_snapshot != nullptr) {
           rdb->GetEnv()->GetCurrentTime(&m_snapshot_timestamp);
-        else
+        } else {
           m_is_delayed_snapshot = true;
+        }
       }
     }
   }
@@ -5246,8 +5254,9 @@ int ha_rocksdb::read_hidden_pk_id_from_rowkey(longlong *const hidden_pk_id) {
 
   // Get hidden primary key from old key slice
   Rdb_string_reader reader(&rowkey_slice);
-  if ((!reader.read(Rdb_key_def::INDEX_NUMBER_SIZE)))
+  if ((!reader.read(Rdb_key_def::INDEX_NUMBER_SIZE))) {
     return HA_ERR_ROCKSDB_CORRUPT_DATA;
+  }
 
   const int length = Field_longlong::PACK_LENGTH;
   const uchar *from = reinterpret_cast<const uchar *>(reader.read(length));
@@ -5597,8 +5606,8 @@ int ha_rocksdb::alloc_key_buffers(const TABLE *const table_arg,
   /* Sometimes, we may use m_sk_packed_tuple for storing packed PK */
   max_packed_sk_len = pack_key_len;
   for (uint i = 0; i < table_arg->s->keys; i++) {
-    if (i == table_arg->s->primary_key) /* Primary key was processed above */
-      continue;
+    /* Primary key was processed above */
+    if (i == table_arg->s->primary_key) continue;
 
     // TODO: move this into get_table_handler() ??
     kd_arr[i]->setup(table_arg, tbl_def_arg);
@@ -7203,8 +7212,9 @@ ulong ha_rocksdb::index_flags(bool &pk_can_be_decoded,
                      HA_READ_ORDER | HA_READ_RANGE | HA_READ_PREV;
 
   if (check_keyread_allowed(pk_can_be_decoded, table_share, inx, part,
-                            all_parts))
+                            all_parts)) {
     base_flags |= HA_KEYREAD_ONLY;
+  }
 
   if (inx == table_share->primary_key) {
     /*
@@ -7321,8 +7331,9 @@ int ha_rocksdb::read_range_first(const key_range *const start_key,
         index_read_map_impl(table->record[0], start_key->key,
                             start_key->keypart_map, start_key->flag, end_key);
   }
-  if (result)
+  if (result) {
     DBUG_RETURN((result == HA_ERR_KEY_NOT_FOUND) ? HA_ERR_END_OF_FILE : result);
+  }
 
   if (compare_key(end_range) <= 0) {
     DBUG_RETURN(HA_EXIT_SUCCESS);
@@ -7420,8 +7431,9 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
     packed_size = kd.pack_index_tuple(table, m_pack_buffer, m_sk_packed_tuple,
                                       key, tmp_map);
     if (table->key_info[active_index].user_defined_key_parts !=
-        kd.get_key_parts())
+        kd.get_key_parts()) {
       using_full_key = false;
+    }
   } else {
     packed_size = kd.pack_index_tuple(table, m_pack_buffer, m_sk_packed_tuple,
                                       key, keypart_map);
@@ -7463,8 +7475,9 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
 
   bool use_all_keys = false;
   if (find_flag == HA_READ_KEY_EXACT &&
-      my_count_bits(keypart_map) == kd.get_key_parts())
+      my_count_bits(keypart_map) == kd.get_key_parts()) {
     use_all_keys = true;
+  }
 
   Rdb_transaction *const tx = get_or_create_tx(table->in_use);
   const bool is_new_snapshot = !tx->has_snapshot();
@@ -7502,10 +7515,11 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
       then we have all the rows we need.  For a secondary key we now need to
       lookup the primary key.
     */
-    if (active_index == table->s->primary_key)
+    if (active_index == table->s->primary_key) {
       rc = read_row_from_primary_key(buf);
-    else
+    } else {
       rc = read_row_from_secondary_key(buf, kd, move_forward);
+    }
 
     if (!should_recreate_snapshot(rc, is_new_snapshot)) {
       break; /* Exit the loop */
@@ -7663,8 +7677,9 @@ int ha_rocksdb::check(THD *const thd, HA_CHECK_OPT *const check_opt) {
       ha_index_init(keyno, true);
       ha_rows rows = 0;
       ha_rows checksums = 0;
-      if (first_index)
+      if (first_index) {
         row_checksums_at_start = m_converter->get_row_checksums_checked();
+      }
       int res;
       // NO_LINT_DEBUG
       sql_print_information("CHECKTABLE %s:   Checking index %s", table_name,
@@ -7706,8 +7721,9 @@ int ha_rocksdb::check(THD *const thd, HA_CHECK_OPT *const check_opt) {
 
         longlong hidden_pk_id = 0;
         if (has_hidden_pk(table) &&
-            read_hidden_pk_id_from_rowkey(&hidden_pk_id))
+            read_hidden_pk_id_from_rowkey(&hidden_pk_id)) {
           goto error;
+        }
 
         /* Check if we get the same PK value */
         uint packed_size = m_pk_descr->pack_record(
@@ -7797,10 +7813,11 @@ error:
 static void dbug_dump_str(FILE *const out, const char *const str, int len) {
   fprintf(out, "\"");
   for (int i = 0; i < len; i++) {
-    if (str[i] > 32)
+    if (str[i] > 32) {
       fprintf(out, "%c", str[i]);
-    else
+    } else {
       fprintf(out, "\\%d", str[i]);
+    }
   }
   fprintf(out, "\"");
 }
@@ -8013,10 +8030,11 @@ int ha_rocksdb::index_next_with_direction(uchar *const buf, bool move_forward) {
       } else if (!m_scan_it->Valid()) {
         DBUG_RETURN(HA_ERR_KEY_NOT_FOUND);
       } else {
-        if (move_forward)
+        if (move_forward) {
           m_scan_it->Next(); /* this call cannot fail */
-        else
+        } else {
           m_scan_it->Prev();
+        }
       }
       rc = rocksdb_skip_expired_records(*m_key_descr_arr[active_index],
                                         m_scan_it, !move_forward);
@@ -9471,10 +9489,11 @@ int ha_rocksdb::rnd_next_with_direction(uchar *const buf, bool move_forward) {
     if (m_skip_scan_it_next_call) {
       m_skip_scan_it_next_call = false;
     } else {
-      if (move_forward)
+      if (move_forward) {
         m_scan_it->Next(); /* this call cannot fail */
-      else
+      } else {
         m_scan_it->Prev(); /* this call cannot fail */
+      }
     }
 
     if (!is_valid(m_scan_it)) {
@@ -9699,8 +9718,9 @@ rocksdb::Status ha_rocksdb::delete_or_singledelete(
     rocksdb::ColumnFamilyHandle *const column_family,
     const rocksdb::Slice &key) {
   const bool assume_tracked = can_assume_tracked(ha_thd());
-  if (can_use_single_delete(index))
+  if (can_use_single_delete(index)) {
     return tx->single_delete(column_family, key, assume_tracked);
+  }
   return tx->delete_key(column_family, key, assume_tracked);
 }
 
@@ -9882,8 +9902,9 @@ void ha_rocksdb::position(const uchar *const record) {
   DBUG_ENTER_FUNC();
 
   longlong hidden_pk_id = 0;
-  if (has_hidden_pk(table) && read_hidden_pk_id_from_rowkey(&hidden_pk_id))
+  if (has_hidden_pk(table) && read_hidden_pk_id_from_rowkey(&hidden_pk_id)) {
     DBUG_ASSERT(false);  // should never reach here
+  }
 
   /*
     Get packed primary key value from the record.
@@ -9905,8 +9926,9 @@ void ha_rocksdb::position(const uchar *const record) {
     It could be that mem-comparable form of PK occupies less than ref_length
     bytes. Fill the remainder with zeros.
   */
-  if (ref_length > packed_size)
+  if (ref_length > packed_size) {
     memset(ref + packed_size, 0, ref_length - packed_size);
+  }
 
   DBUG_VOID_RETURN;
 }
@@ -11123,10 +11145,11 @@ const char *dbug_print_item(Item *const item) {
   str.length(0);
   if (!item) return "(Item*)nullptr";
   item->print(&str, QT_ORDINARY);
-  if (str.c_ptr() == buf)
+  if (str.c_ptr() == buf) {
     return buf;
-  else
+  } else {
     return "Couldn't fit into buffer";
+  }
 }
 
 #endif /*DBUG_OFF*/
@@ -12665,10 +12688,11 @@ bool ha_rocksdb::can_use_bloom_filter(THD *thd, const Rdb_key_def &kd,
       if prefix extractor is not defined, all key parts have to be
       used by eq_cond.
     */
-    if (use_all_keys)
+    if (use_all_keys) {
       can_use = true;
-    else
+    } else {
       can_use = false;
+    }
   }
 
   return can_use;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3099,7 +3099,7 @@ class Rdb_transaction_impl : public Rdb_transaction {
     m_notifier = std::make_shared<Rdb_snapshot_notifier>(this);
   }
 
-  virtual ~Rdb_transaction_impl() {
+  virtual ~Rdb_transaction_impl() override {
     rollback();
 
     // Theoretically the notifier could outlive the Rdb_transaction_impl
@@ -3294,7 +3294,7 @@ class Rdb_writebatch_impl : public Rdb_transaction {
                                                true);
   }
 
-  virtual ~Rdb_writebatch_impl() {
+  virtual ~Rdb_writebatch_impl() override {
     rollback();
     delete m_batch;
   }

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -2589,7 +2589,7 @@ class Rdb_transaction {
         std::max(m_auto_incr_map[gl_index_id], curr_id);
   }
 
-#ifndef NDEBUG
+#ifndef DBUG_OFF
   ulonglong get_auto_incr(const GL_INDEX_ID &gl_index_id) {
     if (m_auto_incr_map.count(gl_index_id) > 0) {
       return m_auto_incr_map[gl_index_id];
@@ -5120,7 +5120,7 @@ ulonglong ha_rocksdb::load_auto_incr_value_from_index() {
     if (last_val != max_val) {
       last_val++;
     }
-#ifndef NDEBUG
+#ifndef DBUG_OFF
     ulonglong dd_val;
     if (last_val <= max_val) {
       const auto &gl_index_id = m_tbl_def->get_autoincr_gl_index_id();
@@ -5469,7 +5469,7 @@ int ha_rocksdb::rocksdb_skip_expired_records(const Rdb_key_def &kd,
   return HA_EXIT_SUCCESS;
 }
 
-#ifndef NDEBUG
+#ifndef DBUG_OFF
 void dbug_append_garbage_at_end(rocksdb::PinnableSlice *on_disk_rec) {
   std::string str(on_disk_rec->data(), on_disk_rec->size());
   on_disk_rec->Reset();

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -235,6 +235,7 @@ static int rocksdb_create_checkpoint(
         status = checkpoint->CreateCheckpoint(checkpoint_dir.c_str());
         delete checkpoint;
         if (status.ok()) {
+          // NO_LINT_DEBUG
           sql_print_information(
               "RocksDB: created checkpoint in directory : %s\n",
               checkpoint_dir.c_str());
@@ -264,6 +265,7 @@ static void rocksdb_force_flush_memtable_now_stub(
 static int rocksdb_force_flush_memtable_now(
     THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
     struct st_mysql_value *const value) {
+  // NO_LINT_DEBUG
   sql_print_information("RocksDB: Manual memtable flush.");
   rocksdb_flush_all_memtables();
   return HA_EXIT_SUCCESS;
@@ -276,6 +278,7 @@ static void rocksdb_force_flush_memtable_and_lzero_now_stub(
 static int rocksdb_force_flush_memtable_and_lzero_now(
     THD *const thd, struct st_mysql_sys_var *const var, void *const var_ptr,
     struct st_mysql_value *const value) {
+  // NO_LINT_DEBUG
   sql_print_information("RocksDB: Manual memtable and L0 flush.");
   rocksdb_flush_all_memtables();
 
@@ -4115,6 +4118,7 @@ static bool rocksdb_show_status(handlerton *const hton, THD *const thd,
     rocksdb::Status s = rdb->GetEnv()->GetThreadList(&thread_list);
 
     if (!s.ok()) {
+      // NO_LINT_DEBUG
       sql_print_error("RocksDB: Returned error (%s) from GetThreadList.\n",
                       s.ToString().c_str());
       res |= true;
@@ -4490,16 +4494,21 @@ static int rocksdb_init_func(void *const p) {
       Checking system errno happens to work right now.
     */
     if (status.IsIOError() && errno == ENOENT) {
+      // NO_LINT_DEBUG
       sql_print_information("RocksDB: Got ENOENT when listing column families");
+
+      // NO_LINT_DEBUG
       sql_print_information(
           "RocksDB:   assuming that we're creating a new database");
     } else {
       rdb_log_status_error(status, "Error listing column families");
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
-  } else
+  } else {
+    // NO_LINT_DEBUG
     sql_print_information("RocksDB: %ld column families found",
                           cf_names.size());
+  }
 
   std::vector<rocksdb::ColumnFamilyDescriptor> cf_descr;
   std::vector<rocksdb::ColumnFamilyHandle *> cf_handles;
@@ -4578,6 +4587,7 @@ static int rocksdb_init_func(void *const p) {
     }
     rocksdb_tbl_options->persistent_cache = pcache;
   } else if (strlen(rocksdb_persistent_cache_path)) {
+    // NO_LINT_DEBUG
     sql_print_error("RocksDB: Must specify rocksdb_persistent_cache_size_mb");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
@@ -4598,13 +4608,20 @@ static int rocksdb_init_func(void *const p) {
   if (cf_names.size() == 0) cf_names.push_back(DEFAULT_CF_NAME);
 
   std::vector<int> compaction_enabled_cf_indices;
+
+  // NO_LINT_DEBUG
   sql_print_information("RocksDB: Column Families at start:");
   for (size_t i = 0; i < cf_names.size(); ++i) {
     rocksdb::ColumnFamilyOptions opts;
     cf_options_map->get_cf_options(cf_names[i], &opts);
 
+    // NO_LINT_DEBUG
     sql_print_information("  cf=%s", cf_names[i].c_str());
+
+    // NO_LINT_DEBUG
     sql_print_information("    write_buffer_size=%ld", opts.write_buffer_size);
+
+    // NO_LINT_DEBUG
     sql_print_information("    target_file_size_base=%" PRIu64,
                           opts.target_file_size_base);
 
@@ -4701,6 +4718,7 @@ static int rocksdb_init_func(void *const p) {
 #endif
   );
   if (err != 0) {
+    // NO_LINT_DEBUG
     sql_print_error("RocksDB: Couldn't start the background thread: (errno=%d)",
                     err);
     DBUG_RETURN(HA_EXIT_FAILURE);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -15,7 +15,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #ifdef USE_PRAGMA_IMPLEMENTATION
-#pragma implementation // gcc: Class implementation
+#pragma implementation  // gcc: Class implementation
 #endif
 
 #define MYSQL_SERVER 1
@@ -24,8 +24,8 @@
 #include "./ha_rocksdb.h"
 
 /* C++ standard header files */
-#include <algorithm>
 #include <inttypes.h>
+#include <algorithm>
 #include <limits>
 #include <map>
 #include <queue>
@@ -82,14 +82,14 @@ extern "C" {
  *   Get the user thread's binary logging format
  *   @param thd  user thread
  *   @return Value to be used as index into the binlog_format_names array
-*/
+ */
 int thd_binlog_format(const MYSQL_THD thd);
 
 /**
  *   Check if binary logging is filtered for thread's current db.
  *   @param  thd   Thread handle
  *   @retval 1 the query is not filtered, 0 otherwise.
-*/
+ */
 bool thd_binlog_filter_ok(const MYSQL_THD thd);
 }
 
@@ -123,8 +123,8 @@ static handler *rocksdb_create_handler(my_core::handlerton *hton,
                                        my_core::TABLE_SHARE *table_arg,
                                        my_core::MEM_ROOT *mem_root);
 
-static rocksdb::CompactRangeOptions
-getCompactRangeOptions(int concurrency = 0) {
+static rocksdb::CompactRangeOptions getCompactRangeOptions(
+    int concurrency = 0) {
   rocksdb::CompactRangeOptions compact_range_options;
   compact_range_options.bottommost_level_compaction =
       rocksdb::BottommostLevelCompaction::kForce;
@@ -185,7 +185,7 @@ static void rocksdb_flush_all_memtables() {
 // Hash map: table name => open table handler
 ///////////////////////////////////////////////////////////
 
-namespace // anonymous namespace = not visible outside this source file
+namespace  // anonymous namespace = not visible outside this source file
 {
 
 struct Rdb_open_tables_map {
@@ -200,7 +200,7 @@ struct Rdb_open_tables_map {
   std::vector<std::string> get_table_names(void) const;
 };
 
-} // anonymous namespace
+}  // anonymous namespace
 
 static Rdb_open_tables_map rdb_open_tables;
 
@@ -211,12 +211,11 @@ static std::string rdb_normalize_dir(std::string dir) {
   return dir;
 }
 
-static int rocksdb_create_checkpoint(THD *const thd MY_ATTRIBUTE((__unused__)),
-                                     struct st_mysql_sys_var *const var
-                                     MY_ATTRIBUTE((__unused__)),
-                                     void *const save
-                                     MY_ATTRIBUTE((__unused__)),
-                                     struct st_mysql_value *const value) {
+static int rocksdb_create_checkpoint(
+    THD *const thd MY_ATTRIBUTE((__unused__)),
+    struct st_mysql_sys_var *const var MY_ATTRIBUTE((__unused__)),
+    void *const save MY_ATTRIBUTE((__unused__)),
+    struct st_mysql_value *const value) {
   char buf[FN_REFLEN];
   int len = sizeof(buf);
   const char *const checkpoint_dir_raw = value->val_str(value, buf, &len);
@@ -396,11 +395,9 @@ static void rocksdb_set_update_cf_options(THD *thd,
                                           struct st_mysql_sys_var *var,
                                           void *var_ptr, const void *save);
 
-static int rocksdb_check_bulk_load(THD *const thd,
-                                   struct st_mysql_sys_var *var
-                                       MY_ATTRIBUTE((__unused__)),
-                                   void *save,
-                                   struct st_mysql_value *value);
+static int rocksdb_check_bulk_load(
+    THD *const thd, struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)),
+    void *save, struct st_mysql_value *value);
 
 static int rocksdb_check_bulk_load_allow_unsorted(
     THD *const thd, struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)),
@@ -431,14 +428,16 @@ static const constexpr ulong RDB_DEFAULT_BULK_LOAD_SIZE = 1000;
 static const constexpr ulong RDB_MAX_BULK_LOAD_SIZE = 1024 * 1024 * 1024;
 static const constexpr size_t RDB_DEFAULT_MERGE_BUF_SIZE = 64 * 1024 * 1024;
 static const constexpr size_t RDB_MIN_MERGE_BUF_SIZE = 100;
-static const constexpr size_t RDB_DEFAULT_MERGE_COMBINE_READ_SIZE = 1024 * 1024 * 1024;
+static const constexpr size_t RDB_DEFAULT_MERGE_COMBINE_READ_SIZE =
+    1024 * 1024 * 1024;
 static const constexpr size_t RDB_MIN_MERGE_COMBINE_READ_SIZE = 100;
 static const constexpr size_t RDB_DEFAULT_MERGE_TMP_FILE_REMOVAL_DELAY = 0;
 static const constexpr size_t RDB_MIN_MERGE_TMP_FILE_REMOVAL_DELAY = 0;
 static const constexpr int64 RDB_DEFAULT_BLOCK_CACHE_SIZE = 512 * 1024 * 1024;
 static const constexpr int64 RDB_MIN_BLOCK_CACHE_SIZE = 1024;
 static const constexpr int RDB_MAX_CHECKSUMS_PCT = 100;
-static const constexpr uint32_t RDB_DEFAULT_FORCE_COMPUTE_MEMTABLE_STATS_CACHETIME = 60 * 1000 * 1000;
+static const constexpr uint32_t
+    RDB_DEFAULT_FORCE_COMPUTE_MEMTABLE_STATS_CACHETIME = 60 * 1000 * 1000;
 static const constexpr ulong RDB_DEADLOCK_DETECT_DEPTH = 50;
 
 static long long rocksdb_block_cache_size = RDB_DEFAULT_BLOCK_CACHE_SIZE;
@@ -495,8 +494,9 @@ static long long rocksdb_compaction_sequential_deletes_file_size = 0l;
 static uint32_t rocksdb_validate_tables = 1;
 #endif  // defined(ROCKSDB_INCLUDE_VALIDATE_TABLES) &&
         // ROCKSDB_INCLUDE_VALIDATE_TABLES
-static char *rocksdb_datadir= nullptr;
-static uint32_t rocksdb_table_stats_sampling_pct = RDB_DEFAULT_TBL_STATS_SAMPLE_PCT;
+static char *rocksdb_datadir = nullptr;
+static uint32_t rocksdb_table_stats_sampling_pct =
+    RDB_DEFAULT_TBL_STATS_SAMPLE_PCT;
 static my_bool rocksdb_enable_bulk_load_api = TRUE;
 static my_bool rpl_skip_tx_api_var = FALSE;
 static my_bool rocksdb_print_snapshot_conflict_queries = FALSE;
@@ -538,7 +538,7 @@ static std::unique_ptr<rocksdb::DBOptions> rdb_init_rocksdb_db_options(void) {
   o->listeners.push_back(std::make_shared<Rdb_event_listener>(&ddl_manager));
   o->info_log_level = rocksdb::InfoLogLevel::INFO_LEVEL;
   o->max_subcompactions = DEFAULT_SUBCOMPACTIONS;
-  o->max_open_files = -2; // auto-tune to 50% open_files_limit
+  o->max_open_files = -2;  // auto-tune to 50% open_files_limit
 
   o->two_write_queues = true;
   o->manual_wal_flush = true;
@@ -598,8 +598,7 @@ static void rocksdb_set_rocksdb_stats_level(THD *const thd,
 
   RDB_MUTEX_LOCK_CHECK(rdb_sysvars_mutex);
   rocksdb_db_options->statistics->set_stats_level(
-      static_cast<rocksdb::StatsLevel>(
-          *static_cast<const uint64_t *>(save)));
+      static_cast<rocksdb::StatsLevel>(*static_cast<const uint64_t *>(save)));
   // Actual stats level is defined at rocksdb dbopt::statistics::stats_level_
   // so adjusting rocksdb_stats_level here to make sure it points to
   // the correct stats level.
@@ -609,8 +608,8 @@ static void rocksdb_set_rocksdb_stats_level(THD *const thd,
 
 static void rocksdb_set_reset_stats(
     my_core::THD *const /* unused */,
-    my_core::st_mysql_sys_var *const /* unused */,
-    void *const var_ptr, const void *const save) {
+    my_core::st_mysql_sys_var *const /* unused */, void *const var_ptr,
+    const void *const save) {
   DBUG_ASSERT(save != nullptr);
   DBUG_ASSERT(rdb != nullptr);
   DBUG_ASSERT(rocksdb_stats != nullptr);
@@ -745,11 +744,9 @@ static MYSQL_THDVAR_BOOL(
 
 static const char *DEFAULT_READ_FREE_RPL_TABLES = ".*";
 
-static int get_regex_flags()
-{
+static int get_regex_flags() {
   int flags = MY_REG_EXTENDED | MY_REG_NOSUB;
-  if (lower_case_table_names)
-    flags |= MY_REG_ICASE;
+  if (lower_case_table_names) flags |= MY_REG_ICASE;
   return flags;
 }
 
@@ -760,7 +757,8 @@ static int rocksdb_validate_read_free_rpl_tables(
   char buff[STRING_BUFFER_USUAL_SIZE];
   int length = sizeof(buff);
   const char *wlist_buf = value->val_str(value, buff, &length);
-  if (wlist_buf) wlist_buf= thd->strmake(wlist_buf, length); // make a temp copy
+  if (wlist_buf)
+    wlist_buf = thd->strmake(wlist_buf, length);  // make a temp copy
   const auto wlist = wlist_buf ? wlist_buf : DEFAULT_READ_FREE_RPL_TABLES;
 
 #if defined(HAVE_PSI_INTERFACE)
@@ -787,7 +785,8 @@ static void rocksdb_update_read_free_rpl_tables(
 
   // This is bound to succeed since we've already checked for bad patterns in
   // rocksdb_validate_read_free_rpl_tables
-  rdb_read_free_regex_handler.compile(wlist, get_regex_flags(), table_alias_charset);
+  rdb_read_free_regex_handler.compile(wlist, get_regex_flags(),
+                                      table_alias_charset);
 
   // update all table defs
   struct Rdb_read_free_rpl_updater : public Rdb_tables_scanner {
@@ -1086,7 +1085,8 @@ static MYSQL_SYSVAR_ULONG(
     persistent_cache_size_mb, rocksdb_persistent_cache_size_mb,
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
     "Size of cache in MB for BlockBasedTableOptions::persistent_cache "
-    "for RocksDB", nullptr, nullptr, rocksdb_persistent_cache_size_mb,
+    "for RocksDB",
+    nullptr, nullptr, rocksdb_persistent_cache_size_mb,
     /* min */ 0L, /* max */ ULONG_MAX, 0);
 
 static MYSQL_SYSVAR_ULONG(
@@ -1434,10 +1434,10 @@ static MYSQL_SYSVAR_UINT(
     nullptr, nullptr, 0, /* min */ 0, /* max */ INT_MAX, 0);
 
 static MYSQL_SYSVAR_BOOL(force_compute_memtable_stats,
-    rocksdb_force_compute_memtable_stats,
-    PLUGIN_VAR_RQCMDARG,
-    "Force to always compute memtable stats",
-    nullptr, nullptr, true);
+                         rocksdb_force_compute_memtable_stats,
+                         PLUGIN_VAR_RQCMDARG,
+                         "Force to always compute memtable stats", nullptr,
+                         nullptr, true);
 
 static MYSQL_SYSVAR_UINT(
     force_compute_memtable_stats_cachetime,
@@ -1472,11 +1472,9 @@ static MYSQL_SYSVAR_BOOL(pause_background_work, rocksdb_pause_background_work,
                          "Disable all rocksdb background operations", nullptr,
                          rocksdb_set_pause_background_work, false);
 
-static MYSQL_SYSVAR_BOOL(
-    enable_native_partition, rocksdb_enable_native_partition,
-    PLUGIN_VAR_READONLY,
-    "Enable native partitioning", nullptr,
-    nullptr, false);
+static MYSQL_SYSVAR_BOOL(enable_native_partition,
+                         rocksdb_enable_native_partition, PLUGIN_VAR_READONLY,
+                         "Enable native partitioning", nullptr, nullptr, false);
 
 static MYSQL_SYSVAR_BOOL(
     enable_ttl, rocksdb_enable_ttl, PLUGIN_VAR_RQCMDARG,
@@ -1893,8 +1891,8 @@ static struct st_mysql_sys_var *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(enable_insert_with_update_caching),
     nullptr};
 
-static rocksdb::WriteOptions
-rdb_get_rocksdb_write_options(my_core::THD *const thd) {
+static rocksdb::WriteOptions rdb_get_rocksdb_write_options(
+    my_core::THD *const thd) {
   rocksdb::WriteOptions opt;
 
   opt.sync = (rocksdb_flush_log_at_trx_commit == FLUSH_LOG_SYNC);
@@ -2005,7 +2003,7 @@ class Rdb_snapshot_notifier : public rocksdb::TransactionNotifier {
 
   void SnapshotCreated(const rocksdb::Snapshot *snapshot) override;
 
-public:
+ public:
   Rdb_snapshot_notifier(const Rdb_snapshot_notifier &) = delete;
   Rdb_snapshot_notifier &operator=(const Rdb_snapshot_notifier &) = delete;
 
@@ -2018,7 +2016,7 @@ public:
 };
 
 /* This is the base class for transactions when interacting with rocksdb.
-*/
+ */
 class Rdb_transaction {
  protected:
   ulonglong m_write_count = 0;
@@ -2060,9 +2058,9 @@ class Rdb_transaction {
   // This should be used only when updating binlog information.
   virtual rocksdb::WriteBatchBase *get_write_batch() = 0;
   virtual bool commit_no_binlog() = 0;
-  virtual rocksdb::Iterator *
-  get_iterator(const rocksdb::ReadOptions &options,
-               rocksdb::ColumnFamilyHandle *column_family) = 0;
+  virtual rocksdb::Iterator *get_iterator(
+      const rocksdb::ReadOptions &options,
+      rocksdb::ColumnFamilyHandle *column_family) = 0;
 
   /*
     @detail
@@ -2125,8 +2123,7 @@ class Rdb_transaction {
 
     RDB_MUTEX_LOCK_CHECK(s_tx_list_mutex);
 
-    for (auto it : s_tx_list)
-      walker->process_tran(it);
+    for (auto it : s_tx_list) walker->process_tran(it);
 
     RDB_MUTEX_UNLOCK_CHECK(s_tx_list_mutex);
   }
@@ -2145,7 +2142,8 @@ class Rdb_transaction {
         convert_error_code_to_mysql() does: force a statement
         rollback before returning HA_ERR_LOCK_WAIT_TIMEOUT:
         */
-      thd->mark_transaction_to_rollback(static_cast<bool>(rocksdb_rollback_on_timeout));
+      thd->mark_transaction_to_rollback(
+          static_cast<bool>(rocksdb_rollback_on_timeout));
 
       rocksdb_row_lock_wait_timeouts++;
 
@@ -2282,7 +2280,7 @@ class Rdb_transaction {
 
   bool has_snapshot() const { return m_read_opts.snapshot != nullptr; }
 
-private:
+ private:
   // The Rdb_sst_info structures we are currently loading.  In a partitioned
   // table this can have more than one entry
   std::vector<std::shared_ptr<Rdb_sst_info>> m_curr_bulk_load;
@@ -2291,7 +2289,7 @@ private:
   /* External merge sorts for bulk load: key ID -> merge sort instance */
   std::unordered_map<GL_INDEX_ID, Rdb_index_merge> m_key_merge;
 
-public:
+ public:
   int get_key_merge(GL_INDEX_ID kd_gl_id, rocksdb::ColumnFamilyHandle *cf,
                     Rdb_index_merge **key_merge) {
     int res;
@@ -2573,12 +2571,10 @@ public:
       inserts while inside a multi-statement transaction.
   */
   bool flush_batch() {
-    if (get_write_count() == 0)
-      return false;
+    if (get_write_count() == 0) return false;
 
     /* Commit the current transaction */
-    if (commit_no_binlog())
-      return true;
+    if (commit_no_binlog()) return true;
 
     /* Start another one */
     start_tx();
@@ -2603,12 +2599,12 @@ public:
                               const rocksdb::Slice &key,
                               const rocksdb::Slice &value,
                               const bool assume_tracked) = 0;
-  virtual rocksdb::Status
-  delete_key(rocksdb::ColumnFamilyHandle *const column_family,
-             const rocksdb::Slice &key, const bool assume_tracked) = 0;
-  virtual rocksdb::Status
-  single_delete(rocksdb::ColumnFamilyHandle *const column_family,
-                const rocksdb::Slice &key, const bool assume_tracked) = 0;
+  virtual rocksdb::Status delete_key(
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, const bool assume_tracked) = 0;
+  virtual rocksdb::Status single_delete(
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, const bool assume_tracked) = 0;
 
   virtual bool has_modifications() const = 0;
 
@@ -2624,25 +2620,23 @@ public:
   virtual rocksdb::Status get(rocksdb::ColumnFamilyHandle *const column_family,
                               const rocksdb::Slice &key,
                               rocksdb::PinnableSlice *const value) const = 0;
-  virtual rocksdb::Status
-  get_for_update(rocksdb::ColumnFamilyHandle *const column_family,
-                 const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
-                 bool exclusive, const bool do_validate) = 0;
+  virtual rocksdb::Status get_for_update(
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
+      bool exclusive, const bool do_validate) = 0;
 
-  rocksdb::Iterator *
-  get_iterator(rocksdb::ColumnFamilyHandle *const column_family,
-               bool skip_bloom_filter, bool fill_cache,
-               const rocksdb::Slice &eq_cond_lower_bound,
-               const rocksdb::Slice &eq_cond_upper_bound,
-               bool read_current = false, bool create_snapshot = true) {
+  rocksdb::Iterator *get_iterator(
+      rocksdb::ColumnFamilyHandle *const column_family, bool skip_bloom_filter,
+      bool fill_cache, const rocksdb::Slice &eq_cond_lower_bound,
+      const rocksdb::Slice &eq_cond_upper_bound, bool read_current = false,
+      bool create_snapshot = true) {
     // Make sure we are not doing both read_current (which implies we don't
     // want a snapshot) and create_snapshot which makes sure we create
     // a snapshot
     DBUG_ASSERT(column_family != nullptr);
     DBUG_ASSERT(!read_current || !create_snapshot);
 
-    if (create_snapshot)
-      acquire_snapshot(true);
+    if (create_snapshot) acquire_snapshot(true);
 
     rocksdb::ReadOptions options = m_read_opts;
 
@@ -2682,7 +2676,6 @@ public:
     successfully and its changes become part of the transaction's changes.
   */
   int make_stmt_savepoint_permanent() {
-
     // Take another RocksDB savepoint only if we had changes since the last
     // one. This is very important for long transactions doing lots of
     // SELECTs.
@@ -2779,7 +2772,7 @@ class Rdb_transaction_impl : public Rdb_transaction {
   rocksdb::Transaction *m_rocksdb_tx = nullptr;
   rocksdb::Transaction *m_rocksdb_reuse_tx = nullptr;
 
-public:
+ public:
   void set_lock_timeout(int timeout_sec_arg) override {
     if (m_rocksdb_tx)
       m_rocksdb_tx->SetLockTimeout(rdb_convert_sec_to_ms(m_timeout_sec));
@@ -2798,7 +2791,7 @@ public:
 
   virtual bool is_writebatch_trx() const override { return false; }
 
-private:
+ private:
   void release_tx(void) {
     // We are done with the current active transaction object.  Preserve it
     // for later reuse.
@@ -2848,7 +2841,7 @@ private:
       goto error;
     }
 
-error:
+  error:
     /* Save the transaction object to be reused */
     release_tx();
 
@@ -2859,7 +2852,7 @@ error:
     return res;
   }
 
-public:
+ public:
   void rollback() override {
     m_write_count = 0;
     m_lock_count = 0;
@@ -2906,8 +2899,7 @@ public:
       m_read_opts.snapshot = nullptr;
     }
 
-    if (need_clear && m_rocksdb_tx != nullptr)
-      m_rocksdb_tx->ClearSnapshot();
+    if (need_clear && m_rocksdb_tx != nullptr) m_rocksdb_tx->ClearSnapshot();
   }
 
   bool has_snapshot() { return m_read_opts.snapshot != nullptr; }
@@ -2932,9 +2924,9 @@ public:
     return m_rocksdb_tx->Delete(column_family, key, assume_tracked);
   }
 
-  rocksdb::Status
-  single_delete(rocksdb::ColumnFamilyHandle *const column_family,
-                const rocksdb::Slice &key, const bool assume_tracked) override {
+  rocksdb::Status single_delete(
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, const bool assume_tracked) override {
     ++m_write_count;
     ++m_lock_count;
     if (m_write_count > m_max_row_locks || m_lock_count > m_max_row_locks)
@@ -2972,10 +2964,10 @@ public:
     return m_rocksdb_tx->Get(m_read_opts, column_family, key, value);
   }
 
-  rocksdb::Status
-  get_for_update(rocksdb::ColumnFamilyHandle *const column_family,
-                 const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
-                 bool exclusive, const bool do_validate) override {
+  rocksdb::Status get_for_update(
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
+      bool exclusive, const bool do_validate) override {
     if (++m_lock_count > m_max_row_locks)
       return rocksdb::Status::Aborted(rocksdb::Status::kLockLimit);
 
@@ -3001,9 +2993,9 @@ public:
     return s;
   }
 
-  rocksdb::Iterator *
-  get_iterator(const rocksdb::ReadOptions &options,
-               rocksdb::ColumnFamilyHandle *const column_family) override {
+  rocksdb::Iterator *get_iterator(
+      const rocksdb::ReadOptions &options,
+      rocksdb::ColumnFamilyHandle *const column_family) override {
     global_stats.queries[QUERIES_RANGE].inc();
     return m_rocksdb_tx->GetIterator(options, column_family);
   }
@@ -3079,8 +3071,7 @@ public:
 
       const rocksdb::Snapshot *const cur_snapshot = m_rocksdb_tx->GetSnapshot();
       if (org_snapshot != cur_snapshot) {
-        if (org_snapshot != nullptr)
-          m_snapshot_timestamp = 0;
+        if (org_snapshot != nullptr) m_snapshot_timestamp = 0;
 
         m_read_opts.snapshot = cur_snapshot;
         if (cur_snapshot != nullptr)
@@ -3129,7 +3120,7 @@ class Rdb_writebatch_impl : public Rdb_transaction {
     m_ddl_transaction = false;
   }
 
-private:
+ private:
   bool prepare(const rocksdb::TransactionName &name) override { return true; }
 
   bool commit_no_binlog() override {
@@ -3153,7 +3144,7 @@ private:
       res = true;
       goto error;
     }
-error:
+  error:
     reset();
 
     m_write_count = 0;
@@ -3192,8 +3183,7 @@ error:
   }
 
   void acquire_snapshot(bool acquire_now) override {
-    if (m_read_opts.snapshot == nullptr)
-      snapshot_created(rdb->GetSnapshot());
+    if (m_read_opts.snapshot == nullptr) snapshot_created(rdb->GetSnapshot());
   }
 
   void release_snapshot() override {
@@ -3221,9 +3211,9 @@ error:
     return rocksdb::Status::OK();
   }
 
-  rocksdb::Status
-  single_delete(rocksdb::ColumnFamilyHandle *const column_family,
-                const rocksdb::Slice &key, const bool assume_tracked) override {
+  rocksdb::Status single_delete(
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, const bool assume_tracked) override {
     ++m_write_count;
     m_batch->SingleDelete(column_family, key);
     return rocksdb::Status::OK();
@@ -3248,10 +3238,10 @@ error:
                                       value);
   }
 
-  rocksdb::Status
-  get_for_update(rocksdb::ColumnFamilyHandle *const column_family,
-                 const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
-                 bool exclusive, const bool do_validate) override {
+  rocksdb::Status get_for_update(
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, rocksdb::PinnableSlice *const value,
+      bool exclusive, const bool do_validate) override {
     if (value == nullptr) {
       rocksdb::PinnableSlice pin_val;
       rocksdb::Status s = get(column_family, key, &pin_val);
@@ -3262,9 +3252,9 @@ error:
     return get(column_family, key, value);
   }
 
-  rocksdb::Iterator *
-  get_iterator(const rocksdb::ReadOptions &options,
-               rocksdb::ColumnFamilyHandle *const column_family) override {
+  rocksdb::Iterator *get_iterator(
+      const rocksdb::ReadOptions &options,
+      rocksdb::ColumnFamilyHandle *const column_family) override {
     const auto it = rdb->NewIterator(options);
     return m_batch->NewIteratorWithBase(it);
   }
@@ -3284,8 +3274,7 @@ error:
   void start_stmt() override {}
 
   void rollback_stmt() override {
-    if (m_batch)
-      rollback_to_stmt_savepoint();
+    if (m_batch) rollback_to_stmt_savepoint();
   }
 
   explicit Rdb_writebatch_impl(THD *const thd)
@@ -3352,7 +3341,7 @@ class Rdb_perf_context_guard {
   }
 };
 
-} // anonymous namespace
+}  // anonymous namespace
 
 /*
   TODO: maybe, call this in external_lock() and store in ha_rocksdb..
@@ -3363,12 +3352,9 @@ static Rdb_transaction *get_or_create_tx(THD *const thd) {
   // TODO: this is called too many times.. O(#rows)
   if (tx == nullptr) {
     if ((rpl_skip_tx_api_var && thd->rli_slave) ||
-        (THDVAR(thd, master_skip_tx_api) && !thd->rli_slave))
-    {
+        (THDVAR(thd, master_skip_tx_api) && !thd->rli_slave)) {
       tx = new Rdb_writebatch_impl(thd);
-    }
-    else
-    {
+    } else {
       tx = new Rdb_transaction_impl(thd);
     }
     tx->set_params(THDVAR(thd, lock_wait_timeout), THDVAR(thd, max_row_locks));
@@ -3390,9 +3376,10 @@ static int rocksdb_close_connection(handlerton *const hton, THD *const thd) {
     int rc = tx->finish_bulk_load(&is_critical_error, false);
     if (rc != 0 && is_critical_error) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Error %d finalizing last SST file while "
-                      "disconnecting",
-                      rc);
+      sql_print_error(
+          "RocksDB: Error %d finalizing last SST file while "
+          "disconnecting",
+          rc);
     }
 
     delete tx;
@@ -3435,8 +3422,7 @@ static std::string rdb_xid_to_string(const XID &src) {
   Called by hton->flush_logs after MySQL group commit prepares a set of
   transactions.
 */
-static bool rocksdb_flush_wal(handlerton *const hton
-                              MY_ATTRIBUTE((__unused__)),
+static bool rocksdb_flush_wal(handlerton *const hton MY_ATTRIBUTE((__unused__)),
                               bool binlog_group_flush) {
   DBUG_ENTER("rocksdb_flush_wal");
   DBUG_ASSERT(rdb != nullptr);
@@ -3492,7 +3478,6 @@ static int rocksdb_prepare(handlerton *const hton, THD *const thd,
   }
   if (prepare_tx ||
       (!my_core::thd_test_options(thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN))) {
-
     if (thd->durability_property == HA_IGNORE_DURABILITY) {
       tx->set_sync(false);
     }
@@ -3546,9 +3531,8 @@ static int rocksdb_commit_by_xid(handlerton *const hton, XID *const xid) {
   DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
-static int rocksdb_rollback_by_xid(handlerton *const hton
-                                   MY_ATTRIBUTE((__unused__)),
-                                   XID *const xid) {
+static int rocksdb_rollback_by_xid(
+    handlerton *const hton MY_ATTRIBUTE((__unused__)), XID *const xid) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(hton != nullptr);
@@ -3643,8 +3627,8 @@ static int rocksdb_commit(handlerton *const hton, THD *const thd,
   Rdb_perf_context_guard guard(tx, rocksdb_perf_context_level(thd));
 
   if (tx != nullptr) {
-    if (commit_tx || (!my_core::thd_test_options(thd, OPTION_NOT_AUTOCOMMIT |
-                                                          OPTION_BEGIN))) {
+    if (commit_tx || (!my_core::thd_test_options(
+                         thd, OPTION_NOT_AUTOCOMMIT | OPTION_BEGIN))) {
       /*
         We get here
          - For a COMMIT statement that finishes a multi-statement transaction
@@ -3741,7 +3725,7 @@ static std::string format_string(const char *const format, ...) {
     char *buff = static_buff;
     std::unique_ptr<char[]> dynamic_buff = nullptr;
 
-    len++; // Add one for null terminator
+    len++;  // Add one for null terminator
 
     // for longer output use an allocated buffer
     if (static_cast<uint>(len) > sizeof(static_buff)) {
@@ -3757,7 +3741,7 @@ static std::string format_string(const char *const format, ...) {
     // the output in place.  This would probably work but feels like a hack.
     // Since this isn't code that needs to be super-performant we are going
     // with this 'safer' method.
-     res = std::string(buff);
+    res = std::string(buff);
   }
 
   va_end(args_copy);
@@ -3766,7 +3750,7 @@ static std::string format_string(const char *const format, ...) {
 }
 
 class Rdb_snapshot_status : public Rdb_tx_list_walker {
-private:
+ private:
   std::string m_data;
 
   static std::string current_timestamp(void) {
@@ -3800,9 +3784,8 @@ private:
            "=========================================\n";
   }
 
-  static Rdb_deadlock_info::Rdb_dl_trx_info
-  get_dl_txn_info(const rocksdb::DeadlockInfo &txn,
-                  const GL_INDEX_ID &gl_index_id) {
+  static Rdb_deadlock_info::Rdb_dl_trx_info get_dl_txn_info(
+      const rocksdb::DeadlockInfo &txn, const GL_INDEX_ID &gl_index_id) {
     Rdb_deadlock_info::Rdb_dl_trx_info txn_data;
 
     txn_data.trx_id = txn.m_txn_id;
@@ -3813,7 +3796,7 @@ private:
           "NOT FOUND; INDEX_ID: " + std::to_string(gl_index_id.index_id);
     }
 
-    const auto& kd = ddl_manager.safe_find(gl_index_id);
+    const auto &kd = ddl_manager.safe_find(gl_index_id);
     txn_data.index_name =
         (kd) ? kd->get_name()
              : "NOT FOUND; INDEX_ID: " + std::to_string(gl_index_id.index_id);
@@ -3829,12 +3812,12 @@ private:
     return txn_data;
   }
 
-  static Rdb_deadlock_info
-  get_dl_path_trx_info(const rocksdb::DeadlockPath &path_entry) {
+  static Rdb_deadlock_info get_dl_path_trx_info(
+      const rocksdb::DeadlockPath &path_entry) {
     Rdb_deadlock_info deadlock_info;
     deadlock_info.path.reserve(path_entry.path.size());
 
-    for (const auto& txn : path_entry.path) {
+    for (const auto &txn : path_entry.path) {
       const GL_INDEX_ID gl_index_id = {
           txn.m_cf_id, rdb_netbuf_to_uint32(reinterpret_cast<const uchar *>(
                            txn.m_waiting_key.c_str()))};
@@ -3843,7 +3826,7 @@ private:
     DBUG_ASSERT_IFF(path_entry.limit_exceeded, path_entry.path.empty());
     /* print the first txn in the path to display the full deadlock cycle */
     if (!path_entry.path.empty() && !path_entry.limit_exceeded) {
-      const auto& deadlocking_txn = *(path_entry.path.end() - 1);
+      const auto &deadlocking_txn = *(path_entry.path.end() - 1);
       deadlock_info.victim_trx_id = deadlocking_txn.m_txn_id;
       deadlock_info.deadlock_time = path_entry.deadlock_time;
     }
@@ -3869,18 +3852,19 @@ private:
       THD *thd = tx->get_thd();
       char buffer[1024];
       thd_security_context(thd, buffer, sizeof buffer, 0);
-      m_data += format_string("---SNAPSHOT, ACTIVE %lld sec\n"
-                              "%s\n"
-                              "lock count %llu, write count %llu\n",
-                              curr_time - snapshot_timestamp, buffer,
-                              tx->get_lock_count(), tx->get_write_count());
+      m_data += format_string(
+          "---SNAPSHOT, ACTIVE %lld sec\n"
+          "%s\n"
+          "lock count %llu, write count %llu\n",
+          curr_time - snapshot_timestamp, buffer, tx->get_lock_count(),
+          tx->get_write_count());
     }
   }
 
   std::vector<Rdb_deadlock_info> get_deadlock_info() {
     std::vector<Rdb_deadlock_info> deadlock_info;
-    const auto& dlock_buffer = rdb->GetDeadlockInfoBuffer();
-    for (const auto& path_entry : dlock_buffer) {
+    const auto &dlock_buffer = rdb->GetDeadlockInfoBuffer();
+    for (const auto &path_entry : dlock_buffer) {
       if (!path_entry.limit_exceeded) {
         deadlock_info.push_back(get_dl_path_trx_info(path_entry));
       }
@@ -3895,10 +3879,10 @@ private:
  * out relevant information for information_schema.rocksdb_trx
  */
 class Rdb_trx_info_aggregator : public Rdb_tx_list_walker {
-private:
+ private:
   std::vector<Rdb_trx_info> *m_trx_info;
 
-public:
+ public:
   explicit Rdb_trx_info_aggregator(std::vector<Rdb_trx_info> *const trx_info)
       : m_trx_info(trx_info) {}
 
@@ -3912,7 +3896,7 @@ public:
         {rocksdb::Transaction::AWAITING_ROLLBACK, "AWAITING_ROLLBACK"},
         {rocksdb::Transaction::ROLLEDBACK, "ROLLEDBACK"},
     };
-    static const size_t trx_query_max_len = 1024; // length stolen from InnoDB
+    static const size_t trx_query_max_len = 1024;  // length stolen from InnoDB
 
     DBUG_ASSERT(tx != nullptr);
 
@@ -4016,9 +4000,10 @@ static bool rocksdb_show_status(handlerton *const hton, THD *const thd,
       // sure that output will look unified.
       DBUG_ASSERT(commit_latency_stats != nullptr);
 
-      snprintf(buf, sizeof(buf), "rocksdb.commit_latency statistics "
-                                 "Percentiles :=> 50 : %.2f 95 : %.2f "
-                                 "99 : %.2f 100 : %.2f\n",
+      snprintf(buf, sizeof(buf),
+               "rocksdb.commit_latency statistics "
+               "Percentiles :=> 50 : %.2f 95 : %.2f "
+               "99 : %.2f 100 : %.2f\n",
                commit_latency_stats->Percentile(50),
                commit_latency_stats->Percentile(95),
                commit_latency_stats->Percentile(99),
@@ -4040,8 +4025,9 @@ static bool rocksdb_show_status(handlerton *const hton, THD *const thd,
       }
 
       if (rdb->GetIntProperty("rocksdb.actual-delayed-write-rate", &v)) {
-        snprintf(buf, sizeof(buf), "rocksdb.actual_delayed_write_rate "
-                                   "COUNT : %lu\n",
+        snprintf(buf, sizeof(buf),
+                 "rocksdb.actual_delayed_write_rate "
+                 "COUNT : %lu\n",
                  v);
         str.append(buf);
       }
@@ -4145,19 +4131,17 @@ static bool rocksdb_show_status(handlerton *const hton, THD *const thd,
               "\noperation_type: " + it.GetOperationName(it.operation_type) +
               "\noperation_stage: " +
               it.GetOperationStageName(it.operation_stage) +
-              "\nelapsed_time_ms: " +
-              it.MicrosToString(it.op_elapsed_micros);
+              "\nelapsed_time_ms: " + it.MicrosToString(it.op_elapsed_micros);
 
-        for (auto &it_props :
-          it.InterpretOperationProperties(it.operation_type,
-                                          it.op_properties)) {
+        for (auto &it_props : it.InterpretOperationProperties(
+                 it.operation_type, it.op_properties)) {
           str += "\n" + it_props.first + ": " + std::to_string(it_props.second);
         }
 
         str += "\nstate_type: " + it.GetStateName(it.state_type);
 
-        res |= print_stats(thd, "BG_THREADS", std::to_string(it.thread_id),
-                           str, stat_print);
+        res |= print_stats(thd, "BG_THREADS", std::to_string(it.thread_id), str,
+                           stat_print);
       }
     }
   }
@@ -4228,16 +4212,14 @@ static int rocksdb_rollback_to_savepoint(handlerton *const hton, THD *const thd,
   return tx->rollback_to_savepoint(savepoint);
 }
 
-static bool
-rocksdb_rollback_to_savepoint_can_release_mdl(handlerton *const hton,
-                                              THD *const thd) {
+static bool rocksdb_rollback_to_savepoint_can_release_mdl(
+    handlerton *const hton, THD *const thd) {
   return true;
 }
 
 static rocksdb::Status check_rocksdb_options_compatibility(
-  const char *const dbpath, const rocksdb::Options& main_opts,
-  const std::vector<rocksdb::ColumnFamilyDescriptor>& cf_descr)
-{
+    const char *const dbpath, const rocksdb::Options &main_opts,
+    const std::vector<rocksdb::ColumnFamilyDescriptor> &cf_descr) {
   DBUG_ASSERT(rocksdb_datadir != nullptr);
 
   rocksdb::DBOptions loaded_db_opt;
@@ -4258,8 +4240,9 @@ static rocksdb::Status check_rocksdb_options_compatibility(
   }
 
   if (loaded_cf_descs.size() != cf_descr.size()) {
-    return rocksdb::Status::NotSupported("Mismatched size of column family "
-                                         "descriptors.");
+    return rocksdb::Status::NotSupported(
+        "Mismatched size of column family "
+        "descriptors.");
   }
 
   // Please see RocksDB documentation for more context about why we need to set
@@ -4299,17 +4282,19 @@ static int rocksdb_init_func(void *const p) {
   DBUG_ENTER_FUNC();
 
   if (rdb_check_rocksdb_corruption()) {
-    sql_print_error("RocksDB: There was corruption detected in the RockDB data"
-                    "files. Check error log emitted earlier for more details.");
+    sql_print_error(
+        "RocksDB: There was corruption detected in the RockDB data"
+        "files. Check error log emitted earlier for more details.");
     if (rocksdb_allow_to_start_after_corruption) {
       sql_print_information(
           "RocksDB: Set rocksdb_allow_to_start_after_corruption=0 to prevent "
           "server from starting when RocksDB data corruption is detected.");
     } else {
-      sql_print_error("RocksDB: The server will exit normally and stop restart "
-                      "attempts. Remove %s file from data directory and "
-                      "start mysqld manually.",
-                      rdb_corruption_marker_file_name().c_str());
+      sql_print_error(
+          "RocksDB: The server will exit normally and stop restart "
+          "attempts. Remove %s file from data directory and "
+          "start mysqld manually.",
+          rdb_corruption_marker_file_name().c_str());
       exit(0);
     }
   }
@@ -4380,11 +4365,12 @@ static int rocksdb_init_func(void *const p) {
 
   DBUG_ASSERT(!mysqld_embedded);
 
-  if (rocksdb_db_options->max_open_files > (long) open_files_limit) {
-    sql_print_information("RocksDB: rocksdb_max_open_files should not be "
-                          "greater than the open_files_limit, effective value "
-                          "of rocksdb_max_open_files is being set to "
-                          "open_files_limit / 2.");
+  if (rocksdb_db_options->max_open_files > (long)open_files_limit) {
+    sql_print_information(
+        "RocksDB: rocksdb_max_open_files should not be "
+        "greater than the open_files_limit, effective value "
+        "of rocksdb_max_open_files is being set to "
+        "open_files_limit / 2.");
     rocksdb_db_options->max_open_files = open_files_limit / 2;
   } else if (rocksdb_db_options->max_open_files == -2) {
     rocksdb_db_options->max_open_files = open_files_limit / 2;
@@ -4430,8 +4416,9 @@ static int rocksdb_init_func(void *const p) {
       rocksdb_db_options->use_direct_reads) {
     // allow_mmap_reads implies !use_direct_reads and RocksDB will not open if
     // mmap_reads and direct_reads are both on.   (NO_LINT_DEBUG)
-    sql_print_error("RocksDB: Can't enable both use_direct_reads "
-                    "and allow_mmap_reads\n");
+    sql_print_error(
+        "RocksDB: Can't enable both use_direct_reads "
+        "and allow_mmap_reads\n");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -4458,9 +4445,10 @@ static int rocksdb_init_func(void *const p) {
     }
 
     if (!check_status.ok()) {
-      sql_print_error("RocksDB: Unable to use direct io in rocksdb-datadir:"
-                      "(%s)",
-                      check_status.getState());
+      sql_print_error(
+          "RocksDB: Unable to use direct io in rocksdb-datadir:"
+          "(%s)",
+          check_status.getState());
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
   }
@@ -4468,17 +4456,19 @@ static int rocksdb_init_func(void *const p) {
   if (rocksdb_db_options->allow_mmap_writes &&
       rocksdb_db_options->use_direct_io_for_flush_and_compaction) {
     // See above comment for allow_mmap_reads. (NO_LINT_DEBUG)
-    sql_print_error("RocksDB: Can't enable both "
-                    "use_direct_io_for_flush_and_compaction and "
-                    "allow_mmap_writes\n");
+    sql_print_error(
+        "RocksDB: Can't enable both "
+        "use_direct_io_for_flush_and_compaction and "
+        "allow_mmap_writes\n");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
   if (rocksdb_db_options->allow_mmap_writes &&
       rocksdb_flush_log_at_trx_commit != FLUSH_LOG_NEVER) {
     // NO_LINT_DEBUG
-    sql_print_error("RocksDB: rocksdb_flush_log_at_trx_commit needs to be 0 "
-                    "to use allow_mmap_writes");
+    sql_print_error(
+        "RocksDB: rocksdb_flush_log_at_trx_commit needs to be 0 "
+        "to use allow_mmap_writes");
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -4540,7 +4530,8 @@ static int rocksdb_init_func(void *const p) {
     }
     std::shared_ptr<rocksdb::Cache> block_cache = rocksdb::NewLRUCache(
         rocksdb_block_cache_size, -1 /*num_shard_bits*/,
-        false /*strict_capcity_limit*/, rocksdb_cache_high_pri_pool_ratio, memory_allocator);
+        false /*strict_capcity_limit*/, rocksdb_cache_high_pri_pool_ratio,
+        memory_allocator);
     if (rocksdb_sim_cache_size > 0) {
       // Simulated cache enabled
       // Wrap block cache inside a simulated cache and pass it to RocksDB
@@ -4575,7 +4566,7 @@ static int rocksdb_init_func(void *const p) {
 
   if (rocksdb_persistent_cache_size_mb > 0) {
     std::shared_ptr<rocksdb::PersistentCache> pcache;
-    uint64_t cache_size_bytes= rocksdb_persistent_cache_size_mb * 1024 * 1024;
+    uint64_t cache_size_bytes = rocksdb_persistent_cache_size_mb * 1024 * 1024;
     status = rocksdb::NewPersistentCache(
         rocksdb::Env::Default(), std::string(rocksdb_persistent_cache_path),
         cache_size_bytes, myrocks_logger, true, &pcache);
@@ -4604,8 +4595,7 @@ static int rocksdb_init_func(void *const p) {
     If there are no column families, we're creating the new database.
     Create one column family named "default".
   */
-  if (cf_names.size() == 0)
-    cf_names.push_back(DEFAULT_CF_NAME);
+  if (cf_names.size() == 0) cf_names.push_back(DEFAULT_CF_NAME);
 
   std::vector<int> compaction_enabled_cf_indices;
   sql_print_information("RocksDB: Column Families at start:");
@@ -4685,7 +4675,6 @@ static int rocksdb_init_func(void *const p) {
     }
   }
 
-
   Rdb_sst_info::init(rdb);
 
   /*
@@ -4710,7 +4699,7 @@ static int rocksdb_init_func(void *const p) {
                                          ,
                                          rdb_background_psi_thread_key
 #endif
-                                         );
+  );
   if (err != 0) {
     sql_print_error("RocksDB: Couldn't start the background thread: (errno=%d)",
                     err);
@@ -4722,7 +4711,7 @@ static int rocksdb_init_func(void *const p) {
                                           ,
                                           rdb_drop_idx_psi_thread_key
 #endif
-                                          );
+  );
   if (err != 0) {
     sql_print_error("RocksDB: Couldn't start the drop index thread: (errno=%d)",
                     err);
@@ -4932,9 +4921,8 @@ static inline bool is_valid(rocksdb::Iterator *scan_it) {
   they are needed to function.
 */
 
-Rdb_table_handler *
-Rdb_open_tables_map::get_table_handler(const char *const table_name) {
-
+Rdb_table_handler *Rdb_open_tables_map::get_table_handler(
+    const char *const table_name) {
   DBUG_ASSERT(table_name != nullptr);
 
   const std::string s_table_name(table_name);
@@ -5009,44 +4997,44 @@ std::vector<std::string> Rdb_open_tables_map::get_table_names(void) const {
 static ulonglong rdb_get_int_col_max_value(const Field *field) {
   ulonglong max_value = 0;
   switch (field->key_type()) {
-  case HA_KEYTYPE_BINARY:
-    max_value = 0xFFULL;
-    break;
-  case HA_KEYTYPE_INT8:
-    max_value = 0x7FULL;
-    break;
-  case HA_KEYTYPE_USHORT_INT:
-    max_value = 0xFFFFULL;
-    break;
-  case HA_KEYTYPE_SHORT_INT:
-    max_value = 0x7FFFULL;
-    break;
-  case HA_KEYTYPE_UINT24:
-    max_value = 0xFFFFFFULL;
-    break;
-  case HA_KEYTYPE_INT24:
-    max_value = 0x7FFFFFULL;
-    break;
-  case HA_KEYTYPE_ULONG_INT:
-    max_value = 0xFFFFFFFFULL;
-    break;
-  case HA_KEYTYPE_LONG_INT:
-    max_value = 0x7FFFFFFFULL;
-    break;
-  case HA_KEYTYPE_ULONGLONG:
-    max_value = 0xFFFFFFFFFFFFFFFFULL;
-    break;
-  case HA_KEYTYPE_LONGLONG:
-    max_value = 0x7FFFFFFFFFFFFFFFULL;
-    break;
-  case HA_KEYTYPE_FLOAT:
-    max_value = 0x1000000ULL;
-    break;
-  case HA_KEYTYPE_DOUBLE:
-    max_value = 0x20000000000000ULL;
-    break;
-  default:
-    abort();
+    case HA_KEYTYPE_BINARY:
+      max_value = 0xFFULL;
+      break;
+    case HA_KEYTYPE_INT8:
+      max_value = 0x7FULL;
+      break;
+    case HA_KEYTYPE_USHORT_INT:
+      max_value = 0xFFFFULL;
+      break;
+    case HA_KEYTYPE_SHORT_INT:
+      max_value = 0x7FFFULL;
+      break;
+    case HA_KEYTYPE_UINT24:
+      max_value = 0xFFFFFFULL;
+      break;
+    case HA_KEYTYPE_INT24:
+      max_value = 0x7FFFFFULL;
+      break;
+    case HA_KEYTYPE_ULONG_INT:
+      max_value = 0xFFFFFFFFULL;
+      break;
+    case HA_KEYTYPE_LONG_INT:
+      max_value = 0x7FFFFFFFULL;
+      break;
+    case HA_KEYTYPE_ULONGLONG:
+      max_value = 0xFFFFFFFFFFFFFFFFULL;
+      break;
+    case HA_KEYTYPE_LONGLONG:
+      max_value = 0x7FFFFFFFFFFFFFFFULL;
+      break;
+    case HA_KEYTYPE_FLOAT:
+      max_value = 0x1000000ULL;
+      break;
+    case HA_KEYTYPE_DOUBLE:
+      max_value = 0x20000000000000ULL;
+      break;
+    default:
+      abort();
   }
 
   return max_value;
@@ -5281,10 +5269,9 @@ void Rdb_open_tables_map::release_table_handler(
 static handler *rocksdb_create_handler(my_core::handlerton *const hton,
                                        my_core::TABLE_SHARE *const table_arg,
                                        my_core::MEM_ROOT *const mem_root) {
-
-  if (rocksdb_enable_native_partition &&
-      table_arg && table_arg->db_type() == rocksdb_hton &&
-      table_arg->partition_info_str && table_arg->partition_info_str_len) {
+  if (rocksdb_enable_native_partition && table_arg &&
+      table_arg->db_type() == rocksdb_hton && table_arg->partition_info_str &&
+      table_arg->partition_info_str_len) {
     ha_rockspart *file = new (mem_root) ha_rockspart(hton, table_arg);
     if (file && file->init_partitioning(mem_root)) {
       delete file;
@@ -5298,21 +5285,35 @@ static handler *rocksdb_create_handler(my_core::handlerton *const hton,
 
 ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
                        my_core::TABLE_SHARE *const table_arg)
-    : handler(hton, table_arg), m_table_handler(nullptr), m_scan_it(nullptr),
-      m_scan_it_skips_bloom(false), m_scan_it_snapshot(nullptr),
-      m_scan_it_lower_bound(nullptr), m_scan_it_upper_bound(nullptr),
-      m_tbl_def(nullptr), m_pk_descr(nullptr), m_key_descr_arr(nullptr),
+    : handler(hton, table_arg),
+      m_table_handler(nullptr),
+      m_scan_it(nullptr),
+      m_scan_it_skips_bloom(false),
+      m_scan_it_snapshot(nullptr),
+      m_scan_it_lower_bound(nullptr),
+      m_scan_it_upper_bound(nullptr),
+      m_tbl_def(nullptr),
+      m_pk_descr(nullptr),
+      m_key_descr_arr(nullptr),
       m_pk_can_be_decoded(false),
-      m_pk_tuple(nullptr), m_pk_packed_tuple(nullptr),
-      m_sk_packed_tuple(nullptr), m_end_key_packed_tuple(nullptr),
-      m_sk_match_prefix(nullptr), m_sk_match_prefix_buf(nullptr),
-      m_sk_packed_tuple_old(nullptr), m_dup_sk_packed_tuple(nullptr),
-      m_dup_sk_packed_tuple_old(nullptr), m_pack_buffer(nullptr),
-      m_lock_rows(RDB_LOCK_NONE), m_keyread_only(false),
-      m_insert_with_update(false), m_dup_pk_found(false)
+      m_pk_tuple(nullptr),
+      m_pk_packed_tuple(nullptr),
+      m_sk_packed_tuple(nullptr),
+      m_end_key_packed_tuple(nullptr),
+      m_sk_match_prefix(nullptr),
+      m_sk_match_prefix_buf(nullptr),
+      m_sk_packed_tuple_old(nullptr),
+      m_dup_sk_packed_tuple(nullptr),
+      m_dup_sk_packed_tuple_old(nullptr),
+      m_pack_buffer(nullptr),
+      m_lock_rows(RDB_LOCK_NONE),
+      m_keyread_only(false),
+      m_insert_with_update(false),
+      m_dup_pk_found(false)
 #if defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
       ,
-      m_in_rpl_delete_rows(false), m_in_rpl_update_rows(false)
+      m_in_rpl_delete_rows(false),
+      m_in_rpl_update_rows(false)
 #endif  // defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
 {
 }
@@ -5405,9 +5406,10 @@ bool ha_rocksdb::should_hide_ttl_rec(const Rdb_key_def &kd,
                       RDB_MAX_HEXDUMP_LEN);
     const GL_INDEX_ID gl_index_id = kd.get_gl_index_id();
     // NO_LINT_DEBUG
-    sql_print_error("Decoding ttl from PK value failed, "
-                    "for index (%u,%u), val: %s",
-                    gl_index_id.cf_id, gl_index_id.index_id, buf.c_str());
+    sql_print_error(
+        "Decoding ttl from PK value failed, "
+        "for index (%u,%u), val: %s",
+        gl_index_id.cf_id, gl_index_id.index_id, buf.c_str());
     DBUG_ASSERT(0);
     return false;
   }
@@ -5482,7 +5484,6 @@ void dbug_create_err_inplace_alter() {
 
 int ha_rocksdb::convert_record_from_storage_format(
     const rocksdb::Slice *const key, uchar *const buf) {
-
   DBUG_EXECUTE_IF("myrocks_simulate_bad_row_read1",
                   dbug_append_garbage_at_end(&m_retrieved_record););
   DBUG_EXECUTE_IF("myrocks_simulate_bad_row_read2",
@@ -5624,10 +5625,10 @@ int ha_rocksdb::alloc_key_buffers(const TABLE *const table_arg,
     goto error;
   }
 
-  /*
-    If inplace alter is happening, allocate special buffers for unique
-    secondary index duplicate checking.
-  */
+    /*
+      If inplace alter is happening, allocate special buffers for unique
+      secondary index duplicate checking.
+    */
 #ifdef HAVE_PSI_INTERFACE
   if (alloc_alter_buffers &&
       (!(m_dup_sk_packed_tuple = static_cast<uchar *>(
@@ -5892,60 +5893,61 @@ int ha_rocksdb::rdb_error_to_mysql(const rocksdb::Status &s,
 
   int err;
   switch (s.code()) {
-  case rocksdb::Status::Code::kOk:
-    err = HA_EXIT_SUCCESS;
-    break;
-  case rocksdb::Status::Code::kNotFound:
-    err = HA_ERR_ROCKSDB_STATUS_NOT_FOUND;
-    break;
-  case rocksdb::Status::Code::kCorruption:
-    err = HA_ERR_ROCKSDB_STATUS_CORRUPTION;
-    break;
-  case rocksdb::Status::Code::kNotSupported:
-    err = HA_ERR_ROCKSDB_STATUS_NOT_SUPPORTED;
-    break;
-  case rocksdb::Status::Code::kInvalidArgument:
-    err = HA_ERR_ROCKSDB_STATUS_INVALID_ARGUMENT;
-    break;
-  case rocksdb::Status::Code::kIOError:
-    err = (s.IsNoSpace()) ? HA_ERR_ROCKSDB_STATUS_NO_SPACE
-                          : HA_ERR_ROCKSDB_STATUS_IO_ERROR;
-    break;
-  case rocksdb::Status::Code::kMergeInProgress:
-    err = HA_ERR_ROCKSDB_STATUS_MERGE_IN_PROGRESS;
-    break;
-  case rocksdb::Status::Code::kIncomplete:
-    err = HA_ERR_ROCKSDB_STATUS_INCOMPLETE;
-    break;
-  case rocksdb::Status::Code::kShutdownInProgress:
-    err = HA_ERR_ROCKSDB_STATUS_SHUTDOWN_IN_PROGRESS;
-    break;
-  case rocksdb::Status::Code::kTimedOut:
-    err = HA_ERR_ROCKSDB_STATUS_TIMED_OUT;
-    break;
-  case rocksdb::Status::Code::kAborted:
-    err = (s.IsLockLimit()) ? HA_ERR_ROCKSDB_STATUS_LOCK_LIMIT
-                            : HA_ERR_ROCKSDB_STATUS_ABORTED;
-    break;
-  case rocksdb::Status::Code::kBusy:
-    err = (s.IsDeadlock()) ? HA_ERR_ROCKSDB_STATUS_DEADLOCK
-                           : HA_ERR_ROCKSDB_STATUS_BUSY;
-    break;
-  case rocksdb::Status::Code::kExpired:
-    err = HA_ERR_ROCKSDB_STATUS_EXPIRED;
-    break;
-  case rocksdb::Status::Code::kTryAgain:
-    err = HA_ERR_ROCKSDB_STATUS_TRY_AGAIN;
-    break;
-  default:
-    DBUG_ASSERT(0);
-    return -1;
+    case rocksdb::Status::Code::kOk:
+      err = HA_EXIT_SUCCESS;
+      break;
+    case rocksdb::Status::Code::kNotFound:
+      err = HA_ERR_ROCKSDB_STATUS_NOT_FOUND;
+      break;
+    case rocksdb::Status::Code::kCorruption:
+      err = HA_ERR_ROCKSDB_STATUS_CORRUPTION;
+      break;
+    case rocksdb::Status::Code::kNotSupported:
+      err = HA_ERR_ROCKSDB_STATUS_NOT_SUPPORTED;
+      break;
+    case rocksdb::Status::Code::kInvalidArgument:
+      err = HA_ERR_ROCKSDB_STATUS_INVALID_ARGUMENT;
+      break;
+    case rocksdb::Status::Code::kIOError:
+      err = (s.IsNoSpace()) ? HA_ERR_ROCKSDB_STATUS_NO_SPACE
+                            : HA_ERR_ROCKSDB_STATUS_IO_ERROR;
+      break;
+    case rocksdb::Status::Code::kMergeInProgress:
+      err = HA_ERR_ROCKSDB_STATUS_MERGE_IN_PROGRESS;
+      break;
+    case rocksdb::Status::Code::kIncomplete:
+      err = HA_ERR_ROCKSDB_STATUS_INCOMPLETE;
+      break;
+    case rocksdb::Status::Code::kShutdownInProgress:
+      err = HA_ERR_ROCKSDB_STATUS_SHUTDOWN_IN_PROGRESS;
+      break;
+    case rocksdb::Status::Code::kTimedOut:
+      err = HA_ERR_ROCKSDB_STATUS_TIMED_OUT;
+      break;
+    case rocksdb::Status::Code::kAborted:
+      err = (s.IsLockLimit()) ? HA_ERR_ROCKSDB_STATUS_LOCK_LIMIT
+                              : HA_ERR_ROCKSDB_STATUS_ABORTED;
+      break;
+    case rocksdb::Status::Code::kBusy:
+      err = (s.IsDeadlock()) ? HA_ERR_ROCKSDB_STATUS_DEADLOCK
+                             : HA_ERR_ROCKSDB_STATUS_BUSY;
+      break;
+    case rocksdb::Status::Code::kExpired:
+      err = HA_ERR_ROCKSDB_STATUS_EXPIRED;
+      break;
+    case rocksdb::Status::Code::kTryAgain:
+      err = HA_ERR_ROCKSDB_STATUS_TRY_AGAIN;
+      break;
+    default:
+      DBUG_ASSERT(0);
+      return -1;
   }
 
   std::string errMsg;
   if (s.IsLockLimit()) {
-    errMsg = "Operation aborted: Failed to acquire lock due to "
-             "rocksdb_max_row_locks limit";
+    errMsg =
+        "Operation aborted: Failed to acquire lock due to "
+        "rocksdb_max_row_locks limit";
   } else {
     errMsg = s.ToString();
   }
@@ -5966,14 +5968,14 @@ int ha_rocksdb::rdb_error_to_mysql(const rocksdb::Status &s,
 static const std::set<const my_core::CHARSET_INFO *> RDB_INDEX_COLLATIONS = {
     &my_charset_bin, &my_charset_utf8_bin, &my_charset_latin1_bin};
 
-static bool
-rdb_is_index_collation_supported(const my_core::Field *const field) {
+static bool rdb_is_index_collation_supported(
+    const my_core::Field *const field) {
   const my_core::enum_field_types type = field->real_type();
   /* Handle [VAR](CHAR|BINARY) or TEXT|BLOB */
   if (type == MYSQL_TYPE_VARCHAR || type == MYSQL_TYPE_STRING ||
       type == MYSQL_TYPE_BLOB || type == MYSQL_TYPE_JSON) {
     return (RDB_INDEX_COLLATIONS.find(field->charset()) !=
-           RDB_INDEX_COLLATIONS.end()) ||
+            RDB_INDEX_COLLATIONS.end()) ||
            rdb_is_collation_supported(field->charset());
   }
   return true;
@@ -6160,8 +6162,8 @@ int ha_rocksdb::create_cfs(
 
     // Generate the name for the column family to use.
     bool per_part_match_found = false;
-    std::string cf_name = generate_cf_name(i, table_arg, tbl_def_arg,
-      &per_part_match_found);
+    std::string cf_name =
+        generate_cf_name(i, table_arg, tbl_def_arg, &per_part_match_found);
 
     // Prevent create from using the system column family.
     if (cf_name == DEFAULT_SYSTEM_CF_NAME) {
@@ -6238,10 +6240,11 @@ int ha_rocksdb::create_inplace_key_defs(
       struct Rdb_index_info index_info;
       if (!dict_manager.get_index_info(gl_index_id, &index_info)) {
         // NO_LINT_DEBUG
-        sql_print_error("RocksDB: Could not get index information "
-                        "for Index Number (%u,%u), table %s",
-                        gl_index_id.cf_id, gl_index_id.index_id,
-                        old_tbl_def_arg->full_tablename().c_str());
+        sql_print_error(
+            "RocksDB: Could not get index information "
+            "for Index Number (%u,%u), table %s",
+            gl_index_id.cf_id, gl_index_id.index_id,
+            old_tbl_def_arg->full_tablename().c_str());
         DBUG_RETURN(HA_EXIT_FAILURE);
       }
 
@@ -6495,13 +6498,13 @@ int rdb_normalize_tablename(const std::string &tablename,
   DBUG_ASSERT(strbuf != nullptr);
 
   if (tablename.size() < 2 || tablename[0] != '.' || tablename[1] != '/') {
-    DBUG_ASSERT(0); // We were not passed table name?
+    DBUG_ASSERT(0);  // We were not passed table name?
     return HA_ERR_ROCKSDB_INVALID_TABLE;
   }
 
   size_t pos = tablename.find_first_of('/', 2);
   if (pos == std::string::npos) {
-    DBUG_ASSERT(0); // We were not passed table name?
+    DBUG_ASSERT(0);  // We were not passed table name?
     return HA_ERR_ROCKSDB_INVALID_TABLE;
   }
 
@@ -6961,65 +6964,66 @@ int ha_rocksdb::position_to_correct_key(
   *move_forward = true;
 
   switch (find_flag) {
-  case HA_READ_KEY_EXACT:
-    rc =
-        read_key_exact(kd, m_scan_it, full_key_match, key_slice, ttl_filter_ts);
-    break;
-  case HA_READ_BEFORE_KEY:
-    *move_forward = false;
-    rc = read_before_key(kd, full_key_match, key_slice, ttl_filter_ts);
-    if (rc == 0 && !kd.covers_key(m_scan_it->key())) {
-      /* The record we've got is not from this index */
-      rc = HA_ERR_KEY_NOT_FOUND;
-    }
-    break;
-  case HA_READ_AFTER_KEY:
-  case HA_READ_KEY_OR_NEXT:
-    rc = read_after_key(kd, key_slice, ttl_filter_ts);
-    if (rc == 0 && !kd.covers_key(m_scan_it->key())) {
-      /* The record we've got is not from this index */
-      rc = HA_ERR_KEY_NOT_FOUND;
-    }
-    break;
-  case HA_READ_KEY_OR_PREV:
-  case HA_READ_PREFIX:
-    /* This flag is not used by the SQL layer, so we don't support it yet. */
-    rc = HA_ERR_UNSUPPORTED;
-    break;
-  case HA_READ_PREFIX_LAST:
-  case HA_READ_PREFIX_LAST_OR_PREV:
-    *move_forward = false;
-    /*
-      Find the last record with the specified index prefix lookup.
-      - HA_READ_PREFIX_LAST requires that the record has the
-        prefix=lookup (if there are no such records,
-        HA_ERR_KEY_NOT_FOUND should be returned).
-      - HA_READ_PREFIX_LAST_OR_PREV has no such requirement. If there are no
-        records with prefix=lookup, we should return the last record
-        before that.
-    */
-    rc = read_before_key(kd, full_key_match, key_slice, ttl_filter_ts);
-    if (rc == 0) {
-      const rocksdb::Slice &rkey = m_scan_it->key();
-      if (!kd.covers_key(rkey)) {
+    case HA_READ_KEY_EXACT:
+      rc = read_key_exact(kd, m_scan_it, full_key_match, key_slice,
+                          ttl_filter_ts);
+      break;
+    case HA_READ_BEFORE_KEY:
+      *move_forward = false;
+      rc = read_before_key(kd, full_key_match, key_slice, ttl_filter_ts);
+      if (rc == 0 && !kd.covers_key(m_scan_it->key())) {
         /* The record we've got is not from this index */
         rc = HA_ERR_KEY_NOT_FOUND;
-      } else if (find_flag == HA_READ_PREFIX_LAST) {
-        uint size = kd.pack_index_tuple(table, m_pack_buffer, m_sk_packed_tuple,
-                                        key, keypart_map);
-        rocksdb::Slice lookup_tuple(reinterpret_cast<char *>(m_sk_packed_tuple),
-                                    size);
-
-        // We need to compare the key we've got with the original search prefix.
-        if (!kd.value_matches_prefix(rkey, lookup_tuple)) {
+      }
+      break;
+    case HA_READ_AFTER_KEY:
+    case HA_READ_KEY_OR_NEXT:
+      rc = read_after_key(kd, key_slice, ttl_filter_ts);
+      if (rc == 0 && !kd.covers_key(m_scan_it->key())) {
+        /* The record we've got is not from this index */
+        rc = HA_ERR_KEY_NOT_FOUND;
+      }
+      break;
+    case HA_READ_KEY_OR_PREV:
+    case HA_READ_PREFIX:
+      /* This flag is not used by the SQL layer, so we don't support it yet. */
+      rc = HA_ERR_UNSUPPORTED;
+      break;
+    case HA_READ_PREFIX_LAST:
+    case HA_READ_PREFIX_LAST_OR_PREV:
+      *move_forward = false;
+      /*
+        Find the last record with the specified index prefix lookup.
+        - HA_READ_PREFIX_LAST requires that the record has the
+          prefix=lookup (if there are no such records,
+          HA_ERR_KEY_NOT_FOUND should be returned).
+        - HA_READ_PREFIX_LAST_OR_PREV has no such requirement. If there are no
+          records with prefix=lookup, we should return the last record
+          before that.
+      */
+      rc = read_before_key(kd, full_key_match, key_slice, ttl_filter_ts);
+      if (rc == 0) {
+        const rocksdb::Slice &rkey = m_scan_it->key();
+        if (!kd.covers_key(rkey)) {
+          /* The record we've got is not from this index */
           rc = HA_ERR_KEY_NOT_FOUND;
+        } else if (find_flag == HA_READ_PREFIX_LAST) {
+          uint size = kd.pack_index_tuple(table, m_pack_buffer,
+                                          m_sk_packed_tuple, key, keypart_map);
+          rocksdb::Slice lookup_tuple(
+              reinterpret_cast<char *>(m_sk_packed_tuple), size);
+
+          // We need to compare the key we've got with the original search
+          // prefix.
+          if (!kd.value_matches_prefix(rkey, lookup_tuple)) {
+            rc = HA_ERR_KEY_NOT_FOUND;
+          }
         }
       }
-    }
-    break;
-  default:
-    DBUG_ASSERT(0);
-    break;
+      break;
+    default:
+      DBUG_ASSERT(0);
+      break;
   }
 
   return rc;
@@ -7031,8 +7035,7 @@ int ha_rocksdb::calc_eq_cond_len(const Rdb_key_def &kd,
                                  const int bytes_changed_by_succ,
                                  const key_range *const end_key,
                                  uint *const end_key_packed_size) {
-  if (find_flag == HA_READ_KEY_EXACT)
-    return slice.size();
+  if (find_flag == HA_READ_KEY_EXACT) return slice.size();
 
   if (find_flag == HA_READ_PREFIX_LAST) {
     /*
@@ -7129,8 +7132,7 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
       global_stats.covered_secondary_key_lookups.inc();
     }
   } else {
-    if (kd.m_is_reverse_cf)
-      move_forward = !move_forward;
+    if (kd.m_is_reverse_cf) move_forward = !move_forward;
 
     rc = find_icp_matching_index_rec(move_forward, buf);
     if (!rc) {
@@ -7179,7 +7181,7 @@ ulong ha_rocksdb::index_flags(bool &pk_can_be_decoded,
                               uint part, bool all_parts) {
   DBUG_ENTER_FUNC();
 
-  ulong base_flags = HA_READ_NEXT | // doesn't seem to be used
+  ulong base_flags = HA_READ_NEXT |  // doesn't seem to be used
                      HA_READ_ORDER | HA_READ_RANGE | HA_READ_PREV;
 
   if (check_keyread_allowed(pk_can_be_decoded, table_share, inx, part,
@@ -7287,7 +7289,7 @@ int ha_rocksdb::read_range_first(const key_range *const start_key,
 
   range_key_part = table->key_info[active_index].key_part;
 
-  if (!start_key) // Read first record
+  if (!start_key)  // Read first record
     result = ha_index_first(table->record[0]);
   else {
     if (is_using_prohibited_gap_locks(
@@ -7366,8 +7368,7 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
   const uint actual_key_parts = kd.get_key_parts();
   bool using_full_key = is_using_full_key(keypart_map, actual_key_parts);
 
-  if (!end_key)
-    end_key = end_range;
+  if (!end_key) end_key = end_range;
 
   /* By default, we don't need the retrieved records to match the prefix */
   m_sk_match_prefix = nullptr;
@@ -7381,8 +7382,7 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
     const uint size = kd.pack_index_tuple(table, m_pack_buffer,
                                           m_pk_packed_tuple, key, keypart_map);
     bool skip_lookup = is_blind_delete_enabled();
-    rc = get_row_by_rowid(buf, m_pk_packed_tuple, size,
-                          false, skip_lookup);
+    rc = get_row_by_rowid(buf, m_pk_packed_tuple, size, false, skip_lookup);
     if (!rc && !skip_lookup) {
       update_row_stats(ROWS_READ);
     }
@@ -7635,7 +7635,7 @@ int ha_rocksdb::check(THD *const thd, HA_CHECK_OPT *const check_opt) {
   // NO_LINT_DEBUG
   sql_print_information("CHECKTABLE %s: Checking table %s", table_name,
                         table_name);
-  ha_rows row_checksums_at_start = 0; // set/used iff first_index==true
+  ha_rows row_checksums_at_start = 0;  // set/used iff first_index==true
   ha_rows row_checksums = ha_rows(-1);
   bool first_index = true;
 
@@ -7658,8 +7658,7 @@ int ha_rocksdb::check(THD *const thd, HA_CHECK_OPT *const check_opt) {
           res = index_next(table->record[0]);
         }
 
-        if (res == HA_ERR_END_OF_FILE)
-          break;
+        if (res == HA_ERR_END_OF_FILE) break;
         if (res) {
           // error
           // NO_LINT_DEBUG
@@ -7680,9 +7679,10 @@ int ha_rocksdb::check(THD *const thd, HA_CHECK_OPT *const check_opt) {
         if ((res = get_row_by_rowid(table->record[0], rowkey_copy.ptr(),
                                     rowkey_copy.length()))) {
           // NO_LINT_DEBUG
-          sql_print_error("CHECKTABLE %s:   .. row %lld: "
-                          "failed to fetch row by rowid",
-                          table_name, rows);
+          sql_print_error(
+              "CHECKTABLE %s:   .. row %lld: "
+              "failed to fetch row by rowid",
+              table_name, rows);
           goto error;
         }
 
@@ -7710,9 +7710,10 @@ int ha_rocksdb::check(THD *const thd, HA_CHECK_OPT *const check_opt) {
         if (packed_size != sec_key_copy.length() ||
             memcmp(m_sk_packed_tuple, sec_key_copy.ptr(), packed_size)) {
           // NO_LINT_DEBUG
-          sql_print_error("CHECKTABLE %s:   .. row %lld: "
-                          "secondary index value mismatch",
-                          table_name, rows);
+          sql_print_error(
+              "CHECKTABLE %s:   .. row %lld: "
+              "secondary index value mismatch",
+              table_name, rows);
           goto print_and_error;
         }
         rows++;
@@ -7739,9 +7740,10 @@ int ha_rocksdb::check(THD *const thd, HA_CHECK_OPT *const check_opt) {
       }
       }
       // NO_LINT_DEBUG
-      sql_print_information("CHECKTABLE %s:   ... %lld index entries checked "
-                            "(%lld had checksums)",
-                            table_name, rows, checksums);
+      sql_print_information(
+          "CHECKTABLE %s:   ... %lld index entries checked "
+          "(%lld had checksums)",
+          table_name, rows, checksums);
 
       if (first_index) {
         row_checksums =
@@ -7793,8 +7795,7 @@ static void dbug_dump_str(FILE *const out, const char *const str, int len) {
 
 void dbug_dump_database(rocksdb::DB *const db) {
   FILE *const out = fopen("/tmp/rocksdb.dump", "wt");
-  if (!out)
-    return;
+  if (!out) return;
 
   rocksdb::Iterator *it = db->NewIterator(rocksdb::ReadOptions());
   for (it->SeekToFirst(); it->Valid(); it->Next()) {
@@ -7827,15 +7828,12 @@ rocksdb::Status ha_rocksdb::get_for_update(
   return s;
 }
 
-bool ha_rocksdb::is_blind_delete_enabled()
-{
+bool ha_rocksdb::is_blind_delete_enabled() {
   THD *thd = ha_thd();
   return (THDVAR(thd, blind_delete_primary_key) &&
           thd->lex->sql_command == SQLCOM_DELETE &&
-          thd->lex->table_count == 1 &&
-          table->s->keys == 1 &&
-          !has_hidden_pk(table) &&
-          !thd->rli_slave);
+          thd->lex->table_count == 1 && table->s->keys == 1 &&
+          !has_hidden_pk(table) && !thd->rli_slave);
 }
 
 /*
@@ -7866,8 +7864,9 @@ int ha_rocksdb::get_row_by_rowid(uchar *const buf, const char *const rowid,
   DEBUG_SYNC(ha_thd(), "rocksdb.get_row_by_rowid");
   DBUG_EXECUTE_IF("dbug.rocksdb.get_row_by_rowid", {
     THD *thd = ha_thd();
-    const char act[] = "now signal Reached "
-                       "wait_for signal.rocksdb.get_row_by_rowid_let_running";
+    const char act[] =
+        "now signal Reached "
+        "wait_for signal.rocksdb.get_row_by_rowid_let_running";
     DBUG_ASSERT(opt_debug_sync_timeout > 0);
     DBUG_ASSERT(!debug_sync_set_action(thd, STRING_WITH_LEN(act)));
   };);
@@ -7876,8 +7875,7 @@ int ha_rocksdb::get_row_by_rowid(uchar *const buf, const char *const rowid,
   rocksdb::Status s;
 
   /* Pretend row found without looking up */
-  if (skip_lookup)
-  {
+  if (skip_lookup) {
     update_row_stats(ROWS_DELETED_BLIND);
     m_last_rowkey.copy((const char *)rowid, rowid_size, &my_charset_bin);
     table->status = 0;
@@ -7952,8 +7950,7 @@ int ha_rocksdb::index_next(uchar *const buf) {
   }
 
   int rc = index_next_with_direction(buf, moves_forward);
-  if (rc == HA_ERR_KEY_NOT_FOUND)
-    rc = HA_ERR_END_OF_FILE;
+  if (rc == HA_ERR_KEY_NOT_FOUND) rc = HA_ERR_END_OF_FILE;
 
   DBUG_RETURN(rc);
 }
@@ -7973,8 +7970,7 @@ int ha_rocksdb::index_prev(uchar *const buf) {
   }
 
   int rc = index_next_with_direction(buf, moves_forward);
-  if (rc == HA_ERR_KEY_NOT_FOUND)
-    rc = HA_ERR_END_OF_FILE;
+  if (rc == HA_ERR_KEY_NOT_FOUND) rc = HA_ERR_END_OF_FILE;
 
   DBUG_RETURN(rc);
 }
@@ -8010,8 +8006,7 @@ int ha_rocksdb::index_next_with_direction(uchar *const buf, bool move_forward) {
         break;
       }
       rc = find_icp_matching_index_rec(move_forward, buf);
-      if (!rc)
-        rc = secondary_index_read(active_index, buf);
+      if (!rc) rc = secondary_index_read(active_index, buf);
       if (!should_skip_invalidated_record(rc)) {
         break;
       }
@@ -8034,8 +8029,7 @@ int ha_rocksdb::index_first(uchar *const buf) {
   int rc = m_key_descr_arr[active_index]->m_is_reverse_cf
                ? index_last_intern(buf)
                : index_first_intern(buf);
-  if (rc == HA_ERR_KEY_NOT_FOUND)
-    rc = HA_ERR_END_OF_FILE;
+  if (rc == HA_ERR_KEY_NOT_FOUND) rc = HA_ERR_END_OF_FILE;
 
   DBUG_RETURN(rc);
 }
@@ -8053,8 +8047,7 @@ int ha_rocksdb::index_last(uchar *const buf) {
   int rc = m_key_descr_arr[active_index]->m_is_reverse_cf
                ? index_first_intern(buf)
                : index_last_intern(buf);
-  if (rc == HA_ERR_KEY_NOT_FOUND)
-    rc = HA_ERR_END_OF_FILE;
+  if (rc == HA_ERR_KEY_NOT_FOUND) rc = HA_ERR_END_OF_FILE;
 
   DBUG_RETURN(rc);
 }
@@ -8211,8 +8204,7 @@ int ha_rocksdb::index_last_intern(uchar *const buf) {
       rc = rnd_next_with_direction(buf, false);
     } else {
       rc = find_icp_matching_index_rec(false /*move_forward*/, buf);
-      if (!rc)
-        rc = secondary_index_read(active_index, buf);
+      if (!rc) rc = secondary_index_read(active_index, buf);
     }
 
     if (!should_recreate_snapshot(rc, is_new_snapshot)) {
@@ -8368,10 +8360,9 @@ const char *ha_rocksdb::get_key_comment(const uint index,
   return table_arg->key_info[index].comment.str;
 }
 
-const std::string ha_rocksdb::generate_cf_name(const uint index,
-                                        const TABLE *const table_arg,
-                                        const Rdb_tbl_def *const tbl_def_arg,
-                                        bool  *per_part_match_found) {
+const std::string ha_rocksdb::generate_cf_name(
+    const uint index, const TABLE *const table_arg,
+    const Rdb_tbl_def *const tbl_def_arg, bool *per_part_match_found) {
   DBUG_ASSERT(table_arg != nullptr);
   DBUG_ASSERT(tbl_def_arg != nullptr);
   DBUG_ASSERT(per_part_match_found != nullptr);
@@ -9331,7 +9322,7 @@ void ha_rocksdb::setup_scan_iterator(const Rdb_key_def &kd,
       m_scan_it_snapshot = rdb->GetSnapshot();
 
       auto read_opts = rocksdb::ReadOptions();
-      read_opts.total_order_seek = true; // TODO: set based on WHERE conditions
+      read_opts.total_order_seek = true;  // TODO: set based on WHERE conditions
       read_opts.snapshot = m_scan_it_snapshot;
       m_scan_it = rdb->NewIterator(read_opts, kd.get_cf());
     } else {
@@ -9424,8 +9415,7 @@ int ha_rocksdb::rnd_next(uchar *const buf) {
 
   m_rnd_scan_is_new_snapshot = false;
 
-  if (rc == HA_ERR_KEY_NOT_FOUND)
-    rc = HA_ERR_END_OF_FILE;
+  if (rc == HA_ERR_KEY_NOT_FOUND) rc = HA_ERR_END_OF_FILE;
 
   DBUG_RETURN(rc);
 }
@@ -9724,8 +9714,7 @@ void ha_rocksdb::update_stats(void) {
 int ha_rocksdb::info(uint flag) {
   DBUG_ENTER_FUNC();
 
-  if (!table)
-    DBUG_RETURN(HA_EXIT_FAILURE);
+  if (!table) DBUG_RETURN(HA_EXIT_FAILURE);
 
   if (flag & HA_STATUS_VARIABLE) {
     /*
@@ -9837,8 +9826,7 @@ int ha_rocksdb::info(uint flag) {
         } else {
           x = 0;
         }
-        if (x > stats.records)
-          x = stats.records;
+        if (x > stats.records) x = stats.records;
         if ((x == 0 && rocksdb_debug_optimizer_no_zero_cardinality) ||
             rocksdb_debug_optimizer_n_rows > 0) {
           // Fake cardinality implementation. For example, (idx1, idx2, idx3)
@@ -9859,7 +9847,7 @@ int ha_rocksdb::info(uint flag) {
       uniqueness violation.
     */
     errkey = m_dupp_errkey;
-    dup_ref = m_pk_tuple; // TODO(?): this should store packed PK.
+    dup_ref = m_pk_tuple;  // TODO(?): this should store packed PK.
   }
 
   if (flag & HA_STATUS_AUTO) {
@@ -9874,7 +9862,7 @@ void ha_rocksdb::position(const uchar *const record) {
 
   longlong hidden_pk_id = 0;
   if (has_hidden_pk(table) && read_hidden_pk_id_from_rowkey(&hidden_pk_id))
-    DBUG_ASSERT(false); // should never reach here
+    DBUG_ASSERT(false);  // should never reach here
 
   /*
     Get packed primary key value from the record.
@@ -9950,8 +9938,7 @@ void ha_rocksdb::calc_updated_indexes() {
       /* Walk over all key parts, including the "extended key" suffix */
       const uint key_parts = kd.get_key_parts();
       for (uint kp = 0; kp < key_parts; kp++) {
-        if (has_hidden_pk(table) && kp + 1 == key_parts)
-          break;
+        if (has_hidden_pk(table) && kp + 1 == key_parts) break;
 
         Field *const field = kd.get_table_field_for_part_no(table, kp);
         if (bitmap_is_set(table->write_set, field->field_index)) {
@@ -10024,7 +10011,6 @@ THR_LOCK_DATA **ha_rocksdb::store_lock(THD *const thd, THR_LOCK_DATA **to,
           lock_type == TL_READ_WITH_SHARED_LOCKS ||
           lock_type == TL_READ_NO_INSERT ||
           (lock_type != TL_IGNORE && sql_command != SQLCOM_SELECT)) {
-
         ulong tx_isolation = my_core::thd_tx_isolation(thd);
         if (sql_command != SQLCOM_CHECKSUM &&
             ((my_core::thd_test_options(thd, OPTION_BIN_LOG) &&
@@ -10236,9 +10222,8 @@ rocksdb::Range get_range(const Rdb_key_def &kd,
   }
 }
 
-rocksdb::Range
-ha_rocksdb::get_range(const int i,
-                      uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) const {
+rocksdb::Range ha_rocksdb::get_range(
+    const int i, uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) const {
   return myrocks::get_range(*m_key_descr_arr[i], buf);
 }
 
@@ -10249,11 +10234,10 @@ ha_rocksdb::get_range(const int i,
  but in drop_index_thread's case, it means index is marked as removed,
  so no further seek will happen for the index id.
 */
-static bool is_myrocks_index_empty(
-  rocksdb::ColumnFamilyHandle *cfh, const bool is_reverse_cf,
-  const rocksdb::ReadOptions &read_opts,
-  const uint index_id)
-{
+static bool is_myrocks_index_empty(rocksdb::ColumnFamilyHandle *cfh,
+                                   const bool is_reverse_cf,
+                                   const rocksdb::ReadOptions &read_opts,
+                                   const uint index_id) {
   bool index_removed = false;
   uchar key_buf[Rdb_key_def::INDEX_NUMBER_SIZE] = {0};
   rdb_netbuf_store_uint32(key_buf, index_id);
@@ -10264,8 +10248,7 @@ static bool is_myrocks_index_empty(
   if (!it->Valid()) {
     index_removed = true;
   } else {
-    if (memcmp(it->key().data(), key_buf,
-        Rdb_key_def::INDEX_NUMBER_SIZE)) {
+    if (memcmp(it->key().data(), key_buf, Rdb_key_def::INDEX_NUMBER_SIZE)) {
       // Key does not have same prefix
       index_removed = true;
     }
@@ -10293,8 +10276,8 @@ void Rdb_drop_index_thread::run() {
     timespec ts;
     clock_gettime(CLOCK_REALTIME, &ts);
     ts.tv_sec += dict_manager.is_drop_index_empty()
-                     ? 24 * 60 * 60 // no filtering
-                     : 60;          // filtering
+                     ? 24 * 60 * 60  // no filtering
+                     : 60;           // filtering
 
     const auto ret MY_ATTRIBUTE((__unused__)) =
         mysql_cond_timedwait(&m_signal_cond, &m_signal_mutex, &ts);
@@ -10310,15 +10293,16 @@ void Rdb_drop_index_thread::run() {
     if (!indices.empty()) {
       std::unordered_set<GL_INDEX_ID> finished;
       rocksdb::ReadOptions read_opts;
-      read_opts.total_order_seek = true; // disable bloom filter
+      read_opts.total_order_seek = true;  // disable bloom filter
 
       for (const auto d : indices) {
         uint32 cf_flags = 0;
         if (!dict_manager.get_cf_flags(d.cf_id, &cf_flags)) {
-          sql_print_error("RocksDB: Failed to get column family flags "
-                          "from cf id %u. MyRocks data dictionary may "
-                          "get corrupted.",
-                          d.cf_id);
+          sql_print_error(
+              "RocksDB: Failed to get column family flags "
+              "from cf id %u. MyRocks data dictionary may "
+              "get corrupted.",
+              d.cf_id);
           abort();
         }
         rocksdb::ColumnFamilyHandle *cfh = cf_manager.get_cf(d.cf_id);
@@ -10344,8 +10328,7 @@ void Rdb_drop_index_thread::run() {
           }
           rdb_handle_io_error(status, RDB_IO_ERROR_BG_THREAD);
         }
-        if (is_myrocks_index_empty(cfh, is_reverse_cf, read_opts, d.index_id))
-        {
+        if (is_myrocks_index_empty(cfh, is_reverse_cf, read_opts, d.index_id)) {
           finished.insert(d);
         }
       }
@@ -10459,8 +10442,7 @@ int ha_rocksdb::delete_partitioned_table(
     const char *const tablename, const std::string &partition_info_str) {
   ha_rockspart file(rocksdb_hton, nullptr);
   int result = init_partition_handler(ha_thd(), partition_info_str, file);
-  if (result)
-    return result;
+  if (result) return result;
   return file.delete_table(tablename);
 }
 
@@ -10539,8 +10521,7 @@ int ha_rocksdb::rename_partitioned_table(const char *const from,
                                          const std::string &partition_string) {
   ha_rockspart file(rocksdb_hton, nullptr);
   int result = init_partition_handler(ha_thd(), partition_string, file);
-  if (result)
-    return result;
+  if (result) return result;
   return file.rename_table(from, to);
 }
 
@@ -10581,7 +10562,6 @@ int ha_rocksdb::rename_non_partitioned_table(const char *const from,
     DBUG_RETURN(rc);
   }
 
-
   // If the user changed the database part of the name then validate that the
   // 'to' database exists.
   if (from_db != to_db && !rdb_database_exists(to_db)) {
@@ -10613,8 +10593,7 @@ int ha_rocksdb::rename_table(const char *const from, const char *const to) {
   std::string partition_info_str;
   if (!native_part::get_part_str_for_table(from, partition_info_str))
     return HA_ERR_TABLE_CORRUPT;
-  if (partition_info_str.empty())
-    return rename_non_partitioned_table(from, to);
+  if (partition_info_str.empty()) return rename_non_partitioned_table(from, to);
   return rename_partitioned_table(from, to, partition_info_str);
 }
 
@@ -10647,33 +10626,33 @@ int ha_rocksdb::extra(enum ha_extra_function operation) {
   DBUG_ENTER_FUNC();
 
   switch (operation) {
-  case HA_EXTRA_KEYREAD:
-    m_keyread_only = true;
-    break;
-  case HA_EXTRA_NO_KEYREAD:
-    m_keyread_only = false;
-    break;
-  case HA_EXTRA_FLUSH:
-    /*
-      If the table has blobs, then they are part of m_retrieved_record.
-      This call invalidates them.
-    */
-    m_retrieved_record.Reset();
-    break;
-  case HA_EXTRA_INSERT_WITH_UPDATE:
-    // INSERT ON DUPLICATE KEY UPDATE
-    if (rocksdb_enable_insert_with_update_caching) {
-      m_insert_with_update = true;
-    }
-    break;
-  case HA_EXTRA_NO_IGNORE_DUP_KEY:
-    // PAIRED with HA_EXTRA_INSERT_WITH_UPDATE or HA_EXTRA_WRITE_CAN_REPLACE
-    // that indicates the end of REPLACE / INSERT ON DUPLICATE KEY
-    m_insert_with_update = false;
-    break;
+    case HA_EXTRA_KEYREAD:
+      m_keyread_only = true;
+      break;
+    case HA_EXTRA_NO_KEYREAD:
+      m_keyread_only = false;
+      break;
+    case HA_EXTRA_FLUSH:
+      /*
+        If the table has blobs, then they are part of m_retrieved_record.
+        This call invalidates them.
+      */
+      m_retrieved_record.Reset();
+      break;
+    case HA_EXTRA_INSERT_WITH_UPDATE:
+      // INSERT ON DUPLICATE KEY UPDATE
+      if (rocksdb_enable_insert_with_update_caching) {
+        m_insert_with_update = true;
+      }
+      break;
+    case HA_EXTRA_NO_IGNORE_DUP_KEY:
+      // PAIRED with HA_EXTRA_INSERT_WITH_UPDATE or HA_EXTRA_WRITE_CAN_REPLACE
+      // that indicates the end of REPLACE / INSERT ON DUPLICATE KEY
+      m_insert_with_update = false;
+      break;
 
-  default:
-    break;
+    default:
+      break;
   }
 
   DBUG_RETURN(HA_EXIT_SUCCESS);
@@ -10744,8 +10723,7 @@ ha_rows ha_rocksdb::records_in_range(uint inx, key_range *const min_key,
 
   uint64_t sz = 0;
   auto disk_size = kd.m_stats.m_actual_disk_size;
-  if (disk_size == 0)
-    disk_size = kd.m_stats.m_data_size;
+  if (disk_size == 0) disk_size = kd.m_stats.m_data_size;
   auto rows = kd.m_stats.m_rows;
   if (rows == 0 || disk_size == 0) {
     rows = 1;
@@ -11122,8 +11100,7 @@ const char *dbug_print_item(Item *const item) {
   char *const buf = dbug_item_print_buf;
   String str(buf, sizeof(dbug_item_print_buf), &my_charset_bin);
   str.length(0);
-  if (!item)
-    return "(Item*)nullptr";
+  if (!item) return "(Item*)nullptr";
   item->print(&str, QT_ORDINARY);
   if (str.c_ptr() == buf)
     return buf;
@@ -11286,7 +11263,6 @@ bool ha_rocksdb::prepare_inplace_alter_table(
        my_core::Alter_inplace_info::DROP_UNIQUE_INDEX |
        my_core::Alter_inplace_info::ADD_INDEX |
        my_core::Alter_inplace_info::ADD_UNIQUE_INDEX)) {
-
     if (has_hidden_pk(altered_table)) {
       new_n_keys += 1;
     }
@@ -11865,22 +11841,22 @@ bool ha_rocksdb::commit_inplace_alter_table(
 
 #define SHOW_FNAME(name) rocksdb_show_##name
 
-#define DEF_SHOW_FUNC(name, key)                                               \
-  static int SHOW_FNAME(name)(MYSQL_THD thd, SHOW_VAR * var, char *buff) {     \
-    rocksdb_status_counters.name =                                             \
-        rocksdb_stats->getTickerCount(rocksdb::key);                           \
-    var->type = SHOW_LONGLONG;                                                 \
-    var->value = (char *)&rocksdb_status_counters.name;                        \
-    return HA_EXIT_SUCCESS;                                                    \
+#define DEF_SHOW_FUNC(name, key)                                           \
+  static int SHOW_FNAME(name)(MYSQL_THD thd, SHOW_VAR * var, char *buff) { \
+    rocksdb_status_counters.name =                                         \
+        rocksdb_stats->getTickerCount(rocksdb::key);                       \
+    var->type = SHOW_LONGLONG;                                             \
+    var->value = (char *)&rocksdb_status_counters.name;                    \
+    return HA_EXIT_SUCCESS;                                                \
   }
 
-#define DEF_STATUS_VAR(name)                                                   \
+#define DEF_STATUS_VAR(name) \
   { "rocksdb_" #name, (char *)&SHOW_FNAME(name), SHOW_FUNC, SHOW_SCOPE_GLOBAL }
 
-#define DEF_STATUS_VAR_PTR(name, ptr, option)                                  \
+#define DEF_STATUS_VAR_PTR(name, ptr, option) \
   { "rocksdb_" name, (char *)ptr, option, SHOW_SCOPE_GLOBAL }
 
-#define DEF_STATUS_VAR_FUNC(name, ptr, option)                                 \
+#define DEF_STATUS_VAR_FUNC(name, ptr, option) \
   { name, reinterpret_cast<char *>(ptr), option, SHOW_SCOPE_GLOBAL }
 
 struct rocksdb_status_counters_t {
@@ -12070,8 +12046,8 @@ static void myrocks_update_memory_status() {
 static SHOW_VAR myrocks_status_variables[] = {
     DEF_STATUS_VAR_FUNC("rows_deleted", &export_stats.rows_deleted,
                         SHOW_LONGLONG),
-    DEF_STATUS_VAR_FUNC("rows_deleted_blind",
-                        &export_stats.rows_deleted_blind, SHOW_LONGLONG),
+    DEF_STATUS_VAR_FUNC("rows_deleted_blind", &export_stats.rows_deleted_blind,
+                        SHOW_LONGLONG),
     DEF_STATUS_VAR_FUNC("rows_inserted", &export_stats.rows_inserted,
                         SHOW_LONGLONG),
     DEF_STATUS_VAR_FUNC("rows_read", &export_stats.rows_read, SHOW_LONGLONG),
@@ -12110,9 +12086,8 @@ static void show_myrocks_vars(THD *thd, SHOW_VAR *var, char *buff) {
   var->value = reinterpret_cast<char *>(&myrocks_status_variables);
 }
 
-static ulonglong
-io_stall_prop_value(const std::map<std::string, std::string> &props,
-                    const std::string &key) {
+static ulonglong io_stall_prop_value(
+    const std::map<std::string, std::string> &props, const std::string &key) {
   std::map<std::string, std::string>::const_iterator iter =
       props.find("io_stalls." + key);
   if (iter != props.end()) {
@@ -12461,8 +12436,7 @@ void Rdb_manual_compaction_thread::run() {
         RDB_MUTEX_LOCK_CHECK(m_signal_mutex);
         const bool local_stop = m_stop;
         RDB_MUTEX_UNLOCK_CHECK(m_signal_mutex);
-        if (local_stop)
-          break;
+        if (local_stop) break;
         my_sleep(1000000);
       }
     }
@@ -12660,8 +12634,8 @@ bool ha_rocksdb::can_use_bloom_filter(THD *thd, const Rdb_key_def &kd,
       shorter require all parts of the key to be available
       for the short key match.
     */
-    if ((use_all_keys && prefix_extractor->InRange(eq_cond))
-        || prefix_extractor->SameResultWhenAppended(eq_cond))
+    if ((use_all_keys && prefix_extractor->InRange(eq_cond)) ||
+        prefix_extractor->SameResultWhenAppended(eq_cond))
       can_use = true;
     else
       can_use = false;
@@ -12740,17 +12714,17 @@ const char *get_rdb_io_error_string(const RDB_IO_ERROR_TYPE err_type) {
   static_assert(RDB_IO_ERROR_LAST == 4, "Please handle all the error types.");
 
   switch (err_type) {
-  case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_TX_COMMIT:
-    return "RDB_IO_ERROR_TX_COMMIT";
-  case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_DICT_COMMIT:
-    return "RDB_IO_ERROR_DICT_COMMIT";
-  case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_BG_THREAD:
-    return "RDB_IO_ERROR_BG_THREAD";
-  case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_GENERAL:
-    return "RDB_IO_ERROR_GENERAL";
-  default:
-    DBUG_ASSERT(false);
-    return "(unknown)";
+    case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_TX_COMMIT:
+      return "RDB_IO_ERROR_TX_COMMIT";
+    case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_DICT_COMMIT:
+      return "RDB_IO_ERROR_DICT_COMMIT";
+    case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_BG_THREAD:
+      return "RDB_IO_ERROR_BG_THREAD";
+    case RDB_IO_ERROR_TYPE::RDB_IO_ERROR_GENERAL:
+      return "RDB_IO_ERROR_GENERAL";
+    default:
+      DBUG_ASSERT(false);
+      return "(unknown)";
   }
 }
 
@@ -12768,31 +12742,31 @@ void rdb_handle_io_error(const rocksdb::Status status,
                          const RDB_IO_ERROR_TYPE err_type) {
   if (status.IsIOError()) {
     switch (err_type) {
-    case RDB_IO_ERROR_TX_COMMIT:
-    case RDB_IO_ERROR_DICT_COMMIT: {
-      rdb_log_status_error(status, "failed to write to WAL");
-      /* NO_LINT_DEBUG */
-      sql_print_error("MyRocks: aborting on WAL write error.");
-      abort();
-      break;
-    }
-    case RDB_IO_ERROR_BG_THREAD: {
-      rdb_log_status_error(status, "BG thread failed to write to RocksDB");
-      /* NO_LINT_DEBUG */
-      sql_print_error("MyRocks: aborting on BG write error.");
-      abort();
-      break;
-    }
-    case RDB_IO_ERROR_GENERAL: {
-      rdb_log_status_error(status, "failed on I/O");
-      /* NO_LINT_DEBUG */
-      sql_print_error("MyRocks: aborting on I/O error.");
-      abort();
-      break;
-    }
-    default:
-      DBUG_ASSERT(0);
-      break;
+      case RDB_IO_ERROR_TX_COMMIT:
+      case RDB_IO_ERROR_DICT_COMMIT: {
+        rdb_log_status_error(status, "failed to write to WAL");
+        /* NO_LINT_DEBUG */
+        sql_print_error("MyRocks: aborting on WAL write error.");
+        abort();
+        break;
+      }
+      case RDB_IO_ERROR_BG_THREAD: {
+        rdb_log_status_error(status, "BG thread failed to write to RocksDB");
+        /* NO_LINT_DEBUG */
+        sql_print_error("MyRocks: aborting on BG write error.");
+        abort();
+        break;
+      }
+      case RDB_IO_ERROR_GENERAL: {
+        rdb_log_status_error(status, "failed on I/O");
+        /* NO_LINT_DEBUG */
+        sql_print_error("MyRocks: aborting on I/O error.");
+        abort();
+        break;
+      }
+      default:
+        DBUG_ASSERT(0);
+        break;
     }
   } else if (status.IsCorruption()) {
     rdb_log_status_error(status, "data corruption detected!");
@@ -12802,16 +12776,16 @@ void rdb_handle_io_error(const rocksdb::Status status,
     abort();
   } else if (!status.ok()) {
     switch (err_type) {
-    case RDB_IO_ERROR_DICT_COMMIT: {
-      rdb_log_status_error(status, "Failed to write to WAL (dictionary)");
-      /* NO_LINT_DEBUG */
-      sql_print_error("MyRocks: aborting on WAL write error.");
-      abort();
-      break;
-    }
-    default:
-      rdb_log_status_error(status, "Failed to read/write in RocksDB");
-      break;
+      case RDB_IO_ERROR_DICT_COMMIT: {
+        rdb_log_status_error(status, "Failed to write to WAL (dictionary)");
+        /* NO_LINT_DEBUG */
+        sql_print_error("MyRocks: aborting on WAL write error.");
+        abort();
+        break;
+      }
+      default:
+        rdb_log_status_error(status, "Failed to read/write in RocksDB");
+        break;
     }
   }
 }
@@ -12820,16 +12794,12 @@ Rdb_dict_manager *rdb_get_dict_manager(void) { return &dict_manager; }
 
 Rdb_ddl_manager *rdb_get_ddl_manager(void) { return &ddl_manager; }
 
-Rdb_hton_init_state *rdb_get_hton_init_state(void) {
-  return &hton_init_state;
-}
+Rdb_hton_init_state *rdb_get_hton_init_state(void) { return &hton_init_state; }
 
-void rocksdb_set_compaction_options(my_core::THD *const thd
-                                    MY_ATTRIBUTE((__unused__)),
-                                    my_core::st_mysql_sys_var *const var
-                                    MY_ATTRIBUTE((__unused__)),
-                                    void *const var_ptr,
-                                    const void *const save) {
+void rocksdb_set_compaction_options(
+    my_core::THD *const thd MY_ATTRIBUTE((__unused__)),
+    my_core::st_mysql_sys_var *const var MY_ATTRIBUTE((__unused__)),
+    void *const var_ptr, const void *const save) {
   if (var_ptr && save) {
     *(uint64_t *)var_ptr = *(const uint64_t *)save;
   }
@@ -12871,12 +12841,10 @@ void rocksdb_set_table_stats_sampling_pct(
   This is similar to the code in innodb_doublewrite_update (found in
   storage/innobase/handler/ha_innodb.cc).
 */
-void rocksdb_set_rate_limiter_bytes_per_sec(my_core::THD *const thd,
-                                            my_core::st_mysql_sys_var *const var
-                                            MY_ATTRIBUTE((__unused__)),
-                                            void *const var_ptr
-                                            MY_ATTRIBUTE((__unused__)),
-                                            const void *const save) {
+void rocksdb_set_rate_limiter_bytes_per_sec(
+    my_core::THD *const thd,
+    my_core::st_mysql_sys_var *const var MY_ATTRIBUTE((__unused__)),
+    void *const var_ptr MY_ATTRIBUTE((__unused__)), const void *const save) {
   const uint64_t new_val = *static_cast<const uint64_t *>(save);
   if (new_val == 0 || rocksdb_rate_limiter_bytes_per_sec == 0) {
     /*
@@ -12907,7 +12875,7 @@ void rocksdb_set_sst_mgr_rate_bytes_per_sec(
     rocksdb_sst_mgr_rate_bytes_per_sec = new_val;
 
     rocksdb_db_options->sst_file_manager->SetDeleteRateBytesPerSecond(
-      rocksdb_sst_mgr_rate_bytes_per_sec);
+        rocksdb_sst_mgr_rate_bytes_per_sec);
   }
 
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
@@ -12924,9 +12892,10 @@ void rocksdb_set_delayed_write_rate(THD *thd, struct st_mysql_sys_var *var,
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning("MyRocks: failed to update delayed_write_rate. "
-                        "status code = %d, status = %s",
-                        s.code(), s.ToString().c_str());
+      sql_print_warning(
+          "MyRocks: failed to update delayed_write_rate. "
+          "status code = %d, status = %s",
+          s.code(), s.ToString().c_str());
     }
   }
   RDB_MUTEX_UNLOCK_CHECK(rdb_sysvars_mutex);
@@ -12947,10 +12916,9 @@ void rdb_set_collation_exception_list(const char *const exception_list) {
   DBUG_ASSERT(rdb_collation_exceptions != nullptr);
 
   int flags = MY_REG_EXTENDED | MY_REG_NOSUB;
-  if (lower_case_table_names)
-    flags |= MY_REG_ICASE;
-  if (!rdb_collation_exceptions->compile(
-          exception_list, flags, table_alias_charset)) {
+  if (lower_case_table_names) flags |= MY_REG_ICASE;
+  if (!rdb_collation_exceptions->compile(exception_list, flags,
+                                         table_alias_charset)) {
     warn_about_bad_patterns(*rdb_collation_exceptions,
                             "strict_collation_exceptions");
   }
@@ -12985,8 +12953,7 @@ int mysql_value_to_bool(struct st_mysql_value *value, my_bool *return_value) {
   } else if (new_value_type == MYSQL_VALUE_TYPE_INT) {
     long long intbuf;
     value->val_int(value, &intbuf);
-    if (intbuf > 1)
-      return 1;
+    if (intbuf > 1) return 1;
     *return_value = intbuf > 0;
   } else {
     return 1;
@@ -13009,9 +12976,10 @@ int rocksdb_check_bulk_load(
     const int rc = tx->finish_bulk_load(&is_critical_error);
     if (rc != 0 && is_critical_error) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Error %d finalizing last SST file while "
-                      "setting bulk loading variable",
-                      rc);
+      sql_print_error(
+          "RocksDB: Error %d finalizing last SST file while "
+          "setting bulk loading variable",
+          rc);
       THDVAR(thd, bulk_load) = 0;
       return 1;
     }
@@ -13030,8 +12998,9 @@ int rocksdb_check_bulk_load_allow_unsorted(
   }
 
   if (THDVAR(thd, bulk_load)) {
-    sql_print_error("RocksDB: Cannot change this setting while bulk load is "
-                    "enabled");
+    sql_print_error(
+        "RocksDB: Cannot change this setting while bulk load is "
+        "enabled");
 
     return 1;
   }
@@ -13059,9 +13028,10 @@ static void rocksdb_set_max_background_jobs(THD *thd,
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning("MyRocks: failed to update max_background_jobs. "
-                        "Status code = %d, status = %s.",
-                        s.code(), s.ToString().c_str());
+      sql_print_warning(
+          "MyRocks: failed to update max_background_jobs. "
+          "Status code = %d, status = %s.",
+          s.code(), s.ToString().c_str());
     }
   }
 
@@ -13087,9 +13057,10 @@ static void rocksdb_set_bytes_per_sync(
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning("MyRocks: failed to update max_background_jobs. "
-                        "Status code = %d, status = %s.",
-                        s.code(), s.ToString().c_str());
+      sql_print_warning(
+          "MyRocks: failed to update max_background_jobs. "
+          "Status code = %d, status = %s.",
+          s.code(), s.ToString().c_str());
     }
   }
 
@@ -13115,9 +13086,10 @@ static void rocksdb_set_wal_bytes_per_sync(
 
     if (!s.ok()) {
       /* NO_LINT_DEBUG */
-      sql_print_warning("MyRocks: failed to update max_background_jobs. "
-                        "Status code = %d, status = %s.",
-                        s.code(), s.ToString().c_str());
+      sql_print_warning(
+          "MyRocks: failed to update max_background_jobs. "
+          "Status code = %d, status = %s.",
+          s.code(), s.ToString().c_str());
     }
   }
 
@@ -13164,7 +13136,6 @@ static int rocksdb_validate_update_cf_options(
     THD *thd MY_ATTRIBUTE((__unused__)),
     struct st_mysql_sys_var *var MY_ATTRIBUTE((__unused__)), void *save,
     struct st_mysql_value *value) {
-
   char buff[STRING_BUFFER_USUAL_SIZE];
   const char *str;
   int length;
@@ -13242,9 +13213,10 @@ static void rocksdb_set_update_cf_options(
 
       if (s != rocksdb::Status::OK()) {
         // NO_LINT_DEBUG
-        sql_print_warning("MyRocks: failed to convert the options for column "
-                          "family '%s' to a map. %s", cf_name.c_str(),
-                          s.ToString().c_str());
+        sql_print_warning(
+            "MyRocks: failed to convert the options for column "
+            "family '%s' to a map. %s",
+            cf_name.c_str(), s.ToString().c_str());
       } else {
         DBUG_ASSERT(rdb != nullptr);
 
@@ -13253,14 +13225,16 @@ static void rocksdb_set_update_cf_options(
 
         if (s != rocksdb::Status::OK()) {
           // NO_LINT_DEBUG
-          sql_print_warning("MyRocks: failed to apply the options for column "
-                            "family '%s'. %s", cf_name.c_str(),
-                            s.ToString().c_str());
+          sql_print_warning(
+              "MyRocks: failed to apply the options for column "
+              "family '%s'. %s",
+              cf_name.c_str(), s.ToString().c_str());
         } else {
           // NO_LINT_DEBUG
-          sql_print_information("MyRocks: options for column family '%s' "
-                                "have been successfully updated.",
-                                cf_name.c_str());
+          sql_print_information(
+              "MyRocks: options for column family '%s' "
+              "have been successfully updated.",
+              cf_name.c_str());
 
           // Make sure that data is internally consistent as well and update
           // the CF options. This is necessary also to make sure that the CF
@@ -13322,9 +13296,7 @@ void ha_rocksdb::rpl_after_update_rows() {
   DBUG_VOID_RETURN;
 }
 
-bool ha_rocksdb::rpl_lookup_rows() {
-  return !use_read_free_rpl();
-}
+bool ha_rocksdb::rpl_lookup_rows() { return !use_read_free_rpl(); }
 
 bool ha_rocksdb::is_read_free_rpl_table() const {
   return table->s && m_tbl_def->m_is_read_free_rpl_table;
@@ -13343,12 +13315,12 @@ bool ha_rocksdb::use_read_free_rpl() const {
   }
 
   switch (rocksdb_read_free_rpl) {
-  case read_free_rpl_type::OFF:
-    DBUG_RETURN(false);
-  case read_free_rpl_type::PK_ONLY:
-    DBUG_RETURN(!has_hidden_pk(table) && table->s->keys == 1);
-  case read_free_rpl_type::PK_SK:
-    DBUG_RETURN(!has_hidden_pk(table));
+    case read_free_rpl_type::OFF:
+      DBUG_RETURN(false);
+    case read_free_rpl_type::PK_ONLY:
+      DBUG_RETURN(!has_hidden_pk(table) && table->s->keys == 1);
+    case read_free_rpl_type::PK_SK:
+      DBUG_RETURN(!has_hidden_pk(table));
   }
 
   DBUG_ASSERT(false);
@@ -13380,7 +13352,7 @@ std::string rdb_corruption_marker_file_name() {
   return ret;
 }
 
-} // namespace myrocks
+}  // namespace myrocks
 
 /*
   Register the storage engine plugin outside of myrocks namespace

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -9811,14 +9811,17 @@ int ha_rocksdb::info(uint flag) {
         stats.records += m_table_handler->m_mtcache_count;
         stats.data_file_length += m_table_handler->m_mtcache_size;
       }
-
-      if (rocksdb_debug_optimizer_n_rows > 0)
-        stats.records = rocksdb_debug_optimizer_n_rows;
     }
 
-    if (stats.records != 0)
+    if (rocksdb_debug_optimizer_n_rows > 0) {
+      stats.records = rocksdb_debug_optimizer_n_rows;
+    }
+
+    if (stats.records != 0) {
       stats.mean_rec_length = stats.data_file_length / stats.records;
+    }
   }
+
   if (flag & (HA_STATUS_VARIABLE | HA_STATUS_CONST)) {
     ref_length = m_pk_descr->max_storage_fmt_length();
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7236,10 +7236,10 @@ ulong ha_rocksdb::index_flags(bool &pk_can_be_decoded,
   ulong base_flags = HA_READ_NEXT |  // doesn't seem to be used
                      HA_READ_ORDER | HA_READ_RANGE | HA_READ_PREV;
 
-  if (check_keyread_allowed(pk_can_be_decoded, table_share, inx, part,
-                            all_parts)) {
+  bool res = check_keyread_allowed(pk_can_be_decoded, table_share, inx, part,
+                                   all_parts);
+  if (res)
     base_flags |= HA_KEYREAD_ONLY;
-  }
 
   if (inx == table_share->primary_key) {
     /*

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -3332,8 +3332,6 @@ static Rdb_transaction *&get_tx_from_thd(THD *const thd) {
       my_core::thd_ha_data(thd, rocksdb_hton));
 }
 
-namespace {
-
 class Rdb_perf_context_guard {
   Rdb_io_perf m_io_perf;
   Rdb_io_perf *m_io_perf_ptr;
@@ -3368,8 +3366,6 @@ class Rdb_perf_context_guard {
     }
   }
 };
-
-}  // anonymous namespace
 
 /*
   TODO: maybe, call this in external_lock() and store in ha_rocksdb..

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -98,7 +98,7 @@ struct Rdb_table_handler {
   uint m_table_name_length;
   int m_ref_count;
 
-  my_core::THR_LOCK m_thr_lock; ///< MySQL latch needed by m_db_lock
+  my_core::THR_LOCK m_thr_lock;  ///< MySQL latch needed by m_db_lock
 
   /* Stores cumulative table statistics */
   my_io_perf_atomic_t m_io_perf_read;
@@ -111,18 +111,19 @@ struct Rdb_table_handler {
   uint64_t m_mtcache_last_update;
 };
 
-} // namespace myrocks
+}  // namespace myrocks
 
 /* Provide hash function for GL_INDEX_ID so we can include it in sets */
 namespace std {
-template <> struct hash<myrocks::GL_INDEX_ID> {
+template <>
+struct hash<myrocks::GL_INDEX_ID> {
   std::size_t operator()(const myrocks::GL_INDEX_ID &gl_index_id) const {
     const uint64_t val =
         ((uint64_t)gl_index_id.cf_id << 32 | (uint64_t)gl_index_id.index_id);
     return std::hash<uint64_t>()(val);
   }
 };
-} // namespace std
+}  // namespace std
 
 namespace myrocks {
 
@@ -132,9 +133,9 @@ namespace myrocks {
 */
 
 class ha_rocksdb : public my_core::handler {
-  my_core::THR_LOCK_DATA m_db_lock; ///< MySQL database lock
+  my_core::THR_LOCK_DATA m_db_lock;  ///< MySQL database lock
 
-  Rdb_table_handler *m_table_handler; ///< Open table handler
+  Rdb_table_handler *m_table_handler;  ///< Open table handler
 
   /* Iterator used for range scans and for full table/index scans */
   rocksdb::Iterator *m_scan_it;
@@ -316,17 +317,18 @@ class ha_rocksdb : public my_core::handler {
                            const bool use_all_keys, const uint eq_cond_len);
   void release_scan_iterator(void);
 
-  rocksdb::Status
-  get_for_update(Rdb_transaction *const tx,
-                 rocksdb::ColumnFamilyHandle *const column_family,
-                 const rocksdb::Slice &key,
-                 rocksdb::PinnableSlice *value) const;
+  rocksdb::Status get_for_update(
+      Rdb_transaction *const tx,
+      rocksdb::ColumnFamilyHandle *const column_family,
+      const rocksdb::Slice &key, rocksdb::PinnableSlice *value) const;
 
   int get_row_by_rowid(uchar *const buf, const char *const rowid,
-                       const uint rowid_size, const bool skip_ttl_check = true, const bool skip_lookup = false)
+                       const uint rowid_size, const bool skip_ttl_check = true,
+                       const bool skip_lookup = false)
       MY_ATTRIBUTE((__warn_unused_result__));
   int get_row_by_rowid(uchar *const buf, const uchar *const rowid,
-                       const uint rowid_size, const bool skip_ttl_check = true, const bool skip_lookup = false)
+                       const uint rowid_size, const bool skip_ttl_check = true,
+                       const bool skip_lookup = false)
       MY_ATTRIBUTE((__nonnull__, __warn_unused_result__)) {
     return get_row_by_rowid(buf, reinterpret_cast<const char *>(rowid),
                             rowid_size, skip_ttl_check, skip_lookup);
@@ -383,7 +385,7 @@ class ha_rocksdb : public my_core::handler {
   */
   void update_stats(void);
 
-public:
+ public:
   /*
     Controls whether writes include checksums. This is updated from the session
     variable
@@ -399,9 +401,10 @@ public:
     int err MY_ATTRIBUTE((__unused__));
     err = finalize_bulk_load(false);
     if (err != 0) {
-      sql_print_error("RocksDB: Error %d finalizing bulk load while closing "
-                      "handler.",
-                      err);
+      sql_print_error(
+          "RocksDB: Error %d finalizing bulk load while closing "
+          "handler.",
+          err);
     }
   }
 
@@ -513,10 +516,9 @@ public:
   static const std::vector<std::string> parse_into_tokens(const std::string &s,
                                                           const char delim);
 
-  static const std::string generate_cf_name(const uint index,
-    const TABLE *const table_arg,
-    const Rdb_tbl_def *const tbl_def_arg,
-    bool *per_part_match_found);
+  static const std::string generate_cf_name(
+      const uint index, const TABLE *const table_arg,
+      const Rdb_tbl_def *const tbl_def_arg, bool *per_part_match_found);
 
   static const char *get_key_name(const uint index,
                                   const TABLE *const table_arg,
@@ -658,7 +660,7 @@ public:
   /*
     Default implementation from cancel_pushed_idx_cond() suits us
   */
-private:
+ private:
   struct key_def_cf_info {
     rocksdb::ColumnFamilyHandle *cf_handle;
     bool is_reverse_cf;
@@ -725,10 +727,9 @@ private:
       uint64 ttl_duration, const std::string &ttl_column) const
       MY_ATTRIBUTE((__warn_unused_result__));
 
-  std::unordered_map<std::string, uint>
-  get_old_key_positions(const TABLE *table_arg, const Rdb_tbl_def *tbl_def_arg,
-                        const TABLE *old_table_arg,
-                        const Rdb_tbl_def *old_tbl_def_arg) const;
+  std::unordered_map<std::string, uint> get_old_key_positions(
+      const TABLE *table_arg, const Rdb_tbl_def *tbl_def_arg,
+      const TABLE *old_table_arg, const Rdb_tbl_def *old_tbl_def_arg) const;
 
   int compare_key_parts(const KEY *const old_key,
                         const KEY *const new_key) const
@@ -745,10 +746,8 @@ private:
                                    rocksdb::Iterator *const iter,
                                    bool seek_backward);
 
-  int index_first_intern(uchar *buf)
-      MY_ATTRIBUTE((__warn_unused_result__));
-  int index_last_intern(uchar *buf)
-      MY_ATTRIBUTE((__warn_unused_result__));
+  int index_first_intern(uchar *buf) MY_ATTRIBUTE((__warn_unused_result__));
+  int index_last_intern(uchar *buf) MY_ATTRIBUTE((__warn_unused_result__));
 
   enum icp_result check_index_cond() const;
   int find_icp_matching_index_rec(const bool move_forward, uchar *const buf)
@@ -961,10 +960,9 @@ private:
       TABLE *const altered_table,
       my_core::Alter_inplace_info *const ha_alter_info) override;
 
-  bool
-  commit_inplace_alter_table(TABLE *const altered_table,
-                             my_core::Alter_inplace_info *const ha_alter_info,
-                             bool commit) override;
+  bool commit_inplace_alter_table(
+      TABLE *const altered_table,
+      my_core::Alter_inplace_info *const ha_alter_info, bool commit) override;
 
   bool is_read_free_rpl_table() const;
 
@@ -976,7 +974,7 @@ private:
   virtual void rpl_after_update_rows() override;
   virtual bool rpl_lookup_rows() override;
 
-  virtual bool use_read_free_rpl() const; // MyRocks only
+  virtual bool use_read_free_rpl() const;  // MyRocks only
 
  private:
   /* Flags tracking if we are inside different replication operation */
@@ -1027,16 +1025,21 @@ struct Rdb_inplace_alter_ctx : public my_core::inplace_alter_handler_ctx {
       std::unordered_set<std::shared_ptr<Rdb_key_def>> added_indexes,
       std::unordered_set<GL_INDEX_ID> dropped_index_ids, uint n_added_keys,
       uint n_dropped_keys, ulonglong max_auto_incr)
-      : my_core::inplace_alter_handler_ctx(), m_new_tdef(new_tdef),
-        m_old_key_descr(old_key_descr), m_new_key_descr(new_key_descr),
-        m_old_n_keys(old_n_keys), m_new_n_keys(new_n_keys),
-        m_added_indexes(added_indexes), m_dropped_index_ids(dropped_index_ids),
-        m_n_added_keys(n_added_keys), m_n_dropped_keys(n_dropped_keys),
+      : my_core::inplace_alter_handler_ctx(),
+        m_new_tdef(new_tdef),
+        m_old_key_descr(old_key_descr),
+        m_new_key_descr(new_key_descr),
+        m_old_n_keys(old_n_keys),
+        m_new_n_keys(new_n_keys),
+        m_added_indexes(added_indexes),
+        m_dropped_index_ids(dropped_index_ids),
+        m_n_added_keys(n_added_keys),
+        m_n_dropped_keys(n_dropped_keys),
         m_max_auto_incr(max_auto_incr) {}
 
   ~Rdb_inplace_alter_ctx() {}
 
-private:
+ private:
   /* Disable Copying */
   Rdb_inplace_alter_ctx(const Rdb_inplace_alter_ctx &);
   Rdb_inplace_alter_ctx &operator=(const Rdb_inplace_alter_ctx &);
@@ -1052,20 +1055,19 @@ private:
 */
 struct Rdb_hton_init_state {
   struct Scoped_lock {
-    Scoped_lock(Rdb_hton_init_state& state, bool write) : m_state(state) {
+    Scoped_lock(Rdb_hton_init_state &state, bool write) : m_state(state) {
       if (write)
         m_state.lock_write();
       else
         m_state.lock_read();
     }
-    ~Scoped_lock() {
-      m_state.unlock();
-    }
-  private:
-    Scoped_lock(const Scoped_lock& sl) : m_state(sl.m_state) {}
-    void operator=(const Scoped_lock&) {}
+    ~Scoped_lock() { m_state.unlock(); }
 
-    Rdb_hton_init_state& m_state;
+   private:
+    Scoped_lock(const Scoped_lock &sl) : m_state(sl.m_state) {}
+    void operator=(const Scoped_lock &) {}
+
+    Rdb_hton_init_state &m_state;
   };
 
   Rdb_hton_init_state() : m_initialized(false) {
@@ -1076,39 +1078,27 @@ struct Rdb_hton_init_state {
     mysql_rwlock_init(0, &m_rwlock);
   }
 
-  ~Rdb_hton_init_state() {
-    mysql_rwlock_destroy(&m_rwlock);
-  }
+  ~Rdb_hton_init_state() { mysql_rwlock_destroy(&m_rwlock); }
 
-  void lock_read() {
-    mysql_rwlock_rdlock(&m_rwlock);
-  }
+  void lock_read() { mysql_rwlock_rdlock(&m_rwlock); }
 
-  void lock_write() {
-    mysql_rwlock_wrlock(&m_rwlock);
-  }
+  void lock_write() { mysql_rwlock_wrlock(&m_rwlock); }
 
-  void unlock() {
-    mysql_rwlock_unlock(&m_rwlock);
-  }
+  void unlock() { mysql_rwlock_unlock(&m_rwlock); }
 
   /*
     Must be called with either a read or write lock held, unable to enforce
     behavior as mysql_rwlock has no means of determining if a thread has a lock
   */
-  bool initialized() const {
-    return m_initialized;
-  }
+  bool initialized() const { return m_initialized; }
 
   /*
     Must be called with only a write lock held, unable to enforce behavior as
     mysql_rwlock has no means of determining if a thread has a lock
   */
-  void set_initialized(bool init) {
-    m_initialized = init;
-  }
+  void set_initialized(bool init) { m_initialized = init; }
 
-private:
+ private:
   mysql_rwlock_t m_rwlock;
   bool m_initialized;
 };
@@ -1116,4 +1106,4 @@ private:
 // file name indicating RocksDB data corruption
 std::string rdb_corruption_marker_file_name();
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -397,7 +397,7 @@ class ha_rocksdb : public my_core::handler {
 
   ha_rocksdb(my_core::handlerton *const hton,
              my_core::TABLE_SHARE *const table_arg);
-  ~ha_rocksdb() {
+  virtual ~ha_rocksdb() override {
     int err MY_ATTRIBUTE((__unused__));
     err = finalize_bulk_load(false);
     if (err != 0) {

--- a/storage/rocksdb/ha_rocksdb_proto.h
+++ b/storage/rocksdb/ha_rocksdb_proto.h
@@ -92,4 +92,4 @@ Rdb_ddl_manager *rdb_get_ddl_manager(void)
 struct Rdb_hton_init_state;
 Rdb_hton_init_state *rdb_get_hton_init_state(void)
     MY_ATTRIBUTE((__warn_unused_result__));
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/ha_rockspart.cc
+++ b/storage/rocksdb/ha_rockspart.cc
@@ -70,15 +70,13 @@ handler *ha_rockspart::clone(const char *name, MEM_ROOT *mem_root) {
 
   DBUG_ENTER("ha_rockspart::clone");
 
-  /* If this->table == nullptr, then the current handler has been created but not
-  opened. Prohibit cloning such handler. */
-  if (!table)
-    DBUG_RETURN(nullptr);
+  /* If this->table == nullptr, then the current handler has been created but
+  not opened. Prohibit cloning such handler. */
+  if (!table) DBUG_RETURN(nullptr);
 
   new_handler =
       new (mem_root) ha_rockspart(ht, table_share, m_part_info, this, mem_root);
-  if (!new_handler)
-    DBUG_RETURN(nullptr);
+  if (!new_handler) DBUG_RETURN(nullptr);
 
   /*
     Allocate new_handler->ref here because otherwise ha_open will allocate it
@@ -121,8 +119,6 @@ const char **ha_rockspart::bas_ext() const {
 /** Get partition row type
 @param[in] Id of partition for which row type to be retrieved
 @return Partition row type */
-enum row_type ha_rockspart::get_partition_row_type(
-        uint part_id)
-{
+enum row_type ha_rockspart::get_partition_row_type(uint part_id) {
   return get_row_type();
 }

--- a/storage/rocksdb/ib_ut0counter.h
+++ b/storage/rocksdb/ib_ut0counter.h
@@ -16,13 +16,13 @@ this program; if not, write to the Free Software Foundation, Inc.,
 
 *****************************************************************************/
 
-/**************************************************//**
-@file include/ut0counter.h
+/**************************************************/ /**
+ @file include/ut0counter.h
 
-Counter utility class
+ Counter utility class
 
-Created 2012/04/12 by Sunny Bains
-*******************************************************/
+ Created 2012/04/12 by Sunny Bains
+ *******************************************************/
 
 #ifndef UT0COUNTER_H
 #define UT0COUNTER_H
@@ -33,7 +33,7 @@ Created 2012/04/12 by Sunny Bains
 #define INNOBASE_CACHE_LINE_SIZE 64
 
 /** Default number of slots to use in ib_counter_t */
-#define IB_N_SLOTS		64
+#define IB_N_SLOTS 64
 
 #ifdef __WIN__
 #define get_curr_thread_id() GetCurrentThreadId()
@@ -46,13 +46,12 @@ Created 2012/04/12 by Sunny Bains
 /** Get the offset into the counter array. */
 template <typename Type, int N>
 struct generic_indexer_t {
-	/** Default constructor/destructor should be OK. */
+  /** Default constructor/destructor should be OK. */
 
-        /** @return offset within m_counter */
-        size_t offset(size_t index) const {
-                return(((index % N) + 1) * (INNOBASE_CACHE_LINE_SIZE /
-			sizeof(Type)));
-        }
+  /** @return offset within m_counter */
+  size_t offset(size_t index) const {
+    return (((index % N) + 1) * (INNOBASE_CACHE_LINE_SIZE / sizeof(Type)));
+  }
 };
 
 #ifdef HAVE_SCHED_GETCPU
@@ -62,150 +61,142 @@ struct generic_indexer_t {
 use the thread id. */
 template <typename Type, int N>
 struct get_sched_indexer_t : public generic_indexer_t<Type, N> {
-	/** Default constructor/destructor should be OK. */
+  /** Default constructor/destructor should be OK. */
 
-	/* @return result from sched_getcpu(), the thread id if it fails. */
-	size_t get_rnd_index() const {
+  /* @return result from sched_getcpu(), the thread id if it fails. */
+  size_t get_rnd_index() const {
+    size_t cpu = sched_getcpu();
+    if (cpu == (size_t)-1) {
+      cpu = get_curr_thread_id();
+    }
 
-		size_t	cpu = sched_getcpu();
-		if (cpu == (size_t) -1) {
-			cpu = get_curr_thread_id();
-		}
-
-		return(cpu);
-	}
+    return (cpu);
+  }
 };
 #endif /* HAVE_SCHED_GETCPU */
 
 /** Use the thread id to index into the counter array. */
 template <typename Type, int N>
 struct thread_id_indexer_t : public generic_indexer_t<Type, N> {
-	/** Default constructor/destructor should are OK. */
+  /** Default constructor/destructor should are OK. */
 
-	/* @return a random number, currently we use the thread id. Where
-	thread id is represented as a pointer, it may not work as
-	effectively. */
-	size_t get_rnd_index() const {
-		return get_curr_thread_id();
-	}
+  /* @return a random number, currently we use the thread id. Where
+  thread id is represented as a pointer, it may not work as
+  effectively. */
+  size_t get_rnd_index() const { return get_curr_thread_id(); }
 };
 
 /** For counters wher N=1 */
-template <typename Type, int N=1>
+template <typename Type, int N = 1>
 struct single_indexer_t {
-	/** Default constructor/destructor should are OK. */
+  /** Default constructor/destructor should are OK. */
 
-        /** @return offset within m_counter */
-        size_t offset(size_t index) const {
-		DBUG_ASSERT(N == 1);
-                return((INNOBASE_CACHE_LINE_SIZE / sizeof(Type)));
-        }
+  /** @return offset within m_counter */
+  size_t offset(size_t index) const {
+    DBUG_ASSERT(N == 1);
+    return ((INNOBASE_CACHE_LINE_SIZE / sizeof(Type)));
+  }
 
-	/* @return 1 */
-	size_t get_rnd_index() const {
-		DBUG_ASSERT(N == 1);
-		return(1);
-	}
+  /* @return 1 */
+  size_t get_rnd_index() const {
+    DBUG_ASSERT(N == 1);
+    return (1);
+  }
 };
 
 /** Class for using fuzzy counters. The counter is not protected by any
 mutex and the results are not guaranteed to be 100% accurate but close
 enough. Creates an array of counters and separates each element by the
 INNOBASE_CACHE_LINE_SIZE bytes */
-template <
-	typename Type,
-	int N = IB_N_SLOTS,
-	template<typename, int> class Indexer = thread_id_indexer_t>
+template <typename Type, int N = IB_N_SLOTS,
+          template <typename, int> class Indexer = thread_id_indexer_t>
 class ib_counter_t {
-public:
-	ib_counter_t() { memset(m_counter, 0x0, sizeof(m_counter)); }
+ public:
+  ib_counter_t() { memset(m_counter, 0x0, sizeof(m_counter)); }
 
-	~ib_counter_t()
-	{
-		DBUG_ASSERT(validate());
-	}
+  ~ib_counter_t() { DBUG_ASSERT(validate()); }
 
-	bool validate() {
+  bool validate() {
 #ifdef UNIV_DEBUG
-		size_t	n = (INNOBASE_CACHE_LINE_SIZE / sizeof(Type));
+    size_t n = (INNOBASE_CACHE_LINE_SIZE / sizeof(Type));
 
-		/* Check that we aren't writing outside our defined bounds. */
-		for (size_t i = 0; i < UT_ARRAY_SIZE(m_counter); i += n) {
-			for (size_t j = 1; j < n - 1; ++j) {
-				DBUG_ASSERT(m_counter[i + j] == 0);
-			}
-		}
+    /* Check that we aren't writing outside our defined bounds. */
+    for (size_t i = 0; i < UT_ARRAY_SIZE(m_counter); i += n) {
+      for (size_t j = 1; j < n - 1; ++j) {
+        DBUG_ASSERT(m_counter[i + j] == 0);
+      }
+    }
 #endif /* UNIV_DEBUG */
-		return(true);
-	}
+    return (true);
+  }
 
-	/** If you can't use a good index id. Increment by 1. */
-	void inc() { add(1); }
+  /** If you can't use a good index id. Increment by 1. */
+  void inc() { add(1); }
 
-	/** If you can't use a good index id.
-	* @param n  - is the amount to increment */
-	void add(Type n) {
-		size_t	i = m_policy.offset(m_policy.get_rnd_index());
+  /** If you can't use a good index id.
+   * @param n  - is the amount to increment */
+  void add(Type n) {
+    size_t i = m_policy.offset(m_policy.get_rnd_index());
 
-		DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
+    DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
 
-		m_counter[i] += n;
-	}
+    m_counter[i] += n;
+  }
 
-	/** Use this if you can use a unique indentifier, saves a
-	call to get_rnd_index().
-	@param i - index into a slot
-	@param n - amount to increment */
-	void add(size_t index, Type n) {
-		size_t	i = m_policy.offset(index);
+  /** Use this if you can use a unique indentifier, saves a
+  call to get_rnd_index().
+  @param i - index into a slot
+  @param n - amount to increment */
+  void add(size_t index, Type n) {
+    size_t i = m_policy.offset(index);
 
-		DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
+    DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
 
-		m_counter[i] += n;
-	}
+    m_counter[i] += n;
+  }
 
-	/** If you can't use a good index id. Decrement by 1. */
-	void dec() { sub(1); }
+  /** If you can't use a good index id. Decrement by 1. */
+  void dec() { sub(1); }
 
-	/** If you can't use a good index id.
-	* @param - n is the amount to decrement */
-	void sub(Type n) {
-		size_t	i = m_policy.offset(m_policy.get_rnd_index());
+  /** If you can't use a good index id.
+   * @param - n is the amount to decrement */
+  void sub(Type n) {
+    size_t i = m_policy.offset(m_policy.get_rnd_index());
 
-		DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
+    DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
 
-		m_counter[i] -= n;
-	}
+    m_counter[i] -= n;
+  }
 
-	/** Use this if you can use a unique indentifier, saves a
-	call to get_rnd_index().
-	@param i - index into a slot
-	@param n - amount to decrement */
-	void sub(size_t index, Type n) {
-		size_t	i = m_policy.offset(index);
+  /** Use this if you can use a unique indentifier, saves a
+  call to get_rnd_index().
+  @param i - index into a slot
+  @param n - amount to decrement */
+  void sub(size_t index, Type n) {
+    size_t i = m_policy.offset(index);
 
-		DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
+    DBUG_ASSERT(i < UT_ARRAY_SIZE(m_counter));
 
-		m_counter[i] -= n;
-	}
+    m_counter[i] -= n;
+  }
 
-	/* @return total value - not 100% accurate, since it is not atomic. */
-	operator Type() const {
-		Type	total = 0;
+  /* @return total value - not 100% accurate, since it is not atomic. */
+  operator Type() const {
+    Type total = 0;
 
-		for (size_t i = 0; i < N; ++i) {
-			total += m_counter[m_policy.offset(i)];
-		}
+    for (size_t i = 0; i < N; ++i) {
+      total += m_counter[m_policy.offset(i)];
+    }
 
-		return(total);
-	}
+    return (total);
+  }
 
-private:
-	/** Indexer into the array */
-	Indexer<Type, N>m_policy;
+ private:
+  /** Indexer into the array */
+  Indexer<Type, N> m_policy;
 
-        /** Slot 0 is unused. */
-	Type m_counter[(N + 1) * (INNOBASE_CACHE_LINE_SIZE / sizeof(Type))];
+  /** Slot 0 is unused. */
+  Type m_counter[(N + 1) * (INNOBASE_CACHE_LINE_SIZE / sizeof(Type))];
 };
 
 #endif /* UT0COUNTER_H */

--- a/storage/rocksdb/logger.h
+++ b/storage/rocksdb/logger.h
@@ -15,14 +15,14 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #pragma once
 
-#include "log.h"
 #include <sstream>
 #include <string>
+#include "log.h"
 
 namespace myrocks {
 
 class Rdb_logger : public rocksdb::Logger {
-public:
+ public:
   explicit Rdb_logger(const rocksdb::InfoLogLevel log_level =
                           rocksdb::InfoLogLevel::ERROR_LEVEL)
       : m_mysql_log_level(log_level) {}
@@ -77,9 +77,9 @@ public:
     m_mysql_log_level = log_level;
   }
 
-private:
+ private:
   std::shared_ptr<rocksdb::Logger> m_logger;
   rocksdb::InfoLogLevel m_mysql_log_level;
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -45,10 +45,17 @@ Rdb_tbl_prop_coll::Rdb_tbl_prop_coll(Rdb_ddl_manager *const ddl_manager,
                                      const Rdb_compact_params &params,
                                      const uint32_t cf_id,
                                      const uint8_t table_stats_sampling_pct)
-    : m_cf_id(cf_id), m_ddl_manager(ddl_manager), m_last_stats(nullptr),
-      m_rows(0l), m_window_pos(0l), m_deleted_rows(0l), m_max_deleted_rows(0l),
-      m_file_size(0), m_params(params),
-      m_cardinality_collector(table_stats_sampling_pct), m_recorded(false) {
+    : m_cf_id(cf_id),
+      m_ddl_manager(ddl_manager),
+      m_last_stats(nullptr),
+      m_rows(0l),
+      m_window_pos(0l),
+      m_deleted_rows(0l),
+      m_max_deleted_rows(0l),
+      m_file_size(0),
+      m_params(params),
+      m_cardinality_collector(table_stats_sampling_pct),
+      m_recorded(false) {
   DBUG_ASSERT(ddl_manager != nullptr);
 
   m_deleted_rows_window.resize(m_params.m_window, false);
@@ -149,28 +156,29 @@ void Rdb_tbl_prop_coll::CollectStatsForRow(const rocksdb::Slice &key,
 
   // Incrementing per-index entry-type statistics
   switch (type) {
-  case rocksdb::kEntryPut:
-    stats->m_rows++;
-    break;
-  case rocksdb::kEntryDelete:
-    stats->m_entry_deletes++;
-    break;
-  case rocksdb::kEntrySingleDelete:
-    stats->m_entry_single_deletes++;
-    break;
-  case rocksdb::kEntryMerge:
-    stats->m_entry_merges++;
-    break;
-  case rocksdb::kEntryOther:
-    stats->m_entry_others++;
-    break;
-  default:
-    // NO_LINT_DEBUG
-    sql_print_error("RocksDB: Unexpected entry type found: %u. "
-                    "This should not happen so aborting the system.",
-                    type);
-    abort();
-    break;
+    case rocksdb::kEntryPut:
+      stats->m_rows++;
+      break;
+    case rocksdb::kEntryDelete:
+      stats->m_entry_deletes++;
+      break;
+    case rocksdb::kEntrySingleDelete:
+      stats->m_entry_single_deletes++;
+      break;
+    case rocksdb::kEntryMerge:
+      stats->m_entry_merges++;
+      break;
+    case rocksdb::kEntryOther:
+      stats->m_entry_others++;
+      break;
+    default:
+      // NO_LINT_DEBUG
+      sql_print_error(
+          "RocksDB: Unexpected entry type found: %u. "
+          "This should not happen so aborting the system.",
+          type);
+      abort();
+      break;
   }
 
   stats->m_actual_disk_size += file_size - m_file_size;
@@ -186,8 +194,8 @@ const char *Rdb_tbl_prop_coll::INDEXSTATS_KEY = "__indexstats__";
 /*
   This function is called by RocksDB to compute properties to store in sst file
 */
-rocksdb::Status
-Rdb_tbl_prop_coll::Finish(rocksdb::UserCollectedProperties *const properties) {
+rocksdb::Status Rdb_tbl_prop_coll::Finish(
+    rocksdb::UserCollectedProperties *const properties) {
   uint64_t num_sst_entry_put = 0;
   uint64_t num_sst_entry_delete = 0;
   uint64_t num_sst_entry_singledelete = 0;
@@ -243,8 +251,8 @@ bool Rdb_tbl_prop_coll::NeedCompact() const {
 /*
   Returns the same as above, but in human-readable way for logging
 */
-rocksdb::UserCollectedProperties
-Rdb_tbl_prop_coll::GetReadableProperties() const {
+rocksdb::UserCollectedProperties Rdb_tbl_prop_coll::GetReadableProperties()
+    const {
   std::string s;
 #ifdef DBUG_OFF
   s.append("[...");
@@ -315,8 +323,8 @@ void Rdb_tbl_prop_coll::read_stats_from_tbl_props(
 /*
   Serializes an array of Rdb_index_stats into a network string.
 */
-std::string
-Rdb_index_stats::materialize(const std::vector<Rdb_index_stats> &stats) {
+std::string Rdb_index_stats::materialize(
+    const std::vector<Rdb_index_stats> &stats) {
   String ret;
   rdb_netstr_append_uint16(&ret, INDEX_STATS_VERSION_ENTRY_TYPES);
   for (const auto &i : stats) {
@@ -362,9 +370,10 @@ int Rdb_index_stats::unmaterialize(const std::string &s,
   if (version < INDEX_STATS_VERSION_INITIAL ||
       version > INDEX_STATS_VERSION_ENTRY_TYPES) {
     // NO_LINT_DEBUG
-    sql_print_error("Index stats version %d was outside of supported range. "
-                    "This should not happen so aborting the system.",
-                    version);
+    sql_print_error(
+        "Index stats version %d was outside of supported range. "
+        "This should not happen so aborting the system.",
+        version);
     abort();
   }
 
@@ -393,8 +402,7 @@ int Rdb_index_stats::unmaterialize(const std::string &s,
       stats.m_entry_merges = rdb_netbuf_read_uint64(&p);
       stats.m_entry_others = rdb_netbuf_read_uint64(&p);
     }
-    if (p +
-            stats.m_distinct_keys_per_prefix.size() *
+    if (p + stats.m_distinct_keys_per_prefix.size() *
                 sizeof(stats.m_distinct_keys_per_prefix[0]) >
         p2) {
       return HA_EXIT_FAILURE;
@@ -527,4 +535,4 @@ void Rdb_tbl_card_coll::AdjustStats(Rdb_index_stats *stats) {
   }
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/properties_collector.cc
+++ b/storage/rocksdb/properties_collector.cc
@@ -260,7 +260,7 @@ rocksdb::UserCollectedProperties Rdb_tbl_prop_coll::GetReadableProperties()
   s.append("  records...]");
 #else
   bool first = true;
-  for (auto it : m_stats) {
+  for (const auto &it : m_stats) {
     if (first) {
       first = false;
     } else {

--- a/storage/rocksdb/properties_collector.h
+++ b/storage/rocksdb/properties_collector.h
@@ -54,7 +54,7 @@ struct Rdb_index_stats {
   int64_t m_entry_deletes, m_entry_single_deletes;
   int64_t m_entry_merges, m_entry_others;
   std::vector<int64_t> m_distinct_keys_per_prefix;
-  std::string m_name; // name is not persisted
+  std::string m_name;  // name is not persisted
 
   static std::string materialize(const std::vector<Rdb_index_stats> &stats);
   static int unmaterialize(const std::string &s,
@@ -62,9 +62,14 @@ struct Rdb_index_stats {
 
   Rdb_index_stats() : Rdb_index_stats({0, 0}) {}
   explicit Rdb_index_stats(GL_INDEX_ID gl_index_id)
-      : m_gl_index_id(gl_index_id), m_data_size(0), m_rows(0),
-        m_actual_disk_size(0), m_entry_deletes(0), m_entry_single_deletes(0),
-        m_entry_merges(0), m_entry_others(0) {}
+      : m_gl_index_id(gl_index_id),
+        m_data_size(0),
+        m_rows(0),
+        m_actual_disk_size(0),
+        m_entry_deletes(0),
+        m_entry_single_deletes(0),
+        m_entry_merges(0),
+        m_entry_others(0) {}
 
   void merge(const Rdb_index_stats &s, const bool increment = true,
              const int64_t estimated_data_len = 0);
@@ -105,38 +110,38 @@ class Rdb_tbl_card_coll {
 };
 
 class Rdb_tbl_prop_coll : public rocksdb::TablePropertiesCollector {
-public:
- Rdb_tbl_prop_coll(Rdb_ddl_manager *const ddl_manager,
-                   const Rdb_compact_params &params, const uint32_t cf_id,
-                   const uint8_t table_stats_sampling_pct);
+ public:
+  Rdb_tbl_prop_coll(Rdb_ddl_manager *const ddl_manager,
+                    const Rdb_compact_params &params, const uint32_t cf_id,
+                    const uint8_t table_stats_sampling_pct);
 
- /*
-   Override parent class's virtual methods of interest.
- */
+  /*
+    Override parent class's virtual methods of interest.
+  */
 
- virtual rocksdb::Status AddUserKey(const rocksdb::Slice &key,
-                                    const rocksdb::Slice &value,
-                                    rocksdb::EntryType type,
-                                    rocksdb::SequenceNumber seq,
-                                    uint64_t file_size) override;
+  virtual rocksdb::Status AddUserKey(const rocksdb::Slice &key,
+                                     const rocksdb::Slice &value,
+                                     rocksdb::EntryType type,
+                                     rocksdb::SequenceNumber seq,
+                                     uint64_t file_size) override;
 
- virtual rocksdb::Status
- Finish(rocksdb::UserCollectedProperties *properties) override;
+  virtual rocksdb::Status Finish(
+      rocksdb::UserCollectedProperties *properties) override;
 
- virtual const char *Name() const override { return "Rdb_tbl_prop_coll"; }
+  virtual const char *Name() const override { return "Rdb_tbl_prop_coll"; }
 
- rocksdb::UserCollectedProperties GetReadableProperties() const override;
+  rocksdb::UserCollectedProperties GetReadableProperties() const override;
 
- bool NeedCompact() const override;
+  bool NeedCompact() const override;
 
-public:
+ public:
   uint64_t GetMaxDeletedRows() const { return m_max_deleted_rows; }
 
   static void read_stats_from_tbl_props(
       const std::shared_ptr<const rocksdb::TableProperties> &table_props,
       std::vector<Rdb_index_stats> *out_stats_vector);
 
-private:
+ private:
   static std::string GetReadableStats(const Rdb_index_stats &it);
 
   bool ShouldCollectStats();
@@ -147,7 +152,7 @@ private:
   Rdb_index_stats *AccessStats(const rocksdb::Slice &key);
   void AdjustDeletedRows(rocksdb::EntryType type);
 
-private:
+ private:
   uint32_t m_cf_id;
   std::shared_ptr<const Rdb_key_def> m_keydef;
   Rdb_ddl_manager *m_ddl_manager;
@@ -169,10 +174,10 @@ private:
 
 class Rdb_tbl_prop_coll_factory
     : public rocksdb::TablePropertiesCollectorFactory {
-public:
+ public:
   Rdb_tbl_prop_coll_factory(const Rdb_tbl_prop_coll_factory &) = delete;
-  Rdb_tbl_prop_coll_factory &
-  operator=(const Rdb_tbl_prop_coll_factory &) = delete;
+  Rdb_tbl_prop_coll_factory &operator=(const Rdb_tbl_prop_coll_factory &) =
+      delete;
 
   explicit Rdb_tbl_prop_coll_factory(Rdb_ddl_manager *ddl_manager)
       : m_ddl_manager(ddl_manager) {}
@@ -192,7 +197,7 @@ public:
     return "Rdb_tbl_prop_coll_factory";
   }
 
-public:
+ public:
   void SetCompactionParams(const Rdb_compact_params &params) {
     m_params = params;
   }
@@ -201,10 +206,10 @@ public:
     m_table_stats_sampling_pct = table_stats_sampling_pct;
   }
 
-private:
+ private:
   Rdb_ddl_manager *const m_ddl_manager;
   Rdb_compact_params m_params;
   uint8_t m_table_stats_sampling_pct;
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_buff.h
+++ b/storage/rocksdb/rdb_buff.h
@@ -273,9 +273,9 @@ class Rdb_string_reader {
 
   bool read_uint8(uint *const res) {
     const uchar *p;
-    if (!(p = reinterpret_cast<const uchar *>(read(1))))
+    if (!(p = reinterpret_cast<const uchar *>(read(1)))) {
       return true;  // error
-    else {
+    } else {
       *res = *p;
       return false;  // Ok
     }
@@ -283,9 +283,9 @@ class Rdb_string_reader {
 
   bool read_uint16(uint *const res) {
     const uchar *p;
-    if (!(p = reinterpret_cast<const uchar *>(read(2))))
+    if (!(p = reinterpret_cast<const uchar *>(read(2)))) {
       return true;  // error
-    else {
+    } else {
       *res = rdb_netbuf_to_uint16(p);
       return false;  // Ok
     }

--- a/storage/rocksdb/rdb_buff.h
+++ b/storage/rocksdb/rdb_buff.h
@@ -221,10 +221,10 @@ class Rdb_string_reader {
   const char *m_ptr;
   uint m_len;
 
-private:
+ private:
   Rdb_string_reader &operator=(const Rdb_string_reader &) = default;
 
-public:
+ public:
   Rdb_string_reader(const Rdb_string_reader &) = default;
   /* named constructor */
   static Rdb_string_reader read_or_empty(const rocksdb::Slice *const slice) {
@@ -274,20 +274,20 @@ public:
   bool read_uint8(uint *const res) {
     const uchar *p;
     if (!(p = reinterpret_cast<const uchar *>(read(1))))
-      return true; // error
+      return true;  // error
     else {
       *res = *p;
-      return false; // Ok
+      return false;  // Ok
     }
   }
 
   bool read_uint16(uint *const res) {
     const uchar *p;
     if (!(p = reinterpret_cast<const uchar *>(read(2))))
-      return true; // error
+      return true;  // error
     else {
       *res = rdb_netbuf_to_uint16(p);
-      return false; // Ok
+      return false;  // Ok
     }
   }
 
@@ -329,7 +329,7 @@ public:
 class Rdb_string_writer {
   std::vector<uchar> m_data;
 
-public:
+ public:
   Rdb_string_writer(const Rdb_string_writer &) = delete;
   Rdb_string_writer &operator=(const Rdb_string_writer &) = delete;
   Rdb_string_writer() = default;
@@ -399,7 +399,7 @@ class Rdb_bit_writer {
   Rdb_string_writer *m_writer;
   uchar m_offset;
 
-public:
+ public:
   Rdb_bit_writer(const Rdb_bit_writer &) = delete;
   Rdb_bit_writer &operator=(const Rdb_bit_writer &) = delete;
 
@@ -431,7 +431,7 @@ class Rdb_bit_reader {
   uint m_ret;
   Rdb_string_reader *const m_reader;
 
-public:
+ public:
   Rdb_bit_reader(const Rdb_bit_reader &) = delete;
   Rdb_bit_reader &operator=(const Rdb_bit_reader &) = delete;
 
@@ -464,7 +464,8 @@ public:
   }
 };
 
-template <size_t buf_length> class Rdb_buf_writer {
+template <size_t buf_length>
+class Rdb_buf_writer {
  public:
   Rdb_buf_writer(const Rdb_buf_writer &) = delete;
   Rdb_buf_writer &operator=(const Rdb_buf_writer &) = delete;
@@ -526,4 +527,4 @@ template <size_t buf_length> class Rdb_buf_writer {
   uchar *m_ptr;
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -36,7 +36,7 @@ bool Rdb_cf_manager::is_cf_name_reverse(const char *const name) {
 }
 
 void Rdb_cf_manager::init(
-    std::unique_ptr<Rdb_cf_options> cf_options,
+    std::unique_ptr<Rdb_cf_options> &&cf_options,
     std::vector<rocksdb::ColumnFamilyHandle *> *const handles) {
 #ifdef HAVE_PSI_INTERFACE
   mysql_mutex_init(rdb_cfm_mutex_key, &m_mutex, MY_MUTEX_INIT_FAST);

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -102,8 +102,10 @@ rocksdb::ColumnFamilyHandle *Rdb_cf_manager::get_or_create_cf(
       // NO_LINT_DEBUG
       sql_print_information("RocksDB: creating a column family %s",
                             cf_name.c_str());
+      // NO_LINT_DEBUG
       sql_print_information("    write_buffer_size=%ld",
                             opts.write_buffer_size);
+      // NO_LINT_DEBUG
       sql_print_information("    target_file_size_base=%" PRIu64,
                             opts.target_file_size_base);
 

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -15,7 +15,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #ifdef USE_PRAGMA_IMPLEMENTATION
-#pragma implementation // gcc: Class implementation
+#pragma implementation  // gcc: Class implementation
 #endif
 
 /* This C++ files header file */
@@ -72,9 +72,8 @@ void Rdb_cf_manager::cleanup() {
   @detail
     See Rdb_cf_manager::get_cf
 */
-rocksdb::ColumnFamilyHandle *
-Rdb_cf_manager::get_or_create_cf(rocksdb::DB *const rdb,
-                                 const std::string &cf_name_arg, bool create) {
+rocksdb::ColumnFamilyHandle *Rdb_cf_manager::get_or_create_cf(
+    rocksdb::DB *const rdb, const std::string &cf_name_arg, bool create) {
   DBUG_ASSERT(rdb != nullptr);
 
   rocksdb::ColumnFamilyHandle *cf_handle = nullptr;
@@ -136,8 +135,8 @@ Rdb_cf_manager::get_or_create_cf(rocksdb::DB *const rdb,
   Find column family by its cf_name.
 */
 
-rocksdb::ColumnFamilyHandle *
-Rdb_cf_manager::get_cf(const std::string &cf_name_arg) const {
+rocksdb::ColumnFamilyHandle *Rdb_cf_manager::get_cf(
+    const std::string &cf_name_arg) const {
   rocksdb::ColumnFamilyHandle *cf_handle;
 
   RDB_MUTEX_LOCK_CHECK(m_mutex);
@@ -162,8 +161,7 @@ rocksdb::ColumnFamilyHandle *Rdb_cf_manager::get_cf(const uint32_t id) const {
 
   RDB_MUTEX_LOCK_CHECK(m_mutex);
   const auto it = m_cf_id_map.find(id);
-  if (it != m_cf_id_map.end())
-    cf_handle = it->second;
+  if (it != m_cf_id_map.end()) cf_handle = it->second;
   RDB_MUTEX_UNLOCK_CHECK(m_mutex);
 
   return cf_handle;
@@ -181,8 +179,8 @@ std::vector<std::string> Rdb_cf_manager::get_cf_names(void) const {
   return names;
 }
 
-std::vector<rocksdb::ColumnFamilyHandle *>
-Rdb_cf_manager::get_all_cf(void) const {
+std::vector<rocksdb::ColumnFamilyHandle *> Rdb_cf_manager::get_all_cf(
+    void) const {
   std::vector<rocksdb::ColumnFamilyHandle *> list;
 
   RDB_MUTEX_LOCK_CHECK(m_mutex);
@@ -197,4 +195,4 @@ Rdb_cf_manager::get_all_cf(void) const {
   return list;
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -58,7 +58,7 @@ void Rdb_cf_manager::init(
 }
 
 void Rdb_cf_manager::cleanup() {
-  for (auto it : m_cf_name_map) {
+  for (const auto &it : m_cf_name_map) {
     delete it.second;
   }
   mysql_mutex_destroy(&m_mutex);
@@ -173,7 +173,7 @@ std::vector<std::string> Rdb_cf_manager::get_cf_names(void) const {
   std::vector<std::string> names;
 
   RDB_MUTEX_LOCK_CHECK(m_mutex);
-  for (auto it : m_cf_name_map) {
+  for (const auto &it : m_cf_name_map) {
     names.push_back(it.first);
   }
   RDB_MUTEX_UNLOCK_CHECK(m_mutex);

--- a/storage/rocksdb/rdb_cf_manager.h
+++ b/storage/rocksdb/rdb_cf_manager.h
@@ -66,7 +66,7 @@ class Rdb_cf_manager {
     column
     families that are present in the database. The first CF is the default CF.
   */
-  void init(std::unique_ptr<Rdb_cf_options> cf_options,
+  void init(std::unique_ptr<Rdb_cf_options> &&cf_options,
             std::vector<rocksdb::ColumnFamilyHandle *> *const handles);
   void cleanup();
 

--- a/storage/rocksdb/rdb_cf_manager.h
+++ b/storage/rocksdb/rdb_cf_manager.h
@@ -105,4 +105,4 @@ class Rdb_cf_manager {
   }
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_cf_options.cc
+++ b/storage/rocksdb/rdb_cf_options.cc
@@ -15,7 +15,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #ifdef USE_PRAGMA_IMPLEMENTATION
-#pragma implementation // gcc: Class implementation
+#pragma implementation  // gcc: Class implementation
 #endif
 
 /* This C++ files header file */
@@ -99,10 +99,9 @@ void Rdb_cf_options::update(const std::string &cf_name,
 bool Rdb_cf_options::set_default(const std::string &default_config) {
   rocksdb::ColumnFamilyOptions options;
 
-  if (!default_config.empty() &&
-      !rocksdb::GetColumnFamilyOptionsFromString(options, default_config,
-                                                 &options)
-           .ok()) {
+  if (!default_config.empty() && !rocksdb::GetColumnFamilyOptionsFromString(
+                                      options, default_config, &options)
+                                      .ok()) {
     fprintf(stderr, "Invalid default column family config: %s\n",
             default_config.c_str());
     return false;
@@ -116,8 +115,7 @@ bool Rdb_cf_options::set_default(const std::string &default_config) {
 void Rdb_cf_options::skip_spaces(const std::string &input, size_t *const pos) {
   DBUG_ASSERT(pos != nullptr);
 
-  while (*pos < input.size() && isspace(input[*pos]))
-    ++(*pos);
+  while (*pos < input.size() && isspace(input[*pos])) ++(*pos);
 }
 
 // Find a valid column family name.  Note that all characters except a
@@ -135,8 +133,7 @@ bool Rdb_cf_options::find_column_family(const std::string &input,
   // Loop through the characters in the string until we see a '='.
   for (; *pos < input.size() && input[*pos] != '='; ++(*pos)) {
     // If this is not a space, move the end position to the current position.
-    if (input[*pos] != ' ')
-      end_pos = *pos;
+    if (input[*pos] != ' ') end_pos = *pos;
   }
 
   if (end_pos == beg_pos - 1) {
@@ -177,24 +174,24 @@ bool Rdb_cf_options::find_options(const std::string &input, size_t *const pos,
   // number of closing curly braces.
   while (*pos < input.size()) {
     switch (input[*pos]) {
-    case '}':
-      // If this is a closing curly brace and we bring the count down to zero
-      // we can exit the loop with a valid options string.
-      if (--brace_count == 0) {
-        *options = input.substr(beg_pos, *pos - beg_pos);
-        ++(*pos); // Move past the last closing curly brace
-        return true;
-      }
+      case '}':
+        // If this is a closing curly brace and we bring the count down to zero
+        // we can exit the loop with a valid options string.
+        if (--brace_count == 0) {
+          *options = input.substr(beg_pos, *pos - beg_pos);
+          ++(*pos);  // Move past the last closing curly brace
+          return true;
+        }
 
-      break;
+        break;
 
-    case '{':
-      // If this is an open curly brace increment the count.
-      ++brace_count;
-      break;
+      case '{':
+        // If this is an open curly brace increment the count.
+        ++brace_count;
+        break;
 
-    default:
-      break;
+      default:
+        break;
     }
 
     // Move to the next character.
@@ -221,8 +218,7 @@ bool Rdb_cf_options::find_cf_options_pair(const std::string &input,
   skip_spaces(input, pos);
 
   // We should now have a column family name.
-  if (!find_column_family(input, pos, cf))
-    return false;
+  if (!find_column_family(input, pos, cf)) return false;
 
   // If we are at the end of the input then we generate an error.
   if (*pos == input.size()) {
@@ -238,8 +234,7 @@ bool Rdb_cf_options::find_cf_options_pair(const std::string &input,
 
   // Find the options for this column family.  This should be in the format
   // {<options>} where <options> may contain embedded pairs of curly braces.
-  if (!find_options(input, pos, opt_str))
-    return false;
+  if (!find_options(input, pos, opt_str)) return false;
 
   // Skip any trailing spaces after the option string.
   skip_spaces(input, pos);
@@ -260,7 +255,7 @@ bool Rdb_cf_options::find_cf_options_pair(const std::string &input,
 }
 
 bool Rdb_cf_options::parse_cf_options(const std::string &cf_options,
-  Name_to_config_t *option_map) {
+                                      Name_to_config_t *option_map) {
   std::string cf;
   std::string opt_str;
   rocksdb::ColumnFamilyOptions options;
@@ -316,8 +311,8 @@ bool Rdb_cf_options::set_override(const std::string &override_config) {
   return true;
 }
 
-const rocksdb::Comparator *
-Rdb_cf_options::get_cf_comparator(const std::string &cf_name) {
+const rocksdb::Comparator *Rdb_cf_options::get_cf_comparator(
+    const std::string &cf_name) {
   if (Rdb_cf_manager::is_cf_name_reverse(cf_name.c_str())) {
     return &s_rev_pk_comparator;
   } else {
@@ -325,8 +320,8 @@ Rdb_cf_options::get_cf_comparator(const std::string &cf_name) {
   }
 }
 
-std::shared_ptr<rocksdb::MergeOperator>
-Rdb_cf_options::get_cf_merge_operator(const std::string &cf_name) {
+std::shared_ptr<rocksdb::MergeOperator> Rdb_cf_options::get_cf_merge_operator(
+    const std::string &cf_name) {
   return (cf_name == DEFAULT_SYSTEM_CF_NAME)
              ? std::make_shared<Rdb_system_merge_op>()
              : nullptr;
@@ -345,4 +340,4 @@ bool Rdb_cf_options::get_cf_options(const std::string &cf_name,
   return ret;
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_cf_options.cc
+++ b/storage/rocksdb/rdb_cf_options.cc
@@ -102,6 +102,7 @@ bool Rdb_cf_options::set_default(const std::string &default_config) {
   if (!default_config.empty() && !rocksdb::GetColumnFamilyOptionsFromString(
                                       options, default_config, &options)
                                       .ok()) {
+    // NO_LINT_DEBUG
     fprintf(stderr, "Invalid default column family config: %s\n",
             default_config.c_str());
     return false;

--- a/storage/rocksdb/rdb_cf_options.h
+++ b/storage/rocksdb/rdb_cf_options.h
@@ -39,7 +39,7 @@ namespace myrocks {
     families not found in the map.
 */
 class Rdb_cf_options {
-public:
+ public:
   using Name_to_config_t = std::unordered_map<std::string, std::string>;
 
   Rdb_cf_options(const Rdb_cf_options &) = delete;
@@ -62,20 +62,20 @@ public:
     return m_default_cf_opts;
   }
 
-  static const rocksdb::Comparator *
-  get_cf_comparator(const std::string &cf_name);
+  static const rocksdb::Comparator *get_cf_comparator(
+      const std::string &cf_name);
 
-  std::shared_ptr<rocksdb::MergeOperator>
-  get_cf_merge_operator(const std::string &cf_name);
+  std::shared_ptr<rocksdb::MergeOperator> get_cf_merge_operator(
+      const std::string &cf_name);
 
   /* bool true return indicates cf_name was found, otherwise default */
   bool get_cf_options(const std::string &cf_name,
                       rocksdb::ColumnFamilyOptions *const opts);
 
   static bool parse_cf_options(const std::string &cf_options,
-    Name_to_config_t *option_map);
+                               Name_to_config_t *option_map);
 
-private:
+ private:
   bool set_default(const std::string &default_config);
   bool set_override(const std::string &overide_config);
 
@@ -89,7 +89,7 @@ private:
                                    std::string *const cf,
                                    std::string *const opt_str);
 
-private:
+ private:
   static Rdb_pk_comparator s_pk_comparator;
   static Rdb_rev_comparator s_rev_pk_comparator;
 
@@ -102,4 +102,4 @@ private:
   rocksdb::ColumnFamilyOptions m_default_cf_opts;
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_compact_filter.h
+++ b/storage/rocksdb/rdb_compact_filter.h
@@ -17,12 +17,12 @@
 #pragma once
 
 #ifdef USE_PRAGMA_IMPLEMENTATION
-#pragma implementation // gcc: Class implementation
+#pragma implementation  // gcc: Class implementation
 #endif
 
 /* C++ system header files */
-#include <string>
 #include <time.h>
+#include <string>
 
 /* RocksDB includes */
 #include "rocksdb/compaction_filter.h"
@@ -34,7 +34,7 @@
 namespace myrocks {
 
 class Rdb_compact_filter : public rocksdb::CompactionFilter {
-public:
+ public:
   Rdb_compact_filter(const Rdb_compact_filter &) = delete;
   Rdb_compact_filter &operator=(const Rdb_compact_filter &) = delete;
 
@@ -133,9 +133,10 @@ public:
     struct Rdb_index_info index_info;
     if (!rdb_get_dict_manager()->get_index_info(gl_index_id, &index_info)) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Could not get index information "
-                      "for Index Number (%u,%u)",
-                      gl_index_id.cf_id, gl_index_id.index_id);
+      sql_print_error(
+          "RocksDB: Could not get index information "
+          "for Index Number (%u,%u)",
+          gl_index_id.cf_id, gl_index_id.index_id);
     }
 
 #if !defined(DBUG_OFF)
@@ -163,9 +164,10 @@ public:
       buf = rdb_hexdump(existing_value.data(), existing_value.size(),
                         RDB_MAX_HEXDUMP_LEN);
       // NO_LINT_DEBUG
-      sql_print_error("Decoding ttl from PK value failed in compaction filter, "
-                      "for index (%u,%u), val: %s",
-                      m_prev_index.cf_id, m_prev_index.index_id, buf.c_str());
+      sql_print_error(
+          "Decoding ttl from PK value failed in compaction filter, "
+          "for index (%u,%u), val: %s",
+          m_prev_index.cf_id, m_prev_index.index_id, buf.c_str());
       abort();
     }
 
@@ -197,10 +199,10 @@ public:
 };
 
 class Rdb_compact_filter_factory : public rocksdb::CompactionFilterFactory {
-public:
+ public:
   Rdb_compact_filter_factory(const Rdb_compact_filter_factory &) = delete;
-  Rdb_compact_filter_factory &
-  operator=(const Rdb_compact_filter_factory &) = delete;
+  Rdb_compact_filter_factory &operator=(const Rdb_compact_filter_factory &) =
+      delete;
   Rdb_compact_filter_factory() {}
 
   ~Rdb_compact_filter_factory() {}
@@ -214,4 +216,4 @@ public:
   }
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_comparator.h
+++ b/storage/rocksdb/rdb_comparator.h
@@ -36,7 +36,7 @@ namespace myrocks {
    Rdb_key_def)
 */
 class Rdb_pk_comparator : public rocksdb::Comparator {
-public:
+ public:
   Rdb_pk_comparator(const Rdb_pk_comparator &) = delete;
   Rdb_pk_comparator &operator=(const Rdb_pk_comparator &) = delete;
   Rdb_pk_comparator() = default;
@@ -63,7 +63,7 @@ public:
 };
 
 class Rdb_rev_comparator : public rocksdb::Comparator {
-public:
+ public:
   Rdb_rev_comparator(const Rdb_rev_comparator &) = delete;
   Rdb_rev_comparator &operator=(const Rdb_rev_comparator &) = delete;
   Rdb_rev_comparator() = default;
@@ -82,4 +82,4 @@ public:
   }
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -512,7 +512,7 @@ int Rdb_converter::decode(const std::shared_ptr<Rdb_key_def> &key_def,
               key_def->m_index_type == Rdb_key_def::INDEX_TYPE_HIDDEN_PRIMARY);
 
   const rocksdb::Slice *updated_key_slice = key_slice;
-#ifndef NDEBUG
+#ifndef DBUG_OFF
   String last_rowkey;
   last_rowkey.copy(key_slice->data(), key_slice->size(), &my_charset_bin);
   DBUG_EXECUTE_IF("myrocks_simulate_bad_pk_read1",
@@ -717,7 +717,7 @@ int Rdb_converter::encode_value_slice(
       DBUG_ASSERT(field->real_type() == MYSQL_TYPE_LONGLONG);
 
       uint64 ts = uint8korr(field->ptr);
-#ifndef NDEBUG
+#ifndef DBUG_OFF
       ts += rdb_dbug_set_ttl_rec_ts();
 #endif
       rdb_netbuf_store_uint64(reinterpret_cast<uchar *>(data), ts);
@@ -739,7 +739,7 @@ int Rdb_converter::encode_value_slice(
         memcpy(data, ttl_bytes, sizeof(uint64));
       } else {
         uint64 ts = static_cast<uint64>(std::time(nullptr));
-#ifndef NDEBUG
+#ifndef DBUG_OFF
         ts += rdb_dbug_set_ttl_rec_ts();
 #endif
         rdb_netbuf_store_uint64(reinterpret_cast<uchar *>(data), ts);

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -32,8 +32,8 @@
 #include "./ha_rocksdb.h"
 #include "./ha_rocksdb_proto.h"
 #include "./rdb_datadic.h"
-#include "./rdb_utils.h"
 #include "./rdb_psi.h"
+#include "./rdb_utils.h"
 
 namespace myrocks {
 
@@ -193,7 +193,6 @@ int Rdb_convert_to_record_value_decoder::decode_fixed_length_field(
 */
 int Rdb_convert_to_record_value_decoder::decode_varchar(
     Field *field, Rdb_string_reader *const reader, bool decode) {
-
   my_core::Field_varstring *const field_var = (my_core::Field_varstring *)field;
 
   const char *data_len_str;
@@ -302,8 +301,8 @@ int Rdb_value_field_iterator<value_field_decoder>::get_field_index() const {
 }
 
 template <typename value_field_decoder>
-enum_field_types
-Rdb_value_field_iterator<value_field_decoder>::get_field_type() const {
+enum_field_types Rdb_value_field_iterator<value_field_decoder>::get_field_type()
+    const {
   DBUG_ASSERT(m_field_dec != nullptr);
   return m_field_dec->m_field_type;
 }
@@ -431,9 +430,11 @@ void Rdb_converter::setup_field_encoders() {
 
   m_encoder_arr = static_cast<Rdb_field_encoder *>(
 #ifdef HAVE_PSI_INTERFACE
-      my_malloc(rdb_handler_memory_key, m_table->s->fields * sizeof(Rdb_field_encoder), MYF(0)));
+      my_malloc(rdb_handler_memory_key,
+                m_table->s->fields * sizeof(Rdb_field_encoder), MYF(0)));
 #else
-      my_malloc(PSI_NOT_INSTRUMENTED, m_table->s->fields * sizeof(Rdb_field_encoder), MYF(0)));
+      my_malloc(PSI_NOT_INSTRUMENTED,
+                m_table->s->fields * sizeof(Rdb_field_encoder), MYF(0)));
 #endif
   if (m_encoder_arr == nullptr) {
     return;

--- a/storage/rocksdb/rdb_converter.h
+++ b/storage/rocksdb/rdb_converter.h
@@ -21,10 +21,10 @@
 #include <vector>
 
 // MySQL header files
-#include "handler.h"    // handler
+#include "handler.h"  // handler
+#include "ib_ut0counter.h"
 #include "my_global.h"  // ulonglong
 #include "sql_string.h"
-#include "ib_ut0counter.h"
 
 // MyRocks header files
 #include "./ha_rocksdb.h"
@@ -54,8 +54,8 @@ class Rdb_convert_to_record_value_decoder {
   Rdb_convert_to_record_value_decoder() = delete;
   Rdb_convert_to_record_value_decoder(
       const Rdb_convert_to_record_value_decoder &decoder) = delete;
-  Rdb_convert_to_record_value_decoder &
-  operator=(const Rdb_convert_to_record_value_decoder &decoder) = delete;
+  Rdb_convert_to_record_value_decoder &operator=(
+      const Rdb_convert_to_record_value_decoder &decoder) = delete;
 
   static int decode(uchar *const buf, uint *offset, TABLE *table,
                     my_core::Field *field, Rdb_field_encoder *field_dec,
@@ -79,7 +79,8 @@ class Rdb_convert_to_record_value_decoder {
   The reason to use template class instead of normal class is to elimate
   virtual method call.
 */
-template <typename value_field_decoder> class Rdb_value_field_iterator {
+template <typename value_field_decoder>
+class Rdb_value_field_iterator {
  private:
   bool m_is_null;
   std::vector<READ_FIELD>::const_iterator m_field_iter;
@@ -101,8 +102,8 @@ template <typename value_field_decoder> class Rdb_value_field_iterator {
                            uchar *const buf);
   Rdb_value_field_iterator(const Rdb_value_field_iterator &field_iterator) =
       delete;
-  Rdb_value_field_iterator &
-  operator=(const Rdb_value_field_iterator &field_iterator) = delete;
+  Rdb_value_field_iterator &operator=(
+      const Rdb_value_field_iterator &field_iterator) = delete;
 
   /*
     Move and decode next field

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -415,9 +415,9 @@ void Rdb_key_def::setup(const TABLE *const tbl,
       m_name = HIDDEN_PK_NAME;
     }
 
-    if (secondary_key)
+    if (secondary_key) {
       m_pk_key_parts = hidden_pk_exists ? 1 : pk_info->actual_key_parts;
-    else {
+    } else {
       pk_info = nullptr;
       m_pk_key_parts = 0;
     }
@@ -443,7 +443,7 @@ void Rdb_key_def::setup(const TABLE *const tbl,
       m_key_parts += m_pk_key_parts;
     }
 
-    if (secondary_key)
+    if (secondary_key) {
 #ifdef HAVE_PSI_INTERFACE
       m_pk_part_no = static_cast<uint *>(my_malloc(
           rdb_datadic_memory_key, sizeof(uint) * m_key_parts, MYF(0)));
@@ -451,8 +451,9 @@ void Rdb_key_def::setup(const TABLE *const tbl,
       m_pk_part_no = static_cast<uint *>(
           my_malloc(PSI_NOT_INSTRUMENTED, sizeof(uint) * m_key_parts, MYF(0)));
 #endif
-    else
+    } else {
       m_pk_part_no = nullptr;
+    }
 
     const size_t size = sizeof(Rdb_field_packing) * m_key_parts;
 #ifdef HAVE_PSI_INTERFACE
@@ -1301,10 +1302,11 @@ uint Rdb_key_def::pack_record(const TABLE *const tbl, uchar *const pack_buffer,
 
   // If hidden pk exists, but hidden pk wasnt passed in, we can't pack the
   // hidden key part.  So we skip it (its always 1 part).
-  if (hidden_pk_exists && !hidden_pk_id && use_all_columns)
+  if (hidden_pk_exists && !hidden_pk_id && use_all_columns) {
     n_key_parts = m_key_parts - 1;
-  else if (use_all_columns)
+  } else if (use_all_columns) {
     n_key_parts = m_key_parts;
+  }
 
   if (n_null_fields) *n_null_fields = 0;
 
@@ -2427,25 +2429,28 @@ int Rdb_key_def::unpack_integer(
   const int length = fpi->m_max_image_len;
 
   const uchar *from;
-  if (!(from = (const uchar *)reader->read(length)))
+  if (!(from = (const uchar *)reader->read(length))) {
     return UNPACK_FAILURE; /* Mem-comparable image doesn't have enough bytes */
+  }
 
 #ifdef WORDS_BIGENDIAN
   {
-    if (((Field_num *)field)->unsigned_flag)
+    if (static_cast<Field_num *>(field)->unsigned_flag) {
       to[0] = from[0];
-    else
-      to[0] = (char)(from[0] ^ 128);  // Reverse the sign bit.
+    } else {
+      to[0] = static_cast<char>(from[0] ^ 128);  // Reverse the sign bit.
+    }
     memcpy(to + 1, from + 1, length - 1);
   }
 #else
   {
     const int sign_byte = from[0];
-    if (((Field_num *)field)->unsigned_flag)
+    if (static_cast<Field_num *>(field)->unsigned_flag) {
       to[length - 1] = sign_byte;
-    else
+    } else {
       to[length - 1] =
           static_cast<char>(sign_byte ^ 128);  // Reverse the sign bit.
+    }
     for (int i = 0, j = length - 1; i < length - 1; ++i, --j) to[i] = from[j];
   }
 #endif
@@ -2492,8 +2497,10 @@ int Rdb_key_def::unpack_floating_point(
     const int exp_digit, const uchar *const zero_pattern,
     const uchar *const zero_val, void (*swap_func)(uchar *, const uchar *)) {
   const uchar *const from = (const uchar *)reader->read(size);
-  if (from == nullptr)
-    return UNPACK_FAILURE; /* Mem-comparable image doesn't have enough bytes */
+  if (from == nullptr) {
+    /* Mem-comparable image doesn't have enough bytes */
+    return UNPACK_FAILURE;
+  }
 
   /* Check to see if the value is zero */
   if (memcmp(from, zero_pattern, size) == 0) {
@@ -2588,8 +2595,10 @@ int Rdb_key_def::unpack_newdate(
   const char *from;
   DBUG_ASSERT(fpi->m_max_image_len == 3);
 
-  if (!(from = reader->read(3)))
-    return UNPACK_FAILURE; /* Mem-comparable image doesn't have enough bytes */
+  if (!(from = reader->read(3))) {
+    /* Mem-comparable image doesn't have enough bytes */
+    return UNPACK_FAILURE;
+  }
 
   field_ptr[0] = from[2];
   field_ptr[1] = from[1];
@@ -2608,8 +2617,10 @@ int Rdb_key_def::unpack_binary_str(
     Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   const char *from;
-  if (!(from = reader->read(fpi->m_max_image_len)))
-    return UNPACK_FAILURE; /* Mem-comparable image doesn't have enough bytes */
+  if (!(from = reader->read(fpi->m_max_image_len))) {
+    /* Mem-comparable image doesn't have enough bytes */
+    return UNPACK_FAILURE;
+  }
 
   memcpy(to, from, fpi->m_max_image_len);
   return UNPACK_SUCCESS;
@@ -2627,8 +2638,10 @@ int Rdb_key_def::unpack_utf8_str(
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   my_core::CHARSET_INFO *const cset = (my_core::CHARSET_INFO *)field->charset();
   const uchar *src;
-  if (!(src = (const uchar *)reader->read(fpi->m_max_image_len)))
-    return UNPACK_FAILURE; /* Mem-comparable image doesn't have enough bytes */
+  if (!(src = (const uchar *)reader->read(fpi->m_max_image_len))) {
+    /* Mem-comparable image doesn't have enough bytes */
+    return UNPACK_FAILURE;
+  }
 
   const uchar *const src_end = src + fpi->m_max_image_len;
   uchar *const dst_end = dst + field->pack_length();
@@ -2911,11 +2924,11 @@ void Rdb_key_def::pack_with_varchar_space_pad(
       const int cmp =
           rdb_compare_string_with_spaces(buf, buf_end, fpi->space_xfrm);
 
-      if (cmp < 0)
+      if (cmp < 0) {
         *ptr = VARCHAR_CMP_LESS_THAN_SPACES;
-      else if (cmp > 0)
+      } else if (cmp > 0) {
         *ptr = VARCHAR_CMP_GREATER_THAN_SPACES;
-      else {
+      } else {
         // It turns out all the rest are spaces.
         *ptr = VARCHAR_CMP_EQUAL_TO_SPACES;
       }
@@ -3131,8 +3144,9 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
     space_padding_bytes =
         -(static_cast<int>(extra_spaces) - RDB_TRIMMED_CHARS_OFFSET);
     extra_spaces = 0;
-  } else
+  } else {
     extra_spaces -= RDB_TRIMMED_CHARS_OFFSET;
+  }
 
   space_padding_bytes *= fpi->space_xfrm_len;
 
@@ -3142,8 +3156,9 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
     size_t used_bytes;
     if (last_byte == VARCHAR_CMP_EQUAL_TO_SPACES)  // this is the last segment
     {
-      if (space_padding_bytes > (fpi->m_segment_size - 1))
+      if (space_padding_bytes > (fpi->m_segment_size - 1)) {
         return UNPACK_FAILURE;  // Cannot happen, corrupted data
+      }
       used_bytes = (fpi->m_segment_size - 1) - space_padding_bytes;
       finished = true;
     } else {
@@ -3403,8 +3418,9 @@ int Rdb_key_def::unpack_simple_varchar_space_pad(
   if (extra_spaces <= 8) {
     space_padding_bytes = -(static_cast<int>(extra_spaces) - 8);
     extra_spaces = 0;
-  } else
+  } else {
     extra_spaces -= 8;
+  }
 
   space_padding_bytes *= fpi->space_xfrm_len;
 
@@ -3415,8 +3431,9 @@ int Rdb_key_def::unpack_simple_varchar_space_pad(
     size_t used_bytes;
     if (last_byte == VARCHAR_CMP_EQUAL_TO_SPACES) {
       // this is the last one
-      if (space_padding_bytes > (fpi->m_segment_size - 1))
+      if (space_padding_bytes > (fpi->m_segment_size - 1)) {
         return UNPACK_FAILURE;  // Cannot happen, corrupted data
+      }
       used_bytes = (fpi->m_segment_size - 1) - space_padding_bytes;
       finished = true;
     } else {
@@ -4506,8 +4523,9 @@ bool Rdb_ddl_manager::validate_auto_incr() {
     GL_INDEX_ID gl_index_id;
 
     if (key.size() >= Rdb_key_def::INDEX_NUMBER_SIZE &&
-        memcmp(key.data(), auto_incr_entry, Rdb_key_def::INDEX_NUMBER_SIZE))
+        memcmp(key.data(), auto_incr_entry, Rdb_key_def::INDEX_NUMBER_SIZE)) {
       break;
+    }
 
     if (key.size() != Rdb_key_def::INDEX_NUMBER_SIZE * 3) {
       return false;
@@ -4623,8 +4641,9 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
     const rocksdb::Slice val = it->value();
 
     if (key.size() >= Rdb_key_def::INDEX_NUMBER_SIZE &&
-        memcmp(key.data(), ddl_entry, Rdb_key_def::INDEX_NUMBER_SIZE))
+        memcmp(key.data(), ddl_entry, Rdb_key_def::INDEX_NUMBER_SIZE)) {
       break;
+    }
 
     if (key.size() <= Rdb_key_def::INDEX_NUMBER_SIZE) {
       sql_print_error("RocksDB: Table_store: key has length %d (corruption?)",

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -4358,6 +4358,7 @@ bool Rdb_validate_tbls::check_frm_file(const std::string &fullpath,
   enum legacy_db_type eng_type;
   frm_type_enum type = dd_frm_type(nullptr, fullfilename.c_ptr(), &eng_type);
   if (type == FRMTYPE_ERROR) {
+    // NO_LINT_DEBUG
     sql_print_warning("RocksDB: Failed to open/read .from file: %s",
                       fullfilename.ptr());
     return false;
@@ -4414,6 +4415,7 @@ bool Rdb_validate_tbls::scan_for_frms(const std::string &datadir,
 
   /* Access the directory */
   if (dir_info == nullptr) {
+    // NO_LINT_DEBUG
     sql_print_warning("RocksDB: Could not open database directory: %s",
                       fullpath.c_str());
     return false;
@@ -4460,6 +4462,7 @@ bool Rdb_validate_tbls::compare_to_actual_tables(const std::string &datadir,
 
   dir_info = my_dir(datadir.c_str(), MYF(MY_DONT_SORT | MY_WANT_STAT));
   if (dir_info == nullptr) {
+    // NO_LINT_DEBUG
     sql_print_warning("RocksDB: could not open datadir: %s", datadir.c_str());
     return false;
   }
@@ -4756,6 +4759,7 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
     return true;
   }
   delete it;
+  // NO_LINT_DEBUG
   sql_print_information("RocksDB: Table_store: loaded DDL data for %d tables",
                         i);
   return false;

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -15,7 +15,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #ifdef USE_PRAGMA_IMPLEMENTATION
-#pragma implementation // gcc: Class implementation
+#pragma implementation  // gcc: Class implementation
 #endif
 
 /* This C++ file's header file */
@@ -286,16 +286,26 @@ Rdb_key_def::Rdb_key_def(uint indexnr_arg, uint keyno_arg,
                          bool is_per_partition_cf_arg, const char *_name,
                          Rdb_index_stats _stats, uint32 index_flags_bitmap,
                          uint32 ttl_rec_offset, uint64 ttl_duration)
-    : m_index_number(indexnr_arg), m_cf_handle(cf_handle_arg),
+    : m_index_number(indexnr_arg),
+      m_cf_handle(cf_handle_arg),
       m_index_dict_version(index_dict_version_arg),
-      m_index_type(index_type_arg), m_kv_format_version(kv_format_version_arg),
+      m_index_type(index_type_arg),
+      m_kv_format_version(kv_format_version_arg),
       m_is_reverse_cf(is_reverse_cf_arg),
-      m_is_per_partition_cf(is_per_partition_cf_arg), m_name(_name),
-      m_stats(_stats), m_index_flags_bitmap(index_flags_bitmap),
-      m_ttl_rec_offset(ttl_rec_offset), m_ttl_duration(ttl_duration),
-      m_ttl_column(""), m_pk_part_no(nullptr), m_pack_info(nullptr),
-      m_keyno(keyno_arg), m_key_parts(0), m_ttl_pk_key_part_offset(UINT_MAX),
-      m_ttl_field_index(UINT_MAX), m_prefix_extractor(nullptr),
+      m_is_per_partition_cf(is_per_partition_cf_arg),
+      m_name(_name),
+      m_stats(_stats),
+      m_index_flags_bitmap(index_flags_bitmap),
+      m_ttl_rec_offset(ttl_rec_offset),
+      m_ttl_duration(ttl_duration),
+      m_ttl_column(""),
+      m_pk_part_no(nullptr),
+      m_pack_info(nullptr),
+      m_keyno(keyno_arg),
+      m_key_parts(0),
+      m_ttl_pk_key_part_offset(UINT_MAX),
+      m_ttl_field_index(UINT_MAX),
+      m_prefix_extractor(nullptr),
       m_maxlength(0)  // means 'not intialized'
 {
   mysql_mutex_init(0, &m_mutex, MY_MUTEX_INIT_FAST);
@@ -312,16 +322,23 @@ Rdb_key_def::Rdb_key_def(uint indexnr_arg, uint keyno_arg,
 }
 
 Rdb_key_def::Rdb_key_def(const Rdb_key_def &k)
-    : m_index_number(k.m_index_number), m_cf_handle(k.m_cf_handle),
+    : m_index_number(k.m_index_number),
+      m_cf_handle(k.m_cf_handle),
       m_is_reverse_cf(k.m_is_reverse_cf),
-      m_is_per_partition_cf(k.m_is_per_partition_cf), m_name(k.m_name),
-      m_stats(k.m_stats), m_index_flags_bitmap(k.m_index_flags_bitmap),
-      m_ttl_rec_offset(k.m_ttl_rec_offset), m_ttl_duration(k.m_ttl_duration),
-      m_ttl_column(k.m_ttl_column), m_pk_part_no(k.m_pk_part_no),
-      m_pack_info(nullptr), m_keyno(k.m_keyno),
+      m_is_per_partition_cf(k.m_is_per_partition_cf),
+      m_name(k.m_name),
+      m_stats(k.m_stats),
+      m_index_flags_bitmap(k.m_index_flags_bitmap),
+      m_ttl_rec_offset(k.m_ttl_rec_offset),
+      m_ttl_duration(k.m_ttl_duration),
+      m_ttl_column(k.m_ttl_column),
+      m_pk_part_no(k.m_pk_part_no),
+      m_pack_info(nullptr),
+      m_keyno(k.m_keyno),
       m_key_parts(k.m_key_parts),
       m_ttl_pk_key_part_offset(k.m_ttl_pk_key_part_offset),
-      m_ttl_field_index(UINT_MAX), m_prefix_extractor(k.m_prefix_extractor),
+      m_ttl_field_index(UINT_MAX),
+      m_prefix_extractor(k.m_prefix_extractor),
       m_maxlength(k.m_maxlength) {
   mysql_mutex_init(0, &m_mutex, MY_MUTEX_INIT_FAST);
   rdb_netbuf_store_index(m_index_number_storage_form, m_index_number);
@@ -336,9 +353,9 @@ Rdb_key_def::Rdb_key_def(const Rdb_key_def &k)
   if (k.m_pack_info) {
     const size_t size = sizeof(Rdb_field_packing) * k.m_key_parts;
 #ifdef HAVE_PSI_INTERFACE
-    void* buf = my_malloc(rdb_datadic_memory_key, size, MYF(0));
+    void *buf = my_malloc(rdb_datadic_memory_key, size, MYF(0));
 #else
-    void* buf = my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0));
+    void *buf = my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0));
 #endif
     m_pack_info = new (buf) Rdb_field_packing(*k.m_pack_info);
   }
@@ -392,8 +409,7 @@ void Rdb_key_def::setup(const TABLE *const tbl,
     KEY *pk_info = nullptr;
     if (!is_hidden_pk) {
       key_info = &tbl->key_info[m_keyno];
-      if (!hidden_pk_exists)
-        pk_info = &tbl->key_info[tbl->s->primary_key];
+      if (!hidden_pk_exists) pk_info = &tbl->key_info[tbl->s->primary_key];
       m_name = std::string(key_info->name);
     } else {
       m_name = HIDDEN_PK_NAME;
@@ -440,9 +456,9 @@ void Rdb_key_def::setup(const TABLE *const tbl,
 
     const size_t size = sizeof(Rdb_field_packing) * m_key_parts;
 #ifdef HAVE_PSI_INTERFACE
-    void* buf = my_malloc(rdb_datadic_memory_key, size, MYF(0));
+    void *buf = my_malloc(rdb_datadic_memory_key, size, MYF(0));
 #else
-    void* buf = my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0));
+    void *buf = my_malloc(PSI_NOT_INSTRUMENTED, size, MYF(0));
 #endif
     m_pack_info = new (buf) Rdb_field_packing;
 
@@ -495,8 +511,7 @@ void Rdb_key_def::setup(const TABLE *const tbl,
           }
         }
 
-        if (field && field->real_maybe_null())
-          max_len += 1; // NULL-byte
+        if (field && field->real_maybe_null()) max_len += 1;  // NULL-byte
 
         m_pack_info[dst_i].setup(this, field, keyno_to_set, keypart_to_set,
                                  key_part ? key_part->length : 0);
@@ -516,8 +531,7 @@ void Rdb_key_def::setup(const TABLE *const tbl,
             appended to the end of the sk.
           */
           m_pk_part_no[dst_i] = -1;
-          if (simulating_extkey)
-            m_pk_part_no[dst_i] = 0;
+          if (simulating_extkey) m_pk_part_no[dst_i] = 0;
         }
 
         max_len += m_pack_info[dst_i].m_max_image_len;
@@ -681,9 +695,8 @@ uint Rdb_key_def::extract_ttl_col(const TABLE *const table_arg,
   return HA_EXIT_SUCCESS;
 }
 
-const std::string
-Rdb_key_def::gen_qualifier_for_table(const char *const qualifier,
-                                     const std::string &partition_name) {
+const std::string Rdb_key_def::gen_qualifier_for_table(
+    const char *const qualifier, const std::string &partition_name) {
   bool has_partition = !partition_name.empty();
   std::string qualifier_str = "";
 
@@ -711,8 +724,8 @@ Rdb_key_def::gen_qualifier_for_table(const char *const qualifier,
   Formats the string and returns the column family name assignment part for a
   specific partition.
 */
-const std::string
-Rdb_key_def::gen_cf_name_qualifier_for_partition(const std::string &prefix) {
+const std::string Rdb_key_def::gen_cf_name_qualifier_for_partition(
+    const std::string &prefix) {
   DBUG_ASSERT(!prefix.empty());
 
   return prefix + RDB_PER_PARTITION_QUALIFIER_NAME_SEP + RDB_CF_NAME_QUALIFIER +
@@ -727,8 +740,8 @@ const std::string Rdb_key_def::gen_ttl_duration_qualifier_for_partition(
          RDB_TTL_DURATION_QUALIFIER + RDB_QUALIFIER_VALUE_SEP;
 }
 
-const std::string
-Rdb_key_def::gen_ttl_col_qualifier_for_partition(const std::string &prefix) {
+const std::string Rdb_key_def::gen_ttl_col_qualifier_for_partition(
+    const std::string &prefix) {
   DBUG_ASSERT(!prefix.empty());
 
   return prefix + RDB_PER_PARTITION_QUALIFIER_NAME_SEP + RDB_TTL_COL_QUALIFIER +
@@ -831,15 +844,13 @@ int Rdb_key_def::read_memcmp_key_part(const TABLE *table_arg,
   /* It is impossible to unpack the column. Skip it. */
   if (m_pack_info[part_num].m_maybe_null) {
     const char *nullp;
-    if (!(nullp = reader->read(1)))
-      return 1;
+    if (!(nullp = reader->read(1))) return 1;
     if (*nullp == 0) {
       /* This is a NULL value */
       return -1;
     } else {
       /* If NULL marker is not '0', it can be only '1'  */
-      if (*nullp != 1)
-        return 1;
+      if (*nullp != 1) return 1;
     }
   }
 
@@ -908,8 +919,7 @@ uint Rdb_key_def::get_primary_key_tuple(const TABLE *const table,
   Rdb_string_reader reader(key);
 
   // Skip the index number
-  if ((!reader.read(INDEX_NUMBER_SIZE)))
-    return RDB_INVALID_KEY_LEN;
+  if ((!reader.read(INDEX_NUMBER_SIZE))) return RDB_INVALID_KEY_LEN;
 
   for (i = 0; i < m_key_parts; i++) {
     if ((pk_key_part = m_pk_part_no[i]) != -1) {
@@ -961,8 +971,7 @@ uint Rdb_key_def::get_memcmp_sk_parts(const TABLE *table,
   const char *start = reader.get_current_ptr();
 
   // Skip the index number
-  if ((!reader.read(INDEX_NUMBER_SIZE)))
-    return RDB_INVALID_KEY_LEN;
+  if ((!reader.read(INDEX_NUMBER_SIZE))) return RDB_INVALID_KEY_LEN;
 
   for (uint i = 0; i < table->key_info[m_keyno].user_defined_key_parts; i++) {
     if ((res = read_memcmp_key_part(table, &reader, i)) > 0) {
@@ -1002,8 +1011,7 @@ uint Rdb_key_def::pack_index_tuple(TABLE *const tbl, uchar *const pack_buffer,
   key_restore(tbl->record[0], key_tuple, &tbl->key_info[m_keyno], key_len);
 
   uint n_used_parts = my_count_bits(keypart_map);
-  if (keypart_map == HA_WHOLE_KEY)
-    n_used_parts = 0; // Full key is used
+  if (keypart_map == HA_WHOLE_KEY) n_used_parts = 0;  // Full key is used
 
   /* Then, convert the record into a mem-comparable form */
   return pack_record(tbl, pack_buffer, tbl->record[0], packed_tuple, nullptr,
@@ -1119,30 +1127,30 @@ void Rdb_key_def::get_lookup_bitmap(const TABLE *table, MY_BITMAP *map) const {
     }
 
     switch (field->real_type()) {
-    // This type may be covered depending on the record. If it was requested,
-    // we require the covered bitmap to have this bit set.
-    case MYSQL_TYPE_VARCHAR:
-      if (curr_bitmap_pos < MAX_REF_PARTS) {
-        if (bitmap_is_set(table->read_set, field->field_index)) {
-          bitmap_set_bit(map, curr_bitmap_pos);
-          bitmap_set_bit(&maybe_covered_bitmap, field->field_index);
+      // This type may be covered depending on the record. If it was requested,
+      // we require the covered bitmap to have this bit set.
+      case MYSQL_TYPE_VARCHAR:
+        if (curr_bitmap_pos < MAX_REF_PARTS) {
+          if (bitmap_is_set(table->read_set, field->field_index)) {
+            bitmap_set_bit(map, curr_bitmap_pos);
+            bitmap_set_bit(&maybe_covered_bitmap, field->field_index);
+          }
+          curr_bitmap_pos++;
+        } else {
+          bitmap_free(&maybe_covered_bitmap);
+          bitmap_free(map);
+          return;
         }
-        curr_bitmap_pos++;
-      } else {
-        bitmap_free(&maybe_covered_bitmap);
-        bitmap_free(map);
-        return;
-      }
-      break;
-    // This column is a type which is never covered. If it was requested, we
-    // know this lookup will never be covered.
-    default:
-      if (bitmap_is_set(table->read_set, field->field_index)) {
-        bitmap_free(&maybe_covered_bitmap);
-        bitmap_free(map);
-        return;
-      }
-      break;
+        break;
+      // This column is a type which is never covered. If it was requested, we
+      // know this lookup will never be covered.
+      default:
+        if (bitmap_is_set(table->read_set, field->field_index)) {
+          bitmap_free(&maybe_covered_bitmap);
+          bitmap_free(map);
+          return;
+        }
+        break;
     }
   }
 
@@ -1192,8 +1200,7 @@ bool Rdb_key_def::covers_lookup(const rocksdb::Slice *const unpack_info,
 /* Indicates that all key parts can be unpacked to cover a secondary lookup */
 bool Rdb_key_def::can_cover_lookup() const {
   for (uint i = 0; i < m_key_parts; i++) {
-    if (!m_pack_info[i].m_covered)
-      return false;
+    if (!m_pack_info[i].m_covered) return false;
   }
   return true;
 }
@@ -1209,8 +1216,7 @@ uchar *Rdb_key_def::pack_field(Field *const field, Rdb_field_packing *pack_info,
       /* NULL value. store '\0' so that it sorts before non-NULL values */
       *tuple++ = 0;
       /* That's it, don't store anything else */
-      if (n_null_fields)
-        (*n_null_fields)++;
+      if (n_null_fields) (*n_null_fields)++;
       return tuple;
     } else {
       /* Not a NULL value. Store '1' */
@@ -1224,8 +1230,8 @@ uchar *Rdb_key_def::pack_field(Field *const field, Rdb_field_packing *pack_info,
   Rdb_pack_field_context pack_ctx(unpack_info);
 
   // Set the offset for methods which do not take an offset as an argument
-  DBUG_ASSERT(is_storage_available(tuple - packed_tuple,
-                                   pack_info->m_max_image_len));
+  DBUG_ASSERT(
+      is_storage_available(tuple - packed_tuple, pack_info->m_max_image_len));
 
   (pack_info->m_pack_func)(pack_info, field, pack_buffer, &tuple, &pack_ctx);
 
@@ -1300,8 +1306,7 @@ uint Rdb_key_def::pack_record(const TABLE *const tbl, uchar *const pack_buffer,
   else if (use_all_columns)
     n_key_parts = m_key_parts;
 
-  if (n_null_fields)
-    *n_null_fields = 0;
+  if (n_null_fields) *n_null_fields = 0;
 
   // Check if we need a covered bitmap. If it is certain that all key parts are
   // covering, we don't need one.
@@ -1369,8 +1374,9 @@ uint Rdb_key_def::pack_record(const TABLE *const tbl, uchar *const pack_buffer,
     uint null_offset = field->null_offset(tbl->record[0]);
     bool maybe_null = field->real_maybe_null();
 
-    field->move_field(const_cast<uchar*>(record) + field_offset,
-        maybe_null ? const_cast<uchar*>(record) + null_offset : nullptr,
+    field->move_field(
+        const_cast<uchar *>(record) + field_offset,
+        maybe_null ? const_cast<uchar *>(record) + null_offset : nullptr,
         field->null_bit);
     // WARNING! Don't return without restoring field->ptr and field->null_ptr
 
@@ -1473,17 +1479,17 @@ uint Rdb_key_def::pack_hidden_pk(const longlong hidden_pk_id,
   return tuple - packed_tuple;
 }
 
-/**
-  Function of type rdb_index_field_pack_t
+  /**
+    Function of type rdb_index_field_pack_t
 
-  The following code (Rdb_key_def::pack_* and dependent functions) is pulled
-  directly from ./sql/field.cc from all of the various Field_*::make_sort_key()
-  functions.  These results of these functions within the server code was never
-  intended to be persisted and as such the encoding and comparison can change
-  over time without any notice.  To protect us from such an event as well as to
-  ensure binary upgrade compatibility, we have copied that code here so that it
-  is entirely within our control.
-*/
+    The following code (Rdb_key_def::pack_* and dependent functions) is pulled
+    directly from ./sql/field.cc from all of the various
+    Field_*::make_sort_key() functions.  These results of these functions within
+    the server code was never intended to be persisted and as such the encoding
+    and comparison can change over time without any notice.  To protect us from
+    such an event as well as to ensure binary upgrade compatibility, we have
+    copied that code here so that it is entirely within our control.
+  */
 
 #if !defined(DBL_EXP_DIG)
 #define DBL_EXP_DIG (sizeof(double) * 8 - DBL_MANT_DIG)
@@ -1524,8 +1530,7 @@ static void change_double_for_sort(double nr, uchar *to) {
     if (tmp[0] & 128) /* Negative */
     {                 /* make complement */
       uint i;
-      for (i = 0; i < sizeof(nr); i++)
-        tmp[i] = tmp[i] ^ (uchar)255;
+      for (i = 0; i < sizeof(nr); i++) tmp[i] = tmp[i] ^ (uchar)255;
     } else { /* Set high and move exponent one up */
       ushort exp_part =
           (((ushort)tmp[0] << 8) | (ushort)tmp[1] | (ushort)32768);
@@ -1808,8 +1813,7 @@ void Rdb_key_def::pack_float(
     if (tmp[0] & 128) /* Negative */
     {                 /* make complement */
       uint i;
-      for (i = 0; i < sizeof(nr); i++)
-        tmp[i] = (uchar)(tmp[i] ^ (uchar)255);
+      for (i = 0; i < sizeof(nr); i++) tmp[i] = (uchar)(tmp[i] ^ (uchar)255);
     } else {
       ushort exp_part =
           (((ushort)tmp[0] << 8) | (ushort)tmp[1] | (ushort)32768);
@@ -1963,7 +1967,7 @@ void Rdb_key_def::pack_blob(
   size_t length = fpi->m_max_image_len;
   const uchar *ptr = field->ptr;
   uchar *to = *dst;
-  Field_blob* const field_blob = dynamic_cast<Field_blob *const>(field);
+  Field_blob *const field_blob = dynamic_cast<Field_blob *const>(field);
   const CHARSET_INFO *field_charset = field_blob->charset();
 
   uchar *blob;
@@ -1983,18 +1987,18 @@ void Rdb_key_def::pack_blob(
       uint key_length = blob_length < length ? blob_length : length;
 
       switch (field_blob->pack_length_no_ptr()) {
-      case 1:
-        *pos = (char)key_length;
-        break;
-      case 2:
-        mi_int2store(pos, key_length);
-        break;
-      case 3:
-        mi_int3store(pos, key_length);
-        break;
-      case 4:
-        mi_int4store(pos, key_length);
-        break;
+        case 1:
+          *pos = (char)key_length;
+          break;
+        case 2:
+          mi_int2store(pos, key_length);
+          break;
+        case 3:
+          mi_int3store(pos, key_length);
+          break;
+        case 4:
+          mi_int4store(pos, key_length);
+          break;
       }
     }
     memcpy(&blob, ptr + field_blob->pack_length_no_ptr(), sizeof(char *));
@@ -2050,11 +2054,9 @@ int Rdb_key_def::compare_keys(const rocksdb::Slice *key1,
   Rdb_string_reader reader2(key2);
 
   // Skip the index number
-  if ((!reader1.read(INDEX_NUMBER_SIZE)))
-    return HA_EXIT_FAILURE;
+  if ((!reader1.read(INDEX_NUMBER_SIZE))) return HA_EXIT_FAILURE;
 
-  if ((!reader2.read(INDEX_NUMBER_SIZE)))
-    return HA_EXIT_FAILURE;
+  if ((!reader2.read(INDEX_NUMBER_SIZE))) return HA_EXIT_FAILURE;
 
   for (uint i = 0; i < m_key_parts; i++) {
     const Rdb_field_packing *const fpi = &m_pack_info[i];
@@ -2241,8 +2243,7 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
     }
   }
 
-  if (reader.remaining_bytes())
-    return HA_ERR_ROCKSDB_CORRUPT_DATA;
+  if (reader.remaining_bytes()) return HA_ERR_ROCKSDB_CORRUPT_DATA;
 
   return HA_EXIT_SUCCESS;
 }
@@ -2269,14 +2270,14 @@ void Rdb_key_def::report_checksum_mismatch(const bool is_key,
 bool Rdb_key_def::index_format_min_check(const int pk_min,
                                          const int sk_min) const {
   switch (m_index_type) {
-  case INDEX_TYPE_PRIMARY:
-  case INDEX_TYPE_HIDDEN_PRIMARY:
-    return (m_kv_format_version >= pk_min);
-  case INDEX_TYPE_SECONDARY:
-    return (m_kv_format_version >= sk_min);
-  default:
-    DBUG_ASSERT(0);
-    return false;
+    case INDEX_TYPE_PRIMARY:
+    case INDEX_TYPE_HIDDEN_PRIMARY:
+      return (m_kv_format_version >= pk_min);
+    case INDEX_TYPE_SECONDARY:
+      return (m_kv_format_version >= sk_min);
+    default:
+      DBUG_ASSERT(0);
+      return false;
   }
 }
 
@@ -2292,28 +2293,27 @@ int Rdb_key_def::skip_max_length(const Rdb_field_packing *const fpi,
                                  const Field *const field
                                      MY_ATTRIBUTE((__unused__)),
                                  Rdb_string_reader *const reader) {
-  if (!reader->read(fpi->m_max_image_len))
-    return HA_EXIT_FAILURE;
+  if (!reader->read(fpi->m_max_image_len)) return HA_EXIT_FAILURE;
   return HA_EXIT_SUCCESS;
 }
 
-/*
-  (RDB_ESCAPE_LENGTH-1) must be an even number so that pieces of lines are not
-  split in the middle of an UTF-8 character. See the implementation of
-  unpack_binary_or_utf8_varchar.
-*/
+  /*
+    (RDB_ESCAPE_LENGTH-1) must be an even number so that pieces of lines are not
+    split in the middle of an UTF-8 character. See the implementation of
+    unpack_binary_or_utf8_varchar.
+  */
 
 #define RDB_ESCAPE_LENGTH 9
 #define RDB_LEGACY_ESCAPE_LENGTH RDB_ESCAPE_LENGTH
 static_assert((RDB_ESCAPE_LENGTH - 1) % 2 == 0,
               "RDB_ESCAPE_LENGTH-1 must be even.");
 
-#define RDB_ENCODED_SIZE(len)                                                  \
-  ((len + (RDB_ESCAPE_LENGTH - 2)) / (RDB_ESCAPE_LENGTH - 1)) *                \
+#define RDB_ENCODED_SIZE(len)                                   \
+  ((len + (RDB_ESCAPE_LENGTH - 2)) / (RDB_ESCAPE_LENGTH - 1)) * \
       RDB_ESCAPE_LENGTH
 
-#define RDB_LEGACY_ENCODED_SIZE(len)                                           \
-  ((len + (RDB_LEGACY_ESCAPE_LENGTH - 1)) / (RDB_LEGACY_ESCAPE_LENGTH - 1)) *  \
+#define RDB_LEGACY_ENCODED_SIZE(len)                                          \
+  ((len + (RDB_LEGACY_ESCAPE_LENGTH - 1)) / (RDB_LEGACY_ESCAPE_LENGTH - 1)) * \
       RDB_LEGACY_ESCAPE_LENGTH
 
 /*
@@ -2435,7 +2435,7 @@ int Rdb_key_def::unpack_integer(
     if (((Field_num *)field)->unsigned_flag)
       to[0] = from[0];
     else
-      to[0] = (char)(from[0] ^ 128); // Reverse the sign bit.
+      to[0] = (char)(from[0] ^ 128);  // Reverse the sign bit.
     memcpy(to + 1, from + 1, length - 1);
   }
 #else
@@ -2445,9 +2445,8 @@ int Rdb_key_def::unpack_integer(
       to[length - 1] = sign_byte;
     else
       to[length - 1] =
-          static_cast<char>(sign_byte ^ 128); // Reverse the sign bit.
-    for (int i = 0, j = length - 1; i < length - 1; ++i, --j)
-      to[i] = from[j];
+          static_cast<char>(sign_byte ^ 128);  // Reverse the sign bit.
+    for (int i = 0, j = length - 1; i < length - 1; ++i, --j) to[i] = from[j];
   }
 #endif
   return UNPACK_SUCCESS;
@@ -2516,15 +2515,14 @@ int Rdb_key_def::unpack_floating_point(
     // If the high bit is set the original value was positive so
     // remove the high bit and subtract one from the exponent.
     ushort exp_part = ((ushort)tmp[0] << 8) | (ushort)tmp[1];
-    exp_part &= 0x7FFF;                            // clear high bit;
-    exp_part -= (ushort)1 << (16 - 1 - exp_digit); // subtract from exponent
+    exp_part &= 0x7FFF;                             // clear high bit;
+    exp_part -= (ushort)1 << (16 - 1 - exp_digit);  // subtract from exponent
     tmp[0] = (uchar)(exp_part >> 8);
     tmp[1] = (uchar)exp_part;
   } else {
     // Otherwise the original value was negative and all bytes have been
     // negated.
-    for (size_t ii = 0; ii < size; ii++)
-      tmp[ii] ^= 0xFF;
+    for (size_t ii = 0; ii < size; ii++) tmp[ii] ^= 0xFF;
   }
 
 #if !defined(WORDS_BIGENDIAN)
@@ -2641,8 +2639,7 @@ int Rdb_key_def::unpack_utf8_str(
     int res = cset->cset->wc_mb(cset, wc, dst, dst_end);
     DBUG_ASSERT(res > 0);
     DBUG_ASSERT(res <= 3);
-    if (res < 0)
-      return UNPACK_FAILURE;
+    if (res < 0) return UNPACK_FAILURE;
     dst += res;
   }
 
@@ -2787,14 +2784,13 @@ void Rdb_key_def::pack_with_varchar_encoding(
   sequence of strings in space_xfrm
 */
 
-static int
-rdb_compare_string_with_spaces(const uchar *buf, const uchar *const buf_end,
-                               const std::vector<uchar> *const space_xfrm) {
+static int rdb_compare_string_with_spaces(
+    const uchar *buf, const uchar *const buf_end,
+    const std::vector<uchar> *const space_xfrm) {
   int cmp = 0;
   while (buf < buf_end) {
     size_t bytes = std::min((size_t)(buf_end - buf), space_xfrm->size());
-    if ((cmp = memcmp(buf, space_xfrm->data(), bytes)) != 0)
-      break;
+    if ((cmp = memcmp(buf, space_xfrm->data(), bytes)) != 0) break;
     buf += bytes;
   }
   return cmp;
@@ -2907,7 +2903,7 @@ void Rdb_key_def::pack_with_varchar_space_pad(
     if (padding_bytes) {
       memcpy(ptr, fpi->space_xfrm->data(), padding_bytes);
       ptr += padding_bytes;
-      *ptr = VARCHAR_CMP_EQUAL_TO_SPACES; // last segment
+      *ptr = VARCHAR_CMP_EQUAL_TO_SPACES;  // last segment
     } else {
       // Compare the string suffix with a hypothetical infinite string of
       // spaces. It could be that the first difference is beyond the end of
@@ -2926,8 +2922,7 @@ void Rdb_key_def::pack_with_varchar_space_pad(
     }
     encoded_size += fpi->m_segment_size;
 
-    if (*(ptr++) == VARCHAR_CMP_EQUAL_TO_SPACES)
-      break;
+    if (*(ptr++) == VARCHAR_CMP_EQUAL_TO_SPACES) break;
   }
 
   // m_unpack_info_stores_value means unpack_info stores the whole original
@@ -2999,13 +2994,13 @@ uint Rdb_key_def::calc_unpack_variable_format(uchar flag, bool *done) {
   treated as a wide-character and converted to its multibyte equivalent in
   the output.
  */
-static int
-unpack_charset(const CHARSET_INFO *cset,  // character set information
-               const uchar *src,          // source data to unpack
-               uint src_len,              // length of source data
-               uchar *dst,                // destination of unpacked data
-               uint dst_len,              // length of destination data
-               uint *used_bytes)          // output number of bytes used
+static int unpack_charset(
+    const CHARSET_INFO *cset,  // character set information
+    const uchar *src,          // source data to unpack
+    uint src_len,              // length of source data
+    uchar *dst,                // destination of unpacked data
+    uint dst_len,              // length of destination data
+    uint *used_bytes)          // output number of bytes used
 {
   if (src_len & 1) {
     /*
@@ -3145,16 +3140,16 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
   while ((ptr = (const uchar *)reader->read(fpi->m_segment_size))) {
     const char last_byte = ptr[fpi->m_segment_size - 1];
     size_t used_bytes;
-    if (last_byte == VARCHAR_CMP_EQUAL_TO_SPACES) // this is the last segment
+    if (last_byte == VARCHAR_CMP_EQUAL_TO_SPACES)  // this is the last segment
     {
       if (space_padding_bytes > (fpi->m_segment_size - 1))
-        return UNPACK_FAILURE; // Cannot happen, corrupted data
+        return UNPACK_FAILURE;  // Cannot happen, corrupted data
       used_bytes = (fpi->m_segment_size - 1) - space_padding_bytes;
       finished = true;
     } else {
       if (last_byte != VARCHAR_CMP_LESS_THAN_SPACES &&
           last_byte != VARCHAR_CMP_GREATER_THAN_SPACES) {
-        return UNPACK_FAILURE; // Invalid value
+        return UNPACK_FAILURE;  // Invalid value
       }
       used_bytes = fpi->m_segment_size - 1;
     }
@@ -3177,14 +3172,12 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
         const CHARSET_INFO *cset = fpi->m_varchar_charset;
         int res = cset->cset->wc_mb(cset, wc, dst, dst_end);
         DBUG_ASSERT(res <= 3);
-        if (res <= 0)
-          return UNPACK_FAILURE;
+        if (res <= 0) return UNPACK_FAILURE;
         dst += res;
         len += res;
       }
     } else {
-      if (dst + used_bytes > dst_end)
-        return UNPACK_FAILURE;
+      if (dst + used_bytes > dst_end) return UNPACK_FAILURE;
       memcpy(dst, ptr, used_bytes);
       dst += used_bytes;
       len += used_bytes;
@@ -3194,8 +3187,7 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
       if (extra_spaces) {
         // Both binary and UTF-8 charset store space as ' ',
         // so the following is ok:
-        if (dst + extra_spaces > dst_end)
-          return UNPACK_FAILURE;
+        if (dst + extra_spaces > dst_end) return UNPACK_FAILURE;
         memset(dst, fpi->m_varchar_charset->pad_char, extra_spaces);
         len += extra_spaces;
       }
@@ -3203,8 +3195,7 @@ int Rdb_key_def::unpack_binary_or_utf8_varchar_space_pad(
     }
   }
 
-  if (!finished)
-    return UNPACK_FAILURE;
+  if (!finished) return UNPACK_FAILURE;
 
   /* Save the length */
   if (field_var->length_bytes == 1) {
@@ -3420,12 +3411,12 @@ int Rdb_key_def::unpack_simple_varchar_space_pad(
   /* Decode the length-emitted encoding here */
   while ((ptr = (const uchar *)reader->read(fpi->m_segment_size))) {
     const char last_byte =
-        ptr[fpi->m_segment_size - 1]; // number of padding bytes
+        ptr[fpi->m_segment_size - 1];  // number of padding bytes
     size_t used_bytes;
     if (last_byte == VARCHAR_CMP_EQUAL_TO_SPACES) {
       // this is the last one
       if (space_padding_bytes > (fpi->m_segment_size - 1))
-        return UNPACK_FAILURE; // Cannot happen, corrupted data
+        return UNPACK_FAILURE;  // Cannot happen, corrupted data
       used_bytes = (fpi->m_segment_size - 1) - space_padding_bytes;
       finished = true;
     } else {
@@ -3452,8 +3443,7 @@ int Rdb_key_def::unpack_simple_varchar_space_pad(
 
     if (finished) {
       if (extra_spaces) {
-        if (dst + extra_spaces > dst_end)
-          return UNPACK_FAILURE;
+        if (dst + extra_spaces > dst_end) return UNPACK_FAILURE;
         // pad_char has a 1-byte form in all charsets that
         // are handled by rdb_init_collation_mapping.
         memset(dst, field_var->charset()->pad_char, extra_spaces);
@@ -3463,8 +3453,7 @@ int Rdb_key_def::unpack_simple_varchar_space_pad(
     }
   }
 
-  if (!finished)
-    return UNPACK_FAILURE;
+  if (!finished) return UNPACK_FAILURE;
 
   /* Save the length */
   if (field_var->length_bytes == 1) {
@@ -3522,7 +3511,7 @@ const int RDB_SPACE_XFRM_SIZE = 32;
 // A class holding information about how space character is represented in a
 // charset.
 class Rdb_charset_space_info {
-public:
+ public:
   Rdb_charset_space_info(const Rdb_charset_space_info &) = delete;
   Rdb_charset_space_info &operator=(const Rdb_charset_space_info &) = delete;
   Rdb_charset_space_info() = default;
@@ -3580,7 +3569,7 @@ static void rdb_get_mem_comparable_space(const CHARSET_INFO *const cs,
       const size_t space_mb_len = cs->cset->wc_mb(
           cs, (my_wc_t)cs->pad_char, space_mb, space_mb + sizeof(space_mb));
 
-      uchar space[20]; // mem-comparable image of the space character
+      uchar space[20];  // mem-comparable image of the space character
 
       const size_t space_len = cs->coll->strnxfrm(cs, space, sizeof(space), 1,
                                                   space_mb, space_mb_len, 0);
@@ -3611,8 +3600,8 @@ bool rdb_is_collation_supported(const my_core::CHARSET_INFO *const cs) {
   return (cs->coll == &my_collation_8bit_simple_ci_handler);
 }
 
-static const Rdb_collation_codec *
-rdb_init_collation_mapping(const my_core::CHARSET_INFO *const cs) {
+static const Rdb_collation_codec *rdb_init_collation_mapping(
+    const my_core::CHARSET_INFO *const cs) {
   DBUG_ASSERT(cs);
   DBUG_ASSERT(cs->state & MY_CS_AVAILABLE);
   const Rdb_collation_codec *codec = rdb_collation_data[cs->number];
@@ -3649,10 +3638,11 @@ rdb_init_collation_mapping(const my_core::CHARSET_INFO *const cs) {
           }
         }
 
-        cur->m_make_unpack_info_func = {{Rdb_key_def::make_unpack_simple_varchar,
-                                        Rdb_key_def::make_unpack_simple}};
+        cur->m_make_unpack_info_func = {
+            {Rdb_key_def::make_unpack_simple_varchar,
+             Rdb_key_def::make_unpack_simple}};
         cur->m_unpack_func = {{Rdb_key_def::unpack_simple_varchar_space_pad,
-                              Rdb_key_def::unpack_simple}};
+                               Rdb_key_def::unpack_simple}};
       } else {
         // Out of luck for now.
       }
@@ -3704,26 +3694,43 @@ Rdb_field_packing::Rdb_field_packing(const Rdb_field_packing &o)
     : m_max_image_len(o.m_max_image_len),
       m_unpack_data_len(o.m_unpack_data_len),
       m_unpack_data_offset(o.m_unpack_data_offset),
-      m_maybe_null(o.m_maybe_null), m_varchar_charset(o.m_varchar_charset),
+      m_maybe_null(o.m_maybe_null),
+      m_varchar_charset(o.m_varchar_charset),
       m_segment_size(o.m_segment_size),
       m_unpack_info_uses_two_bytes(o.m_unpack_info_uses_two_bytes),
-      m_covered(o.m_covered), space_xfrm(o.space_xfrm),
-      space_xfrm_len(o.space_xfrm_len), space_mb_len(o.space_mb_len),
+      m_covered(o.m_covered),
+      space_xfrm(o.space_xfrm),
+      space_xfrm_len(o.space_xfrm_len),
+      space_mb_len(o.space_mb_len),
       m_charset_codec(o.m_charset_codec),
       m_unpack_info_stores_value(o.m_unpack_info_stores_value),
       m_pack_func(o.m_pack_func),
       m_make_unpack_info_func(o.m_make_unpack_info_func),
-      m_unpack_func(o.m_unpack_func), m_skip_func(o.m_skip_func),
-      m_keynr(o.m_keynr), m_key_part(o.m_key_part) {}
+      m_unpack_func(o.m_unpack_func),
+      m_skip_func(o.m_skip_func),
+      m_keynr(o.m_keynr),
+      m_key_part(o.m_key_part) {}
 
 Rdb_field_packing::Rdb_field_packing()
-    : m_max_image_len(0), m_unpack_data_len(0), m_unpack_data_offset(0),
-      m_maybe_null(false), m_varchar_charset(nullptr), m_segment_size(0),
-      m_unpack_info_uses_two_bytes(false), m_covered(false),
-      space_xfrm(nullptr), space_xfrm_len(0), space_mb_len(0),
-      m_charset_codec(nullptr), m_unpack_info_stores_value(false),
-      m_pack_func(nullptr), m_make_unpack_info_func(nullptr),
-      m_unpack_func(nullptr), m_skip_func(nullptr), m_keynr(0), m_key_part(0) {}
+    : m_max_image_len(0),
+      m_unpack_data_len(0),
+      m_unpack_data_offset(0),
+      m_maybe_null(false),
+      m_varchar_charset(nullptr),
+      m_segment_size(0),
+      m_unpack_info_uses_two_bytes(false),
+      m_covered(false),
+      space_xfrm(nullptr),
+      space_xfrm_len(0),
+      space_mb_len(0),
+      m_charset_codec(nullptr),
+      m_unpack_info_stores_value(false),
+      m_pack_func(nullptr),
+      m_make_unpack_info_func(nullptr),
+      m_unpack_func(nullptr),
+      m_skip_func(nullptr),
+      m_keynr(0),
+      m_key_part(0) {}
 
 /*
   @brief
@@ -3759,7 +3766,7 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
   m_unpack_func = nullptr;
   m_make_unpack_info_func = nullptr;
   m_unpack_data_len = 0;
-  space_xfrm = nullptr; // safety
+  space_xfrm = nullptr;  // safety
   // whether to use legacy format for varchar
   m_use_legacy_varbinary_format = false;
   // ha_rocksdb::index_flags() will pass key_descr == null to
@@ -3778,115 +3785,115 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
   m_covered = false;
 
   switch (type) {
-  case MYSQL_TYPE_LONGLONG:
-    m_pack_func = Rdb_key_def::pack_longlong;
-    m_unpack_func = Rdb_key_def::unpack_integer;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_LONGLONG:
+      m_pack_func = Rdb_key_def::pack_longlong;
+      m_unpack_func = Rdb_key_def::unpack_integer;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_LONG:
-    m_pack_func = Rdb_key_def::pack_long;
-    m_unpack_func = Rdb_key_def::unpack_integer;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_LONG:
+      m_pack_func = Rdb_key_def::pack_long;
+      m_unpack_func = Rdb_key_def::unpack_integer;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_INT24:
-    m_pack_func = Rdb_key_def::pack_medium;
-    m_unpack_func = Rdb_key_def::unpack_integer;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_INT24:
+      m_pack_func = Rdb_key_def::pack_medium;
+      m_unpack_func = Rdb_key_def::unpack_integer;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_SHORT:
-    m_pack_func = Rdb_key_def::pack_short;
-    m_unpack_func = Rdb_key_def::unpack_integer;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_SHORT:
+      m_pack_func = Rdb_key_def::pack_short;
+      m_unpack_func = Rdb_key_def::unpack_integer;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_TINY:
-    m_pack_func = Rdb_key_def::pack_tiny;
-    m_unpack_func = Rdb_key_def::unpack_integer;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_TINY:
+      m_pack_func = Rdb_key_def::pack_tiny;
+      m_unpack_func = Rdb_key_def::unpack_integer;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_DOUBLE:
-    m_pack_func = Rdb_key_def::pack_double;
-    m_unpack_func = Rdb_key_def::unpack_double;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_DOUBLE:
+      m_pack_func = Rdb_key_def::pack_double;
+      m_unpack_func = Rdb_key_def::unpack_double;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_FLOAT:
-    m_pack_func = Rdb_key_def::pack_float;
-    m_unpack_func = Rdb_key_def::unpack_float;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_FLOAT:
+      m_pack_func = Rdb_key_def::pack_float;
+      m_unpack_func = Rdb_key_def::unpack_float;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_NEWDECIMAL:
-    m_pack_func = Rdb_key_def::pack_new_decimal;
-    m_unpack_func = Rdb_key_def::unpack_binary_str;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_NEWDECIMAL:
+      m_pack_func = Rdb_key_def::pack_new_decimal;
+      m_unpack_func = Rdb_key_def::unpack_binary_str;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_DATETIME2:
-    m_pack_func = Rdb_key_def::pack_datetime2;
-    m_unpack_func = Rdb_key_def::unpack_binary_str;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_DATETIME2:
+      m_pack_func = Rdb_key_def::pack_datetime2;
+      m_unpack_func = Rdb_key_def::unpack_binary_str;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_TIMESTAMP2:
-    m_pack_func = Rdb_key_def::pack_timestamp2;
-    m_unpack_func = Rdb_key_def::unpack_binary_str;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_TIMESTAMP2:
+      m_pack_func = Rdb_key_def::pack_timestamp2;
+      m_unpack_func = Rdb_key_def::unpack_binary_str;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_TIME2:
-    m_pack_func = Rdb_key_def::pack_time2;
-    m_unpack_func = Rdb_key_def::unpack_binary_str;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_TIME2:
+      m_pack_func = Rdb_key_def::pack_time2;
+      m_unpack_func = Rdb_key_def::unpack_binary_str;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_YEAR:
-    m_pack_func = Rdb_key_def::pack_year;
-    m_unpack_func = Rdb_key_def::unpack_binary_str;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_YEAR:
+      m_pack_func = Rdb_key_def::pack_year;
+      m_unpack_func = Rdb_key_def::unpack_binary_str;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_NEWDATE:
-    m_pack_func = Rdb_key_def::pack_newdate;
-    m_unpack_func = Rdb_key_def::unpack_newdate;
-    m_covered = true;
-    return true;
+    case MYSQL_TYPE_NEWDATE:
+      m_pack_func = Rdb_key_def::pack_newdate;
+      m_unpack_func = Rdb_key_def::unpack_newdate;
+      m_covered = true;
+      return true;
 
-  case MYSQL_TYPE_TINY_BLOB:
-  case MYSQL_TYPE_MEDIUM_BLOB:
-  case MYSQL_TYPE_LONG_BLOB:
-  case MYSQL_TYPE_BLOB:
-  case MYSQL_TYPE_JSON: {
-    m_pack_func = Rdb_key_def::pack_blob;
-    if (key_descr) {
-      // The my_charset_bin collation is special in that it will consider
-      // shorter strings sorting as less than longer strings.
-      //
-      // See Field_blob::make_sort_key for details.
-      m_max_image_len =
-          key_length +
-          (field->charset() == &my_charset_bin
-               ? dynamic_cast<const Field_blob *>(field)->pack_length_no_ptr()
-               : 0);
-      // Return false because indexes on text/blob will always require
-      // a prefix. With a prefix, the optimizer will not be able to do an
-      // index-only scan since there may be content occuring after the prefix
-      // length.
-      return false;
-    }
-  } break;
-  // Obsolete
-  case MYSQL_TYPE_DECIMAL:
-  case MYSQL_TYPE_TIMESTAMP:
-  case MYSQL_TYPE_TIME:
-  case MYSQL_TYPE_DATETIME:
-    DBUG_ASSERT(0);
-  default:
-    break;
+    case MYSQL_TYPE_TINY_BLOB:
+    case MYSQL_TYPE_MEDIUM_BLOB:
+    case MYSQL_TYPE_LONG_BLOB:
+    case MYSQL_TYPE_BLOB:
+    case MYSQL_TYPE_JSON: {
+      m_pack_func = Rdb_key_def::pack_blob;
+      if (key_descr) {
+        // The my_charset_bin collation is special in that it will consider
+        // shorter strings sorting as less than longer strings.
+        //
+        // See Field_blob::make_sort_key for details.
+        m_max_image_len =
+            key_length +
+            (field->charset() == &my_charset_bin
+                 ? dynamic_cast<const Field_blob *>(field)->pack_length_no_ptr()
+                 : 0);
+        // Return false because indexes on text/blob will always require
+        // a prefix. With a prefix, the optimizer will not be able to do an
+        // index-only scan since there may be content occuring after the prefix
+        // length.
+        return false;
+      }
+    } break;
+    // Obsolete
+    case MYSQL_TYPE_DECIMAL:
+    case MYSQL_TYPE_TIMESTAMP:
+    case MYSQL_TYPE_TIME:
+    case MYSQL_TYPE_DATETIME:
+      DBUG_ASSERT(0);
+    default:
+      break;
   }
 
   m_unpack_info_stores_value = false;
@@ -3967,7 +3974,7 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
     } else {
       // This is [VAR]CHAR(n) and the collation is not $(charset_name)_bin
 
-      res = true; // index-only scans are possible
+      res = true;  // index-only scans are possible
       m_unpack_data_len = is_varchar ? 0 : field->field_length;
       const uint idx = is_varchar ? 0 : 1;
       const Rdb_collation_codec *codec = nullptr;
@@ -3993,12 +4000,14 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
                                        &space_mb_len);
         } else {
           //  NO_LINT_DEBUG
-          sql_print_warning("RocksDB: you're trying to create an index "
-                            "with a multi-level collation %s",
-                            cs->name);
+          sql_print_warning(
+              "RocksDB: you're trying to create an index "
+              "with a multi-level collation %s",
+              cs->name);
           //  NO_LINT_DEBUG
-          sql_print_warning("MyRocks will handle this collation internally "
-                            " as if it had a NO_PAD attribute.");
+          sql_print_warning(
+              "MyRocks will handle this collation internally "
+              " as if it had a NO_PAD attribute.");
           m_pack_func = Rdb_key_def::pack_with_varchar_encoding;
           m_skip_func = Rdb_key_def::skip_variable_length;
         }
@@ -4027,7 +4036,7 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
         // Here, we just indicate to the SQL layer we can't do it.
         DBUG_ASSERT(m_unpack_func == nullptr);
         m_unpack_info_stores_value = false;
-        res = false; // Indicate that index-only reads are not possible
+        res = false;  // Indicate that index-only reads are not possible
       }
     }
 
@@ -4145,8 +4154,8 @@ bool Rdb_tbl_def::put_dict(Rdb_dict_manager *const dict,
       flags &= ~Rdb_key_def::CF_FLAGS_TO_IGNORE;
 
       if (existing_cf_flags != flags) {
-         my_error(ER_CF_DIFFERENT, MYF(0), cf_name.c_str(), flags,
-                  existing_cf_flags);
+        my_error(ER_CF_DIFFERENT, MYF(0), cf_name.c_str(), flags,
+                 existing_cf_flags);
         return true;
       }
     } else {
@@ -4187,7 +4196,6 @@ bool Rdb_key_def::has_index_flag(uint32 index_flags, enum INDEX_FLAG flag) {
 uint32 Rdb_key_def::calculate_index_flag_offset(uint32 index_flags,
                                                 enum INDEX_FLAG flag,
                                                 uint *const length) {
-
   DBUG_ASSERT_IMP(flag != MAX_FLAG,
                   Rdb_key_def::has_index_flag(index_flags, flag));
 
@@ -4222,7 +4230,9 @@ void Rdb_key_def::write_index_flag_field(Rdb_string_writer *const buf,
 
 void Rdb_tbl_def::check_if_is_mysql_system_table() {
   static const char *const system_dbs[] = {
-      "mysql", "performance_schema", "information_schema",
+      "mysql",
+      "performance_schema",
+      "information_schema",
   };
 
   m_is_mysql_system_table = false;
@@ -4287,7 +4297,7 @@ void Rdb_ddl_manager::remove_uncommitted_keydefs(
 }
 
 #if defined(ROCKSDB_INCLUDE_VALIDATE_TABLES) && ROCKSDB_INCLUDE_VALIDATE_TABLES
-namespace // anonymous namespace = not visible outside this source file
+namespace  // anonymous namespace = not visible outside this source file
 {
 struct Rdb_validate_tbls : public Rdb_tables_scanner {
   using tbl_info_t = std::pair<std::string, bool>;
@@ -4305,7 +4315,7 @@ struct Rdb_validate_tbls : public Rdb_tables_scanner {
   bool check_frm_file(const std::string &fullpath, const std::string &dbname,
                       const std::string &tablename, bool *has_errors);
 };
-} // anonymous namespace
+}  // anonymous namespace
 
 /*
   Get a list of tables that we expect to have .frm files for.  This will use the
@@ -4360,8 +4370,7 @@ bool Rdb_validate_tbls::check_frm_file(const std::string &fullpath,
     return false;
   }
 
-  if (!partition_info_str.empty())
-    eng_type = DB_TYPE_PARTITION_DB;
+  if (!partition_info_str.empty()) eng_type = DB_TYPE_PARTITION_DB;
 
   if (type == FRMTYPE_TABLE) {
     /* For a RocksDB table do we have a reference in the data dictionary? */
@@ -4372,10 +4381,11 @@ bool Rdb_validate_tbls::check_frm_file(const std::string &fullpath,
       */
       tbl_info_t element(tablename, false);
       if (m_list.count(dbname) == 0 || m_list[dbname].erase(element) == 0) {
-        sql_print_warning("RocksDB: Schema mismatch - "
-                          "A .frm file exists for table %s.%s, "
-                          "but that table is not registered in RocksDB",
-                          dbname.c_str(), tablename.c_str());
+        sql_print_warning(
+            "RocksDB: Schema mismatch - "
+            "A .frm file exists for table %s.%s, "
+            "but that table is not registered in RocksDB",
+            dbname.c_str(), tablename.c_str());
         *has_errors = true;
       }
     } else if (eng_type == DB_TYPE_PARTITION_DB) {
@@ -4456,12 +4466,10 @@ bool Rdb_validate_tbls::compare_to_actual_tables(const std::string &datadir,
   file_info = dir_info->dir_entry;
   for (uint ii = 0; ii < dir_info->number_off_files; ii++, file_info++) {
     /* Ignore files/dirs starting with '.' */
-    if (file_info->name[0] == '.')
-      continue;
+    if (file_info->name[0] == '.') continue;
 
     /* Ignore all non-directory files */
-    if (!MY_S_ISDIR(file_info->mystat->st_mode))
-      continue;
+    if (!MY_S_ISDIR(file_info->mystat->st_mode)) continue;
 
     /* Scan all the .frm files in the directory */
     if (!scan_for_frms(datadir, file_info->name, has_errors)) {
@@ -4512,10 +4520,11 @@ bool Rdb_ddl_manager::validate_auto_incr() {
     rdb_netbuf_read_gl_index(&ptr, &gl_index_id);
     if (!m_dict->get_index_info(gl_index_id, nullptr)) {
       // NO_LINT_DEBUG
-      sql_print_warning("RocksDB: AUTOINC mismatch - "
-                        "Index number (%u, %u) found in AUTOINC "
-                        "but does not exist as a DDL entry",
-                        gl_index_id.cf_id, gl_index_id.index_id);
+      sql_print_warning(
+          "RocksDB: AUTOINC mismatch - "
+          "Index number (%u, %u) found in AUTOINC "
+          "but does not exist as a DDL entry",
+          gl_index_id.cf_id, gl_index_id.index_id);
       return false;
     }
 
@@ -4523,10 +4532,11 @@ bool Rdb_ddl_manager::validate_auto_incr() {
     const int version = rdb_netbuf_read_uint16(&ptr);
     if (version > Rdb_key_def::AUTO_INCREMENT_VERSION) {
       // NO_LINT_DEBUG
-      sql_print_warning("RocksDB: AUTOINC mismatch - "
-                        "Index number (%u, %u) found in AUTOINC "
-                        "is on unsupported version %d",
-                        gl_index_id.cf_id, gl_index_id.index_id, version);
+      sql_print_warning(
+          "RocksDB: AUTOINC mismatch - "
+          "Index number (%u, %u) found in AUTOINC "
+          "is on unsupported version %d",
+          gl_index_id.cf_id, gl_index_id.index_id, version);
       return false;
     }
   }
@@ -4563,10 +4573,11 @@ bool Rdb_ddl_manager::validate_schemas(void) {
   */
   for (const auto &db : table_list.m_list) {
     for (const auto &table : db.second) {
-      sql_print_warning("RocksDB: Schema mismatch - "
-                        "Table %s.%s is registered in RocksDB "
-                        "but does not have a .frm file",
-                        db.first.c_str(), table.first.c_str());
+      sql_print_warning(
+          "RocksDB: Schema mismatch - "
+          "Table %s.%s is registered in RocksDB "
+          "but does not have a .frm file",
+          db.first.c_str(), table.first.c_str());
       has_errors = true;
     }
   }
@@ -4633,9 +4644,10 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
     ptr = reinterpret_cast<const uchar *>(val.data());
     const int version = rdb_netbuf_read_uint16(&ptr);
     if (version != Rdb_key_def::DDL_ENTRY_INDEX_VERSION) {
-      sql_print_error("RocksDB: DDL ENTRY Version was not expected."
-                      "Expected: %d, Actual: %d",
-                      Rdb_key_def::DDL_ENTRY_INDEX_VERSION, version);
+      sql_print_error(
+          "RocksDB: DDL ENTRY Version was not expected."
+          "Expected: %d, Actual: %d",
+          Rdb_key_def::DDL_ENTRY_INDEX_VERSION, version);
       return true;
     }
     ptr_end = ptr + real_val_size;
@@ -4645,32 +4657,36 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
       uint flags = 0;
       struct Rdb_index_info index_info;
       if (!m_dict->get_index_info(gl_index_id, &index_info)) {
-        sql_print_error("RocksDB: Could not get index information "
-                        "for Index Number (%u,%u), table %s",
-                        gl_index_id.cf_id, gl_index_id.index_id,
-                        tdef->full_tablename().c_str());
+        sql_print_error(
+            "RocksDB: Could not get index information "
+            "for Index Number (%u,%u), table %s",
+            gl_index_id.cf_id, gl_index_id.index_id,
+            tdef->full_tablename().c_str());
         return true;
       }
       if (max_index_id_in_dict < gl_index_id.index_id) {
-        sql_print_error("RocksDB: Found max index id %u from data dictionary "
-                        "but also found larger index id %u from dictionary. "
-                        "This should never happen and possibly a bug.",
-                        max_index_id_in_dict, gl_index_id.index_id);
+        sql_print_error(
+            "RocksDB: Found max index id %u from data dictionary "
+            "but also found larger index id %u from dictionary. "
+            "This should never happen and possibly a bug.",
+            max_index_id_in_dict, gl_index_id.index_id);
         return true;
       }
       if (!m_dict->get_cf_flags(gl_index_id.cf_id, &flags)) {
-        sql_print_error("RocksDB: Could not get Column Family Flags "
-                        "for CF Number %d, table %s",
-                        gl_index_id.cf_id, tdef->full_tablename().c_str());
+        sql_print_error(
+            "RocksDB: Could not get Column Family Flags "
+            "for CF Number %d, table %s",
+            gl_index_id.cf_id, tdef->full_tablename().c_str());
         return true;
       }
 
       if ((flags & Rdb_key_def::AUTO_CF_FLAG) != 0) {
         // The per-index cf option is deprecated.  Make sure we don't have the
         // flag set in any existing database.   NO_LINT_DEBUG
-        sql_print_error("RocksDB: The defunct AUTO_CF_FLAG is enabled for CF "
-                        "number %d, table %s",
-                        gl_index_id.cf_id, tdef->full_tablename().c_str());
+        sql_print_error(
+            "RocksDB: The defunct AUTO_CF_FLAG is enabled for CF "
+            "number %d, table %s",
+            gl_index_id.cf_id, tdef->full_tablename().c_str());
       }
 
       rocksdb::ColumnFamilyHandle *const cfh =
@@ -4709,11 +4725,13 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
   if (validate_tables > 0) {
     std::string msg;
     if (!validate_schemas()) {
-      msg = "RocksDB: Problems validating data dictionary "
-            "against .frm files, exiting";
+      msg =
+          "RocksDB: Problems validating data dictionary "
+          "against .frm files, exiting";
     } else if (!validate_auto_incr()) {
-      msg = "RocksDB: Problems validating auto increment values in "
-            "data dictionary, exiting";
+      msg =
+          "RocksDB: Problems validating auto increment values in "
+          "data dictionary, exiting";
     }
     if (validate_tables == 1 && !msg.empty()) {
       // NO_LINT_DEBUG
@@ -4751,8 +4769,7 @@ Rdb_tbl_def *Rdb_ddl_manager::find(const std::string &table_name,
   }
 
   const auto &it = m_ddl_hash.find(table_name);
-  if (it != m_ddl_hash.end())
-    ret = it->second;
+  if (it != m_ddl_hash.end()) ret = it->second;
 
   if (lock) {
     mysql_rwlock_unlock(&m_rwlock);
@@ -4765,8 +4782,8 @@ Rdb_tbl_def *Rdb_ddl_manager::find(const std::string &table_name,
 // lock on m_rwlock to make sure the Rdb_key_def is not discarded while we
 // are finding it.  Copying it into 'ret' increments the count making sure
 // that the object will not be discarded until we are finished with it.
-std::shared_ptr<const Rdb_key_def>
-Rdb_ddl_manager::safe_find(GL_INDEX_ID gl_index_id) {
+std::shared_ptr<const Rdb_key_def> Rdb_ddl_manager::safe_find(
+    GL_INDEX_ID gl_index_id) {
   std::shared_ptr<const Rdb_key_def> ret(nullptr);
 
   mysql_rwlock_rdlock(&m_rwlock);
@@ -4796,8 +4813,8 @@ Rdb_ddl_manager::safe_find(GL_INDEX_ID gl_index_id) {
 }
 
 // this method assumes at least read-only lock on m_rwlock
-const std::shared_ptr<Rdb_key_def> &
-Rdb_ddl_manager::find(GL_INDEX_ID gl_index_id) {
+const std::shared_ptr<Rdb_key_def> &Rdb_ddl_manager::find(
+    GL_INDEX_ID gl_index_id) {
   auto it = m_index_num_to_keydef.find(gl_index_id);
   if (it != m_index_num_to_keydef.end()) {
     auto table_def = find(it->second.first, false);
@@ -4820,8 +4837,8 @@ Rdb_ddl_manager::find(GL_INDEX_ID gl_index_id) {
 
 // this method returns the name of the table based on an index id. It acquires
 // a read lock on m_rwlock.
-const std::string
-Rdb_ddl_manager::safe_get_table_name(const GL_INDEX_ID &gl_index_id) {
+const std::string Rdb_ddl_manager::safe_get_table_name(
+    const GL_INDEX_ID &gl_index_id) {
   std::string ret;
   mysql_rwlock_rdlock(&m_rwlock);
   auto it = m_index_num_to_keydef.find(gl_index_id);
@@ -4922,8 +4939,7 @@ int Rdb_ddl_manager::put_and_write(Rdb_tbl_def *const tbl,
 int Rdb_ddl_manager::put(Rdb_tbl_def *const tbl, const bool lock) {
   const std::string &dbname_tablename = tbl->full_tablename();
 
-  if (lock)
-    mysql_rwlock_wrlock(&m_rwlock);
+  if (lock) mysql_rwlock_wrlock(&m_rwlock);
 
   // We have to do this find because 'tbl' is not yet in the list.  We need
   // to find the one we are replacing ('rec')
@@ -4940,16 +4956,14 @@ int Rdb_ddl_manager::put(Rdb_tbl_def *const tbl, const bool lock) {
   }
   tbl->check_and_set_read_free_rpl_table();
 
-  if (lock)
-    mysql_rwlock_unlock(&m_rwlock);
+  if (lock) mysql_rwlock_unlock(&m_rwlock);
   return 0;
 }
 
 void Rdb_ddl_manager::remove(Rdb_tbl_def *const tbl,
                              rocksdb::WriteBatch *const batch,
                              const bool lock) {
-  if (lock)
-    mysql_rwlock_wrlock(&m_rwlock);
+  if (lock) mysql_rwlock_wrlock(&m_rwlock);
 
   Rdb_buf_writer<FN_LEN * 2 + Rdb_key_def::INDEX_NUMBER_SIZE> key_writer;
   key_writer.write_index(Rdb_key_def::DDL_ENTRY_INDEX_START_NUMBER);
@@ -4964,8 +4978,7 @@ void Rdb_ddl_manager::remove(Rdb_tbl_def *const tbl,
     m_ddl_hash.erase(it);
   }
 
-  if (lock)
-    mysql_rwlock_unlock(&m_rwlock);
+  if (lock) mysql_rwlock_unlock(&m_rwlock);
 }
 
 bool Rdb_ddl_manager::rename(const std::string &from, const std::string &to,
@@ -5004,7 +5017,7 @@ bool Rdb_ddl_manager::rename(const std::string &from, const std::string &to,
   if (!new_rec->put_dict(m_dict, batch, new_buf_writer.to_slice())) {
     remove(rec, batch, false);
     put(new_rec, false);
-    res = false; // ok
+    res = false;  // ok
   }
 
   mysql_rwlock_unlock(&m_rwlock);
@@ -5012,8 +5025,7 @@ bool Rdb_ddl_manager::rename(const std::string &from, const std::string &to,
 }
 
 void Rdb_ddl_manager::cleanup() {
-  for (const auto &it : m_ddl_hash)
-    delete it.second;
+  for (const auto &it : m_ddl_hash) delete it.second;
 
   m_ddl_hash.clear();
 
@@ -5033,8 +5045,7 @@ int Rdb_ddl_manager::scan_for_tables(Rdb_tables_scanner *const tables_scanner) {
 
   for (const auto &it : m_ddl_hash) {
     ret = tables_scanner->add_table(it.second);
-    if (ret)
-      break;
+    if (ret) break;
     i++;
   }
 
@@ -5112,15 +5123,14 @@ rocksdb::Iterator *Rdb_dict_manager::new_iterator() const {
 
 int Rdb_dict_manager::commit(rocksdb::WriteBatch *const batch,
                              const bool sync) const {
-  if (!batch)
-    return HA_ERR_ROCKSDB_COMMIT_FAILED;
+  if (!batch) return HA_ERR_ROCKSDB_COMMIT_FAILED;
   int res = HA_EXIT_SUCCESS;
   rocksdb::WriteOptions options;
   options.sync = sync;
   rocksdb::TransactionDBWriteOptimizations optimize;
   optimize.skip_concurrency_control = true;
   rocksdb::Status s = m_db->Write(options, optimize, batch);
-  res = !s.ok(); // we return true when something failed
+  res = !s.ok();  // we return true when something failed
   if (res) {
     rdb_handle_io_error(s, RDB_IO_ERROR_DICT_COMMIT);
   }
@@ -5191,7 +5201,6 @@ void Rdb_dict_manager::delete_index_info(rocksdb::WriteBatch *batch,
 bool Rdb_dict_manager::get_index_info(
     const GL_INDEX_ID &gl_index_id,
     struct Rdb_index_info *const index_info) const {
-
   if (index_info) {
     index_info->m_gl_index_id = gl_index_id;
   }
@@ -5214,73 +5223,73 @@ bool Rdb_dict_manager::get_index_info(
     ptr += RDB_SIZEOF_INDEX_INFO_VERSION;
 
     switch (index_info->m_index_dict_version) {
-    case Rdb_key_def::INDEX_INFO_VERSION_FIELD_FLAGS:
-      /* Sanity check to prevent reading bogus TTL record. */
-      if (value.size() != RDB_SIZEOF_INDEX_INFO_VERSION +
-                              RDB_SIZEOF_INDEX_TYPE + RDB_SIZEOF_KV_VERSION +
-                              RDB_SIZEOF_INDEX_FLAGS +
-                              ROCKSDB_SIZEOF_TTL_RECORD) {
+      case Rdb_key_def::INDEX_INFO_VERSION_FIELD_FLAGS:
+        /* Sanity check to prevent reading bogus TTL record. */
+        if (value.size() != RDB_SIZEOF_INDEX_INFO_VERSION +
+                                RDB_SIZEOF_INDEX_TYPE + RDB_SIZEOF_KV_VERSION +
+                                RDB_SIZEOF_INDEX_FLAGS +
+                                ROCKSDB_SIZEOF_TTL_RECORD) {
+          error = true;
+          break;
+        }
+        index_info->m_index_type = rdb_netbuf_to_byte(ptr);
+        ptr += RDB_SIZEOF_INDEX_TYPE;
+        index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
+        ptr += RDB_SIZEOF_KV_VERSION;
+        index_info->m_index_flags = rdb_netbuf_to_uint32(ptr);
+        ptr += RDB_SIZEOF_INDEX_FLAGS;
+        index_info->m_ttl_duration = rdb_netbuf_to_uint64(ptr);
+        found = true;
+        break;
+
+      case Rdb_key_def::INDEX_INFO_VERSION_TTL:
+        /* Sanity check to prevent reading bogus into TTL record. */
+        if (value.size() != RDB_SIZEOF_INDEX_INFO_VERSION +
+                                RDB_SIZEOF_INDEX_TYPE + RDB_SIZEOF_KV_VERSION +
+                                ROCKSDB_SIZEOF_TTL_RECORD) {
+          error = true;
+          break;
+        }
+        index_info->m_index_type = rdb_netbuf_to_byte(ptr);
+        ptr += RDB_SIZEOF_INDEX_TYPE;
+        index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
+        ptr += RDB_SIZEOF_KV_VERSION;
+        index_info->m_ttl_duration = rdb_netbuf_to_uint64(ptr);
+        if ((index_info->m_kv_version ==
+             Rdb_key_def::PRIMARY_FORMAT_VERSION_TTL) &&
+            index_info->m_ttl_duration > 0) {
+          index_info->m_index_flags = Rdb_key_def::TTL_FLAG;
+        }
+        found = true;
+        break;
+
+      case Rdb_key_def::INDEX_INFO_VERSION_VERIFY_KV_FORMAT:
+      case Rdb_key_def::INDEX_INFO_VERSION_GLOBAL_ID:
+        index_info->m_index_type = rdb_netbuf_to_byte(ptr);
+        ptr += RDB_SIZEOF_INDEX_TYPE;
+        index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
+        found = true;
+        break;
+
+      default:
         error = true;
         break;
-      }
-      index_info->m_index_type = rdb_netbuf_to_byte(ptr);
-      ptr += RDB_SIZEOF_INDEX_TYPE;
-      index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
-      ptr += RDB_SIZEOF_KV_VERSION;
-      index_info->m_index_flags = rdb_netbuf_to_uint32(ptr);
-      ptr += RDB_SIZEOF_INDEX_FLAGS;
-      index_info->m_ttl_duration = rdb_netbuf_to_uint64(ptr);
-      found = true;
-      break;
-
-    case Rdb_key_def::INDEX_INFO_VERSION_TTL:
-      /* Sanity check to prevent reading bogus into TTL record. */
-      if (value.size() != RDB_SIZEOF_INDEX_INFO_VERSION +
-                              RDB_SIZEOF_INDEX_TYPE + RDB_SIZEOF_KV_VERSION +
-                              ROCKSDB_SIZEOF_TTL_RECORD) {
-        error = true;
-        break;
-      }
-      index_info->m_index_type = rdb_netbuf_to_byte(ptr);
-      ptr += RDB_SIZEOF_INDEX_TYPE;
-      index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
-      ptr += RDB_SIZEOF_KV_VERSION;
-      index_info->m_ttl_duration = rdb_netbuf_to_uint64(ptr);
-      if ((index_info->m_kv_version ==
-           Rdb_key_def::PRIMARY_FORMAT_VERSION_TTL) &&
-          index_info->m_ttl_duration > 0) {
-        index_info->m_index_flags = Rdb_key_def::TTL_FLAG;
-      }
-      found = true;
-      break;
-
-    case Rdb_key_def::INDEX_INFO_VERSION_VERIFY_KV_FORMAT:
-    case Rdb_key_def::INDEX_INFO_VERSION_GLOBAL_ID:
-      index_info->m_index_type = rdb_netbuf_to_byte(ptr);
-      ptr += RDB_SIZEOF_INDEX_TYPE;
-      index_info->m_kv_version = rdb_netbuf_to_uint16(ptr);
-      found = true;
-      break;
-
-    default:
-      error = true;
-      break;
     }
 
     switch (index_info->m_index_type) {
-    case Rdb_key_def::INDEX_TYPE_PRIMARY:
-    case Rdb_key_def::INDEX_TYPE_HIDDEN_PRIMARY: {
-      error =
-          index_info->m_kv_version > Rdb_key_def::PRIMARY_FORMAT_VERSION_LATEST;
-      break;
-    }
-    case Rdb_key_def::INDEX_TYPE_SECONDARY:
-      error = index_info->m_kv_version >
-              Rdb_key_def::SECONDARY_FORMAT_VERSION_LATEST;
-      break;
-    default:
-      error = true;
-      break;
+      case Rdb_key_def::INDEX_TYPE_PRIMARY:
+      case Rdb_key_def::INDEX_TYPE_HIDDEN_PRIMARY: {
+        error = index_info->m_kv_version >
+                Rdb_key_def::PRIMARY_FORMAT_VERSION_LATEST;
+        break;
+      }
+      case Rdb_key_def::INDEX_TYPE_SECONDARY:
+        error = index_info->m_kv_version >
+                Rdb_key_def::SECONDARY_FORMAT_VERSION_LATEST;
+        break;
+      default:
+        error = true;
+        break;
     }
   }
 
@@ -5541,12 +5550,12 @@ void Rdb_dict_manager::resume_drop_indexes() const {
   for (const auto &gl_index_id : gl_index_ids) {
     log_start_drop_index(gl_index_id, "Resume");
     if (max_index_id_in_dict < gl_index_id.index_id) {
-      sql_print_error("RocksDB: Found max index id %u from data dictionary "
-                      "but also found dropped index id (%u,%u) from drop_index "
-                      "dictionary. This should never happen and is possibly a "
-                      "bug.",
-                      max_index_id_in_dict, gl_index_id.cf_id,
-                      gl_index_id.index_id);
+      sql_print_error(
+          "RocksDB: Found max index id %u from data dictionary "
+          "but also found dropped index id (%u,%u) from drop_index "
+          "dictionary. This should never happen and is possibly a "
+          "bug.",
+          max_index_id_in_dict, gl_index_id.cf_id, gl_index_id.index_id);
       abort();
     }
   }
@@ -5592,10 +5601,11 @@ void Rdb_dict_manager::log_start_drop_index(GL_INDEX_ID gl_index_id,
 
     if (!incomplete_create_indexes.count(gl_index_id)) {
       /* If it's not a partially created index, something is very wrong. */
-      sql_print_error("RocksDB: Failed to get column family info "
-                      "from index id (%u,%u). MyRocks data dictionary may "
-                      "get corrupted.",
-                      gl_index_id.cf_id, gl_index_id.index_id);
+      sql_print_error(
+          "RocksDB: Failed to get column family info "
+          "from index id (%u,%u). MyRocks data dictionary may "
+          "get corrupted.",
+          gl_index_id.cf_id, gl_index_id.index_id);
       abort();
     }
   }
@@ -5624,10 +5634,11 @@ bool Rdb_dict_manager::update_max_index_id(rocksdb::WriteBatch *const batch,
   uint32_t old_index_id = -1;
   if (get_max_index_id(&old_index_id)) {
     if (old_index_id > index_id) {
-      sql_print_error("RocksDB: Found max index id %u from data dictionary "
-                      "but trying to update to older value %u. This should "
-                      "never happen and possibly a bug.",
-                      old_index_id, index_id);
+      sql_print_error(
+          "RocksDB: Found max index id %u from data dictionary "
+          "but trying to update to older value %u. This should "
+          "never happen and possibly a bug.",
+          old_index_id, index_id);
       return true;
     }
   }
@@ -5676,10 +5687,9 @@ Rdb_index_stats Rdb_dict_manager::get_stats(GL_INDEX_ID gl_index_id) const {
   return Rdb_index_stats();
 }
 
-rocksdb::Status
-Rdb_dict_manager::put_auto_incr_val(rocksdb::WriteBatchBase *batch,
-                                    GL_INDEX_ID gl_index_id,
-                                    ulonglong val, bool overwrite) const {
+rocksdb::Status Rdb_dict_manager::put_auto_incr_val(
+    rocksdb::WriteBatchBase *batch, GL_INDEX_ID gl_index_id, ulonglong val,
+    bool overwrite) const {
   Rdb_buf_writer<Rdb_key_def::INDEX_NUMBER_SIZE * 3> key_writer;
   dump_index_id(&key_writer, Rdb_key_def::AUTO_INC, gl_index_id);
 
@@ -5738,4 +5748,4 @@ uint Rdb_seq_generator::get_and_update_next_number(
   return res;
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3569,16 +3569,17 @@ static void rdb_get_mem_comparable_space(const CHARSET_INFO *const cs,
       const size_t space_mb_len = cs->cset->wc_mb(
           cs, (my_wc_t)cs->pad_char, space_mb, space_mb + sizeof(space_mb));
 
-      uchar space[20];  // mem-comparable image of the space character
+      // mem-comparable image of the space character
+      std::array<uchar, 20> space;
 
-      const size_t space_len = cs->coll->strnxfrm(cs, space, sizeof(space), 1,
-                                                  space_mb, space_mb_len, 0);
+      const size_t space_len = cs->coll->strnxfrm(
+          cs, space.data(), sizeof(space), 1, space_mb, space_mb_len, 0);
       Rdb_charset_space_info *const info = new Rdb_charset_space_info;
       info->space_xfrm_len = space_len;
       info->space_mb_len = space_mb_len;
       while (info->spaces_xfrm.size() < RDB_SPACE_XFRM_SIZE) {
-        info->spaces_xfrm.insert(info->spaces_xfrm.end(), space,
-                                 space + space_len);
+        info->spaces_xfrm.insert(info->spaces_xfrm.end(), space.data(),
+                                 space.data() + space_len);
       }
       rdb_mem_comparable_space[cs->number].reset(info);
     }

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -3525,6 +3525,8 @@ int Rdb_key_def::unpack_simple(Rdb_field_packing *const fpi,
 // See Rdb_charset_space_info::spaces_xfrm
 const int RDB_SPACE_XFRM_SIZE = 32;
 
+namespace {
+
 // A class holding information about how space character is represented in a
 // charset.
 class Rdb_charset_space_info {
@@ -3544,6 +3546,8 @@ class Rdb_charset_space_info {
   // (length=2)
   size_t space_mb_len;
 };
+
+}  // namespace
 
 static std::array<std::unique_ptr<Rdb_charset_space_info>, MY_ALL_CHARSETS_SIZE>
     rdb_mem_comparable_space;
@@ -4814,7 +4818,7 @@ std::shared_ptr<const Rdb_key_def> Rdb_ddl_manager::safe_find(
 
   mysql_rwlock_rdlock(&m_rwlock);
 
-  auto it = m_index_num_to_keydef.find(gl_index_id);
+  const auto it = m_index_num_to_keydef.find(gl_index_id);
   if (it != m_index_num_to_keydef.end()) {
     const auto table_def = find(it->second.first, false);
     if (table_def && it->second.second < table_def->m_key_count) {
@@ -4824,9 +4828,10 @@ std::shared_ptr<const Rdb_key_def> Rdb_ddl_manager::safe_find(
       }
     }
   } else {
-    auto it = m_index_num_to_uncommitted_keydef.find(gl_index_id);
-    if (it != m_index_num_to_uncommitted_keydef.end()) {
-      const auto &kd = it->second;
+    const auto uncommitted_it =
+        m_index_num_to_uncommitted_keydef.find(gl_index_id);
+    if (uncommitted_it != m_index_num_to_uncommitted_keydef.end()) {
+      const auto &kd = uncommitted_it->second;
       if (kd->max_storage_fmt_length() != 0) {
         ret = kd;
       }
@@ -4841,18 +4846,19 @@ std::shared_ptr<const Rdb_key_def> Rdb_ddl_manager::safe_find(
 // this method assumes at least read-only lock on m_rwlock
 const std::shared_ptr<Rdb_key_def> &Rdb_ddl_manager::find(
     GL_INDEX_ID gl_index_id) {
-  auto it = m_index_num_to_keydef.find(gl_index_id);
+  const auto it = m_index_num_to_keydef.find(gl_index_id);
   if (it != m_index_num_to_keydef.end()) {
-    auto table_def = find(it->second.first, false);
+    const auto table_def = find(it->second.first, false);
     if (table_def) {
       if (it->second.second < table_def->m_key_count) {
         return table_def->m_key_descr_arr[it->second.second];
       }
     }
   } else {
-    auto it = m_index_num_to_uncommitted_keydef.find(gl_index_id);
-    if (it != m_index_num_to_uncommitted_keydef.end()) {
-      return it->second;
+    const auto uncommitted_it =
+        m_index_num_to_uncommitted_keydef.find(gl_index_id);
+    if (uncommitted_it != m_index_num_to_uncommitted_keydef.end()) {
+      return uncommitted_it->second;
     }
   }
 
@@ -4878,7 +4884,7 @@ const std::string Rdb_ddl_manager::safe_get_table_name(
 void Rdb_ddl_manager::set_stats(
     const std::unordered_map<GL_INDEX_ID, Rdb_index_stats> &stats) {
   mysql_rwlock_wrlock(&m_rwlock);
-  for (auto src : stats) {
+  for (const auto &src : stats) {
     const auto &keydef = find(src.second.m_gl_index_id);
     if (keydef) {
       keydef->m_stats = src.second;

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -50,8 +50,8 @@ class Rdb_convert_to_record_key_decoder {
   Rdb_convert_to_record_key_decoder() = default;
   Rdb_convert_to_record_key_decoder(
       const Rdb_convert_to_record_key_decoder &decoder) = delete;
-  Rdb_convert_to_record_key_decoder &
-  operator=(const Rdb_convert_to_record_key_decoder &decoder) = delete;
+  Rdb_convert_to_record_key_decoder &operator=(
+      const Rdb_convert_to_record_key_decoder &decoder) = delete;
   static int decode(uchar *const buf, uint *offset, Rdb_field_packing *fpi,
                     TABLE *table, Field *field, bool has_unpack_info,
                     Rdb_string_reader *reader,
@@ -81,7 +81,7 @@ class Rdb_convert_to_record_key_decoder {
   unpack_info is passed as context data between the two.
 */
 class Rdb_pack_field_context {
-public:
+ public:
   Rdb_pack_field_context(const Rdb_pack_field_context &) = delete;
   Rdb_pack_field_context &operator=(const Rdb_pack_field_context &) = delete;
 
@@ -245,7 +245,7 @@ enum {
 */
 
 class Rdb_key_def {
-public:
+ public:
   /* Convert a key from KeyTupleFormat to mem-comparable form */
   uint pack_index_tuple(TABLE *const tbl, uchar *const pack_buffer,
                         uchar *const packed_tuple, const uchar *const key_tuple,
@@ -368,8 +368,7 @@ public:
 
   /* Check if given mem-comparable key belongs to this index */
   bool covers_key(const rocksdb::Slice &slice) const {
-    if (slice.size() < INDEX_NUMBER_SIZE)
-      return false;
+    if (slice.size() < INDEX_NUMBER_SIZE) return false;
 
     if (memcmp(slice.data(), m_index_number_storage_form, INDEX_NUMBER_SIZE))
       return false;
@@ -465,7 +464,7 @@ public:
     VERSION_SIZE = 2,
     CF_NUMBER_SIZE = 4,
     CF_FLAG_SIZE = 4,
-    PACKED_SIZE = 4, // one int
+    PACKED_SIZE = 4,  // one int
   };
 
   // bit flags for combining bools when writing to disk
@@ -605,15 +604,14 @@ public:
                               const uchar *const val,
                               enum INDEX_FLAG flag) const;
 
-  static const std::string
-  gen_qualifier_for_table(const char *const qualifier,
-                          const std::string &partition_name = "");
-  static const std::string
-  gen_cf_name_qualifier_for_partition(const std::string &s);
-  static const std::string
-  gen_ttl_duration_qualifier_for_partition(const std::string &s);
-  static const std::string
-  gen_ttl_col_qualifier_for_partition(const std::string &s);
+  static const std::string gen_qualifier_for_table(
+      const char *const qualifier, const std::string &partition_name = "");
+  static const std::string gen_cf_name_qualifier_for_partition(
+      const std::string &s);
+  static const std::string gen_ttl_duration_qualifier_for_partition(
+      const std::string &s);
+  static const std::string gen_ttl_col_qualifier_for_partition(
+      const std::string &s);
 
   static const std::string parse_comment_for_qualifier(
       const std::string &comment, const TABLE *const table_arg,
@@ -638,74 +636,74 @@ public:
   bool index_format_min_check(const int pk_min, const int sk_min) const;
 
   static void pack_tiny(Rdb_field_packing *const fpi, Field *const field,
-                 uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                 Rdb_pack_field_context *const pack_ctx
-                     MY_ATTRIBUTE((__unused__)));
-
-  static void pack_short(Rdb_field_packing *const fpi, Field *const field,
-                  uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                  Rdb_pack_field_context *const pack_ctx
-                      MY_ATTRIBUTE((__unused__)));
-
-  static void pack_medium(Rdb_field_packing *const fpi, Field *const field,
-                   uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                   Rdb_pack_field_context *const pack_ctx
-                       MY_ATTRIBUTE((__unused__)));
-
-  static void pack_long(Rdb_field_packing *const fpi, Field *const field,
-                 uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                 Rdb_pack_field_context *const pack_ctx
-                     MY_ATTRIBUTE((__unused__)));
-
-  static void pack_longlong(Rdb_field_packing *const fpi, Field *const field,
-                     uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                     Rdb_pack_field_context *const pack_ctx
-                         MY_ATTRIBUTE((__unused__)));
-
-  static void pack_double(Rdb_field_packing *const fpi, Field *const field,
-                   uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                   Rdb_pack_field_context *const pack_ctx
-                       MY_ATTRIBUTE((__unused__)));
-
-  static void pack_float(Rdb_field_packing *const fpi, Field *const field,
-                  uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                  Rdb_pack_field_context *const pack_ctx
-                      MY_ATTRIBUTE((__unused__)));
-
-  static void pack_new_decimal(Rdb_field_packing *const fpi, Field *const field,
                         uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
                         Rdb_pack_field_context *const pack_ctx
                             MY_ATTRIBUTE((__unused__)));
 
-  static void pack_datetime2(Rdb_field_packing *const fpi, Field *const field,
-                     uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                     Rdb_pack_field_context *const pack_ctx
-                         MY_ATTRIBUTE((__unused__)));
+  static void pack_short(Rdb_field_packing *const fpi, Field *const field,
+                         uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                         Rdb_pack_field_context *const pack_ctx
+                             MY_ATTRIBUTE((__unused__)));
 
-  static void pack_timestamp2(Rdb_field_packing *const fpi, Field *const field,
-                      uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                      Rdb_pack_field_context *const pack_ctx
-                          MY_ATTRIBUTE((__unused__)));
+  static void pack_medium(Rdb_field_packing *const fpi, Field *const field,
+                          uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                          Rdb_pack_field_context *const pack_ctx
+                              MY_ATTRIBUTE((__unused__)));
+
+  static void pack_long(Rdb_field_packing *const fpi, Field *const field,
+                        uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                        Rdb_pack_field_context *const pack_ctx
+                            MY_ATTRIBUTE((__unused__)));
+
+  static void pack_longlong(Rdb_field_packing *const fpi, Field *const field,
+                            uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                            Rdb_pack_field_context *const pack_ctx
+                                MY_ATTRIBUTE((__unused__)));
+
+  static void pack_double(Rdb_field_packing *const fpi, Field *const field,
+                          uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                          Rdb_pack_field_context *const pack_ctx
+                              MY_ATTRIBUTE((__unused__)));
+
+  static void pack_float(Rdb_field_packing *const fpi, Field *const field,
+                         uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                         Rdb_pack_field_context *const pack_ctx
+                             MY_ATTRIBUTE((__unused__)));
+
+  static void pack_new_decimal(
+      Rdb_field_packing *const fpi, Field *const field,
+      uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+      Rdb_pack_field_context *const pack_ctx MY_ATTRIBUTE((__unused__)));
+
+  static void pack_datetime2(Rdb_field_packing *const fpi, Field *const field,
+                             uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                             Rdb_pack_field_context *const pack_ctx
+                                 MY_ATTRIBUTE((__unused__)));
+
+  static void pack_timestamp2(
+      Rdb_field_packing *const fpi, Field *const field,
+      uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+      Rdb_pack_field_context *const pack_ctx MY_ATTRIBUTE((__unused__)));
 
   static void pack_time2(Rdb_field_packing *const fpi, Field *const field,
-                  uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                  Rdb_pack_field_context *const pack_ctx
-                      MY_ATTRIBUTE((__unused__)));
+                         uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                         Rdb_pack_field_context *const pack_ctx
+                             MY_ATTRIBUTE((__unused__)));
 
   static void pack_year(Rdb_field_packing *const fpi, Field *const field,
-                 uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                 Rdb_pack_field_context *const pack_ctx
-                     MY_ATTRIBUTE((__unused__)));
+                        uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                        Rdb_pack_field_context *const pack_ctx
+                            MY_ATTRIBUTE((__unused__)));
 
   static void pack_newdate(Rdb_field_packing *const fpi, Field *const field,
-                    uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                    Rdb_pack_field_context *const pack_ctx
-                        MY_ATTRIBUTE((__unused__)));
+                           uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                           Rdb_pack_field_context *const pack_ctx
+                               MY_ATTRIBUTE((__unused__)));
 
   static void pack_blob(Rdb_field_packing *const fpi, Field *const field,
-                 uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
-                 Rdb_pack_field_context *const pack_ctx
-                     MY_ATTRIBUTE((__unused__)));
+                        uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
+                        Rdb_pack_field_context *const pack_ctx
+                            MY_ATTRIBUTE((__unused__)));
 
   static void pack_with_make_sort_key(
       Rdb_field_packing *const fpi, Field *const field,
@@ -716,27 +714,26 @@ public:
       Rdb_field_packing *const fpi, Field *const field, uchar *buf, uchar **dst,
       Rdb_pack_field_context *const pack_ctx MY_ATTRIBUTE((__unused__)));
 
-  static void
-  pack_with_varchar_space_pad(Rdb_field_packing *const fpi, Field *const field,
-                              uchar *buf, uchar **dst,
-                              Rdb_pack_field_context *const pack_ctx);
+  static void pack_with_varchar_space_pad(
+      Rdb_field_packing *const fpi, Field *const field, uchar *buf, uchar **dst,
+      Rdb_pack_field_context *const pack_ctx);
 
   static int unpack_integer(Rdb_field_packing *const fpi, Field *const field,
                             uchar *const to, Rdb_string_reader *const reader,
                             Rdb_string_reader *const unp_reader
                                 MY_ATTRIBUTE((__unused__)));
 
-  static int
-  unpack_double(Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-                Field *const field MY_ATTRIBUTE((__unused__)),
-                uchar *const field_ptr, Rdb_string_reader *const reader,
-                Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  static int unpack_double(
+      Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
+      Field *const field MY_ATTRIBUTE((__unused__)), uchar *const field_ptr,
+      Rdb_string_reader *const reader,
+      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
-  static int
-  unpack_float(Rdb_field_packing *const fpi,
-               Field *const field MY_ATTRIBUTE((__unused__)),
-               uchar *const field_ptr, Rdb_string_reader *const reader,
-               Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
+  static int unpack_float(
+      Rdb_field_packing *const fpi,
+      Field *const field MY_ATTRIBUTE((__unused__)), uchar *const field_ptr,
+      Rdb_string_reader *const reader,
+      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   static int unpack_binary_str(Rdb_field_packing *const fpi, Field *const field,
                                uchar *const to, Rdb_string_reader *const reader,
@@ -788,10 +785,9 @@ public:
                                    const uchar *const zero_val,
                                    void (*swap_func)(uchar *, const uchar *));
 
-  static void
-  make_unpack_simple_varchar(const Rdb_collation_codec *const codec,
-                             const Field *const field,
-                             Rdb_pack_field_context *const pack_ctx);
+  static void make_unpack_simple_varchar(
+      const Rdb_collation_codec *const codec, const Field *const field,
+      Rdb_pack_field_context *const pack_ctx);
 
   static void make_unpack_simple(const Rdb_collation_codec *const codec,
                                  const Field *const field,
@@ -810,10 +806,10 @@ public:
       const Field *field MY_ATTRIBUTE((__unused__)),
       Rdb_pack_field_context *pack_ctx MY_ATTRIBUTE((__unused__)));
 
-  static int
-  skip_max_length(const Rdb_field_packing *const fpi,
-                  const Field *const field MY_ATTRIBUTE((__unused__)),
-                  Rdb_string_reader *const reader);
+  static int skip_max_length(const Rdb_field_packing *const fpi,
+                             const Field *const field
+                                 MY_ATTRIBUTE((__unused__)),
+                             Rdb_string_reader *const reader);
 
   static int skip_variable_length(const Rdb_field_packing *const fpi,
                                   const Field *const field,
@@ -894,7 +890,6 @@ public:
   std::string m_ttl_column;
 
  private:
-
   /* Number of key parts in the primary key*/
   uint m_pk_key_parts;
 
@@ -973,7 +968,7 @@ extern std::array<const Rdb_collation_codec *, MY_ALL_CHARSETS_SIZE>
     rdb_collation_data;
 
 class Rdb_field_packing {
-public:
+ public:
   Rdb_field_packing(const Rdb_field_packing &);
   Rdb_field_packing &operator=(const Rdb_field_packing &) = delete;
   Rdb_field_packing();
@@ -994,7 +989,7 @@ public:
   bool m_use_legacy_varbinary_format;
 
   // (Valid when Variable Length Space Padded Encoding is used):
-  uint m_segment_size; // size of segment used
+  uint m_segment_size;  // size of segment used
 
   // number of bytes used to store number of trimmed (or added)
   // spaces in the upack_info
@@ -1037,38 +1032,38 @@ public:
   */
   rdb_index_field_skip_t m_skip_func;
 
-private:
- /*
-   Location of the field in the table (key number and key part number).
+ private:
+  /*
+    Location of the field in the table (key number and key part number).
 
-   Note that this describes not the field, but rather a position of field in
-   the index. Consider an example:
+    Note that this describes not the field, but rather a position of field in
+    the index. Consider an example:
 
-     col1 VARCHAR (100),
-     INDEX idx1 (col1)),
-     INDEX idx2 (col1(10)),
+      col1 VARCHAR (100),
+      INDEX idx1 (col1)),
+      INDEX idx2 (col1(10)),
 
-   Here, idx2 has a special Field object that is set to describe a 10-char
-   prefix of col1.
+    Here, idx2 has a special Field object that is set to describe a 10-char
+    prefix of col1.
 
-   We must also store the keynr. It is needed for implicit "extended keys".
-   Every key in MyRocks needs to include PK columns.  Generally, SQL layer
-   includes PK columns as part of its "Extended Keys" feature, but sometimes
-   it does not (known examples are unique secondary indexes and partitioned
-   tables).
-   In that case, MyRocks's index descriptor has invisible suffix of PK
-   columns (and the point is that these columns are parts of PK, not parts
-   of the current index).
- */
- uint m_keynr;
- uint m_key_part;
+    We must also store the keynr. It is needed for implicit "extended keys".
+    Every key in MyRocks needs to include PK columns.  Generally, SQL layer
+    includes PK columns as part of its "Extended Keys" feature, but sometimes
+    it does not (known examples are unique secondary indexes and partitioned
+    tables).
+    In that case, MyRocks's index descriptor has invisible suffix of PK
+    columns (and the point is that these columns are parts of PK, not parts
+    of the current index).
+  */
+  uint m_keynr;
+  uint m_key_part;
 
-public:
- bool setup(const Rdb_key_def *const key_descr, const Field *const field,
-            const uint keynr_arg, const uint key_part_arg,
-            const uint16 key_length);
- Field *get_field_in_table(const TABLE *const tbl) const;
- void fill_hidden_pk_val(uchar **dst, const longlong hidden_pk_id) const;
+ public:
+  bool setup(const Rdb_key_def *const key_descr, const Field *const field,
+             const uint keynr_arg, const uint key_part_arg,
+             const uint16 key_length);
+  Field *get_field_in_table(const TABLE *const tbl) const;
+  void fill_hidden_pk_val(uchar **dst, const longlong hidden_pk_id) const;
 };
 
 /*
@@ -1079,7 +1074,7 @@ public:
   For encoding/decoding of index tuples, see Rdb_key_def.
   */
 class Rdb_field_encoder {
-public:
+ public:
   Rdb_field_encoder(const Rdb_field_encoder &) = delete;
   Rdb_field_encoder &operator=(const Rdb_field_encoder &) = delete;
   /*
@@ -1100,7 +1095,7 @@ public:
   uint m_null_offset;
   uint16 m_field_index;
 
-  uchar m_null_mask; // 0 means the field cannot be null
+  uchar m_null_mask;  // 0 means the field cannot be null
 
   my_core::enum_field_types m_field_type;
 
@@ -1141,7 +1136,7 @@ inline bool Rdb_key_def::has_unpack_info(const uint kp) const {
 */
 
 class Rdb_tbl_def {
-private:
+ private:
   void check_if_is_mysql_system_table();
 
   /* Stores 'dbname.tablename' */
@@ -1154,7 +1149,7 @@ private:
 
   void set_name(const std::string &name);
 
-public:
+ public:
   Rdb_tbl_def(const Rdb_tbl_def &) = delete;
   Rdb_tbl_def &operator=(const Rdb_tbl_def &) = delete;
 
@@ -1212,7 +1207,7 @@ class Rdb_seq_generator {
 
   mysql_mutex_t m_mutex;
 
-public:
+ public:
   Rdb_seq_generator(const Rdb_seq_generator &) = delete;
   Rdb_seq_generator &operator=(const Rdb_seq_generator &) = delete;
   Rdb_seq_generator() = default;
@@ -1249,7 +1244,7 @@ class Rdb_ddl_manager {
   // Maps index id to key definitons not yet committed to data dictionary.
   // This is mainly used to store key definitions during ALTER TABLE.
   std::map<GL_INDEX_ID, std::shared_ptr<Rdb_key_def>>
-    m_index_num_to_uncommitted_keydef;
+      m_index_num_to_uncommitted_keydef;
   mysql_rwlock_t m_rwlock;
 
   Rdb_seq_generator m_sequence;
@@ -1260,12 +1255,12 @@ class Rdb_ddl_manager {
 
   const std::shared_ptr<Rdb_key_def> &find(GL_INDEX_ID gl_index_id);
 
-public:
+ public:
   Rdb_ddl_manager(const Rdb_ddl_manager &) = delete;
   Rdb_ddl_manager &operator=(const Rdb_ddl_manager &) = delete;
   Rdb_ddl_manager() {}
 
-  /* Load the data dictionary from on-disk storage */
+    /* Load the data dictionary from on-disk storage */
 #if defined(ROCKSDB_INCLUDE_VALIDATE_TABLES) && ROCKSDB_INCLUDE_VALIDATE_TABLES
   bool init(Rdb_dict_manager *const dict_arg, Rdb_cf_manager *const cf_manager,
             const uint32_t validate_tables);
@@ -1383,7 +1378,7 @@ public:
 
 */
 class Rdb_dict_manager {
-private:
+ private:
   mysql_mutex_t m_mutex;
   rocksdb::TransactionDB *m_db = nullptr;
   rocksdb::ColumnFamilyHandle *m_system_cfh = nullptr;
@@ -1445,9 +1440,9 @@ private:
   rocksdb::Iterator *new_iterator() const;
 
   /* Internal Index id => CF */
-  void
-  add_or_update_index_cf_mapping(rocksdb::WriteBatch *batch,
-                                 struct Rdb_index_info *const index_info) const;
+  void add_or_update_index_cf_mapping(
+      rocksdb::WriteBatch *batch,
+      struct Rdb_index_info *const index_info) const;
   void delete_index_info(rocksdb::WriteBatch *batch,
                          const GL_INDEX_ID &index_id) const;
   bool get_index_info(const GL_INDEX_ID &gl_index_id,
@@ -1459,9 +1454,9 @@ private:
   bool get_cf_flags(const uint cf_id, uint *const cf_flags) const;
 
   /* Functions for fast CREATE/DROP TABLE/INDEX */
-  void
-  get_ongoing_index_operation(std::unordered_set<GL_INDEX_ID> *gl_index_ids,
-                              Rdb_key_def::DATA_DICT_TYPE dd_type) const;
+  void get_ongoing_index_operation(
+      std::unordered_set<GL_INDEX_ID> *gl_index_ids,
+      Rdb_key_def::DATA_DICT_TYPE dd_type) const;
   bool is_index_operation_ongoing(const GL_INDEX_ID &gl_index_id,
                                   Rdb_key_def::DATA_DICT_TYPE dd_type) const;
   void start_ongoing_index_operation(rocksdb::WriteBatch *batch,
@@ -1478,9 +1473,9 @@ private:
                       rocksdb::WriteBatch *const batch) const;
   void add_create_index(const std::unordered_set<GL_INDEX_ID> &gl_index_ids,
                         rocksdb::WriteBatch *const batch) const;
-  void
-  finish_indexes_operation(const std::unordered_set<GL_INDEX_ID> &gl_index_ids,
-                           Rdb_key_def::DATA_DICT_TYPE dd_type) const;
+  void finish_indexes_operation(
+      const std::unordered_set<GL_INDEX_ID> &gl_index_ids,
+      Rdb_key_def::DATA_DICT_TYPE dd_type) const;
   void rollback_ongoing_index_creation() const;
 
   inline void get_ongoing_drop_indexes(
@@ -1529,11 +1524,9 @@ private:
   Rdb_index_stats get_stats(GL_INDEX_ID gl_index_id) const;
 
   rocksdb::Status put_auto_incr_val(rocksdb::WriteBatchBase *batch,
-                                    GL_INDEX_ID gl_index_id,
-                                    ulonglong val,
+                                    GL_INDEX_ID gl_index_id, ulonglong val,
                                     bool overwrite = false) const;
-  bool get_auto_incr_val(GL_INDEX_ID gl_index_id,
-                         ulonglong *new_val) const;
+  bool get_auto_incr_val(GL_INDEX_ID gl_index_id, ulonglong *new_val) const;
 };
 
 struct Rdb_index_info {
@@ -1650,4 +1643,4 @@ class Rdb_system_merge_op : public rocksdb::AssociativeMergeOperator {
   }
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -24,6 +24,7 @@
 #include <map>
 #include <mutex>
 #include <string>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -1237,8 +1238,10 @@ interface Rdb_tables_scanner {
 
 class Rdb_ddl_manager {
   Rdb_dict_manager *m_dict = nullptr;
+
   // Contains Rdb_tbl_def elements
-  std::unordered_map<std::string, Rdb_tbl_def *> m_ddl_hash;
+  std::unordered_map<std::string, Rdb_tbl_def *> m_ddl_map;
+
   // Maps index id to <table_name, index number>
   std::map<GL_INDEX_ID, std::pair<std::string, uint>> m_index_num_to_keydef;
 

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -370,8 +370,9 @@ class Rdb_key_def {
   bool covers_key(const rocksdb::Slice &slice) const {
     if (slice.size() < INDEX_NUMBER_SIZE) return false;
 
-    if (memcmp(slice.data(), m_index_number_storage_form, INDEX_NUMBER_SIZE))
+    if (memcmp(slice.data(), m_index_number_storage_form, INDEX_NUMBER_SIZE)) {
       return false;
+    }
 
     return true;
   }

--- a/storage/rocksdb/rdb_global.h
+++ b/storage/rocksdb/rdb_global.h
@@ -19,6 +19,7 @@
 #pragma once
 
 /* C++ standard header files */
+#include <limits>
 #include <string>
 #include <vector>
 

--- a/storage/rocksdb/rdb_global.h
+++ b/storage/rocksdb/rdb_global.h
@@ -24,10 +24,10 @@
 #include <vector>
 
 /* MySQL header files */
-#include "handler.h"   /* handler */
+#include "handler.h" /* handler */
+#include "ib_ut0counter.h"
 #include "my_global.h" /* ulonglong */
 #include "sql_string.h"
-#include "ib_ut0counter.h"
 
 namespace myrocks {
 /*
@@ -241,9 +241,9 @@ const constexpr uint MAX_INDEX_COL_LEN_SMALL = 767;
 */
 #define HA_ERR_ROCKSDB_FIRST (HA_ERR_LAST + 1)
 #define HA_ERR_ROCKSDB_PK_REQUIRED (HA_ERR_ROCKSDB_FIRST + 0)
-#define HA_ERR_ROCKSDB_TABLE_DATA_DIRECTORY_NOT_SUPPORTED                      \
+#define HA_ERR_ROCKSDB_TABLE_DATA_DIRECTORY_NOT_SUPPORTED \
   (HA_ERR_ROCKSDB_FIRST + 1)
-#define HA_ERR_ROCKSDB_TABLE_INDEX_DIRECTORY_NOT_SUPPORTED                     \
+#define HA_ERR_ROCKSDB_TABLE_INDEX_DIRECTORY_NOT_SUPPORTED \
   (HA_ERR_ROCKSDB_FIRST + 2)
 #define HA_ERR_ROCKSDB_COMMIT_FAILED (HA_ERR_ROCKSDB_FIRST + 3)
 #define HA_ERR_ROCKSDB_BULK_LOAD (HA_ERR_ROCKSDB_FIRST + 4)
@@ -378,10 +378,15 @@ struct st_io_stall_stats {
   ulonglong total_slowdown;
 
   st_io_stall_stats()
-      : level0_slowdown(0), level0_slowdown_with_compaction(0),
-        level0_numfiles(0), level0_numfiles_with_compaction(0),
+      : level0_slowdown(0),
+        level0_slowdown_with_compaction(0),
+        level0_numfiles(0),
+        level0_numfiles_with_compaction(0),
         stop_for_pending_compaction_bytes(0),
-        slowdown_for_pending_compaction_bytes(0), memtable_compaction(0),
-        memtable_slowdown(0), total_stop(0), total_slowdown(0) {}
+        slowdown_for_pending_compaction_bytes(0),
+        memtable_compaction(0),
+        memtable_slowdown(0),
+        total_stop(0),
+        total_slowdown(0) {}
 };
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_i_s.cc
+++ b/storage/rocksdb/rdb_i_s.cc
@@ -49,10 +49,10 @@ namespace myrocks {
   engine.
 */
 
-#define ROCKSDB_FIELD_INFO(_name_, _len_, _type_, _flag_)                      \
+#define ROCKSDB_FIELD_INFO(_name_, _len_, _type_, _flag_) \
   { _name_, _len_, _type_, 0, _flag_, nullptr, 0 }
 
-#define ROCKSDB_FIELD_INFO_END                                                 \
+#define ROCKSDB_FIELD_INFO_END \
   ROCKSDB_FIELD_INFO(nullptr, 0, MYSQL_TYPE_NULL, 0)
 
 /*
@@ -60,7 +60,7 @@ namespace myrocks {
  */
 namespace RDB_CFSTATS_FIELD {
 enum { CF_NAME = 0, STAT_TYPE, VALUE };
-} // namespace RDB_CFSTATS_FIELD
+}  // namespace RDB_CFSTATS_FIELD
 
 static ST_FIELD_INFO rdb_i_s_cfstats_fields_info[] = {
     ROCKSDB_FIELD_INFO("CF_NAME", NAME_LEN + 1, MYSQL_TYPE_STRING, 0),
@@ -68,10 +68,9 @@ static ST_FIELD_INFO rdb_i_s_cfstats_fields_info[] = {
     ROCKSDB_FIELD_INFO("VALUE", sizeof(uint64_t), MYSQL_TYPE_LONGLONG, 0),
     ROCKSDB_FIELD_INFO_END};
 
-static int rdb_i_s_cfstats_fill_table(my_core::THD *const thd,
-                                      my_core::TABLE_LIST *const tables,
-                                      my_core::Item *const cond
-                                      MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_cfstats_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(tables != nullptr);
@@ -164,17 +163,16 @@ static int rdb_i_s_cfstats_init(void *p) {
  */
 namespace RDB_DBSTATS_FIELD {
 enum { STAT_TYPE = 0, VALUE };
-} // namespace RDB_DBSTATS_FIELD
+}  // namespace RDB_DBSTATS_FIELD
 
 static ST_FIELD_INFO rdb_i_s_dbstats_fields_info[] = {
     ROCKSDB_FIELD_INFO("STAT_TYPE", NAME_LEN + 1, MYSQL_TYPE_STRING, 0),
     ROCKSDB_FIELD_INFO("VALUE", sizeof(uint64_t), MYSQL_TYPE_LONGLONG, 0),
     ROCKSDB_FIELD_INFO_END};
 
-static int rdb_i_s_dbstats_fill_table(my_core::THD *const thd,
-                                      my_core::TABLE_LIST *const tables,
-                                      my_core::Item *const cond
-                                      MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_dbstats_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(tables != nullptr);
@@ -265,7 +263,7 @@ static int rdb_i_s_dbstats_init(void *const p) {
  */
 namespace RDB_PERF_CONTEXT_FIELD {
 enum { TABLE_SCHEMA = 0, TABLE_NAME, PARTITION_NAME, STAT_TYPE, VALUE };
-} // namespace RDB_PERF_CONTEXT_FIELD
+}  // namespace RDB_PERF_CONTEXT_FIELD
 
 static ST_FIELD_INFO rdb_i_s_perf_context_fields_info[] = {
     ROCKSDB_FIELD_INFO("TABLE_SCHEMA", NAME_LEN + 1, MYSQL_TYPE_STRING, 0),
@@ -276,10 +274,9 @@ static ST_FIELD_INFO rdb_i_s_perf_context_fields_info[] = {
     ROCKSDB_FIELD_INFO("VALUE", sizeof(uint64_t), MYSQL_TYPE_LONGLONG, 0),
     ROCKSDB_FIELD_INFO_END};
 
-static int rdb_i_s_perf_context_fill_table(my_core::THD *const thd,
-                                           my_core::TABLE_LIST *const tables,
-                                           my_core::Item *const cond
-                                           MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_perf_context_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(thd != nullptr);
@@ -375,7 +372,7 @@ static int rdb_i_s_perf_context_init(void *const p) {
  */
 namespace RDB_PERF_CONTEXT_GLOBAL_FIELD {
 enum { STAT_TYPE = 0, VALUE };
-} // namespace RDB_PERF_CONTEXT_GLOBAL_FIELD
+}  // namespace RDB_PERF_CONTEXT_GLOBAL_FIELD
 
 static ST_FIELD_INFO rdb_i_s_perf_context_global_fields_info[] = {
     ROCKSDB_FIELD_INFO("STAT_TYPE", NAME_LEN + 1, MYSQL_TYPE_STRING, 0),
@@ -449,7 +446,7 @@ static int rdb_i_s_perf_context_global_init(void *const p) {
  */
 namespace RDB_CFOPTIONS_FIELD {
 enum { CF_NAME = 0, OPTION_TYPE, VALUE };
-} // namespace RDB_CFOPTIONS_FIELD
+}  // namespace RDB_CFOPTIONS_FIELD
 
 static ST_FIELD_INFO rdb_i_s_cfoptions_fields_info[] = {
     ROCKSDB_FIELD_INFO("CF_NAME", NAME_LEN + 1, MYSQL_TYPE_STRING, 0),
@@ -457,10 +454,9 @@ static ST_FIELD_INFO rdb_i_s_cfoptions_fields_info[] = {
     ROCKSDB_FIELD_INFO("VALUE", NAME_LEN + 1, MYSQL_TYPE_STRING, 0),
     ROCKSDB_FIELD_INFO_END};
 
-static int rdb_i_s_cfoptions_fill_table(my_core::THD *const thd,
-                                        my_core::TABLE_LIST *const tables,
-                                        my_core::Item *const cond
-                                        MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_cfoptions_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(thd != nullptr);
@@ -617,20 +613,20 @@ static int rdb_i_s_cfoptions_fill_table(my_core::THD *const thd,
 
     // get COMPACTION_STYLE option
     switch (opts.compaction_style) {
-    case rocksdb::kCompactionStyleLevel:
-      val = "kCompactionStyleLevel";
-      break;
-    case rocksdb::kCompactionStyleUniversal:
-      val = "kCompactionStyleUniversal";
-      break;
-    case rocksdb::kCompactionStyleFIFO:
-      val = "kCompactionStyleFIFO";
-      break;
-    case rocksdb::kCompactionStyleNone:
-      val = "kCompactionStyleNone";
-      break;
-    default:
-      val = "NULL";
+      case rocksdb::kCompactionStyleLevel:
+        val = "kCompactionStyleLevel";
+        break;
+      case rocksdb::kCompactionStyleUniversal:
+        val = "kCompactionStyleUniversal";
+        break;
+      case rocksdb::kCompactionStyleFIFO:
+        val = "kCompactionStyleFIFO";
+        break;
+      case rocksdb::kCompactionStyleNone:
+        val = "kCompactionStyleNone";
+        break;
+      default:
+        val = "NULL";
     }
 
     cf_option_types.push_back({"COMPACTION_STYLE", val});
@@ -653,14 +649,14 @@ static int rdb_i_s_cfoptions_fill_table(my_core::THD *const thd,
     val.append("; STOP_STYLE=");
 
     switch (compac_opts.stop_style) {
-    case rocksdb::kCompactionStopStyleSimilarSize:
-      val.append("kCompactionStopStyleSimilarSize}");
-      break;
-    case rocksdb::kCompactionStopStyleTotalSize:
-      val.append("kCompactionStopStyleTotalSize}");
-      break;
-    default:
-      val.append("}");
+      case rocksdb::kCompactionStopStyleSimilarSize:
+        val.append("kCompactionStopStyleSimilarSize}");
+        break;
+      case rocksdb::kCompactionStopStyleTotalSize:
+        val.append("kCompactionStopStyleTotalSize}");
+        break;
+      default:
+        val.append("}");
     }
 
     cf_option_types.push_back({"COMPACTION_OPTIONS_UNIVERSAL", val});
@@ -757,10 +753,9 @@ static int rdb_global_info_fill_row(my_core::THD *const thd,
   return my_core::schema_table_store_record(thd, tables->table);
 }
 
-static int rdb_i_s_global_info_fill_table(my_core::THD *const thd,
-                                          my_core::TABLE_LIST *const tables,
-                                          my_core::Item *const cond
-                                          MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_global_info_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(thd != nullptr);
@@ -804,10 +799,11 @@ static int rdb_i_s_global_info_fill_table(my_core::THD *const thd,
 
     if (!dict_manager->get_cf_flags(cf_handle->GetID(), &flags)) {
       // NO_LINT_DEBUG
-      sql_print_error("RocksDB: Failed to get column family flags "
-                      "from CF with id = %u. MyRocks data dictionary may "
-                      "be corrupted.",
-                      cf_handle->GetID());
+      sql_print_error(
+          "RocksDB: Failed to get column family flags "
+          "from CF with id = %u. MyRocks data dictionary may "
+          "be corrupted.",
+          cf_handle->GetID());
       abort();
     }
 
@@ -847,10 +843,9 @@ static int rdb_i_s_global_info_fill_table(my_core::THD *const thd,
 /*
   Support for INFORMATION_SCHEMA.ROCKSDB_COMPACTION_STATS dynamic table
  */
-static int rdb_i_s_compact_stats_fill_table(my_core::THD *thd,
-                                            my_core::TABLE_LIST *tables,
-                                            my_core::Item *cond
-                                            MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_compact_stats_fill_table(
+    my_core::THD *thd, my_core::TABLE_LIST *tables,
+    my_core::Item *cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(tables != nullptr);
 
@@ -925,7 +920,7 @@ static ST_FIELD_INFO rdb_i_s_compact_stats_fields_info[] = {
     ROCKSDB_FIELD_INFO("VALUE", sizeof(double), MYSQL_TYPE_DOUBLE, 0),
     ROCKSDB_FIELD_INFO_END};
 
-namespace // anonymous namespace = not visible outside this source file
+namespace  // anonymous namespace = not visible outside this source file
 {
 struct Rdb_ddl_scanner : public Rdb_tables_scanner {
   my_core::THD *m_thd;
@@ -933,7 +928,7 @@ struct Rdb_ddl_scanner : public Rdb_tables_scanner {
 
   int add_table(Rdb_tbl_def *tdef) override;
 };
-} // anonymous namespace
+}  // anonymous namespace
 
 /*
   Support for INFORMATION_SCHEMA.ROCKSDB_DDL dynamic table
@@ -953,7 +948,7 @@ enum {
   CF,
   AUTO_INCREMENT
 };
-} // namespace RDB_DDL_FIELD
+}  // namespace RDB_DDL_FIELD
 
 static ST_FIELD_INFO rdb_i_s_ddl_fields_info[] = {
     ROCKSDB_FIELD_INFO("TABLE_SCHEMA", NAME_LEN + 1, MYSQL_TYPE_STRING, 0),
@@ -1028,8 +1023,7 @@ int Rdb_ddl_scanner::add_table(Rdb_tbl_def *tdef) {
     }
 
     ret = my_core::schema_table_store_record(m_thd, m_table);
-    if (ret)
-      return ret;
+    if (ret) return ret;
   }
   return HA_EXIT_SUCCESS;
 }
@@ -1341,7 +1335,7 @@ enum {
   ENTRY_OTHERS,
   DISTINCT_KEYS_PREFIX
 };
-} // namespace RDB_INDEX_FILE_MAP_FIELD
+}  // namespace RDB_INDEX_FILE_MAP_FIELD
 
 static ST_FIELD_INFO rdb_i_s_index_file_map_fields_info[] = {
     /* The information_schema.rocksdb_index_file_map virtual table has four
@@ -1367,10 +1361,9 @@ static ST_FIELD_INFO rdb_i_s_index_file_map_fields_info[] = {
     ROCKSDB_FIELD_INFO_END};
 
 /* Fill the information_schema.rocksdb_index_file_map virtual table */
-static int rdb_i_s_index_file_map_fill_table(my_core::THD *const thd,
-                                             my_core::TABLE_LIST *const tables,
-                                             my_core::Item *const cond
-                                             MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_index_file_map_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(thd != nullptr);
@@ -1501,7 +1494,7 @@ static int rdb_i_s_index_file_map_init(void *const p) {
  */
 namespace RDB_LOCKS_FIELD {
 enum { COLUMN_FAMILY_ID = 0, TRANSACTION_ID, KEY, MODE };
-} // namespace RDB_LOCKS_FIELD
+}  // namespace RDB_LOCKS_FIELD
 
 static ST_FIELD_INFO rdb_i_s_lock_info_fields_info[] = {
     ROCKSDB_FIELD_INFO("COLUMN_FAMILY_ID", sizeof(uint32_t), MYSQL_TYPE_LONG,
@@ -1512,10 +1505,9 @@ static ST_FIELD_INFO rdb_i_s_lock_info_fields_info[] = {
     ROCKSDB_FIELD_INFO_END};
 
 /* Fill the information_schema.rocksdb_locks virtual table */
-static int rdb_i_s_lock_info_fill_table(my_core::THD *const thd,
-                                        my_core::TABLE_LIST *const tables,
-                                        my_core::Item *const cond
-                                        MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_lock_info_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(thd != nullptr);
@@ -1608,7 +1600,7 @@ enum {
   THREAD_ID,
   QUERY
 };
-} // namespace RDB_TRX_FIELD
+}  // namespace RDB_TRX_FIELD
 
 static ST_FIELD_INFO rdb_i_s_trx_info_fields_info[] = {
     ROCKSDB_FIELD_INFO("TRANSACTION_ID", sizeof(ulonglong), MYSQL_TYPE_LONGLONG,
@@ -1634,10 +1626,9 @@ static ST_FIELD_INFO rdb_i_s_trx_info_fields_info[] = {
     ROCKSDB_FIELD_INFO_END};
 
 /* Fill the information_schema.rocksdb_trx virtual table */
-static int rdb_i_s_trx_info_fill_table(my_core::THD *const thd,
-                                       my_core::TABLE_LIST *const tables,
-                                       my_core::Item *const cond
-                                       MY_ATTRIBUTE((__unused__))) {
+static int rdb_i_s_trx_info_fill_table(
+    my_core::THD *const thd, my_core::TABLE_LIST *const tables,
+    my_core::Item *const cond MY_ATTRIBUTE((__unused__))) {
   DBUG_ENTER_FUNC();
 
   DBUG_ASSERT(thd != nullptr);
@@ -1741,7 +1732,7 @@ enum {
   TABLE_NAME,
   ROLLED_BACK,
 };
-} // namespace RDB_TRX_FIELD
+}  // namespace RDB_DEADLOCK_FIELD
 
 static ST_FIELD_INFO rdb_i_s_deadlock_info_fields_info[] = {
     ROCKSDB_FIELD_INFO("DEADLOCK_ID", sizeof(ulonglong), MYSQL_TYPE_LONGLONG,
@@ -2065,4 +2056,4 @@ struct st_mysql_plugin rdb_i_s_deadlock_info = {
     nullptr, /* config options */
     0,       /* flags */
 };
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_i_s.cc
+++ b/storage/rocksdb/rdb_i_s.cc
@@ -670,7 +670,7 @@ static int rdb_i_s_cfoptions_fill_table(
     std::vector<std::string> table_options =
         split_into_vector(opts.table_factory->GetPrintableTableOptions(), '\n');
 
-    for (auto option : table_options) {
+    for (std::string option : table_options) {
       option.erase(std::remove(option.begin(), option.end(), ' '),
                    option.end());
 
@@ -868,7 +868,7 @@ static int rdb_i_s_compact_stats_fill_table(
 
   Rdb_cf_manager &cf_manager = rdb_get_cf_manager();
 
-  for (auto cf_name : cf_manager.get_cf_names()) {
+  for (const auto &cf_name : cf_manager.get_cf_names()) {
     rocksdb::ColumnFamilyHandle *cfh = cf_manager.get_cf(cf_name);
 
     if (cfh == nullptr) {

--- a/storage/rocksdb/rdb_i_s.h
+++ b/storage/rocksdb/rdb_i_s.h
@@ -34,4 +34,4 @@ extern struct st_mysql_plugin rdb_i_s_index_file_map;
 extern struct st_mysql_plugin rdb_i_s_lock_info;
 extern struct st_mysql_plugin rdb_i_s_trx_info;
 extern struct st_mysql_plugin rdb_i_s_deadlock_info;
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_index_merge.cc
+++ b/storage/rocksdb/rdb_index_merge.cc
@@ -32,10 +32,13 @@ Rdb_index_merge::Rdb_index_merge(const char *const tmpfile_path,
                                  const ulonglong merge_combine_read_size,
                                  const ulonglong merge_tmp_file_removal_delay,
                                  rocksdb::ColumnFamilyHandle *cf)
-    : m_tmpfile_path(tmpfile_path), m_merge_buf_size(merge_buf_size),
+    : m_tmpfile_path(tmpfile_path),
+      m_merge_buf_size(merge_buf_size),
       m_merge_combine_read_size(merge_combine_read_size),
       m_merge_tmp_file_removal_delay(merge_tmp_file_removal_delay),
-      m_cf_handle(cf), m_rec_buf_unsorted(nullptr), m_output_buf(nullptr) {}
+      m_cf_handle(cf),
+      m_rec_buf_unsorted(nullptr),
+      m_output_buf(nullptr) {}
 
 Rdb_index_merge::~Rdb_index_merge() {
   /*
@@ -160,8 +163,9 @@ int Rdb_index_merge::add(const rocksdb::Slice &key, const rocksdb::Slice &val) {
     */
     if (m_offset_tree.empty()) {
       // NO_LINT_DEBUG
-      sql_print_error("Sort buffer size is too small to process merge. "
-                      "Please set merge buffer size to a higher value.");
+      sql_print_error(
+          "Sort buffer size is too small to process merge. "
+          "Please set merge buffer size to a higher value.");
       return HA_ERR_ROCKSDB_MERGE_FILE_ERR;
     }
 
@@ -631,4 +635,4 @@ void Rdb_index_merge::merge_reset() {
   }
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_index_merge.h
+++ b/storage/rocksdb/rdb_index_merge.h
@@ -61,7 +61,7 @@ class Rdb_index_merge {
     /* heap memory allocated for main memory sort/merge  */
     std::unique_ptr<uchar[]> m_block;
     const ulonglong
-        m_block_len;       /* amount of data bytes allocated for block above */
+        m_block_len; /* amount of data bytes allocated for block above */
     ulonglong m_curr_offset; /* offset of the record pointer for the block */
     ulonglong m_disk_start_offset; /* where the chunk starts on disk */
     ulonglong m_disk_curr_offset;  /* current offset on disk */
@@ -87,8 +87,11 @@ class Rdb_index_merge {
     }
 
     explicit merge_buf_info(const ulonglong merge_block_size)
-        : m_block(nullptr), m_block_len(merge_block_size), m_curr_offset(0),
-          m_disk_start_offset(0), m_disk_curr_offset(0),
+        : m_block(nullptr),
+          m_block_len(merge_block_size),
+          m_curr_offset(0),
+          m_disk_start_offset(0),
+          m_disk_curr_offset(0),
           m_total_size(merge_block_size) {
       /* Will throw an exception if it runs out of memory here */
       m_block = std::unique_ptr<uchar[]>(new uchar[merge_block_size]);

--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -69,9 +69,9 @@ Status Rdb_cond_var::Wait(const std::shared_ptr<TransactionDBMutex> mutex_arg) {
                          thd_killed() to determine which occurred)
 */
 
-Status
-Rdb_cond_var::WaitFor(const std::shared_ptr<TransactionDBMutex> mutex_arg,
-                      int64_t timeout_micros) {
+Status Rdb_cond_var::WaitFor(
+    const std::shared_ptr<TransactionDBMutex> mutex_arg,
+    int64_t timeout_micros) {
   auto *mutex_obj = reinterpret_cast<Rdb_mutex *>(mutex_arg.get());
   DBUG_ASSERT(mutex_obj != nullptr);
 
@@ -80,8 +80,7 @@ Rdb_cond_var::WaitFor(const std::shared_ptr<TransactionDBMutex> mutex_arg,
   int res = 0;
   struct timespec wait_timeout;
 
-  if (timeout_micros < 0)
-    timeout_micros = ONE_YEAR_IN_MICROSECS;
+  if (timeout_micros < 0) timeout_micros = ONE_YEAR_IN_MICROSECS;
   set_timespec_nsec(&wait_timeout, timeout_micros * 1000);
 
 #ifndef STANDALONE_UNITTEST
@@ -110,8 +109,7 @@ Rdb_cond_var::WaitFor(const std::shared_ptr<TransactionDBMutex> mutex_arg,
     res = mysql_cond_timedwait(&m_cond, mutex_ptr, &wait_timeout);
 
 #ifndef STANDALONE_UNITTEST
-    if (current_thd)
-      killed = my_core::thd_killed(current_thd);
+    if (current_thd) killed = my_core::thd_killed(current_thd);
 #endif
   } while (!killed && res == EINTR);
 
@@ -216,4 +214,4 @@ void Rdb_mutex::UnLock() {
   RDB_MUTEX_UNLOCK_CHECK(m_mutex);
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_mutex_wrapper.cc
+++ b/storage/rocksdb/rdb_mutex_wrapper.cc
@@ -113,10 +113,11 @@ Status Rdb_cond_var::WaitFor(
 #endif
   } while (!killed && res == EINTR);
 
-  if (res || killed)
+  if (res || killed) {
     return Status::TimedOut();
-  else
+  } else {
     return Status::OK();
+  }
 }
 
 /*

--- a/storage/rocksdb/rdb_mutex_wrapper.h
+++ b/storage/rocksdb/rdb_mutex_wrapper.h
@@ -38,7 +38,7 @@ class Rdb_mutex : public rocksdb::TransactionDBMutex {
 
  public:
   Rdb_mutex();
-  virtual ~Rdb_mutex();
+  virtual ~Rdb_mutex() override;
 
   /*
     Override parent class's virtual methods of interrest.
@@ -80,7 +80,7 @@ class Rdb_cond_var : public rocksdb::TransactionDBCondVar {
 #else
   Rdb_cond_var();
 #endif
-  virtual ~Rdb_cond_var();
+  virtual ~Rdb_cond_var() override;
 
   /*
     Override parent class's virtual methods of interrest.
@@ -147,7 +147,7 @@ class Rdb_mutex_factory : public rocksdb::TransactionDBMutexFactory {
   }
 #endif
 
-  virtual ~Rdb_mutex_factory() {}
+  virtual ~Rdb_mutex_factory() override {}
 };
 
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_mutex_wrapper.h
+++ b/storage/rocksdb/rdb_mutex_wrapper.h
@@ -36,7 +36,7 @@ class Rdb_mutex : public rocksdb::TransactionDBMutex {
   Rdb_mutex(const Rdb_mutex &p) = delete;
   Rdb_mutex &operator=(const Rdb_mutex &p) = delete;
 
-public:
+ public:
   Rdb_mutex();
   virtual ~Rdb_mutex();
 
@@ -54,13 +54,13 @@ public:
   //         TimedOut if timed out,
   //         or other Status on failure.
   // If returned status is OK, TransactionDB will eventually call UnLock().
-  virtual rocksdb::Status TryLockFor(int64_t timeout_time
-                                     MY_ATTRIBUTE((__unused__))) override;
+  virtual rocksdb::Status TryLockFor(
+      int64_t timeout_time MY_ATTRIBUTE((__unused__))) override;
 
   // Unlock Mutex that was successfully locked by Lock() or TryLockUntil()
   virtual void UnLock() override;
 
-private:
+ private:
   mysql_mutex_t m_mutex;
   friend class Rdb_cond_var;
 
@@ -74,7 +74,7 @@ class Rdb_cond_var : public rocksdb::TransactionDBCondVar {
   Rdb_cond_var(const Rdb_cond_var &) = delete;
   Rdb_cond_var &operator=(const Rdb_cond_var &) = delete;
 
-public:
+ public:
 #ifdef HAVE_PSI_INTERFACE
   explicit Rdb_cond_var(PSI_memory_key psi_key);
 #else
@@ -91,8 +91,8 @@ public:
   // Returns OK if notified.
   // Returns non-OK if TransactionDB should stop waiting and fail the operation.
   // May return OK spuriously even if not notified.
-  virtual rocksdb::Status
-  Wait(const std::shared_ptr<rocksdb::TransactionDBMutex> mutex) override;
+  virtual rocksdb::Status Wait(
+      const std::shared_ptr<rocksdb::TransactionDBMutex> mutex) override;
 
   // Block current thread until condition variable is notifiesd by a call to
   // Notify() or NotifyAll(), or if the timeout is reached.
@@ -106,9 +106,9 @@ public:
   // Returns other status if TransactionDB should otherwis stop waiting and
   //  fail the operation.
   // May return OK spuriously even if not notified.
-  virtual rocksdb::Status
-  WaitFor(const std::shared_ptr<rocksdb::TransactionDBMutex> mutex,
-          int64_t timeout_time) override;
+  virtual rocksdb::Status WaitFor(
+      const std::shared_ptr<rocksdb::TransactionDBMutex> mutex,
+      int64_t timeout_time) override;
 
   // If any threads are waiting on *this, unblock at least one of the
   // waiting threads.
@@ -117,12 +117,12 @@ public:
   // Unblocks all threads waiting on *this.
   virtual void NotifyAll() override;
 
-private:
+ private:
   mysql_cond_t m_cond;
 };
 
 class Rdb_mutex_factory : public rocksdb::TransactionDBMutexFactory {
-public:
+ public:
   Rdb_mutex_factory(const Rdb_mutex_factory &) = delete;
   Rdb_mutex_factory &operator=(const Rdb_mutex_factory &) = delete;
   Rdb_mutex_factory() {}
@@ -130,19 +130,19 @@ public:
     Override parent class's virtual methods of interrest.
   */
 
-  virtual std::shared_ptr<rocksdb::TransactionDBMutex>
-  AllocateMutex() override {
+  virtual std::shared_ptr<rocksdb::TransactionDBMutex> AllocateMutex()
+      override {
     return std::make_shared<Rdb_mutex>();
   }
 
-  virtual std::shared_ptr<rocksdb::TransactionDBCondVar>
-  AllocateCondVar() override {
+  virtual std::shared_ptr<rocksdb::TransactionDBCondVar> AllocateCondVar()
+      override {
     return std::make_shared<Rdb_cond_var>(PSI_NOT_INSTRUMENTED);
   }
 
 #ifdef HAVE_PSI_INTERFACE
-  virtual std::shared_ptr<rocksdb::TransactionDBCondVar>
-  AllocateCondVar(PSI_memory_key psi_key) {
+  virtual std::shared_ptr<rocksdb::TransactionDBCondVar> AllocateCondVar(
+      PSI_memory_key psi_key) {
     return std::make_shared<Rdb_cond_var>(psi_key);
   }
 #endif
@@ -150,4 +150,4 @@ public:
   virtual ~Rdb_mutex_factory() {}
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_perf_context.cc
+++ b/storage/rocksdb/rdb_perf_context.cc
@@ -97,14 +97,16 @@ std::string rdb_pc_stat_types[] = {
 
 #define IO_PERF_RECORD(_field_)                                       \
   do {                                                                \
-    if (rocksdb::get_perf_context()->_field_ > 0)                     \
+    if (rocksdb::get_perf_context()->_field_ > 0) {                   \
       counters->m_value[idx] += rocksdb::get_perf_context()->_field_; \
+    }                                                                 \
     idx++;                                                            \
   } while (0)
 #define IO_STAT_RECORD(_field_)                                          \
   do {                                                                   \
-    if (rocksdb::get_iostats_context()->_field_ > 0)                     \
+    if (rocksdb::get_iostats_context()->_field_ > 0) {                   \
       counters->m_value[idx] += rocksdb::get_iostats_context()->_field_; \
+    }                                                                    \
     idx++;                                                               \
   } while (0)
 

--- a/storage/rocksdb/rdb_perf_context.cc
+++ b/storage/rocksdb/rdb_perf_context.cc
@@ -95,17 +95,17 @@ std::string rdb_pc_stat_types[] = {
     "IO_RANGE_SYNC_NANOS",
     "IO_LOGGER_NANOS"};
 
-#define IO_PERF_RECORD(_field_)                                                \
-  do {                                                                         \
-    if (rocksdb::get_perf_context()->_field_ > 0)                              \
-      counters->m_value[idx] += rocksdb::get_perf_context()->_field_;          \
-    idx++;                                                                     \
+#define IO_PERF_RECORD(_field_)                                       \
+  do {                                                                \
+    if (rocksdb::get_perf_context()->_field_ > 0)                     \
+      counters->m_value[idx] += rocksdb::get_perf_context()->_field_; \
+    idx++;                                                            \
   } while (0)
-#define IO_STAT_RECORD(_field_)                                                \
-  do {                                                                         \
-    if (rocksdb::get_iostats_context()->_field_ > 0)                           \
-      counters->m_value[idx] += rocksdb::get_iostats_context()->_field_;       \
-    idx++;                                                                     \
+#define IO_STAT_RECORD(_field_)                                          \
+  do {                                                                   \
+    if (rocksdb::get_iostats_context()->_field_ > 0)                     \
+      counters->m_value[idx] += rocksdb::get_iostats_context()->_field_; \
+    idx++;                                                               \
   } while (0)
 
 static void harvest_diffs(Rdb_atomic_perf_counters *const counters) {

--- a/storage/rocksdb/rdb_perf_context.h
+++ b/storage/rocksdb/rdb_perf_context.h
@@ -107,7 +107,7 @@ class Rdb_perf_counters {
   Rdb_perf_counters(const Rdb_perf_counters &) = delete;
   Rdb_perf_counters &operator=(const Rdb_perf_counters &) = delete;
 
-public:
+ public:
   Rdb_perf_counters() = default;
   uint64_t m_value[PC_MAX_IDX];
 
@@ -125,7 +125,7 @@ class Rdb_io_perf {
   my_io_perf_atomic_t *m_shared_io_perf_read = nullptr;
   ha_statistics *m_stats = nullptr;
 
-public:
+ public:
   Rdb_io_perf(const Rdb_io_perf &) = delete;
   Rdb_io_perf &operator=(const Rdb_io_perf &) = delete;
 
@@ -145,8 +145,9 @@ public:
   void end_and_record(const uint32_t perf_context_level);
 
   explicit Rdb_io_perf()
-      : m_atomic_counters(nullptr), m_shared_io_perf_read(nullptr),
+      : m_atomic_counters(nullptr),
+        m_shared_io_perf_read(nullptr),
         m_stats(nullptr) {}
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_psi.cc
+++ b/storage/rocksdb/rdb_psi.cc
@@ -14,7 +14,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #ifdef USE_PRAGMA_IMPLEMENTATION
-#pragma implementation // gcc: Class implementation
+#pragma implementation  // gcc: Class implementation
 #endif
 
 #define MYSQL_SERVER 1
@@ -120,7 +120,7 @@ void init_rocksdb_psi_keys() {
   count = array_elements(all_rocksdb_memory);
   mysql_memory_register(category, all_rocksdb_memory, count);
 }
-#else  // HAVE_PSI_INTERFACE
+#else   // HAVE_PSI_INTERFACE
 void init_rocksdb_psi_keys() {}
 #endif  // HAVE+PSI_INTERFACE
 

--- a/storage/rocksdb/rdb_psi.h
+++ b/storage/rocksdb/rdb_psi.h
@@ -54,7 +54,7 @@ extern my_core::PSI_cond_key rdb_signal_bg_psi_cond_key,
 extern my_core::PSI_memory_key rdb_datadic_memory_key,
     rdb_open_tables_memory_key, rdb_handler_memory_key;
 
-#endif // HAVE_PSI_INTERFACE
+#endif  // HAVE_PSI_INTERFACE
 
 void init_rocksdb_psi_keys();
 

--- a/storage/rocksdb/rdb_sst_info.cc
+++ b/storage/rocksdb/rdb_sst_info.cc
@@ -44,8 +44,13 @@ Rdb_sst_file_ordered::Rdb_sst_file::Rdb_sst_file(
     rocksdb::DB *const db, rocksdb::ColumnFamilyHandle *const cf,
     const rocksdb::DBOptions &db_options, const std::string &name,
     const bool tracing)
-    : m_db(db), m_cf(cf), m_db_options(db_options), m_sst_file_writer(nullptr),
-      m_name(name), m_tracing(tracing), m_comparator(cf->GetComparator()) {
+    : m_db(db),
+      m_cf(cf),
+      m_db_options(db_options),
+      m_sst_file_writer(nullptr),
+      m_name(name),
+      m_tracing(tracing),
+      m_comparator(cf->GetComparator()) {
   DBUG_ASSERT(db != nullptr);
   DBUG_ASSERT(cf != nullptr);
 }
@@ -90,9 +95,8 @@ rocksdb::Status Rdb_sst_file_ordered::Rdb_sst_file::open() {
   return s;
 }
 
-rocksdb::Status
-Rdb_sst_file_ordered::Rdb_sst_file::put(const rocksdb::Slice &key,
-                                        const rocksdb::Slice &value) {
+rocksdb::Status Rdb_sst_file_ordered::Rdb_sst_file::put(
+    const rocksdb::Slice &key, const rocksdb::Slice &value) {
   DBUG_ASSERT(m_sst_file_writer != nullptr);
 
   // Add the specified key/value to the sst file writer
@@ -102,8 +106,8 @@ Rdb_sst_file_ordered::Rdb_sst_file::put(const rocksdb::Slice &key,
 #pragma GCC diagnostic pop
 }
 
-std::string
-Rdb_sst_file_ordered::Rdb_sst_file::generateKey(const std::string &key) {
+std::string Rdb_sst_file_ordered::Rdb_sst_file::generateKey(
+    const std::string &key) {
   static char const hexdigit[] = {'0', '1', '2', '3', '4', '5', '6', '7',
                                   '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
@@ -124,7 +128,7 @@ rocksdb::Status Rdb_sst_file_ordered::Rdb_sst_file::commit() {
   DBUG_ASSERT(m_sst_file_writer != nullptr);
 
   rocksdb::Status s;
-  rocksdb::ExternalSstFileInfo fileinfo; /// Finish may should be modified
+  rocksdb::ExternalSstFileInfo fileinfo;  /// Finish may should be modified
 
   // Close out the sst file
   s = m_sst_file_writer->Finish(&fileinfo);
@@ -137,13 +141,14 @@ rocksdb::Status Rdb_sst_file_ordered::Rdb_sst_file::commit() {
   if (s.ok()) {
     if (m_tracing) {
       // NO_LINT_DEBUG
-      sql_print_information("SST Tracing: Adding file %s, smallest key: %s, "
-                            "largest key: %s, file size: %lu, "
-                            "num_entries: %lu",
-                            fileinfo.file_path.c_str(),
-                            generateKey(fileinfo.smallest_key).c_str(),
-                            generateKey(fileinfo.largest_key).c_str(),
-                            fileinfo.file_size, fileinfo.num_entries);
+      sql_print_information(
+          "SST Tracing: Adding file %s, smallest key: %s, "
+          "largest key: %s, file size: %lu, "
+          "num_entries: %lu",
+          fileinfo.file_path.c_str(),
+          generateKey(fileinfo.smallest_key).c_str(),
+          generateKey(fileinfo.largest_key).c_str(), fileinfo.file_size,
+          fileinfo.num_entries);
     }
   }
 
@@ -189,7 +194,9 @@ Rdb_sst_file_ordered::Rdb_sst_file_ordered(
     rocksdb::DB *const db, rocksdb::ColumnFamilyHandle *const cf,
     const rocksdb::DBOptions &db_options, const std::string &name,
     const bool tracing, size_t max_size)
-    : m_use_stack(false), m_first(true), m_stack(max_size),
+    : m_use_stack(false),
+      m_first(true),
+      m_stack(max_size),
       m_file(db, cf, db_options, name, tracing) {
   m_stack.reset();
 }
@@ -297,17 +304,25 @@ Rdb_sst_info::Rdb_sst_info(rocksdb::DB *const db, const std::string &tablename,
                            rocksdb::ColumnFamilyHandle *const cf,
                            const rocksdb::DBOptions &db_options,
                            const bool tracing)
-    : m_db(db), m_cf(cf), m_db_options(db_options), m_curr_size(0),
-      m_sst_count(0), m_background_error(HA_EXIT_SUCCESS), m_done(false),
-      m_sst_file(nullptr), m_tracing(tracing), m_print_client_error(true) {
+    : m_db(db),
+      m_cf(cf),
+      m_db_options(db_options),
+      m_curr_size(0),
+      m_sst_count(0),
+      m_background_error(HA_EXIT_SUCCESS),
+      m_done(false),
+      m_sst_file(nullptr),
+      m_tracing(tracing),
+      m_print_client_error(true) {
   m_prefix = db->GetName() + "/";
 
   std::string normalized_table;
   if (rdb_normalize_tablename(tablename.c_str(), &normalized_table)) {
     // We failed to get a normalized table name.  This should never happen,
     // but handle it anyway.
-    m_prefix += "fallback_" + std::to_string(reinterpret_cast<intptr_t>(
-                                  reinterpret_cast<void *>(this))) +
+    m_prefix += "fallback_" +
+                std::to_string(reinterpret_cast<intptr_t>(
+                    reinterpret_cast<void *>(this))) +
                 "_" + indexname + "_";
   } else {
     m_prefix += normalized_table + "_" + indexname + "_";
@@ -350,8 +365,8 @@ int Rdb_sst_info::open_new_sst_file() {
   const std::string name = m_prefix + std::to_string(m_sst_count++) + m_suffix;
 
   // Create the new sst file object
-  m_sst_file = new Rdb_sst_file_ordered(m_db, m_cf, m_db_options,
-                                        name, m_tracing, m_max_size);
+  m_sst_file = new Rdb_sst_file_ordered(m_db, m_cf, m_db_options, name,
+                                        m_tracing, m_max_size);
 
   // Open the sst file
   const rocksdb::Status s = m_sst_file->open();
@@ -475,8 +490,7 @@ int Rdb_sst_info::finish(Rdb_sst_commit_info *commit_info,
 
 void Rdb_sst_info::set_error_msg(const std::string &sst_file_name,
                                  const rocksdb::Status &s) {
-  if (!m_print_client_error)
-    return;
+  if (!m_print_client_error) return;
 
   report_error_msg(s, sst_file_name.c_str());
 }
@@ -492,8 +506,9 @@ void Rdb_sst_info::report_error_msg(const rocksdb::Status &s,
   } else if (s.IsInvalidArgument() &&
              strcmp(s.getState(), "Global seqno is required, but disabled") ==
                  0) {
-    my_printf_error(ER_OVERLAPPING_KEYS, "Rows inserted during bulk load "
-                                         "must not overlap existing rows",
+    my_printf_error(ER_OVERLAPPING_KEYS,
+                    "Rows inserted during bulk load "
+                    "must not overlap existing rows",
                     MYF(0));
   } else {
     my_printf_error(ER_UNKNOWN_ERROR, "[%s] bulk load error: %s", MYF(0),
@@ -532,4 +547,4 @@ void Rdb_sst_info::init(const rocksdb::DB *const db) {
 
 std::atomic<uint64_t> Rdb_sst_info::m_prefix_counter(0);
 std::string Rdb_sst_info::m_suffix = ".bulk_load.tmp";
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_sst_info.cc
+++ b/storage/rocksdb/rdb_sst_info.cc
@@ -347,7 +347,7 @@ Rdb_sst_info::Rdb_sst_info(rocksdb::DB *const db, const std::string &tablename,
 Rdb_sst_info::~Rdb_sst_info() {
   DBUG_ASSERT(m_sst_file == nullptr);
 
-  for (auto sst_file : m_committed_files) {
+  for (const auto &sst_file : m_committed_files) {
     // In case something went wrong attempt to delete the temporary file.
     // If everything went fine that file will have been renamed and this
     // function call will fail.

--- a/storage/rocksdb/rdb_sst_info.h
+++ b/storage/rocksdb/rdb_sst_info.h
@@ -188,7 +188,7 @@ class Rdb_sst_info {
 
     void reset() {
       if (!m_committed) {
-        for (auto sst_file : m_committed_files) {
+        for (const auto &sst_file : m_committed_files) {
           // In case something went wrong attempt to delete the temporary file.
           // If everything went fine that file will have been renamed and this
           // function call will fail.

--- a/storage/rocksdb/rdb_sst_info.h
+++ b/storage/rocksdb/rdb_sst_info.h
@@ -161,7 +161,8 @@ class Rdb_sst_info {
     Rdb_sst_commit_info() : m_committed(true), m_cf(nullptr) {}
 
     Rdb_sst_commit_info(Rdb_sst_commit_info &&rhs) noexcept
-        : m_committed(rhs.m_committed), m_cf(rhs.m_cf),
+        : m_committed(rhs.m_committed),
+          m_cf(rhs.m_cf),
           m_committed_files(std::move(rhs.m_committed_files)) {
       rhs.m_committed = true;
       rhs.m_cf = nullptr;
@@ -261,4 +262,4 @@ class Rdb_sst_info {
                                const char *sst_file_name);
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_threads.cc
+++ b/storage/rocksdb/rdb_threads.cc
@@ -16,7 +16,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 
 #ifdef USE_PRAGMA_IMPLEMENTATION
-#pragma implementation // gcc: Class implementation
+#pragma implementation  // gcc: Class implementation
 #endif
 
 /* The C++ file's header */
@@ -39,7 +39,7 @@ void Rdb_thread::init(
     my_core::PSI_mutex_key stop_bg_psi_mutex_key,
     my_core::PSI_cond_key stop_bg_psi_cond_key
 #endif
-    ) {
+) {
   DBUG_ASSERT(!m_run_once);
   mysql_mutex_init(stop_bg_psi_mutex_key, &m_signal_mutex, MY_MUTEX_INIT_FAST);
   mysql_cond_init(stop_bg_psi_cond_key, &m_signal_cond);
@@ -55,7 +55,7 @@ int Rdb_thread::create_thread(const std::string &thread_name
                               ,
                               PSI_thread_key background_psi_thread_key
 #endif
-                              ) {
+) {
   DBUG_ASSERT(!thread_name.empty());
 
   int err = mysql_thread_create(background_psi_thread_key, &m_handle, nullptr,
@@ -76,4 +76,4 @@ void Rdb_thread::signal(const bool stop_thread) {
   RDB_MUTEX_UNLOCK_CHECK(m_signal_mutex);
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -34,7 +34,7 @@
 namespace myrocks {
 
 class Rdb_thread {
-private:
+ private:
   // Disable Copying
   Rdb_thread(const Rdb_thread &);
   Rdb_thread &operator=(const Rdb_thread &);
@@ -44,12 +44,12 @@ private:
 
   my_thread_handle m_handle;
 
-protected:
+ protected:
   mysql_mutex_t m_signal_mutex;
   mysql_cond_t m_signal_cond;
   bool m_stop = false;
 
-public:
+ public:
   Rdb_thread() : m_run_once(false) {}
 
 #ifdef HAVE_PSI_INTERFACE
@@ -72,7 +72,7 @@ public:
 
   virtual ~Rdb_thread() {}
 
-private:
+ private:
   static void *thread_func(void *const thread_ptr);
 };
 
@@ -83,7 +83,7 @@ private:
 */
 
 class Rdb_background_thread : public Rdb_thread {
-private:
+ private:
   bool m_save_stats = false;
 
   void reset() {
@@ -92,7 +92,7 @@ private:
     m_save_stats = false;
   }
 
-public:
+ public:
   virtual void run() override;
 
   void request_save_stats() {
@@ -137,4 +137,4 @@ struct Rdb_drop_index_thread : public Rdb_thread {
   virtual void run() override;
 };
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_utils.cc
+++ b/storage/rocksdb/rdb_utils.cc
@@ -19,9 +19,9 @@
 
 /* C++ standard header files */
 #include <array>
+#include <sstream>
 #include <string>
 #include <vector>
-#include <sstream>
 
 /* C standard header files */
 #include <ctype.h>
@@ -220,8 +220,8 @@ const char *rdb_skip_id(const struct charset_info_st *const cs,
 /*
   Parses a given string into tokens (if any) separated by a specific delimiter.
 */
-const std::vector<std::string> parse_into_tokens(
-  const std::string& s, const char delim) {
+const std::vector<std::string> parse_into_tokens(const std::string &s,
+                                                 const char delim) {
   std::vector<std::string> tokens;
   std::string t;
   std::stringstream ss(s);
@@ -325,16 +325,14 @@ std::vector<std::string> split_into_vector(const std::string &input,
   // Find next delimiter
   while ((pos = input.find(delimiter, start)) != std::string::npos) {
     // If there is any data since the last delimiter add it to the list
-    if (pos > start)
-      elems.push_back(input.substr(start, pos - start));
+    if (pos > start) elems.push_back(input.substr(start, pos - start));
 
     // Set our start position to the character after the delimiter
     start = pos + 1;
   }
 
   // Add a possible string since the last delimiter
-  if (input.length() > start)
-    elems.push_back(input.substr(start));
+  if (input.length() > start) elems.push_back(input.substr(start));
 
   // Return the resulting list back to the caller
   return elems;
@@ -345,23 +343,28 @@ bool rdb_check_rocksdb_corruption() {
 }
 
 void rdb_persist_corruption_marker() {
-  const std::string& fileName = myrocks::rdb_corruption_marker_file_name();
+  const std::string &fileName = myrocks::rdb_corruption_marker_file_name();
   int fd = my_open(fileName.c_str(), O_CREAT | O_SYNC, MYF(MY_WME));
   if (fd < 0) {
-    sql_print_error("RocksDB: Can't create file %s to mark rocksdb as "
-                    "corrupted.",
-                    fileName.c_str());
+    // NO_LINT_DEBUG
+    sql_print_error(
+        "RocksDB: Can't create file %s to mark rocksdb as "
+        "corrupted.",
+        fileName.c_str());
   } else {
-    sql_print_information("RocksDB: Creating the file %s to abort mysqld "
-                          "restarts. Remove this file from the data directory "
-                          "after fixing the corruption to recover. ",
-                          fileName.c_str());
+    // NO_LINT_DEBUG
+    sql_print_information(
+        "RocksDB: Creating the file %s to abort mysqld "
+        "restarts. Remove this file from the data directory "
+        "after fixing the corruption to recover. ",
+        fileName.c_str());
   }
 
   int ret = my_close(fd, MYF(MY_WME));
   if (ret) {
-    sql_print_error("RocksDB: Error (%d) closing the file %s", ret, fileName.c_str());
+    sql_print_error("RocksDB: Error (%d) closing the file %s", ret,
+                    fileName.c_str());
   }
 }
 
-} // namespace myrocks
+}  // namespace myrocks

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -68,7 +68,7 @@ namespace myrocks {
   The intent behind a SHIP_ASSERT() macro is to have a mechanism for validating
   invariants in retail builds. Traditionally assertions (such as macros defined
   in <cassert>) are evaluated for performance reasons only in debug builds and
-  become NOOP in retail builds when NDEBUG is defined.
+  become NOOP in retail builds when DBUG_OFF is defined.
 
   This macro is intended to validate the invariants which are critical for
   making sure that data corruption and data loss won't take place. Proper

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -303,11 +303,20 @@ std::vector<std::string> split_into_vector(const std::string &input,
  */
 class Ensure_cleanup {
  public:
-  explicit Ensure_cleanup(std::function<void()> cleanup) : m_cleanup(cleanup) {}
+  explicit Ensure_cleanup(std::function<void()> cleanup)
+      : m_cleanup(cleanup), m_skip_cleanup(false) {}
 
-  ~Ensure_cleanup() { m_cleanup(); }
+  ~Ensure_cleanup() {
+    if (!m_skip_cleanup) {
+      m_cleanup();
+    }
+  }
+
+  // If you want to skip cleanup (such as when the operation is successful)
+  void skip() { m_skip_cleanup = true; }
 
  private:
   std::function<void()> m_cleanup;
+  bool m_skip_cleanup;
 };
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -17,8 +17,8 @@
 
 /* C++ standard header files */
 #include <chrono>
-#include <string>
 #include <regex>
+#include <string>
 #include <vector>
 
 /* MySQL header files */
@@ -44,7 +44,7 @@ namespace myrocks {
 
 #ifndef interface
 #define interface struct
-#endif // interface
+#endif  // interface
 
 /*
   Introduce C-style pseudo-namespaces, a handy way to make code more readble
@@ -62,7 +62,7 @@ namespace myrocks {
 // to non-obvious MySQL functions, like the ones that do not start with well
 // known prefixes: "my_", "sql_", and "mysql_".
 #define my_core
-#endif // my_core
+#endif  // my_core
 
 /*
   The intent behind a SHIP_ASSERT() macro is to have a mechanism for validating
@@ -79,12 +79,12 @@ namespace myrocks {
   Use the power of SHIP_ASSERT() wisely.
 */
 #ifndef SHIP_ASSERT
-#define SHIP_ASSERT(expr)                                                      \
-  do {                                                                         \
-    if (!(expr)) {                                                             \
-      my_safe_printf_stderr("\nShip assert failure: \'%s\'\n", #expr);         \
-      abort();                                                                 \
-    }                                                                          \
+#define SHIP_ASSERT(expr)                                              \
+  do {                                                                 \
+    if (!(expr)) {                                                     \
+      my_safe_printf_stderr("\nShip assert failure: \'%s\'\n", #expr); \
+      abort();                                                         \
+    }                                                                  \
   } while (0)
 #endif  // SHIP_ASSERT
 
@@ -102,7 +102,7 @@ namespace myrocks {
   a and b must be both true or both false.
 */
 #ifndef DBUG_ASSERT_IFF
-#define DBUG_ASSERT_IFF(a, b)                                                  \
+#define DBUG_ASSERT_IFF(a, b) \
   DBUG_ASSERT(static_cast<bool>(a) == static_cast<bool>(b))
 #endif
 
@@ -138,10 +138,10 @@ namespace myrocks {
   Macros to better convey the intent behind checking the results from locking
   and unlocking mutexes.
 */
-#define RDB_MUTEX_LOCK_CHECK(m)                                                \
+#define RDB_MUTEX_LOCK_CHECK(m) \
   rdb_check_mutex_call_result(__PRETTY_FUNCTION__, true, mysql_mutex_lock(&m))
-#define RDB_MUTEX_UNLOCK_CHECK(m)                                              \
-  rdb_check_mutex_call_result(__PRETTY_FUNCTION__, false,                      \
+#define RDB_MUTEX_UNLOCK_CHECK(m)                         \
+  rdb_check_mutex_call_result(__PRETTY_FUNCTION__, false, \
                               mysql_mutex_unlock(&m))
 
 /*
@@ -229,10 +229,10 @@ inline void rdb_check_mutex_call_result(const char *function_name,
                                         const int result) {
   if (unlikely(result)) {
     /* NO_LINT_DEBUG */
-    sql_print_error("%s a mutex inside %s failed with an "
-                    "error code %d.",
-                    attempt_lock ? "Locking" : "Unlocking", function_name,
-                    result);
+    sql_print_error(
+        "%s a mutex inside %s failed with an "
+        "error code %d.",
+        attempt_lock ? "Locking" : "Unlocking", function_name, result);
 
     // This will hopefully result in a meaningful stack trace which we can use
     // to efficiently debug the root cause.
@@ -277,7 +277,7 @@ const char *rdb_parse_id(const struct charset_info_st *const cs,
 const char *rdb_skip_id(const struct charset_info_st *const cs, const char *str)
     MY_ATTRIBUTE((__warn_unused_result__));
 
-const std::vector<std::string> parse_into_tokens(const std::string& s,
+const std::vector<std::string> parse_into_tokens(const std::string &s,
                                                  const char delim);
 
 /*
@@ -294,7 +294,7 @@ bool rdb_database_exists(const std::string &db_name);
 
 void warn_about_bad_patterns(const Regex &regex, const char *name);
 
-std::vector<std::string> split_into_vector(const std::string& input,
+std::vector<std::string> split_into_vector(const std::string &input,
                                            char delimiter);
 
 /*
@@ -310,4 +310,4 @@ class Ensure_cleanup {
  private:
   std::function<void()> m_cleanup;
 };
-} // namespace myrocks
+}  // namespace myrocks


### PR DESCRIPTION
1. Cherry-pick the following commits from `fb-prod201905`:
- [3d699aa2acd9937303b82a32b5aef65fb4947d8e Trying to fix rocksdb.rocksdb_read_free_rpl_stress](https://github.com/facebook/mysql-5.6/commit/3d699aa2acd9937303b82a32b5aef65fb4947d8e)
- [643510a0ff947f740af2151f5058c7f6c725a995 T42691730 - Bump mysql session rows_examined count whenever MyRocks filters out a row due to expired TTL](https://github.com/facebook/mysql-5.6/commit/643510a0ff947f740af2151f5058c7f6c725a995)
- [ace6368991f48f0748523c5a2127b389698fb65a Use LLONG_MAX instead of LONGLONG_MAX as MySQL 8.0 no longer has it](https://github.com/facebook/mysql-5.6/commit/ace6368991f48f0748523c5a2127b389698fb65a)
- [5b55b17b26d401c8e77889c539050a8a2b71c7f9 Update lint to use clang 5.0.1 with 8.0 .clang-format by default and update all MyRocks code accordingly](https://github.com/facebook/mysql-5.6/commit/5b55b17b26d401c8e77889c539050a8a2b71c7f9)
- [356ffd94f79848b954890bdc746cdd9a11e2d9f0 Fix 2 howtoeven warnings](https://github.com/facebook/mysql-5.6/commit/356ffd94f79848b954890bdc746cdd9a11e2d9f0)
- [ed7e921c1825af04b16c469ce671108082801284 fix all sql_print linter warnings](https://github.com/facebook/mysql-5.6/commit/ed7e921c1825af04b16c469ce671108082801284)
- [06e1d3aea4522eaef1ce26f35591efed0a529a7d Use DBUG_OFF instead of NDEBUG](https://github.com/facebook/mysql-5.6/commit/06e1d3aea4522eaef1ce26f35591efed0a529a7d)
- [75929903de7e6d02865d671d95e9f7eec6f0c88d Fix rocksdb.group_min_max](https://github.com/facebook/mysql-5.6/commit/75929903de7e6d02865d671d95e9f7eec6f0c88d)
- [85fc98f8faba57ed65c0dbda1ac57eb062edc34a Fix all MissingBraces HOWTOEVEN warnings](https://github.com/facebook/mysql-5.6/commit/85fc98f8faba57ed65c0dbda1ac57eb062edc34a)
- [d89f26ffa61e098adfcc66a48d01af2170a9d94d Fix all inconsistent overrides](https://github.com/facebook/mysql-5.6/commit/d89f26ffa61e098adfcc66a48d01af2170a9d94d)
- [56040e200bae4b9247f52cec39c4d198c58fabec Fix AutoInitCopy](https://github.com/facebook/mysql-5.6/commit/56040e200bae4b9247f52cec39c4d198c58fabec)
- [37606b7e3836db3b0793a97040c5c552b179cad7 Fix flaky test rocksdb.issue255](https://github.com/facebook/mysql-5.6/commit/37606b7e3836db3b0793a97040c5c552b179cad7)
- [1023429b32fd596722497d4fad576a4aecc1539b Use unordered_map instead of my_hash](https://github.com/facebook/mysql-5.6/commit/1023429b32fd596722497d4fad576a4aecc1539b)
- [603097e97d615c141f21f61b4bf440ad2a40557c Include RocksDB fix that address deadlock](https://github.com/facebook/mysql-5.6/commit/603097e97d615c141f21f61b4bf440ad2a40557c)
- [911d1a387a0d80f3ba52b7432c1abdbd7e8cb220 Fix AutoInitCopy #2](https://github.com/facebook/mysql-5.6/commit/911d1a387a0d80f3ba52b7432c1abdbd7e8cb220)

2. Null cherry-picked upstream commits:
- [ceebea4effd85241eda78ddbdd13c298b3e0c232 Fix main.mysqld--help-notwin](https://github.com/facebook/mysql-5.6/commit/ceebea4effd85241eda78ddbdd13c298b3e0c232)
- [44b7fcb9826a7f7c74cd5a46e0397de946a9b79e SELECT INTO OUTFILE COMPRESSED](https://github.com/facebook/mysql-5.6/commit/44b7fcb9826a7f7c74cd5a46e0397de946a9b79e)
- [a21a6dc5e34d44917fff7c62e00b5272a4fc4b61 Fixed compilation issue for oss-gcc6 and oss-clang builds](https://github.com/facebook/mysql-5.6/commit/a21a6dc5e34d44917fff7c62e00b5272a4fc4b61)
- [ccf2b062689beac21adc2d490d26f4b1e6789a8e Fix funny bug where mysql prints garbage](https://github.com/facebook/mysql-5.6/commit/ccf2b062689beac21adc2d490d26f4b1e6789a8e)
- [2d00882d29a4bfc3fffe90e8fca92b32853279f3 Fix MySQLTestResultLinter to use project root](https://github.com/facebook/mysql-5.6/commit/2d00882d29a4bfc3fffe90e8fca92b32853279f3)
- [08426f132d8c81dfd5641b4da6a3c265c8c604a5 Revert "Platform007 test fixes in MySQL 5.6"](https://github.com/facebook/mysql-5.6/commit/08426f132d8c81dfd5641b4da6a3c265c8c604a5)
- [856ac17a2996c4adbc8091d72940b899ca83bab3 Fix a plausible memory leak in prod build and an assert in debug build](https://github.com/facebook/mysql-5.6/commit/856ac17a2996c4adbc8091d72940b899ca83bab3)
- [784cc509a73e4f1f479e3e4be0af1d5d7bab654b LOAD DATA INFILE with COMPRESSED option](https://github.com/facebook/mysql-5.6/commit/784cc509a73e4f1f479e3e4be0af1d5d7bab654b)
- [24cf129e40d535ad8b474781b24781c14c4cc38e Fix innodb_stats_on_metadata corrupting index stats on partitioned tables](https://github.com/facebook/mysql-5.6/commit/24cf129e40d535ad8b474781b24781c14c4cc38e)
- [c391300228d291a19b681fe048615cfd5df7e621 Fixed test rpl.rpl_cross_version](https://github.com/facebook/mysql-5.6/commit/c391300228d291a19b681fe048615cfd5df7e621)
- [b42b911fa152a5449d10ca87aa3a5a6d7f996dc0 Fix rpl_wait_for_semi_sync_ack feature](https://github.com/facebook/mysql-5.6/commit/b42b911fa152a5449d10ca87aa3a5a6d7f996dc0)
- [79b84c61160097f339ffc014e972ebedbf644b64 New variable to specify list of columns on slaves where non-lossy type mismatches are allowed](https://github.com/facebook/mysql-5.6/commit/79b84c61160097f339ffc014e972ebedbf644b64)
- [7a3b0cd3803008ce379ccb7c298e35ac51fc0f57 Big files slow removal](https://github.com/facebook/mysql-5.6/commit/7a3b0cd3803008ce379ccb7c298e35ac51fc0f57)
- [f34bf7600984300b54bef5629f2c50da87581576 Revert "Big files slow removal"](https://github.com/facebook/mysql-5.6/commit/f34bf7600984300b54bef5629f2c50da87581576)
- [2d636fa67c4fff843c80f7ca349e9eca93fc45bb Avoid throwing exception when no db_metadata is present](https://github.com/facebook/mysql-5.6/commit/2d636fa67c4fff843c80f7ca349e9eca93fc45bb)
- [224b0a2ad80a9e614c9da4e9edad3be3c9e7324c Backporting WL#6784: SHUTDOWN SQL command](https://github.com/facebook/mysql-5.6/commit/224b0a2ad80a9e614c9da4e9edad3be3c9e7324c)
- [77794304677b65c5de09343696c3761ca7c24729 Add OPT_ARG to innodb_stats_on_metadata](https://github.com/facebook/mysql-5.6/commit/77794304677b65c5de09343696c3761ca7c24729)
- [cc9b09ba97c3bcf5093ab2fcd9e0e4d50e8c7199 Big files slow removal](https://github.com/facebook/mysql-5.6/commit/cc9b09ba97c3bcf5093ab2fcd9e0e4d50e8c7199)
- [9d5a76838c8ff1dfa8a9590e831f6faa97e884ad Revert "Add OPT_ARG to innodb_stats_on_metadata"](https://github.com/facebook/mysql-5.6/commit/9d5a76838c8ff1dfa8a9590e831f6faa97e884ad)
- [f0590c3a4417d83f8cc1e5caa6c457d56adf55e5 Using rapidjson instead of boost](https://github.com/facebook/mysql-5.6/commit/f0590c3a4417d83f8cc1e5caa6c457d56adf55e5)
- [e7963d7c4ba327d4e757e0c42ce0c4ca69a41622 Cache global variables related to dep repl in rli for thread safety](https://github.com/facebook/mysql-5.6/commit/e7963d7c4ba327d4e757e0c42ce0c4ca69a41622)
- [ca7d7cecc8b3c7c219bfed7ab9ffd4c95f62d782 Introduce a class to assign monotonically increasing timestamp in binlog](https://github.com/facebook/mysql-5.6/commit/ca7d7cecc8b3c7c219bfed7ab9ffd4c95f62d782)
- [d5891b5db2963be4398b27b1ad7c4376e6926c49 Fix Google Test upgrade](https://github.com/facebook/mysql-5.6/commit/d5891b5db2963be4398b27b1ad7c4376e6926c49)
- [1865e9d5d44a6e1db52492cabcd5e70b88a7f280 Fix dangling SLAVE_INFO/THD in slave_list in case of slave communication failure](https://github.com/facebook/mysql-5.6/commit/1865e9d5d44a6e1db52492cabcd5e70b88a7f280)
- [de0bf9449975a80e07b5afb0cdedd07dd6831729 Log create/alter/drop table to slow query log](https://github.com/facebook/mysql-5.6/commit/de0bf9449975a80e07b5afb0cdedd07dd6831729)
- [0faa001c53b4c8ad6fe41753c3b96fcee75ce91e PSI fix](https://github.com/facebook/mysql-5.6/commit/0faa001c53b4c8ad6fe41753c3b96fcee75ce91e)
- [94b066fc7b3c828c09f7d8d7ea7acccb09778edb MySQL Bypass Project Initial Change](https://github.com/facebook/mysql-5.6/commit/94b066fc7b3c828c09f7d8d7ea7acccb09778edb)
- [e04edc791c2d781f9b0396f54a8b6c759de0fd8e removed hack to set opt_core_file in mysqld.cc](https://github.com/facebook/mysql-5.6/commit/e04edc791c2d781f9b0396f54a8b6c759de0fd8e)
- [9148245029cca4b8963cc1eab12af81282149c6a Check before image consistency before applying row events](https://github.com/facebook/mysql-5.6/commit/9148245029cca4b8963cc1eab12af81282149c6a)
- [d4cc605f9e811bcad4c0791a41689937786d87e6 Fix memory leak in rocksdb_validate_update_cf_options](https://github.com/facebook/mysql-5.6/commit/d4cc605f9e811bcad4c0791a41689937786d87e6)
- [c6ab7e88f39faed8d887150a425897e46dd04fcd Extending SHUTDOWN query to support read_only/aborting](https://github.com/facebook/mysql-5.6/commit/c6ab7e88f39faed8d887150a425897e46dd04fcd)
- [893faf26d088b9593824f598ad7885fb8db9c083 Fix valgrind errors on rocksdb.skip_core_dump_on_error](https://github.com/facebook/mysql-5.6/commit/893faf26d088b9593824f598ad7885fb8db9c083)
- [7654caf77bdd2ab21a07f32436d8d170b02c7429 fix block_create_no_primary_key](https://github.com/facebook/mysql-5.6/commit/7654caf77bdd2ab21a07f32436d8d170b02c7429)
- [dcd9379eb5707bc7514a2ff4d9127790356505cb Skip valgrind for rocksdb.force_shutdown](https://github.com/facebook/mysql-5.6/commit/dcd9379eb5707bc7514a2ff4d9127790356505cb)
- [c659beb4cf9da1728f869c315f952dbeeb3acfc5 Fix cf_option if parse_cf_option fail](https://github.com/facebook/mysql-5.6/commit/c659beb4cf9da1728f869c315f952dbeeb3acfc5)
