### PR TITLE
Fixed PS-7221 (crash on select Sys_var_tz::session_value_ptr)

### DIFF
--- a/mysql-test/r/order_by_sortkey.result
+++ b/mysql-test/r/order_by_sortkey.result
@@ -172,3 +172,17 @@ Sort_range	0
 Sort_rows	2
 Sort_scan	2
 DROP TABLE t1, t2, tmp;
+#
+# BUG: PS-7221 - crash on select Sys_var_tz::session_value_ptr
+#
+CREATE TABLE t1 (
+id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+dt DATETIME NOT NULL
+);
+INSERT INTO t1 SET dt=NOW();
+INSERT INTO t1 (dt) SELECT NOW() FROM t1;
+SELECT id FROM t1 ORDER BY convert_tz(dt,'UTC',@@session.time_zone);
+id
+1
+2
+DROP TABLE t1;

--- a/mysql-test/t/order_by_sortkey.test
+++ b/mysql-test/t/order_by_sortkey.test
@@ -78,3 +78,16 @@ SELECT * FROM t2 where f1 =
 SHOW SESSION STATUS LIKE 'Sort%';
 
 DROP TABLE t1, t2, tmp;
+
+--echo #
+--echo # BUG: PS-7221 - crash on select Sys_var_tz::session_value_ptr
+--echo #
+
+CREATE TABLE t1 (
+  id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+  dt DATETIME NOT NULL
+);
+INSERT INTO t1 SET dt=NOW();
+INSERT INTO t1 (dt) SELECT NOW() FROM t1;
+SELECT id FROM t1 ORDER BY convert_tz(dt,'UTC',@@session.time_zone);
+DROP TABLE t1;

--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -992,6 +992,7 @@ static my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t, const TIME_ZONE_INFO *sp,
   String with names of SYSTEM time zone.
 */
 static const String tz_SYSTEM_name("SYSTEM", 6, &my_charset_latin1);
+static const String tz_UTC_name("UTC", 3, &my_charset_latin1);
 
 Time_zone *my_tz_find(const int64 displacement);
 
@@ -1169,19 +1170,10 @@ void Time_zone_utc::gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const {
   SYNOPSIS
     get_name()
 
-  DESCRIPTION
-    Since Time_zone_utc is used only internally by SQL's UTC_* functions it
-    is not accessible directly, and hence this function of Time_zone
-    interface is not implemented for this class and should not be called.
-
   RETURN VALUE
-    0
+    Name of time zone as String
 */
-const String *Time_zone_utc::get_name() const {
-  /* Should be never called */
-  DBUG_ASSERT(0);
-  return nullptr;
-}
+const String *Time_zone_utc::get_name() const { return &tz_UTC_name; }
 
 /*
   Instance of this class represents some time zone which is


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7221

This is a regression introduced in 6d587a60738842b1f7e5e5b0839acd62db6b9d43.
A new function called get_int_sort_key_for_item_inline temporarily sets
the time_zone session variable to UTC.
This results on *Time_zone_utc::get_name() been called and up to now, get_name
was not meant to be called directly and thus always asserting.

Adjusted the function to properly return UTC string instead of asserting.