### PR TITLE
8.0 PS-6979 - SHOW PROCESSLIST shows CREATE USER all the time till next w…

### DIFF
--- a/mysql-test/suite/rpl/r/percona_bug_ps6979_showprocesslist.result
+++ b/mysql-test/suite/rpl/r/percona_bug_ps6979_showprocesslist.result
@@ -1,0 +1,13 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+CREATE USER `bugddl1`@`localhost` IDENTIFIED BY 'S0meRand0mPWD!';
+CREATE USER `bugddl2`@`localhost` IDENTIFIED BY 'S0meRand0mPWD!';
+include/sync_slave_sql_with_master.inc
+include/assert.inc [Check that CREATE USER statement has been removed from IS.PROCESSLIST.]
+[connection master]
+DROP USER `bugddl1`@`localhost`;
+DROP USER `bugddl2`@`localhost`;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/percona_bug_ps6979_showprocesslist.test
+++ b/mysql-test/suite/rpl/t/percona_bug_ps6979_showprocesslist.test
@@ -1,0 +1,22 @@
+--source include/master-slave.inc
+
+CREATE USER `bugddl1`@`localhost` IDENTIFIED BY 'S0meRand0mPWD!';
+
+# performance_schema.threads requires 2 DDL's to manifest the issue.
+CREATE USER `bugddl2`@`localhost` IDENTIFIED BY 'S0meRand0mPWD!';
+
+--source include/sync_slave_sql_with_master.inc
+
+let $wait_timeout= 10;
+let $wait_condition= SELECT COUNT(*)=0 FROM performance_schema.threads WHERE PROCESSLIST_INFO LIKE "CREATE USER%";
+--source include/wait_condition.inc
+
+--let $assert_text= Check that CREATE USER statement has been removed from IS.PROCESSLIST.
+--let $assert_cond= [SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST WHERE INFO LIKE "CREATE USER%"] = 0
+--source include/assert.inc
+
+# Cleanup
+--source include/rpl_connection_master.inc
+DROP USER `bugddl1`@`localhost`;
+DROP USER `bugddl2`@`localhost`;
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -5217,6 +5217,13 @@ end:
   thd->m_digest= NULL;
 
   /*
+    Prevent rewritten query from getting "stuck" in SHOW PROCESSLIST,
+    and performance_schema.threads.
+  */
+  thd->rewritten_query.mem_free();
+  thd->reset_query_for_display();
+
+  /*
     As a disk space optimization, future masters will not log an event for
     LAST_INSERT_ID() if that function returned 0 (and thus they will be able
     to replace the THD::stmt_depends_on_first_successful_insert_id_in_prev_stmt


### PR DESCRIPTION
…riteset

Problem
If a query had been rewritten by the parser because it contains
sensitive information ( mysql_rewrite_query ), it wont be cleaned up
when sql thread applies it, making it get stuck on SHOW PROCESSLIST and
performance_schema.threads.

Solution
Call proper cleanup functions as part of
Query_log_event::do_apply_event end block.