### PR TITLE
PS-5620: Add OpenSSL to dependencies of packages

### DIFF
--- a/build-ps/debian/control
+++ b/build-ps/debian/control
@@ -178,7 +178,8 @@ Pre-Depends: percona-server-common-5.7 (= ${binary:Version}),
              debconf (>= 0.2.17)
 Depends: percona-server-client-5.7 (= ${binary:Version}),
          ${shlibs:Depends}, ${misc:Depends},
-         psmisc
+         psmisc,
+         openssl
 Provides: mysql-server,
           virtual-mysql-server, virtual-mysql-server-core,
           mysql-server-5.7, mysql-server-core-5.7

--- a/build-ps/debian/control.notokudb
+++ b/build-ps/debian/control.notokudb
@@ -149,7 +149,8 @@ Pre-Depends: percona-server-common-5.7 (= ${binary:Version}),
              debconf (>= 0.2.17)
 Depends: percona-server-client-5.7 (= ${binary:Version}),
          ${shlibs:Depends}, ${misc:Depends},
-         psmisc
+         psmisc,
+         openssl
 Provides: mysql-server,
           virtual-mysql-server, virtual-mysql-server-core,
           mysql-server-5.7, mysql-server-core-5.7

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -193,6 +193,7 @@ Requires:       grep
 Requires:       procps
 Requires:       shadow-utils
 Requires:       net-tools
+Requires:       openssl
 Requires(pre):  Percona-Server-shared%{product_suffix}
 Requires:       Percona-Server-client%{product_suffix}
 Provides:       MySQL-server%{?_isa} = %{version}-%{release}

--- a/build-ps/ubuntu/control
+++ b/build-ps/ubuntu/control
@@ -179,7 +179,8 @@ Pre-Depends: percona-server-common-5.7 (= ${binary:Version}),
              debconf (>= 0.2.17)
 Depends: percona-server-client-5.7 (= ${binary:Version}),
          ${shlibs:Depends}, ${misc:Depends},
-         psmisc
+         psmisc,
+         openssl
 Provides: mysql-server,
           virtual-mysql-server, virtual-mysql-server-core,
           mysql-server-5.7, mysql-server-core-5.7

--- a/build-ps/ubuntu/control.notokudb
+++ b/build-ps/ubuntu/control.notokudb
@@ -150,7 +150,8 @@ Pre-Depends: percona-server-common-5.7 (= ${binary:Version}),
              debconf (>= 0.2.17)
 Depends: percona-server-client-5.7 (= ${binary:Version}),
          ${shlibs:Depends}, ${misc:Depends},
-         psmisc
+         psmisc,
+         openssl
 Provides: mysql-server,
           virtual-mysql-server, virtual-mysql-server-core,
           mysql-server-5.7, mysql-server-core-5.7


### PR DESCRIPTION
All OS **exept** Docker images have OpenSSL installed by default

Because `mysql_ssl_rsa_setup` uses OpenSSL CLI utils and invokes them as `command()`