### PR TITLE
PS-6974: rocksdb.drop_cf_* tests are unstable (5.7)

### DIFF
--- a/mysql-test/suite/rocksdb/r/drop_cf_during_drop_table.result
+++ b/mysql-test/suite/rocksdb/r/drop_cf_during_drop_table.result
@@ -43,3 +43,4 @@ set debug_sync = "now signal mark_cf_dropped_done_after_delete_table";
 show tables;
 Tables_in_test
 set @@global.debug = @old_debug;
+set debug_sync = "now signal ready_to_drop_cf";

--- a/mysql-test/suite/rocksdb/t/drop_cf_during_drop_table.test
+++ b/mysql-test/suite/rocksdb/t/drop_cf_during_drop_table.test
@@ -75,6 +75,9 @@ show tables;
 
 set @@global.debug = @old_debug;
 
+# in case "Rdb_drop_index_thread::run" is waiting for "ready_to_drop_cf"
+set debug_sync = "now signal ready_to_drop_cf";
+
 --connection default
 --disconnect conn1
 --disconnect conn2


### PR DESCRIPTION
The following combinations always fail:
```
mysql-test-run.pl --parallel=1 rocksdb.drop_cf_during_drop_table rocksdb.drop_cf_during_show_global_info
mysql-test-run.pl --parallel=1 rocksdb.drop_cf_during_drop_table rocksdb.drop_cf_during_alter_table_drop_index
mysql-test-run.pl --parallel=1 rocksdb.drop_cf_during_drop_table rocksdb.drop_cf_before_show_deadlock_info
```

This patch fixes `rocksdb.drop_cf_during_drop_table` for a case when `Rdb_drop_index_thread::run` is waiting for `ready_to_drop_cf` after the test was finished what breaks subsequent tests.