### PR TITLE
Fixed PS-7212 (Datatype inside JSON column changes unexpectedly)

### DIFF
--- a/mysql-test/suite/json/r/json_innodb.result
+++ b/mysql-test/suite/json/r/json_innodb.result
@@ -258,3 +258,21 @@ SUM(col_int)	col_int
 4572643328	NULL
 DROP VIEW view1;
 DROP TABLE D;
+#
+# BUG: PS-7212 - Datatype inside JSON column changes unexpectedly
+#
+CREATE TABLE json (
+id int NOT NULL,
+j json DEFAULT NULL,
+s tinyint NOT NULL,
+PRIMARY KEY (id)
+) ENGINE=InnoDB;
+INSERT INTO json VALUES (2, '{"amount": 70.0}', 1);
+SELECT json_type(j->"$.amount") FROM json;
+json_type(j->"$.amount")
+DOUBLE
+INSERT INTO json VALUES (2, '{}', 1) ON DUPLICATE KEY UPDATE j=if(s=0, '{}', j);
+SELECT json_type(j->"$.amount") FROM json;
+json_type(j->"$.amount")
+DOUBLE
+DROP TABLE json;

--- a/mysql-test/suite/json/t/json_innodb.test
+++ b/mysql-test/suite/json/t/json_innodb.test
@@ -249,3 +249,18 @@ DROP TABLE D;
 
 --source include/restore_sql_mode_after_turn_off_only_full_group_by.inc
 
+--echo #
+--echo # BUG: PS-7212 - Datatype inside JSON column changes unexpectedly
+--echo #
+
+CREATE TABLE json (
+id int NOT NULL,
+j json DEFAULT NULL,
+s tinyint NOT NULL,
+PRIMARY KEY (id)
+) ENGINE=InnoDB;
+INSERT INTO json VALUES (2, '{"amount": 70.0}', 1);
+SELECT json_type(j->"$.amount") FROM json;
+INSERT INTO json VALUES (2, '{}', 1) ON DUPLICATE KEY UPDATE j=if(s=0, '{}', j);
+SELECT json_type(j->"$.amount") FROM json;
+DROP TABLE json;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9169,6 +9169,27 @@ bool Field_json::get_time(MYSQL_TIME *ltime)
   return result;
 }
 
+int Field_json::cmp_binary(const uchar *a_ptr, const uchar *b_ptr,
+                           uint32 /* max_length */)
+{
+  char *a;
+  char *b;
+  memcpy(&a, a_ptr + packlength, sizeof(a));
+  memcpy(&b, b_ptr + packlength, sizeof(b));
+  uint32 a_length= get_length(a_ptr);
+  uint32 b_length= get_length(b_ptr);
+  using namespace json_binary;
+  /*
+    The length is 0 if NULL has been inserted into a NOT NULL column
+    using INSERT IGNORE or similar. If so, interpret the value as the
+    JSON null literal.
+  */
+  Value        null_literal(Value::LITERAL_NULL);
+  Json_wrapper aw(a_length == 0 ? null_literal : parse_binary(a, a_length));
+  Json_wrapper bw(b_length == 0 ? null_literal : parse_binary(b, b_length));
+  return aw.compare(bw);
+}
+
 
 void Field_json::make_sort_key(uchar *to, size_t length)
 {

--- a/sql/field.h
+++ b/sql/field.h
@@ -4196,6 +4196,7 @@ public:
   Field_json *clone() const;
   uint is_equal(Create_field *new_field);
   Item_result cast_to_int_type () const { return INT_RESULT; }
+  int  cmp_binary(const uchar *a, const uchar *b, uint32 max_length= ~0L);
   void make_sort_key(uchar *to, size_t length);
 
   /**


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7212

JSON fields are using Field_blob::cmp_binary to validate if data
has changed. Cherry picked changes from [1] to implement
Field_json::cmp_binary in order to do native JSON comparison.
Added a test case to validate the fix.

[1]:

commit 372d9611a2d47f625530ffdb30dc3b60bcdf6a3f
Author: Knut Anders Hatlen <knut.hatlen@oracle.com>
Date:   Thu Jun 1 13:41:04 2017 +0200

    Bug#26177130: SLAVE CAN'T FIND ROW USING HASH_SCAN
                  IF JSON HAS DIFFERENT BINARY FORMAT

    The same JSON document may have different binary representation after
    WL#8963. Row-based replication uses binary equality to find the
    matching row on the slave, and this may now fail if the binary
    representation of the document is different on the slave than it is on
    the master.

    This fix overrides cmp_binary() in Field_json and makes it use
    Json_wrapper::compare() to compare the JSON values.

    cmp_binary() is also used in UPDATE statements in order to see if a
    record has changed before it is updated in the table. The update is
    skipped if the new record is found to be equal to the original record.
    With these changes, it is now able to skip updates in more cases
    (where the binary representation has changed, but not the contents of
    the document). Some test cases in json_functions_innodb and
    json_functions_ndb, which inspected the binary representation of the
    JSON documents, got changed results because of this.

    Change-Id: If00c4f35d32d2435a148eafc7e0d6a3183bc1b00