### PR TITLE
PS-6922: Running ALTER TABLE with with expand_fast_index_creation

### DIFF
--- a/mysql-test/r/percona_expand_fast_index_creation.result
+++ b/mysql-test/r/percona_expand_fast_index_creation.result
@@ -153,4 +153,36 @@ DROP TABLE t1;
 # PS-6903: CREATE TEMPORARY TABLE crashes with expand_fast index creation
 #
 CREATE TEMPORARY TABLE t1 LIKE information_schema.processlist;
+#
+# PS-6922: Running ALTER TABLE with with expand_fast_index_creation enabled can lead to a crash
+#
+# Below queries would crash the server. Check that they work OK now.
+ALTER TABLE mysql.db ORDER BY db DESC;
+Warnings:
+Warning	1105	ORDER BY ignored as there is a user-defined clustered index in the table 'db'
+1
+ALTER TABLE mysql.tables_priv MODIFY User CHAR DEFAULT'',MODIFY gRANTOR CHAR DEFAULT'';
+ERROR 01000: Data truncated for column 'User' at row 1
+CREATE TABLE t_part
+(a int,
+b int,
+c varchar(64),
+KEY (a),
+KEY (b),
+KEY (c,b))
+ENGINE = InnoDB
+ENCRYPTION='N'
+PARTITION BY HASH (a) PARTITIONS 5;
+ALTER TABLE t_part ORDER BY a DESC;
+CREATE TABLE t2_part
+(a int,
+b int,
+c varchar(64),
+KEY (a),
+KEY (b),
+KEY (c,b))
+ENGINE = InnoDB
+PARTITION BY HASH (a) PARTITIONS 5;
+ALTER TABLE t2_part ENCRYPTION='N', ORDER BY a DESC;
+DROP TABLE t_part,t2_part;
 SET SESSION expand_fast_index_creation=OFF;

--- a/mysql-test/t/percona_expand_fast_index_creation.test
+++ b/mysql-test/t/percona_expand_fast_index_creation.test
@@ -156,6 +156,43 @@ DROP TABLE t1;
 --echo #
 CREATE TEMPORARY TABLE t1 LIKE information_schema.processlist;
 
+--echo #
+--echo # PS-6922: Running ALTER TABLE with with expand_fast_index_creation enabled can lead to a crash
+--echo #
+--echo # Below queries would crash the server. Check that they work OK now.
+
+ALTER TABLE mysql.db ORDER BY db DESC;
+--echo 1
+--error 1265 #WARN_DATA_TRUNCATED
+ALTER TABLE mysql.tables_priv MODIFY User CHAR DEFAULT'',MODIFY gRANTOR CHAR DEFAULT'';
+
+CREATE TABLE t_part
+(a int,
+ b int,
+ c varchar(64),
+ KEY (a),
+ KEY (b),
+ KEY (c,b))
+ENGINE = InnoDB
+ENCRYPTION='N'
+PARTITION BY HASH (a) PARTITIONS 5;
+
+ALTER TABLE t_part ORDER BY a DESC;
+
+CREATE TABLE t2_part
+(a int,
+ b int,
+ c varchar(64),
+ KEY (a),
+ KEY (b),
+ KEY (c,b))
+ENGINE = InnoDB
+PARTITION BY HASH (a) PARTITIONS 5;
+
+ALTER TABLE t2_part ENCRYPTION='N', ORDER BY a DESC;
+
+DROP TABLE t_part,t2_part;
+
 SET SESSION expand_fast_index_creation=OFF;
 
 


### PR DESCRIPTION
enabled can lead to a crash

Statement like:
SET expand_fast_index_creation=1;
alter table mysql.db order by db desc;
Would cause server to crash. This is because ALTER TABLE would rebuild
mysql tablespace. This ALTER would rebuild mysql TABLESPACE because
table db was created with statement CREATE TABLE db TABLESPACE=mysql
ENCRYPTION='N'. So it has assigned explicit_encryption=true.
We always rebuild tablespace for explicit_encryption=true and ENCRYPTION
clause = 'N' - in order to add information to page0 - so the encryption
threads would skip the space. However, we did this also for tables in
general tablespace and we should rebuild only in case of file_per_table
tablespaces. This is now fixed.