### PR TITLE
PS-7010: Lock buffer blocks before sanity check in btr_cur_latch_leaves (5.7)

### DIFF
--- a/storage/innobase/btr/btr0cur.cc
+++ b/storage/innobase/btr/btr0cur.cc
@@ -396,13 +396,6 @@ btr_cur_latch_leaves(
 			cursor->left_block = get_block;
 
 			SRV_CORRUPT_TABLE_CHECK(get_block, return latch_leaves;);
-
-#ifdef UNIV_BTR_DEBUG
-			ut_a(page_is_comp(get_block->frame)
-			     == page_is_comp(page));
-			ut_a(btr_page_get_next(get_block->frame, mtr)
-			     == page_get_page_no(page));
-#endif /* UNIV_BTR_DEBUG */
 		}
 
 		latch_leaves.savepoints[1] = mtr_set_savepoint(mtr);
@@ -413,6 +406,13 @@ btr_cur_latch_leaves(
 
 		latch_leaves.blocks[1] = get_block;
 #ifdef UNIV_BTR_DEBUG
+		/* Sanity check only after both the blocks are latched. */
+		if (latch_leaves.blocks[0] != NULL) {
+			ut_a(page_is_comp(latch_leaves.blocks[0]->frame)
+			     == page_is_comp(page));;
+			ut_a(btr_page_get_next(latch_leaves.blocks[0]->frame, mtr)
+			     == page_get_page_no(page));
+		}
 		ut_a(page_is_comp(get_block->frame) == page_is_comp(page));
 #endif /* UNIV_BTR_DEBUG */
 		return(latch_leaves);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7010

Problem:
Sanity/integrity check in btr_cur_latch_leaves() for latch_mode == BTR_SEARCH_PREV is done before both buffers are latched. In parallel PAGE_N_HEAP field can be modified with page latched when the row is inserted.

Solution:
Move sanity/integrity check to the point when both validated buffers are latched. This fix is similar to the one done in commit 777bf2aab05fb58fad7838aed4ef307b50722786 for latch_mode == BTR_MODIFY_TREE.