### PR TITLE
PS-7020: convert MTR tests from python2 to python3 (5.6)

### DIFF
--- a/mysql-test/suite/innodb_stress/include/innodb_stress.inc
+++ b/mysql-test/suite/innodb_stress/include/innodb_stress.inc
@@ -41,7 +41,7 @@ if ($do_checksum)
 {
     # populate the table and store its checksum before any load.
     let $exec =
-python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records 0 0 $user $master_host $MASTER_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 0 0;
     exec $exec;
@@ -70,14 +70,14 @@ while ($num_crashes)
   if ($use_blob)
   {
     let $exec =
-python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records  $num_workers $num_transactions $user $master_host $MASTER_MYPORT
 $table 1 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_checks;
   }
   if (!$use_blob)
   {
     let $exec =
-python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
+python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $pid_file $kill_db_after
 $num_records  $num_workers $num_transactions $user $master_host $MASTER_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_checks;
   }
@@ -108,7 +108,7 @@ $table 0 $max_rows $MYSQL_TMP_DIR/load_generator 0 $checksum $secondary_index_ch
     --echo applying fake updates to the slave
     let $slave_pid_file = `SELECT @@pid_file`;
     let $slave_exec =
-python2 $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $slave_pid_file $kill_db_after
+python $MYSQL_BASEDIR/mysql-test/suite/innodb_stress/t/load_generator.py $slave_pid_file $kill_db_after
 0  $num_workers $num_transactions $user $master_host $SLAVE_MYPORT
 $table 0 $max_rows $MYSQL_TMP_DIR/load_generator_slave 1 $checksum $secondary_index_checks;
     exec $slave_exec;

--- a/mysql-test/suite/innodb_stress/t/load_generator.py
+++ b/mysql-test/suite/innodb_stress/t/load_generator.py
@@ -1,4 +1,5 @@
-import cStringIO
+from __future__ import print_function
+import io
 import hashlib
 import MySQLdb
 import os
@@ -9,10 +10,10 @@ import threading
 import time
 import string
 
-CHARS = string.letters + string.digits
+CHARS = string.ascii_letters + string.digits
 
 def sha1(x):
-  return hashlib.sha1(str(x)).hexdigest()
+  return hashlib.sha1(str(x).encode('utf-8')).hexdigest()
 
 # Should be deterministic given an idx
 def get_msg(do_blob, idx):
@@ -24,7 +25,7 @@ def get_msg(do_blob, idx):
 
   if random.randint(1, 2) == 1:
     # blob that cannot be compressed (well, compresses to 85% of original size)
-    return ''.join([random.choice(CHARS) for x in xrange(blob_length)])
+    return ''.join([random.choice(CHARS) for x in range(blob_length)])
   else:
     # blob that can be compressed
     return random.choice(CHARS) * blob_length
@@ -46,29 +47,29 @@ class PopulateWorker(threading.Thread):
   def run(self):
     try:
       self.runme()
-      print >> self.log, "ok"
-    except Exception, e:
+      print("ok", file=self.log)
+    except Exception as e:
       self.exception = e
       try:
         cursor = self.con.cursor()
         cursor.execute("INSERT INTO errors VALUES('%s')" % e)
-      except MySQLdb.Error, e2:
-        print >> self.log, "caught while inserting error (%s)" % e2
-      print >> self.log, "caught (%s)" % e
+      except MySQLdb.Error as e2:
+        print("caught while inserting error (%s)" % e2, file=self.log)
+      print("caught (%s)" % e, file=self.log)
     finally:
       self.finish()
 
   def finish(self):
-    print >> self.log, "total time: %.2f s" % (time.time() - self.start_time)
+    print("total time: %.2f s" % (time.time() - self.start_time), file=self.log)
     self.log.close()
     self.con.commit()
     self.con.close()
 
   def runme(self):
-    print >> self.log, "populate thread-%d started" % self.num
+    print("populate thread-%d started" % self.num, file=self.log)
     cur = self.con.cursor()
     stmt = None
-    for i in xrange(self.start_id, self.end_id):
+    for i in range(self.start_id, self.end_id):
       msg = get_msg(do_blob, i)
       stmt = """
 INSERT INTO t1(id,msg_prefix,msg,msg_length,msg_checksum) VALUES (%d,'%s','%s',%d,'%s')
@@ -82,15 +83,15 @@ def populate_table(con, num_records_before, do_blob, log):
   cur = con.cursor()
   stmt = None
   workers = []
-  N = num_records_before / 10
+  N = int(num_records_before / 10)
   start_id = 0
-  for i in xrange(10):
+  for i in range(10):
      w = PopulateWorker(MySQLdb.connect(user=user, host=host, port=port, db=db),
                         start_id, start_id + N, i)
      start_id += N
      workers.append(w)
 
-  for i in xrange(start_id, num_records_before):
+  for i in range(start_id, num_records_before):
       msg = get_msg(do_blob, i)
       # print >> log, "length is %d, complen is %d" % (len(msg), len(zlib.compress(msg, 6)))
       stmt = """
@@ -102,7 +103,7 @@ INSERT INTO t1(id,msg_prefix,msg,msg_length,msg_checksum) VALUES (%d,'%s','%s',%
   for w in workers:
     w.join()
     if w.exception:
-      print >>log, "populater thead %d threw an exception" % w.num
+      print("populater thead %d threw an exception" % w.num, file=log)
       return False
   return True
 
@@ -140,32 +141,32 @@ class ChecksumWorker(threading.Thread):
     con.autocommit(False)
     self.log = open('/%s/worker-checksum.log' % LG_TMP_DIR, 'a')
     self.checksum = checksum
-    print >> self.log, "given checksum=%d" % checksum
+    print("given checksum=%d" % checksum, file=self.log)
     self.start()
 
   def run(self):
     try:
       self.runme()
-      print >> self.log, "ok"
-    except Exception, e:
+      print("ok", file=self.log)
+    except Exception as e:
       try:
         cursor = self.con.cursor()
         cursor.execute("INSERT INTO errors VALUES('%s')" % e)
         con.commit()
-      except MySQLdb.Error, e2:
-        print >> self.log, "caught while inserting error (%s)" % e2
+      except MySQLdb.Error as e2:
+        print("caught while inserting error (%s)" % e2, file=self.log)
 
-      print >> self.log, "caught (%s)" % e
+      print("caught (%s)" % e, file=self.log)
     finally:
       self.finish()
 
   def finish(self):
-    print >> self.log, "total time: %.2f s" % (time.time() - self.start_time)
+    print("total time: %.2f s" % (time.time() - self.start_time), file=self.log)
     self.log.close()
     self.con.close()
 
   def runme(self):
-    print >> self.log, "checksum thread started"
+    print("checksum thread started", file=self.log)
     self.start_time = time.time()
     cur = self.con.cursor()
     cur.execute("SET SESSION innodb_lra_size=16")
@@ -173,10 +174,10 @@ class ChecksumWorker(threading.Thread):
     checksum = cur.fetchone()[1]
     self.con.commit()
     if checksum != self.checksum:
-      print >> self.log, "checksums do not match. given checksum=%d, calculated checksum=%d" % (self.checksum, checksum)
+      print("checksums do not match. given checksum=%d, calculated checksum=%d" % (self.checksum, checksum), file=self.log)
       self.checksum = checksum
     else:
-      print >> self.log, "checksums match! (both are %d)" % checksum
+      print("checksums match! (both are %d)" % checksum, file=self.log)
 
 
 class Worker(threading.Thread):
@@ -209,12 +210,12 @@ class Worker(threading.Thread):
     self.start()
 
   def finish(self):
-    print >> self.log, "loop_num:%d, total time: %.2f s" % (
-        self.loop_num, time.time() - self.start_time + self.time_spent)
-    print >> self.log, "num_primary_select=%d,num_secondary_select=%d,num_secondary_only_select=%d" %\
-      (self.num_primary_select, self.num_secondary_select, self.num_secondary_only_select)
-    print >> self.log, "num_inserts=%d,num_updates=%d,num_deletes=%d,time_spent=%d" %\
-      (self.num_inserts, self.num_updates, self.num_deletes, self.time_spent)
+    print("loop_num:%d, total time: %.2f s" % (
+        self.loop_num, time.time() - self.start_time + self.time_spent), file=self.log)
+    print("num_primary_select=%d,num_secondary_select=%d,num_secondary_only_select=%d" %\
+      (self.num_primary_select, self.num_secondary_select, self.num_secondary_only_select), file=self.log)
+    print("num_inserts=%d,num_updates=%d,num_deletes=%d,time_spent=%d" %\
+      (self.num_inserts, self.num_updates, self.num_deletes, self.time_spent), file=self.log)
     self.log.close()
 
   def validate_msg(self, msg_prefix, msg, msg_length, msg_checksum, idx):
@@ -232,14 +233,14 @@ class Worker(threading.Thread):
           len_match, len(msg), msg_length,
           checksum_match, checksum, msg_checksum,
           prefix_match, msg_prefix, msg[0:255])
-      print >> self.log, errmsg
+      print(errmsg, file=self.log)
 
       cursor = self.con.cursor()
       cursor.execute("INSERT INTO errors VALUES('%s')" % errmsg)
       cursor.execute("COMMIT")
       raise Exception('validate_msg failed')
     else:
-      print >> self.log, "Validated for length(%d) and id(%d)" % (msg_length, idx)
+      print("Validated for length(%d) and id(%d)" % (msg_length, idx), file=self.log)
 
   # Check to see if the idx is in the first column of res_array
   def check_exists(self, res_array, idx):
@@ -251,25 +252,25 @@ class Worker(threading.Thread):
   def run(self):
     try:
       self.runme()
-      print >> self.log, "ok, with do_blob %s" % self.do_blob
-    except Exception, e:
+      print("ok, with do_blob %s" % self.do_blob, file=self.log)
+    except Exception as e:
 
       try:
         cursor = self.con.cursor()
         cursor.execute("INSERT INTO errors VALUES('%s')" % e)
         cursor.execute("COMMIT")
-      except MySQLdb.Error, e2:
-        print >> self.log, "caught while inserting error (%s)" % e2
+      except MySQLdb.Error as e2:
+        print("caught while inserting error (%s)" % e2, file=self.log)
 
-      print >> self.log, "caught (%s)" % e
+      print("caught (%s)" % e, file=self.log)
     finally:
       self.finish()
 
   def runme(self):
     self.start_time = time.time()
     cur = self.con.cursor()
-    print >> self.log, "thread %d started, run from %d to %d" % (
-        self.xid, self.loop_num, self.num_xactions)
+    print("thread %d started, run from %d to %d" % (
+        self.xid, self.loop_num, self.num_xactions), file=self.log)
 
     while not self.num_xactions or (self.loop_num < self.num_xactions):
       idx = self.rand.randint(0, self.max_id)
@@ -338,18 +339,18 @@ class Worker(threading.Thread):
           if insert_or_update:
             if insert_with_index:
               if not self.check_exists(res_array, idx):
-                print >> self.log, "Error: Inserted row doesn't exist in secondary index"
+                print("Error: Inserted row doesn't exist in secondary index", file=self.log)
                 raise Exception("Error: Inserted row doesn't exist in secondary index")
           else:
             if self.check_exists(res_array, idx):
-              print >> self.log, "Error: Deleted row still exists in secondary index"
+              print("Error: Deleted row still exists in secondary index", file=self.log)
               raise Exception("Error: Deleted row still exists in secondary index")
 
 
         if (self.loop_num % 100) == 0:
-          print >> self.log, "Thread %d loop_num %d: result %d: %s" % (self.xid,
+          print("Thread %d loop_num %d: result %d: %s" % (self.xid,
                                                             self.loop_num, query_result,
-                                                            stmt)
+                                                            stmt), file=self.log)
 
         # 30% commit, 10% rollback, 60% don't end the trx
         r = self.rand.randint(1,10)
@@ -358,17 +359,17 @@ class Worker(threading.Thread):
         elif r == 4:
           self.con.rollback()
 
-      except MySQLdb.Error, e:
+      except MySQLdb.Error as e:
         if e.args[0] == 2006:  # server is killed
-          print >> self.log, "mysqld down, transaction %d" % self.xid
+          print("mysqld down, transaction %d" % self.xid, file=self.log)
           return
         else:
-          print >> self.log, "mysql error for stmt(%s) %s" % (stmt, e)
+          print("mysql error for stmt(%s) %s" % (stmt, e), file=self.log)
 
     try:
       self.con.commit()
-    except Exception, e:
-      print >> self.log, "commit error %s" % e
+    except Exception as e:
+      print("commit error %s" % e, file=self.log)
 
 if  __name__ == '__main__':
   global LG_TMP_DIR
@@ -400,36 +401,36 @@ if  __name__ == '__main__':
 #" db = ", db, " server_pid = ", server_pid
 
   if num_records_before:
-    print >> log, "populate table do_blob is %d" % do_blob
+    print("populate table do_blob is %d" % do_blob, file=log)
     con = MySQLdb.connect(user=user, host=host, port=port, db=db)
     if not populate_table(con, num_records_before, do_blob, log):
       sys.exit(1)
     con.close()
 
   if checksum:
-    print >> log, "start the checksum thread"
+    print("start the checksum thread", file=log)
     checksum_worker = ChecksumWorker(MySQLdb.connect(user=user, host=host, port=port, db=db), checksum)
     workers.append(checksum_worker)
 
-  print >> log, "start %d threads" % num_workers
-  for i in xrange(num_workers):
+  print("start %d threads" % num_workers, file=log)
+  for i in range(num_workers):
     worker = Worker(num_xactions_per_worker, i,
                     MySQLdb.connect(user=user, host=host, port=port, db=db),
                     server_pid, do_blob, max_id, fake_changes, secondary_checks)
     workers.append(worker)
 
   if kill_db_after:
-    print >> log, "kill mysqld"
+    print("kill mysqld", file=log)
     time.sleep(kill_db_after)
     os.kill(server_pid, signal.SIGKILL)
 
-  print >> log, "wait for threads"
+  print("wait for threads", file=log)
   for w in workers:
     w.join()
 
   if checksum_worker and checksum_worker.checksum != checksum:
-    print >> log, "checksums do not match. given checksum=%d, calculated checksum=%d" % (checksum, checksum_worker.checksum)
+    print("checksums do not match. given checksum=%d, calculated checksum=%d" % (checksum, checksum_worker.checksum), file=log)
     sys.exit(1)
 
-  print >> log, "all threads done"
+  print("all threads done", file=log)
 

--- a/mysql-test/suite/rocksdb.stress/r/rocksdb_stress.result
+++ b/mysql-test/suite/rocksdb.stress/r/rocksdb_stress.result
@@ -1,3 +1,4 @@
+SET @@session.default_storage_engine = ROCKSDB;
 include/master-slave.inc
 [connection master]
 DROP TABLE IF EXISTS t1;

--- a/mysql-test/suite/rocksdb.stress/t/load_generator.py
+++ b/mysql-test/suite/rocksdb.stress/t/load_generator.py
@@ -1,4 +1,4 @@
-import cStringIO
+import io
 import array
 import hashlib
 import MySQLdb
@@ -81,7 +81,7 @@ class TestError(Exception):
   """Raised when the test cannot make forward progress"""
   pass
 
-CHARS = string.letters + string.digits
+CHARS = string.ascii_letters + string.digits
 OPTIONS = {}
 
 # max number of rows per transaction
@@ -110,7 +110,7 @@ def roll_d100(p):
   return p >= random.randint(1, 100)
 
 def sha1(x):
-  return hashlib.sha1(str(x)).hexdigest()
+  return hashlib.sha1(str(x).encode('utf-8')).hexdigest()
 
 def is_connection_error(exc):
   error_code = exc.args[0]
@@ -134,7 +134,7 @@ def gen_msg(idx, thread_id, request_id):
 
   if roll_d100(50):
     # blob that cannot be compressed (well, compresses to 85% of original size)
-    msg = ''.join([random.choice(CHARS) for x in xrange(blob_length)])
+    msg = ''.join([random.choice(CHARS) for x in range(blob_length)])
   else:
     # blob that can be compressed
     msg = random.choice(CHARS) * blob_length
@@ -143,7 +143,7 @@ def gen_msg(idx, thread_id, request_id):
   return ''.join([msg, ' tid: %d req: %d' % (thread_id, request_id)])
 
 def execute(cur, stmt):
-  ROW_COUNT_ERROR = 18446744073709551615L
+  ROW_COUNT_ERROR = 18446744073709551615
   logging.debug("Executing %s" % stmt)
   cur.execute(stmt)
   if cur.rowcount < 0 or cur.rowcount == ROW_COUNT_ERROR:
@@ -162,7 +162,7 @@ def wait_for_workers(workers, min_active = 0):
   try:
     while threading.active_count() > min_active:
       time.sleep(1)
-  except KeyboardInterrupt, e:
+  except KeyboardInterrupt as e:
     os._exit(1)
 
   num_failures = 0
@@ -194,7 +194,7 @@ class WorkerThread(threading.Thread):
       logging.info("Started")
       self.runme()
       logging.info("Completed successfully")
-    except Exception, e:
+    except Exception as e:
       self.exception = traceback.format_exc()
       logging.error(self.exception)
       TEST_STOP = True
@@ -220,7 +220,7 @@ class WorkerThread(threading.Thread):
           self.set_isolation_level(self.isolation_level)
           logging.info("Connection successful after attempt %d" % attempts)
           break
-      except MySQLdb.Error, e:
+      except MySQLdb.Error as e:
         logging.debug(traceback.format_exc())
       time.sleep(SECONDS_BETWEEN_RETRY)
       timeout -= SECONDS_BETWEEN_RETRY
@@ -297,7 +297,7 @@ class PopulateWorker(WorkerThread):
       raise Exception("Unable to connect to MySQL server")
 
     stmt = None
-    for i in xrange(self.start_id, self.start_id + self.num_to_add):
+    for i in range(self.start_id, self.start_id + self.num_to_add):
       stmt = gen_insert(self.table, i, 0, 0, 0)
       execute(self.cur, stmt)
       if i % 101 == 0:
@@ -312,12 +312,12 @@ def populate_table(num_records):
   if num_records == 0:
     return False
 
-  num_workers = min(10, num_records / 100)
+  num_workers = min(10, int(num_records / 100))
   workers = []
 
-  N = num_records / num_workers
+  N = int(num_records / num_workers)
   start_id = 0
-  for i in xrange(num_workers):
+  for i in range(num_workers):
      workers.append(PopulateWorker(i, start_id, N))
      start_id += N
   if num_records > start_id:
@@ -427,11 +427,11 @@ class LoadGenWorker(WorkerThread):
 
     self.cur_txn = {idx:request_id}
     self.cur_txn_state = self.TXN_COMMITTED
-    for i in xrange(OPTIONS.committed_txns):
+    for i in range(OPTIONS.committed_txns):
       self.prev_txn.append(self.cur_txn)
 
     # fetch the rest of the row for the id space owned by this thread
-    for idx in xrange(self.start_id + 1, self.start_id + self.num_id):
+    for idx in range(self.start_id + 1, self.start_id + self.num_id):
       execute(self.cur, stmt % (self.table, idx))
       if self.cur.rowcount == 0:
         # Negative number is used to indicated a missing row
@@ -574,7 +574,7 @@ class LoadGenWorker(WorkerThread):
     idx = random.randint(self.start_id, self.start_id + self.num_id - 1)
     ids.append(idx)
 
-    for i in xrange(1, num_rows):
+    for i in range(1, num_rows):
       # The valid ranges for ids is from start_id to start_id + num_id and from
       # start_share_id to max_id. The randint() uses the range from
       # start_share_id to max_id + num_id - 1. start_share_id to max_id covers
@@ -600,7 +600,7 @@ class LoadGenWorker(WorkerThread):
     # the row. MyRocks will prevent any updates to this row until the
     # snapshot is released and re-acquired.
     NUM_RETRIES = 100
-    for i in xrange(NUM_RETRIES):
+    for i in range(NUM_RETRIES):
       ids_found = {}
       try:
         for idx in ids:
@@ -611,7 +611,7 @@ class LoadGenWorker(WorkerThread):
             res = self.cur.fetchone()
             ids_found[res[ID_COL]] = res[ZERO_SUM_COL]
         break
-      except MySQLdb.OperationalError, e:
+      except MySQLdb.OperationalError as e:
         if not is_deadlock_error(e):
           raise e
 
@@ -719,7 +719,7 @@ class LoadGenWorker(WorkerThread):
 
         self.execute_one()
         self.loop_num += 1
-      except MySQLdb.OperationalError, e:
+      except MySQLdb.OperationalError as e:
         if not is_connection_error(e):
           raise e
         if self.reconnect():
@@ -775,7 +775,7 @@ class CheckerWorker(WorkerThread):
         if self.cur.rowcount == 0:
           break
 
-        for i in xrange(self.cur.rowcount - 1):
+        for i in range(self.cur.rowcount - 1):
           sum += self.cur.fetchone()[ZERO_SUM_COL]
 
         last_row = self.cur.fetchone()
@@ -803,7 +803,7 @@ class CheckerWorker(WorkerThread):
     #  2. range scan
     if roll_d100(90):
       ids = []
-      for i in xrange(random.randint(1, MAX_ROWS_PER_REQ)):
+      for i in range(random.randint(1, MAX_ROWS_PER_REQ)):
         ids.append(random.randint(0, self.max_id - 1))
       stmt += "id in (%s)" % ','.join(str(x) for x in ids)
     else:
@@ -862,7 +862,7 @@ class CheckerWorker(WorkerThread):
         self.loop_num += 1
         if self.loop_num % 10000 == 0:
           logging.info("Processed %d transactions so far" % self.loop_num)
-      except MySQLdb.OperationalError, e:
+      except MySQLdb.OperationalError as e:
         if not is_connection_error(e):
           raise e
         if self.reconnect():
@@ -995,12 +995,12 @@ if  __name__ == '__main__':
 
   logging.info("Starting %d loaders" % OPTIONS.num_loaders)
   loaders = []
-  for i in xrange(OPTIONS.num_loaders):
+  for i in range(OPTIONS.num_loaders):
     loaders.append(LoadGenWorker(i))
 
   logging.info("Starting %d checkers" % OPTIONS.num_checkers)
   checkers = []
-  for i in xrange(OPTIONS.num_checkers):
+  for i in range(OPTIONS.num_checkers):
     checkers.append(CheckerWorker(i))
 
   while LOADERS_READY < OPTIONS.num_loaders:

--- a/mysql-test/suite/rocksdb.stress/t/rocksdb_stress.test
+++ b/mysql-test/suite/rocksdb.stress/t/rocksdb_stress.test
@@ -1,4 +1,5 @@
 # basic stress tests for myrocks, just runs the load generator without any crashes
+SET @@session.default_storage_engine = ROCKSDB;
 
 # Don't test this under valgrind, memory leaks will occur
 --disable_warnings

--- a/mysql-test/suite/rocksdb/t/check_log_for_xa.py
+++ b/mysql-test/suite/rocksdb/t/check_log_for_xa.py
@@ -16,16 +16,12 @@ all_filters = [
     re.compile('(\[Note\] Found \d+ prepared transaction\(s\) in \w+)')),
 ]
 
-active_filters = filter(lambda f: f[0] in desired_filters, all_filters)
+active_filters = [f for f in all_filters if f[0] in desired_filters]
 
-results = set()
 with open(log_path) as log:
   for line in log:
     line = line.strip()
     for f in active_filters:
       match = f[1].search(line)
       if match:
-        results.add("**found '%s' log entry**" % f[0])
-
-for res in results:
-  print res
+        print("**found '%s' log entry**" % f[0])

--- a/mysql-test/suite/rocksdb/t/rocksdb_concurrent_insert.py
+++ b/mysql-test/suite/rocksdb/t/rocksdb_concurrent_insert.py
@@ -9,7 +9,7 @@ Example Usage (in Mysql Test Framework):
   exec $exec;
 
 """
-import cStringIO
+import io
 import hashlib
 import MySQLdb
 import os
@@ -39,14 +39,14 @@ class Inserter(threading.Thread):
   def run(self):
     try:
       self.runme()
-    except Exception, e:
+    except Exception as e:
       self.exception = traceback.format_exc()
-      print "caught (%s)" % e
+      print("caught (%s)" % e)
     finally:
       self.finish()
   def runme(self):
     cur = self.con.cursor()
-    for i in xrange(self.num_inserts):
+    for i in range(self.num_inserts):
       try:
         cur.execute(get_insert(self.table_name, i))
         r = self.rand.randint(1,10)
@@ -56,17 +56,17 @@ class Inserter(threading.Thread):
         cur = self.con.cursor()
     try:
       self.con.commit()
-    except Exception, e:
+    except Exception as e:
       self.exception = traceback.format_exc()
-      print "caught (%s)" % e
+      print("caught (%s)" % e)
       pass
   def finish(self):
     self.finished = True
 
 if __name__ == '__main__':
   if len(sys.argv) != 8:
-    print "Usage: rocksdb_concurrent_insert.py user host port db_name " \
-          "table_name num_inserts num_threads"
+    print("Usage: rocksdb_concurrent_insert.py user host port db_name " \
+          "table_name num_inserts num_threads")
     sys.exit(1)
 
   user = sys.argv[1]
@@ -79,7 +79,7 @@ if __name__ == '__main__':
 
   worker_failed = False
   workers = []
-  for i in xrange(num_workers):
+  for i in range(num_workers):
     inserter = Inserter(
       MySQLdb.connect(user=user, host=host, port=port, db=db), table_name,
       num_inserts)
@@ -88,7 +88,7 @@ if __name__ == '__main__':
   for w in workers:
     w.join()
     if w.exception:
-      print "Worker hit an exception:\n%s\n" % w.exception
+      print("Worker hit an exception:\n%s\n" % w.exception)
       worker_failed = True
 
   if worker_failed:

--- a/mysql-test/suite/rocksdb/t/rocksdb_deadlock_stress.inc
+++ b/mysql-test/suite/rocksdb/t/rocksdb_deadlock_stress.inc
@@ -11,7 +11,7 @@ set @prior_rocksdb_deadlock_detect = @@rocksdb_deadlock_detect;
 set global rocksdb_lock_wait_timeout = 100000;
 set global rocksdb_deadlock_detect = ON;
 
-exec python suite/rocksdb/t/rocksdb_deadlock_stress.py root 127.0.0.1 $MASTER_MYPORT test t1 10000 10;
+--exec python suite/rocksdb/include/rocksdb_deadlock_stress.py root 127.0.0.1 $MASTER_MYPORT test t1 10000 10
 
 set global rocksdb_lock_wait_timeout = @prior_rocksdb_lock_wait_timeout;
 set global rocksdb_deadlock_detect = @prior_rocksdb_deadlock_detect;

--- a/mysql-test/suite/rocksdb/t/rocksdb_deadlock_stress.py
+++ b/mysql-test/suite/rocksdb/t/rocksdb_deadlock_stress.py
@@ -4,7 +4,7 @@ This script stress tests deadlock detection.
 Usage: rocksdb_deadlock_stress.py user host port db_name table_name
        num_iters num_threads
 """
-import cStringIO
+import io
 import hashlib
 import MySQLdb
 from MySQLdb.constants import ER
@@ -47,16 +47,16 @@ class Worker(threading.Thread):
   def run(self):
     try:
       self.runme()
-    except Exception, e:
+    except Exception as e:
       self.exception = traceback.format_exc()
   def runme(self):
     cur = self.con.cursor()
-    for x in xrange(self.num_iters):
+    for x in range(self.num_iters):
       try:
-        for i in random.sample(xrange(100), 10):
+        for i in random.sample(range(100), 10):
           cur.execute(get_query(self.table_name, i))
         self.con.commit()
-      except MySQLdb.OperationalError, e:
+      except MySQLdb.OperationalError as e:
         self.con.rollback()
         cur = self.con.cursor()
         if not is_deadlock_error(e):
@@ -64,8 +64,8 @@ class Worker(threading.Thread):
 
 if __name__ == '__main__':
   if len(sys.argv) != 8:
-    print "Usage: rocksdb_deadlock_stress.py user host port db_name " \
-          "table_name num_iters num_threads"
+    print("Usage: rocksdb_deadlock_stress.py user host port db_name " \
+          "table_name num_iters num_threads")
     sys.exit(1)
 
   user = sys.argv[1]
@@ -78,7 +78,7 @@ if __name__ == '__main__':
 
   worker_failed = False
   workers = []
-  for i in xrange(num_workers):
+  for i in range(num_workers):
     w = Worker(
       MySQLdb.connect(user=user, host=host, port=port, db=db), table_name,
       num_iters)
@@ -87,7 +87,7 @@ if __name__ == '__main__':
   for w in workers:
     w.join()
     if w.exception:
-      print "Worker hit an exception:\n%s\n" % w.exception
+      print("Worker hit an exception:\n%s\n" % w.exception)
       worker_failed = True
 
   if worker_failed:


### PR DESCRIPTION
1. Fix failing `rocksdb_stress.rocksdb_stress`
2. Convert `python2` scripts to support both `python2` and `python3`

Current requirements to run these scripts are:
a) python2.6+ (because of `from __future__ import print_function`)
b) `python` linked to either `python2` or `python3`