### PR TITLE
PS-5770 : Message output typo: missing a space on warning

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2134,7 +2134,7 @@ static int log_in_use(const char* log_name)
       if(!strncmp(log_name, linfo->log_file_name, log_name_len))
       {
         thread_count++;
-        sql_print_warning("file %s was not purged because it was being read"
+        sql_print_warning("file %s was not purged because it was being read "
                           "by thread number %llu", log_name,
                           (ulonglong)(*it)->thread_id);
       }


### PR DESCRIPTION
Typo in the output of:
"2019-07-11T18:00:17.795682Z 9 [Warning] file ./carlos-tutte-replication57-replication-1-bin.000011 was not purged because it was being readby thread number 2010 "

Notice there is a space missing between "read" and "by".