### PR TITLE
PS-7032: fix gcc-10 compilation issues (5.7)

### DIFF
--- a/cmake/build_configurations/compiler_options.cmake
+++ b/cmake/build_configurations/compiler_options.cmake
@@ -48,7 +48,10 @@ IF(UNIX)
 
   # Default GCC flags
   IF(CMAKE_COMPILER_IS_GNUCC)
-    SET(COMMON_C_FLAGS               "-g -fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
+    SET(COMMON_C_FLAGS               "-g -fno-omit-frame-pointer -fno-strict-aliasing")
+    IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)  # gcc-9 or older
+      STRING(APPEND COMMON_C_FLAGS " -fabi-version=2")
+    ENDIF()
     # Disable inline optimizations for valgrind testing to avoid false positives
     IF(WITH_VALGRIND)
       SET(COMMON_C_FLAGS             "-fno-inline ${COMMON_C_FLAGS}")
@@ -72,7 +75,10 @@ IF(UNIX)
     SET(CMAKE_C_FLAGS_RELWITHDEBINFO "-O3 -D_FORTIFY_SOURCE=2 ${COMMON_C_FLAGS}")
   ENDIF()
   IF(CMAKE_COMPILER_IS_GNUCXX)
-    SET(COMMON_CXX_FLAGS               "-g -fabi-version=2 -fno-omit-frame-pointer -fno-strict-aliasing")
+    SET(COMMON_CXX_FLAGS               "-g -fno-omit-frame-pointer -fno-strict-aliasing")
+    IF(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)  # gcc-9 or older
+      STRING(APPEND COMMON_CXX_FLAGS " -fabi-version=2")
+    ENDIF()
     # GCC 6 has C++14 as default, set it explicitly to the old default.
     EXECUTE_PROCESS(COMMAND ${CMAKE_CXX_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GXX_VERSION)

--- a/sql/auth/sql_user.cc
+++ b/sql/auth/sql_user.cc
@@ -122,7 +122,7 @@ void append_user(THD *thd, String *str, LEX_USER *user, bool comma= true,
           /*
             With old_passwords == 2 the scrambled password will be binary.
           */
-          DBUG_ASSERT(thd->variables.old_passwords = 2);
+          DBUG_ASSERT(thd->variables.old_passwords == 2);
           str->append("<secret>");
         }
         str->append("'");

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4610,7 +4610,6 @@ innobase_rename_columns_try(
 		ha_alter_info->alter_info->create_list);
 	uint i = 0;
 
-	DBUG_ASSERT(ctx);
 	DBUG_ASSERT(ha_alter_info->handler_flags
 		    & Alter_inplace_info::ALTER_COLUMN_NAME);
 
@@ -4792,7 +4791,6 @@ innobase_update_foreign_try(
 	ulint	i;
 
 	DBUG_ENTER("innobase_update_foreign_try");
-	DBUG_ASSERT(ctx);
 
 	foreign_id = dict_table_get_highest_foreign_id(ctx->new_table);
 

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2420,7 +2420,7 @@ purge_archived_logs(
 		if (dirnamelen + strlen(fileinfo.name) + 2 > OS_FILE_MAX_PATH)
 			continue;
 
-		snprintf(archived_log_filename + dirnamelen, OS_FILE_MAX_PATH,
+		snprintf(archived_log_filename + dirnamelen, OS_FILE_MAX_PATH - dirnamelen,
 				"%s", fileinfo.name);
 
 		if (before_no) {


### PR DESCRIPTION
1. Fix gcc-10 issue:
```
In file included from /data/mysql-server/mysql-5.7/include/my_global.h:80,
                 from /data/mysql-server/mysql-5.7/sql/sql_parse.h:26,
                 from /data/mysql-server/mysql-5.7/sql/auth/sql_user.cc:22:
/data/mysql-server/mysql-5.7/sql/auth/sql_user.cc: In function ‘void append_user(THD*, String*, LEX_USER*, bool, bool)’:
/data/mysql-server/mysql-5.7/sql/auth/sql_user.cc:125:52: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
  125 |           DBUG_ASSERT(thd->variables.old_passwords = 2);
```

2. Fix gcc-10 compilation issues with MyRocks:
```
In file included from /usr/include/c++/10/memory:83,
                 from /data/mysql-server/percona-5.7/storage/rocksdb/rocksdb/include/rocksdb/db.h:14,
                 from /data/mysql-server/percona-5.7/storage/rocksdb/rocksdb/include/rocksdb/ldb_tool.h:9,
                 from /data/mysql-server/percona-5.7/storage/rocksdb/rocksdb/tools/ldb_tool.cc:7:
/usr/include/c++/10/bits/unique_ptr.h: In instantiation of ‘constexpr std::unique_ptr<_Tp, _Dp>::unique_ptr() [with _Del = std::default_delete<rocksdb::WriteBatch>; <template-parameter-2-2> = void; _Tp = rocksdb::WriteBatch; _Dp = std::default_delete<rocksdb::WriteBatch>]’:
/data/mysql-server/percona-5.7/storage/rocksdb/rocksdb/include/rocksdb/transaction_log.h:63:17:   required from here
/usr/include/c++/10/bits/unique_ptr.h:269:9: error: no matching function for call to ‘std::__uniq_ptr_data<rocksdb::WriteBatch, std::default_delete<rocksdb::WriteBatch>, true, true>::__uniq_ptr_data()’
  269 |  : _M_t()
      |         ^
/usr/include/c++/10/bits/unique_ptr.h:209:40: note: candidate: ‘std::__uniq_ptr_data<rocksdb::WriteBatch, std::default_delete<rocksdb::WriteBatch>, true, true>::__uniq_ptr_data(std::__uniq_ptr_impl<rocksdb::WriteBatch, std::default_delete<rocksdb::WriteBatch> >::pointer) [inherited from std::__uniq_ptr_impl<rocksdb::WriteBatch, std::default_delete<rocksdb::WriteBatch> >]’
  209 |       using __uniq_ptr_impl<_Tp, _Dp>::__uniq_ptr_impl;
```