### PR TITLE
PS-5893: Add missing mysql@.service for *DEB family

### DIFF
--- a/build-ps/debian/percona-server-server-5.7.mysql@.service
+++ b/build-ps/debian/percona-server-server-5.7.mysql@.service
@@ -1,0 +1,23 @@
+#
+# Percona Server systemd service file
+#
+
+[Unit]
+Description=Percona Server
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=forking
+User=mysql
+Group=mysql
+PermissionsStartOnly=true
+EnvironmentFile=-/etc/default/mysql
+ExecStartPre=/usr/share/mysql/mysql-systemd-start pre @%I
+ExecStartPre=/usr/bin/ps_mysqld_helper
+ExecStart=/usr/sbin/mysqld --defaults-group-suffix=@%I --daemonize --pid-file=/var/run/mysqld/mysqld-%i.pid $MYSQLD_OPTS
+TimeoutSec=0
+Restart=on-failure
+RestartPreventExitStatus=1

--- a/build-ps/debian/rules
+++ b/build-ps/debian/rules
@@ -172,7 +172,7 @@ override_dh_strip:
 
 override_dh_installinit:
 	@echo "RULES.$@"
-	if [ "$(DISTRELEASE)" != "precise" -a "$(DISTRELEASE)" != "trusty" -a "$(DISTRELEASE)" != "wheezy" ]; then dh_systemd_enable --name=mysql; fi
+	if [ "$(DISTRELEASE)" != "precise" -a "$(DISTRELEASE)" != "trusty" -a "$(DISTRELEASE)" != "wheezy" ]; then dh_systemd_enable --name=mysql; dh_systemd_enable --no-enable --name=mysql@; fi
 	dh_installinit --name=mysql -- defaults 19 21
 	if [ "$(DISTRELEASE)" != "precise" -a "$(DISTRELEASE)" != "trusty" -a "$(DISTRELEASE)" != "wheezy" ]; then dh_systemd_start --restart-after-upgrade; fi
 	touch $@

--- a/build-ps/ubuntu/percona-server-server-5.7.mysql@.service
+++ b/build-ps/ubuntu/percona-server-server-5.7.mysql@.service
@@ -1,0 +1,23 @@
+#
+# Percona Server systemd service file
+#
+
+[Unit]
+Description=Percona Server
+After=network.target
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+Type=forking
+User=mysql
+Group=mysql
+PermissionsStartOnly=true
+EnvironmentFile=-/etc/default/mysql
+ExecStartPre=/usr/share/mysql/mysql-systemd-start pre @%I
+ExecStartPre=/usr/bin/ps_mysqld_helper
+ExecStart=/usr/sbin/mysqld --defaults-group-suffix=@%I --daemonize --pid-file=/var/run/mysqld/mysqld-%i.pid $MYSQLD_OPTS
+TimeoutSec=0
+Restart=on-failure
+RestartPreventExitStatus=1

--- a/build-ps/ubuntu/rules
+++ b/build-ps/ubuntu/rules
@@ -166,6 +166,8 @@ override_dh_strip:
 override_dh_installinit:
 	@echo "RULES.$@"
 	dh_systemd_enable --name=mysql
+	dh_systemd_enable --no-enable --name=mysql@
 	dh_installinit --name=mysql -- defaults 19 21
+	dh_installinit --name=mysql@
 	dh_systemd_start --restart-after-upgrade
 	touch $@


### PR DESCRIPTION
As upstream and RHEL version has `mysql@.service` which is required to run multiple instances of SQL on same machine. Implement this feature for *DEB family 
