### PR TITLE
PS-7140: crypt redo logs are not applied correctly

### DIFF
--- a/mysql-test/suite/encryption/r/crypt_data_redo.result
+++ b/mysql-test/suite/encryption/r/crypt_data_redo.result
@@ -1,0 +1,35 @@
+# Make sure that changes to disk will not get
+# applied and stay only in redo.
+set global innodb_page_cleaner_disabled_debug=on;
+create table t1(a varchar(255)) encryption='N';
+insert t1 values (repeat('foobarsecret', 12));
+create table t2(a varchar(255)) encryption='KEYRING';
+insert t2 values (repeat('tempsecret', 12));
+# Kill and restart
+include/assert.inc [Make sure t1 is included in INFORMATION_SCHEMA tablespace with MIN_KEY_VERSION equal to 0]
+include/assert.inc [Make sure t2 is included in INFORMATION_SCHEMA tablespace with MIN_KEY_VERSION equal to 1]
+#cleanup
+DROP TABLE t1,t2;
+# Now check that tablespace encrypted by encryption threads is retrieved correctly from redo log.
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;
+create table t1(a varchar(255));
+insert t1 values (repeat('foobarsecret', 12));
+set global innodb_page_cleaner_disabled_debug=on;
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+# Wait max 10 min for key encryption threads to encrypt all spaces
+# Kill and restart
+include/assert.inc [Encryption threads should be disabled]
+include/assert.inc [Make sure t1 is included in INFORMATION_SCHEMA tablespace with ENCRYPTION_SCHEME equal to 1]
+include/assert.inc [Make sure t1 is included in INFORMATION_SCHEMA tablespace with MIN_KEY_VERSION equal to 1]
+#cleanup
+DROP TABLE t1;
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+# Wait max 10 min for key encryption threads to decrypt all spaces
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;

--- a/mysql-test/suite/encryption/r/innodb_alter_mk_to_rk.result
+++ b/mysql-test/suite/encryption/r/innodb_alter_mk_to_rk.result
@@ -25,7 +25,7 @@ ALTER TABLE t1 encryption='Y';
 SELECT * FROM t1;
 a
 foobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecretfoobarsecret
-include/assert.inc [Table t1 has been re_encrypted to Master key encryption - should disappear from INNODB_TABLESPACES_ENCRYPTION => thus only t2 should remain]
+include/assert.inc [Table t1 has been re_encrypted to Master key encryption - should disappear from INNODB_TABLESPACES_ENCRYPTION]
 # 4. Alter from MK to unencrypted
 ALTER TABLE t1 encryption='n';
 include/assert.inc [t1 should be marked as unencrypted in INNODB_TABLESPACES_ENCRYPTION]

--- a/mysql-test/suite/encryption/t/crypt_data_redo-master.opt
+++ b/mysql-test/suite/encryption/t/crypt_data_redo-master.opt
@@ -1,0 +1,3 @@
+$KEYRING_PLUGIN_OPT
+--early-plugin-load="keyring_file=$KEYRING_PLUGIN"
+--loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring

--- a/mysql-test/suite/encryption/t/crypt_data_redo.test
+++ b/mysql-test/suite/encryption/t/crypt_data_redo.test
@@ -1,0 +1,117 @@
+--source include/have_debug.inc
+
+# PS-7140: crypt redo logs are not applied correctly
+
+--let $MYSQLD_DATADIR=`select @@datadir`
+--let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd
+--let t2_IBD = $MYSQLD_DATADIR/test/t2.ibd
+--let t3_IBD = $MYSQLD_DATADIR/test/t3.ibd
+
+--echo # Make sure that changes to disk will not get
+--echo # applied and stay only in redo.
+set global innodb_page_cleaner_disabled_debug=on;
+create table t1(a varchar(255)) encryption='N';
+insert t1 values (repeat('foobarsecret', 12));
+create table t2(a varchar(255)) encryption='KEYRING';
+insert t2 values (repeat('tempsecret', 12));
+
+--source include/kill_and_restart_mysqld.inc
+
+--let $assert_text= Make sure t1 is included in INFORMATION_SCHEMA tablespace with MIN_KEY_VERSION equal to 0
+--let $assert_cond= "[SELECT MIN_KEY_VERSION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t1\\']" = 0
+--source include/assert.inc
+
+--let $assert_text= Make sure t2 is included in INFORMATION_SCHEMA tablespace with MIN_KEY_VERSION equal to 1
+--let $assert_cond= "[SELECT MIN_KEY_VERSION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t2\\']" = 1
+--source include/assert.inc
+
+--let SEARCH_PATTERN=PSC
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+--let SEARCH_FILE=$t2_IBD
+--source include/search_pattern_in_file.inc
+
+--let SEARCH_PATTERN=foobarsecret
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=tempsecret
+--let ABORT_ON=FOUND
+--let SEARCH_FILE=$t2_IBD
+--source include/search_pattern_in_file.inc
+
+--echo #cleanup
+DROP TABLE t1,t2;
+
+--echo # Now check that tablespace encrypted by encryption threads is retrieved correctly from redo log.
+
+#--let $MYSQLD_DATADIR=`select @@datadir`
+#--let t1_IBD = $MYSQLD_DATADIR/test/t1.ibd
+
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+
+#We do not encrypt temporary tablespace
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;
+
+create table t1(a varchar(255));
+insert t1 values (repeat('foobarsecret', 12));
+
+set global innodb_page_cleaner_disabled_debug=on;
+
+SET GLOBAL default_table_encryption=ONLINE_TO_KEYRING;
+SET GLOBAL innodb_encryption_threads=4;
+
+--let tables_count=`select count(*) from INFORMATION_SCHEMA.INNODB_TABLESPACES`
+--echo # Wait max 10 min for key encryption threads to encrypt all spaces
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = $tables_count - 1 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+--source include/kill_and_restart_mysqld.inc
+
+--let $assert_text= Encryption threads should be disabled
+--let $assert_cond= "[SELECT @@innodb_encryption_threads]" = 0
+--source include/assert.inc
+
+--let $assert_text= Make sure t1 is included in INFORMATION_SCHEMA tablespace with ENCRYPTION_SCHEME equal to 1
+--let $assert_cond= "[SELECT ENCRYPTION_SCHEME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t1\\']" = 1
+--source include/assert.inc
+
+--let $assert_text= Make sure t1 is included in INFORMATION_SCHEMA tablespace with MIN_KEY_VERSION equal to 1
+--let $assert_cond= "[SELECT MIN_KEY_VERSION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE name=\\'test/t1\\']" = 1
+--source include/assert.inc
+
+--let SEARCH_PATTERN=PSC
+--let ABORT_ON=NOT_FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+--let SEARCH_PATTERN=foobarsecret
+--let ABORT_ON=FOUND
+--let SEARCH_FILE=$t1_IBD
+--source include/search_pattern_in_file.inc
+
+--echo #cleanup
+DROP TABLE t1;
+
+SET GLOBAL default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+SET GLOBAL innodb_encryption_threads=4;
+
+--echo # Wait max 10 min for key encryption threads to decrypt all spaces
+--let $wait_timeout= 600
+--let $wait_condition=SELECT COUNT(*) = 0 FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 1
+--source include/wait_condition.inc
+
+SET GLOBAL innodb_encryption_threads=0;
+SET GLOBAL default_table_encryption=OFF;
+
+

--- a/mysql-test/suite/encryption/t/innodb_alter_mk_to_rk.test
+++ b/mysql-test/suite/encryption/t/innodb_alter_mk_to_rk.test
@@ -40,18 +40,18 @@ SELECT * FROM t2;
 ALTER TABLE t1 encryption='Y';
 SELECT * FROM t1;
 
---let $assert_text= Table t1 has been re_encrypted to Master key encryption - should disappear from INNODB_TABLESPACES_ENCRYPTION => thus only t2 should remain
---let $assert_cond= "[SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION]" = "test/t2"
+--let $assert_text= Table t1 has been re_encrypted to Master key encryption - should disappear from INNODB_TABLESPACES_ENCRYPTION
+--let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE NAME = \\"test/t1\\"]" = 0
 --source include/assert.inc
 
 --echo # 4. Alter from MK to unencrypted
 ALTER TABLE t1 encryption='n';
 
 --let $assert_text= t1 should be marked as unencrypted in INNODB_TABLESPACES_ENCRYPTION
---let $assert_cond= "[SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0]" = "test/t1"
+--let $assert_cond= "[SELECT MIN_KEY_VERSION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE NAME = \\"test/t1\\"]" = 0
 --source include/assert.inc
 --let $assert_text= t2 should be marked as encrypted in INNODB_TABLESPACES_ENCRYPTION
---let $assert_cond= "[SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION <> 0]" = "test/t2"
+--let $assert_cond= "[SELECT MIN_KEY_VERSION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE NAME = \\"test/t2\\"]" <> 0
 
 --echo # 5. Alter from unencrypted to RK
 ALTER TABLE t1 encryption='KEYRING';

--- a/mysql-test/suite/encryption/t/innodb_alters.test
+++ b/mysql-test/suite/encryption/t/innodb_alters.test
@@ -57,10 +57,8 @@ ALTER TABLE t1 encryption='n';
 SHOW CREATE TABLE t1;
 
 --let $assert_text= t1 should be marked as unencrypted in INNODB_TABLESPACES_ENCRYPTION
---let $assert_cond= "[SELECT NAME FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE MIN_KEY_VERSION = 0]" = "test/t1"
+--let $assert_cond= "[SELECT MIN_KEY_VERSION FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE NAME = \\"test/t1\\"]" = 0
 --source include/assert.inc
---let $assert_text= t1 should be only table from test database in INNODB_TABLESPACES_ENCRYPTION
---let $assert_cond= "[SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_TABLESPACES_ENCRYPTION WHERE NAME LIKE \\"test/%\\"]" = 1
 
 --echo # 5. Alter from unencrypted to KEYRING
 ALTER TABLE t1 ENCRYPTION='KEYRING';

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -1137,8 +1137,7 @@ bool fsp_header_init(space_id_t space_id, page_no_t size, mtr_t *mtr,
     if (space->crypt_data) {
       space->crypt_data->write_page0(
           space, page, mtr, space->crypt_data->min_key_version,
-          space->crypt_data->max_key_version, space->crypt_data->type,
-          space->crypt_data->encryption_rotation);
+          space->crypt_data->max_key_version, space->crypt_data->type);
     }
   }
 

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -519,9 +519,11 @@ byte *fil_parse_write_crypt_data_v2(space_id_t space_id, byte *ptr,
 @param[in]  ptr  Log entry start
 @param[in]  end_ptr  Log entry end
 @param[in]  len  Log entry length
+@param[in]  recv_needed_recovery  Missing keys will report an error
 @return position on log buffer */
 byte *fil_parse_write_crypt_data_v3(space_id_t space_id, byte *ptr,
-                                    const byte *end_ptr, ulint len)
+                                    const byte *end_ptr, ulint len,
+                                    bool recv_needed_recovery)
     MY_ATTRIBUTE((warn_unused_result));
 
 /**

--- a/storage/innobase/include/fil0crypt.h
+++ b/storage/innobase/include/fil0crypt.h
@@ -89,8 +89,8 @@ extern os_event_t fil_crypt_threads_event;
 
 /* Cached L or key for given key_version */
 struct key_struct {
-  uint key_version;                      /*!< Version of the key */
-  uint key_length;                       /*!< Key length */
+  uint key_version;                       /*!< Version of the key */
+  uint key_length;                        /*!< Key length */
   unsigned char key[Encryption::KEY_LEN]; /*!< Cached key
                                           (that is L in CRYPT_SCHEME_1) */
 };
@@ -169,9 +169,7 @@ struct fil_space_crypt_t {
   has been zero-initialized. */
   fil_space_crypt_t(uint new_min_key_version, uint new_key_id, const char *uuid,
                     fil_encryption_t new_encryption,
-                    Crypt_key_operation key_operation,
-                    Encryption_rotation encryption_rotation =
-                        Encryption_rotation::NO_ROTATION);
+                    Crypt_key_operation key_operation);
 
   /** Destructor */
   ~fil_space_crypt_t() {
@@ -221,11 +219,9 @@ struct fil_space_crypt_t {
   @param[in,out]	mtr	mini-transaction
   @param[in]	        a_min_key_verion min key version used in encryption
   @param[in]            a_max_key_verion max key version used in encryption
-  @param[in]            a_type encryption type
-  @param[in]            current_encryption_rotation - encryption rotation */
+  @param[in]            a_type encryption type */
   void write_page0(const fil_space_t *space, byte *page0, mtr_t *mtr,
-                   uint a_min_key_version, uint a_max_key_version, uint a_type,
-                   Encryption_rotation current_encryption_rotation);
+                   uint a_min_key_version, uint a_max_key_version, uint a_type);
 
   void set_tablespace_key(const uchar *tablespace_key) {
     if (tablespace_key == NULL) {

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -2026,10 +2026,9 @@ byte *fil_tablespace_redo_rename(byte *ptr, const byte *end,
 @param[in]	ptr		redo log record
 @param[in]	end		end of the redo log buffer
 @param[in]	space_id	the tablespace ID
-@param[in]	apply		whether to apply the record
 @return log record end, nullptr if not a complete record */
 byte *fil_tablespace_redo_encryption(byte *ptr, const byte *end,
-                                     space_id_t space_id, bool apply)
+                                     space_id_t space_id)
     MY_ATTRIBUTE((warn_unused_result));
 
 /** Read the tablespace id to path mapping from the file

--- a/storage/innobase/include/os0enc.h
+++ b/storage/innobase/include/os0enc.h
@@ -50,7 +50,15 @@ extern ulint os_io_ptr_align;
 
 enum class Encryption_rotation : std::uint8_t {
   NO_ROTATION,
-  MASTER_KEY_TO_KEYRING
+  /** For Master Key encrypted pages use the tablespace key to read.
+   * Use the crypt_data's key when writing (encrypting). */
+  MASTER_KEY_TO_KEYRING,
+  /** Encrypt all the pages that go through I/O level */
+  ENCRYPTING,
+  /** Do not encrypt pages that go through I/O level.
+   * When encryption threads decrypt pages, they just pass I/O level
+   * unencrypted (the encryption is disabled). */
+  DECRYPTING
 };
 
 /** Encryption algorithm. */

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -376,7 +376,7 @@ bool log_parse_buffer::parse_next_record(mlog_id_t *type, space_id_t *space,
   of a live database should not be corrupt. */
   const auto len = recv_parse_log_rec(type, const_cast<byte *>(&*ccurrent()),
                                       const_cast<byte *>(&*cend()), space,
-                                      page_no, false, &body);
+                                      page_no, true, &body);
   if (len > 0) {
     if (advance(len)) {
       ut_ad(len >= 3 || !log_online_rec_has_page(*type));
@@ -639,8 +639,8 @@ static bool log_online_read_bitmap_page(
   IORequest io_request(IORequest::LOG | IORequest::READ |
                        IORequest::NO_ENCRYPTION);
   const bool success =
-      os_file_read(io_request, bitmap_file->name, bitmap_file->file, page, bitmap_file->offset,
-                   MODIFIED_PAGE_BLOCK_SIZE);
+      os_file_read(io_request, bitmap_file->name, bitmap_file->file, page,
+                   bitmap_file->offset, MODIFIED_PAGE_BLOCK_SIZE);
 
   if (UNIV_UNLIKELY(!success)) {
     /* The following call prints an error message */

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -1648,7 +1648,8 @@ static byte *recv_parse_or_apply_log_rec_body(
           } else if (memcmp(ptr_copy, Encryption::KEY_MAGIC_PS_V3,
                             Encryption::MAGIC_SIZE) == 0 &&
                      !recv_sys->apply_log_recs) {
-            return (fil_parse_write_crypt_data_v3(space_id, ptr, end_ptr, len));
+            return (fil_parse_write_crypt_data_v3(space_id, ptr, end_ptr, len,
+                                                  recv_needed_recovery));
           }
         }
         break;

--- a/storage/innobase/log/log0recv.cc
+++ b/storage/innobase/log/log0recv.cc
@@ -145,6 +145,7 @@ void meb_print_page_header(const page_t *page) {
 #ifndef UNIV_HOTBACKUP
 PSI_memory_key mem_log_recv_page_hash_key;
 PSI_memory_key mem_log_recv_space_hash_key;
+PSI_memory_key mem_log_recv_crypt_data_hash_key;
 #endif /* !UNIV_HOTBACKUP */
 
 /** true when recv_init_crash_recovery() has been called. */
@@ -267,13 +268,10 @@ the metadata locally
 @param[in]	version	table dynamic metadata version
 @param[in]	ptr	redo log start
 @param[in]	end	end of redo log
-@param[in]      apply   if false, this is coming from changed page
-                        tracking and changes should be parsed only
 @retval ptr to next redo log record, nullptr if this log record
 was truncated */
 byte *MetadataRecover::parseMetadataLog(table_id_t id, uint64_t version,
-                                        byte *ptr, byte *end, bool apply) {
-  ut_ad(!(read_only && apply));
+                                        byte *ptr, byte *end) {
   if (ptr + 2 > end) {
     /* At least we should get type byte and another one byte
     for data, if not, it's an incomplete log */
@@ -623,6 +621,9 @@ void recv_sys_init(ulint max_mem) {
 
   recv_sys->metadata_recover = UT_NEW_NOKEY(MetadataRecover(false));
 
+  using CryptDatas = recv_sys_t::CryptDatas;
+  recv_sys->crypt_datas = UT_NEW(CryptDatas(), mem_log_recv_space_hash_key);
+
   mutex_exit(&recv_sys->mutex);
 }
 
@@ -789,6 +790,13 @@ void recv_sys_free() {
     UT_DELETE(recv_sys->keys);
     recv_sys->keys = nullptr;
   }
+
+  for (auto &crypt_data : *recv_sys->crypt_datas) {
+    UT_DELETE(crypt_data.second);
+  }
+
+  UT_DELETE(recv_sys->crypt_datas);
+  recv_sys->crypt_datas = nullptr;
 
   mutex_exit(&recv_sys->mutex);
 }
@@ -1527,7 +1535,6 @@ specified.
 @param[in]	end_ptr		end of buffer
 @param[in]	space_id	tablespace identifier
 @param[in]	page_no		page number
-@param[in]	apply		Whether to apply the record
 @param[in,out]	block		buffer block, or nullptr if
                                 a page log record should not be applied
                                 or if it is a MLOG_FILE_ operation
@@ -1535,12 +1542,9 @@ specified.
                                 a page log record should not be applied
 @param[in]	parsed_bytes	Number of bytes parsed so far
 @return log record end, nullptr if not a complete record */
-static byte *recv_parse_or_apply_log_rec_body(mlog_id_t type, byte *ptr,
-                                              byte *end_ptr,
-                                              space_id_t space_id,
-                                              page_no_t page_no, bool apply,
-                                              buf_block_t *block, mtr_t *mtr,
-                                              ulint parsed_bytes) {
+static byte *recv_parse_or_apply_log_rec_body(
+    mlog_id_t type, byte *ptr, byte *end_ptr, space_id_t space_id,
+    page_no_t page_no, buf_block_t *block, mtr_t *mtr, ulint parsed_bytes) {
   bool applying_redo = (block != nullptr);
 
   switch (type) {
@@ -1632,19 +1636,18 @@ static byte *recv_parse_or_apply_log_rec_body(mlog_id_t type, byte *ptr,
             if (fsp_is_system_or_temp_tablespace(space_id)) {
               break;
             }
-            return (
-                fil_tablespace_redo_encryption(ptr, end_ptr, space_id, apply));
+            return (fil_tablespace_redo_encryption(ptr, end_ptr, space_id));
           } else if (memcmp(ptr_copy, Encryption::KEY_MAGIC_PS_V1,
                             Encryption::MAGIC_SIZE) == 0 &&
-                     apply) {
+                     !recv_sys->apply_log_recs) {
             return (fil_parse_write_crypt_data_v1(space_id, ptr, end_ptr, len));
           } else if (memcmp(ptr_copy, Encryption::KEY_MAGIC_PS_V2,
                             Encryption::MAGIC_SIZE) == 0 &&
-                     apply) {
+                     !recv_sys->apply_log_recs) {
             return (fil_parse_write_crypt_data_v2(space_id, ptr, end_ptr, len));
           } else if (memcmp(ptr_copy, Encryption::KEY_MAGIC_PS_V3,
                             Encryption::MAGIC_SIZE) == 0 &&
-                     apply) {
+                     !recv_sys->apply_log_recs) {
             return (fil_parse_write_crypt_data_v3(space_id, ptr, end_ptr, len));
           }
         }
@@ -2537,7 +2540,7 @@ void recv_recover_page_func(
 
       recv_parse_or_apply_log_rec_body(recv->type, buf, buf + recv->len,
                                        recv_addr->space, recv_addr->page_no,
-                                       true, block, &mtr, ULINT_UNDEFINED);
+                                       block, &mtr, ULINT_UNDEFINED);
 
       end_lsn = recv->start_lsn + recv->len;
 
@@ -2608,12 +2611,12 @@ void recv_recover_page_func(
 @param[in]	end_ptr		end of the buffer
 @param[out]	space_id	tablespace identifier
 @param[out]	page_no		page number
-@param[in]	apply		whether to apply the record
+@param[in]	online_log	do we process DDL online log
 @param[out]	body		start of log record body
 @return length of the record, or 0 if the record was not complete */
 ulint recv_parse_log_rec(mlog_id_t *type, byte *ptr, byte *end_ptr,
-                         space_id_t *space_id, page_no_t *page_no, bool apply,
-                         byte **body) {
+                         space_id_t *space_id, page_no_t *page_no,
+                         bool online_log, byte **body) {
   byte *new_ptr;
 
   *body = nullptr;
@@ -2670,9 +2673,9 @@ ulint recv_parse_log_rec(mlog_id_t *type, byte *ptr, byte *end_ptr,
           mlog_parse_initial_dict_log_record(ptr, end_ptr, type, &id, &version);
 
       if (new_ptr != nullptr) {
-        new_ptr =
-            (apply ? recv_sys->metadata_recover : log_online_metadata_recover)
-                ->parseMetadataLog(id, version, new_ptr, end_ptr, apply);
+        new_ptr = (online_log ? log_online_metadata_recover
+                              : recv_sys->metadata_recover)
+                      ->parseMetadataLog(id, version, new_ptr, end_ptr);
       }
 
       return (new_ptr == nullptr ? 0 : new_ptr - ptr);
@@ -2688,7 +2691,7 @@ ulint recv_parse_log_rec(mlog_id_t *type, byte *ptr, byte *end_ptr,
   }
 
   new_ptr = recv_parse_or_apply_log_rec_body(*type, new_ptr, end_ptr, *space_id,
-                                             *page_no, apply, nullptr, nullptr,
+                                             *page_no, nullptr, nullptr,
                                              new_ptr - ptr);
 
   if (new_ptr == nullptr) {
@@ -2770,8 +2773,8 @@ static bool recv_single_rec(byte *ptr, byte *end_ptr) {
   page_no_t page_no;
   space_id_t space_id;
 
-  ulint len =
-      recv_parse_log_rec(&type, ptr, end_ptr, &space_id, &page_no, true, &body);
+  ulint len = recv_parse_log_rec(&type, ptr, end_ptr, &space_id, &page_no,
+                                 false, &body);
 
   if (recv_sys->found_corrupt_log) {
     recv_report_corrupt_log(ptr, type, space_id, page_no);
@@ -2880,7 +2883,7 @@ static bool recv_multi_rec(byte *ptr, byte *end_ptr) {
     space_id_t space_id = 0;
 
     ulint len = recv_parse_log_rec(&type, ptr, end_ptr, &space_id, &page_no,
-                                   true, &body);
+                                   false, &body);
 
     if (recv_sys->found_corrupt_log) {
       recv_report_corrupt_log(ptr, type, space_id, page_no);
@@ -2951,7 +2954,7 @@ static bool recv_multi_rec(byte *ptr, byte *end_ptr) {
     space_id_t space_id = 0;
 
     ulint len = recv_parse_log_rec(&type, ptr, end_ptr, &space_id, &page_no,
-                                   true, &body);
+                                   false, &body);
 
     if (recv_sys->found_corrupt_log &&
         !recv_report_corrupt_log(ptr, type, space_id, page_no)) {
@@ -3774,7 +3777,6 @@ dberr_t recv_recovery_from_checkpoint_start(log_t &log, lsn_t flush_lsn) {
   lsn_t recovered_lsn;
 
   recovered_lsn = recv_sys->recovered_lsn;
-
 
   ut_a(recv_needed_recovery || checkpoint_lsn == recovered_lsn);
 


### PR DESCRIPTION
In 5.7 redo log applier (log0recv.cc) would go though all the redo logs
twice. First with apply variable set to false and the second time with
apply variable set to true. The first pass was to parse MLOG_FILE_*
family of redo log records (and MLOG_WRITE_STRING). On this first pass
necessary updates to in-memory structures were made, but no actual
changes were made to the underlying table's pages. In 8.0 upstream
decided to abandon apply variable and now goes twice though the redo
logs. In case of redoing Master Key encryption, in 5.7 log0recv would go
twice through the redo logs (encryption info is written as
MLOG_WRITE_STRING) - first time setting all necessary keys in memory and
the second time applying changes to page0. It was similar with
crypt_data - the first pass would create the crypt_data in-memory and
associate it with space (in case it would exists) and the second pass
would apply changes to page0. The problem was that apply was never set
properly - it was always true and for true it would create in memory
crypt_data only. The fix was to create in memory crypt_data only when
apply is equal to false and also to go through redo logs first with
apply == false and the second time with apply == true. The crypt_data
applied to page0 by redo will be read during opening a tablespace for
recovery (after it was created) and thus crypt_data will get assigned to
tablespace.