### PR TITLE
PS-5735: Handle linking of %{_datadir}/mysql directory properly

### DIFF
--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -552,7 +552,7 @@ rm -rf %{buildroot}%{_bindir}/mysql_embedded
 
 %pretrans -n Percona-Server-server%{product_suffix}
 if [ -d %{_datadir}/mysql ] && [ ! -L %{_datadir}/mysql ]; then
-  MYCNF_PACKAGE=$(rpm -qi `rpm -qf /usr/share/mysql` | grep -m 1 Name | awk '{print $3}')
+  MYCNF_PACKAGE=$(rpm -qf /usr/share/mysql --queryformat "%{NAME}")
 fi
 
 if [ "$MYCNF_PACKAGE" == "mariadb-libs" -o "$MYCNF_PACKAGE" == "mysql-libs" ]; then
@@ -687,6 +687,13 @@ fi
 %endif
 
 %posttrans -n Percona-Server-server%{product_suffix}
+if [ -d %{_datadir}/mysql ] && [ ! -L %{_datadir}/mysql ]; then
+  MYCNF_PACKAGE=$(rpm -qf /usr/share/mysql --queryformat "%{NAME}")
+  if [ "$MYCNF_PACKAGE" == "file %{_datadir}/mysql is not owned by any package" ]; then
+    mv %{_datadir}/mysql %{_datadir}/mysql.old
+  fi
+fi
+
 if [ ! -d %{_datadir}/mysql ] && [ ! -L %{_datadir}/mysql ]; then
     ln -s %{_datadir}/percona-server %{_datadir}/mysql
 fi

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -551,7 +551,7 @@ rm -rf %{buildroot}%{_bindir}/mysql_embedded
 %endif
 
 %pretrans -n Percona-Server-server%{product_suffix}
-if [ -d %{_datadir}/mysql ]; then
+if [ -d %{_datadir}/mysql ] && [ ! -L %{_datadir}/mysql ]; then
   MYCNF_PACKAGE=$(rpm -qi `rpm -qf /usr/share/mysql` | grep -m 1 Name | awk '{print $3}')
 fi
 
@@ -687,7 +687,7 @@ fi
 %endif
 
 %posttrans -n Percona-Server-server%{product_suffix}
-if [ ! -d %{_datadir}/mysql ]; then
+if [ ! -d %{_datadir}/mysql ] && [ ! -L %{_datadir}/mysql ]; then
     ln -s %{_datadir}/percona-server %{_datadir}/mysql
 fi
 

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -554,13 +554,12 @@ rm -rf %{buildroot}%{_bindir}/mysql_embedded
 if [ -d %{_datadir}/mysql ]; then
   MYCNF_PACKAGE=$(rpm -qi `rpm -qf /usr/share/mysql` | grep -m 1 Name | awk '{print $3}')
 fi
-if [ "$MYCNF_PACKAGE" == "mariadb-libs" -o "$MYCNF_PACKAGE" == "mysql-libs" -o "$MYCNF_PACKAGE" == "Percona-Server-server-57" ]; then
+
+if [ "$MYCNF_PACKAGE" == "mariadb-libs" -o "$MYCNF_PACKAGE" == "mysql-libs" ]; then
   MODIFIED=$(rpm -Va "$MYCNF_PACKAGE" | grep '/usr/share/mysql' | awk '{print $1}' | grep -c 5)
   if [ "$MODIFIED" == 1 ]; then
     cp -r %{_datadir}/mysql %{_datadir}/mysql.old
   fi
-else
-  cp -r %{_datadir}/mysql %{_datadir}/mysql.old
 fi
 
 %pre -n Percona-Server-server%{product_suffix}


### PR DESCRIPTION
By default, CentOS 7 comes with mariadb-libs preinstalled as dependency for postfix. Re-worked scheme of linking /usr/share/percona-server to /usr/share/mysql as `if` check will always fail by default because of mariadb-libs existance and because order of processing package operations in RPM.