### PR TITLE
PS-7119: Tests encryption.innodb_encryption_aborted_rotation* sometime

### DIFF
--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation.result
@@ -82,8 +82,10 @@ SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Now restart the server and select from t1. Validation of t1's flags should proceed.
 # It should be discovered that there is mismatch of flags in t1. However it shoud be possible to use
@@ -104,8 +106,10 @@ COUNT(1)
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Make sure that t1 has been encrypted
 # Now start the server and select from t1. Validation of t1's flags should proceed.

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk.result
@@ -82,8 +82,10 @@ SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Now restart the server and select from t1. Validation of t1's flags should proceed.
 # It should be discovered that there is mismatch of flags in t1. However it shoud be possible to use
@@ -104,8 +106,10 @@ COUNT(1)
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Make sure that t1 has been encrypted
 # Now start the server and select from t1. Validation of t1's flags should proceed.

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_page_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_page_compressed.result
@@ -82,8 +82,10 @@ SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Now restart the server and select from t1. Validation of t1's flags should proceed.
 # It should be discovered that there is mismatch of flags in t1. However it shoud be possible to use
@@ -104,8 +106,10 @@ COUNT(1)
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Make sure that t1 has been encrypted
 # Now start the server and select from t1. Validation of t1's flags should proceed.

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_row_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_mk_row_compressed.result
@@ -82,8 +82,10 @@ SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Now restart the server and select from t1. Validation of t1's flags should proceed.
 # It should be discovered that there is mismatch of flags in t1. However it shoud be possible to use
@@ -104,8 +106,10 @@ COUNT(1)
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Make sure that t1 has been encrypted
 # Now start the server and select from t1. Validation of t1's flags should proceed.

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_page_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_page_compressed.result
@@ -82,8 +82,10 @@ SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Now restart the server and select from t1. Validation of t1's flags should proceed.
 # It should be discovered that there is mismatch of flags in t1. However it shoud be possible to use
@@ -104,8 +106,10 @@ COUNT(1)
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Make sure that t1 has been encrypted
 # Now start the server and select from t1. Validation of t1's flags should proceed.

--- a/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_row_compressed.result
+++ b/mysql-test/suite/encryption/r/innodb_encryption_aborted_rotation_row_compressed.result
@@ -82,8 +82,10 @@ SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SET GLOBAL innodb_encryption_threads = 4;
 # Make sure that t1 has been decrypted
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Now restart the server and select from t1. Validation of t1's flags should proceed.
 # It should be discovered that there is mismatch of flags in t1. However it shoud be possible to use
@@ -104,8 +106,10 @@ COUNT(1)
 SET GLOBAL debug="+d,crash_on_t1_flush_after_dd_update";
 SET GLOBAL innodb_encryption_threads=4;
 # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
-# t1 will be opened without validating idb file to DD.
-# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+# t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+# in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+# to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+# restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
 # Make sure that t1 has been encrypted
 # Now start the server and select from t1. Validation of t1's flags should proceed.

--- a/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation.inc
+++ b/mysql-test/suite/encryption/t/innodb_encryption_aborted_rotation.inc
@@ -255,8 +255,10 @@ if (!$is_t1_compressed)
 }
 
 --echo # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
---echo # t1 will be opened without validating idb file to DD.
---let $restart_parameters=restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+--echo # t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+--echo # in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+--echo # to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+--let $restart_parameters=restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 --source include/start_mysqld.inc
 
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";
@@ -318,8 +320,10 @@ SET GLOBAL innodb_encryption_threads=4;
 --source include/wait_until_disconnected.inc
 
 --echo # First restart the server after crash so any redo logs for t1 were proceed. If there are any logs available
---echo # t1 will be opened without validating idb file to DD.
---let $restart_parameters=restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=0
+--echo # t1 will be opened without validating idb file to DD. We set here innodb-encryption-threads to value > 0 - so
+--echo # in case there is no redo for t1 and validation to DD would occur we would not get an error in the log
+--echo # to set innodb-encryption-threads to value > 0 to finish rotation. We grep for this error later.
+--let $restart_parameters=restart:--innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=1
 --source include/start_mysqld.inc
 
 SET GLOBAL debug="-d,crash_on_t1_flush_after_dd_update";


### PR DESCRIPTION
fail.

This set of tests enforce crash of the server between updating DD with
encryption flag and write to page0 (by encryption threads). Sometimes
the redo record for DD update stays in the redo log and sometimes it
doesn't. In case it doesn't and update to DD is written to disk before
the crash - after the restart mismatch between DD flag and flag in page0
will be visible in the error log. To get rid of this error, the server
is restarted after the crash with innodb-encryption-threads=1.