### PR TITLE
PS-6105. innodb.mysqld_core_dump_without_buffer_pool_dynamic/

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -3577,9 +3577,6 @@ static void srv_shutdown_page_cleaners() {
   ut_a(srv_shutdown_state.load() == SRV_SHUTDOWN_MASTER_STOP);
   ut_a(!srv_master_thread_is_active());
 
-  ut_ad(buf_flush_active_lru_managers() == srv_buf_pool_instances ||
-        buf_flush_active_lru_managers() == 0);
-
   srv_shutdown_state.store(SRV_SHUTDOWN_FLUSH_PHASE);
 
   /* We force DD to flush table buffers, so they have opportunity
@@ -3600,6 +3597,8 @@ static void srv_shutdown_page_cleaners() {
     os_event_set(buf_flush_event);
     os_thread_sleep(SHUTDOWN_SLEEP_TIME_US);
   }
+
+  ut_ad(buf_flush_active_lru_managers() == 0);
 
   for (uint32_t count = 0;; ++count) {
     const ulint pending_io = buf_pool_check_no_pending_io();


### PR DESCRIPTION
The tests is unstable and sometimes fails with this assertion:
```
2019-11-20T16:45:43.232618Z 0 [ERROR] [MY-013183] [InnoDB] Assertion failure: srv0start.cc:3502:buf_flush_active_lru_managers() == srv_buf_pool_instances || buf_flush_active_lru_managers() == 0
```

In a function `srv_shutdown_page_cleaners()`, we are already moving into a shutdown state `SRV_SHUTDOWN_FLUSH_PHASE` (lru manager threads are active in `SRV_SHUTDOWN_NONE` or `SRV_SHUTDOWN_CLEANUP`) and a certain number of lru manager threads have completed, and a certain number of lru manager threads are active, but it cannot be guaranteed that all
threads are active (`buf_flush_active_lru_managers() == srv_buf_pool_instances`) or all have ended (`buf_flush_active_lru_managers() == 0`).

Only after waiting for the completion of all threads can we expect
that there will be no active threads.