### PR TITLE
PS-7032: fix gcc-10 compilation issues (5.6)

### DIFF
--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4610,7 +4610,6 @@ innobase_rename_columns_try(
 		ha_alter_info->alter_info->create_list);
 	uint i = 0;
 
-	DBUG_ASSERT(ctx);
 	DBUG_ASSERT(ha_alter_info->handler_flags
 		    & Alter_inplace_info::ALTER_COLUMN_NAME);
 
@@ -4792,7 +4791,6 @@ innobase_update_foreign_try(
 	ulint	i;
 
 	DBUG_ENTER("innobase_update_foreign_try");
-	DBUG_ASSERT(ctx);
 
 	foreign_id = dict_table_get_highest_foreign_id(ctx->new_table);
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2420,7 +2420,7 @@ purge_archived_logs(
 		if (dirnamelen + strlen(fileinfo.name) + 2 > OS_FILE_MAX_PATH)
 			continue;
 
-		snprintf(archived_log_filename + dirnamelen, OS_FILE_MAX_PATH,
+		snprintf(archived_log_filename + dirnamelen, OS_FILE_MAX_PATH - dirnamelen,
 				"%s", fileinfo.name);
 
 		if (before_no) {


### PR DESCRIPTION
1. Fix gcc-6 issue:
```
/data/mysql-server/percona-5.6/storage/innobase/handler/handler0alter.cc: In function ‘bool innobase_update_foreign_try(ha_innobase_inplace_ctx*, trx_t*, const char*)’:
/data/mysql-server/percona-5.6/storage/innobase/handler/handler0alter.cc:4795:18: error: nonnull argument ‘ctx’ compared to NULL [-Werror=nonnull-compare]
  DBUG_ASSERT(ctx);
```
2. Fix gcc-10 RelWithDebInfo issue:
```
/data/mysql-server/percona-5.6/storage/innobase/srv/srv0srv.cc: In function ‘dberr_t purge_archived_logs(time_t, lsn_t)’:
/data/mysql-server/percona-5.6/storage/innobase/srv/srv0srv.cc:2424:6: error: ‘%s’ directive output may be truncated writing up to 4047 bytes into a region of size 4000 [-Werror=format-truncation=]
 2424 |     "%s", fileinfo.name);
      |      ^~   ~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:862,
                 from /data/mysql-server/percona-5.6/include/my_global.h:321,
                 from /data/mysql-server/percona-5.6/storage/innobase/include/univ.i:111,
                 from /data/mysql-server/percona-5.6/storage/innobase/include/srv0srv.h:52,
                 from /data/mysql-server/percona-5.6/storage/innobase/srv/srv0srv.cc:50:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:35: note: ‘__builtin_snprintf’ output between 1 and 4048 bytes into a destination of size 4000
```