### PR TITLE
PS-6944 Removed internal only tasks from 8.0 Release Notes.

### DIFF
--- a/doc/source/release-notes/Percona-Server-8.0.15-5.rst
+++ b/doc/source/release-notes/Percona-Server-8.0.15-5.rst
@@ -82,7 +82,6 @@ Other bugs fixed:
 :psbug:`4640`,
 :psbug:`5055`,
 :psbug:`5218`,
-:psbug:`5263`,
 :psbug:`5328`,
 :psbug:`5369`.
 

--- a/doc/source/release-notes/Percona-Server-8.0.15-6.rst
+++ b/doc/source/release-notes/Percona-Server-8.0.15-6.rst
@@ -136,15 +136,10 @@ Bugs Fixed
   Bug fixed :psbug:`5501`.
 
 Other bugs fixed:
-:psbug:`5537`,
 :psbug:`5243`,
-:psbug:`5371`,
-:psbug:`5475`,
 :psbug:`5484`,
 :psbug:`5512`,
-:psbug:`5514`,
 :psbug:`5523`,
-:psbug:`5528`,
 :psbug:`5536`,
 :psbug:`5550`,
 :psbug:`5570`,

--- a/doc/source/release-notes/Percona-Server-8.0.16-7.rst
+++ b/doc/source/release-notes/Percona-Server-8.0.16-7.rst
@@ -93,7 +93,6 @@ Other bugs fixed:
 :psbug:`5669`,
 :psbug:`5753`,
 :psbug:`5696`,
-:psbug:`5733`,
 :psbug:`5803`,
 :psbug:`5804`,
 :psbug:`5820`,

--- a/doc/source/release-notes/Percona-Server-8.0.17-8.rst
+++ b/doc/source/release-notes/Percona-Server-8.0.17-8.rst
@@ -74,10 +74,10 @@ Bugs Fixed
 - MyRocks does not allow index condition pushdown optimization for specific data
   types, such as ``varchar``.  Bugs fixed :psbug:`5024`.
 
-Other bugs fixed: :psbug:`5880`, :psbug:`5427`, :psbug:`5838`, :psbug:`5682`,
-:psbug:`5979`, :psbug:`5793`, :psbug:`6020`, :psbug:`6025`, :psbug:`5327`,
+Other bugs fixed: :psbug:`5880`, :psbug:`5838`, :psbug:`5682`,
+:psbug:`5979`, :psbug:`5793`, :psbug:`6020`, :psbug:`5327`,
 :psbug:`5839`, :psbug:`5933`, :psbug:`5939`, :psbug:`5659`, :psbug:`5924`,
-:psbug:`5687`, :psbug:`5926`, :psbug:`5925`, :psbug:`5875`, :psbug:`5533`,
+:psbug:`5926`, :psbug:`5925`, :psbug:`5875`, :psbug:`5533`,
 :psbug:`5867`, :psbug:`5864`, :psbug:`5760`, :psbug:`5909`, :psbug:`5985`,
 :psbug:`5941`, :psbug:`5954`, :psbug:`5790`, and :psbug:`5593`.
 

--- a/doc/source/release-notes/Percona-Server-8.0.18-9.rst
+++ b/doc/source/release-notes/Percona-Server-8.0.18-9.rst
@@ -56,11 +56,9 @@ Other bugs fixed:
 :psbug:`6054`,
 :psbug:`6056`,
 :psbug:`6058`,
-:psbug:`6059`,
 :psbug:`6078`,
 :psbug:`6057`,
-:psbug:`6111`,
-:psbug:`6117`, and
+:psbug:`6111`, and
 :psbug:`6073`.
 
 .. |release| replace:: 8.0.18-9


### PR DESCRIPTION
modified file: release-notes/Percona-Server-8.0.17-8, 8.0.18-9, 8.0.16-7, 8.0.15-5, 8.0-15-6
removed internal task only Jira tickets: 5263, 5371, 5471, 5475, 5514, 5528, 5537, 5733, 5427, 5687, 6025, 6117, 6059

based on Release Notes Link Failures spreadsheet