### PR TITLE
PS-7100 Change approach to rows counting in rocksdb_read_free_rpl test

### DIFF
--- a/mysql-test/suite/rocksdb/r/rocksdb_read_free_rpl.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_read_free_rpl.result
@@ -209,9 +209,10 @@ call mtr.add_suppression("Slave SQL.*Could not execute Update_rows event on tabl
 call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
 include/wait_for_slave_sql_error.inc [errno=1032]
 [connection slave]
-select count(*) from t2 force index(primary);
-count(*)
-2
+select id from t2 force index(primary);
+id
+1
+3
 select * from t2 where id=1;
 id	i1	i2	value
 1	1	100	100
@@ -221,15 +222,15 @@ i1
 select i2 from t2 where i2=100;
 i2
 100
-select count(*) from u2 force index(primary);
-count(*)
-1
-select count(*) from u2 force index(i1);
-count(*)
-1
-select count(*) from u2 force index(i2);
-count(*)
-1
+select id from u2 force index(primary);
+id
+3
+select i1 from u2 force index(i1);
+i1
+3
+select i2 from u2 force index(i2);
+i2
+3
 select * from u2 where id=1;
 id	i1	i2	value
 select i1 from u2 where i1=1;
@@ -259,15 +260,17 @@ delete from t3 where id <= 2;
 update t3 set i2=100, value=100 where id=1;
 include/sync_slave_sql_with_master.inc
 [connection slave]
-select count(*) from t3 force index(primary);
-count(*)
-2
-select count(*) from t3 force index(i1);
-count(*)
+select id from t3 force index(primary);
+id
 1
-select count(*) from t3 force index(i2);
-count(*)
-2
+3
+select i1 from t3 force index(i1);
+i1
+3
+select i2 from t3 force index(i2);
+i2
+3
+100
 select * from t3 where id=1;
 id	i1	i2	value
 1	1	100	100
@@ -293,15 +296,19 @@ delete from t4 where id=1;
 include/sync_slave_sql_with_master.inc
 [connection slave]
 [on slave]
-select count(*) from t4 force index(primary);
-count(*)
+select id from t4 force index(primary);
+id
 2
-select count(*) from t4 force index(i1);
-count(*)
+3
+select i1 from t4 force index(i1);
+i1
 2
-select count(*) from t4 force index(i2);
-count(*)
+3
+100
+select i2 from t4 force index(i2);
+i2
 2
+3
 select i1 from t4 where i1=100;
 i1
 100

--- a/mysql-test/suite/rocksdb/t/rocksdb_read_free_rpl.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_read_free_rpl.test
@@ -224,15 +224,15 @@ call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
 
 # query the t2 table on the slave
 --source include/rpl_connection_slave.inc
-select count(*) from t2 force index(primary);
+select id from t2 force index(primary);
 select * from t2 where id=1;
 select i1 from t2 where i1=1;
 select i2 from t2 where i2=100;
 
 # query the u2 table on the slave
-select count(*) from u2 force index(primary);
-select count(*) from u2 force index(i1);
-select count(*) from u2 force index(i2);
+select id from u2 force index(primary);
+select i1 from u2 force index(i1);
+select i2 from u2 force index(i2);
 select * from u2 where id=1;
 select i1 from u2 where i1=1;
 select i2 from u2 where i2=100;
@@ -293,13 +293,13 @@ call mtr.add_suppression("Slave: Can't find record in 'u2'.*");
 
 # query the t2 table on the slave
 --source include/rpl_connection_slave.inc
-select count(*) from t2 force index(primary);
+select id from t2 force index(primary);
 select * from t2 where id=1;
 select i1 from t2 where i1=1;
 select i2 from t2 where i2=100;
 
 # query the u2 table on the slave
-select count(*) from u2 force index(primary);
+select id from u2 force index(primary);
 select * from u2 where id=1;
 select i1 from u2 where i1=1;
 select i2 from u2 where i2=100;
@@ -344,9 +344,9 @@ update t3 set i2=100, value=100 where id=1;
 
 # query the t3 table on the slave
 --source include/rpl_connection_slave.inc
-select count(*) from t3 force index(primary);
-select count(*) from t3 force index(i1);
-select count(*) from t3 force index(i2);
+select id from t3 force index(primary);
+select i1 from t3 force index(i1);
+select i2 from t3 force index(i2);
 select * from t3 where id=1;
 select i1 from t3 where i1=1;
 select i2 from t3 where i2=100;
@@ -376,9 +376,9 @@ delete from t4 where id=1;
 # query the t4 table on the slave
 --source include/rpl_connection_slave.inc
 --echo [on slave]
-select count(*) from t4 force index(primary);
-select count(*) from t4 force index(i1);
-select count(*) from t4 force index(i2);
+select id from t4 force index(primary);
+select i1 from t4 force index(i1);
+select i2 from t4 force index(i2);
 select i1 from t4 where i1=100;
 
 --echo


### PR DESCRIPTION
Using "select count(column_name)" doesn't reveal an issue with
broken index entries when there is an inconsistency between
tables on primary and secondary servers. Use "select column_name"
instead.