### PR TITLE
5.6 PS-7043 - Incorrect result when constant equality expression is used …

### DIFF
--- a/mysql-test/r/join_outer.result
+++ b/mysql-test/r/join_outer.result
@@ -2106,3 +2106,65 @@ SELECT straight_join t1.vc, t1.ik
 FROM t1 JOIN t1 AS t2 ON t1.vc=t2.vc LEFT JOIN t1 AS t3 ON t1.vc=t3.vc;
 vc	ik
 DROP TABLE t1;
+#
+# Bug#29493830 CONST'IFIED OUTER JOIN RETURN INCORRECT RESULTS
+#
+CREATE TABLE t1 (
+col_int_unique INT DEFAULT NULL,
+col_int_key INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (5,0);
+CREATE TABLE t2 (
+col_char_16_unique char(16) DEFAULT NULL,
+col_int_key INT DEFAULT NULL,
+col_int_unique INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t2 VALUES ("just",21,5);
+CREATE TABLE t3 (
+col_int INT DEFAULT NULL,
+col_char_16_unique CHAR(16) DEFAULT NULL,
+UNIQUE KEY col_char_16_unique (col_char_16_unique)
+) ENGINE=InnoDB;
+INSERT INTO t3 VALUES (9,"foo");
+CREATE TABLE t4 (
+col_int INT DEFAULT NULL,
+col_int_unique INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t4 VALUES (9,5);
+explain SELECT STRAIGHT_JOIN
+t3.col_int, t4.col_int,
+t3.col_int = t4.col_int or t4.col_int IS NULL
+FROM (t1
+LEFT JOIN t2
+ON t1.col_int_key = t2.col_int_key AND
+t1.col_int_unique = t2.col_int_unique
+LEFT JOIN t3
+ON t3.col_char_16_unique = t2.col_char_16_unique
+LEFT JOIN t4
+ON t4.col_int = t3.col_int AND    #Note, this pred term
+t4.col_int_unique = t1.col_int_unique
+) WHERE t1.col_int_unique = 5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	const	col_int_unique	col_int_unique	5	const	1	NULL
+1	SIMPLE	t2	const	col_int_unique	col_int_unique	5	const	1	NULL
+1	SIMPLE	t3	const	col_char_16_unique	NULL	NULL	NULL	1	NULL
+1	SIMPLE	t4	const	col_int_unique	col_int_unique	5	const	1	NULL
+SELECT STRAIGHT_JOIN
+t3.col_int, t4.col_int,
+t3.col_int = t4.col_int or t4.col_int IS NULL
+FROM (t1
+LEFT JOIN t2
+ON t1.col_int_key = t2.col_int_key AND
+t1.col_int_unique = t2.col_int_unique
+LEFT JOIN t3
+ON t3.col_char_16_unique = t2.col_char_16_unique
+LEFT JOIN t4
+ON t4.col_int = t3.col_int AND    #Note, this pred term
+t4.col_int_unique = t1.col_int_unique
+) WHERE t1.col_int_unique = 5;
+col_int	col_int	t3.col_int = t4.col_int or t4.col_int IS NULL
+NULL	NULL	1
+DROP TABLE t1, t2, t3, t4;

--- a/mysql-test/r/join_outer_bka.result
+++ b/mysql-test/r/join_outer_bka.result
@@ -2107,4 +2107,66 @@ SELECT straight_join t1.vc, t1.ik
 FROM t1 JOIN t1 AS t2 ON t1.vc=t2.vc LEFT JOIN t1 AS t3 ON t1.vc=t3.vc;
 vc	ik
 DROP TABLE t1;
+#
+# Bug#29493830 CONST'IFIED OUTER JOIN RETURN INCORRECT RESULTS
+#
+CREATE TABLE t1 (
+col_int_unique INT DEFAULT NULL,
+col_int_key INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (5,0);
+CREATE TABLE t2 (
+col_char_16_unique char(16) DEFAULT NULL,
+col_int_key INT DEFAULT NULL,
+col_int_unique INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t2 VALUES ("just",21,5);
+CREATE TABLE t3 (
+col_int INT DEFAULT NULL,
+col_char_16_unique CHAR(16) DEFAULT NULL,
+UNIQUE KEY col_char_16_unique (col_char_16_unique)
+) ENGINE=InnoDB;
+INSERT INTO t3 VALUES (9,"foo");
+CREATE TABLE t4 (
+col_int INT DEFAULT NULL,
+col_int_unique INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t4 VALUES (9,5);
+explain SELECT STRAIGHT_JOIN
+t3.col_int, t4.col_int,
+t3.col_int = t4.col_int or t4.col_int IS NULL
+FROM (t1
+LEFT JOIN t2
+ON t1.col_int_key = t2.col_int_key AND
+t1.col_int_unique = t2.col_int_unique
+LEFT JOIN t3
+ON t3.col_char_16_unique = t2.col_char_16_unique
+LEFT JOIN t4
+ON t4.col_int = t3.col_int AND    #Note, this pred term
+t4.col_int_unique = t1.col_int_unique
+) WHERE t1.col_int_unique = 5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	const	col_int_unique	col_int_unique	5	const	1	NULL
+1	SIMPLE	t2	const	col_int_unique	col_int_unique	5	const	1	NULL
+1	SIMPLE	t3	const	col_char_16_unique	NULL	NULL	NULL	1	NULL
+1	SIMPLE	t4	const	col_int_unique	col_int_unique	5	const	1	NULL
+SELECT STRAIGHT_JOIN
+t3.col_int, t4.col_int,
+t3.col_int = t4.col_int or t4.col_int IS NULL
+FROM (t1
+LEFT JOIN t2
+ON t1.col_int_key = t2.col_int_key AND
+t1.col_int_unique = t2.col_int_unique
+LEFT JOIN t3
+ON t3.col_char_16_unique = t2.col_char_16_unique
+LEFT JOIN t4
+ON t4.col_int = t3.col_int AND    #Note, this pred term
+t4.col_int_unique = t1.col_int_unique
+) WHERE t1.col_int_unique = 5;
+col_int	col_int	t3.col_int = t4.col_int or t4.col_int IS NULL
+NULL	NULL	1
+DROP TABLE t1, t2, t3, t4;
 set optimizer_switch=default;

--- a/mysql-test/r/join_outer_bka_nixbnl.result
+++ b/mysql-test/r/join_outer_bka_nixbnl.result
@@ -2105,4 +2105,66 @@ SELECT straight_join t1.vc, t1.ik
 FROM t1 JOIN t1 AS t2 ON t1.vc=t2.vc LEFT JOIN t1 AS t3 ON t1.vc=t3.vc;
 vc	ik
 DROP TABLE t1;
+#
+# Bug#29493830 CONST'IFIED OUTER JOIN RETURN INCORRECT RESULTS
+#
+CREATE TABLE t1 (
+col_int_unique INT DEFAULT NULL,
+col_int_key INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (5,0);
+CREATE TABLE t2 (
+col_char_16_unique char(16) DEFAULT NULL,
+col_int_key INT DEFAULT NULL,
+col_int_unique INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t2 VALUES ("just",21,5);
+CREATE TABLE t3 (
+col_int INT DEFAULT NULL,
+col_char_16_unique CHAR(16) DEFAULT NULL,
+UNIQUE KEY col_char_16_unique (col_char_16_unique)
+) ENGINE=InnoDB;
+INSERT INTO t3 VALUES (9,"foo");
+CREATE TABLE t4 (
+col_int INT DEFAULT NULL,
+col_int_unique INT DEFAULT NULL,
+UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+INSERT INTO t4 VALUES (9,5);
+explain SELECT STRAIGHT_JOIN
+t3.col_int, t4.col_int,
+t3.col_int = t4.col_int or t4.col_int IS NULL
+FROM (t1
+LEFT JOIN t2
+ON t1.col_int_key = t2.col_int_key AND
+t1.col_int_unique = t2.col_int_unique
+LEFT JOIN t3
+ON t3.col_char_16_unique = t2.col_char_16_unique
+LEFT JOIN t4
+ON t4.col_int = t3.col_int AND    #Note, this pred term
+t4.col_int_unique = t1.col_int_unique
+) WHERE t1.col_int_unique = 5;
+id	select_type	table	type	possible_keys	key	key_len	ref	rows	Extra
+1	SIMPLE	t1	const	col_int_unique	col_int_unique	5	const	1	NULL
+1	SIMPLE	t2	const	col_int_unique	col_int_unique	5	const	1	NULL
+1	SIMPLE	t3	const	col_char_16_unique	NULL	NULL	NULL	1	NULL
+1	SIMPLE	t4	const	col_int_unique	col_int_unique	5	const	1	NULL
+SELECT STRAIGHT_JOIN
+t3.col_int, t4.col_int,
+t3.col_int = t4.col_int or t4.col_int IS NULL
+FROM (t1
+LEFT JOIN t2
+ON t1.col_int_key = t2.col_int_key AND
+t1.col_int_unique = t2.col_int_unique
+LEFT JOIN t3
+ON t3.col_char_16_unique = t2.col_char_16_unique
+LEFT JOIN t4
+ON t4.col_int = t3.col_int AND    #Note, this pred term
+t4.col_int_unique = t1.col_int_unique
+) WHERE t1.col_int_unique = 5;
+col_int	col_int	t3.col_int = t4.col_int or t4.col_int IS NULL
+NULL	NULL	1
+DROP TABLE t1, t2, t3, t4;
 set optimizer_switch=default;

--- a/mysql-test/t/join_outer.test
+++ b/mysql-test/t/join_outer.test
@@ -1556,3 +1556,65 @@ eval explain format=json $query;
 eval $query;
 
 DROP TABLE t1;
+
+--echo #
+--echo # Bug#29493830 CONST'IFIED OUTER JOIN RETURN INCORRECT RESULTS
+--echo #
+
+CREATE TABLE t1 (
+  col_int_unique INT DEFAULT NULL,
+  col_int_key INT DEFAULT NULL,
+  UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES (5,0);
+
+CREATE TABLE t2 (
+  col_char_16_unique char(16) DEFAULT NULL,
+  col_int_key INT DEFAULT NULL,
+  col_int_unique INT DEFAULT NULL,
+  UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+
+INSERT INTO t2 VALUES ("just",21,5);
+
+CREATE TABLE t3 (
+  col_int INT DEFAULT NULL,
+  col_char_16_unique CHAR(16) DEFAULT NULL,
+  UNIQUE KEY col_char_16_unique (col_char_16_unique)
+) ENGINE=InnoDB;
+
+INSERT INTO t3 VALUES (9,"foo");
+
+CREATE TABLE t4 (
+  col_int INT DEFAULT NULL,
+  col_int_unique INT DEFAULT NULL,
+  UNIQUE KEY col_int_unique (col_int_unique)
+) ENGINE=InnoDB;
+
+INSERT INTO t4 VALUES (9,5);
+
+# t3 will be marked by the optimizer as 'Impossible ON condition'
+# and const optimized as a NULL row. However the optimizer failed
+# to set 'TABLE::const_table = true'. When later also const optimizing
+# t4, join_read_const_table() failed to evaluate the predicate term
+# 't3.col_int = t4.col_int' on t4. -> incorrect result.
+
+let query = SELECT STRAIGHT_JOIN
+  t3.col_int, t4.col_int,
+  t3.col_int = t4.col_int or t4.col_int IS NULL
+  FROM (t1
+    LEFT JOIN t2
+    ON t1.col_int_key = t2.col_int_key AND
+       t1.col_int_unique = t2.col_int_unique
+    LEFT JOIN t3
+    ON t3.col_char_16_unique = t2.col_char_16_unique
+    LEFT JOIN t4
+    ON t4.col_int = t3.col_int AND    #Note, this pred term
+       t4.col_int_unique = t1.col_int_unique
+ ) WHERE t1.col_int_unique = 5;
+
+eval explain $query;
+eval $query;
+
+DROP TABLE t1, t2, t3, t4;

--- a/sql/sql_optimizer.cc
+++ b/sql/sql_optimizer.cc
@@ -3528,6 +3528,7 @@ const_table_extraction_done:
           {
             s->type= JT_CONST;
             mark_as_null_row(table);
+            table->const_table= 1;
             join->found_const_table_map|= table->map;
 	    join->const_table_map|= table->map;
 	    set_position(join, const_count++, s, NULL);


### PR DESCRIPTION
…in LEFT JOIN condition

Problem
Optimizer is converting ON condition into a multiple equality. When
transforming the condition (table1.id=table2.id AND table2.id=1), it
transformed the query as only (multiple equal(1,'1', table2.id)).

Solution
This has been fixed on 8.0 series already. Partially cherry picked
commit [1] and its test case. Adjusted tests that were failing as result
of imported test case.

[1]:

commit 035fc0f6600253294834482fcad00050db55864c
Author: Ole John Aske <ole.john.aske@oracle.com>
Date:   Wed Mar 20 13:55:26 2019 +0100

    Bug#29493830 CONST'IFIED OUTER JOIN RETURN INCORRECT RESULTS

    When a table is const optimized, any predicate terms on the joins ON-condition
    is also evaluated on the const'ified tables to make sure that the row
    qualifies on the ON-condition.

    The ON-conditions might have been transformed to a 'multiple equality Item',
    represented as a Item_equal object at this point of the optimization process.
    Effectively the ON-condition is evaluated in Item_equal::val_int(), which
    will only check the equality for any Item_field where the fields table
    has been marked as a 'const_table' - comparison of other field values
    are intentionaly skipped.

    It turned out that the optimizer failed to mark a table as a 'const_table'
    when it was handled as a 'impossible ON condition'. In this case the resulting
    row from this table will always be a NULL-extended row.

    This patch set the 'const_table' flag together with setting the
    row as a NULL-row.

    Patch also change some explain output from other test cases.
    These changes are exclusively related to table being
    'Impossible ON-condition' optimized, where the resulting NULL values from
    this row is now const propagated into the rows Field values.
    (Just like any other const-row)