### PR TITLE
PS-5008 Memory leak in sync_latch_meta_init() after mysqld shutdown d…

### DIFF
--- a/mysql-test/include/keyring_tests/innodb/log_encrypt_4.inc
+++ b/mysql-test/include/keyring_tests/innodb/log_encrypt_4.inc
@@ -71,7 +71,7 @@ DROP TABLE tab1,tab2;
 let NEW_CMD = $MYSQLD --no-defaults $PLUGIN_DIR_OPT --innodb_dedicated_server=OFF --initialize-insecure --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR2 --init-file=$BOOTSTRAP_SQL  --secure-file-priv="" --innodb_redo_log_encrypt=ON  </dev/null>>$MYSQLTEST_VARDIR/tmp/bootstrap2.log 2>&1;
 
 --echo # Run the bootstrap command of datadir2, it should fail since the keyring is not loaded.
---error 1,42
+--error 1
 --exec $NEW_CMD
 
 --force-rmdir $MYSQL_TMP_DIR/log_encrypt_dir2

--- a/mysql-test/include/keyring_tests/innodb/log_encrypt_6.inc
+++ b/mysql-test/include/keyring_tests/innodb/log_encrypt_6.inc
@@ -97,7 +97,7 @@ DROP DATABASE tde_db;
 
 --echo # Try starting without keyring : Error
 let NEW_CMD = $MYSQLD --no-defaults $PLUGIN_DIR_OPT --innodb_dedicated_server=OFF --innodb_page_size=$START_PAGE_SIZE --innodb_log_file_size=$LOG_FILE_SIZE --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR1  --secure-file-priv="" --console </dev/null>>$MYSQL_TMP_DIR/wl9290.err 2>&1;
---error 1,42
+--error 1
 --exec $NEW_CMD
 
 --echo # Search for error message

--- a/mysql-test/include/keyring_tests/innodb/tablespace_encrypt_9.inc
+++ b/mysql-test/include/keyring_tests/innodb/tablespace_encrypt_9.inc
@@ -78,7 +78,7 @@ SET GLOBAL innodb_master_thread_disabled_debug = 1;
 ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
 --echo # Restart after crash without Keyring plugin loaded
 --source include/keyring_tests/helper/instance_backup_manifest.inc
---error 1,42
+--error 1
 --exec $MYSQLD_CMD $PLUGIN_DIR_OPT --log-error=$MYSQLTEST_VARDIR/log/my_restart.err
 
 # Search the failure pattern in error log

--- a/mysql-test/include/keyring_tests/mats/undo_encrypt_bootstrap.inc
+++ b/mysql-test/include/keyring_tests/mats/undo_encrypt_bootstrap.inc
@@ -39,7 +39,7 @@ EOF
 let NEW_CMD = $MYSQLD --no-defaults $PLUGIN_DIR_OPT --innodb_dedicated_server=OFF --initialize-insecure --secure-file-priv="" --innodb_log_file_size=$LOG_FILE_SIZE --innodb_page_size=$START_PAGE_SIZE --innodb_data_home_dir=$MYSQLD_HOME_DATA_DIR --innodb_undo_directory=$MYSQLD_UNDO_DATADIR --basedir=$MYSQLD_BASEDIR --datadir=$MYSQLD_DATADIR --init-file=$BOOTSTRAP_SQL --innodb_undo_log_encrypt=ON </dev/null>>$MYSQLTEST_VARDIR/tmp/bootstrap.log 2>&1;
 
 --echo # Run the bootstrap command with no keyring
---error 1,42
+--error 1
 --exec $NEW_CMD
 
 # Remove residue files

--- a/mysql-test/suite/innodb/r/startup_failure.result
+++ b/mysql-test/suite/innodb/r/startup_failure.result
@@ -1,0 +1,10 @@
+SET GLOBAL innodb_file_per_table=ON;
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+RENAME TABLE t1 TO t2;
+# Kill the server
+# Fault (no real fault): Orphan file with duplicate space_id.
+# restart
+DROP TABLE t2;
+# List of files:
+SHOW TABLES;
+Tables_in_test

--- a/mysql-test/suite/innodb/t/autoinc_persist_debug.test
+++ b/mysql-test/suite/innodb/t/autoinc_persist_debug.test
@@ -316,7 +316,7 @@ SELECT * FROM t1 ORDER BY col1;
 
 --echo # Stop mysqld and trigger failure during boot.
 --source include/kill_mysqld.inc
---error 1,42
+--error 1
 --exec $MYSQLD_CMD --debug=+d,error_during_bootstrap
 
 --echo # Start server normally.

--- a/mysql-test/suite/innodb/t/innodb_page_size_func.test
+++ b/mysql-test/suite/innodb/t/innodb_page_size_func.test
@@ -214,8 +214,8 @@ let SEARCH_PATTERN=  innodb-page-size has been changed from the default value $d
 # Properties of the value:
 # 1. not supported
 # 2. between smallest (4k) and biggest (16k) supported one
-# InnoDB aborts, so ASAN may report leaks
---error 1,42
+# InnoDB aborts
+--error 1
 --exec $mysqld=$illegal_pagesize
 # InnoDB cannot handle this value.
 --replace_result $illegal_pagesize ILLEGAL_PAGESIZE

--- a/mysql-test/suite/innodb/t/log_file_size.test
+++ b/mysql-test/suite/innodb/t/log_file_size.test
@@ -42,8 +42,8 @@ DELETE FROM t1;
 
 --source include/kill_mysqld.inc
 
-# InnoDB aborts, so ASAN may report leaks
---error 1,42
+# InnoDB aborts
+--error 1
 --exec $MYSQLD_CMD $args --innodb-log-group-home-dir=foo\;bar
 let SEARCH_PATTERN= syntax error in innodb_log_group_home_dir;
 --source include/search_pattern.inc

--- a/mysql-test/suite/innodb/t/log_file_size_1.test
+++ b/mysql-test/suite/innodb/t/log_file_size_1.test
@@ -166,8 +166,8 @@ SET GLOBAL innodb_fast_shutdown=0;
 --source include/shutdown_mysqld.inc
 
 --echo "test misc 1"
-# InnoDB aborts, so ASAN may report leaks
---error 1,42
+# InnoDB aborts
+--error 1
 --exec $MYSQLD_CMD $args --innodb-log-group-home-dir=foo\;bar
 let SEARCH_PATTERN= syntax error in innodb_log_group_home_dir;
 --source include/search_pattern.inc

--- a/mysql-test/suite/innodb/t/readonly.test
+++ b/mysql-test/suite/innodb/t/readonly.test
@@ -42,7 +42,7 @@ INSERT INTO t1 VALUES(1);
 --source include/shutdown_mysqld.inc
 
 # Start with an invalid tmpdir and search the error log for the error message.
---error 1,42,134,138,139,-1073741571,-1073741819,-1073740940
+--error 1,134,138,139,-1073741571,-1073741819,-1073740940
 --exec $MYSQLD --no-defaults --secure-file-priv="" --basedir=$BASEDIR --lc-messages-dir=$MYSQL_SHAREDIR --log-error=$MYSQLD_LOG --datadir=$MYSQLD_DATADIR --tmpdir=no/such/directory > $MYSQLD_LOG 2>&1
 --let $grep_file= $MYSQLD_LOG
 --let $grep_pattern= No such file or directory

--- a/mysql-test/suite/innodb/t/session_temp_tablespaces.test
+++ b/mysql-test/suite/innodb/t/session_temp_tablespaces.test
@@ -199,23 +199,23 @@ SELECT PATH, SIZE, STATE, PURPOSE FROM INFORMATION_SCHEMA.INNODB_SESSION_TEMP_TA
 
 --echo "Test with invalid values of innodb_temp_tablespaces_dir"
 --echo "invalid abc dir"
---error 1,42
+--error 1
 --exec $MYSQLD --datadir=$MYSQLD_DATADIR --innodb_temp_tablespaces_dir="abc"
 
 --echo "invalid ./sys/ dir"
---error 1,42
+--error 1
 --exec $MYSQLD --datadir=$MYSQLD_DATADIR --innodb_temp_tablespaces_dir="./sys/"
 
 --echo "invalid /wl11613-do-not-exists/ dir"
---error 1,42
+--error 1
 --exec $MYSQLD --datadir=$MYSQLD_DATADIR --innodb_temp_tablespaces_dir="/wl11613-do-not-exist/"
 
 --echo "invalid empty \"\" "
---error 1,42
+--error 1
 --exec $MYSQLD --datadir=$MYSQLD_DATADIR --innodb_temp_tablespaces_dir=""
 
 --echo "invalid #innodb_temp "
---error 1,42
+--error 1
 --exec $MYSQLD --datadir=$MYSQLD_DATADIR --innodb_temp_tablespaces_dir="#innodb_temp"
 
 # Remove #innodb_temp directory manually and check if on next restart the

--- a/mysql-test/suite/innodb/t/slow_shutdown.test
+++ b/mysql-test/suite/innodb/t/slow_shutdown.test
@@ -18,7 +18,7 @@ SET GLOBAL innodb_log_flush_now = ON;
 # LCTN mismatch will cause server startup to abort but transaction won't
 # be rollbacked. Without the patch, abort will be hung.
 --echo # Start MySQL after crash with different LCTN value and slow shutdown.
---error 1,42
+--error 1
 --exec $MYSQLD_CMD --innodb-fast-shutdown=0 --lower_case_table_names=1 --log-error=$MYSQLTEST_VARDIR/log/my_restart.err
 
 --echo # Verifying that recovery found transaction which needs rollback

--- a/mysql-test/suite/innodb/t/startup_failure.test
+++ b/mysql-test/suite/innodb/t/startup_failure.test
@@ -1,0 +1,36 @@
+# Test the detection of memory leak in sync_latch_meta_init() in case of a
+# failed innodb start by ASan.
+
+--source include/have_innodb_max_16k.inc
+
+SET GLOBAL innodb_file_per_table=ON;
+
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+
+RENAME TABLE t1 TO t2;
+
+let MYSQLD_DATADIR= `select @@datadir`;
+--source include/kill_mysqld.inc
+
+--echo # Fault (no real fault): Orphan file with duplicate space_id.
+--copy_file $MYSQLD_DATADIR/test/t2.ibd $MYSQLD_DATADIR/test/t1.ibd
+
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/my_restart.err;
+let $mysqld=$MYSQLD_CMD --core-file --console > $SEARCH_FILE 2>&1;
+
+# The InnoDB cannot start and server shutdowns, for this reason, resource leaks
+# occur
+--error 1
+--exec $mysqld
+
+--remove_file $MYSQLD_DATADIR/test/t1.ibd
+--remove_file $SEARCH_FILE
+
+--source include/start_mysqld.inc
+
+DROP TABLE t2;
+
+--echo # List of files:
+--list_files $MYSQLD_DATADIR/test
+
+SHOW TABLES;

--- a/mysql-test/suite/innodb/t/temporary_table.test
+++ b/mysql-test/suite/innodb/t/temporary_table.test
@@ -169,8 +169,8 @@ create temporary table t1 (keyc int, c1 char(100), c2 char(100)) engine = innodb
 #
 --source include/shutdown_mysqld.inc
 --echo "testing system and temp tablespace name conflict"
-# InnoDB aborts, so ASAN may report leaks
---error 1,42
+# InnoDB aborts
+--error 1
 --exec $MYSQLD_CMD $nameconflicts
 let SEARCH_PATTERN = innodb_temporary and innodb_system file names seem to be the same;
 --source ./include/search_pattern.inc
@@ -607,15 +607,15 @@ set innodb_strict_mode = OFF;
 #
 --source include/shutdown_mysqld.inc
 --echo "testing temp tablespace non-support for raw device"
-# InnoDB aborts, so ASAN may report leaks
---error 1,42
+# InnoDB aborts
+--error 1
 --exec $MYSQLD_CMD $rawdevice1
 let SEARCH_PATTERN = support raw device;
 --source include/search_pattern.inc
 --remove_file $SEARCH_FILE
 --echo "testing temp tablespace non-support for raw device"
-# InnoDB aborts, so ASAN may report leaks
---error 1,42
+# InnoDB aborts
+--error 1
 --exec $MYSQLD_CMD $rawdevice2
 let SEARCH_PATTERN = support raw device;
 --source include/search_pattern.inc
@@ -663,8 +663,8 @@ drop table t1;
 --source include/shutdown_mysqld.inc
 
 --echo "try starting server with no file specified for temp-tablespace"
-# InnoDB aborts, so ASAN may report leaks
---error 1,42
+# InnoDB aborts
+--error 1
 --exec $MYSQLD_CMD $notemptablespacefile
 let SEARCH_PATTERN = init function returned error;
 --source ./include/search_pattern.inc

--- a/mysql-test/t/tmpdir.test
+++ b/mysql-test/t/tmpdir.test
@@ -13,7 +13,7 @@ SET @@tmpdir= 'no/such/directory';
 --source include/shutdown_mysqld.inc
 
 # Start with an invalid tmpdir.
---error 1,42,134,138,139
+--error 1,134,138,139
 --exec $MYSQLD --no-defaults --secure-file-priv="" --basedir=$BASEDIR --lc-messages-dir=$MYSQL_SHAREDIR --log-error=$MYSQLD_LOG --datadir=$MYSQLD_DATADIR --tmpdir=no/such/directory > $MYSQLD_LOG 2>&1
 
 # Search the error log for error message.

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -300,6 +300,8 @@ static void btr_search_disable_ref_count(dict_table_t *table) {
 /** Disable the adaptive hash search system and empty the index.
 @param[in]	need_mutex	Need to acquire dict_sys->mutex */
 void btr_search_disable(bool need_mutex) {
+  if (!dict_sys) return;
+
   if (need_mutex) {
     dict_sys_mutex_enter();
   }

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -6729,10 +6729,14 @@ ulint buf_pool_check_no_pending_io(void) {
   ulint i;
   ulint pending_io = 0;
 
+  if (!buf_pool_ptr) return 0;
+
   for (i = 0; i < srv_buf_pool_instances; i++) {
     buf_pool_t *buf_pool;
 
     buf_pool = buf_pool_from_array(i);
+
+    if (!buf_pool) continue;
 
     pending_io += buf_pool->n_pend_reads;
 
@@ -6815,6 +6819,8 @@ const char *buf_block_t::get_page_type_str() const noexcept {
 #ifndef UNIV_HOTBACKUP
 /** Frees the buffer pool instances and the global data structures. */
 void buf_pool_free_all() {
+  if (!buf_pool_ptr) return;
+
   for (ulint i = 0; i < srv_buf_pool_instances; ++i) {
     buf_pool_t *ptr = &buf_pool_ptr[i];
 

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -391,10 +391,14 @@ void buf_flush_init_flush_rbt(void) {
 void buf_flush_free_flush_rbt(void) {
   ulint i;
 
+  if (!buf_pool_ptr) return;
+
   for (i = 0; i < srv_buf_pool_instances; i++) {
     buf_pool_t *buf_pool;
 
     buf_pool = buf_pool_from_array(i);
+
+    if (!buf_pool || !buf_pool->flush_rbt) continue;
 
     buf_flush_list_mutex_enter(buf_pool);
 

--- a/storage/innobase/clone/clone0api.cc
+++ b/storage/innobase/clone/clone0api.cc
@@ -1614,6 +1614,8 @@ dberr_t clone_init() {
 }
 
 void clone_free() {
+  if (!clone_sys) return;
+
   Clone_handler::uninit_xa();
   if (clone_sys != nullptr) {
     ut_ad(Clone_Sys::s_clone_sys_state == CLONE_SYS_ACTIVE);

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -3863,6 +3863,8 @@ void dict_persist_init(void) {
 
 /** Clear the structure */
 void dict_persist_close(void) {
+  if (!dict_persist) return;
+
   ut::delete_(dict_persist->persisters);
 
 #ifndef UNIV_HOTBACKUP

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -4047,7 +4047,11 @@ void Fil_system::close_all_files() {
 
 /** Closes all open files. There must not be any pending i/o's or not flushed
 modifications in the files. */
-void fil_close_all_files() { fil_system->close_all_files(); }
+void fil_close_all_files() {
+  if (!fil_system) return;
+
+  fil_system->close_all_files();
+}
 
 /** Close log files.
 @param[in]	free_all	If set then free all instances */
@@ -4250,6 +4254,7 @@ for concurrency control.
 @param[in]	space_id	Tablespace ID
 @return the tablespace, or nullptr if missing or being deleted */
 fil_space_t *fil_space_acquire(space_id_t space_id) {
+  if (!fil_system) return nullptr;
   return fil_system->space_acquire(space_id, false);
 }
 
@@ -9278,6 +9283,8 @@ possibly cached by the OS.
 @param[in]	purpose		FIL_TYPE_TABLESPACE or FIL_TYPE_LOG, can be
 ORred. */
 void fil_flush_file_spaces(uint8_t purpose) {
+  if (!fil_system) return;
+
   fil_system->flush_file_spaces(purpose);
 }
 

--- a/storage/innobase/ha/hash0hash.cc
+++ b/storage/innobase/ha/hash0hash.cc
@@ -138,6 +138,8 @@ hash_table_t *hash_create(ulint n) /*!< in: number of array cells */
 /** Frees a hash table. */
 void hash_table_free(hash_table_t *table) /*!< in, own: hash table */
 {
+  if (!table) return;
+
   ut_ad(table->magic_n == HASH_TABLE_MAGIC_N);
 
   ut::free(table->cells);

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1776,29 +1776,28 @@ static void innodb_space_shutdown() {
 static int innodb_shutdown(handlerton *, ha_panic_function) {
   DBUG_TRACE;
 
+  hash_table_free(innobase_open_tables);
+  innobase_open_tables = nullptr;
+
+  for (auto file : innobase_sys_files) {
+    ut::delete_(file);
+  }
+  innobase_sys_files.clear();
+  innobase_sys_files.shrink_to_fit();
+
+  if (mutex_monitor) mutex_free(&master_key_id_mutex);
+  srv_shutdown();
+  innodb_space_shutdown();
+
   if (innodb_inited) {
-    innodb_inited = false;
-    hash_table_free(innobase_open_tables);
-    innobase_open_tables = nullptr;
-
-    for (auto file : innobase_sys_files) {
-      ut::delete_(file);
-    }
-    innobase_sys_files.clear();
-    innobase_sys_files.shrink_to_fit();
-
-    mutex_free(&master_key_id_mutex);
-    srv_shutdown();
-    innodb_space_shutdown();
-
     mysql_mutex_destroy(&innobase_share_mutex);
     mysql_mutex_destroy(&commit_cond_m);
     mysql_cond_destroy(&commit_cond);
     mysql_mutex_destroy(&resume_encryption_cond_m);
     mysql_cond_destroy(&resume_encryption_cond);
-
-    os_event_global_destroy();
   }
+
+  os_event_global_destroy();
 
   innobase::component_services::deinitialize_service_handles();
 
@@ -5846,8 +5845,8 @@ static int innodb_init(void *p) {
 
   os_event_global_init();
 
-  if (int error = innodb_init_params()) {
-    return error;
+  if (innodb_init_params()) {
+    return innodb_init_abort();
   }
 
   /* After this point, error handling has to use

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -390,6 +390,8 @@ void lock_sys_close(void) {
     lock_latest_err_file = nullptr;
   }
 
+  if (!lock_sys) return;
+
   hash_table_free(lock_sys->rec_hash);
   hash_table_free(lock_sys->prdt_hash);
   hash_table_free(lock_sys->prdt_page_hash);

--- a/storage/innobase/log/log0chkp.cc
+++ b/storage/innobase/log/log0chkp.cc
@@ -1308,6 +1308,7 @@ void log_set_dict_persist_margin(log_t &log, sn_t margin) {
 }
 
 void log_set_dict_max_allowed_checkpoint_lsn(log_t &log, lsn_t max_lsn) {
+  if (!log_sys) return;
   log_limits_mutex_enter(log);
   log.dict_max_allowed_checkpoint_lsn = max_lsn;
   log_limits_mutex_exit(log);

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -680,7 +680,7 @@ void log_start(log_t &log, checkpoint_no_t checkpoint_no, lsn_t checkpoint_lsn,
 }
 
 void log_sys_close() {
-  ut_a(log_sys != nullptr);
+  if (!log_sys_object) return;
 
   log_t &log = *log_sys;
 

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -770,6 +770,9 @@ void MetadataRecover::store() {
 
 /** Frees the recovery system. */
 void recv_sys_free() {
+  if (!recv_sys) return;
+  if (!recv_sys->crypt_datas) return;
+
   mutex_enter(&recv_sys->mutex);
 
   recv_sys_finish();

--- a/storage/innobase/log/log0write.cc
+++ b/storage/innobase/log/log0write.cc
@@ -2927,6 +2927,7 @@ bool log_read_encryption() {
   if (memcmp(log_block_buf + LOG_HEADER_CREATOR_END,
              Encryption::KEY_MAGIC_RK_V1, Encryption::MAGIC_SIZE) == 0) {
     // can only happen during the upgrade
+    ut::aligned_free(log_block_buf);
     ib::error(ER_REDO_ENCRYPTION_CANT_UPGRADE_OLD_VERSION);
     return false;
   }
@@ -2987,6 +2988,7 @@ bool log_read_encryption() {
             : static_cast<redo_log_encrypt_enum>(srv_redo_log_encrypt);
     if (existing_redo_encryption_mode != set_encryption &&
         srv_redo_log_encrypt != REDO_LOG_ENCRYPT_OFF) {
+      ut::aligned_free(log_block_buf);
       ib::error(ER_REDO_ENCRYPTION_CANT_BE_CHANGED,
                 log_encrypt_name(existing_redo_encryption_mode),
                 log_encrypt_name(

--- a/storage/innobase/os/os0event.cc
+++ b/storage/innobase/os/os0event.cc
@@ -641,7 +641,7 @@ void os_event_global_init(void) {
 }
 
 void os_event_global_destroy(void) {
-  ut_a(os_event::global_initialized);
+  if (!os_event::global_initialized) return;
 #ifndef _WIN32
   os_event::cond_attr_has_monotonic_clock = false;
 #ifdef UNIV_DEBUG

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -7001,6 +7001,8 @@ bool os_aio_init(ulint n_readers, ulint n_writers, ulint n_slots_sync) {
 
 /** Frees the asynchronous io system. */
 void os_aio_free() {
+  if (!os_aio_segment_wait_events) return;
+
   AIO::shutdown();
 
   for (ulint i = 0; i < os_aio_n_segments; i++) {

--- a/storage/innobase/pars/pars0pars.cc
+++ b/storage/innobase/pars/pars0pars.cc
@@ -93,11 +93,23 @@ ulint pars_star_denoter = 12345678;
 /** Mutex to protect the sql parser */
 ib_mutex_t pars_mutex;
 
+/** Parsing inited */
+static bool pars_inited = false;
+
 /** Initialize for the internal parser */
-void pars_init() { mutex_create(LATCH_ID_PARSER, &pars_mutex); }
+void pars_init() {
+  mutex_create(LATCH_ID_PARSER, &pars_mutex);
+  pars_inited = true;
+}
 
 /** Clean up the internal parser */
-void pars_close() { mutex_free(&pars_mutex); }
+void pars_close() {
+  if (!pars_inited) return;
+
+  mutex_free(&pars_mutex);
+
+  pars_inited = false;
+}
 
 /********************************************************************
 Get user function with the given name.*/

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -5254,6 +5254,8 @@ void row_mysql_init(void) {
 
 /** Close this module */
 void row_mysql_close(void) {
+  if (!row_mysql_drop_list_inited) return;
+
   ut_a(UT_LIST_GET_LEN(row_mysql_drop_list) == 0);
 
   mutex_free(&row_drop_list_mutex);

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1265,6 +1265,8 @@ static void srv_init(void) {
 
 /** Frees the data structures created in srv_init(). */
 void srv_free(void) {
+  if (!srv_sys) return;
+
   mutex_free(&srv_innodb_monitor_mutex);
   mutex_free(&page_zip_stat_per_index_mutex);
 

--- a/storage/innobase/srv/srv0tmp.cc
+++ b/storage/innobase/srv/srv0tmp.cc
@@ -460,6 +460,8 @@ void delete_pool_manager() { ut::delete_(tbsp_pool); }
 void close_files() {
   auto close = [&](const ibt::Tablespace *ts) { ts->close(); };
 
+  if (!ibt::tbsp_pool) return;
+
   ibt::tbsp_pool->iterate_tbsp(close);
 }
 

--- a/storage/innobase/sync/sync0debug.cc
+++ b/storage/innobase/sync/sync0debug.cc
@@ -1713,6 +1713,8 @@ void sync_check_init(size_t max_threads) {
 
 /** Frees the resources in InnoDB's own synchronization data structures. */
 void sync_check_close() {
+  if (!mutex_monitor) return;
+
   ut_d(LatchDebug::shutdown());
 
   mutex_free(&rw_lock_list_mutex);

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -273,6 +273,8 @@ void trx_purge_sys_initialize(uint32_t n_purge_threads,
 /************************************************************************
 Frees the global purge system control structure. */
 void trx_purge_sys_close() {
+  if (!purge_sys) return;
+
   for (que_thr_t *thr = UT_LIST_GET_FIRST(purge_sys->query->thrs);
        thr != nullptr; thr = UT_LIST_GET_NEXT(thrs, thr)) {
     if (thr->prebuilt != nullptr && thr->prebuilt->compress_heap != nullptr) {

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -652,8 +652,10 @@ void trx_sys_close(void) {
                               << size << " read views open";
   }
 
-  sess_close(trx_dummy_sess);
-  trx_dummy_sess = nullptr;
+  if (trx_dummy_sess) {
+    sess_close(trx_dummy_sess);
+    trx_dummy_sess = nullptr;
+  }
 
   trx_purge_sys_close();
 
@@ -717,6 +719,8 @@ void trx_sys_before_pre_dd_shutdown_validate() {
 }
 
 void trx_sys_after_pre_dd_shutdown_validate() {
+  if (!trx_sys) return;
+
   trx_sys_mutex_enter();
   /** At this point we check the mysql_trx_list again, now we don't expect purge
   thread transactions in the list */
@@ -749,6 +753,7 @@ void trx_sys_after_pre_dd_shutdown_validate() {
 }
 
 void trx_sys_after_background_threads_shutdown_validate() {
+  if (!trx_sys) return;
   trx_sys_after_pre_dd_shutdown_validate();
 
   ut_a(UT_LIST_GET_LEN(trx_sys->mysql_trx_list) == 0);


### PR DESCRIPTION
…etected by ASan

Free all the resources acquired by InnoDB (mutexes, events, memory) in
case of a failed start (errors in
storage/innobase/srv/srv0start.cc::srv_start())

Run test with `--sanitize`
 `mtr --debug-server --sanitize innodb.log_file_name`