### PR TITLE
PS-7082: Incorrect link displayed on \help client command

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -3135,7 +3135,7 @@ static int com_help(String *buffer MY_ATTRIBUTE((unused)),
   put_info(
       "\nFor information about Percona products and services, visit:\n"
       "   http://www.percona.com/\n"
-      "Percona Server manual: http://www.percona.com/doc/percona-server/%d.%d\n"
+      "Percona Server manual: http://www.percona.com/doc/percona-server/8.0/\n"
       "For the MySQL Reference Manual: http://dev.mysql.com/\n"
       "To buy Percona support, training, or other products, visit:\n"
       "   https://www.percona.com/\n",


### PR DESCRIPTION
Fixed the documentation link.