### PR TITLE
PS-6885 Documented the new variable rocksdb_rollback_on_timeout which allows the rollback of an entire transaction on timeout.

### DIFF
--- a/doc/source/myrocks/variables.rst
+++ b/doc/source/myrocks/variables.rst
@@ -424,6 +424,10 @@ Also, all variables can exist in one or both of the following scopes:
      - Yes
      - Yes
      - Global
+   * - :variable:`rocksdb_rollback_on_timeout`
+     - Yes
+     - Yes
+     - Global
    * - :variable:`rocksdb_rpl_skip_tx_api`
      - Yes
      - Yes
@@ -1988,6 +1992,19 @@ Allowed range is up to ``2147483647``.
 
 Resets MyRocks internal statistics dynamically
 (without restarting the server).
+
+.. variable:: rocksdb_rollback_on_timeout
+
+   :version 5.7.30-33: Implemented
+   :cli: ``--rocksdb-rollback-on-timeout``
+   :dyn: Yes
+   :scope: Global
+   :vartype: Boolean
+   :default: ``OFF``
+
+By default, only the last statement on a transaction is rolled back. If
+``--rocksdb-rollback-on-timeout=ON``, a transaction timeout causes a rollback of
+the entire transaction.
 
 .. variable:: rocksdb_rpl_skip_tx_api
 

--- a/doc/source/myrocks/variables.rst
+++ b/doc/source/myrocks/variables.rst
@@ -1892,7 +1892,7 @@ Resets MyRocks internal statistics dynamically
 
 .. variable:: rocksdb_rollback_on_timeout
 
-   :version 5.7.30-33: Implemented
+   :version 8.0.20-11: Implemented
    :cli: ``--rocksdb-rollback-on-timeout``
    :dyn: Yes
    :scope: Global


### PR DESCRIPTION
Merged 5.7 version
Modified variable description.