### PR TITLE
Test innodb.mysql_ts_alter_encrypt_X and innodb.tablespace_encrypt_X is not stable

### DIFF
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -4466,7 +4466,10 @@ static void resume_alter_encrypt_tablespace(THD *thd) {
   }
 
   /* Let the startup thread proceed now */
+  mysql_mutex_lock(&resume_encryption_cond_m);
+  shared_mdl_is_taken = true;
   mysql_cond_signal(&resume_encryption_cond);
+  mysql_mutex_unlock(&resume_encryption_cond_m);
 
   /* In following loop :
       - traverse every tablespace one by one and roll forward (un)encryption

--- a/storage/innobase/include/srv0start.h
+++ b/storage/innobase/include/srv0start.h
@@ -204,6 +204,10 @@ enum srv_shutdown_t {
 SRV_SHUTDOWN_CLEANUP and then to SRV_SHUTDOWN_LAST_PHASE, and so on */
 extern std::atomic<enum srv_shutdown_t> srv_shutdown_state;
 
+/** true if shared MDL is taken by background thread for all tablespaces, for
+ *  which (un)encryption is to be rolled forward*/
+extern bool shared_mdl_is_taken;
+
 /** Call exit(3) */
 void srv_fatal_error() MY_ATTRIBUTE((noreturn));
 /**

--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -170,6 +170,10 @@ static uint64_t srv_start_state = SRV_START_STATE_NONE;
 SRV_SHUTDOWN_CLEANUP and then to SRV_SHUTDOWN_LAST_PHASE, and so on */
 std::atomic<enum srv_shutdown_t> srv_shutdown_state{SRV_SHUTDOWN_NONE};
 
+/** true if shared MDL is taken by background thread for all tablespaces, for
+ *  which (un)encryption is to be rolled forward*/
+bool shared_mdl_is_taken = false;
+
 /** Files comprising the system tablespace */
 static pfs_os_file_t files[1000];
 
@@ -3292,7 +3296,8 @@ void srv_start_threads_after_ddl_recovery() {
     /* Wait till shared MDL is taken by background thread for all tablespaces,
     for which (un)encryption is to be rolled forward. */
     mysql_mutex_lock(&resume_encryption_cond_m);
-    mysql_cond_wait(&resume_encryption_cond, &resume_encryption_cond_m);
+    while (!shared_mdl_is_taken)
+      mysql_cond_wait(&resume_encryption_cond, &resume_encryption_cond_m);
     mysql_mutex_unlock(&resume_encryption_cond_m);
   }
 


### PR DESCRIPTION
A situation may arise when a signal from (un)encryption process in background thread can arrive earlier than we start waiting on a conditional variable and mysql freezes