### PR TITLE
PS-5263: no tmpdir space can lead to assert in THD::send_statement_status (5.7)

### DIFF
--- a/mysql-test/r/bug93770.result
+++ b/mysql-test/r/bug93770.result
@@ -1,0 +1,16 @@
+CALL mtr.add_suppression("An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.");
+RESET MASTER;
+CREATE TABLE t1(c1 varchar(8192));
+SET @save.binlog_cache_size = @@global.binlog_cache_size;
+SET @save.binlog_error_action = @@global.binlog_error_action;
+SET GLOBAL binlog_cache_size = 4096;
+SET GLOBAL binlog_error_action = IGNORE_ERROR;
+SET SESSION debug = "+d,simulate_tmpdir_partition_full";
+INSERT INTO t1 VALUES (repeat("a", 8192));
+Warnings:
+Error	3	Error writing file <file_name> (Errcode: 28 - No space left on device)
+Error	1026	Error writing file <file_name> (errno: 28 - No space left on device)
+SET SESSION debug = "-d,simulate_tmpdir_partition_full";
+DROP TABLE t1;
+SET @@global.binlog_cache_size = @save.binlog_cache_size;
+SET @@global.binlog_error_action = @save.binlog_error_action;

--- a/mysql-test/t/bug93770.test
+++ b/mysql-test/t/bug93770.test
@@ -1,0 +1,31 @@
+#
+# Bug 93770: no tmpdir space can cause a DBUG_ASSERT(0) call in send_statement_status
+#
+# https://jira.percona.com/browse/PS-5263
+# https://bugs.mysql.com/bug.php?id=93770
+
+--source include/have_binlog_format_row.inc
+--source include/have_log_bin.inc
+--source include/have_debug.inc
+
+CALL mtr.add_suppression("An error occurred during flush stage of the commit. 'binlog_error_action' is set to 'IGNORE_ERROR'.");
+
+RESET MASTER;
+CREATE TABLE t1(c1 varchar(8192));
+
+SET @save.binlog_cache_size = @@global.binlog_cache_size;
+SET @save.binlog_error_action = @@global.binlog_error_action;
+SET GLOBAL binlog_cache_size = 4096;
+SET GLOBAL binlog_error_action = IGNORE_ERROR;
+
+--connect(con1,localhost,root,,)
+SET SESSION debug = "+d,simulate_tmpdir_partition_full";
+--replace_regex /'.*'/<file_name>/
+INSERT INTO t1 VALUES (repeat("a", 8192));
+SET SESSION debug = "-d,simulate_tmpdir_partition_full";
+DROP TABLE t1;
+--disconnect con1
+
+--connection default
+SET @@global.binlog_cache_size = @save.binlog_cache_size;
+SET @@global.binlog_error_action = @save.binlog_error_action;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -10129,8 +10129,17 @@ void MYSQL_BIN_LOG::handle_binlog_flush_or_sync_error(THD *thd,
       binlog_error_action=IGNORE_ERROR, clear the error
       and allow the commit to happen in storage engine.
     */
-    if (check_write_error(thd))
-      thd->clear_error();
+    if (check_write_error(thd)) { /* we have DA_ERROR */
+      thd->clear_error(); /* sets thd->get_stmt_da()->status() to DA_EMPTY */
+      /* For SQLCOM_COMMIT, ROLLBACK, ROLLBACK TO SAVEPOINT, there is already
+      my_ok() in mysql_execute_command. Doing double my_ok() is not allowed. So
+      we avoid that here */
+      if (thd_sql_command(thd) != SQLCOM_COMMIT &&
+          thd_sql_command(thd) != SQLCOM_ROLLBACK &&
+          thd_sql_command(thd) != SQLCOM_ROLLBACK_TO_SAVEPOINT) {
+        my_ok(thd); /* sets thd->get_stmt_da()->status() to DA_OK */
+      }
+    }
 
     if (need_lock_log)
       mysql_mutex_unlock(&LOCK_log);


### PR DESCRIPTION
1. Update `handle_binlog_flush_or_sync_error()` to set `my_ok(thd)` after `thd->clear_error()`.
2. Add `main.bug93770` test.
