### PR TITLE
PS-6949 Updated 5.7 Release Notes to remove incorrect tickets

### DIFF
--- a/doc/source/release-notes/Percona-Server-5.7.26-29.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.26-29.rst
@@ -89,7 +89,6 @@ Bugs Fixed
   assertion. Bug fixed :psbug:`3410` (upstream :mysqlbug:`82940`).
 
 Other bugs fixed:
-:psbug:`5537`,
 :psbug:`5007` (upstream :mysqlbug:`93164`),
 :psbug:`5018`,
 :psbug:`5561`,

--- a/doc/source/release-notes/Percona-Server-5.7.27-30.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.27-30.rst
@@ -57,7 +57,6 @@ Other bugs fixed:
 :psbug:`5743`,
 :psbug:`5742`,
 :psbug:`5740`,
-:psbug:`5711`,
 :psbug:`5695`,
 :psbug:`5681`,
 :psbug:`5669`,

--- a/doc/source/release-notes/Percona-Server-5.7.28-31.rst
+++ b/doc/source/release-notes/Percona-Server-5.7.28-31.rst
@@ -27,7 +27,6 @@ Bugs Fixed
 
 
 Other bugs fixed:
-:psbug:`5427`,
 :psbug:`5859`,
 :psbug:`5910`,
 :psbug:`5966`,
@@ -37,7 +36,6 @@ Other bugs fixed:
 :psbug:`5584`,
 :psbug:`5642`,
 :psbug:`5659`,
-:psbug:`5687`,
 :psbug:`5754`,
 :psbug:`5761`,
 :psbug:`5797`,


### PR DESCRIPTION
modified files - source/release-notes:
Percona-Server-5.7.26-29
Percona-Server-5.7.27-30
Percona-Server-5.7.28-31

removed the following ticket references:
PS-5537
PS-5565
PS-5711
PS-5427
PS-5687