### PR TITLE
PS-7219: Correct PRODUCT_FULL variable

### DIFF
--- a/build-ps/percona-server-5.6_builder.sh
+++ b/build-ps/percona-server-5.6_builder.sh
@@ -153,7 +153,7 @@ get_sources(){
     BRANCH_NAME="${BRANCH}"
     echo "BRANCH_NAME=${BRANCH_NAME}" >> ../percona-server-5.6.properties
     echo "PRODUCT=Percona-Server-${MYSQL_VERSION_MAJOR}.${MYSQL_VERSION_MINOR}" >> ../percona-server-5.6.properties
-    echo 'PRODUCT_FULL=${PRODUCT}.${MYSQL_VERSION_PATCH}${MYSQL_VERSION_EXTRA}' >> ../percona-server-5.6.properties
+    echo "PRODUCT_FULL=${PRODUCT}.${MYSQL_VERSION_PATCH}${MYSQL_VERSION_EXTRA}" >> ../percona-server-5.6.properties
     echo "BUILD_NUMBER=${BUILD_NUMBER}" >> ../percona-server-5.6.properties
     echo "BUILD_ID=${BUILD_ID}" >> ../percona-server-5.6.properties
     echo "PERCONAFT_REPO=${PERCONAFT_REPO}" >> ../percona-server-5.6.properties


### PR DESCRIPTION
```
[root@compile-cent-7 mnt]# cat test/percona-server-5.6.properties
MYSQL_VERSION_MAJOR=5
MYSQL_VERSION_MINOR=6
MYSQL_VERSION_PATCH=49
MYSQL_VERSION_EXTRA=-89.0
REVISION=d043d30
BRANCH_NAME=5.6
PRODUCT=Percona-Server-5.6
PRODUCT_FULL=Percona-Server-5.6.49-89.0
```

Before it was:
```
[root@compile-cent-7 mnt]# cat test/percona-server-5.6.properties
MYSQL_VERSION_MAJOR=5
MYSQL_VERSION_MINOR=6
MYSQL_VERSION_PATCH=49
MYSQL_VERSION_EXTRA=-89.0
REVISION=d043d30
BRANCH_NAME=5.6
PRODUCT=Percona-Server-5.6
PRODUCT_FULL=${PRODUCT}.${MYSQL_VERSION_PATCH}${MYSQL_VERSION_EXTRA}
```