### PR TITLE
[PS-7010] Fix crash in BTR_CUR_LATCH_LEAVES

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -397,12 +397,6 @@ btr_cur_latch_leaves(
 
 			SRV_CORRUPT_TABLE_CHECK(get_block, return latch_leaves;);
 
-#ifdef UNIV_BTR_DEBUG
-			ut_a(page_is_comp(get_block->frame)
-			     == page_is_comp(page));
-			ut_a(btr_page_get_next(get_block->frame, mtr)
-			     == page_get_page_no(page));
-#endif /* UNIV_BTR_DEBUG */
 		}
 
 		latch_leaves.savepoints[1] = mtr_set_savepoint(mtr);
@@ -413,6 +407,13 @@ btr_cur_latch_leaves(
 
 		latch_leaves.blocks[1] = get_block;
 #ifdef UNIV_BTR_DEBUG
+		/* Sanity check only after both the blocks are latched. */
+		if (latch_leaves.blocks[0] != NULL) {
+			ut_a(page_is_comp(latch_leaves.blocks[0]->frame)
+			     == page_get_page_no(page));
+			ut_a(btr_page_get_next(latch_leaves.blocks[0]->frame, mtr)
+			     == page_get_page_no(page));
+		}
 		ut_a(page_is_comp(get_block->frame) == page_is_comp(page));
 #endif /* UNIV_BTR_DEBUG */
 		return(latch_leaves);


### PR DESCRIPTION
This is a fix for PS-7010, which is a similar bug to https://bugs.mysql.com/bug.php?id=74596. Like 74596, the problem comes from doing the check before 'page' is latched. This time
in the BTR_MODIFY_PREV/SEARCH_PREV case.  Like the bugfix for 74596 in 777bf2aab05fb58fad7838aed4ef307b50722786, the fix is to move the check below after 'page' is latched. 