### PR TITLE
PS-6989: "Cannot write: No space left on device" error with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -249,6 +249,7 @@ jobs:
         -DMYSQL_MAINTAINER_MODE=ON
         -DCMAKE_C_COMPILER_LAUNCHER=/usr/bin/ccache
         -DCMAKE_CXX_COMPILER_LAUNCHER=/usr/bin/ccache
+        -DMERGE_UNITTESTS=ON
         -DWITH_KEYRING_VAULT=ON
         -DWITH_PAM=ON
         -DWITH_TOKUDB=ON


### PR DESCRIPTION
Use `-DMERGE_UNITTESTS=ON` to save about 900 MB with `gcc-9` in Debug compilation.