### PR TITLE
PS-6110: libHotBackup.so missing from Percona-Server-5.6.46-rel86.2-Linux.x86_64.ssl101.tar.gz

### DIFF
--- a/build-ps/percona-server-5.6_builder.sh
+++ b/build-ps/percona-server-5.6_builder.sh
@@ -629,6 +629,15 @@ build_tarball(){
     TMPREL=$(echo ${TARFILE}| awk -F '-' '{print $4}')
     RELEASE=${TMPREL%.tar.gz}
     #
+    if [ -f /etc/redhat-release ]; then
+      if [ ${RHEL} = 6 ]; then
+        if [ ${ARCH} = x86_64 ]; then
+          source /opt/percona-devtoolset/enable
+        else
+          source /opt/rh/devtoolset-2/enable
+        fi
+      fi
+    fi
     export CFLAGS=$(rpm --eval %{optflags} | sed -e "s|march=i386|march=i686|g")
     export CXXFLAGS="${CFLAGS}"
     if [ "${YASSL}" = 0 ]; then


### PR DESCRIPTION
Library is missing because building step is being skipped as test fails every time with following error:
```
/usr/bin/c++   -DHAVE_READLINE_HISTORY_H -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Wall -Wextra -Wformat-security -Wvla -Woverloaded-virtual -Wno-unused-parameter -DTOKUDB_OK -I/usr/include/readline    -o CMakeFiles/cmTryCompileExec1863146557.dir/src.cxx.o -c /home/vagrant/test/percona-server/CMakeFiles/CMakeTmp/src.cxx
/home/vagrant/test/percona-server/CMakeFiles/CMakeTmp/src.cxx:3: error: expected primary-expression before '.' token
/home/vagrant/test/percona-server/CMakeFiles/CMakeTmp/src.cxx:3: error: expected primary-expression before '.' token
```

And there's no issues with RPM packages on same machine, after investigation came to conclusion of using percona-devtoolset GCC