### PR TITLE
PS-7000: Fix newer collations for proper space padding in MyRocks (8.0)

### DIFF
--- a/include/m_ctype.h
+++ b/include/m_ctype.h
@@ -137,8 +137,6 @@ extern MY_UNI_CTYPE my_uni_ctype[256];
 
 /* Flags for strxfrm */
 #define MY_STRXFRM_PAD_TO_MAXLEN 0x00000080 /* if pad tail(for filesort) */
-/* for MyRocks packing, do NOT pad with spaces, follow < 8.0.2 behavior */
-#define MY_STRXFRM_NOPAD_WITH_SPACE 0x10000000
 
 typedef struct MY_UNI_IDX {
   uint16 from;

--- a/mysql-test/suite/rocksdb/r/type_char_indexes_collation.result
+++ b/mysql-test/suite/rocksdb/r/type_char_indexes_collation.result
@@ -113,3 +113,16 @@ select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 index_name	count
 email_i	1
 drop table t;
+create table t1 (
+str char(255) character set utf8mb4,
+val int,
+key str (str(100))) default character set utf8mb4 engine=rocksdb;
+insert into t1 values ('abc  ', 1), ('abc ', 2), ('abc', 3), ('abc\t', 4), ('abca', 5);
+select str, val from t1 force index (str) where str like 'abc%' order by str, val;
+str	val
+abc	1
+abc	2
+abc	3
+abc		4
+abca	5
+drop table t1;

--- a/mysql-test/suite/rocksdb/r/type_varchar_packing.result
+++ b/mysql-test/suite/rocksdb/r/type_varchar_packing.result
@@ -1,3 +1,28 @@
+call mtr.add_suppression("Trying to create an index with a multi-level collation");
+call mtr.add_suppression("Will handle this collation internally as if it had a NO_PAD attribute.");
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY WHERE COLLATION_NAME NOT IN ("binary", "latin2_czech_cs");
+# Testing character set armscii8 collation armscii8_general_ci
+CREATE TABLE t_armscii8 (pk_varchar VARCHAR(64) CHARACTER SET armscii8 COLLATE armscii8_general_ci, pk_char CHAR(64) CHARACTER SET armscii8 COLLATE armscii8_general_ci, d_varchar VARCHAR(64) CHARACTER SET armscii8 COLLATE armscii8_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_armscii8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_armscii8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_armscii8.PRIMARY'
+INSERT INTO t_armscii8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_armscii8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_armscii8.PRIMARY'
+INSERT INTO t_armscii8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_armscii8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_armscii8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_armscii8.PRIMARY'
+INSERT INTO t_armscii8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_armscii8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_armscii8;
 # Testing character set armscii8 collation armscii8_bin
 CREATE TABLE t_armscii8 (pk_varchar VARCHAR(64) CHARACTER SET armscii8 COLLATE armscii8_bin, pk_char CHAR(64) CHARACTER SET armscii8 COLLATE armscii8_bin, d_varchar VARCHAR(64) CHARACTER SET armscii8 COLLATE armscii8_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_armscii8 VALUES('a ', 'a ', 'a ', 'a ');
@@ -20,6 +45,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_armscii8;
+# Testing character set ascii collation ascii_general_ci
+CREATE TABLE t_ascii (pk_varchar VARCHAR(64) CHARACTER SET ascii COLLATE ascii_general_ci, pk_char CHAR(64) CHARACTER SET ascii COLLATE ascii_general_ci, d_varchar VARCHAR(64) CHARACTER SET ascii COLLATE ascii_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ascii VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ascii VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ascii.PRIMARY'
+INSERT INTO t_ascii VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ascii VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ascii.PRIMARY'
+INSERT INTO t_ascii VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ascii VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ascii VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ascii.PRIMARY'
+INSERT INTO t_ascii VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ascii;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ascii;
 # Testing character set ascii collation ascii_bin
 CREATE TABLE t_ascii (pk_varchar VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin, pk_char CHAR(64) CHARACTER SET ascii COLLATE ascii_bin, d_varchar VARCHAR(64) CHARACTER SET ascii COLLATE ascii_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_ascii VALUES('a ', 'a ', 'a ', 'a ');
@@ -42,6 +89,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_ascii;
+# Testing character set big5 collation big5_chinese_ci
+CREATE TABLE t_big5 (pk_varchar VARCHAR(64) CHARACTER SET big5 COLLATE big5_chinese_ci, pk_char CHAR(64) CHARACTER SET big5 COLLATE big5_chinese_ci, d_varchar VARCHAR(64) CHARACTER SET big5 COLLATE big5_chinese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_big5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_big5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_big5.PRIMARY'
+INSERT INTO t_big5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_big5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_big5.PRIMARY'
+INSERT INTO t_big5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_big5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_big5 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_big5.PRIMARY'
+INSERT INTO t_big5 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_big5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_big5;
 # Testing character set big5 collation big5_bin
 CREATE TABLE t_big5 (pk_varchar VARCHAR(64) CHARACTER SET big5 COLLATE big5_bin, pk_char CHAR(64) CHARACTER SET big5 COLLATE big5_bin, d_varchar VARCHAR(64) CHARACTER SET big5 COLLATE big5_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_big5 VALUES('a ', 'a ', 'a ', 'a ');
@@ -64,6 +133,72 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_big5;
+# Testing character set cp1250 collation cp1250_general_ci
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_general_ci, pk_char CHAR(64) CHARACTER SET cp1250 COLLATE cp1250_general_ci, d_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1250 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set cp1250 collation cp1250_czech_cs
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_czech_cs, pk_char CHAR(64) CHARACTER SET cp1250 COLLATE cp1250_czech_cs, d_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_czech_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1250 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set cp1250 collation cp1250_croatian_ci
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_croatian_ci, pk_char CHAR(64) CHARACTER SET cp1250 COLLATE cp1250_croatian_ci, d_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_croatian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1250 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
 # Testing character set cp1250 collation cp1250_bin
 CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_bin, pk_char CHAR(64) CHARACTER SET cp1250 COLLATE cp1250_bin, d_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
@@ -86,6 +221,72 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp1250;
+# Testing character set cp1250 collation cp1250_polish_ci
+CREATE TABLE t_cp1250 (pk_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_polish_ci, pk_char CHAR(64) CHARACTER SET cp1250 COLLATE cp1250_polish_ci, d_varchar VARCHAR(64) CHARACTER SET cp1250 COLLATE cp1250_polish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1250 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1250 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1250 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1250 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1250 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1250.PRIMARY'
+INSERT INTO t_cp1250 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1250;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1250;
+# Testing character set cp1251 collation cp1251_bulgarian_ci
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_bulgarian_ci, pk_char CHAR(64) CHARACTER SET cp1251 COLLATE cp1251_bulgarian_ci, d_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_bulgarian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1251 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set cp1251 collation cp1251_ukrainian_ci
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_ukrainian_ci, pk_char CHAR(64) CHARACTER SET cp1251 COLLATE cp1251_ukrainian_ci, d_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_ukrainian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1251 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	C       `	9	432020202020202060	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
 # Testing character set cp1251 collation cp1251_bin
 CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_bin, pk_char CHAR(64) CHARACTER SET cp1251 COLLATE cp1251_bin, d_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
@@ -108,6 +309,72 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp1251;
+# Testing character set cp1251 collation cp1251_general_ci
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_general_ci, pk_char CHAR(64) CHARACTER SET cp1251 COLLATE cp1251_general_ci, d_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1251 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set cp1251 collation cp1251_general_cs
+CREATE TABLE t_cp1251 (pk_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_general_cs, pk_char CHAR(64) CHARACTER SET cp1251 COLLATE cp1251_general_cs, d_varchar VARCHAR(64) CHARACTER SET cp1251 COLLATE cp1251_general_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1251 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1251 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1251 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1251 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1251 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1251.PRIMARY'
+INSERT INTO t_cp1251 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1251;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1251;
+# Testing character set cp1256 collation cp1256_general_ci
+CREATE TABLE t_cp1256 (pk_varchar VARCHAR(64) CHARACTER SET cp1256 COLLATE cp1256_general_ci, pk_char CHAR(64) CHARACTER SET cp1256 COLLATE cp1256_general_ci, d_varchar VARCHAR(64) CHARACTER SET cp1256 COLLATE cp1256_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1256 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1256 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1256.PRIMARY'
+INSERT INTO t_cp1256 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1256 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1256.PRIMARY'
+INSERT INTO t_cp1256 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1256 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1256 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1256.PRIMARY'
+INSERT INTO t_cp1256 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1256;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1256;
 # Testing character set cp1256 collation cp1256_bin
 CREATE TABLE t_cp1256 (pk_varchar VARCHAR(64) CHARACTER SET cp1256 COLLATE cp1256_bin, pk_char CHAR(64) CHARACTER SET cp1256 COLLATE cp1256_bin, d_varchar VARCHAR(64) CHARACTER SET cp1256 COLLATE cp1256_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp1256 VALUES('a ', 'a ', 'a ', 'a ');
@@ -130,6 +397,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp1256;
+# Testing character set cp1257 collation cp1257_lithuanian_ci
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64) CHARACTER SET cp1257 COLLATE cp1257_lithuanian_ci, pk_char CHAR(64) CHARACTER SET cp1257 COLLATE cp1257_lithuanian_ci, d_varchar VARCHAR(64) CHARACTER SET cp1257 COLLATE cp1257_lithuanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1257.PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1257.PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1257 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1257.PRIMARY'
+INSERT INTO t_cp1257 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
 # Testing character set cp1257 collation cp1257_bin
 CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64) CHARACTER SET cp1257 COLLATE cp1257_bin, pk_char CHAR(64) CHARACTER SET cp1257 COLLATE cp1257_bin, d_varchar VARCHAR(64) CHARACTER SET cp1257 COLLATE cp1257_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
@@ -152,6 +441,50 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp1257;
+# Testing character set cp1257 collation cp1257_general_ci
+CREATE TABLE t_cp1257 (pk_varchar VARCHAR(64) CHARACTER SET cp1257 COLLATE cp1257_general_ci, pk_char CHAR(64) CHARACTER SET cp1257 COLLATE cp1257_general_ci, d_varchar VARCHAR(64) CHARACTER SET cp1257 COLLATE cp1257_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp1257 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp1257 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp1257.PRIMARY'
+INSERT INTO t_cp1257 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp1257 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp1257.PRIMARY'
+INSERT INTO t_cp1257 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp1257 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp1257 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp1257.PRIMARY'
+INSERT INTO t_cp1257 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp1257;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp1257;
+# Testing character set cp850 collation cp850_general_ci
+CREATE TABLE t_cp850 (pk_varchar VARCHAR(64) CHARACTER SET cp850 COLLATE cp850_general_ci, pk_char CHAR(64) CHARACTER SET cp850 COLLATE cp850_general_ci, d_varchar VARCHAR(64) CHARACTER SET cp850 COLLATE cp850_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp850 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp850 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp850.PRIMARY'
+INSERT INTO t_cp850 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp850 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp850.PRIMARY'
+INSERT INTO t_cp850 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp850 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp850 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp850.PRIMARY'
+INSERT INTO t_cp850 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp850;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp850;
 # Testing character set cp850 collation cp850_bin
 CREATE TABLE t_cp850 (pk_varchar VARCHAR(64) CHARACTER SET cp850 COLLATE cp850_bin, pk_char CHAR(64) CHARACTER SET cp850 COLLATE cp850_bin, d_varchar VARCHAR(64) CHARACTER SET cp850 COLLATE cp850_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp850 VALUES('a ', 'a ', 'a ', 'a ');
@@ -174,6 +507,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp850;
+# Testing character set cp852 collation cp852_general_ci
+CREATE TABLE t_cp852 (pk_varchar VARCHAR(64) CHARACTER SET cp852 COLLATE cp852_general_ci, pk_char CHAR(64) CHARACTER SET cp852 COLLATE cp852_general_ci, d_varchar VARCHAR(64) CHARACTER SET cp852 COLLATE cp852_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp852 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp852 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp852.PRIMARY'
+INSERT INTO t_cp852 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp852 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp852.PRIMARY'
+INSERT INTO t_cp852 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp852 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp852 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp852.PRIMARY'
+INSERT INTO t_cp852 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp852;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp852;
 # Testing character set cp852 collation cp852_bin
 CREATE TABLE t_cp852 (pk_varchar VARCHAR(64) CHARACTER SET cp852 COLLATE cp852_bin, pk_char CHAR(64) CHARACTER SET cp852 COLLATE cp852_bin, d_varchar VARCHAR(64) CHARACTER SET cp852 COLLATE cp852_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp852 VALUES('a ', 'a ', 'a ', 'a ');
@@ -196,6 +551,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp852;
+# Testing character set cp866 collation cp866_general_ci
+CREATE TABLE t_cp866 (pk_varchar VARCHAR(64) CHARACTER SET cp866 COLLATE cp866_general_ci, pk_char CHAR(64) CHARACTER SET cp866 COLLATE cp866_general_ci, d_varchar VARCHAR(64) CHARACTER SET cp866 COLLATE cp866_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp866 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp866 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp866.PRIMARY'
+INSERT INTO t_cp866 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp866 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp866.PRIMARY'
+INSERT INTO t_cp866 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp866 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp866 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp866.PRIMARY'
+INSERT INTO t_cp866 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp866;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp866;
 # Testing character set cp866 collation cp866_bin
 CREATE TABLE t_cp866 (pk_varchar VARCHAR(64) CHARACTER SET cp866 COLLATE cp866_bin, pk_char CHAR(64) CHARACTER SET cp866 COLLATE cp866_bin, d_varchar VARCHAR(64) CHARACTER SET cp866 COLLATE cp866_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp866 VALUES('a ', 'a ', 'a ', 'a ');
@@ -218,6 +595,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp866;
+# Testing character set cp932 collation cp932_japanese_ci
+CREATE TABLE t_cp932 (pk_varchar VARCHAR(64) CHARACTER SET cp932 COLLATE cp932_japanese_ci, pk_char CHAR(64) CHARACTER SET cp932 COLLATE cp932_japanese_ci, d_varchar VARCHAR(64) CHARACTER SET cp932 COLLATE cp932_japanese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_cp932 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_cp932 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_cp932.PRIMARY'
+INSERT INTO t_cp932 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_cp932 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_cp932.PRIMARY'
+INSERT INTO t_cp932 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_cp932 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_cp932 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_cp932.PRIMARY'
+INSERT INTO t_cp932 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_cp932;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_cp932;
 # Testing character set cp932 collation cp932_bin
 CREATE TABLE t_cp932 (pk_varchar VARCHAR(64) CHARACTER SET cp932 COLLATE cp932_bin, pk_char CHAR(64) CHARACTER SET cp932 COLLATE cp932_bin, d_varchar VARCHAR(64) CHARACTER SET cp932 COLLATE cp932_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_cp932 VALUES('a ', 'a ', 'a ', 'a ');
@@ -240,6 +639,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_cp932;
+# Testing character set dec8 collation dec8_swedish_ci
+CREATE TABLE t_dec8 (pk_varchar VARCHAR(64) CHARACTER SET dec8 COLLATE dec8_swedish_ci, pk_char CHAR(64) CHARACTER SET dec8 COLLATE dec8_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET dec8 COLLATE dec8_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_dec8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_dec8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_dec8.PRIMARY'
+INSERT INTO t_dec8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_dec8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_dec8.PRIMARY'
+INSERT INTO t_dec8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_dec8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_dec8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_dec8.PRIMARY'
+INSERT INTO t_dec8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_dec8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_dec8;
 # Testing character set dec8 collation dec8_bin
 CREATE TABLE t_dec8 (pk_varchar VARCHAR(64) CHARACTER SET dec8 COLLATE dec8_bin, pk_char CHAR(64) CHARACTER SET dec8 COLLATE dec8_bin, d_varchar VARCHAR(64) CHARACTER SET dec8 COLLATE dec8_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_dec8 VALUES('a ', 'a ', 'a ', 'a ');
@@ -262,6 +683,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_dec8;
+# Testing character set eucjpms collation eucjpms_japanese_ci
+CREATE TABLE t_eucjpms (pk_varchar VARCHAR(64) CHARACTER SET eucjpms COLLATE eucjpms_japanese_ci, pk_char CHAR(64) CHARACTER SET eucjpms COLLATE eucjpms_japanese_ci, d_varchar VARCHAR(64) CHARACTER SET eucjpms COLLATE eucjpms_japanese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_eucjpms VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_eucjpms VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_eucjpms.PRIMARY'
+INSERT INTO t_eucjpms VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_eucjpms VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_eucjpms.PRIMARY'
+INSERT INTO t_eucjpms VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_eucjpms VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_eucjpms VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_eucjpms.PRIMARY'
+INSERT INTO t_eucjpms VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_eucjpms;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_eucjpms;
 # Testing character set eucjpms collation eucjpms_bin
 CREATE TABLE t_eucjpms (pk_varchar VARCHAR(64) CHARACTER SET eucjpms COLLATE eucjpms_bin, pk_char CHAR(64) CHARACTER SET eucjpms COLLATE eucjpms_bin, d_varchar VARCHAR(64) CHARACTER SET eucjpms COLLATE eucjpms_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_eucjpms VALUES('a ', 'a ', 'a ', 'a ');
@@ -284,6 +727,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_eucjpms;
+# Testing character set euckr collation euckr_korean_ci
+CREATE TABLE t_euckr (pk_varchar VARCHAR(64) CHARACTER SET euckr COLLATE euckr_korean_ci, pk_char CHAR(64) CHARACTER SET euckr COLLATE euckr_korean_ci, d_varchar VARCHAR(64) CHARACTER SET euckr COLLATE euckr_korean_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_euckr VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_euckr VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_euckr.PRIMARY'
+INSERT INTO t_euckr VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_euckr VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_euckr.PRIMARY'
+INSERT INTO t_euckr VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_euckr VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_euckr VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_euckr.PRIMARY'
+INSERT INTO t_euckr VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_euckr;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_euckr;
 # Testing character set euckr collation euckr_bin
 CREATE TABLE t_euckr (pk_varchar VARCHAR(64) CHARACTER SET euckr COLLATE euckr_bin, pk_char CHAR(64) CHARACTER SET euckr COLLATE euckr_bin, d_varchar VARCHAR(64) CHARACTER SET euckr COLLATE euckr_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_euckr VALUES('a ', 'a ', 'a ', 'a ');
@@ -306,6 +771,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_euckr;
+# Testing character set gb18030 collation gb18030_chinese_ci
+CREATE TABLE t_gb18030 (pk_varchar VARCHAR(64) CHARACTER SET gb18030 COLLATE gb18030_chinese_ci, pk_char CHAR(64) CHARACTER SET gb18030 COLLATE gb18030_chinese_ci, d_varchar VARCHAR(64) CHARACTER SET gb18030 COLLATE gb18030_chinese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_gb18030 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb18030 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_gb18030.PRIMARY'
+INSERT INTO t_gb18030 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb18030 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_gb18030.PRIMARY'
+INSERT INTO t_gb18030 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb18030 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_gb18030 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_gb18030.PRIMARY'
+INSERT INTO t_gb18030 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb18030;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb18030;
 # Testing character set gb18030 collation gb18030_bin
 CREATE TABLE t_gb18030 (pk_varchar VARCHAR(64) CHARACTER SET gb18030 COLLATE gb18030_bin, pk_char CHAR(64) CHARACTER SET gb18030 COLLATE gb18030_bin, d_varchar VARCHAR(64) CHARACTER SET gb18030 COLLATE gb18030_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_gb18030 VALUES('a ', 'a ', 'a ', 'a ');
@@ -328,6 +815,50 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_gb18030;
+# Testing character set gb18030 collation gb18030_unicode_520_ci
+CREATE TABLE t_gb18030 (pk_varchar VARCHAR(64) CHARACTER SET gb18030 COLLATE gb18030_unicode_520_ci, pk_char CHAR(64) CHARACTER SET gb18030 COLLATE gb18030_unicode_520_ci, d_varchar VARCHAR(64) CHARACTER SET gb18030 COLLATE gb18030_unicode_520_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_gb18030 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb18030 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_gb18030.PRIMARY'
+INSERT INTO t_gb18030 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb18030 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_gb18030.PRIMARY'
+INSERT INTO t_gb18030 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb18030 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_gb18030 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_gb18030.PRIMARY'
+INSERT INTO t_gb18030 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb18030;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb18030;
+# Testing character set gb2312 collation gb2312_chinese_ci
+CREATE TABLE t_gb2312 (pk_varchar VARCHAR(64) CHARACTER SET gb2312 COLLATE gb2312_chinese_ci, pk_char CHAR(64) CHARACTER SET gb2312 COLLATE gb2312_chinese_ci, d_varchar VARCHAR(64) CHARACTER SET gb2312 COLLATE gb2312_chinese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_gb2312 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gb2312 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_gb2312.PRIMARY'
+INSERT INTO t_gb2312 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gb2312 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_gb2312.PRIMARY'
+INSERT INTO t_gb2312 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gb2312 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_gb2312 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_gb2312.PRIMARY'
+INSERT INTO t_gb2312 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gb2312;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gb2312;
 # Testing character set gb2312 collation gb2312_bin
 CREATE TABLE t_gb2312 (pk_varchar VARCHAR(64) CHARACTER SET gb2312 COLLATE gb2312_bin, pk_char CHAR(64) CHARACTER SET gb2312 COLLATE gb2312_bin, d_varchar VARCHAR(64) CHARACTER SET gb2312 COLLATE gb2312_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_gb2312 VALUES('a ', 'a ', 'a ', 'a ');
@@ -350,6 +881,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_gb2312;
+# Testing character set gbk collation gbk_chinese_ci
+CREATE TABLE t_gbk (pk_varchar VARCHAR(64) CHARACTER SET gbk COLLATE gbk_chinese_ci, pk_char CHAR(64) CHARACTER SET gbk COLLATE gbk_chinese_ci, d_varchar VARCHAR(64) CHARACTER SET gbk COLLATE gbk_chinese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_gbk VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_gbk VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_gbk.PRIMARY'
+INSERT INTO t_gbk VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_gbk VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_gbk.PRIMARY'
+INSERT INTO t_gbk VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_gbk VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_gbk VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_gbk.PRIMARY'
+INSERT INTO t_gbk VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_gbk;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_gbk;
 # Testing character set gbk collation gbk_bin
 CREATE TABLE t_gbk (pk_varchar VARCHAR(64) CHARACTER SET gbk COLLATE gbk_bin, pk_char CHAR(64) CHARACTER SET gbk COLLATE gbk_bin, d_varchar VARCHAR(64) CHARACTER SET gbk COLLATE gbk_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_gbk VALUES('a ', 'a ', 'a ', 'a ');
@@ -372,6 +925,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_gbk;
+# Testing character set geostd8 collation geostd8_general_ci
+CREATE TABLE t_geostd8 (pk_varchar VARCHAR(64) CHARACTER SET geostd8 COLLATE geostd8_general_ci, pk_char CHAR(64) CHARACTER SET geostd8 COLLATE geostd8_general_ci, d_varchar VARCHAR(64) CHARACTER SET geostd8 COLLATE geostd8_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_geostd8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_geostd8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_geostd8.PRIMARY'
+INSERT INTO t_geostd8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_geostd8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_geostd8.PRIMARY'
+INSERT INTO t_geostd8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_geostd8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_geostd8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_geostd8.PRIMARY'
+INSERT INTO t_geostd8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_geostd8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_geostd8;
 # Testing character set geostd8 collation geostd8_bin
 CREATE TABLE t_geostd8 (pk_varchar VARCHAR(64) CHARACTER SET geostd8 COLLATE geostd8_bin, pk_char CHAR(64) CHARACTER SET geostd8 COLLATE geostd8_bin, d_varchar VARCHAR(64) CHARACTER SET geostd8 COLLATE geostd8_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_geostd8 VALUES('a ', 'a ', 'a ', 'a ');
@@ -394,6 +969,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_geostd8;
+# Testing character set greek collation greek_general_ci
+CREATE TABLE t_greek (pk_varchar VARCHAR(64) CHARACTER SET greek COLLATE greek_general_ci, pk_char CHAR(64) CHARACTER SET greek COLLATE greek_general_ci, d_varchar VARCHAR(64) CHARACTER SET greek COLLATE greek_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_greek VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_greek VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_greek.PRIMARY'
+INSERT INTO t_greek VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_greek VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_greek.PRIMARY'
+INSERT INTO t_greek VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_greek VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_greek VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_greek.PRIMARY'
+INSERT INTO t_greek VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_greek;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_greek;
 # Testing character set greek collation greek_bin
 CREATE TABLE t_greek (pk_varchar VARCHAR(64) CHARACTER SET greek COLLATE greek_bin, pk_char CHAR(64) CHARACTER SET greek COLLATE greek_bin, d_varchar VARCHAR(64) CHARACTER SET greek COLLATE greek_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_greek VALUES('a ', 'a ', 'a ', 'a ');
@@ -416,6 +1013,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_greek;
+# Testing character set hebrew collation hebrew_general_ci
+CREATE TABLE t_hebrew (pk_varchar VARCHAR(64) CHARACTER SET hebrew COLLATE hebrew_general_ci, pk_char CHAR(64) CHARACTER SET hebrew COLLATE hebrew_general_ci, d_varchar VARCHAR(64) CHARACTER SET hebrew COLLATE hebrew_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_hebrew VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hebrew VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_hebrew.PRIMARY'
+INSERT INTO t_hebrew VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hebrew VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_hebrew.PRIMARY'
+INSERT INTO t_hebrew VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hebrew VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_hebrew VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_hebrew.PRIMARY'
+INSERT INTO t_hebrew VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hebrew;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hebrew;
 # Testing character set hebrew collation hebrew_bin
 CREATE TABLE t_hebrew (pk_varchar VARCHAR(64) CHARACTER SET hebrew COLLATE hebrew_bin, pk_char CHAR(64) CHARACTER SET hebrew COLLATE hebrew_bin, d_varchar VARCHAR(64) CHARACTER SET hebrew COLLATE hebrew_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_hebrew VALUES('a ', 'a ', 'a ', 'a ');
@@ -438,6 +1057,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_hebrew;
+# Testing character set hp8 collation hp8_english_ci
+CREATE TABLE t_hp8 (pk_varchar VARCHAR(64) CHARACTER SET hp8 COLLATE hp8_english_ci, pk_char CHAR(64) CHARACTER SET hp8 COLLATE hp8_english_ci, d_varchar VARCHAR(64) CHARACTER SET hp8 COLLATE hp8_english_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_hp8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_hp8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_hp8.PRIMARY'
+INSERT INTO t_hp8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_hp8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_hp8.PRIMARY'
+INSERT INTO t_hp8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_hp8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_hp8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_hp8.PRIMARY'
+INSERT INTO t_hp8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_hp8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_hp8;
 # Testing character set hp8 collation hp8_bin
 CREATE TABLE t_hp8 (pk_varchar VARCHAR(64) CHARACTER SET hp8 COLLATE hp8_bin, pk_char CHAR(64) CHARACTER SET hp8 COLLATE hp8_bin, d_varchar VARCHAR(64) CHARACTER SET hp8 COLLATE hp8_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_hp8 VALUES('a ', 'a ', 'a ', 'a ');
@@ -460,6 +1101,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_hp8;
+# Testing character set keybcs2 collation keybcs2_general_ci
+CREATE TABLE t_keybcs2 (pk_varchar VARCHAR(64) CHARACTER SET keybcs2 COLLATE keybcs2_general_ci, pk_char CHAR(64) CHARACTER SET keybcs2 COLLATE keybcs2_general_ci, d_varchar VARCHAR(64) CHARACTER SET keybcs2 COLLATE keybcs2_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_keybcs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_keybcs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_keybcs2.PRIMARY'
+INSERT INTO t_keybcs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_keybcs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_keybcs2.PRIMARY'
+INSERT INTO t_keybcs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_keybcs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_keybcs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_keybcs2.PRIMARY'
+INSERT INTO t_keybcs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_keybcs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_keybcs2;
 # Testing character set keybcs2 collation keybcs2_bin
 CREATE TABLE t_keybcs2 (pk_varchar VARCHAR(64) CHARACTER SET keybcs2 COLLATE keybcs2_bin, pk_char CHAR(64) CHARACTER SET keybcs2 COLLATE keybcs2_bin, d_varchar VARCHAR(64) CHARACTER SET keybcs2 COLLATE keybcs2_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_keybcs2 VALUES('a ', 'a ', 'a ', 'a ');
@@ -482,6 +1145,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_keybcs2;
+# Testing character set koi8r collation koi8r_general_ci
+CREATE TABLE t_koi8r (pk_varchar VARCHAR(64) CHARACTER SET koi8r COLLATE koi8r_general_ci, pk_char CHAR(64) CHARACTER SET koi8r COLLATE koi8r_general_ci, d_varchar VARCHAR(64) CHARACTER SET koi8r COLLATE koi8r_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_koi8r VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8r VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_koi8r.PRIMARY'
+INSERT INTO t_koi8r VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8r VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_koi8r.PRIMARY'
+INSERT INTO t_koi8r VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8r VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_koi8r VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_koi8r.PRIMARY'
+INSERT INTO t_koi8r VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8r;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8r;
 # Testing character set koi8r collation koi8r_bin
 CREATE TABLE t_koi8r (pk_varchar VARCHAR(64) CHARACTER SET koi8r COLLATE koi8r_bin, pk_char CHAR(64) CHARACTER SET koi8r COLLATE koi8r_bin, d_varchar VARCHAR(64) CHARACTER SET koi8r COLLATE koi8r_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_koi8r VALUES('a ', 'a ', 'a ', 'a ');
@@ -504,6 +1189,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_koi8r;
+# Testing character set koi8u collation koi8u_general_ci
+CREATE TABLE t_koi8u (pk_varchar VARCHAR(64) CHARACTER SET koi8u COLLATE koi8u_general_ci, pk_char CHAR(64) CHARACTER SET koi8u COLLATE koi8u_general_ci, d_varchar VARCHAR(64) CHARACTER SET koi8u COLLATE koi8u_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_koi8u VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_koi8u VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_koi8u.PRIMARY'
+INSERT INTO t_koi8u VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_koi8u VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_koi8u.PRIMARY'
+INSERT INTO t_koi8u VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_koi8u VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_koi8u VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_koi8u.PRIMARY'
+INSERT INTO t_koi8u VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_koi8u;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	C       `	9	432020202020202060	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_koi8u;
 # Testing character set koi8u collation koi8u_bin
 CREATE TABLE t_koi8u (pk_varchar VARCHAR(64) CHARACTER SET koi8u COLLATE koi8u_bin, pk_char CHAR(64) CHARACTER SET koi8u COLLATE koi8u_bin, d_varchar VARCHAR(64) CHARACTER SET koi8u COLLATE koi8u_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_koi8u VALUES('a ', 'a ', 'a ', 'a ');
@@ -526,6 +1233,94 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_koi8u;
+# Testing character set latin1 collation latin1_german1_ci
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_german1_ci, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_german1_ci, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_german1_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin1 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set latin1 collation latin1_swedish_ci
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_swedish_ci, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin1 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set latin1 collation latin1_danish_ci
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_danish_ci, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_danish_ci, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_danish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin1 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set latin1 collation latin1_german2_ci
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_german2_ci, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_german2_ci, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_german2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin1 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
 # Testing character set latin1 collation latin1_bin
 CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_bin, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_bin, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
@@ -548,6 +1343,138 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_latin1;
+# Testing character set latin1 collation latin1_general_ci
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_general_ci, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_general_ci, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin1 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set latin1 collation latin1_general_cs
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_general_cs, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_general_cs, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_general_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin1 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set latin1 collation latin1_spanish_ci
+CREATE TABLE t_latin1 (pk_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_spanish_ci, pk_char CHAR(64) CHARACTER SET latin1 COLLATE latin1_spanish_ci, d_varchar VARCHAR(64) CHARACTER SET latin1 COLLATE latin1_spanish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin1 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin1 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin1 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin1 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin1 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin1.PRIMARY'
+INSERT INTO t_latin1 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin1;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin1;
+# Testing character set latin2 collation latin2_general_ci
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_general_ci, pk_char CHAR(64) CHARACTER SET latin2 COLLATE latin2_general_ci, d_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set latin2 collation latin2_hungarian_ci
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_hungarian_ci, pk_char CHAR(64) CHARACTER SET latin2 COLLATE latin2_hungarian_ci, d_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_hungarian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
+# Testing character set latin2 collation latin2_croatian_ci
+CREATE TABLE t_latin2 (pk_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_croatian_ci, pk_char CHAR(64) CHARACTER SET latin2 COLLATE latin2_croatian_ci, d_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_croatian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin2.PRIMARY'
+INSERT INTO t_latin2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin2;
 # Testing character set latin2 collation latin2_bin
 CREATE TABLE t_latin2 (pk_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_bin, pk_char CHAR(64) CHARACTER SET latin2 COLLATE latin2_bin, d_varchar VARCHAR(64) CHARACTER SET latin2 COLLATE latin2_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_latin2 VALUES('a ', 'a ', 'a ', 'a ');
@@ -570,6 +1497,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_latin2;
+# Testing character set latin5 collation latin5_turkish_ci
+CREATE TABLE t_latin5 (pk_varchar VARCHAR(64) CHARACTER SET latin5 COLLATE latin5_turkish_ci, pk_char CHAR(64) CHARACTER SET latin5 COLLATE latin5_turkish_ci, d_varchar VARCHAR(64) CHARACTER SET latin5 COLLATE latin5_turkish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin5 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin5 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin5.PRIMARY'
+INSERT INTO t_latin5 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin5 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin5.PRIMARY'
+INSERT INTO t_latin5 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin5 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin5 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin5.PRIMARY'
+INSERT INTO t_latin5 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin5;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin5;
 # Testing character set latin5 collation latin5_bin
 CREATE TABLE t_latin5 (pk_varchar VARCHAR(64) CHARACTER SET latin5 COLLATE latin5_bin, pk_char CHAR(64) CHARACTER SET latin5 COLLATE latin5_bin, d_varchar VARCHAR(64) CHARACTER SET latin5 COLLATE latin5_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_latin5 VALUES('a ', 'a ', 'a ', 'a ');
@@ -592,6 +1541,72 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_latin5;
+# Testing character set latin7 collation latin7_estonian_cs
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_estonian_cs, pk_char CHAR(64) CHARACTER SET latin7 COLLATE latin7_estonian_cs, d_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_estonian_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin7 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set latin7 collation latin7_general_ci
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_general_ci, pk_char CHAR(64) CHARACTER SET latin7 COLLATE latin7_general_ci, d_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin7 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
+# Testing character set latin7 collation latin7_general_cs
+CREATE TABLE t_latin7 (pk_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_general_cs, pk_char CHAR(64) CHARACTER SET latin7 COLLATE latin7_general_cs, d_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_general_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_latin7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_latin7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_latin7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_latin7 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_latin7.PRIMARY'
+INSERT INTO t_latin7 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_latin7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_latin7;
 # Testing character set latin7 collation latin7_bin
 CREATE TABLE t_latin7 (pk_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_bin, pk_char CHAR(64) CHARACTER SET latin7 COLLATE latin7_bin, d_varchar VARCHAR(64) CHARACTER SET latin7 COLLATE latin7_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_latin7 VALUES('a ', 'a ', 'a ', 'a ');
@@ -614,6 +1629,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_latin7;
+# Testing character set macce collation macce_general_ci
+CREATE TABLE t_macce (pk_varchar VARCHAR(64) CHARACTER SET macce COLLATE macce_general_ci, pk_char CHAR(64) CHARACTER SET macce COLLATE macce_general_ci, d_varchar VARCHAR(64) CHARACTER SET macce COLLATE macce_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_macce VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macce VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_macce.PRIMARY'
+INSERT INTO t_macce VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macce VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_macce.PRIMARY'
+INSERT INTO t_macce VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macce VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_macce VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_macce.PRIMARY'
+INSERT INTO t_macce VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macce;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macce;
 # Testing character set macce collation macce_bin
 CREATE TABLE t_macce (pk_varchar VARCHAR(64) CHARACTER SET macce COLLATE macce_bin, pk_char CHAR(64) CHARACTER SET macce COLLATE macce_bin, d_varchar VARCHAR(64) CHARACTER SET macce COLLATE macce_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_macce VALUES('a ', 'a ', 'a ', 'a ');
@@ -636,6 +1673,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_macce;
+# Testing character set macroman collation macroman_general_ci
+CREATE TABLE t_macroman (pk_varchar VARCHAR(64) CHARACTER SET macroman COLLATE macroman_general_ci, pk_char CHAR(64) CHARACTER SET macroman COLLATE macroman_general_ci, d_varchar VARCHAR(64) CHARACTER SET macroman COLLATE macroman_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_macroman VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_macroman VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_macroman.PRIMARY'
+INSERT INTO t_macroman VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_macroman VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_macroman.PRIMARY'
+INSERT INTO t_macroman VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_macroman VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_macroman VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_macroman.PRIMARY'
+INSERT INTO t_macroman VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_macroman;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_macroman;
 # Testing character set macroman collation macroman_bin
 CREATE TABLE t_macroman (pk_varchar VARCHAR(64) CHARACTER SET macroman COLLATE macroman_bin, pk_char CHAR(64) CHARACTER SET macroman COLLATE macroman_bin, d_varchar VARCHAR(64) CHARACTER SET macroman COLLATE macroman_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_macroman VALUES('a ', 'a ', 'a ', 'a ');
@@ -658,6 +1717,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_macroman;
+# Testing character set sjis collation sjis_japanese_ci
+CREATE TABLE t_sjis (pk_varchar VARCHAR(64) CHARACTER SET sjis COLLATE sjis_japanese_ci, pk_char CHAR(64) CHARACTER SET sjis COLLATE sjis_japanese_ci, d_varchar VARCHAR(64) CHARACTER SET sjis COLLATE sjis_japanese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_sjis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_sjis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_sjis.PRIMARY'
+INSERT INTO t_sjis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_sjis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_sjis.PRIMARY'
+INSERT INTO t_sjis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_sjis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_sjis VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_sjis.PRIMARY'
+INSERT INTO t_sjis VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_sjis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_sjis;
 # Testing character set sjis collation sjis_bin
 CREATE TABLE t_sjis (pk_varchar VARCHAR(64) CHARACTER SET sjis COLLATE sjis_bin, pk_char CHAR(64) CHARACTER SET sjis COLLATE sjis_bin, d_varchar VARCHAR(64) CHARACTER SET sjis COLLATE sjis_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_sjis VALUES('a ', 'a ', 'a ', 'a ');
@@ -680,6 +1761,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_sjis;
+# Testing character set swe7 collation swe7_swedish_ci
+CREATE TABLE t_swe7 (pk_varchar VARCHAR(64) CHARACTER SET swe7 COLLATE swe7_swedish_ci, pk_char CHAR(64) CHARACTER SET swe7 COLLATE swe7_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET swe7 COLLATE swe7_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_swe7 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_swe7 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_swe7.PRIMARY'
+INSERT INTO t_swe7 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_swe7 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_swe7.PRIMARY'
+INSERT INTO t_swe7 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_swe7 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_swe7 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_swe7.PRIMARY'
+INSERT INTO t_swe7 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_swe7;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_swe7;
 # Testing character set swe7 collation swe7_bin
 CREATE TABLE t_swe7 (pk_varchar VARCHAR(64) CHARACTER SET swe7 COLLATE swe7_bin, pk_char CHAR(64) CHARACTER SET swe7 COLLATE swe7_bin, d_varchar VARCHAR(64) CHARACTER SET swe7 COLLATE swe7_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_swe7 VALUES('a ', 'a ', 'a ', 'a ');
@@ -702,6 +1805,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_swe7;
+# Testing character set tis620 collation tis620_thai_ci
+CREATE TABLE t_tis620 (pk_varchar VARCHAR(64) CHARACTER SET tis620 COLLATE tis620_thai_ci, pk_char CHAR(64) CHARACTER SET tis620 COLLATE tis620_thai_ci, d_varchar VARCHAR(64) CHARACTER SET tis620 COLLATE tis620_thai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_tis620 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_tis620 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_tis620.PRIMARY'
+INSERT INTO t_tis620 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_tis620 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_tis620.PRIMARY'
+INSERT INTO t_tis620 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_tis620 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_tis620 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_tis620.PRIMARY'
+INSERT INTO t_tis620 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_tis620;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_tis620;
 # Testing character set tis620 collation tis620_bin
 CREATE TABLE t_tis620 (pk_varchar VARCHAR(64) CHARACTER SET tis620 COLLATE tis620_bin, pk_char CHAR(64) CHARACTER SET tis620 COLLATE tis620_bin, d_varchar VARCHAR(64) CHARACTER SET tis620 COLLATE tis620_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_tis620 VALUES('a ', 'a ', 'a ', 'a ');
@@ -724,6 +1849,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_tis620;
+# Testing character set ucs2 collation ucs2_general_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_general_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_general_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
 # Testing character set ucs2 collation ucs2_bin
 CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_bin, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_bin, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
@@ -746,6 +1893,578 @@ a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
 b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
 c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
 DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_unicode_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_unicode_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_unicode_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_unicode_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_icelandic_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_icelandic_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_icelandic_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_icelandic_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_latvian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_latvian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_latvian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_latvian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_romanian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_romanian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_romanian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_romanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_slovenian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_slovenian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_slovenian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_slovenian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_polish_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_polish_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_polish_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_polish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_estonian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_estonian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_estonian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_estonian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_spanish_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_spanish_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_spanish_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_spanish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_swedish_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_swedish_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_turkish_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_turkish_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_turkish_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_turkish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_czech_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_czech_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_czech_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_czech_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_danish_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_danish_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_danish_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_danish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_lithuanian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_lithuanian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_lithuanian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_lithuanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_slovak_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_slovak_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_slovak_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_slovak_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_spanish2_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_spanish2_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_spanish2_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_spanish2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_roman_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_roman_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_roman_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_roman_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_persian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_persian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_persian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_persian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_esperanto_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_esperanto_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_esperanto_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_esperanto_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_hungarian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_hungarian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_hungarian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_hungarian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_sinhala_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_sinhala_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_sinhala_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_sinhala_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_german2_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_german2_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_german2_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_german2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_croatian_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_croatian_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_croatian_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_croatian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_unicode_520_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_unicode_520_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_unicode_520_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_unicode_520_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_vietnamese_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_vietnamese_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_vietnamese_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_vietnamese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ucs2 collation ucs2_general_mysql500_ci
+CREATE TABLE t_ucs2 (pk_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_general_mysql500_ci, pk_char CHAR(64) CHARACTER SET ucs2 COLLATE ucs2_general_mysql500_ci, d_varchar VARCHAR(64) CHARACTER SET ucs2 COLLATE ucs2_general_mysql500_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ucs2 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ucs2 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ucs2 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ucs2 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ucs2 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ucs2.PRIMARY'
+INSERT INTO t_ucs2 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ucs2;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_ucs2;
+# Testing character set ujis collation ujis_japanese_ci
+CREATE TABLE t_ujis (pk_varchar VARCHAR(64) CHARACTER SET ujis COLLATE ujis_japanese_ci, pk_char CHAR(64) CHARACTER SET ujis COLLATE ujis_japanese_ci, d_varchar VARCHAR(64) CHARACTER SET ujis COLLATE ujis_japanese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_ujis VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_ujis VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_ujis.PRIMARY'
+INSERT INTO t_ujis VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_ujis VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_ujis.PRIMARY'
+INSERT INTO t_ujis VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_ujis VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_ujis VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_ujis.PRIMARY'
+INSERT INTO t_ujis VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_ujis;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_ujis;
 # Testing character set ujis collation ujis_bin
 CREATE TABLE t_ujis (pk_varchar VARCHAR(64) CHARACTER SET ujis COLLATE ujis_bin, pk_char CHAR(64) CHARACTER SET ujis COLLATE ujis_bin, d_varchar VARCHAR(64) CHARACTER SET ujis COLLATE ujis_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_ujis VALUES('a ', 'a ', 'a ', 'a ');
@@ -768,6 +2487,28 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_ujis;
+# Testing character set utf16 collation utf16_general_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_general_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_general_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
 # Testing character set utf16 collation utf16_bin
 CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_bin, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_bin, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
@@ -790,6 +2531,556 @@ a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
 b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
 c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
 DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_unicode_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_unicode_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_unicode_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_unicode_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_icelandic_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_icelandic_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_icelandic_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_icelandic_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_latvian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_latvian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_latvian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_latvian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_romanian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_romanian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_romanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_romanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_slovenian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_slovenian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_slovenian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_slovenian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_polish_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_polish_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_polish_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_polish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_estonian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_estonian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_estonian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_estonian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_spanish_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_spanish_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_spanish_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_spanish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_swedish_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_swedish_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_turkish_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_turkish_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_turkish_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_turkish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_czech_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_czech_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_czech_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_czech_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_danish_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_danish_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_danish_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_danish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_lithuanian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_lithuanian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_lithuanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_lithuanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_slovak_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_slovak_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_slovak_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_slovak_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_spanish2_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_spanish2_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_spanish2_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_spanish2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_roman_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_roman_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_roman_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_roman_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_persian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_persian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_persian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_persian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_esperanto_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_esperanto_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_esperanto_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_esperanto_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_hungarian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_hungarian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_hungarian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_hungarian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_sinhala_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_sinhala_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_sinhala_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_sinhala_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_german2_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_german2_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_german2_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_german2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_croatian_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_croatian_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_croatian_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_croatian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_unicode_520_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_unicode_520_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_unicode_520_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_unicode_520_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16 collation utf16_vietnamese_ci
+CREATE TABLE t_utf16 (pk_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_vietnamese_ci, pk_char CHAR(64) CHARACTER SET utf16 COLLATE utf16_vietnamese_ci, d_varchar VARCHAR(64) CHARACTER SET utf16 COLLATE utf16_vietnamese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16.PRIMARY'
+INSERT INTO t_utf16 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	00610009	a		4	00610009	a		4	00610009	a		2	6109
+a 		6	006100200009	a 		6	006100200009	a 		6	006100200009	a 		3	612009
+a 	4	00610020	a	2	0061	a 	4	00610020	a	1	61
+b  	6	006200200020	b	2	0062	b  	6	006200200020	b	1	62
+c          	22	00630020002000200020002000200020002000200020	c	2	0063	c          	22	00630020002000200020002000200020002000200020	c	1	63
+DROP TABLE t_utf16;
+# Testing character set utf16le collation utf16le_general_ci
+CREATE TABLE t_utf16le (pk_varchar VARCHAR(64) CHARACTER SET utf16le COLLATE utf16le_general_ci, pk_char CHAR(64) CHARACTER SET utf16le COLLATE utf16le_general_ci, d_varchar VARCHAR(64) CHARACTER SET utf16le COLLATE utf16le_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf16le VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf16le VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf16le.PRIMARY'
+INSERT INTO t_utf16le VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf16le VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf16le.PRIMARY'
+INSERT INTO t_utf16le VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf16le VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf16le VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf16le.PRIMARY'
+INSERT INTO t_utf16le VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf16le;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		4	61000900	a		4	61000900	a		4	61000900	a		2	6109
+a 		6	610020000900	a 		6	610020000900	a 		6	610020000900	a 		3	612009
+a 	4	61002000	a	2	6100	a 	4	61002000	a	1	61
+b  	6	620020002000	b	2	6200	b  	6	620020002000	b	1	62
+c          	22	63002000200020002000200020002000200020002000	c	2	6300	c          	22	63002000200020002000200020002000200020002000	c	1	63
+DROP TABLE t_utf16le;
 # Testing character set utf16le collation utf16le_bin
 CREATE TABLE t_utf16le (pk_varchar VARCHAR(64) CHARACTER SET utf16le COLLATE utf16le_bin, pk_char CHAR(64) CHARACTER SET utf16le COLLATE utf16le_bin, d_varchar VARCHAR(64) CHARACTER SET utf16le COLLATE utf16le_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_utf16le VALUES('a ', 'a ', 'a ', 'a ');
@@ -812,6 +3103,28 @@ a 	4	61002000	a	2	6100	a 	4	61002000	a	1	61
 b  	6	620020002000	b	2	6200	b  	6	620020002000	b	1	62
 c          	22	63002000200020002000200020002000200020002000	c	2	6300	c          	22	63002000200020002000200020002000200020002000	c	1	63
 DROP TABLE t_utf16le;
+# Testing character set utf32 collation utf32_general_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_general_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_general_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
 # Testing character set utf32 collation utf32_bin
 CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_bin, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_bin, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
@@ -834,6 +3147,592 @@ a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
 b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
 c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
 DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_unicode_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_unicode_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_unicode_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_unicode_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_icelandic_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_icelandic_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_icelandic_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_icelandic_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_latvian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_latvian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_latvian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_latvian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_romanian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_romanian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_romanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_romanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_slovenian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_slovenian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_slovenian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_slovenian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_polish_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_polish_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_polish_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_polish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_estonian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_estonian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_estonian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_estonian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_spanish_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_spanish_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_spanish_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_spanish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_swedish_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_swedish_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_turkish_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_turkish_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_turkish_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_turkish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_czech_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_czech_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_czech_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_czech_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_danish_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_danish_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_danish_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_danish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_lithuanian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_lithuanian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_lithuanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_lithuanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_slovak_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_slovak_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_slovak_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_slovak_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_spanish2_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_spanish2_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_spanish2_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_spanish2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_roman_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_roman_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_roman_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_roman_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_persian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_persian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_persian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_persian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_esperanto_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_esperanto_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_esperanto_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_esperanto_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_hungarian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_hungarian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_hungarian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_hungarian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_sinhala_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_sinhala_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_sinhala_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_sinhala_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_german2_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_german2_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_german2_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_german2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_croatian_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_croatian_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_croatian_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_croatian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_unicode_520_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_unicode_520_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_unicode_520_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_unicode_520_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf32 collation utf32_vietnamese_ci
+CREATE TABLE t_utf32 (pk_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_vietnamese_ci, pk_char CHAR(64) CHARACTER SET utf32 COLLATE utf32_vietnamese_ci, d_varchar VARCHAR(64) CHARACTER SET utf32 COLLATE utf32_vietnamese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf32 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf32 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf32 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf32 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf32 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf32.PRIMARY'
+INSERT INTO t_utf32 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf32;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		8	0000006100000009	a		8	0000006100000009	a		8	0000006100000009	a		2	6109
+a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		12	000000610000002000000009	a 		3	612009
+a 	8	0000006100000020	a	4	00000061	a 	8	0000006100000020	a	1	61
+b  	12	000000620000002000000020	b	4	00000062	b  	12	000000620000002000000020	b	1	62
+c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	4	00000063	c          	44	0000006300000020000000200000002000000020000000200000002000000020000000200000002000000020	c	1	63
+DROP TABLE t_utf32;
+# Testing character set utf8 collation utf8_general_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_general_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_general_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_tolower_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_tolower_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_tolower_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_tolower_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_tolower_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_tolower_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_tolower_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
 # Testing character set utf8 collation utf8_bin
 CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_bin, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_bin, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 Warnings:
@@ -863,8 +3762,733 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_utf8;
-# Testing character set utf8mb4 collation utf8mb4_0900_bin
-CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+# Testing character set utf8 collation utf8_unicode_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_icelandic_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_icelandic_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_icelandic_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_icelandic_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_icelandic_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_icelandic_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_icelandic_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_latvian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_latvian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_latvian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_latvian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_latvian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_latvian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_latvian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_romanian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_romanian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_romanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_romanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_romanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_romanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_romanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_slovenian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_slovenian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_slovenian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_slovenian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovenian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovenian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovenian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_polish_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_polish_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_polish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_polish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_polish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_polish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_polish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_estonian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_estonian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_estonian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_estonian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_estonian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_estonian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_estonian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_spanish_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_spanish_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_spanish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_spanish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_swedish_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_swedish_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_swedish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_swedish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_swedish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_turkish_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_turkish_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_turkish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_turkish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_turkish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_turkish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_turkish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_czech_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_czech_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_czech_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_czech_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_czech_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_czech_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_czech_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_danish_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_danish_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_danish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_danish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_danish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_danish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_danish_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_lithuanian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_lithuanian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_lithuanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_lithuanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_lithuanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_lithuanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_lithuanian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_slovak_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_slovak_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_slovak_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_slovak_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovak_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovak_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_slovak_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_spanish2_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_spanish2_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_spanish2_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_spanish2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_spanish2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_roman_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_roman_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_roman_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_roman_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_roman_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_roman_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_roman_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_persian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_persian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_persian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_persian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_persian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_persian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_persian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_esperanto_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_esperanto_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_esperanto_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_esperanto_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_esperanto_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_esperanto_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_esperanto_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_hungarian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_hungarian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_hungarian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_hungarian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_hungarian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_hungarian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_hungarian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_sinhala_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_sinhala_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_sinhala_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_sinhala_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_sinhala_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_sinhala_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_sinhala_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_german2_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_german2_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_german2_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_german2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_german2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_german2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_german2_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_croatian_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_croatian_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_croatian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_croatian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_croatian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_croatian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_croatian_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_unicode_520_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_520_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_520_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_unicode_520_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_520_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_520_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_unicode_520_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_vietnamese_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_vietnamese_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_vietnamese_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_vietnamese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_vietnamese_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_vietnamese_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_vietnamese_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8 collation utf8_general_mysql500_ci
+CREATE TABLE t_utf8 (pk_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_general_mysql500_ci, pk_char CHAR(64) CHARACTER SET utf8 COLLATE utf8_general_mysql500_ci, d_varchar VARCHAR(64) CHARACTER SET utf8 COLLATE utf8_general_mysql500_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_mysql500_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_mysql500_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+Warning	3778	'utf8_general_mysql500_ci' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+INSERT INTO t_utf8 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8.PRIMARY'
+INSERT INTO t_utf8 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8;
+# Testing character set utf8mb4 collation utf8mb4_general_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
 INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
 INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
 ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
@@ -907,3 +4531,1610 @@ a 	2	6120	a	1	61	a 	2	6120	a	1	61
 b  	3	622020	b	1	62	b  	3	622020	b	1	62
 c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
 DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_unicode_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_icelandic_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_icelandic_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_icelandic_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_icelandic_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_latvian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_latvian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_latvian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_latvian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_romanian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_romanian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_romanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_romanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_slovenian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_slovenian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_slovenian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_slovenian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_polish_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_polish_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_polish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_polish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_estonian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_estonian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_estonian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_estonian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_spanish_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_swedish_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_swedish_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_swedish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_swedish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_turkish_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_turkish_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_turkish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_turkish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_czech_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_danish_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_danish_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_danish_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_danish_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_lithuanian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lithuanian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lithuanian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lithuanian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_slovak_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_slovak_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_slovak_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_slovak_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_spanish2_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish2_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish2_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_spanish2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_roman_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_roman_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_roman_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_roman_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_persian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_persian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_persian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_persian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_esperanto_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_esperanto_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_esperanto_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_esperanto_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_hungarian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hungarian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hungarian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hungarian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_sinhala_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sinhala_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sinhala_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sinhala_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_german2_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_german2_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_german2_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_german2_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_croatian_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_croatian_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_croatian_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_croatian_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_unicode_520_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_vietnamese_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vietnamese_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vietnamese_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vietnamese_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_de_pb_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_de_pb_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_de_pb_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_de_pb_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_is_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_is_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_is_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_is_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_lv_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lv_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lv_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lv_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_ro_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ro_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ro_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ro_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_sl_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sl_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sl_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sl_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_pl_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_pl_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_pl_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_pl_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_et_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_et_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_et_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_et_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_es_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_sv_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sv_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sv_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sv_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_tr_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_tr_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_tr_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_tr_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_cs_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_cs_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_cs_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_cs_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_da_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_da_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_da_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_da_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_lt_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lt_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lt_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lt_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_sk_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sk_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sk_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sk_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_es_trad_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_trad_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_trad_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_trad_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_la_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_la_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_la_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_la_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_eo_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_eo_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_eo_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_eo_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_hu_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hu_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hu_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hu_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_hr_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hr_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hr_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hr_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_vi_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vi_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vi_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vi_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_de_pb_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_de_pb_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_de_pb_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_de_pb_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_is_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_is_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_is_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_is_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_lv_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lv_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lv_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lv_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_ro_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ro_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ro_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ro_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_sl_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sl_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sl_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sl_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_pl_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_pl_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_pl_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_pl_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_et_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_et_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_et_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_et_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_es_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_sv_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sv_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sv_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sv_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_tr_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_tr_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_tr_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_tr_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_cs_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_cs_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_cs_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_cs_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_da_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_da_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_da_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_da_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_lt_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lt_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lt_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_lt_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_sk_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sk_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sk_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_sk_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_es_trad_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_trad_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_trad_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_es_trad_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_la_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_la_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_la_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_la_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_eo_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_eo_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_eo_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_eo_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_hu_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hu_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hu_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hu_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_hr_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hr_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hr_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_hr_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_vi_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vi_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vi_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_vi_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_ja_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ja_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ja_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ja_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_ja_0900_as_cs_ks
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ja_0900_as_cs_ks, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ja_0900_as_cs_ks, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ja_0900_as_cs_ks, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_0900_as_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_ru_0900_ai_ci
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ru_0900_ai_ci, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ru_0900_ai_ci, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ru_0900_ai_ci, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_ru_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ru_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ru_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_ru_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_zh_0900_as_cs
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_zh_0900_as_cs, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_zh_0900_as_cs, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_zh_0900_as_cs, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+# Testing character set utf8mb4 collation utf8mb4_0900_bin
+CREATE TABLE t_utf8mb4 (pk_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin, pk_char CHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin, d_varchar VARCHAR(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_bin, d_char CHAR(64), PRIMARY KEY(pk_varchar, pk_char)) ENGINE=rocksdb;
+INSERT INTO t_utf8mb4 VALUES('a ', 'a ', 'a ', 'a ');
+INSERT INTO t_utf8mb4 VALUES ('a', 'a', 'a', 'a');
+ERROR 23000: Duplicate entry 'a-a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('b  ', 'b  ', 'b  ', 'b  ');;
+INSERT INTO t_utf8mb4 VALUES('b', 'b', 'b', 'b');
+ERROR 23000: Duplicate entry 'b-b' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES('a\t', 'a\t', 'a\t', 'a\t');
+INSERT INTO t_utf8mb4 VALUES('a \t', 'a \t', 'a \t', 'a \t');
+# Try longer values
+INSERT INTO t_utf8mb4 VALUES(concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)), concat('a', repeat(' ',10)));
+ERROR 23000: Duplicate entry 'a          -a' for key 't_utf8mb4.PRIMARY'
+INSERT INTO t_utf8mb4 VALUES(concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)), concat('c', repeat(' ',10)));
+SELECT pk_varchar, length(pk_varchar), hex(pk_varchar), pk_char, length(pk_char), hex(pk_char), d_varchar, length(d_varchar), hex(d_varchar), d_char, length(d_char), hex(d_char) FROM t_utf8mb4;
+pk_varchar	length(pk_varchar)	hex(pk_varchar)	pk_char	length(pk_char)	hex(pk_char)	d_varchar	length(d_varchar)	hex(d_varchar)	d_char	length(d_char)	hex(d_char)
+a		2	6109	a		2	6109	a		2	6109	a		2	6109
+a 		3	612009	a 		3	612009	a 		3	612009	a 		3	612009
+a 	2	6120	a	1	61	a 	2	6120	a	1	61
+b  	3	622020	b	1	62	b  	3	622020	b	1	62
+c          	11	6320202020202020202020	c	1	63	c          	11	6320202020202020202020	c	1	63
+DROP TABLE t_utf8mb4;
+DROP TABLE collations;

--- a/mysql-test/suite/rocksdb/t/type_char_indexes_collation.test
+++ b/mysql-test/suite/rocksdb/t/type_char_indexes_collation.test
@@ -134,3 +134,14 @@ create table t (id int primary key, email varchar(767), KEY email_i (email)) eng
 insert into t values (1, REPEAT('a', 700));
 select 'email_i' as index_name, count(*) AS count from t force index(email_i);
 drop table t;
+
+# test utf8mb4 and padding behavior
+create table t1 (
+  str char(255) character set utf8mb4,
+  val int,
+  key str (str(100))) default character set utf8mb4 engine=rocksdb;
+
+insert into t1 values ('abc  ', 1), ('abc ', 2), ('abc', 3), ('abc\t', 4), ('abca', 5);
+# Use like to trigger prefix scan using index
+select str, val from t1 force index (str) where str like 'abc%' order by str, val;
+drop table t1;

--- a/mysql-test/suite/rocksdb/t/type_varchar_packing.test
+++ b/mysql-test/suite/rocksdb/t/type_varchar_packing.test
@@ -1,8 +1,13 @@
 --source include/have_rocksdb.inc
 
+call mtr.add_suppression("Trying to create an index with a multi-level collation");
+call mtr.add_suppression("Will handle this collation internally as if it had a NO_PAD attribute.");
+
+CREATE TABLE collations AS SELECT * FROM information_schema.COLLATION_CHARACTER_SET_APPLICABILITY WHERE COLLATION_NAME NOT IN ("binary", "latin2_czech_cs");
+
 --let $i=1
---let $charset=query_get_value(select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME like '%_bin' ORDER BY CHARACTER_SET_NAME, CHARACTER_SET_NAME, $i)
---let $collate=query_get_value(select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME like '%_bin' ORDER BY CHARACTER_SET_NAME, COLLATION_NAME, $i)
+--let $charset=query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+--let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
 while ($charset != 'No such row')
 {
   --echo # Testing character set $charset collation $collate
@@ -24,6 +29,8 @@ while ($charset != 'No such row')
   --eval DROP TABLE $table_name
 
   --inc $i
-  --let $charset=query_get_value(select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME like '%_bin' ORDER BY CHARACTER_SET_NAME, CHARACTER_SET_NAME, $i)
-  --let $collate=query_get_value(select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME like '%_bin' ORDER BY CHARACTER_SET_NAME, COLLATION_NAME, $i)
+  --let $charset=query_get_value(select * from collations, CHARACTER_SET_NAME, $i)
+  --let $collate=query_get_value(select * from collations, COLLATION_NAME, $i)
 }
+
+DROP TABLE collations;

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2787,8 +2787,7 @@ void Rdb_key_def::pack_with_varchar_encoding(
                                   : uint2korr(field->ptr);
   size_t xfrm_len = charset->coll->strnxfrm(
       charset, buf, fpi->m_max_image_len, field_var->char_length(),
-      field_var->ptr + field_var->length_bytes, value_length,
-      MY_STRXFRM_NOPAD_WITH_SPACE);
+      field_var->ptr + field_var->length_bytes, value_length, 0);
 
   /* Got a mem-comparable image in 'buf'. Now, produce varlength encoding */
   if (fpi->m_use_legacy_varbinary_format) {
@@ -2910,7 +2909,7 @@ void Rdb_key_def::pack_with_varchar_space_pad(
   const size_t xfrm_len = charset->coll->strnxfrm(
       charset, buf, fpi->m_max_image_len, field_var->char_length(),
       reinterpret_cast<const uchar *>(src),
-      std::min<size_t>(trimmed_len, max_xfrm_len), MY_STRXFRM_NOPAD_WITH_SPACE);
+      std::min<size_t>(trimmed_len, max_xfrm_len), 0);
 
   /* Got a mem-comparable image in 'buf'. Now, produce varlength encoding */
   uchar *const buf_end = buf + xfrm_len;
@@ -3608,7 +3607,7 @@ static void rdb_get_mem_comparable_space(const CHARSET_INFO *const cs,
 
       const size_t space_len =
           cs->coll->strnxfrm(cs, space.data(), sizeof(space), 1, space_mb,
-                             space_mb_len, MY_STRXFRM_NOPAD_WITH_SPACE);
+                             space_mb_len, 0);
       Rdb_charset_space_info *const info = new Rdb_charset_space_info;
       info->space_xfrm_len = space_len;
       info->space_mb_len = space_mb_len;

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2785,9 +2785,29 @@ void Rdb_key_def::pack_with_varchar_encoding(
   const size_t value_length = (field_var->length_bytes == 1)
                                   ? (uint)*field->ptr
                                   : uint2korr(field->ptr);
-  size_t xfrm_len = charset->coll->strnxfrm(
-      charset, buf, fpi->m_max_image_len, field_var->char_length(),
-      field_var->ptr + field_var->length_bytes, value_length, 0);
+  const char *src =
+      reinterpret_cast<const char *>(field_var->ptr + field_var->length_bytes);
+
+  // We only store the trimmed contents but encode the missing char with
+  // removed_chars later to save space
+  const size_t trimmed_len =
+      charset->cset->lengthsp(charset, src, value_length);
+
+  // Max memcmp byte length with char_length(), in case we need to truncate
+  const size_t max_xfrm_len = charset->cset->charpos(
+      charset, src, src + trimmed_len, field_var->char_length());
+
+  // Trimmed length in code points - this is needed to avoid the padding
+  // behavior in strnxfrm for padding collations otherwise strnxfrm would
+  // pad to max length which defeats the trimming earlier
+  const size_t trimmed_codepoints =
+      charset->cset->numchars(charset, src, src + trimmed_len);
+
+  const size_t xfrm_len = charset->coll->strnxfrm(
+      charset, buf, fpi->m_max_image_len_before_encoding,
+      std::min<size_t>(trimmed_codepoints, field_var->char_length()),
+      reinterpret_cast<const uchar *>(src),
+      std::min<size_t>(trimmed_len, max_xfrm_len), 0);
 
   /* Got a mem-comparable image in 'buf'. Now, produce varlength encoding */
   if (fpi->m_use_legacy_varbinary_format) {
@@ -2900,14 +2920,25 @@ void Rdb_key_def::pack_with_varchar_space_pad(
                                   ? (uint)*field->ptr
                                   : uint2korr(field->ptr);
 
+  // We only store the trimmed contents but encode the missing char with
+  // removed_chars later to save space
   const size_t trimmed_len =
       charset->cset->lengthsp(charset, src, value_length);
 
+  // Max memcmp byte length with char_length(), in case we need to truncate
+  // for prefix keys
   const size_t max_xfrm_len = charset->cset->charpos(
       charset, src, src + trimmed_len, field_var->char_length());
 
+  // Trimmed length in code points - this is needed to avoid the padding
+  // behavior in strnxfrm for padding collations otherwise strnxfrm would
+  // pad to max length which defeats the trimming earlier
+  const size_t trimmed_codepoints =
+      charset->cset->numchars(charset, src, src + trimmed_len);
+
   const size_t xfrm_len = charset->coll->strnxfrm(
-      charset, buf, fpi->m_max_image_len, field_var->char_length(),
+      charset, buf, fpi->m_max_image_len_before_encoding,
+      std::min<size_t>(trimmed_codepoints, field_var->char_length()),
       reinterpret_cast<const uchar *>(src),
       std::min<size_t>(trimmed_len, max_xfrm_len), 0);
 
@@ -3605,9 +3636,8 @@ static void rdb_get_mem_comparable_space(const CHARSET_INFO *const cs,
       // mem-comparable image of the space character
       std::array<uchar, 20> space;
 
-      const size_t space_len =
-          cs->coll->strnxfrm(cs, space.data(), sizeof(space), 1, space_mb,
-                             space_mb_len, 0);
+      const size_t space_len = cs->coll->strnxfrm(
+          cs, space.data(), sizeof(space), 1, space_mb, space_mb_len, 0);
       Rdb_charset_space_info *const info = new Rdb_charset_space_info;
       info->space_xfrm_len = space_len;
       info->space_mb_len = space_mb_len;
@@ -3814,6 +3844,8 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
   /* Calculate image length. By default, is is pack_length() */
   m_max_image_len =
       field ? field->pack_length() : ROCKSDB_SIZEOF_HIDDEN_PK_COLUMN;
+  m_max_image_len_before_encoding = 0;
+
   m_skip_func = Rdb_key_def::skip_max_length;
   m_pack_func = Rdb_key_def::pack_with_make_sort_key;
 
@@ -3941,6 +3973,10 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
     */
     const CHARSET_INFO *cs = field->charset();
     m_max_image_len = cs->coll->strnxfrmlen(cs, field->field_length);
+
+    /* Remember the original length before encoding - we'll use it in
+      packing / padding calculations later */
+    m_max_image_len_before_encoding = m_max_image_len;
   }
   const bool is_varchar = (type == MYSQL_TYPE_VARCHAR);
   const CHARSET_INFO *cs = field->charset();
@@ -4032,8 +4068,7 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
           m_skip_func = Rdb_key_def::skip_variable_space_pad;
           m_segment_size = get_segment_size_from_collation(cs);
           m_max_image_len =
-              (max_image_len_before_chunks / (m_segment_size - 1) +
-               cs->mbmaxlen) *
+              (max_image_len_before_chunks / (m_segment_size - 1) + 1) *
               m_segment_size;
           rdb_get_mem_comparable_space(cs, &space_xfrm, &space_xfrm_len,
                                        &space_mb_len);

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -983,6 +983,12 @@ class Rdb_field_packing {
   /* Length of mem-comparable image of the field, in bytes */
   int m_max_image_len;
 
+  /*
+    Length of mem-comparable image of the field, before taking varchar chunk
+    encoding into account. For non-varchar case the value isn't used.
+   */
+  int m_max_image_len_before_encoding;
+
   /* Length of image in the unpack data */
   int m_unpack_data_len;
   int m_unpack_data_offset;

--- a/strings/ctype-simple.cc
+++ b/strings/ctype-simple.cc
@@ -1494,7 +1494,8 @@ uint my_strxfrm_flag_normalize(uint flags) {
 
 size_t my_strxfrm_pad(const CHARSET_INFO *cs, uchar *str, uchar *frmend,
                       uchar *strend, uint nweights, uint flags) {
-  if (nweights && frmend < strend && !(flags & MY_STRXFRM_NOPAD_WITH_SPACE)) {
+  if (nweights && frmend < strend) {
+    // PAD SPACE behavior.
     uint fill_length = MY_MIN((uint)(strend - frmend), nweights * cs->mbminlen);
     cs->cset->fill(cs, (char *)frmend, fill_length, cs->pad_char);
     frmend += fill_length;

--- a/strings/ctype-uca.cc
+++ b/strings/ctype-uca.cc
@@ -2084,7 +2084,7 @@ static size_t my_strnxfrm_uca(const CHARSET_INFO *cs, Mb_wc mb_wc, uchar *dst,
     if (dst < de) *dst++ = s_res & 0xFF;
   }
 
-  if (dst < de && !(flags & MY_STRXFRM_NOPAD_WITH_SPACE)) {
+  if (dst < de) {
     /*
       PAD SPACE behavior.
 

--- a/strings/ctype-utf8.cc
+++ b/strings/ctype-utf8.cc
@@ -5303,7 +5303,7 @@ static inline size_t my_strnxfrm_unicode_tmpl(const CHARSET_INFO *cs,
   }
 
 pad:
-  if (dst < de && nweights && !(flags & MY_STRXFRM_NOPAD_WITH_SPACE))
+  if (dst < de && nweights)  // PAD SPACE behavior.
     dst += my_strxfrm_pad_nweights_unicode(dst, de, nweights);
 
   if ((flags & MY_STRXFRM_PAD_TO_MAXLEN) && dst < de)


### PR DESCRIPTION
1. Revert code changes related to `MY_STRXFRM_NOPAD_WITH_SPACE` at
https://github.com/Percona/percona-server/commit/309003670166ebd084ed0f63d5a49a534006a682
2. Revert `cs->mbmaxlen` at https://github.com/Percona/percona-server/commit/2452a628610f11c92f3a1f0d5cb27fc8ab8f445a
3. Port FB implementation from https://github.com/facebook/mysql-5.6/commit/c5bd81632b55
