### PR TITLE
PS-7032: fix gcc-10 compilation issues (8.0)

### DIFF
--- a/sql/rpl_applier_reader.cc
+++ b/sql/rpl_applier_reader.cc
@@ -66,7 +66,7 @@ class Rpl_applier_reader::Stage_controller {
   }
 
   void enter_stage() {
-    DBUG_ASSERT(m_state = LOCKED);
+    DBUG_ASSERT(m_state == LOCKED);
     m_thd->ENTER_COND(m_cond, m_mutex, &m_new_stage, &m_old_stage);
     m_state = IN_STAGE;
   }

--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -356,12 +356,12 @@ void Binlog_sender::run() {
   if (reader.is_open()) {
     if (is_fatal_error()) {
       /* output events range to error message */
-      snprintf(error_text, sizeof(error_text),
-               "%s; the first event '%s' at %lld, "
-               "the last event read from '%s' at %lld, "
-               "the last byte read from '%s' at %lld.",
-               m_errmsg, m_start_file, m_start_pos, m_last_file, m_last_pos,
-               log_file, reader.position());
+      my_snprintf_8bit(nullptr, error_text, sizeof(error_text),
+                       "%s; the first event '%s' at %lld, "
+                       "the last event read from '%s' at %lld, "
+                       "the last byte read from '%s' at %lld.",
+                       m_errmsg, m_start_file, m_start_pos, m_last_file,
+                       m_last_pos, log_file, reader.position());
       set_fatal_error(error_text);
     }
 

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -1496,7 +1496,8 @@ dberr_t buf_parallel_dblwr_create(void) noexcept {
     return (DB_SUCCESS);
   }
 
-  memset(parallel_dblwr_buf.shard, 0, sizeof(parallel_dblwr_buf.shard));
+  memset(static_cast<void *>(parallel_dblwr_buf.shard), 0,
+         sizeof(parallel_dblwr_buf.shard));
 
   dberr_t err = buf_parallel_dblwr_file_create();
   if (err != DB_SUCCESS) {

--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -274,6 +274,11 @@ IF(HAS_WARN_FLAG)
   ADD_COMPILE_FLAGS(segfault-t.cc COMPILE_FLAGS ${HAS_WARN_FLAG})
 ENDIF()
 
+# Suppress warnings for gcc-10 or newer
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-stringop-overflow FILES integer_digits-t.cc)
+ENDIF()
+
 # Warnings about missing PGO profile data are not useful for unit tests.
 DISABLE_MISSING_PROFILE_WARNING()
 


### PR DESCRIPTION
Fix gcc-10 compilation issues:
1.
```
In file included from /home/travis/build/percona/percona-server/include/my_time.h:37,
                 from /home/travis/build/percona/percona-server/sql/field.h:46,
                 from /home/travis/build/percona/percona-server/sql/table_column_iterator.h:28,
                 from /home/travis/build/percona/percona-server/sql/log_event.h:88,
                 from /home/travis/build/percona/percona-server/sql/binlog_reader.h:27,
                 from /home/travis/build/percona/percona-server/sql/rpl_applier_reader.h:28,
                 from /home/travis/build/percona/percona-server/sql/rpl_applier_reader.cc:23:
/home/travis/build/percona/percona-server/sql/rpl_applier_reader.cc: In member function ‘void Rpl_applier_reader::Stage_controller::enter_stage()’:
/home/travis/build/percona/percona-server/sql/rpl_applier_reader.cc:69:25: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
   69 |     DBUG_ASSERT(m_state = LOCKED);
      |                 ~~~~~~~~^~~~~~~~
/home/travis/build/percona/percona-server/sql/rpl_applier_reader.cc:69:5: note: in expansion of macro ‘DBUG_ASSERT’
   69 |     DBUG_ASSERT(m_state = LOCKED);
      |     ^~~~~~~~~~~
```
2.
```
/data/mysql-server/percona-8.0/storage/innobase/buf/buf0dblwr.cc: In function ‘dberr_t buf_parallel_dblwr_create()’:
/data/mysql-server/percona-8.0/storage/innobase/buf/buf0dblwr.cc:1499:71: error: ‘void* memset(void*, int, size_t)’ clearing an object of type ‘struct parallel_dblwr_shard_t’ with no trivial copy-assignment; use value-initialization instead [-Werror=class-memaccess]
 1499 |   memset(parallel_dblwr_buf.shard, 0, sizeof(parallel_dblwr_buf.shard));
      |                                                                       ^
In file included from /data/mysql-server/percona-8.0/storage/innobase/buf/buf0dblwr.cc:38:
/data/mysql-server/percona-8.0/storage/innobase/include/buf0dblwr.h:182:8: note: ‘struct parallel_dblwr_shard_t’ declared here
  182 | struct parallel_dblwr_shard_t {
      |        ^~~~~~~~~~~~~~~~~~~~~~
```
3.
```
/data/mysql-server/percona-8.0/sql/rpl_binlog_sender.cc: In member function 'void Binlog_sender::run()':
/data/mysql-server/percona-8.0/sql/rpl_binlog_sender.cc:362:42: error: '%s' directive output may be trun$
  362 |                "the last byte read from '%s' at %lld.",
      |                                          ^~
/data/mysql-server/percona-8.0/sql/rpl_binlog_sender.cc:360:16: note: using the range [-9223372036854775$
  360 |                "%s; the first event '%s' at %lld, "
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  361 |                "the last event read from '%s' at %lld, "
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  362 |                "the last byte read from '%s' at %lld.",
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:862,
                 from /usr/include/c++/10/cstdio:42,
                 from /data/mysql-server/percona-8.0/libbinlogevents/include/binlog_event.h:42,
                 from /data/mysql-server/percona-8.0/sql/rpl_binlog_sender.h:30,
                 from /data/mysql-server/percona-8.0/sql/rpl_binlog_sender.cc:23:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:64:35: note: '__builtin___snprintf_chk' output 94 or more by$
   64 |   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   65 |        __bos (__s), __fmt, __va_arg_pack ());
```
4.
```
In file included from /data/mysql-server/percona-8.0/unittest/gunit/integer_digits-t.cc:25:
In function 'char* write_digits(T, int, char*) [with T = long unsigned int]',
    inlined from 'virtual void integer_digits_unittest::IntegerDigits_WriteDigits_Test::TestBody()' at /$
/data/mysql-server/percona-8.0/include/integer_digits.h:152:12: error: writing 1 byte into a region of s$
  152 |     *--pos = '0' + number % 10;
      |     ~~~~~~~^~~~~~~~~~~~~~~~~~~
/data/mysql-server/percona-8.0/unittest/gunit/integer_digits-t.cc: In member function 'virtual void inte$
/data/mysql-server/percona-8.0/unittest/gunit/integer_digits-t.cc:73:8: note: at offset -1 to object 'bu$
   73 |   char buffer[100];
```
