### PR TITLE
fix 'service mysql start' doesn't wait service started (5.7, ubuntu)

### DIFF
--- a/build-ps/ubuntu/percona-server-server-5.7.mysql.init
+++ b/build-ps/ubuntu/percona-server-server-5.7.mysql.init
@@ -62,7 +62,7 @@ fix_thp_setting() {
 
 check_exit_status() {
         errcode=$1
-        if [ $errcode > 0 ];
+        if [ $errcode -gt 0 ];
         then
                 exit $errcode
         fi


### PR DESCRIPTION
Hello masters, 

I noticed that PR(#3544) only fixed the init script in Debian.
This PR is for Percona Server 5.7 in Ubuntu.