### PR TITLE
PS-6969: rocksdb.index_stats_large_table is unstable (5.7)

### DIFF
--- a/mysql-test/suite/rocksdb/r/index_stats_large_table.result
+++ b/mysql-test/suite/rocksdb/r/index_stats_large_table.result
@@ -2,8 +2,8 @@ create table t0(
 id bigint not null primary key, 
 i1 bigint, #unique
 i2 bigint, #repeating
-c1 char(20), #unique
-c2 char(20), #repeating
+c1 varchar(20), #unique
+c2 varchar(20), #repeating
 index t0_1(id, i1),
 index t0_2(i1, i2),
 index t0_3(i2, i1),

--- a/mysql-test/suite/rocksdb/t/index_stats_basic-master.opt
+++ b/mysql-test/suite/rocksdb/t/index_stats_basic-master.opt
@@ -1,3 +1,3 @@
---skip-rocksdb_debug_optimizer_no_zero_cardinality
---rocksdb_table_stats_sampling_pct=100
+--loose-rocksdb_debug_optimizer_no_zero_cardinality=0
+--loose-rocksdb_table_stats_sampling_pct=100
 

--- a/mysql-test/suite/rocksdb/t/index_stats_concurrency-master.opt
+++ b/mysql-test/suite/rocksdb/t/index_stats_concurrency-master.opt
@@ -1,5 +1,5 @@
---skip-rocksdb_debug_optimizer_no_zero_cardinality
---rocksdb_table_stats_sampling_pct=100
---rocksdb_table_stats_use_table_scan=1
---rocksdb_table_stats_recalc_threshold_count=0
+--loose-rocksdb_debug_optimizer_no_zero_cardinality=0
+--loose-rocksdb_table_stats_sampling_pct=100
+--loose-rocksdb_table_stats_use_table_scan=1
+--loose-rocksdb_table_stats_recalc_threshold_count=0
 

--- a/mysql-test/suite/rocksdb/t/index_stats_large_table-master.opt
+++ b/mysql-test/suite/rocksdb/t/index_stats_large_table-master.opt
@@ -1,4 +1,4 @@
---skip-rocksdb_debug_optimizer_no_zero_cardinality
+--loose-rocksdb_debug_optimizer_no_zero_cardinality=0
 --force-restart
---rocksdb_table_stats_sampling_pct=100
---rocksdb_table_stats_use_table_scan=1
+--loose-rocksdb_table_stats_sampling_pct=100
+--loose-rocksdb_table_stats_use_table_scan=1

--- a/mysql-test/suite/rocksdb/t/index_stats_large_table.test
+++ b/mysql-test/suite/rocksdb/t/index_stats_large_table.test
@@ -5,8 +5,8 @@ create table t0(
        id bigint not null primary key, 
        i1 bigint, #unique
        i2 bigint, #repeating
-       c1 char(20), #unique
-       c2 char(20), #repeating
+       c1 varchar(20), #unique
+       c2 varchar(20), #repeating
        index t0_1(id, i1),
        index t0_2(i1, i2),
        index t0_3(i2, i1),

--- a/mysql-test/suite/rocksdb/t/rocksdb_timeout_rollback-master.opt
+++ b/mysql-test/suite/rocksdb/t/rocksdb_timeout_rollback-master.opt
@@ -1,1 +1,1 @@
---rocksdb_lock_wait_timeout=2
+--loose-rocksdb_lock_wait_timeout=2

--- a/mysql-test/suite/rocksdb/t/rpl_row_not_found_rc-slave.opt
+++ b/mysql-test/suite/rocksdb/t/rpl_row_not_found_rc-slave.opt
@@ -1,1 +1,2 @@
---binlog_format=row --slave_parallel_workers=4 --rocksdb_lock_wait_timeout=5 --transaction_isolation=read-committed
+--binlog_format=row --slave_parallel_workers=4 --transaction_isolation=read-committed
+--loose-rocksdb_lock_wait_timeout=5

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -11503,6 +11503,7 @@ static int calculate_cardinality_table_scan(
       rows_scanned++;
     }
 
+    cardinality_collector.Reset(); /* reset m_last_key for each key definition */
     cardinality_collector.SetCardinality(&stat);
     cardinality_collector.AdjustStats(&stat);
 


### PR DESCRIPTION
1. Fix `rocksdb.index_stats_large_table` by adding `cardinality_collector.Reset()`
2. Prefix all myrocks options with `--loose` for the cases/platforms where myrocks isn't built but the default suites are run.