### PR TITLE
PS-7125 feature: Reloading X ssl certificates on ALTER INSTANCE RELOAD TLS

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -994,6 +994,10 @@ void thd_kill(unsigned long id);
 */
 int thd_get_ft_query_extra_word_chars(void);
 
+typedef bool (*ssl_reload_callback_t)(void *);
+bool register_ssl_reload_callback(ssl_reload_callback_t);
+bool deregister_ssl_reload_callback(ssl_reload_callback_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -146,6 +146,9 @@ int thd_command(const void * thd);
 long long thd_start_time(const void * thd);
 void thd_kill(unsigned long id);
 int thd_get_ft_query_extra_word_chars(void);
+typedef bool (*ssl_reload_callback_t)(void *);
+bool register_ssl_reload_callback(ssl_reload_callback_t);
+bool deregister_ssl_reload_callback(ssl_reload_callback_t);
 #include <mysql/components/services/bits/plugin_audit_connection_types.h>
 typedef enum {
   MYSQL_AUDIT_CONNECTION_CONNECT = 1 << 0,

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -137,6 +137,9 @@ int thd_command(const void * thd);
 long long thd_start_time(const void * thd);
 void thd_kill(unsigned long id);
 int thd_get_ft_query_extra_word_chars(void);
+typedef bool (*ssl_reload_callback_t)(void *);
+bool register_ssl_reload_callback(ssl_reload_callback_t);
+bool deregister_ssl_reload_callback(ssl_reload_callback_t);
 #include "plugin_auth_common.h"
 struct MYSQL_PLUGIN_VIO_INFO {
   enum {

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -137,6 +137,9 @@ int thd_command(const void * thd);
 long long thd_start_time(const void * thd);
 void thd_kill(unsigned long id);
 int thd_get_ft_query_extra_word_chars(void);
+typedef bool (*ssl_reload_callback_t)(void *);
+bool register_ssl_reload_callback(ssl_reload_callback_t);
+bool deregister_ssl_reload_callback(ssl_reload_callback_t);
 enum enum_ftparser_mode {
   MYSQL_FTPARSER_SIMPLE_MODE = 0,
   MYSQL_FTPARSER_WITH_STOPWORDS = 1,

--- a/include/mysql/plugin_keyring.h.pp
+++ b/include/mysql/plugin_keyring.h.pp
@@ -137,6 +137,9 @@ int thd_command(const void * thd);
 long long thd_start_time(const void * thd);
 void thd_kill(unsigned long id);
 int thd_get_ft_query_extra_word_chars(void);
+typedef bool (*ssl_reload_callback_t)(void *);
+bool register_ssl_reload_callback(ssl_reload_callback_t);
+bool deregister_ssl_reload_callback(ssl_reload_callback_t);
 struct st_mysql_keyring {
   int interface_version;
   bool (*mysql_key_store)(const char *key_id, const char *key_type,

--- a/mysql-test/suite/x/r/ssl_dynamic.result
+++ b/mysql-test/suite/x/r/ssl_dynamic.result
@@ -1,0 +1,105 @@
+CREATE USER xuser_sha256@localhost
+IDENTIFIED WITH 'sha256_password' BY 'sha256';
+GRANT ALL ON *.* TO xuser_sha256@localhost;
+call mtr.add_suppression("Failed to set up SSL because of the following SSL library error");
+call mtr.add_suppression("mysqlx reported: 'Failed at SSL configuration");
+Ssl connection by sha256 plugin  -> success
+user	plugin
+xuser_sha256	sha256_password
+0 rows affected
+Variable_name	Value
+Mysqlx_ssl_active	ON
+0 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+################## Test reload
+ALTER INSTANCE RELOAD TLS;
+Ssl connection by sha256 plugin  -> success
+user	plugin
+xuser_sha256	sha256_password
+0 rows affected
+Variable_name	Value
+Mysqlx_ssl_active	ON
+0 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+################## Test wrong value
+# Save the defaults
+SET @orig_ssl_ca= @@global.ssl_ca;
+# Set CA to invalid value
+SET GLOBAL ssl_ca = 'gizmo';
+Ssl connection by sha256 plugin  -> success
+user	plugin
+xuser_sha256	sha256_password
+0 rows affected
+Variable_name	Value
+Mysqlx_ssl_active	ON
+0 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# Must fail and not change the SSL params
+ALTER INSTANCE RELOAD TLS;
+ERROR HY000: Failed to set up SSL because of the following SSL library error: SSL_CTX_set_default_verify_paths failed
+# Must be 1
+SELECT COUNT(*) FROM performance_schema.session_status
+WHERE VARIABLE_NAME = 'Current_tls_ca' AND VARIABLE_VALUE = @orig_ssl_ca;
+COUNT(*)
+1
+Ssl connection by sha256 plugin  -> success
+user	plugin
+xuser_sha256	sha256_password
+0 rows affected
+Variable_name	Value
+Mysqlx_ssl_active	ON
+0 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# Must pass with a warning and disable SSL
+ALTER INSTANCE RELOAD TLS NO ROLLBACK ON ERROR;
+Warnings:
+Warning	3888	Failed to set up SSL because of the following SSL library error: SSL_CTX_set_default_verify_paths failed
+Ssl connection by sha256 plugin  -> failure
+in main, line 0:ERROR: Capability prepare failed for 'tls' (code 5001)
+not ok
+# cleanup
+SET GLOBAL ssl_ca = @orig_ssl_ca;
+ALTER INSTANCE RELOAD TLS;
+################## Change certificate
+# Save the defaults
+SET @orig_ssl_ca= @@global.ssl_ca;
+SET @orig_ssl_cert= @@global.ssl_cert;
+SET @orig_ssl_key= @@global.ssl_key;
+SET @orig_mysqlx_ssl_ca= @@global.mysqlx_ssl_ca;
+SET @orig_mysqlx_ssl_cert= @@global.mysqlx_ssl_cert;
+SET @orig_mysqlx_ssl_key= @@global.mysqlx_ssl_key;
+# setting new values for ssl_cert, ssl_key and ssl_ca
+SET GLOBAL ssl_cert = "MYSQL_TEST_DIR/std_data/server-cert-sha512.pem";
+SET GLOBAL ssl_key = "MYSQL_TEST_DIR/std_data/server-key-sha512.pem";
+SET GLOBAL ssl_ca = "MYSQL_TEST_DIR/std_data/ca-sha512.pem";
+ALTER INSTANCE RELOAD TLS;
+Ssl connection by sha256 plugin  -> success
+user	plugin
+xuser_sha256	sha256_password
+0 rows affected
+Variable_name	Value
+Mysqlx_ssl_active	ON
+0 rows affected
+Mysqlx.Ok {
+  msg: "bye!"
+}
+ok
+# cleanup
+SET GLOBAL ssl_cert = @orig_ssl_cert;
+SET GLOBAL ssl_key = @orig_ssl_key;
+SET GLOBAL ssl_ca = @orig_ssl_ca;
+ALTER INSTANCE RELOAD TLS;
+################## End of dynamic SSL tests
+DROP USER xuser_sha256@localhost;

--- a/mysql-test/suite/x/t/ssl_dynamic-client.opt
+++ b/mysql-test/suite/x/t/ssl_dynamic-client.opt
@@ -1,0 +1,1 @@
+--ssl-mode=REQUIRED

--- a/mysql-test/suite/x/t/ssl_dynamic.test
+++ b/mysql-test/suite/x/t/ssl_dynamic.test
@@ -1,0 +1,106 @@
+
+--source include/xplugin_preamble.inc
+--source include/xplugin_create_user.inc
+
+## Test starts here
+
+--let $xtest_file= $MYSQL_TMP_DIR/connection_auth_plugin.tmp
+--write_file $xtest_file
+-->quiet
+-->sql
+SELECT user, plugin FROM mysql.user WHERE user = REPLACE(USER(), '@localhost', '');
+SHOW STATUS LIKE 'Mysqlx_ssl_active';
+-->endsql
+EOF
+
+CREATE USER xuser_sha256@localhost
+            IDENTIFIED WITH 'sha256_password' BY 'sha256';
+GRANT ALL ON *.* TO xuser_sha256@localhost;
+
+--let $XBASIC= --file=$xtest_file 2>&1
+--let $XSSLPARAM= --ssl-cipher='DHE-RSA-AES256-SHA' $XBASIC
+
+# The SSL library may fail initializing during this one
+call mtr.add_suppression("Failed to set up SSL because of the following SSL library error");
+call mtr.add_suppression("mysqlx reported: 'Failed at SSL configuration");
+
+--echo Ssl connection by sha256 plugin  -> success
+--exec $MYSQLXTEST -uxuser_sha256 -psha256 $XSSLPARAM
+
+--echo ################## Test reload
+ALTER INSTANCE RELOAD TLS;
+
+--echo Ssl connection by sha256 plugin  -> success
+--exec $MYSQLXTEST -uxuser_sha256 -psha256 $XSSLPARAM
+
+--echo ################## Test wrong value
+
+--echo # Save the defaults
+SET @orig_ssl_ca= @@global.ssl_ca;
+
+--echo # Set CA to invalid value
+SET GLOBAL ssl_ca = 'gizmo';
+
+--echo Ssl connection by sha256 plugin  -> success
+--exec $MYSQLXTEST -uxuser_sha256 -psha256 $XSSLPARAM
+
+--echo # Must fail and not change the SSL params
+--error ER_DA_SSL_LIBRARY_ERROR
+ALTER INSTANCE RELOAD TLS;
+
+--echo # Must be 1
+SELECT COUNT(*) FROM performance_schema.session_status
+WHERE VARIABLE_NAME = 'Current_tls_ca' AND VARIABLE_VALUE = @orig_ssl_ca;
+
+--echo Ssl connection by sha256 plugin  -> success
+--exec $MYSQLXTEST -uxuser_sha256 -psha256 $XSSLPARAM
+
+#
+--echo # Must pass with a warning and disable SSL
+ALTER INSTANCE RELOAD TLS NO ROLLBACK ON ERROR;
+
+--echo Ssl connection by sha256 plugin  -> failure
+--error 1
+--exec $MYSQLXTEST -uxuser_sha256 -psha256 $XSSLPARAM
+
+--echo # cleanup
+SET GLOBAL ssl_ca = @orig_ssl_ca;
+ALTER INSTANCE RELOAD TLS;
+
+# Must work
+
+
+--echo ################## Change certificate
+
+--echo # Save the defaults
+SET @orig_ssl_ca= @@global.ssl_ca;
+SET @orig_ssl_cert= @@global.ssl_cert;
+SET @orig_ssl_key= @@global.ssl_key;
+SET @orig_mysqlx_ssl_ca= @@global.mysqlx_ssl_ca;
+SET @orig_mysqlx_ssl_cert= @@global.mysqlx_ssl_cert;
+SET @orig_mysqlx_ssl_key= @@global.mysqlx_ssl_key;
+
+--echo # setting new values for ssl_cert, ssl_key and ssl_ca
+--replace_result "$MYSQL_TEST_DIR" MYSQL_TEST_DIR
+eval SET GLOBAL ssl_cert = "$MYSQL_TEST_DIR/std_data/server-cert-sha512.pem";
+--replace_result "$MYSQL_TEST_DIR" MYSQL_TEST_DIR
+eval SET GLOBAL ssl_key = "$MYSQL_TEST_DIR/std_data/server-key-sha512.pem";
+--replace_result "$MYSQL_TEST_DIR" MYSQL_TEST_DIR
+eval SET GLOBAL ssl_ca = "$MYSQL_TEST_DIR/std_data/ca-sha512.pem";
+ALTER INSTANCE RELOAD TLS;
+
+--echo Ssl connection by sha256 plugin  -> success
+--exec $MYSQLXTEST -uxuser_sha256 -psha256 $XSSLPARAM
+#
+--echo # cleanup
+SET GLOBAL ssl_cert = @orig_ssl_cert;
+SET GLOBAL ssl_key = @orig_ssl_key;
+SET GLOBAL ssl_ca = @orig_ssl_ca;
+ALTER INSTANCE RELOAD TLS;
+
+
+--echo ################## End of dynamic SSL tests
+
+DROP USER xuser_sha256@localhost;
+--remove_file $xtest_file
+--source include/xplugin_drop_user.inc

--- a/plugin/x/ngs/include/ngs/client.h
+++ b/plugin/x/ngs/include/ngs/client.h
@@ -151,6 +151,7 @@ class Client : public xpl::iface::Client {
   uint16_t m_client_port;
   std::atomic<Client::State> m_state;
   std::atomic<bool> m_removed;
+  std::shared_ptr<xpl::iface::Ssl_context> m_ssl;
 
   std::shared_ptr<xpl::iface::Session> m_session;
 

--- a/plugin/x/ngs/src/client.cc
+++ b/plugin/x/ngs/src/client.cc
@@ -125,8 +125,9 @@ void Client::activate_tls() {
   const auto real_connect_timeout =
       std::min<uint32_t>(connect_timeout, m_read_timeout);
 
-  if (m_server.ssl_context()->activate_tls(&connection(),
-                                           real_connect_timeout)) {
+  m_ssl = m_server.ssl_context();
+
+  if (m_ssl->activate_tls(&connection(), real_connect_timeout)) {
     session()->mark_as_tls_session();
   } else {
     log_debug("%s: Error during SSL handshake", client_id());

--- a/plugin/x/src/interface/server.h
+++ b/plugin/x/src/interface/server.h
@@ -58,6 +58,7 @@ class Server {
   virtual void delayed_start_tasks() = 0;
   virtual void start_tasks() = 0;
   virtual void stop() = 0;
+  virtual void reload_ssl_context() = 0;
 
   virtual iface::Authentication_container &get_authentications() = 0;
 
@@ -67,7 +68,7 @@ class Server {
 
   virtual xpl::Mutex &get_client_exit_mutex() = 0;
 
-  virtual Ssl_context *ssl_context() const = 0;
+  virtual std::shared_ptr<Ssl_context> ssl_context() const = 0;
 
   virtual std::shared_ptr<Session> create_session(Client *client,
                                                   Protocol_encoder *proto,

--- a/plugin/x/src/module_mysqlx.cc
+++ b/plugin/x/src/module_mysqlx.cc
@@ -125,6 +125,12 @@ void Module_mysqlx::unregister_udfs() {
   m_udf_register = nullptr;
 }
 
+static bool x_ssl_reload_cb(void *) {
+  auto server = Module_mysqlx::get_instance_server();
+  server->reload_ssl_context();
+  return true;
+}
+
 int Module_mysqlx::initialize(MYSQL_PLUGIN plugin_handle) {
   xpl::plugin_handle = plugin_handle;
 
@@ -198,12 +204,18 @@ int Module_mysqlx::initialize(MYSQL_PLUGIN plugin_handle) {
     return 1;
   }
 
+  if (!register_ssl_reload_callback(&x_ssl_reload_cb)) {
+    log_warning(ER_XPLUGIN_SSL_RELOAD_REGISTER_FAILED);
+  }
+
   return 0;
 }
 
 int Module_mysqlx::deinitialize(MYSQL_PLUGIN) {
   // this flag will trigger the on_verify_server_state() timer to trigger an
   // acceptor thread exit
+  deregister_ssl_reload_callback(&x_ssl_reload_cb);
+
   if (m_server) m_server->stop();
 
   xpl::Plugin_system_variables::cleanup();

--- a/plugin/x/src/server/server.cc
+++ b/plugin/x/src/server/server.cc
@@ -134,6 +134,10 @@ void Server::delayed_start_tasks() {
   });
 }
 
+void Server::reload_ssl_context() {
+  m_ssl_context = xpl::Ssl_context_builder().get_result_context();
+}
+
 void Server::start_tasks() {
   // We can't fetch the servers ssl config at plugin-load
   // this method allows to setup it at better time.

--- a/plugin/x/src/server/server.h
+++ b/plugin/x/src/server/server.h
@@ -82,8 +82,8 @@ class Server : public xpl::iface::Server {
          Server_properties *properties, const Server_task_vector &tasks,
          std::shared_ptr<xpl::iface::Timeout_callback> timeout_callback);
 
-  xpl::iface::Ssl_context *ssl_context() const override {
-    return m_ssl_context.get();
+  std::shared_ptr<xpl::iface::Ssl_context> ssl_context() const override {
+    return m_ssl_context;
   }
 
   bool reset() override;
@@ -92,6 +92,7 @@ class Server : public xpl::iface::Server {
   void start_tasks() override;
   void start_failed() override;
   void stop() override;
+  void reload_ssl_context() override;
 
   void close_all_clients();
 
@@ -149,7 +150,7 @@ class Server : public xpl::iface::Server {
   std::shared_ptr<Protocol_global_config> m_config;
   std::unique_ptr<xpl::iface::Document_id_generator> m_id_generator;
 
-  std::unique_ptr<xpl::iface::Ssl_context> m_ssl_context;
+  std::shared_ptr<xpl::iface::Ssl_context> m_ssl_context;
   xpl::Sync_variable<State> m_state;
   xpl::Authentication_container m_auth_handlers;
   Client_list m_client_list;

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11200,6 +11200,9 @@ ER_REDO_TABLESPACE_ENCRYPTION_CORRUPTED_KEYS
 ER_IB_MSG_UNDO_TRUNCATE_DELAY_BY_LTFB
   eng "Delaying truncate of undo tablespace %s due to lock tables for backup."
 
+ER_XPLUGIN_SSL_RELOAD_REGISTER_FAILED
+  eng "X plugin failed to register SSL reload callback. ALTER INSTANCE RELOAD TLS will have no effect on the plugin."
+
 #
 # End of Percona Server 8.0 server error log messages
 #

--- a/sql/sql_admin.cc
+++ b/sql/sql_admin.cc
@@ -42,6 +42,7 @@
 #include "my_sys.h"
 #include "myisam.h"  // TT_USEFRM
 #include "mysql/components/services/log_builtins.h"
+#include "mysql/plugin.h"
 #include "mysql/psi/mysql_file.h"
 #include "mysql/psi/mysql_mutex.h"
 #include "mysql_com.h"
@@ -1698,10 +1699,42 @@ class Alter_instance_reload_tls : public Alter_instance {
       }
     }
 
-    if (!res) my_ok(m_thd);
+    if (!res) {
+      String specified_channel(channel_name_.str, channel_name_.length,
+                               system_charset_info);
+      if (!my_strcasecmp(system_charset_info, mysql_main_channel.c_str(),
+                         specified_channel.ptr())) {
+        for (auto const &cb : callbacks_) {
+          if (!cb(nullptr)) {
+            push_warning_printf(m_thd, Sql_condition::SL_WARNING,
+                                ER_DA_SSL_LIBRARY_ERROR,
+                                ER_THD(m_thd, ER_DA_SSL_LIBRARY_ERROR),
+                                "One of the TLS reload callbacks failed");
+            LogErr(WARNING_LEVEL, ER_SSL_LIBRARY_ERROR,
+                   "One of the TLS reload callbacks failed");
+          }
+        };
+      }
+
+      my_ok(m_thd);
+    }
     return res;
   }
   ~Alter_instance_reload_tls() override {}
+
+  static bool register_callback(ssl_reload_callback_t c) {
+    auto it = std::find(callbacks_.begin(), callbacks_.end(), c);
+    if (it != callbacks_.end()) return false;
+    callbacks_.push_back(c);
+    return true;
+  }
+
+  static bool deregister_callback(ssl_reload_callback_t c) {
+    auto it = std::find(callbacks_.begin(), callbacks_.end(), c);
+    if (it == callbacks_.end()) return false;
+    callbacks_.erase(it);
+    return true;
+  }
 
  protected:
   bool match_channel_name() {
@@ -1727,7 +1760,21 @@ class Alter_instance_reload_tls : public Alter_instance {
   LEX_CSTRING channel_name_;
   bool force_;
   Ssl_acceptor_context_type context_type_;
+  static std::vector<ssl_reload_callback_t> callbacks_;
 };
+
+std::vector<ssl_reload_callback_t> Alter_instance_reload_tls::callbacks_;
+
+extern "C" {
+
+bool register_ssl_reload_callback(ssl_reload_callback_t c) {
+  return Alter_instance_reload_tls::register_callback(c);
+}
+
+bool deregister_ssl_reload_callback(ssl_reload_callback_t c) {
+  return Alter_instance_reload_tls::deregister_callback(c);
+}
+}
 
 bool Sql_cmd_alter_instance::execute(THD *thd) {
   bool res = true;

--- a/unittest/gunit/xplugin/xpl/capabilities_handlers_t.cc
+++ b/unittest/gunit/xplugin/xpl/capabilities_handlers_t.cc
@@ -57,12 +57,12 @@ class CapabilityHanderTlsTestSuite : public Test {
         .WillRepeatedly(ReturnRef(mock_connection));
     EXPECT_CALL(mock_client, server()).WillRepeatedly(ReturnRef(mock_server));
     EXPECT_CALL(mock_server, ssl_context())
-        .WillRepeatedly(Return(&mock_ssl_context));
+        .WillRepeatedly(Return(mock_ssl_context));
   }
 
   StrictMock<Mock_vio> mock_connection;
   StrictMock<Mock_client> mock_client;
-  StrictMock<Mock_ssl_context> mock_ssl_context;
+  std::shared_ptr<Mock_ssl_context> mock_ssl_context;
   StrictMock<Mock_server> mock_server;
 
   Capability_tls sut;
@@ -71,7 +71,7 @@ class CapabilityHanderTlsTestSuite : public Test {
 TEST_F(
     CapabilityHanderTlsTestSuite,
     isSupported_returnsCurrentConnectionOption_on_supported_connection_type) {
-  EXPECT_CALL(mock_ssl_context, has_ssl())
+  EXPECT_CALL(*mock_ssl_context, has_ssl())
       .WillOnce(Return(true))
       .WillOnce(Return(false));
   EXPECT_CALL(mock_connection, get_type())
@@ -84,7 +84,7 @@ TEST_F(
 
 TEST_F(CapabilityHanderTlsTestSuite,
        isSupported_returnsFailure_on_unsupported_connection_type) {
-  EXPECT_CALL(mock_ssl_context, has_ssl())
+  EXPECT_CALL(*mock_ssl_context, has_ssl())
       .WillOnce(Return(true))
       .WillOnce(Return(false));
   EXPECT_CALL(mock_connection, get_type())
@@ -141,7 +141,7 @@ TEST_P(SuccessSetCapabilityHanderTlsTestSuite,
        get_success_forValidParametersAndTlsSupportedOnTcpip) {
   auto s = GetParam();
 
-  EXPECT_CALL(mock_ssl_context, has_ssl()).WillOnce(Return(true));
+  EXPECT_CALL(*mock_ssl_context, has_ssl()).WillOnce(Return(true));
   EXPECT_CALL(mock_connection, get_type())
       .WillRepeatedly(Return(xpl::Connection_tcpip));
 
@@ -156,7 +156,7 @@ TEST_P(SuccessSetCapabilityHanderTlsTestSuite,
        get_failure_forValidParametersAndTlsSupportedOnNamedPipe) {
   Set_params s = GetParam();
 
-  EXPECT_CALL(mock_ssl_context, has_ssl()).WillOnce(Return(true));
+  EXPECT_CALL(*mock_ssl_context, has_ssl()).WillOnce(Return(true));
   EXPECT_CALL(mock_connection, get_type())
       .WillRepeatedly(Return(xpl::Connection_namedpipe));
 
@@ -167,7 +167,7 @@ TEST_P(SuccessSetCapabilityHanderTlsTestSuite,
        get_failure_forValidParametersAndTlsIsntSupported) {
   Set_params s = GetParam();
 
-  EXPECT_CALL(mock_ssl_context, has_ssl()).WillOnce(Return(false));
+  EXPECT_CALL(*mock_ssl_context, has_ssl()).WillOnce(Return(false));
   EXPECT_CALL(mock_connection, get_type())
       .WillRepeatedly(Return(xpl::Connection_tcpip));
 

--- a/unittest/gunit/xplugin/xpl/mock/mock_component_services.cc
+++ b/unittest/gunit/xplugin/xpl/mock/mock_component_services.cc
@@ -24,6 +24,8 @@
 
 #include "mock_component_services.h"
 
+#include "mysql/plugin.h"
+
 namespace xpl {
 namespace test {
 
@@ -34,3 +36,8 @@ Mock_mysql_plugin_registry
 
 }  // namespace test
 }  // namespace xpl
+
+extern "C" {
+bool register_ssl_reload_callback(ssl_reload_callback_t) { return true; }
+bool deregister_ssl_reload_callback(ssl_reload_callback_t) { return true; }
+}

--- a/unittest/gunit/xplugin/xpl/mock/session.h
+++ b/unittest/gunit/xplugin/xpl/mock/session.h
@@ -121,7 +121,8 @@ class Mock_server : public iface::Server {
   MOCK_METHOD0(is_running, bool());
   MOCK_CONST_METHOD0(get_worker_scheduler,
                      std::shared_ptr<ngs::Scheduler_dynamic>());
-  MOCK_CONST_METHOD0(ssl_context, iface::Ssl_context *());
+  MOCK_CONST_METHOD0(ssl_context, std::shared_ptr<iface::Ssl_context>());
+  MOCK_METHOD0(reload_ssl_context, void());
   MOCK_METHOD1(on_client_closed, void(const iface::Client &));
   MOCK_METHOD3(create_session,
                std::shared_ptr<iface::Session>(iface::Client *,

--- a/unittest/gunit/xplugin/xpl/timeouts_t.cc
+++ b/unittest/gunit/xplugin/xpl/timeouts_t.cc
@@ -131,7 +131,9 @@ TEST_F(Timers_test_suite,
   config->m_timeouts.m_interactive_timeout = 11;
   std::shared_ptr<Strict_mock_vio> temp_vio(new Strict_mock_vio());
 
-  StrictMock<Mock_ssl_context> mock_ssl_context;
+  std::shared_ptr<Mock_ssl_context> mock_ssl_context;
+  mock_ssl_context.reset(new StrictMock<Mock_ssl_context>());
+
   Mock_ngs_client client(temp_vio, mock_server, /* id */ 1,
                          &mock_protocol_monitor);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7125

Issue: MySQL lets users change certificates while the server is running,
but this change isn't propagated to the X plugin. X connections still
keep using the old certificate.

Fix: this commit adds a callback to the plugin interface, notifying
plugins if the user executed ALTER INSTANCE RELOAD TLS. The X plugin
implements this callback, and reloads certificates correctly. Existing
connections also keep using the previous certificate, similarly to
normal connections.