### PR TITLE
PS-7077: Azure Pipelines: clang-5.0 fails if gcc-9+ is installed

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -239,6 +239,13 @@ jobs:
         '-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2 -g1 -DNDEBUG'
       )
 
+      if [ "$CC" == "clang-5.0" ]; then
+        COMPILE_OPT+=(
+          '-DCMAKE_C_FLAGS=-isystem /usr/include/c++/9 -isystem /usr/include'
+          '-DCMAKE_CXX_FLAGS=-isystem /usr/include/c++/9 -isystem /usr/include'
+        )
+      fi
+
       CMAKE_OPT="
         -DCMAKE_BUILD_TYPE=$(BuildType)
         -DBUILD_CONFIG=mysql_release


### PR DESCRIPTION
This is workaround for clang-5 bug with incorrect order of using system include directories that collide with gcc-9/gcc-10 include files.