### PR TITLE
PS-5801: Max value for innodb_default_encryption_key_id differs in

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_default_encryption_key_id_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_default_encryption_key_id_basic.result
@@ -1,3 +1,34 @@
 SELECT @@global.innodb_default_encryption_key_id;
 @@global.innodb_default_encryption_key_id
 0
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=4294967295 --log-error=MYSQL_TMP_DIR/my_restart.err
+# restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=-1 --log-error=MYSQL_TMP_DIR/my_restart.err
+SET innodb_default_encryption_key_id=4294967295;
+ERROR 42000: Variable 'innodb_default_encryption_key_id' can't be set to the value of '4294967295'
+SET innodb_default_encryption_key_id=-1;
+ERROR 42000: Variable 'innodb_default_encryption_key_id' can't be set to the value of '-1'
+SET innodb_default_encryption_key_id=0;
+CREATE TABLE t_exceeded_id (a varchar(255)) ENCRYPTION_KEY_ID=4294967295;
+ERROR HY000: InnoDB system key id cannot have value greater than 4294967294
+CREATE TABLE t_below_0 (a varchar(255)) ENCRYPTION_KEY_ID=-1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-1' at line 1
+CREATE TABLE t_MAX (a varchar(255)) ENCRYPTION_KEY_ID=4294967294;
+CREATE TABLE t_MIN (a varchar(255)) ENCRYPTION_KEY_ID=0;
+ALTER TABLE t_MAX ENCRYPTION_KEY_ID=4294967295;
+ERROR HY000: InnoDB system key id cannot have value greater than 4294967294
+ALTER TABLE t_MIN ENCRYPTION_KEY_ID=-1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-1' at line 1
+CREATE TABLESPACE ts_exceeded_id ENCRYPTION_KEY_ID=4294967295;
+ERROR HY000: InnoDB system key id cannot have value greater than 4294967294
+CREATE TABLESPACE ts_below_0 ENCRYPTION_KEY_ID=-1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-1' at line 1
+CREATE TABLESPACE ts_MAX ENCRYPTION_KEY_ID=4294967294;
+CREATE TABLESPACE ts_MIN ENCRYPTION_KEY_ID=0;
+ALTER TABLESPACE ts_MAX ENCRYPTION_KEY_ID=4294967295;
+ERROR HY000: InnoDB system key id cannot have value greater than 4294967294
+ALTER TABLESPACE ts_MIN ENCRYPTION_KEY_ID=-1;
+ERROR 42000: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '-1' at line 1
+DROP TABLE t_MAX,t_MIN;
+DROP TABLESPACE ts_MAX;
+DROP TABLESPACE ts_MIN;
+# restart

--- a/mysql-test/suite/sys_vars/t/innodb_default_encryption_key_id_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_default_encryption_key_id_basic.test
@@ -1,3 +1,66 @@
---skip Not implemented
-
 SELECT @@global.innodb_default_encryption_key_id;
+
+--let $error_log=$MYSQL_TMP_DIR/my_restart.err
+
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=4294967295 --log-error=$error_log
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+--source include/restart_mysqld.inc
+
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$error_log
+--let SEARCH_PATTERN=\[Server\] option 'innodb-default-encryption-key-id': unsigned value 4294967295 adjusted to 4294967294\.
+--source include/search_pattern_in_file.inc
+
+--let $restart_parameters=restart:--default-table-encryption=ONLINE_TO_KEYRING --innodb-encryption-rotate-key-age=15 --innodb-encryption-threads=4 --innodb-default-encryption-key-id=-1 --log-error=$error_log
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+--source include/restart_mysqld.inc
+
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$error_log
+--let SEARCH_PATTERN=\[Server\] option 'innodb-default-encryption-key-id': value -1 adjusted to 0\.
+--source include/search_pattern_in_file.inc
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET innodb_default_encryption_key_id=4294967295;
+--error ER_WRONG_VALUE_FOR_VAR
+SET innodb_default_encryption_key_id=-1;
+
+SET innodb_default_encryption_key_id=0;
+
+--error ER_ENCRYPTION_KEY_ID_MAX_EXCEEDED
+CREATE TABLE t_exceeded_id (a varchar(255)) ENCRYPTION_KEY_ID=4294967295;
+
+--error ER_PARSE_ERROR
+CREATE TABLE t_below_0 (a varchar(255)) ENCRYPTION_KEY_ID=-1;
+
+CREATE TABLE t_MAX (a varchar(255)) ENCRYPTION_KEY_ID=4294967294;
+CREATE TABLE t_MIN (a varchar(255)) ENCRYPTION_KEY_ID=0;
+
+--error ER_ENCRYPTION_KEY_ID_MAX_EXCEEDED
+ALTER TABLE t_MAX ENCRYPTION_KEY_ID=4294967295;
+--error ER_PARSE_ERROR
+ALTER TABLE t_MIN ENCRYPTION_KEY_ID=-1;
+
+--error ER_ENCRYPTION_KEY_ID_MAX_EXCEEDED
+CREATE TABLESPACE ts_exceeded_id ENCRYPTION_KEY_ID=4294967295;
+
+--error ER_PARSE_ERROR
+CREATE TABLESPACE ts_below_0 ENCRYPTION_KEY_ID=-1;
+
+CREATE TABLESPACE ts_MAX ENCRYPTION_KEY_ID=4294967294;
+CREATE TABLESPACE ts_MIN ENCRYPTION_KEY_ID=0;
+
+--error ER_ENCRYPTION_KEY_ID_MAX_EXCEEDED
+ALTER TABLESPACE ts_MAX ENCRYPTION_KEY_ID=4294967295;
+--error ER_PARSE_ERROR
+ALTER TABLESPACE ts_MIN ENCRYPTION_KEY_ID=-1;
+
+DROP TABLE t_MAX,t_MIN;
+DROP TABLESPACE ts_MAX;
+DROP TABLESPACE ts_MIN;
+
+# restart with default options
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+--remove_file $error_log

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -9409,6 +9409,9 @@ ER_SYSTEM_KEY_ROTATION_MAX_KEY_ID_EXCEEDED
 ER_SYSTEM_KEY_ROTATION_CANT_GENERATE_NEW_VERSION
   eng "Cannot generate new version of system key %lu. Keyring reported an error. Please check if keyring is available."
 
+ER_ENCRYPTION_KEY_ID_MAX_EXCEEDED
+ eng "InnoDB system key id cannot have value greater than 4294967294"
+
 ER_DTE_ENCRYPTION_THREADS_ACTIVE
   eng "In order to change default_table_encryption, disable encryption threads. Please set number of innodb_encryption_threads to 0."
 

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -5621,6 +5621,11 @@ ts_option_encryption:
 ts_option_encryption_key_id:
           ENCRYPTION_KEY_ID_SYM opt_equal real_ulong_num
           {
+            if ($3 > UINT_MAX32 - 1)
+            {
+              my_error(ER_ENCRYPTION_KEY_ID_MAX_EXCEEDED, MYF(0));
+              MYSQL_YYABORT;
+            }
             $$= NEW_PTN PT_alter_tablespace_option_encryption_key_id($3);
           }
         ;
@@ -6187,6 +6192,11 @@ create_table_option:
 	  }
         | ENCRYPTION_KEY_ID_SYM opt_equal real_ulong_num
           {
+            if ($3 > UINT_MAX32 - 1)
+            {
+              my_error(ER_ENCRYPTION_KEY_ID_MAX_EXCEEDED, MYF(0));
+              MYSQL_YYABORT;
+            }
             $$= NEW_PTN PT_create_encryption_key_id_option($3);
           }
         | AUTO_INC opt_equal ulonglong_num

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -870,7 +870,7 @@ static MYSQL_THDVAR_UINT(default_encryption_key_id, PLUGIN_VAR_RQCMDARG,
                          "Default encryption key id used for table encryption.",
                          default_encryption_key_id_validate,
                          default_encryption_key_id_update,
-                         FIL_DEFAULT_ENCRYPTION_KEY, 0, UINT_MAX32, 0);
+                         FIL_DEFAULT_ENCRYPTION_KEY, 0, UINT_MAX32 - 1, 0);
 
 uint get_global_default_encryption_key_id_value() {
   return THDVAR(NULL, default_encryption_key_id);


### PR DESCRIPTION
startup and cli

Restricted value that can be assigned to encryption_key_id to the range
from 0 to UINT_MAX32-1. Value can be assigned via cli, as a startup option
or via ENCRYPTION_KEY_ID.