### PR TITLE
Fixed PS-7019 (Wrong query results for LEFT JOIN with GROUP BY since …

### DIFF
--- a/mysql-test/r/join.result
+++ b/mysql-test/r/join.result
@@ -2032,3 +2032,15 @@ a
 drop table t;
 set optimizer_switch=default;
 set global default_storage_engine=myisam;
+#
+BUG #99398 / PS-7019: Wrong query results for LEFT JOIN with GROUP BY since 8.0.20
+#
+CREATE TABLE t1 (t1_id INT PRIMARY KEY AUTO_INCREMENT, t2_id INT DEFAULT NULL);
+CREATE TABLE t2 (t2_id INT PRIMARY KEY AUTO_INCREMENT, is_active TINYINT NOT NULL DEFAULT '1');
+INSERT INTO t2 VALUES (2,1),(3,0),(1000,1);
+INSERT INTO t1 VALUES (1,1000),(2,5);
+SELECT t1.t1_id,t1.t2_id,t2.t2_id FROM t1 LEFT JOIN t2 ON (t1.t2_id = t2.t2_id AND t2.is_active=1) GROUP BY t1_id ORDER BY t1_id LIMIT 2;
+t1_id	t2_id	t2_id
+1	1000	1000
+2	5	NULL
+DROP TABLE t1,t2;

--- a/mysql-test/t/join.test
+++ b/mysql-test/t/join.test
@@ -1411,3 +1411,12 @@ drop table t;
 set optimizer_switch=default;
 
 set global default_storage_engine=myisam;
+--echo #
+--echo BUG #99398 / PS-7019: Wrong query results for LEFT JOIN with GROUP BY since 8.0.20
+--echo #
+CREATE TABLE t1 (t1_id INT PRIMARY KEY AUTO_INCREMENT, t2_id INT DEFAULT NULL);
+CREATE TABLE t2 (t2_id INT PRIMARY KEY AUTO_INCREMENT, is_active TINYINT NOT NULL DEFAULT '1');
+INSERT INTO t2 VALUES (2,1),(3,0),(1000,1);
+INSERT INTO t1 VALUES (1,1000),(2,5);
+SELECT t1.t1_id,t1.t2_id,t2.t2_id FROM t1 LEFT JOIN t2 ON (t1.t2_id = t2.t2_id AND t2.is_active=1) GROUP BY t1_id ORDER BY t1_id LIMIT 2;
+DROP TABLE t1,t2;

--- a/sql/field_conv.cc
+++ b/sql/field_conv.cc
@@ -600,7 +600,7 @@ Copy_field::Copy_field(MEM_ROOT *mem_root, Item_field *item) : Copy_field() {
   m_from_field = item->field->new_field(mem_root, item->field->table);
   if (m_from_field == nullptr) return;
 
-  if (m_from_field->is_nullable()) {
+  if (m_from_field->is_nullable() || m_from_field->table->is_nullable()) {
     // We need to allocate one extra byte for null handling.
     uchar *ptr = mem_root->ArrayAlloc<uchar>(m_from_field->pack_length() + 1);
     m_to_field =


### PR DESCRIPTION
…8.0.20)

https://jira.percona.com/browse/PS-7019

From https://bugs.mysql.com/bug.php?id=99398:
Refactoring work done in MySQL 8.0.20 caused single-row
buffering for GROUP BY of non-nullable columns not to function
correctly, not taking into account that such a column could be
the inner table for an outer join, and thus would have a NULL
flag that would need to be copied. In a GROUP BY without a
temporary table, this would cause the NULL flag to come from the
next output row instead of the previous one, and data returned
to be inconsistent.