### PR TITLE
PS-7147: MTS Slave crashes inside Transaction_ctx::THD_TRANS::cannot_safely_rollback()

### DIFF
--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -489,8 +489,8 @@ bool Relay_log_info::cannot_safely_rollback() const {
        ++it) {
     Slave_worker *worker = *it;
     mysql_mutex_lock(&worker->jobs_lock);
-    ret = worker->info_thd->get_transaction()->cannot_safely_rollback(
-        Transaction_ctx::SESSION);
+    const auto &trx = worker->info_thd->get_transaction();
+    ret = trx ? trx->cannot_safely_rollback(Transaction_ctx::SESSION) : false;
     mysql_mutex_unlock(&worker->jobs_lock);
   }
   return ret;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7147

Problem & Analysis
------------------
As part of the bugfix for [PS-5824](https://jira.percona.com/browse/PS-5824) (commit 205b48f017a9842c736d3), the
co-ordinator thread was made to check for the safeness of the ongoing
transactions and if found that all transactions executed by the worker
threads are safe to rollback, then it immediately would stop all the worker
threads making the STOP SLAVE to execute faster.

However, while checking for the safeness, it doesn't take into account that
the transaction objects can be empty if the worker thread had performed the
clean up of the transaction objects.

This caused the the function call to
`worker->info_thd->get_transaction()->cannot_safely_rollback(Transaction_ctx::SESSION);`
result in dereferencing a null pointer and caused the mysqld to crash.

Fix
---
Added a check for null pointer.

Testing
----
v1 - Jenkins: https://ps80.cd.percona.com/job/percona-server-8.0-param/720/testReport/
Summary: Failing tests are unrelated to the current patch.

Note
---
1. This fix also fixes the sporadic failure of the `rpl_gtid.rpl_mts_slave_preserve_commit_order_xa_commit_error_nobinlog` test on 8.0.