### PR TITLE
PS-7245: Block redo log disabling with LTFB

### DIFF
--- a/mysql-test/suite/innodb/r/redo_log_disable.result
+++ b/mysql-test/suite/innodb/r/redo_log_disable.result
@@ -951,3 +951,9 @@ ALTER INSTANCE ENABLE INNODB REDO_LOG;
 SELECT * FROM performance_schema.global_status WHERE variable_name like 'Innodb_redo_log_enabled';
 VARIABLE_NAME	VARIABLE_VALUE
 Innodb_redo_log_enabled	ON
+LOCK TABLES FOR BACKUP;
+ALTER INSTANCE ENABLE INNODB REDO_LOG;
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+SET @@session.lock_wait_timeout=1;
+ALTER INSTANCE ENABLE INNODB REDO_LOG;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction

--- a/mysql-test/suite/innodb/t/redo_log_disable.test
+++ b/mysql-test/suite/innodb/t/redo_log_disable.test
@@ -1,5 +1,7 @@
 # Test Enable and Disable redo logging
 
+--source include/count_sessions.inc
+
 --disable_query_log
 call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* InnoDB redo logging is disabled. All data could be lost in case of a server crash");
 call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* InnoDB redo logging is enabled. Data is now safe and can be recovered in case of a server crash.");
@@ -151,3 +153,18 @@ SELECT * FROM performance_schema.global_status WHERE variable_name like 'Innodb_
 ALTER INSTANCE ENABLE INNODB REDO_LOG;
 
 SELECT * FROM performance_schema.global_status WHERE variable_name like 'Innodb_redo_log_enabled';
+
+# Check that it won't work with LTFB
+LOCK TABLES FOR BACKUP;
+--error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
+ALTER INSTANCE ENABLE INNODB REDO_LOG;
+
+--connect (con1,'localhost','root',,)
+SET @@session.lock_wait_timeout=1;
+--error ER_LOCK_WAIT_TIMEOUT
+
+ALTER INSTANCE ENABLE INNODB REDO_LOG;
+--connection default
+--disconnect con1
+
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_alter_instance.cc
+++ b/sql/sql_alter_instance.cc
@@ -269,6 +269,13 @@ bool Innodb_redo_log::execute() {
     return true;
   }
 
+  // Acquire Percona's LOCK TABLES FOR BACKUP lock
+  if (m_thd->backup_tables_lock.abort_if_acquired() ||
+      m_thd->backup_tables_lock.acquire_protection(
+          m_thd, MDL_TRANSACTION, m_thd->variables.lock_wait_timeout)) {
+    return true;
+  }
+
   if (hton->redo_log_set_state(m_thd, m_enable)) {
     /* SE should have raised error */
     DBUG_ASSERT(m_thd->get_stmt_da()->is_error());


### PR DESCRIPTION
Problem: upstream blocks the ALTER INSTANCE DISABLE INNODB REDO_LOG
statements if there is a backup lock is held. This is required to avoid
taking corrupt backups.
PS however also has the LOCK TABLES FOR BACKUP lock, which is preferred
by xtrabackup when taking a backup from a Percona Server. This lock
currently doesn't block the above alter instance statement.

Fix: block the statement when LTFB lock is held.