### PR TITLE
PS-5978: Handle --numa-interleave flag properly in mysqld_safe script

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -309,7 +309,7 @@ parse_arguments() {
       --syslog-tag=*) syslog_tag="$val" ;;
       --timezone=*) TZ="$val"; export TZ; ;;
       --flush-caches=*) flush_caches="$val" ;;
-
+      --numa-interleave) append_arg_to_args "--innodb-numa-interleave=1" ;;
       --help) usage ;;
 
       *)
@@ -798,11 +798,6 @@ fi
 if test -n "$mysql_tcp_port"
 then
   append_arg_to_args "--port=$mysql_tcp_port"
-fi
-
-if test -n "$numa_interleave"
-then
-  append_arg_to_args "--innodb-numa-interleave=1"
 fi
 
 if test $niceness -eq 0


### PR DESCRIPTION
 Removed unneeded check of variable and moved to top into case() section, in order to prevent flag exposure as mysqld flag(which is incorrect)