### PR TITLE
Fix PS-7161 (CreateTempFile gunit test fails)

### DIFF
--- a/unittest/gunit/mysys_pathfuncs-t.cc
+++ b/unittest/gunit/mysys_pathfuncs-t.cc
@@ -152,7 +152,7 @@ TEST(Mysys, CreateTempFile) {
   File fileno = create_temp_file(dst, "/tmp", prefix, 42, UNLINK_FILE, 0);
   EXPECT_GE(fileno, 0);
   my_close(fileno, 0);
-  EXPECT_THAT(dst, MatchesRegex("/tmp/[a]+[a-z0-9]+"));
+  EXPECT_THAT(dst, MatchesRegex("/tmp/[a]+(fd=[0-9]+|[a-zA-Z0-9]+)"));
   aset(dst, 0xaa);
 
   char *env_tmpdir = getenv("TMPDIR");


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7161

Fixed 'CreateTempFile' gunit test to support both 'HAVE_O_TMPFILE'-style
('fd=nnn') and legacy temp file name format.