### PR TITLE
5.7 Fixed PS-7203 (Audit plugin memory leak on slave)

### DIFF
--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -642,6 +642,10 @@ int mysql_audit_table_access_notify(THD *thd, TABLE_LIST *table)
   const char *subclass_name;
   int ret;
 
+  if ((thd->system_thread &
+       (SYSTEM_THREAD_SLAVE_SQL | SYSTEM_THREAD_SLAVE_WORKER)) != 0)
+    return 0;
+
   /* Do not generate events for non query table access. */
   if (!thd->lex->query_tables)
     return 0;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7203

Audit plugin has the ability to include exclude databases
based on rules defined by variables
audit_log_include_databases or audit_log_exclude_databases .
Each table MySQL access via open_tables it notifies the plugin
about it. The plugin keeps track of amount of used databases and
if the database is part of the include / exclude list.
Later it uses this information to decide if the event should be written
to audit log or not. And finally, as part of dispatch_command end part
once the statement has been executed it validates if the variable that
keeps track of used databases needs to be cleaned up.

Slave code uses a mix of its own code and shared server code.
Tables are opened using open_tables shared function and thus
it allocates memory to keep track of databases used by the executing
query. However, it does not use dispatch_command to execute the command,
instead, it uses do_apply_event() from log_event.cc.
This code never calls the cleanup function
(nor any audit log notify function since the
sql_thread/sql worker threads never write anything to audit_log),
causing the slave to keeps allocating memory
(can be tracked as memory/sql/THD::variables ) and never releasing it,
unless one issue a STOP SLAVE.

Since the slave does not log audit entries that were generated from
SQL Thread, we should skip the notifying audit plugin in open_tables if
the thread originating it is sql thread or
any slave worker thread (in case of Multi thread replication).