### PR TITLE
PS-5008 Memory leak in sync_latch_meta_init() after mysqld shutdown d…

### DIFF
--- a/mysql-test/suite/innodb/r/startup_failure.result
+++ b/mysql-test/suite/innodb/r/startup_failure.result
@@ -1,0 +1,13 @@
+SET GLOBAL innodb_file_per_table=ON;
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+RENAME TABLE t1 TO t2;
+# Kill the server
+# Fault (no real fault): Orphan file with duplicate space_id.
+# restart
+DROP TABLE t2;
+# List of files:
+SHOW TABLES;
+Tables_in_test
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES
+WHERE NAME NOT LIKE 'SYS_%' AND NAME NOT LIKE 'mysql/%';
+TABLE_ID	NAME	FLAG	N_COLS	SPACE	FILE_FORMAT	ROW_FORMAT	ZIP_PAGE_SIZE	SPACE_TYPE

--- a/mysql-test/suite/innodb/t/startup_failure.test
+++ b/mysql-test/suite/innodb/t/startup_failure.test
@@ -1,0 +1,42 @@
+# Test the detection of memory leak in sync_latch_meta_init() in case of a
+# failed innodb start by ASan.
+
+--source include/have_innodb.inc
+--source include/have_innodb_max_16k.inc
+
+# Embedded server does not support crashing
+--source include/not_embedded.inc
+
+SET GLOBAL innodb_file_per_table=ON;
+
+CREATE TABLE t1(a INT PRIMARY KEY) ENGINE=InnoDB;
+
+RENAME TABLE t1 TO t2;
+
+let MYSQLD_DATADIR= `select @@datadir`;
+--source include/kill_mysqld.inc
+
+--echo # Fault (no real fault): Orphan file with duplicate space_id.
+--copy_file $MYSQLD_DATADIR/test/t2.ibd $MYSQLD_DATADIR/test/t1.ibd
+
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/my_restart.err;
+let $mysqld=$MYSQLD_CMD --core-file --console > $SEARCH_FILE 2>&1;
+
+# The InnoDB cannot start and server shutdowns, for this reason, resource leaks
+# occur
+--error 1
+--exec $mysqld
+
+--remove_file $MYSQLD_DATADIR/test/t1.ibd
+--remove_file $SEARCH_FILE
+
+--source include/start_mysqld.inc
+
+DROP TABLE t2;
+
+--echo # List of files:
+--list_files $MYSQLD_DATADIR/test
+
+SHOW TABLES;
+SELECT * FROM INFORMATION_SCHEMA.INNODB_SYS_TABLES
+WHERE NAME NOT LIKE 'SYS_%' AND NAME NOT LIKE 'mysql/%';

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -325,6 +325,8 @@ btr_search_sys_resize(ulint hash_size)
 void
 btr_search_sys_free()
 {
+	if (!btr_search_sys) return;
+
 	ut_ad(btr_search_sys != NULL && btr_search_latches != NULL);
 
 	/* Step-1: Release the hash tables. */
@@ -381,6 +383,8 @@ btr_search_disable(
 	bool	need_mutex)
 {
 	dict_table_t*	table;
+
+	if (!dict_sys) return;
 
 	if (need_mutex) {
 		mutex_enter(&dict_sys->mutex);

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2203,6 +2203,8 @@ buf_pool_free(
 /*==========*/
 	ulint	n_instances)	/*!< in: numbere of instances to free */
 {
+	if (!buf_pool_ptr) return;
+
 	for (ulint i = 0; i < n_instances; i++) {
 		buf_pool_free_instance(buf_pool_from_array(i));
 	}

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -769,6 +769,8 @@ buffer at the end of crash recovery */
 void
 buf_parallel_dblwr_finish_recovery(void)
 {
+	if (!recv_sys) return;
+
 	recv_sys->dblwr.pages.clear();
 	ut_free(parallel_dblwr_buf.recovery_buf_unaligned);
 	parallel_dblwr_buf.recovery_buf_unaligned = NULL;
@@ -962,6 +964,8 @@ void
 buf_dblwr_free(void)
 /*================*/
 {
+	if (!buf_dblwr) return;
+
 	/* Free the double write data structures. */
 	ut_a(buf_dblwr != NULL);
 	ut_ad(buf_dblwr->s_reserved == 0);

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -397,10 +397,14 @@ buf_flush_free_flush_rbt(void)
 {
 	ulint	i;
 
+	if (!buf_pool_ptr) return;
+
 	for (i = 0; i < srv_buf_pool_instances; i++) {
 		buf_pool_t*	buf_pool;
 
 		buf_pool = buf_pool_from_array(i);
+
+		if (!buf_pool || !buf_pool->flush_rbt) continue;
 
 		buf_flush_list_mutex_enter(buf_pool);
 

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -6676,6 +6676,8 @@ dict_close(void)
 {
 	ulint	i;
 
+	if (!dict_sys) return;
+
 	/* Free the hash elements. We don't remove them from the table
 	because we are going to destroy the table anyway. */
 	for (i = 0; i < hash_get_n_cells(dict_sys->table_hash); i++) {

--- a/storage/innobase/dict/dict0stats_bg.cc
+++ b/storage/innobase/dict/dict0stats_bg.cc
@@ -279,6 +279,8 @@ dict_stats_thread_deinit()
 	ut_a(!srv_read_only_mode);
 	ut_ad(!srv_dict_stats_thread_active);
 
+	if (!dict_stats_event) return;
+
 	dict_stats_recalc_pool_deinit();
 
 	mutex_free(&recalc_pool_mutex);

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -6882,13 +6882,11 @@ void
 fil_close(void)
 /*===========*/
 {
+	if (!fil_system) return;
+
 	hash_table_free(fil_system->spaces);
 
 	hash_table_free(fil_system->name_hash);
-
-	ut_a(UT_LIST_GET_LEN(fil_system->LRU) == 0);
-	ut_a(UT_LIST_GET_LEN(fil_system->unflushed_spaces) == 0);
-	ut_a(UT_LIST_GET_LEN(fil_system->space_list) == 0);
 
 	mutex_free(&fil_system->mutex);
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4986,6 +4986,8 @@ innobase_end(
 		os_event_global_destroy();
 	}
 
+	srv_free_resources();
+
 	DBUG_RETURN(err);
 }
 

--- a/storage/innobase/ibuf/ibuf0ibuf.cc
+++ b/storage/innobase/ibuf/ibuf0ibuf.cc
@@ -461,6 +461,8 @@ void
 ibuf_close(void)
 /*============*/
 {
+	if (!ibuf) return;
+
 	mutex_free(&ibuf_pessimistic_insert_mutex);
 
 	mutex_free(&ibuf_mutex);

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -777,6 +777,18 @@ fil_node_create(
 	ulint		max_pages = ULINT_MAX)
 	MY_ATTRIBUTE((warn_unused_result));
 
+/** Tries to close a file in the LRU list. The caller must hold the fil_sys
+mutex.
+@return true if success, false if should retry later; since i/o's
+generally complete in < 100 ms, and as InnoDB writes at most 128 pages
+from the buffer pool in a batch, and then immediately flushes the
+files, there is a good chance that the next time we find a suitable
+node from the LRU list.
+@param[in] print_info if true, prints information why it
+                        cannot close a file */
+bool
+fil_try_to_close_file_in_LRU(bool print_info);
+
 /** Create a space memory object and put it to the fil_system hash table.
 The tablespace name is independent from the tablespace file-name.
 Error messages are issued to the server log.

--- a/storage/innobase/include/srv0start.h
+++ b/storage/innobase/include/srv0start.h
@@ -97,6 +97,13 @@ Shuts down the Innobase database.
 @return DB_SUCCESS or error code */
 dberr_t
 innobase_shutdown_for_mysql(void);
+/*=============================*/
+
+/****************************************************************//**
+Free all the resources acquired by InnoDB (mutexes, events, memory). */
+void
+srv_free_resources();
+/*================*/
 
 /********************************************************************
 Signal all per-table background threads to shutdown, and wait for them to do

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -541,6 +541,8 @@ void
 lock_sys_close(void)
 /*================*/
 {
+	if (!lock_sys) return;
+
 	if (lock_latest_err_file != NULL) {
 		fclose(lock_latest_err_file);
 		lock_latest_err_file = NULL;

--- a/storage/innobase/log/log0log.cc
+++ b/storage/innobase/log/log0log.cc
@@ -2983,6 +2983,8 @@ void
 log_shutdown(void)
 /*==============*/
 {
+	if (!log_sys) return;
+
 	log_group_close_all();
 
 	ut_free(log_sys->buf_ptr);

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -100,6 +100,9 @@ name, the 2nd tag is the stem, the 3rd tag is a file sequence number, the 4th
 tag is the start LSN for the file. */
 static const char* bmp_file_name_template = "%s%s%lu_" LSN_PF ".xdb";
 
+/** Database log parsing inited */
+static bool log_online_inited = false;
+
 /* On server startup with empty database srv_start_lsn == 0, in
 which case the first LSN of actual log records will be this. */
 #define MIN_TRACKED_LSN (LOG_START_LSN + OS_FILE_LOG_BLOCK_SIZE + \
@@ -604,6 +607,7 @@ void
 log_online_init(void)
 {
 	mutex_create(LATCH_ID_LOG_ONLINE, &log_bmp_sys_mutex);
+	log_online_inited = true;
 }
 
 /** Initialize the dynamic part of the log tracking subsystem */
@@ -814,6 +818,8 @@ log_online_read_shutdown(void)
 void
 log_online_shutdown(void)
 {
+	if (!log_online_inited) return;
+
 	mutex_free(&log_bmp_sys_mutex);
 }
 

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -7397,6 +7397,8 @@ os_aio_init(
 void
 os_aio_free()
 {
+	if (!os_aio_segment_wait_events) return;
+
 	AIO::shutdown();
 
 	for (ulint i = 0; i < os_aio_n_segments; i++) {

--- a/storage/innobase/os/os0thread.cc
+++ b/storage/innobase/os/os0thread.cc
@@ -363,6 +363,9 @@ os_thread_free()
 	}
 
 #ifdef _WIN32
+	/* If mutex_monitor != nullptr, then thread_mutex was created. */
+	if (!mutex_monitor) return;
+
 	mutex_destroy(&thread_mutex);
 #endif
 }

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -6717,6 +6717,8 @@ void
 row_mysql_close(void)
 /*================*/
 {
+	if (!row_mysql_drop_list_inited) return;
+
 	ut_a(UT_LIST_GET_LEN(row_mysql_drop_list) == 0);
 
 	mutex_free(&row_drop_list_mutex);

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1174,6 +1174,8 @@ void
 srv_free(void)
 /*==========*/
 {
+	if (!srv_sys) return;
+
 	mutex_free(&srv_innodb_monitor_mutex);
 	mutex_free(&page_zip_stat_per_index_mutex);
 
@@ -3510,6 +3512,7 @@ srv_fatal_error()
 	ut_d(innodb_calling_exit = true);
 
 	srv_shutdown_all_bg_threads();
+	srv_free_resources();
 
 	exit(3);
 }

--- a/storage/innobase/sync/sync0debug.cc
+++ b/storage/innobase/sync/sync0debug.cc
@@ -1860,6 +1860,8 @@ sync_check_init()
 void
 sync_check_close()
 {
+	if (!mutex_monitor) return;
+
 	ut_d(LatchDebug::shutdown());
 
 	mutex_free(&rw_lock_list_mutex);

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -289,6 +289,8 @@ void
 trx_purge_sys_close(void)
 /*======================*/
 {
+	if (!purge_sys) return;
+
 	for (que_thr_t* thr = UT_LIST_GET_FIRST(purge_sys->query->thrs);
 		thr != NULL;
 		thr = UT_LIST_GET_NEXT(thrs, thr)) {

--- a/storage/innobase/trx/trx0undo.cc
+++ b/storage/innobase/trx/trx0undo.cc
@@ -2042,7 +2042,8 @@ trx_undo_free_prepared(
 /*===================*/
 	trx_t*	trx)	/*!< in/out: PREPARED transaction */
 {
-	ut_ad(srv_shutdown_state == SRV_SHUTDOWN_EXIT_THREADS);
+	ut_ad(srv_shutdown_state == SRV_SHUTDOWN_EXIT_THREADS ||
+	      srv_shutdown_state == SRV_SHUTDOWN_NONE);
 
 	if (trx->rsegs.m_redo.update_undo) {
 		ut_a(trx->rsegs.m_redo.update_undo->state == TRX_UNDO_PREPARED);


### PR DESCRIPTION
…etected by ASan

Free all the resources acquired by InnoDB (mutexes, events, memory) in
case of a failed start (errors in
storage/innobase/srv/srv0start.cc::innobase_start_or_create_for_mysql())

Also fixed the launch of tests under asan