### PR TITLE
ENG-164: [PS80] Create minimal tarball

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -293,6 +293,10 @@ fi
     #PS-4854 Percona Server for MySQL tarball without AGPLv3 dependency/license
     find $PRODUCT_FULL -type f -name 'COPYING.AGPLv3' -delete
     $TAR --owner=0 --group=0 -czf "$WORKDIR_ABS/$PRODUCT_FULL.tar.gz" $PRODUCT_FULL
+
+    rm -rf $PRODUCT_FULL/mysql-test 2> /dev/null
+    find $PRODUCT_FULL -type f -exec file '{}' \; | grep ': ELF ' | cut -d':' -f1 | xargs strip --strip-unneeded
+    $TAR --owner=0 --group=0 -czf "$WORKDIR_ABS/$PRODUCT_FULL-minimal.tar.gz" $PRODUCT_FULL
 )
 
 # Clean up


### PR DESCRIPTION
This change creates usual and minimal tarball inside `build_tarball()` function

Size chart:
```
root@ubuntu-20:/mnt/tarball# du -h Percona-Server-8.0.19-10-Linux.x86_64.ssl11.tar.gz
1.3G	Percona-Server-8.0.19-10-Linux.x86_64.ssl11.tar.gz
root@ubuntu-20:/mnt/tarball# du -h Percona-Server-8.0.19-10-Linux.x86_64.ssl11-minimal.tar.gz
95M	Percona-Server-8.0.19-10-Linux.x86_64.ssl11-minimal.tar.gz
```