### PR TITLE
Fixed PS-7279 (Stacktrace and coredumps not generating on Percona ser…

### DIFF
--- a/mysql-test/t/coredump.test
+++ b/mysql-test/t/coredump.test
@@ -97,7 +97,7 @@ remove_files_wildcard $MYSQLD_DATADIR mycore.*;
 # Check Build ID and server version has been written to error log
 --let $assert_text= Checking MySQL wrote Build ID
 --let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
---let $assert_select= Build ID: [a-f0-9]{40}
+--let $assert_select= Build ID: ([a-f0-9]{40}|Not Available)
 --let $assert_only_after=CURRENT_TEST: main.coredump
 --let $assert_count=2
 --source include/assert_grep.inc

--- a/mysys/stacktrace.c
+++ b/mysys/stacktrace.c
@@ -259,6 +259,7 @@ void my_print_buildID()
   unsigned char *build_id;
   char           buff[3];
   uint           i;
+  uint           bytes_read;
   snprintf(proc_path, sizeof(proc_path), "/proc/%d/exe", getpid());
   readlink_bytes= readlink(proc_path, mysqld_path, sizeof(mysqld_path));
   if (readlink_bytes < 1)
@@ -285,10 +286,18 @@ void my_print_buildID()
     ++phdr;
   }
   nhdr= (ElfW(Nhdr) *)(phdr->p_offset + (size_t)ehdr);
+  bytes_read= sizeof(ElfW(Nhdr));
   while (nhdr->n_type != NT_GNU_BUILD_ID)
   {
     nhdr= (ElfW(Nhdr) *)((size_t)nhdr + sizeof(ElfW(Nhdr)) + nhdr->n_namesz +
                          nhdr->n_descsz);
+    bytes_read+= nhdr->n_namesz + nhdr->n_descsz;
+    if (bytes_read > phdr->p_filesz)
+    {
+      my_safe_printf_stderr("Build ID: Not Available \n");
+      fclose(mysqld);
+      return;
+    }
   }
   build_id= (unsigned char *)my_malloc(PSI_NOT_INSTRUMENTED, nhdr->n_descsz,
                                        MYF(0));


### PR DESCRIPTION
…ver) (8.0)

https://jira.percona.com/browse/PS-7279

This is a regression introduced on PS-7114. It was assumed that a
BuildID would always be available on ELF Header section.
This fix makes the server print BuildID: Not Available in case the
server has been compiled with --build-id=none.