### PR TITLE
PS-6994: Reimplement rocksdb_validate_tables functionality in PS-8.0

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -96,14 +96,9 @@ rocksdb.level_serializable : BUG#0 MyRocks does not yet support ISO serializable
 rocksdb.slow_query_log : BUG#26 MYR-26
 # 8.0
 rocksdb.allow_to_start_after_corruption : BUG#4584 PS-4584
-rocksdb.skip_validate_tmp_table : BUG#4218 PS-4218
-rocksdb.validate_datadic : BUG#4218 PS-4218
 
 # rocksdb_rpl suite tests
 rocksdb_rpl.rpl_rocksdb_snapshot : BUG#0 LOCK BINLOG FOR BACKUP
-
-# rocksdb_sys_vars suite tests
-rocksdb_sys_vars.rocksdb_validate_tables_basic : BUG#0 disabled until validation is figured out
 
 # tokudb suite tests
 tokudb.mvcc-19 : BUG#0 tokutek

--- a/mysql-test/suite/rocksdb/r/duplicate_table.result
+++ b/mysql-test/suite/rocksdb/r/duplicate_table.result
@@ -1,10 +1,12 @@
-CREATE TABLE t(id int primary key) engine=ROCKSDB;
+CALL mtr.add_suppression("Schema mismatch - Table test\.t is registered in RocksDB but does not have a corresponding DD table");
+# restart
+CREATE TABLE t(id INT PRIMARY KEY) ENGINE=RocksDB;
 INSERT INTO t values (1), (2), (3);
-CREATE TABLE t(id int primary key) engine=ROCKSDB;
+CREATE TABLE t(id INT PRIMARY KEY) ENGINE=RocksDB;
 ERROR 42S01: Table 't' already exists
-SELECT * FROM t;
-id
-1
-2
-3
+# restart:--rocksdb_validate_tables=2
+CREATE TABLE t(id INT PRIMARY KEY) ENGINE=RocksDB;
+ERROR HY000: Table 'test.t' does not exist, but metadata information exists inside MyRocks. This is a sign of data inconsistency.
+# restart:--rocksdb_validate_tables=2
+include/assert.inc [t should have 3 rows]
 DROP TABLE t;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -1026,6 +1026,7 @@ rocksdb_use_adaptive_mutex	OFF
 rocksdb_use_direct_io_for_flush_and_compaction	OFF
 rocksdb_use_direct_reads	OFF
 rocksdb_use_fsync	OFF
+rocksdb_validate_tables	1
 rocksdb_verify_row_debug_checksums	OFF
 rocksdb_wal_bytes_per_sync	0
 rocksdb_wal_dir	

--- a/mysql-test/suite/rocksdb/r/skip_validate_tmp_table.result
+++ b/mysql-test/suite/rocksdb/r/skip_validate_tmp_table.result
@@ -1,6 +1,26 @@
-CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
-# restart
-set session debug="+d,gen_sql_table_name";
-rename table t1 to t2;
-set session debug= "-d,gen_sql_table_name";
-# restart
+CALL mtr.add_suppression("Schema mismatch - A DD table exists for table test\.t2, but that table is not registered in RocksDB");
+CALL mtr.add_suppression("Schema mismatch - Table test\.t2_rdb_only is registered in RocksDB but does not have a corresponding DD table");
+CREATE TABLE t1 (pk INT PRIMARY KEY) ENGINE=RocksDB;
+SET @@session.debug = "+d,gen_sql_table_name";
+RENAME TABLE t1 TO t2;
+SET @@session.debug = "-d,gen_sql_table_name";
+# restart:--rocksdb_validate_tables=2
+include/assert.inc [The "test" database should have 1 table in MySQL DD (t2)]
+include/assert.inc [The "test" database should have 1 table in RocksDB DD (t2_rdb_only)]
+CREATE TABLE t2_rdb_only (pk INT PRIMARY KEY) ENGINE=RocksDB;
+ERROR HY000: Table 'test.t2_rdb_only' does not exist, but metadata information exists inside MyRocks. This is a sign of data inconsistency.
+INSERT INTO t2_rdb_only VALUES (1);
+ERROR 42S02: Table 'test.t2_rdb_only' doesn't exist
+DROP TABLE t2_rdb_only;
+ERROR 42S02: Unknown table 'test.t2_rdb_only'
+include/assert.inc [The "test" database should have 1 table in RocksDB DD (t2_rdb_only)]
+CREATE TABLE t2 (pk INT PRIMARY KEY) ENGINE=RocksDB;
+ERROR HY000: Internal error: Attempt to open a table that is not present in RocksDB-SE data dictionary
+INSERT INTO t2 VALUES (1);
+ERROR HY000: Internal error: Attempt to open a table that is not present in RocksDB-SE data dictionary
+DROP TABLE t2;
+ERROR HY000: Storage engine can't drop table 'test.t2' because it is missing. Use DROP TABLE IF EXISTS to remove it from data-dictionary.
+DROP TABLE IF EXISTS t2;
+Warnings:
+Warning	1146	Table 'test.t2' doesn't exist
+include/assert.inc [The "test" database should have no tables in MySQL DD]

--- a/mysql-test/suite/rocksdb/r/upgrade_parts_from_prev_ver.result
+++ b/mysql-test/suite/rocksdb/r/upgrade_parts_from_prev_ver.result
@@ -1,3 +1,4 @@
+CALL mtr.add_suppression("Schema mismatch - Table test\.t1 is registered in RocksDB but does not have a corresponding DD table");
 #########
 # Begin upgrade testing with mysql_upgrade
 ###

--- a/mysql-test/suite/rocksdb/r/validate_datadic.result
+++ b/mysql-test/suite/rocksdb/r/validate_datadic.result
@@ -1,11 +1,12 @@
+CALL mtr.add_suppression("Schema mismatch - Table test\.t.+ is registered in RocksDB but does not have a corresponding DD table");
+CALL mtr.add_suppression("Schema mismatch - A DD table exists for table test\.t1, but that table is not registered in RocksDB");
+# restart
 CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
 CREATE TABLE t2 (pk int primary key) ENGINE=ROCKSDB PARTITION BY KEY(pk) PARTITIONS 4;
-Warnings:
-Warning	1287	The partition engine, used by table 'test.t2', is deprecated and will be removed in a future release. Please use native partitioning instead.
-# restart
-# restart:--log-error=MYSQLTEST_VARDIR/tmp/validate_datadic.err --rocksdb_validate_tables=2
-"Expect errors that we are missing two .frm files"
-# restart:--log-error=MYSQLTEST_VARDIR/tmp/validate_datadic.err --rocksdb_validate_tables=2
-"Expect an error that we have an extra .frm file"
-# restart
-DROP TABLE t1, t2;
+# restart:--rocksdb_validate_tables=2
+include/assert_grep.inc [Expect 2 warnings that we are missing two DD tables]
+# restart:--rocksdb_validate_tables=2
+DROP TABLE t1;
+# restart:--rocksdb_validate_tables=2
+include/assert_grep.inc [Expect 1 warning that we are missing one RocksDB table]
+DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/t/duplicate_table.test
+++ b/mysql-test/suite/rocksdb/t/duplicate_table.test
@@ -1,8 +1,44 @@
 --source include/have_rocksdb.inc
 
-CREATE TABLE t(id int primary key) engine=ROCKSDB;
+CALL mtr.add_suppression("Schema mismatch - Table test\.t is registered in RocksDB but does not have a corresponding DD table");
+
+--let $MYSQLD_DATADIR= `select @@datadir`
+
+# Shut down and save MySQL DD without user tables
+--source include/shutdown_mysqld.inc
+--copy_file $MYSQLD_DATADIR/mysql.ibd $MYSQL_TMP_DIR/mysql.ibd.no_tables
+
+# Restart the server
+--let $restart_parameters=
+--source include/start_mysqld.inc
+
+CREATE TABLE t(id INT PRIMARY KEY) ENGINE=RocksDB;
 INSERT INTO t values (1), (2), (3); 
+
 --error ER_TABLE_EXISTS_ERROR 
-CREATE TABLE t(id int primary key) engine=ROCKSDB;
-SELECT * FROM t;
+CREATE TABLE t(id INT PRIMARY KEY) ENGINE=RocksDB;
+
+# Shut down, save MySQL DD with t table, and restore MySQL DD without user tables
+--source include/shutdown_mysqld.inc
+--copy_file $MYSQLD_DATADIR/mysql.ibd $MYSQL_TMP_DIR/mysql.ibd.t_table
+--move_file $MYSQL_TMP_DIR/mysql.ibd.no_tables $MYSQLD_DATADIR/mysql.ibd
+
+# Restart the server
+--let $restart_parameters=restart:--rocksdb_validate_tables=2
+--source include/start_mysqld.inc
+
+--error ER_METADATA_INCONSISTENCY
+CREATE TABLE t(id INT PRIMARY KEY) ENGINE=RocksDB;
+
+# Shut down and restore MySQL DD with t table
+--source include/shutdown_mysqld.inc
+--move_file $MYSQL_TMP_DIR/mysql.ibd.t_table $MYSQLD_DATADIR/mysql.ibd
+
+# Restart the server
+--source include/start_mysqld.inc
+
+--let $assert_text = t should have 3 rows
+--let $assert_cond = [SELECT COUNT(*) from t] = 3
+--source include/assert.inc
+
 DROP TABLE t;

--- a/mysql-test/suite/rocksdb/t/skip_validate_tmp_table.test
+++ b/mysql-test/suite/rocksdb/t/skip_validate_tmp_table.test
@@ -1,28 +1,56 @@
 --source include/have_rocksdb.inc
 --source include/have_debug.inc
 
---let $_server_id= `SELECT @@server_id`
-CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
+CALL mtr.add_suppression("Schema mismatch - A DD table exists for table test\.t2, but that table is not registered in RocksDB");
+CALL mtr.add_suppression("Schema mismatch - Table test\.t2_rdb_only is registered in RocksDB but does not have a corresponding DD table");
 
-# Create a .frm file without a matching table
---exec cp $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test/t1.frm $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test/t1#sql-test.frm
+CREATE TABLE t1 (pk INT PRIMARY KEY) ENGINE=RocksDB;
 
-# Restart the server with a .frm file exist but that table is not registered in RocksDB
+# This will append '_rdb_only' to the end of new name
+SET @@session.debug = "+d,gen_sql_table_name";
+RENAME TABLE t1 TO t2;
+SET @@session.debug = "-d,gen_sql_table_name";
+
+# Restart the server
+--let $restart_parameters=restart:--rocksdb_validate_tables=2
 --source include/restart_mysqld.inc
 
-# This will append '#sql-test' to the end of new name
-set session debug="+d,gen_sql_table_name";
-rename table t1 to t2;
-set session debug= "-d,gen_sql_table_name";
+--let $assert_text = The "test" database should have 1 table in MySQL DD (t2)
+--let $assert_cond = [SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = "test"] = 1
+--source include/assert.inc
 
-# Remove the corresponding .frm files
---remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test *t1*.frm
---remove_files_wildcard $MYSQLTEST_VARDIR/mysqld.$_server_id/data/test *t2*.frm
+--let $assert_text = The "test" database should have 1 table in RocksDB DD (t2_rdb_only)
+--let $assert_cond = [SELECT COUNT(*) FROM information_schema.rocksdb_ddl WHERE table_schema = "test"] = 1
+--source include/assert.inc
 
-# Restart the server with a table registered in RocksDB but does not have a .frm file
---source include/restart_mysqld.inc
 
-# Test can not drop table t2 as starting MyRocks with no .frm file causes
-# MyRocks to remove the tables metadata from its internal dictionary. So an
-# attempt to restart again with the .frm file back in place will result in an
-# error on startup and failure of the plugin to load.
+# Test statements on "t2_rdb_only" table
+--error ER_METADATA_INCONSISTENCY
+CREATE TABLE t2_rdb_only (pk INT PRIMARY KEY) ENGINE=RocksDB;
+
+--error ER_NO_SUCH_TABLE
+INSERT INTO t2_rdb_only VALUES (1);
+
+--error ER_BAD_TABLE_ERROR
+DROP TABLE t2_rdb_only;
+
+--let $assert_text = The "test" database should have 1 table in RocksDB DD (t2_rdb_only)
+--let $assert_cond = [SELECT COUNT(*) FROM information_schema.rocksdb_ddl WHERE table_schema = "test"] = 1
+--source include/assert.inc
+
+
+# Test statements on "t2" table
+--error ER_INTERNAL_ERROR
+CREATE TABLE t2 (pk INT PRIMARY KEY) ENGINE=RocksDB;
+
+--error ER_INTERNAL_ERROR
+INSERT INTO t2 VALUES (1);
+
+--error ER_ENGINE_CANT_DROP_MISSING_TABLE
+DROP TABLE t2;
+
+DROP TABLE IF EXISTS t2;
+
+--let $assert_text = The "test" database should have no tables in MySQL DD
+--let $assert_cond = [SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = "test"] = 0
+--source include/assert.inc

--- a/mysql-test/suite/rocksdb/t/upgrade_parts_from_prev_ver-master.opt
+++ b/mysql-test/suite/rocksdb/t/upgrade_parts_from_prev_ver-master.opt
@@ -1,0 +1,1 @@
+--loose-rocksdb_validate_tables=2

--- a/mysql-test/suite/rocksdb/t/upgrade_parts_from_prev_ver.test
+++ b/mysql-test/suite/rocksdb/t/upgrade_parts_from_prev_ver.test
@@ -9,6 +9,8 @@
 # due to difference in path format.
 --source include/not_windows.inc
 
+CALL mtr.add_suppression("Schema mismatch - Table test\.t1 is registered in RocksDB but does not have a corresponding DD table");
+
 --source include/upgrade_from_prev_ver_suppressions.inc
 
 --let $ADDITIONAL_OPTS=

--- a/mysql-test/suite/rocksdb/t/validate_datadic.test
+++ b/mysql-test/suite/rocksdb/t/validate_datadic.test
@@ -2,65 +2,68 @@
 
 #
 # Validate that the server starts when everything is okay, but detects errors
-# if a table exists in the data dictionary but not as an .frm or vice versa.
+# if a table exists in the RocksDB data dictionary but not in the MySQL data
+# dictionary or vice versa.
 # The default mode causes these failures to keep the server from starting, but
 # this is problematic for the test as a server start failure is not easily
 # trappable.  Instead use the mode where it will detect the problem and report
 # it in the log bug still start:  --rocksdb_validate_tables=2
 #
 
-CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
-CREATE TABLE t2 (pk int primary key) ENGINE=ROCKSDB PARTITION BY KEY(pk) PARTITIONS 4;
+CALL mtr.add_suppression("Schema mismatch - Table test\.t.+ is registered in RocksDB but does not have a corresponding DD table");
+CALL mtr.add_suppression("Schema mismatch - A DD table exists for table test\.t1, but that table is not registered in RocksDB");
 
---source include/restart_mysqld.inc
+--let $MYSQLD_DATADIR= `select @@datadir`
 
+# Shut down and save MySQL DD without tables
 --source include/shutdown_mysqld.inc
+--copy_file $MYSQLD_DATADIR/mysql.ibd $MYSQL_TMP_DIR/mysql.ibd.no_tables
 
---let LOG=$MYSQLTEST_VARDIR/tmp/validate_datadic.err
-
-# Rename the file
---move_file $MYSQLTEST_VARDIR/mysqld.1/data/test/t1.frm $MYSQLTEST_VARDIR/mysqld.1/data/test/t1.frm.tmp
---move_file $MYSQLTEST_VARDIR/mysqld.1/data/test/t2.frm $MYSQLTEST_VARDIR/mysqld.1/data/test/t2.frm.tmp
-
-# Attempt to restart the server
---let $restart_parameters=restart:--log-error=$LOG --rocksdb_validate_tables=2
---replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
---source include/start_mysqld.inc
-
-# We should now have an error message
---echo "Expect errors that we are missing two .frm files"
---let SEARCH_FILE=$LOG
---let SEARCH_PATTERN=Schema mismatch
---source include/search_pattern.inc
-
-# Now shut down again and rename one the .frm file back and make a copy of it
---source include/shutdown_mysqld.inc
-
-# Clear the log
---remove_file $LOG
-
-# Rename the file
---move_file $MYSQLTEST_VARDIR/mysqld.1/data/test/t1.frm.tmp $MYSQLTEST_VARDIR/mysqld.1/data/test/t1.frm
---move_file $MYSQLTEST_VARDIR/mysqld.1/data/test/t2.frm.tmp $MYSQLTEST_VARDIR/mysqld.1/data/test/t2.frm
---copy_file $MYSQLTEST_VARDIR/mysqld.1/data/test/t1.frm $MYSQLTEST_VARDIR/mysqld.1/data/test/t1_dummy.frm
-
-# Attempt to restart the server
---replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
---source include/start_mysqld.inc
-
-# We should now have an error message for the second case
---echo "Expect an error that we have an extra .frm file"
---let SEARCH_FILE=$LOG
---let SEARCH_PATTERN=Schema mismatch
---source include/search_pattern.inc
-
-# Shut down an clean up
---source include/shutdown_mysqld.inc
-
---remove_file $LOG
---remove_file $MYSQLTEST_VARDIR/mysqld.1/data/test/t1_dummy.frm
-
+# Restart the server
 --let $restart_parameters=
 --source include/start_mysqld.inc
 
-DROP TABLE t1, t2;
+CREATE TABLE t1 (pk int primary key) ENGINE=ROCKSDB;
+CREATE TABLE t2 (pk int primary key) ENGINE=ROCKSDB PARTITION BY KEY(pk) PARTITIONS 4;
+
+# Shut down, save MySQL DD with t1 and t2 tables, and replace MySQL DD with no tables
+--source include/shutdown_mysqld.inc
+--copy_file $MYSQLD_DATADIR/mysql.ibd $MYSQL_TMP_DIR/mysql.ibd.t1_t2
+--move_file $MYSQL_TMP_DIR/mysql.ibd.no_tables $MYSQLD_DATADIR/mysql.ibd
+
+# Restart the server
+--let $restart_parameters=restart:--rocksdb_validate_tables=2
+--source include/start_mysqld.inc
+
+--let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST: rocksdb.validate_datadic
+--let $assert_count = 2
+--let $assert_select = Schema mismatch - Table test\.t.+ is registered in RocksDB but does not have a corresponding DD table
+--let $assert_text = Expect 2 warnings that we are missing two DD tables
+--source include/assert_grep.inc
+
+# Shut down and replace MySQL DD with t1 and t2 tables
+--source include/shutdown_mysqld.inc
+--remove_file $MYSQLD_DATADIR/mysql.ibd
+--copy_file $MYSQL_TMP_DIR/mysql.ibd.t1_t2 $MYSQLD_DATADIR/mysql.ibd
+
+# Restart the server
+--source include/start_mysqld.inc
+
+DROP TABLE t1;
+
+# Shut down and replace MySQL DD with t1 and t2 tables (RocksDB DD has t1 removed now)
+--source include/shutdown_mysqld.inc
+--move_file $MYSQL_TMP_DIR/mysql.ibd.t1_t2 $MYSQLD_DATADIR/mysql.ibd
+
+# Restart the server
+--source include/start_mysqld.inc
+
+--let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST: rocksdb.validate_datadic
+--let $assert_count = 1
+--let $assert_select = Schema mismatch - A DD table exists for table test\.t1, but that table is not registered in RocksDB
+--let $assert_text = Expect 1 warning that we are missing one RocksDB table
+--source include/assert_grep.inc
+
+DROP TABLE t2;

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -9399,7 +9399,7 @@ ER_UNSUPPORTED_COLLATION
   eng "Unsupported collation on string indexed column %s.%s Use binary collation (%s)."
 
 ER_METADATA_INCONSISTENCY
-  eng "Table '%s' does not exist, but metadata information exists inside MyRocks. This is a sign of data inconsistency. Please check if '%s.frm' exists, and try to restore it if it does not exist."
+  eng "Table '%s' does not exist, but metadata information exists inside MyRocks. This is a sign of data inconsistency."
 
 ER_KEY_CREATE_DURING_ALTER
   eng "MyRocks failed creating new key definitions during alter."

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1908,7 +1908,7 @@ static MYSQL_THDVAR_BOOL(master_skip_tx_api, PLUGIN_VAR_RQCMDARG,
 static MYSQL_SYSVAR_UINT(
     validate_tables, rocksdb_validate_tables,
     PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
-    "Verify all .frm files match all RocksDB tables (0 means no verification, "
+    "Verify all DD tables match all RocksDB tables (0 means no verification, "
     "1 means verify and fail on error, and 2 means verify but continue",
     nullptr, nullptr, 1 /* default value */, 0 /* min value */,
     2 /* max value */, 0);
@@ -7368,11 +7368,8 @@ error:
 
   @details
   When create() is called you do not need to worry about
-  opening the table. Also, the .frm file will have already been
-  created so adjusting create_info is not necessary. You can overwrite
-  the .frm file at this point if you wish to change the table
-  definition, but there are no methods currently provided for doing
-  so.
+  opening the table. Also, the DD table have already been
+  created so adjusting create_info is not necessary.
 
   Called from handle.cc by ha_create_table().
 
@@ -7446,7 +7443,7 @@ int ha_rocksdb::create(const char *const name, TABLE *const table_arg,
         DBUG_RETURN(err);
       }
     } else {
-      my_error(ER_METADATA_INCONSISTENCY, MYF(0), str.c_str(), name);
+      my_error(ER_METADATA_INCONSISTENCY, MYF(0), str.c_str());
       DBUG_RETURN(HA_ERR_ROCKSDB_CORRUPT_DATA);
     }
   }
@@ -11279,7 +11276,7 @@ int ha_rocksdb::rename_table(
     DBUG_RETURN(-1);
   }
 
-  DBUG_EXECUTE_IF("gen_sql_table_name", to_str = to_str + "#sql-test";);
+  DBUG_EXECUTE_IF("gen_sql_table_name", to_str = to_str + "_rdb_only";);
 
   const std::unique_ptr<rocksdb::WriteBatch> wb = dict_manager.begin();
   rocksdb::WriteBatch *const batch = wb.get();

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -37,6 +37,8 @@
 #include "my_bitmap.h"
 #include "my_stacktrace.h"
 #include "myisampack.h"
+#include "mysql/thread_pool_priv.h"
+#include "sql/dd/cache/dictionary_client.h"  // dd::cache::Dictionary_client
 #include "sql/field.h"
 #include "sql/key.h"
 #include "sql/mysqld.h"
@@ -4344,25 +4346,18 @@ int Rdb_ddl_manager::find_in_uncommitted_keydef(const uint32_t &cf_id) {
 namespace  // anonymous namespace = not visible outside this source file
 {
 struct Rdb_validate_tbls : public Rdb_tables_scanner {
-  using tbl_info_t = std::pair<std::string, bool>;
-  using tbl_list_t = std::map<std::string, std::set<tbl_info_t>>;
+  using tbl_list_t = std::map<std::string, std::set<std::string>>;
 
   tbl_list_t m_list;
 
   int add_table(Rdb_tbl_def *tdef) override;
 
-  bool compare_to_actual_tables(const std::string &datadir, bool *has_errors);
-
-  bool scan_for_frms(const std::string &datadir, const std::string &dbname,
-                     bool *has_errors);
-
-  bool check_frm_file(const std::string &fullpath, const std::string &dbname,
-                      const std::string &tablename, bool *has_errors);
+  bool compare_to_mysql_dd_tables(bool *has_errors);
 };
 }  // anonymous namespace
 
 /*
-  Get a list of tables that we expect to have .frm files for.  This will use the
+  Get a list of tables that we expect to have DD tables for.  This will use the
   information just read from the RocksDB data dictionary.
 */
 int Rdb_validate_tbls::add_table(Rdb_tbl_def *tdef) {
@@ -4370,152 +4365,92 @@ int Rdb_validate_tbls::add_table(Rdb_tbl_def *tdef) {
 
   /* Add the database/table into the list that are not temp table */
   if (tdef->base_tablename().find(tmp_file_prefix) == std::string::npos) {
-    bool is_partition = tdef->base_partition().size() != 0;
-    m_list[tdef->base_dbname()].insert(
-        tbl_info_t(tdef->base_tablename(), is_partition));
+    m_list[tdef->base_dbname()].insert(tdef->base_tablename());
   }
 
   return HA_EXIT_SUCCESS;
 }
 
 /*
-  Access the .frm file for this dbname/tablename and see if it is a RocksDB
-  table (or partition table).
+  Get the list of RocksDB tables from the MySQL data dictionary
+  and compare them to the list of tables from the RocksDB database dictionary
 */
-bool Rdb_validate_tbls::check_frm_file(const std::string &fullpath,
-                                       const std::string &dbname,
-                                       const std::string &tablename,
-                                       bool *has_errors) {
-  /* Check this .frm file to see what engine it uses */
-  String fullfilename(fullpath.c_str(), &my_charset_bin);
-  fullfilename.append(FN_DIRSEP);
-  fullfilename.append(tablename.c_str());
-  fullfilename.append(".frm");
+bool Rdb_validate_tbls::compare_to_mysql_dd_tables(bool *has_errors) {
+  THD *const thd = my_core::thd_get_current_thd();
+  bool result = true;
 
-  /*
-    This function will return the legacy_db_type of the table.  Currently
-    it does not reference the first parameter (THD* thd), but if it ever
-    did in the future we would need to make a version that does it without
-    the connection handle as we don't have one here.
-  */
-  enum legacy_db_type eng_type;
-  frm_type_enum type = dd_frm_type(nullptr, fullfilename.c_ptr(), &eng_type);
-  if (type == FRMTYPE_ERROR) {
-    LogPluginErrMsg(WARNING_LEVEL, 0, "Failed to open/read .from file: %s",
-                    fullfilename.ptr());
-    return false;
-  }
+  dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
 
-  if (type == FRMTYPE_TABLE) {
-    /* For a RocksDB table do we have a reference in the data dictionary? */
-    if (eng_type == DB_TYPE_ROCKSDB) {
+  std::vector<const dd::Schema *> schema_vector;
+  if (thd->dd_client()->fetch_global_components(&schema_vector)) return false;
+
+  for (const dd::Schema *schema : schema_vector) {
+    std::vector<dd::String_type> tables;
+    if (thd->dd_client()->fetch_schema_table_names_by_engine(schema, "rocksdb",
+                                                             &tables))
+      return false;
+
+    if (tables.size() == 0) continue;
+
+    const std::string dbname = schema->name().c_str();
+    for (const dd::String_type &table_name : tables) {
+      const std::string tablename = table_name.c_str();
       /*
         Attempt to remove the table entry from the list of tables.  If this
-        fails then we know we had a .frm file that wasn't registered in RocksDB.
+        fails then we know we had a DD table that wasn't registered in RocksDB.
       */
-      tbl_info_t element(tablename, false);
-      if (m_list.count(dbname) == 0 || m_list[dbname].erase(element) == 0) {
+      if (m_list.count(dbname) == 0 || m_list[dbname].erase(tablename) == 0) {
         LogPluginErrMsg(WARNING_LEVEL, 0,
-                        "Schema mismatch - A .frm file exists for table %s.%s, "
+                        "RocksDB: Schema mismatch - "
+                        "A DD table exists for table %s.%s, "
                         "but that table is not registered in RocksDB",
                         dbname.c_str(), tablename.c_str());
         *has_errors = true;
       }
-    } else if (eng_type == DB_TYPE_PARTITION_DB) {
-      /*
-        For partition tables, see if it is in the m_list as a partition,
-        but don't generate an error if it isn't there - we don't know that the
-        .frm is for RocksDB.
-      */
-      if (m_list.count(dbname) > 0) {
-        m_list[dbname].erase(tbl_info_t(tablename, true));
-      }
+    }
+
+    /* Remove any databases which have no more tables listed */
+    if (m_list.count(dbname) == 1 && m_list[dbname].size() == 0) {
+      m_list.erase(dbname);
     }
   }
-
-  return true;
-}
-
-/* Scan the database subdirectory for .frm files */
-bool Rdb_validate_tbls::scan_for_frms(const std::string &datadir,
-                                      const std::string &dbname,
-                                      bool *has_errors) {
-  bool result = true;
-  std::string fullpath = datadir + dbname;
-  struct st_my_dir *dir_info = my_dir(fullpath.c_str(), MYF(MY_DONT_SORT));
-
-  /* Access the directory */
-  if (dir_info == nullptr) {
-    LogPluginErrMsg(WARNING_LEVEL, 0, "Could not open database directory: %s",
-                    fullpath.c_str());
-    return false;
-  }
-
-  /* Scan through the files in the directory */
-  struct fileinfo *file_info = dir_info->dir_entry;
-  for (uint ii = 0; ii < dir_info->number_off_files; ii++, file_info++) {
-    /* Find .frm files that are not temp files (those that contain '#sql') */
-    const char *ext = strrchr(file_info->name, '.');
-    if (ext != nullptr && strstr(file_info->name, tmp_file_prefix) == nullptr &&
-        strcmp(ext, ".frm") == 0) {
-      std::string tablename =
-          std::string(file_info->name, ext - file_info->name);
-
-      /* Check to see if the .frm file is from RocksDB */
-      if (!check_frm_file(fullpath, dbname, tablename, has_errors)) {
-        result = false;
-        break;
-      }
-    }
-  }
-
-  /* Remove any databases who have no more tables listed */
-  if (m_list.count(dbname) == 1 && m_list[dbname].size() == 0) {
-    m_list.erase(dbname);
-  }
-
-  /* Release the directory entry */
-  my_dirend(dir_info);
 
   return result;
 }
 
 /*
-  Scan the datadir for all databases (subdirectories) and get a list of .frm
-  files they contain
+  Validate that all the tables in the RocksDB database dictionary match the
+  MySQL data dictionary
 */
-bool Rdb_validate_tbls::compare_to_actual_tables(const std::string &datadir,
-                                                 bool *has_errors) {
-  bool result = true;
-  struct st_my_dir *dir_info;
-  struct fileinfo *file_info;
+bool Rdb_ddl_manager::validate_schemas(void) {
+  bool has_errors = false;
+  Rdb_validate_tbls table_list;
 
-  dir_info = my_dir(datadir.c_str(), MYF(MY_DONT_SORT | MY_WANT_STAT));
-  if (dir_info == nullptr) {
-    LogPluginErrMsg(WARNING_LEVEL, 0, "Could not open datadir: %s",
-                    datadir.c_str());
+  /* Get the list of tables from the RocksDB database dictionary */
+  if (scan_for_tables(&table_list) != 0) {
     return false;
   }
 
-  file_info = dir_info->dir_entry;
-  for (uint ii = 0; ii < dir_info->number_off_files; ii++, file_info++) {
-    /* Ignore files/dirs starting with '.' */
-    if (file_info->name[0] == '.') continue;
+  /* Compare that to the list of RocksDB tables in the MySQL data dictionary */
+  if (!table_list.compare_to_mysql_dd_tables(&has_errors)) {
+    return false;
+  }
 
-    /* Ignore all non-directory files */
-    if (!MY_S_ISDIR(file_info->mystat->st_mode)) continue;
-
-    /* Scan all the .frm files in the directory */
-    if (!scan_for_frms(datadir, file_info->name, has_errors)) {
-      result = false;
-      break;
+  /*
+    Any tables left in the tables list are ones that are registered in RocksDB
+    but don't have a corresponding DD table.
+  */
+  for (const auto &db : table_list.m_list) {
+    for (const auto &table : db.second) {
+      LogPluginErrMsg(WARNING_LEVEL, 0,
+                      "Schema mismatch - Table %s.%s is registered in RocksDB "
+                      "but does not have a corresponding DD table",
+                      db.first.c_str(), table.c_str());
+      has_errors = true;
     }
   }
 
-  /* Release the directory info */
-  my_dirend(dir_info);
-
-  return result;
+  return !has_errors;
 }
 
 /*
@@ -4577,42 +4512,6 @@ bool Rdb_ddl_manager::validate_auto_incr() {
   }
 
   return true;
-}
-
-/*
-  Validate that all the tables in the RocksDB database dictionary match the .frm
-  files in the datadir
-*/
-bool Rdb_ddl_manager::validate_schemas(void) {
-  bool has_errors = false;
-  const std::string datadir = std::string(mysql_real_data_home);
-  Rdb_validate_tbls table_list;
-
-  /* Get the list of tables from the database dictionary */
-  if (scan_for_tables(&table_list) != 0) {
-    return false;
-  }
-
-  /* Compare that to the list of actual .frm files */
-  if (!table_list.compare_to_actual_tables(datadir, &has_errors)) {
-    return false;
-  }
-
-  /*
-    Any tables left in the tables list are ones that are registered in RocksDB
-    but don't have .frm files.
-  */
-  for (const auto &db : table_list.m_list) {
-    for (const auto &table : db.second) {
-      LogPluginErrMsg(WARNING_LEVEL, 0,
-                      "Schema mismatch - Table %s.%s is registered in RocksDB "
-                      "but does not have a .frm file",
-                      db.first.c_str(), table.first.c_str());
-      has_errors = true;
-    }
-  }
-
-  return !has_errors;
 }
 #endif  // defined(ROCKSDB_INCLUDE_VALIDATE_TABLES) &&
         // ROCKSDB_INCLUDE_VALIDATE_TABLES
@@ -4767,7 +4666,7 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
     if (!validate_schemas()) {
       msg =
           "RocksDB: Problems validating data dictionary "
-          "against .frm files, exiting";
+          "against DD tables, exiting";
     } else if (!validate_auto_incr()) {
       msg =
           "RocksDB: Problems validating auto increment values in "

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -15,7 +15,7 @@
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA */
 #pragma once
 
-#define ROCKSDB_INCLUDE_VALIDATE_TABLES 0
+#define ROCKSDB_INCLUDE_VALIDATE_TABLES 1
 
 /* C++ standard header files */
 #include <algorithm>


### PR DESCRIPTION
Jira issue: https://jira.percona.com/browse/PS-6994
Reference Patch: https://github.com/facebook/mysql-5.6/commit/ec717d138bbae6ad987d8f3b85670915a65218a0
Reference Patch: https://github.com/facebook/mysql-5.6/commit/e8347c0b1e6d3f934e484de877be8f8dd7ece2aa

---------- https://github.com/facebook/mysql-5.6/commit/ec717d138 ----------

Add an optional setting to validate the ddl against the .frm files

Summary:
During table open we would like to be able to validate that
the data dictionary we have matches what MySQL stores in the .frm
files

Test Plan: MTR

Original Reviewers: yoshinorim, maykov, hermanlee4

Originally Reviewed By: hermanlee4

---------- https://github.com/facebook/mysql-5.6/commit/e8347c0b1 ----------

Improve code style for data dictionary

Summary:
Rename a bunch of functions to conform with the coding style

Replace scan callback with interface Rdb_tables_scanner

Test Plan:
myqlbuild.sh --clean
mysqltest.sh
mysqltest.sh --testset=RocksDB

Original Reviewers: jkedgar

Originally Reviewed By: jkedgar

Subscribers: webscalesql-eng

Projects: #webscalesql