### PR TITLE
PS-6963: tokudb-backup-plugin: error: redefinition of 'read' for clang with RelWithDebInfo (5.7)

### DIFF
--- a/plugin/tokudb-backup-plugin/CMakeLists.txt
+++ b/plugin/tokudb-backup-plugin/CMakeLists.txt
@@ -44,6 +44,12 @@ macro(append_cflags_if_supported)
 endmacro(append_cflags_if_supported)
 append_cflags_if_supported(-Wno-vla)
 
+# compiler_options.cmake sets "-D_FORTIFY_SOURCE=2" for clang what causes
+# "error: redefinition of 'read'" for "Percona-TokuBackup/backup/backup.cc"
+IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  STRING (REPLACE "-D_FORTIFY_SOURCE=2" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
+ENDIF()
+
 IF(DEFINED TOKUDB_BACKUP_PLUGIN_VERSION)
   ADD_DEFINITIONS("-DTOKUDB_BACKUP_PLUGIN_VERSION=${TOKUDB_BACKUP_PLUGIN_VERSION}")
   IF (${TOKUDB_BACKUP_PLUGIN_VERSION} MATCHES "^tokudb-backup-([0-9]+)\\.([0-9]+)")


### PR DESCRIPTION
Fix the following issue:
compiler_options.cmake sets "-D_FORTIFY_SOURCE=2" for clang with RelWithDebInfo what
causes "error: redefinition of 'read'" for "Percona-TokuBackup/backup/backup.cc"