### PR TITLE
PS-6989: "Cannot write: No space left on device" error with Azure Piplines (8.0)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,8 @@ jobs:
     CCACHE_COMPRESS: 1
     CCACHE_COMPRESSLEVEL: 9
     CCACHE_CPP2: 1
-    CCACHE_MAXSIZE: 4G
-    Agent.Source.Git.ShallowFetchDepth: 512
+    CCACHE_MAXSIZE: 2G
+    Agent.Source.Git.ShallowFetchDepth: 256
 
   strategy:
     matrix:
@@ -239,7 +239,6 @@ jobs:
           -DWITH_ICU=system
           -DWITH_LZ4=system
           -DWITH_PROTOBUF=system
-          -DWITH_RE2=system
           -DWITH_ZLIB=system
           -DWITH_NUMA=ON
         "
@@ -249,7 +248,6 @@ jobs:
           -DWITH_ICU=bundled
           -DWITH_LZ4=bundled
           -DWITH_PROTOBUF=bundled
-          -DWITH_RE2=bundled
           -DWITH_ZLIB=bundled
           -DWITH_NUMA=OFF
           -DWITH_ARCHIVE_STORAGE_ENGINE=OFF
@@ -281,6 +279,8 @@ jobs:
       BUILD_TIME=$SECONDS
       echo --- Total time $(($BUILD_TIME + $UPDATE_TIME + $CMAKE_TIME)) seconds. Build time $BUILD_TIME seconds. CMake took $CMAKE_TIME seconds. Packages updated in $UPDATE_TIME seconds.
       rm -f $(Pipeline.Workspace)/boost/$(BOOST_VERSION).tar.gz
+      df -Th
+      rm -rf *
       df -Th
 
     displayName: '*** Compile'


### PR DESCRIPTION
1. Limit ccache cache size to 2 GB
2. Change `Git.ShallowFetchDepth` to 256
3. Remove compiled files before uploading caches