### PR TITLE
PS-6925: Mismatch in default socket values for mysqld and mysqld_safe

### DIFF
--- a/build-ps/rpm/mysqld_safe.cnf
+++ b/build-ps/rpm/mysqld_safe.cnf
@@ -10,5 +10,5 @@
 
 [mysqld_safe]
 pid-file = /var/run/mysqld/mysqld.pid
-socket   = /var/run/mysqld/mysqld.sock
+socket   = /var/lib/mysql/mysql.sock
 nice     = 0


### PR DESCRIPTION
As *RPM distributions have different path for socket and mysql-client expects it in `/var/lib/mysql/mysql.sock` -- `[mysqld_safe]` should have same one as well.