### PR TITLE
PS-7132 : Make default value of rocksdb_wal_recovery_mode compatible …

### DIFF
--- a/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_wal_recovery_mode_basic.result
+++ b/mysql-test/suite/rocksdb.sys_vars/r/rocksdb_wal_recovery_mode_basic.result
@@ -6,7 +6,7 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 SET @start_global_value = @@global.ROCKSDB_WAL_RECOVERY_MODE;
 SELECT @start_global_value;
 @start_global_value
-1
+2
 '# Setting to valid values in global scope#'
 "Trying to set variable @@global.ROCKSDB_WAL_RECOVERY_MODE to 1"
 SET @@global.ROCKSDB_WAL_RECOVERY_MODE   = 1;
@@ -17,7 +17,7 @@ SELECT @@global.ROCKSDB_WAL_RECOVERY_MODE;
 SET @@global.ROCKSDB_WAL_RECOVERY_MODE = DEFAULT;
 SELECT @@global.ROCKSDB_WAL_RECOVERY_MODE;
 @@global.ROCKSDB_WAL_RECOVERY_MODE
-1
+2
 "Trying to set variable @@global.ROCKSDB_WAL_RECOVERY_MODE to 0"
 SET @@global.ROCKSDB_WAL_RECOVERY_MODE   = 0;
 SELECT @@global.ROCKSDB_WAL_RECOVERY_MODE;
@@ -27,7 +27,7 @@ SELECT @@global.ROCKSDB_WAL_RECOVERY_MODE;
 SET @@global.ROCKSDB_WAL_RECOVERY_MODE = DEFAULT;
 SELECT @@global.ROCKSDB_WAL_RECOVERY_MODE;
 @@global.ROCKSDB_WAL_RECOVERY_MODE
-1
+2
 "Trying to set variable @@session.ROCKSDB_WAL_RECOVERY_MODE to 444. It should fail because it is not session."
 SET @@session.ROCKSDB_WAL_RECOVERY_MODE   = 444;
 ERROR HY000: Variable 'rocksdb_wal_recovery_mode' is a GLOBAL variable and should be set with SET GLOBAL
@@ -37,10 +37,10 @@ SET @@global.ROCKSDB_WAL_RECOVERY_MODE   = 'aaa';
 Got one of the listed errors
 SELECT @@global.ROCKSDB_WAL_RECOVERY_MODE;
 @@global.ROCKSDB_WAL_RECOVERY_MODE
-1
+2
 SET @@global.ROCKSDB_WAL_RECOVERY_MODE = @start_global_value;
 SELECT @@global.ROCKSDB_WAL_RECOVERY_MODE;
 @@global.ROCKSDB_WAL_RECOVERY_MODE
-1
+2
 DROP TABLE valid_values;
 DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb/r-native-partitioning/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r-native-partitioning/rocksdb.result
@@ -1011,7 +1011,7 @@ rocksdb_validate_tables	1
 rocksdb_verify_row_debug_checksums	OFF
 rocksdb_wal_bytes_per_sync	0
 rocksdb_wal_dir	
-rocksdb_wal_recovery_mode	1
+rocksdb_wal_recovery_mode	2
 rocksdb_wal_size_limit_mb	0
 rocksdb_wal_ttl_seconds	0
 rocksdb_whole_key_filtering	ON

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -1013,7 +1013,7 @@ rocksdb_validate_tables	1
 rocksdb_verify_row_debug_checksums	OFF
 rocksdb_wal_bytes_per_sync	0
 rocksdb_wal_dir	
-rocksdb_wal_recovery_mode	1
+rocksdb_wal_recovery_mode	2
 rocksdb_wal_size_limit_mb	0
 rocksdb_wal_ttl_seconds	0
 rocksdb_whole_key_filtering	ON

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -466,7 +466,7 @@ static uint32_t rocksdb_force_compute_memtable_stats_cachetime =
     RDB_DEFAULT_FORCE_COMPUTE_MEMTABLE_STATS_CACHETIME;
 static my_bool rocksdb_debug_optimizer_no_zero_cardinality = TRUE;
 static uint32_t rocksdb_wal_recovery_mode =
-    static_cast<uint32_t>(rocksdb::WALRecoveryMode::kAbsoluteConsistency);
+    static_cast<uint32_t>(rocksdb::WALRecoveryMode::kPointInTimeRecovery);
 static uint32_t rocksdb_access_hint_on_compaction_start =
     rocksdb::Options::AccessHint::NORMAL;
 static char *rocksdb_compact_cf_name = nullptr;
@@ -884,9 +884,9 @@ static MYSQL_THDVAR_INT(
 
 static MYSQL_SYSVAR_UINT(
     wal_recovery_mode, rocksdb_wal_recovery_mode, PLUGIN_VAR_RQCMDARG,
-    "DBOptions::wal_recovery_mode for RocksDB. Default is kAbsoluteConsistency",
+    "DBOptions::wal_recovery_mode for RocksDB. Default is kPointInTimeRecovery",
     nullptr, nullptr,
-    /* default */ (uint)rocksdb::WALRecoveryMode::kAbsoluteConsistency,
+    /* default */ (uint)rocksdb::WALRecoveryMode::kPointInTimeRecovery,
     /* min */ (uint)rocksdb::WALRecoveryMode::kTolerateCorruptedTailRecords,
     /* max */ (uint)rocksdb::WALRecoveryMode::kSkipAnyCorruptedRecords, 0);
 


### PR DESCRIPTION
…with InnoDB

- Changed default value of rocksdb_wal_mode from kAbsoluteConsistency to
  kPointInTimeRecovery.
- Touched up impacted tests.