### PR TITLE
PS-5454: Fix unstable test percona_changed_page_bmp_log_resize

### DIFF
--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash-master.opt
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_crash-master.opt
@@ -1,1 +1,1 @@
---innodb_track_changed_pages=TRUE --innodb_log_file_size=5M --skip-stack-trace --skip-core-file
+--innodb_track_changed_pages=TRUE --innodb_log_file_size=5M --skip-core-file


### PR DESCRIPTION
After recent changes to redo log design checkpoint behavior
changed. Now checkpoint LSN may point into a middle of a log
record. The online log tracker wasn't aware of such checkpoint
behavior.

To fix this online log tracker was improved in order to correctly
process log records around checkpoint. As checkpoint may point into
a middle of a log record it needs to properly find a point in log
around checkpoint LSN where to stop log parsing. This will be a
beginning of the next record group which starts at or after
checkpoint LSN.

The same is correct to a point where to start parsing data during
an iteration. This again will be a beginning of a record group
but this time it's searched around previous checkpoint LSN.
