### PR TITLE
PS-7143 : Server freezes and reaches max connections due to ACL Cache…

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -112,7 +112,7 @@
 #define MAX_VAR_NAME_LENGTH 256
 #define MAX_COLUMNS 256
 #define MAX_DELIMITER_LENGTH 16
-#define DEFAULT_MAX_CONN 128
+#define DEFAULT_MAX_CONN 1024
 #define REPLACE_ROUND_MAX 16
 
 /* Flags controlling send and reap */
@@ -7400,8 +7400,8 @@ static struct my_option my_long_options[] = {
      REQUIRED_ARG, 500, 1, 10000, nullptr, 0, nullptr},
     {"max-connections", OPT_MAX_CONNECTIONS,
      "Max number of open connections to server", &opt_max_connections,
-     &opt_max_connections, nullptr, GET_INT, REQUIRED_ARG, 128, 8, 5120,
-     nullptr, 0, nullptr},
+     &opt_max_connections, nullptr, GET_INT, REQUIRED_ARG, DEFAULT_MAX_CONN, 8,
+     9120, nullptr, 0, nullptr},
     {"no-skip", OPT_NO_SKIP, "Force the test to run without skip.", &no_skip,
      &no_skip, nullptr, GET_BOOL, NO_ARG, 0, 0, 0, nullptr, 0, nullptr},
     {"no-skip-exclude-list", 'n',

--- a/mysql-test/r/acl_mdl_scalability.result
+++ b/mysql-test/r/acl_mdl_scalability.result
@@ -1,0 +1,71 @@
+#
+# PS-7143 : Server freezes and reaches max connections due to ACL Cache Lock waits
+#
+# Check if system can handle 12k concurrent threads
+# 12K because server creates 6K threads and clients
+# another 6k threads/processes
+# There is no easy way to check if the system can
+# handle 12K threads. We compile C-program (need g++)
+# and execute it and check return status
+# Require g++ to compile this program. If the exec fails "sh: 1: g++: not found". Please install g++ and retry
+# if the below exec fails, it means the operating system has limit of threads less than 12K
+# This testcase needs OS that can create 12k threads.
+# Try these settings (only if they are less 12,000)
+# ulimit -i  12000
+# echo 12000 > /proc/sys/kernel/threads-max
+# echo 60000 > /proc/sys/vm/max_map_count
+# echo 12000 > /proc/sys/kernel/pid_max
+# echo 12000 > /sys/fs/cgroup/pids/user.slice/user-.slice/pids.max
+# Precondition check of the system is completed. The system can handle 12K concurrent threads
+# Adding debug point 'skip_session_admin_check' to @@GLOBAL.debug
+CREATE USER satya@'%' IDENTIFIED BY 'hello';
+GRANT ALL on test.* to satya@'%';
+GRANT ALL on mysql.* to satya@'%';
+SET GLOBAL max_connections = 6000;
+# Sleeping 15 seconds for allowing user to connect client for observability
+# we cannot establish connection later as database freezes. Do now if you wish
+# be in mysql-source/bld/mysql-test directory and execute the below command
+# ../runtime_output_directory/mysql -uroot -S ./var/tmp/mysqld.1.sock
+# connection con0: Hold ACL x lock and let readers wait
+SET DEBUG_SYNC= 'acl_x_lock SIGNAL x_locked WAIT_FOR all_wait_s_locks_done';
+FLUSH PRIVILEGES;
+# 200 connections try for SHARED ACL lock and go into waiting list
+# because FLUSH PRIVILEGES holds EXCLUSIVE lock
+# Connection default. Waiting for 200 connections to reach blocking state
+# Now release X-lock by FLUSH PRIVILEGES. Now All 200 readers get the
+# SHARED lock and they wait on debug sync point after acquiring SHARED
+# ACL MDL lock
+SET DEBUG_SYNC = 'now SIGNAL all_wait_s_locks_done';
+# Wait for 200 connection to reach acquired SHARED ACL MDL lock state
+# Start 5000 connection will go into ACL cache lock waiting state
+FLUSH PRIVILEGES;;
+# Connection default: Wait for those 5000 new connections to reach ACL cache lock waiting state
+# Start another 500 connections and stop them in just before deadlock check iteration
+# Connection default: Make 500 threads stop just before deadlock check
+SET DEBUG_SYNC = 'now WAIT_FOR before_dead_lock NO_CLEAR_EVENT';
+# Now signal waiting threads to start deadlock checks
+SET DEBUG_SYNC = 'now SIGNAL start_dead_lock_check';
+# Waiting for 500 threads to reach before deadlock check state
+# Signal 500 threads to start deadlocks checks
+SET DEBUG_SYNC = 'now SIGNAL resume_wait_graph';
+# Now let the initial 200 readers who took the SHARED lock to resume
+# They will not be able to release the lock/ticket to internal rwlock
+# taken as SHARED by Deadlock check threads. These threads need exclusive
+# mode to remove ticket from granted list
+SET DEBUG_SYNC = 'now SIGNAL new_xlock';
+# database freezes now and new connections are blocked
+# and finally we hit max_connections limit
+# Freeze start..  Also observe high cpu usage.. mysql server is doing deadlock checks
+SELECT NOW() INTO @start;
+# Waiting for connections to finish
+# initial_con_count is 704
+SELECT NOW() INTO @end;
+# Cleanup
+SET GLOBAL max_connections = 151;
+# closing connections
+# all new connections disconnected.
+DROP USER satya@'%';
+# Removing debug point 'skip_session_admin_check' from @@GLOBAL.debug
+SET DEBUG_SYNC = RESET;
+include/assert.inc [All the connections should finish within 60 seconds if there is no hang due to ACL]
+# restart

--- a/mysql-test/t/acl_mdl_scalability.test
+++ b/mysql-test/t/acl_mdl_scalability.test
@@ -1,0 +1,268 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+# We rely on g++ to compile c-program
+--source include/not_windows.inc
+# Because of 6K connections, mysqld consumes close to
+# 14G virtual memory
+--source include/big_test.inc
+--source include/not_valgrind.inc
+
+--echo #
+--echo # PS-7143 : Server freezes and reaches max connections due to ACL Cache Lock waits
+--echo #
+
+--echo # Check if system can handle 12k concurrent threads
+--echo # 12K because server creates 6K threads and clients
+--echo # another 6k threads/processes
+
+--echo # There is no easy way to check if the system can
+--echo # handle 12K threads. We compile C-program (need g++)
+--echo # and execute it and check return status
+
+--write_file $MYSQL_TMP_DIR/thread_limit_test.cc
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
+#include <atomic>
+#include <iostream>
+#include <thread>
+#include <chrono>
+
+#define NUM_THREADS     12000
+std::atomic<int> current_threads{0};
+using namespace std;
+
+void* ThreadTask(void *threadid)
+{
+   long tid;
+   tid = (long)threadid;
+   std::cout << "Hello World! It's me, thread# " << tid << std::endl;
+   ++current_threads;
+   while (current_threads.load() < NUM_THREADS) {
+          std::this_thread::sleep_for(std::chrono::seconds(1));
+   }
+   std::cout << "Thread exiting # " << tid << std::endl;
+   pthread_exit(NULL);
+}
+
+int main ()
+{
+   pthread_t threads[NUM_THREADS];
+   int rc;
+   for(long t=0; t<NUM_THREADS; t++){
+      std::cout << "In main: creating thread: " << t << std::endl;
+      rc = pthread_create(&threads[t], NULL, ThreadTask, (void *)t);
+      if (rc){
+         std::cout << "ERROR: return code from pthread_create() is " << strerror(rc) << std::endl;
+         exit(-1);
+      }
+   }
+
+   for(long t=0; t<NUM_THREADS; t++){
+	pthread_join(threads[t], NULL);
+   }
+
+   std::cout << "finish executing main " << std::endl;
+   return(0);
+}
+EOF
+--echo # Require g++ to compile this program. If the exec fails "sh: 1: g++: not found". Please install g++ and retry
+--exec g++ $MYSQL_TMP_DIR/thread_limit_test.cc -std=c++11 -lpthread -o $MYSQL_TMP_DIR/thread_limit 2>&1 > $MYSQL_TMP_DIR/thread_limit_gcc_error.txt
+
+--echo # if the below exec fails, it means the operating system has limit of threads less than 12K
+--echo # This testcase needs OS that can create 12k threads.
+--echo # Try these settings (only if they are less 12,000)
+--echo # ulimit -i  12000
+--echo # echo 12000 > /proc/sys/kernel/threads-max
+--echo # echo 60000 > /proc/sys/vm/max_map_count
+--echo # echo 12000 > /proc/sys/kernel/pid_max
+--echo # echo 12000 > /sys/fs/cgroup/pids/user.slice/user-$UID.slice/pids.max
+--exec $MYSQL_TMP_DIR/thread_limit 2>&1 > $MYSQL_TMP_DIR/thread_limit_gcc_error.txt
+--remove_file $MYSQL_TMP_DIR/thread_limit_test.cc
+--remove_file $MYSQL_TMP_DIR/thread_limit_gcc_error.txt
+--remove_file $MYSQL_TMP_DIR/thread_limit
+
+--echo # Precondition check of the system is completed. The system can handle 12K concurrent threads
+
+--source include/count_sessions.inc
+
+--let $debug_point = skip_session_admin_check
+--source include/add_debug_point.inc
+
+CREATE USER satya@'%' IDENTIFIED BY 'hello';
+GRANT ALL on test.* to satya@'%';
+GRANT ALL on mysql.* to satya@'%';
+
+--let $old_max_conn=`SELECT @@global.max_connections`
+SET GLOBAL max_connections = 6000;
+
+--connect (con_flush,localhost,root,,)
+--connect (con0,localhost,root,,)
+
+--let $i = 1
+while ($i <= 200) {
+ --connect (con$i, localhost, root)
+ --inc $i
+}
+
+--let $i = 201
+while ($i <= 700) {
+ --connect (con$i, 127.0.0.1, satya,hello,test)
+ --inc $i
+}
+
+--connection default
+--let $initial_con_count=`SELECT COUNT(*) FROM information_schema.processlist`
+
+--echo # Sleeping 15 seconds for allowing user to connect client for observability
+--echo # we cannot establish connection later as database freezes. Do now if you wish
+--echo # be in mysql-source/bld/mysql-test directory and execute the below command
+--echo # ../runtime_output_directory/mysql -uroot -S ./var/tmp/mysqld.1.sock
+#--sleep 15
+#--echo # sleep over
+
+--echo # connection con0: Hold ACL x lock and let readers wait
+--connection con0
+SET DEBUG_SYNC= 'acl_x_lock SIGNAL x_locked WAIT_FOR all_wait_s_locks_done';
+--send FLUSH PRIVILEGES
+
+--echo # 200 connections try for SHARED ACL lock and go into waiting list
+--echo # because FLUSH PRIVILEGES holds EXCLUSIVE lock
+--disable_query_log
+--let $i = 1
+while ($i <= 200) {
+ --connection con$i
+ SET DEBUG_SYNC = 'now WAIT_FOR x_locked NO_CLEAR_EVENT';
+ SET DEBUG_SYNC = 'acl_s_lock SIGNAL s_locked WAIT_FOR new_xlock NO_CLEAR_EVENT';
+ --send SHOW CREATE USER root@localhost
+ --inc $i
+}
+--enable_query_log
+
+--echo # Connection default. Waiting for 200 connections to reach blocking state
+--connection default
+--let $wait_timeout = 600
+let $wait_condition=
+  SELECT COUNT(*) = 200 FROM information_schema.processlist
+    WHERE state = 'Waiting for acl cache lock' AND
+          info = 'SHOW CREATE USER root@localhost';
+--source include/wait_condition.inc
+
+--echo # Now release X-lock by FLUSH PRIVILEGES. Now All 200 readers get the
+--echo # SHARED lock and they wait on debug sync point after acquiring SHARED
+--echo # ACL MDL lock
+SET DEBUG_SYNC = 'now SIGNAL all_wait_s_locks_done';
+
+--echo # Wait for 200 connection to reach acquired SHARED ACL MDL lock state
+--let $wait_timeout = 600
+let $wait_condition=
+ SELECT COUNT(*) = 200 FROM information_schema.processlist
+   WHERE state = 'debug sync point: acl_s_lock' AND
+         info = 'SHOW CREATE USER root@localhost';
+--source include/wait_condition.inc
+
+--echo # Start 5000 connection will go into ACL cache lock waiting state
+--let $i = 1
+while ($i <= 5000) {
+ --exec_in_background $MYSQL -usatya -phello -h 127.0.0.1 -P $MASTER_MYPORT test -e "SELECT 1" 2>&1 > /dev/null
+ if ($i == 1500) {
+   --connection con_flush
+   --send FLUSH PRIVILEGES;
+ }
+ --inc $i
+}
+
+--echo # Connection default: Wait for those 5000 new connections to reach ACL cache lock waiting state
+--connection default
+--let $wait_timeout = 600
+let $wait_condition=
+  SELECT COUNT(*) = 5000 FROM information_schema.processlist
+    WHERE USER = 'unauthenticated user' AND STATE = 'Waiting for acl cache lock';
+--source include/wait_condition.inc
+
+--echo # Start another 500 connections and stop them in just before deadlock check iteration
+--disable_query_log
+--let $i = 201
+while ($i <= 700) {
+  --connection con$i
+  SET DEBUG_SYNC = 'now WAIT_FOR s_locked NO_CLEAR_EVENT';
+  SET DEBUG_SYNC = 'mdl_acquire_lock_wait SIGNAL before_dead_lock WAIT_FOR start_dead_lock_check NO_CLEAR_EVENT';
+  SET DEBUG_SYNC = 'acl_mdl_dead_lock SIGNAL dead_locked WAIT_FOR resume_wait_graph NO_CLEAR_EVENT';
+  --send SHOW CREATE USER root@localhost
+  --inc $i
+}
+--enable_query_log
+
+--echo # Connection default: Make 500 threads stop just before deadlock check
+--connection default
+SET DEBUG_SYNC = 'now WAIT_FOR before_dead_lock NO_CLEAR_EVENT';
+
+--echo # Now signal waiting threads to start deadlock checks
+SET DEBUG_SYNC = 'now SIGNAL start_dead_lock_check';
+
+--echo # Waiting for 500 threads to reach before deadlock check state
+--let $wait_timeout = 60
+let $wait_condition=
+  SELECT COUNT(*) = 500 FROM information_schema.processlist
+    WHERE STATE = 'debug sync point: mdl_acquire_lock_wait'
+    AND info = 'SHOW CREATE USER root@localhost';
+
+--echo # Signal 500 threads to start deadlocks checks
+SET DEBUG_SYNC = 'now SIGNAL resume_wait_graph';
+--echo # Now let the initial 200 readers who took the SHARED lock to resume
+--echo # They will not be able to release the lock/ticket to internal rwlock
+--echo # taken as SHARED by Deadlock check threads. These threads need exclusive
+--echo # mode to remove ticket from granted list
+SET DEBUG_SYNC = 'now SIGNAL new_xlock';
+
+--echo # database freezes now and new connections are blocked
+--echo # and finally we hit max_connections limit
+--echo # Freeze start..  Also observe high cpu usage.. mysql server is doing deadlock checks
+
+SELECT NOW() INTO @start;
+
+--connection default
+--echo # Waiting for connections to finish
+--echo # initial_con_count is $initial_con_count
+--let $wait_timeout = 600
+let $wait_condition=
+  SELECT COUNT(*) = $initial_con_count FROM information_schema.processlist;
+--source include/wait_condition.inc
+
+SELECT NOW() INTO @end;
+#--echo # Freeze over..
+#--echo # total time mysqld freezed:
+#--echo #########################################################################
+#SELECT TIMEDIFF(@end, @start) AS freeze_time;
+#--echo #########################################################################
+
+--echo # Cleanup
+--eval SET GLOBAL max_connections = $old_max_conn
+--disable_result_log
+--echo # closing connections
+--let $i = 0
+while ($i <= 700) {
+ --connection con$i
+ --reap
+ --disconnect con$i
+ --inc $i
+}
+--connection con_flush
+--reap
+--disconnect con_flush
+
+--enable_result_log
+
+--connection default
+--echo # all new connections disconnected.
+--source include/wait_until_count_sessions.inc
+DROP USER satya@'%';
+--source include/remove_debug_point.inc
+SET DEBUG_SYNC = RESET;
+--let $assert_text = All the connections should finish within 60 seconds if there is no hang due to ACL
+--let $assert_cond= "[SELECT TIMEDIFF(@end, @start) < 60]" = 1
+--source include/assert.inc
+# Restart to release virtual memory
+--source include/restart_mysqld.inc

--- a/sql/auth/sql_auth_cache.cc
+++ b/sql/auth/sql_auth_cache.cc
@@ -2438,6 +2438,8 @@ bool acl_reload(THD *thd, bool mdl_locked) {
 
   if (!acl_cache_lock.lock()) goto end;
 
+  DEBUG_SYNC(thd, "acl_x_lock");
+
   old_acl_users = acl_users;
   old_acl_dbs = acl_dbs;
   old_acl_proxy_users = acl_proxy_users;
@@ -3653,8 +3655,11 @@ void shutdown_acl_cache() {
   delete g_mandatory_roles;
 }
 
-/* Constants used by Acl_cache_lock_guard */
-static const ulong ACL_CACHE_LOCK_TIMEOUT = 3600UL;
+/* Constants used by Acl_cache_lock_guard. Upstream value of 3600UL
+(60mins) is too high. InnoDB max latch wait timeout
+(srv_fatal_semaphore_wait_threshold is 600 sec). 15mins (900 seconds)
+is good enough value for timeout */
+static const ulong ACL_CACHE_LOCK_TIMEOUT = 900UL;
 static const MDL_key ACL_CACHE_KEY(MDL_key::ACL_CACHE, "", "");
 
 /**

--- a/sql/auth/sql_user.cc
+++ b/sql/auth/sql_user.cc
@@ -226,6 +226,8 @@ bool mysql_show_create_user(THD *thd, LEX_USER *user_name,
   Acl_cache_lock_guard acl_cache_lock(thd, Acl_cache_lock_mode::READ_MODE);
   if (!acl_cache_lock.lock()) return true;
 
+  DEBUG_SYNC(thd, "acl_s_lock");
+
   if (!(acl_user =
             find_acl_user(user_name->host.str, user_name->user.str, true))) {
     String wrong_users;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -278,6 +278,10 @@ static bool check_session_admin(sys_var *self MY_ATTRIBUTE((unused)), THD *thd,
   DBUG_ASSERT(self->scope() !=
               sys_var::GLOBAL);  // don't abuse check_session_admin()
   Security_context *sctx = thd->security_context();
+
+  /* Skip ACL checks for SET commands */
+  DBUG_EXECUTE_IF("skip_session_admin_check", return false;);
+
   if ((setv->type == OPT_SESSION || setv->type == OPT_DEFAULT) &&
       !sctx->has_global_grant(STRING_WITH_LEN("SESSION_VARIABLES_ADMIN"))
            .first &&


### PR DESCRIPTION
… Lock waits

Problem:
--------
ACL (Access Control Lists) caches since 8.0 are handled by MDL lock.
Previously(5.7) it was handled by a mix of mutex(acl_cache->lock)
+ Paritioned_RW_lock (LOCK_grant)

From 8.0, the cache (of user, hosts, other ACL structures) is handled by MDL
lock. Readers(ex acl_check_host) take MDL_SHARED and Writers (DDLs: GRANT, FLUSH
PRIVILEGES) take MDL_EXCLUSIVE. So ideally we should see improvement when
compared to mutex.

But MDL Lock suffers a performance issue when there are huge number of readers
and atleast (or with just one) writer. MDL lock suffers from contention on its
internal rwlock (lock->m_rwlock). Lets see how

~~~~~
Keywords used:

ACL1 -> any grant/revoke/FLUSH PRIVILEGE (takes MDL EXCLUSIVE)
ACL2 -> is from one of the connection login with default_db
(acl_authenticate()->mysql_change_db()->acl_get()->insert_entry_in_db_cache()->
requires MDL EXCLUSIVE lock onACL cache)
ACL3 -> connection login requests (acl_check_host() etc) that check
cache. These are readers that only need MDL_SHARED
 batch1 size : 200
 batch2 size : 5000
 batch3 size : 200
~~~~~

1.  ACL1 command takes MDL EXCLUSIVE

2.  allow hord of readers (ACL3s) batch1 to come and wait for MDL_SARED lock
(they cannot take it yet as MDL_EXCLUSIVE is already acquired. So these requests
go into something called slow_path and are registered in m_waiting_list and
later in m_granted list after MDL_EXCLUSIVE is released)

3.  let ACL1 command release MDL_EXCLUSIVE lock

4.  All ACL3 Batch1 readers acquire MDL_SHARED lock. (they are in m_granted list
of ACL Cache lock)

5.  Before all the ACL3 Batch1 readers finish, Let there be a new ACL2 command
that requests for MDL_EXCLUSIVE lock

6.  ACL2 goes into m_waitng list, cannot take MDL_EXCLUSIVE lock yet as ACL3
Batch1 readers hold MDL_SHARED lock

7.  Allow new set of readers to come. ALC3 batch2 (size of around 5000). Now,
even though there is no MDL_EXCLUSIVE lock taken, since there is waiting
MDL_EXCLUISVE lock, all new readers (ACL3 batch2) go into m_waiting list.

    At this stage, ACL Cache MDL lock looks like this
    m_granted list: size 200: All MDL_SHARED
    m_waiting list: one MDL_EXCLUSIVE, 5000 MDL_SHARED requests

8.  Allow another set of readers. ALC3 batch3 (size of 200) to come. These
readers, do deadlock checks before going to waiting list. As the
granted list and waiting list are of huge size, the deadlock check now takes lot
of time. These deadlock checks happen after taking the internal RWlock (of ACL
MDL lock) in SHARED MODE.

9.  the ACL1 batch1 readers who are granted, cannot release the MDL LOCK. This
is because for releasing the lock/ticket they need EXCLUSIVE mode of internal
RWlock to remove ticket from m_granted list. (The internal RWlock is taken by
readers who are doing deadlock checks for long long time)

10. Any more new readers (ACL3), they also get stuck at internal RWlock (at much
early stage).

11. Due to contention on internal RW lock of MDL lock, every connection
(requires ACL CACHE Lock SHARED See acl_check_host()) also get stuck

12. Eventually, we will soon run of max_connections.

13. Freeze lasts until ACL3 batch3 readers complete deadlock checks.

Fix:
----
Ideally, we only need a simple RW-lock. The MDL lock seems to suffer when used a
pure RW lock.

The only benefit of ACL Cache lock as MDL is that it can detect lock ordering
issues. (they can arise only due to buggy code) For example opening ACL TABLES
take MDL lock on grant table (TABLE lock. Lets say A). And ACL Cache lock MDL
(Lets say B). Threads should acquire in same order (first A and then B)

If we don't, then

thread1: can acquire lock A wait for B

thread2: acquire B and wait for lock A

With proper lock ordering,  we always acquire in same order for all threads.
Lets say first A and then B..

MDL deadlock detector found this issue (bug in code) and it is solved in 8.0.18.
See cda465b69d5381a739c4669be55e5c500536c7dd

Another minor benefit is ACL cache lock is acquired at higher layers and lower
layers can check if it has already acquired lock or not (using thd->mdl_context)

[Final Fix chosen]
------------------
We simply suppress the expensive deadlock check for ACL Cache MDL lock. This
removes the contention on internal RWlock of MDL lock.

If ever there is really deadlock caused by buggy code, we rely on
ACL_CACHE_LOCK_TIMEOUT value. The value of ACL_CACHE_LOCK_TIMEOUT is reduced to
15mins (from upstream's default of 60 mins). 60 mins is too much. Even InnoDB
Semaphore latch wait timeout is around 15mins