### PR TITLE
PS-7220: Fix activity counter update in purge coordinator and workers. [8.0]

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2967,8 +2967,6 @@ srv_task_execute(void)
 
 		os_atomic_inc_ulint(
 			&purge_sys->pq_mutex, &purge_sys->n_completed, 1);
-
-		srv_inc_activity_count();
 	}
 
 	return(thr != NULL);
@@ -3316,7 +3314,9 @@ DECLARE_THREAD(srv_purge_coordinator_thread)(
 		rseg_history_len = srv_do_purge(
 			srv_n_purge_threads, &n_total_purged);
 
-		srv_inc_activity_count();
+		if (n_total_purged != 0) {
+			srv_inc_activity_count();
+		}
 
 	} while (!srv_purge_should_exit(n_total_purged));
 


### PR DESCRIPTION
The upstream fix for the bug #30875956 "PURGE ACTIVITY IS TOO MUCH AT
CPU% BOUND AND CAUSES IDLE OVERDRIVE"
mysql/mysql-server@e52529d
reveals an issue with an improvement "Server activity check fixes for page cleaner thread"
05255ba.

With the upstream patch purge coordinator will be woken up once a second
from srv_master_do_active_tasks and as a side effect of our improvement
it will increase activity counter each time. The combination of these two makes
page cleaner thread do adpative flushing instead of background flushing (which PCT(100) and uses
full io_capacity). With adaptive flushing, the amount of pages to be flushed is dependent
on checkpoint age, free page list length and dirty page ratio. So this makes flusher not
to flush all pages and causes the timeout in mtr testcase.

Fix:
To fix the issue srv_inc_activity_count inside of srv_purge_coordinator_thread
will be invoked only in case there were actual page purges. In addition,
remove the redundant srv_inc_activity_count increment in srv_task_execute().
Purge coordinator increases it anyway if it has purged something.