### PR TITLE
PS-6990: Server doesn't restart after crash when there are too many gaps in the mysql.gtid_executed table

### DIFF
--- a/mysql-test/suite/binlog_gtid/r/binlog_gtid_persister_validation.result
+++ b/mysql-test/suite/binlog_gtid/r/binlog_gtid_persister_validation.result
@@ -1,0 +1,25 @@
+RESET MASTER;
+#
+# 1. Create an InnoDB table and insert 2 rows.
+#    Wait till each entry appears individually in the table.
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE = INNODB;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+#
+# 2. Assert that table is not compressed.
+include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
+include/assert.inc [The mysql gtid table should have 3 rows.]
+#
+# 3. Enable debug point to print the compression info for validation purpose.
+# Adding debug point 'print_gtid_compression_info' to @@GLOBAL.debug
+#
+# 4. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+FLUSH ENGINE LOGS;
+include/assert.inc [The mysql gtid table should have 1 row.]
+
+# 5. Assert that the compression was done by the gtid persister thread.
+include/assert_grep.inc [GTID table compression is done by persister thread.]
+#
+# 6. Cleanup
+# Removing debug point 'print_gtid_compression_info' from @@GLOBAL.debug
+DROP TABLE t1;

--- a/mysql-test/suite/binlog_gtid/t/binlog_gtid_persister_validation.test
+++ b/mysql-test/suite/binlog_gtid/t/binlog_gtid_persister_validation.test
@@ -1,0 +1,90 @@
+# ==== Purpose ====
+#
+# This test verifies that compression of mysql.gtid_executed table shall be
+# done only by the gtid persister thread when binlogging is enabled.
+#
+# ==== Implementation ====
+#
+# 0. This test requires only one server.
+# 1. Create an InnoDB table and insert 2 rows.
+#    Wait till each entry appears individually in the mysql.gtid_executed table.
+# 2. Assert that table is not compressed.
+# 3. Enable debug point to print the compression info for validation purpose.
+# 4. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+# 5. Assert that the compression was done by the gtid persister thread.
+# 6. Cleanup
+#
+# ==== References ====
+#
+# PS-6990: Gaps in mysql.gtid_executed but not in @@GLOBAL.gtid_executed
+
+# This test requires debug binaries.
+--source include/have_debug.inc
+# This test is binlog format agnostic
+--source include/have_binlog_format_row.inc
+
+--let $server_uuid = `SELECT @@GLOBAL.SERVER_UUID`
+
+# Clean the table before starting the test.
+RESET MASTER;
+
+--echo #
+--echo # 1. Create an InnoDB table and insert 2 rows.
+--echo #    Wait till each entry appears individually in the table.
+
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE = INNODB;
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 1
+--source include/wait_condition.inc
+
+INSERT INTO t1 VALUES (1);
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 2 AND interval_end = 2
+--source include/wait_condition.inc
+
+INSERT INTO t1 VALUES (2);
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 3 AND interval_end = 3
+--source include/wait_condition.inc
+
+--echo #
+--echo # 2. Assert that table is not compressed.
+
+--let $assert_text = COMMITTED_GTIDS SERVER_UUID:1-3
+--let $assert_cond = "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$server_uuid:1-3"
+--source include/assert.inc
+
+--let $assert_cond = COUNT(*) = 3 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table should have 3 rows.
+--source include/assert.inc
+
+--echo #
+--echo # 3. Enable debug point to print the compression info for validation purpose.
+--let $debug_point = print_gtid_compression_info
+--source include/add_debug_point.inc
+
+--echo #
+--echo # 4. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+FLUSH ENGINE LOGS;
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 3
+--source include/wait_condition.inc
+
+--let $assert_cond = COUNT(*) = 1 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table should have 1 row.
+--source include/assert.inc
+
+--echo
+--echo # 5. Assert that the compression was done by the gtid persister thread.
+
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_match= .*Compression done by persister thread, first gapless row = 1-3.*
+--let $assert_select= Compression done by persister thread, first gapless row = 1-3
+--let $assert_text= GTID table compression is done by persister thread.
+--source include/assert_grep.inc
+
+--echo #
+--echo # 6. Cleanup
+--let $debug_point = print_gtid_compression_info
+--source include/remove_debug_point.inc
+DROP TABLE t1;

--- a/mysql-test/suite/rpl_gtid/r/rpl_gtid_binlogless_slave_compressor_validation.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_gtid_binlogless_slave_compressor_validation.result
@@ -14,10 +14,12 @@ INSERT INTO t1 VALUES (2);
 include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
 include/assert.inc [The mysql gtid table should have 3 rows.]
 include/sync_slave_sql_with_master.inc
-include/stop_slave.inc
 #
 # 3. Assert that table is not compressed on replica server.
 include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
+[connection master]
+INSERT INTO t1 VALUES (3);
+include/sync_slave_sql_with_master.inc
 include/assert.inc [The mysql gtid table is not compressed.]
 #
 # 4. Enable debug point to print the compression info for validation purpose.
@@ -35,7 +37,6 @@ CALL mtr.add_suppression("You need to use --log-bin to make --binlog-format work
 # 7. Cleanup
 # Removing debug point 'print_gtid_compression_info' from @@GLOBAL.debug
 # Removing debug point 'simulate_force_compress' from @@GLOBAL.debug
-include/start_slave.inc
 [connection master]
 DROP TABLE t1;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/r/rpl_gtid_binlogless_slave_compressor_validation.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_gtid_binlogless_slave_compressor_validation.result
@@ -1,0 +1,41 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+#
+# 1. Create an InnoDB table and insert 2 rows.
+#    Wait till each entry appears individually in the table.
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE = INNODB;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+#
+# 2. Assert that table is not compressed on primary server.
+include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
+include/assert.inc [The mysql gtid table should have 3 rows.]
+include/sync_slave_sql_with_master.inc
+include/stop_slave.inc
+#
+# 3. Assert that table is not compressed on replica server.
+include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
+include/assert.inc [The mysql gtid table is not compressed.]
+#
+# 4. Enable debug point to print the compression info for validation purpose.
+# Adding debug point 'print_gtid_compression_info' to @@GLOBAL.debug
+# Adding debug point 'simulate_force_compress' to @@GLOBAL.debug
+#
+# 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+FLUSH ENGINE LOGS;
+include/assert.inc [The mysql gtid table should have 1 row.]
+
+# 6. Assert that the compression was done by the gtid compressor thread.
+include/assert_grep.inc [GTID table compression is done by compressor thread.]
+CALL mtr.add_suppression("You need to use --log-bin to make --binlog-format work.");
+#
+# 7. Cleanup
+# Removing debug point 'print_gtid_compression_info' from @@GLOBAL.debug
+# Removing debug point 'simulate_force_compress' from @@GLOBAL.debug
+include/start_slave.inc
+[connection master]
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/r/rpl_gtid_slave_persister_validation.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_gtid_slave_persister_validation.result
@@ -1,0 +1,38 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+#
+# 1. Create an InnoDB table and insert 2 rows.
+#    Wait till each entry appears individually in the table.
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE = INNODB;
+INSERT INTO t1 VALUES (1);
+INSERT INTO t1 VALUES (2);
+#
+# 2. Assert that table is not compressed on primary server.
+include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
+include/assert.inc [The mysql gtid table should have 3 rows.]
+include/sync_slave_sql_with_master.inc
+include/stop_slave.inc
+#
+# 3. Assert that table is not compressed on replica server.
+include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
+include/assert.inc [The mysql gtid table is not compressed.]
+#
+# 4. Enable debug point to print the compression info for validation purpose.
+# Adding debug point 'print_gtid_compression_info' to @@GLOBAL.debug
+#
+# 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+FLUSH ENGINE LOGS;
+include/assert.inc [The mysql gtid table should have 1 row.]
+
+# 6. Assert that the compression was done by the gtid persister thread.
+include/assert_grep.inc [GTID table compression is done by persister thread.]
+#
+# 7. Cleanup
+# Removing debug point 'print_gtid_compression_info' from @@GLOBAL.debug
+include/start_slave.inc
+[connection master]
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/r/rpl_gtid_slave_persister_validation.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_gtid_slave_persister_validation.result
@@ -14,10 +14,12 @@ INSERT INTO t1 VALUES (2);
 include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
 include/assert.inc [The mysql gtid table should have 3 rows.]
 include/sync_slave_sql_with_master.inc
-include/stop_slave.inc
 #
 # 3. Assert that table is not compressed on replica server.
 include/assert.inc [COMMITTED_GTIDS SERVER_UUID:1-3]
+[connection master]
+INSERT INTO t1 VALUES (3);
+include/sync_slave_sql_with_master.inc
 include/assert.inc [The mysql gtid table is not compressed.]
 #
 # 4. Enable debug point to print the compression info for validation purpose.
@@ -32,7 +34,6 @@ include/assert_grep.inc [GTID table compression is done by persister thread.]
 #
 # 7. Cleanup
 # Removing debug point 'print_gtid_compression_info' from @@GLOBAL.debug
-include/start_slave.inc
 [connection master]
 DROP TABLE t1;
 include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_binlogless_slave_compressor_validation-slave.opt
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_binlogless_slave_compressor_validation-slave.opt
@@ -1,0 +1,1 @@
+--disable-log-bin

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_binlogless_slave_compressor_validation.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_binlogless_slave_compressor_validation.test
@@ -1,0 +1,115 @@
+# ==== Purpose ====
+#
+# This test verifies that compression of mysql.gtid_executed table shall be
+# done only by the gtid compressor thread when binlogging is disabled.
+#
+# ==== Implementation ====
+#
+# 0. This test requires two servers. Create a primary-replica setup.
+# 1. Create an InnoDB table and insert 2 rows.
+#    Wait till each entry appears individually in the mysql.gtid_executed table.
+# 2. Assert that table is not compressed on primary server.
+# 3. Assert that table is not compressed on replica server.
+# 4. Enable debug point to print the compression info for validation purpose.
+# 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+# 6. Assert that the compression was done by the gtid compressor thread.
+# 7. Cleanup
+#
+# ==== References ====
+#
+# PS-6990: Gaps in mysql.gtid_executed but not in @@GLOBAL.gtid_executed
+
+# This test requires debug binaries.
+--source include/have_debug.inc
+# This test is binlog format agnostic
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+--let $server_uuid = `SELECT @@GLOBAL.SERVER_UUID`
+
+--echo #
+--echo # 1. Create an InnoDB table and insert 2 rows.
+--echo #    Wait till each entry appears individually in the table.
+
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE = INNODB;
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 1
+--source include/wait_condition.inc
+
+INSERT INTO t1 VALUES (1);
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 2 AND interval_end = 2
+--source include/wait_condition.inc
+
+INSERT INTO t1 VALUES (2);
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 3 AND interval_end = 3
+--source include/wait_condition.inc
+
+--echo #
+--echo # 2. Assert that table is not compressed on primary server.
+
+--let $assert_text = COMMITTED_GTIDS SERVER_UUID:1-3
+--let $assert_cond = "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$server_uuid:1-3"
+--source include/assert.inc
+
+--let $assert_cond = COUNT(*) = 3 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table should have 3 rows.
+--source include/assert.inc
+
+# Sync replica with the primary.
+--source include/sync_slave_sql_with_master.inc
+--source include/stop_slave.inc
+--echo #
+--echo # 3. Assert that table is not compressed on replica server.
+
+--let $assert_text = COMMITTED_GTIDS SERVER_UUID:1-3
+--let $assert_cond = "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$server_uuid:1-3"
+--source include/assert.inc
+
+--let $assert_cond = COUNT(*) > 1 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table is not compressed.
+--source include/assert.inc
+
+--echo #
+--echo # 4. Enable debug point to print the compression info for validation purpose.
+--let $debug_point = print_gtid_compression_info
+--source include/add_debug_point.inc
+--let $debug_point = simulate_force_compress
+--source include/add_debug_point.inc
+
+--echo #
+--echo # 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+FLUSH ENGINE LOGS;
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 3
+--source include/wait_condition.inc
+
+--let $assert_cond = COUNT(*) = 1 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table should have 1 row.
+--source include/assert.inc
+
+--echo
+--echo # 6. Assert that the compression was done by the gtid compressor thread.
+
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_match= .*Compression done by compressor thread, first gapless row = 1-3.*
+--let $assert_select= Compression done by compressor thread, first gapless row = 1-3
+--let $assert_text= GTID table compression is done by compressor thread.
+--source include/assert_grep.inc
+
+# Test Suppression
+CALL mtr.add_suppression("You need to use --log-bin to make --binlog-format work.");
+
+--echo #
+--echo # 7. Cleanup
+--let $debug_point = print_gtid_compression_info
+--source include/remove_debug_point.inc
+--let $debug_point = simulate_force_compress
+--source include/remove_debug_point.inc
+
+--source include/start_slave.inc
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+
+--source include/rpl_end.inc

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_binlogless_slave_compressor_validation.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_binlogless_slave_compressor_validation.test
@@ -59,13 +59,24 @@ INSERT INTO t1 VALUES (2);
 
 # Sync replica with the primary.
 --source include/sync_slave_sql_with_master.inc
---source include/stop_slave.inc
 --echo #
 --echo # 3. Assert that table is not compressed on replica server.
 
 --let $assert_text = COMMITTED_GTIDS SERVER_UUID:1-3
 --let $assert_cond = "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$server_uuid:1-3"
 --source include/assert.inc
+
+# It could happen that the GTID persister thread on the replica server may add
+# GTIDs 1-3 in a single transaction, and this may cause the following assert to
+# fail. So, execute one more transaction on primary server, so that there are
+# at least two rows in the mysql.gtid_executed table.
+--source include/rpl_connection_master.inc
+INSERT INTO t1 VALUES (3);
+--source include/sync_slave_sql_with_master.inc
+
+# Wait till the above transaction get reflected in the mysql.gtid_executed table.
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 4 AND interval_end = 4
+--source include/wait_condition.inc
 
 --let $assert_cond = COUNT(*) > 1 FROM mysql.gtid_executed
 --let $assert_text = The mysql gtid table is not compressed.
@@ -82,7 +93,7 @@ INSERT INTO t1 VALUES (2);
 --echo # 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
 FLUSH ENGINE LOGS;
 
---let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 3
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 4
 --source include/wait_condition.inc
 
 --let $assert_cond = COUNT(*) = 1 FROM mysql.gtid_executed
@@ -93,8 +104,8 @@ FLUSH ENGINE LOGS;
 --echo # 6. Assert that the compression was done by the gtid compressor thread.
 
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.2.err
---let $assert_match= .*Compression done by compressor thread, first gapless row = 1-3.*
---let $assert_select= Compression done by compressor thread, first gapless row = 1-3
+--let $assert_match= .*Compression done by compressor thread, first gapless row = 1-4.*
+--let $assert_select= Compression done by compressor thread, first gapless row = 1-4
 --let $assert_text= GTID table compression is done by compressor thread.
 --source include/assert_grep.inc
 
@@ -108,7 +119,6 @@ CALL mtr.add_suppression("You need to use --log-bin to make --binlog-format work
 --let $debug_point = simulate_force_compress
 --source include/remove_debug_point.inc
 
---source include/start_slave.inc
 --source include/rpl_connection_master.inc
 DROP TABLE t1;
 

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_slave_persister_validation.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_slave_persister_validation.test
@@ -60,13 +60,24 @@ INSERT INTO t1 VALUES (2);
 
 # Sync replica with the primary.
 --source include/sync_slave_sql_with_master.inc
---source include/stop_slave.inc
 --echo #
 --echo # 3. Assert that table is not compressed on replica server.
 
 --let $assert_text = COMMITTED_GTIDS SERVER_UUID:1-3
 --let $assert_cond = "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$server_uuid:1-3"
 --source include/assert.inc
+
+# It could happen that the GTID persister thread on the replica server may add
+# GTIDs 1-3 in a single transaction, and this may cause the following assert to
+# fail. So, execute one more transaction on primary server, so that there are
+# at least two rows in the mysql.gtid_executed table.
+--source include/rpl_connection_master.inc
+INSERT INTO t1 VALUES (3);
+--source include/sync_slave_sql_with_master.inc
+
+# Wait till the above transaction get reflected in the mysql.gtid_executed table.
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 4 AND interval_end = 4
+--source include/wait_condition.inc
 
 --let $assert_cond = COUNT(*) > 1 FROM mysql.gtid_executed
 --let $assert_text = The mysql gtid table is not compressed.
@@ -81,7 +92,7 @@ INSERT INTO t1 VALUES (2);
 --echo # 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
 FLUSH ENGINE LOGS;
 
---let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 3
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 4
 --source include/wait_condition.inc
 
 --let $assert_cond = COUNT(*) = 1 FROM mysql.gtid_executed
@@ -92,8 +103,8 @@ FLUSH ENGINE LOGS;
 --echo # 6. Assert that the compression was done by the gtid persister thread.
 
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.2.err
---let $assert_match= .*Compression done by persister thread, first gapless row = 1-3.*
---let $assert_select= Compression done by persister thread, first gapless row = 1-3
+--let $assert_match= .*Compression done by persister thread, first gapless row = 1-4.*
+--let $assert_select= Compression done by persister thread, first gapless row = 1-4
 --let $assert_text= GTID table compression is done by persister thread.
 --source include/assert_grep.inc
 
@@ -102,7 +113,6 @@ FLUSH ENGINE LOGS;
 --let $debug_point = print_gtid_compression_info
 --source include/remove_debug_point.inc
 
---source include/start_slave.inc
 --source include/rpl_connection_master.inc
 DROP TABLE t1;
 

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtid_slave_persister_validation.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtid_slave_persister_validation.test
@@ -1,0 +1,109 @@
+# ==== Purpose ====
+#
+# This test verifies that compression of mysql.gtid_executed table shall be
+# done only by the gtid persister thread when binlogging is enabled and
+# log_slave_updates is set.
+#
+# ==== Implementation ====
+#
+# 0. This test requires two servers. Create a primary-replica setup.
+# 1. Create an InnoDB table and insert 2 rows.
+#    Wait till each entry appears individually in the mysql.gtid_executed table.
+# 2. Assert that table is not compressed on primary server.
+# 3. Assert that table is not compressed on replica server.
+# 4. Enable debug point to print the compression info for validation purpose.
+# 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+# 6. Assert that the compression was done by the gtid persister thread.
+# 7. Cleanup
+#
+# ==== References ====
+#
+# PS-6990: Gaps in mysql.gtid_executed but not in @@GLOBAL.gtid_executed
+
+# This test requires debug binaries.
+--source include/have_debug.inc
+# This test is binlog format agnostic
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+--let $server_uuid = `SELECT @@GLOBAL.SERVER_UUID`
+
+--echo #
+--echo # 1. Create an InnoDB table and insert 2 rows.
+--echo #    Wait till each entry appears individually in the table.
+
+CREATE TABLE t1 (a INT NOT NULL PRIMARY KEY) ENGINE = INNODB;
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 1
+--source include/wait_condition.inc
+
+INSERT INTO t1 VALUES (1);
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 2 AND interval_end = 2
+--source include/wait_condition.inc
+
+INSERT INTO t1 VALUES (2);
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 3 AND interval_end = 3
+--source include/wait_condition.inc
+
+--echo #
+--echo # 2. Assert that table is not compressed on primary server.
+
+--let $assert_text = COMMITTED_GTIDS SERVER_UUID:1-3
+--let $assert_cond = "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$server_uuid:1-3"
+--source include/assert.inc
+
+--let $assert_cond = COUNT(*) = 3 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table should have 3 rows.
+--source include/assert.inc
+
+# Sync replica with the primary.
+--source include/sync_slave_sql_with_master.inc
+--source include/stop_slave.inc
+--echo #
+--echo # 3. Assert that table is not compressed on replica server.
+
+--let $assert_text = COMMITTED_GTIDS SERVER_UUID:1-3
+--let $assert_cond = "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$server_uuid:1-3"
+--source include/assert.inc
+
+--let $assert_cond = COUNT(*) > 1 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table is not compressed.
+--source include/assert.inc
+
+--echo #
+--echo # 4. Enable debug point to print the compression info for validation purpose.
+--let $debug_point = print_gtid_compression_info
+--source include/add_debug_point.inc
+
+--echo #
+--echo # 5. Execute FLUSH ENGINE LOGS and assert that table is compressed.
+FLUSH ENGINE LOGS;
+
+--let $wait_condition = SELECT count(*) = 1 FROM mysql.gtid_executed WHERE interval_start = 1 AND interval_end = 3
+--source include/wait_condition.inc
+
+--let $assert_cond = COUNT(*) = 1 FROM mysql.gtid_executed
+--let $assert_text = The mysql gtid table should have 1 row.
+--source include/assert.inc
+
+--echo
+--echo # 6. Assert that the compression was done by the gtid persister thread.
+
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.2.err
+--let $assert_match= .*Compression done by persister thread, first gapless row = 1-3.*
+--let $assert_select= Compression done by persister thread, first gapless row = 1-3
+--let $assert_text= GTID table compression is done by persister thread.
+--source include/assert_grep.inc
+
+--echo #
+--echo # 7. Cleanup
+--let $debug_point = print_gtid_compression_info
+--source include/remove_debug_point.inc
+
+--source include/start_slave.inc
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+
+--source include/rpl_end.inc

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -65,6 +65,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "mysql/components/services/system_variable_source.h"
 
 #ifndef UNIV_HOTBACKUP
+#include <binlog.h>
 #include <current_thd.h>
 #include <debug_sync.h>
 #include <derror.h>
@@ -5922,10 +5923,16 @@ static bool innobase_flush_logs(handlerton *hton, bool binlog_group_flush) {
     return false;
   }
 
-  /* Signal and wait for all GTIDs to persist on disk. */
+  /* Wait for all GTIDs to persist on disk and create an explicit request for
+  the compression of mysql.gtid_executed table if both binary logging and
+  log_slave_updates are enabled. This is required to avoid the
+  clone_gtid_thread getting stuck while scanning the gtid_executed table when
+  there is a mixed (transactional and non-transactional) workload on the
+  server. */
   if (!binlog_group_flush) {
+    bool compress_gtid = mysql_bin_log.is_open() && opt_log_slave_updates;
     auto &gtid_persistor = clone_sys->get_gtid_persistor();
-    gtid_persistor.wait_flush(true, true, true, nullptr);
+    gtid_persistor.wait_flush(true, compress_gtid, true, nullptr);
   }
 
   /* Flush the redo log buffer to the redo log file.


### PR DESCRIPTION
Problem & Analysis
------------------
On a binlogless slave, explicit gtid compression requests raised from
the below queries caused the persister thread to be stuck while
compressing the gtid_executed table.

1. FLUSH ENGINE LOGS
2. LOCK TABLES FOR BACKUP / PXB.
3. RESET MASTER, RESET SLAVE and CHANGE MASTER
4. Binary/relay log rotation
5. expire logs_by_seconds and expire_logs_by_days

Fix
---
Made the GTID persister thread to compress the mysql.gtid_executed table
only on explicit request from innobase_flush_logs() when both binary
logging and log_slave_updates are enabled.

As per the current fix, the final truth table of server behavior is:
```
+-------------+----------+-------------------+-------------------+--------------+
|  Is server  |          |                   |  Explicit request |    Result    |
| Standalone/ |  Binlog  | log_slave_updates |    created on     |              |
|    Slave?   | enabled? |      enabled?     | FLUSH ENGINE LOGS |  Persister/  |
|             |          |                   |                   |  Compressor  |
+=============+==========+===================+===================+==============+
|  Standalone |    Yes   |        Yes        |        Yes        |   Persister  |
+-------------+----------+-------------------+-------------------+--------------+
|  Standalone |    Yes   |         No        |         No        |  Compressor  |
+-------------+----------+-------------------+-------------------+--------------+
|  Standalone |    No    |        Yes        |        N/A        |              |
+-------------+----------+-------------------+-------------------+ Invalid case |
|  Standalone |    No    |         No        |        N/A        |              |
+-------------+----------+-------------------+-------------------+--------------+
|    Slave    |    Yes   |        Yes        |        Yes        |   Persister  |
+-------------+----------+-------------------+-------------------+--------------+
|    Slave    |    Yes   |         No        |         No        |  Compressor  |
+-------------+----------+-------------------+-------------------+--------------+
|    Slave    |    No    |        Yes        |        N/A        | Invalid case |
+-------------+----------+-------------------+-------------------+--------------+
|    Slave    |    No    |         No        |         No        |  Compressor  |
+-------------+----------+-------------------+-------------------+--------------+

```
Testing
---
v1-Jenkins: https://ps80.cd.percona.com/job/percona-server-8.0-param/711/testReport/

v2-Jenkins: https://ps80.cd.percona.com/job/percona-server-8.0-param/728/testReport/

Note
---
v1-All failing tests are unrelated to the current fix.