### PR TITLE
mysqld_safe fails to respawn mysql if the --thp-setting option is set

### DIFF
--- a/scripts/mysqld_safe.sh
+++ b/scripts/mysqld_safe.sh
@@ -978,9 +978,7 @@ then
     if [ -f /sys/kernel/mm/transparent_hugepage/enabled ]; then
       CONTENT_THP=$(cat /sys/kernel/mm/transparent_hugepage/enabled)
       STATUS_THP=0
-      set +e
       STATUS_THP=$(echo $CONTENT_THP | grep -cv "\[${thp_setting}\]")
-      set -e
     fi
     if [ $STATUS_THP -eq 0 ]; then
       log_notice "Transparent huge pages are already set to: ${thp_setting}."


### PR DESCRIPTION
The code that deals with the --thp-setting option disables and then leaves enabled error checking, causing mysqld_safe to stop if mysql terminates unexpectedly.
As error checking is not enabled in the script there is no need to temporarily disable it, so I've both instructions.
