### PR TITLE
PS-7133: keyring_vault unit tests fail on Jenkins.

### DIFF
--- a/unittest/gunit/keyring_vault/vault_io-t.cc
+++ b/unittest/gunit/keyring_vault/vault_io-t.cc
@@ -26,7 +26,7 @@ using ::testing::Return;
 using ::testing::SetArgPointee;
 using ::testing::StrEq;
 
-std::string credential_file_url = "./keyring_vault.conf";
+std::string credential_file_url = "./keyring_vault_vault_io.conf";
 
 class Vault_io_test : public ::testing::Test {
  protected:
@@ -642,7 +642,7 @@ int main(int argc, char **argv) {
 
   keyring::ILogger *logger = new keyring::Mock_logger();
   keyring::Vault_mount vault_mount(curl, logger);
-  std::string mount_point_path = "cicd/" + uuid;
+  std::string mount_point_path = "cicd/" + uuid + "_vault_io";
   if (generate_credential_file(keyring__vault_io_unittest::credential_file_url,
                                CORRECT, mount_point_path)) {
     std::cout << "Could not generate credential file" << std::endl;

--- a/unittest/gunit/keyring_vault/vault_keyring-api-t.cc
+++ b/unittest/gunit/keyring_vault/vault_keyring-api-t.cc
@@ -33,7 +33,7 @@ namespace keyring__api_unittest {
 using ::testing::StrEq;
 using namespace keyring;
 
-std::string credential_file_url = "./keyring_vault.conf";
+std::string credential_file_url = "./keyring_vault_vault_keyring_api.conf";
 
 class Keyring_vault_api_test : public ::testing::Test {
  public:
@@ -533,7 +533,7 @@ int main(int argc, char **argv) {
   // create unique secret mount point for this test suite
   keyring::Vault_mount vault_mount(curl, logger);
 
-  std::string mount_point_path = "cicd/" + uuid;
+  std::string mount_point_path = "cicd/" + uuid + "_vault_keyring_api";
   if (generate_credential_file(keyring__api_unittest::credential_file_url,
                                CORRECT, mount_point_path)) {
     std::cout << "Could not generate credential file" << std::endl;

--- a/unittest/gunit/keyring_vault/vault_keys_container-t.cc
+++ b/unittest/gunit/keyring_vault/vault_keys_container-t.cc
@@ -42,7 +42,8 @@ using ::testing::SetArgPointee;
 using ::testing::StrEq;
 using ::testing::WithArgs;
 
-static std::string credential_file_url = "./keyring_vault.conf";
+static std::string credential_file_url =
+    "./keyring_vault_vault_keys_container.conf";
 
 class Vault_keys_container_test : public ::testing::Test {
  public:
@@ -1214,7 +1215,7 @@ int main(int argc, char **argv) {
 
   keyring::ILogger *logger = new keyring::Mock_logger();
   keyring::Vault_mount vault_mount(curl, logger);
-  std::string mount_point_path = "cicd/" + uuid;
+  std::string mount_point_path = "cicd/" + uuid + "_vault_keys_container";
 
   if (generate_credential_file(
           keyring__vault_keys_container_unittest::credential_file_url, CORRECT,


### PR DESCRIPTION
Keyring Vault unittests started to fail when ctest started to run tests
in parallel. Each vault test suite created a mount point called <<server_uuid>> in
Vault server and created/removed keys in this mount point. When the
vault server test suites started to be executed in parallel all of
sudden they all started to use the same mount point, causing the tests
to fail. I have modified the test suites so each would create a
separate mount point called <<server_uuid_test_suite_name>>. Also the
configuration file generated to connect to Vault server is different per
each test suite.