### PR TITLE
PS-5741: Incorrect use of memset_s in keyring_vault.

### DIFF
--- a/plugin/keyring_vault/vault_base64.cc
+++ b/plugin/keyring_vault/vault_base64.cc
@@ -29,7 +29,7 @@ bool Vault_base64::encode(const void *src, size_t src_len,
   // provide access to underlying  data when they are empty. Calling reserve on
   // those containers does not help.
   if (::base64_encode(src, src_len, base64_encoded_text.get()) != 0) {
-    memset_s(base64_encoded_text.get(), 0, memory_needed, memory_needed);
+    memset_s(base64_encoded_text.get(), memory_needed, 0, memory_needed);
     return true;
   }
   if (format == Format::SINGLE_LINE) {
@@ -41,7 +41,7 @@ bool Vault_base64::encode(const void *src, size_t src_len,
   // base64 encode below returns data with NULL terminating string - which we do
   // not care about
   encoded->assign(base64_encoded_text.get(), memory_needed - 1);
-  memset_s(base64_encoded_text.get(), 0, memory_needed, memory_needed);
+  memset_s(base64_encoded_text.get(), memory_needed, 0, memory_needed);
 
   return false;
 }
@@ -51,7 +51,7 @@ bool Vault_base64::decode(const Secure_string &src, Secure_string *dst) {
   uint64 data_length;
   if (decode(src, &data, &data_length)) return true;
   dst->assign(data, data_length);
-  memset_s(data, 0, data_length, data_length);
+  memset_s(data, data_length, 0, data_length);
   delete[] data;
   return false;
 }
@@ -66,7 +66,7 @@ bool Vault_base64::decode(const Secure_string &src, char **dst,
   int64 decoded_length =
       ::base64_decode(src.c_str(), src.length(), data.get(), NULL, 0);
   if (decoded_length <= 0) {
-    memset_s(data.get(), 0, base64_length_of_memory_needed_for_decode,
+    memset_s(data.get(), base64_length_of_memory_needed_for_decode, 0,
              base64_length_of_memory_needed_for_decode);
     return true;
   }


### PR DESCRIPTION
Fixed the usage of memset_s. The arguments should be:
void memset_s(void *dest, size_t dest_max, int c, size_t n)
where the 2nd argument is size of buffer and the 3rd is
argument is character to fill.