### PR TITLE
PS-7195: After merging PS-5635 - test keyring_and_mk_ecryption_exclus…

### DIFF
--- a/mysql-test/suite/encryption/r/keyring_and_mk_encryption_exclusions.result
+++ b/mysql-test/suite/encryption/r/keyring_and_mk_encryption_exclusions.result
@@ -84,6 +84,7 @@ SET GLOBAL default_table_encryption=OFF;
 SET DEBUG_SYNC = 'now SIGNAL go_alter_encryption_to_y';
 ERROR HY000: Tablespace ts_hang cannot have its ENCRYPTION altered as it is being currently encrypted/decrypted by encryption threads. Please try again later.
 SET GLOBAL debug="-d,hang_on_ts_hang_rotation";
+SET GLOBAL innodb_encryption_threads=0;
 DROP TABLESPACE ts_hang;
 # Now check when TABLESPACE ENCRYPTION is ALTERED to 'N' while encryption threads start to process
 # tablespace first.
@@ -98,6 +99,7 @@ SET GLOBAL default_table_encryption=OFF;
 SET DEBUG_SYNC = 'now SIGNAL go_alter_encryption_to_n';
 ERROR HY000: Tablespace ts_hang cannot have its ENCRYPTION altered as it is being currently encrypted/decrypted by encryption threads. Please try again later.
 SET GLOBAL debug="-d,hang_on_ts_hang_rotation";
+SET GLOBAL innodb_encryption_threads=0;
 DROP TABLESPACE ts_hang;
 # Here we check that encryption threads are dissallowed from running on a tablespace for which
 # ALTER ENCRYPTION='Y' is in progress.

--- a/mysql-test/suite/encryption/t/keyring_and_mk_encryption_exclusions.test
+++ b/mysql-test/suite/encryption/t/keyring_and_mk_encryption_exclusions.test
@@ -145,6 +145,7 @@ SET DEBUG_SYNC = 'now SIGNAL go_alter_encryption_to_y';
 
 --connection con1
 SET GLOBAL debug="-d,hang_on_ts_hang_rotation";
+SET GLOBAL innodb_encryption_threads=0;
 DROP TABLESPACE ts_hang;
 
 --echo # Now check when TABLESPACE ENCRYPTION is ALTERED to 'N' while encryption threads start to process
@@ -179,6 +180,7 @@ SET DEBUG_SYNC = 'now SIGNAL go_alter_encryption_to_n';
 
 --connection con1
 SET GLOBAL debug="-d,hang_on_ts_hang_rotation";
+SET GLOBAL innodb_encryption_threads=0;
 DROP TABLESPACE ts_hang;
 
 --echo # Here we check that encryption threads are dissallowed from running on a tablespace for which


### PR DESCRIPTION
…ion started

to fail

PS-5635 introduced updating DD with online_enc_progress flag when
encryption threads are starting to rotate a space.
keyring_and_mk_encryption introduced a hang during ALTER operation on
ts_hang tablespace. ALTER operation locks DD and thus blocked encryption
threads from updating DD with online_enc_progress. Test is watiting for
encryption threads to start hanging also. Since ALTER is waiting for a
signal from a test a deadlock was introduced. In order to break this
deadlock, hang in encryption thread was moved before updating DD with
online_enc_progress flag, which in turns allows test to signal the ALTER
statement that it can continue running. DD is updated by encryption
thread after ALTER statement stops blocking DD for updates.