### PR TITLE
PS-7284: Fix MTR test innodb.percona_changed_page_bmp_requests_debug

### DIFF
--- a/mysql-test/suite/innodb/include/percona_get_last_bmp_file_name_size.inc
+++ b/mysql-test/suite/innodb/include/percona_get_last_bmp_file_name_size.inc
@@ -1,0 +1,62 @@
+# Purpose:
+# To get name and size of the latest file written
+# by online log tracking. In additional it returns
+# number of bitmap files found in the provided directory.
+#
+# Parameters:
+# --let $bmp_data_dir = path/to/bmp/files/dir
+#
+# $bmp_data_dir
+# Path to the directory where bitmap files will be searched
+#
+# Usage:
+# --let $bmp_data_dir = path/to/pmp/files/dir
+# --source include/percona_get_last_bmp_file_name_size.inc
+#
+# Return Value:
+# $last_bmp_file_name
+# $last_bmp_file_size
+# $bmp_files_count
+#
+
+--let _BMP_DATA_DIR = $bmp_data_dir
+--perl
+    use strict;
+    use warnings;
+    use File::stat;
+
+    my $tmp_files_dir = $ENV{'MYSQLTEST_VARDIR'};
+    my $bmp_data_dir = $ENV{'_BMP_DATA_DIR'};
+
+    open(OUTPUT, ">$tmp_files_dir/tmp/last_bmp_file.inc")
+        or die "Could not open $tmp_files_dir/tmp/active_bmp_file.inc";
+    opendir(DATADIR, $bmp_data_dir)
+        or die "Could not open $bmp_data_dir\n";
+
+    my $last_bmp_file_name = '';
+    my $last_bmp_file_size = 0;
+    my $files = {};
+
+    while (my $filename = readdir(DATADIR)) {
+        next if ($filename !~ m/xdb/);
+
+        $files->{$filename} = 1;
+        my $fs = stat($bmp_data_dir . '/' . $filename)->size;
+        if ($filename gt $last_bmp_file_name) {
+            $last_bmp_file_name = $filename;
+            $last_bmp_file_size = $fs;
+        }
+    }
+
+    my $bmp_files_count = keys(%$files);
+
+    print OUTPUT "--let \$last_bmp_file_name = $last_bmp_file_name\n";
+    print OUTPUT "--let \$last_bmp_file_size = $last_bmp_file_size\n";
+    print OUTPUT "--let \$bmp_files_count = $bmp_files_count\n";
+
+    close(OUTPUT);
+    closedir(DATADIR);
+EOF
+
+--source  $MYSQLTEST_VARDIR/tmp/last_bmp_file.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/last_bmp_file.inc

--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests_debug.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_requests_debug.result
@@ -28,45 +28,36 @@ FLUSH TABLES t1;
 SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 
+# Checking if bitmap files updated after the first flush
+
 # Inserting and flushing one more time for compatibility with 5.5.
 INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 FLUSH TABLES t1;
 SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 
-# Listing .xdb files after the flush.
-# The output must show 6 .xdb files: ib_modified_log_1_0.xdb to ib_modified_log_6_nnn.xdb.
-ib_modified_log_1_<nnn>.xdb
-ib_modified_log_2_<nnn>.xdb
-ib_modified_log_3_<nnn>.xdb
-ib_modified_log_4_<nnn>.xdb
-ib_modified_log_5_<nnn>.xdb
-ib_modified_log_6_<nnn>.xdb
+# Checking if bitmap files updated after the second flush
 
 # Purging changed page bitmaps (tracking enabled).
 # All but the last one bitmap file must be deleted
 PURGE CHANGED_PAGE_BITMAPS BEFORE PREVIOUS_LSN;
 
-# Listing .xdb files after the purge (tracking enabled).
-# The output must show only one .xdb file - ib_modified_log_6_nnn.xdb.
-ib_modified_log_6_<nnn>.xdb
+# Checking .xdb files after the purge (tracking enabled).
+# There must be only one file.
 
 # Restarting with redo log tracking disabled.
 # restart:--innodb-data-home-dir=CUSTOM_INNODB_DATA_HOME_DIR --innodb-log-group-home-dir=CUSTOM_INNODB_DATA_HOME_DIR --innodb-file-per-table=0 --datadir=MYSQLD_DATADIR1  --innodb-track-changed-pages=1 --innodb-max-bitmap-file-size=4096 --innodb-track-changed-pages=0
 include/assert.inc [InnoDB redo log tracking must be disabled]
 
-# Listing .xdb files after the restart with tracking disabled.
-# The output must show the same and a new .xdb file: ib_modified_log_6_nnn.xdb and ib_modified_log_7_nnn.xdb.
-ib_modified_log_6_<nnn>.xdb
-ib_modified_log_7_<nnn>.xdb
+# Checking .xdb files after the restart with tracking disabled.
+# There must stay some .xdb files.
 
 # Purging changed page bitmaps (tracking disabled).
-# The next-to-last one .xdb file (ib_modified_log_6_nnn.xdb) must be deleted.
+# The next-to-last one .xdb file must be deleted.
 PURGE CHANGED_PAGE_BITMAPS BEFORE PREVIOUS_LSN;
 
-# Listing .xdb files after the purge (tracking disabled).
-# The output must show only the last one .xdb file - ib_modified_log_7_nnn.xdb.
-ib_modified_log_7_<nnn>.xdb
+# Checking .xdb files after the purge (tracking disabled).
+# There must stay only the last one .xdb file.
 
 # Dropping the table.
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests_debug.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_requests_debug.test
@@ -68,6 +68,10 @@ EOF
 --let $assert_cond = @@innodb_file_per_table = 0
 --source include/assert.inc
 
+# Read current state of bitmaps after restarts
+--let $bmp_data_dir = $CUSTOM_INNODB_DATA_HOME_DIR
+--source suite/innodb/include/percona_get_last_bmp_file_name_size.inc
+
 --echo
 --echo # Creating a simple table and filling it with some records.
 CREATE TABLE t1(id INT) ENGINE=InnoDB STATS_PERSISTENT=0 STATS_AUTO_RECALC=0;
@@ -79,6 +83,16 @@ FLUSH TABLES t1;
 SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 
+--let $prev_last_bmp_file_name = $last_bmp_file_name
+--let $prev_last_bmp_file_size = $last_bmp_file_size
+--source suite/innodb/include/percona_get_last_bmp_file_name_size.inc
+
+--echo
+--echo # Checking if bitmap files updated after the first flush
+if (`SELECT "$last_bmp_file_name" = "$prev_last_bmp_file_name" AND $last_bmp_file_size = $prev_last_bmp_file_size`) {
+    --die "Bitmap files should be updated after the flush"
+}
+
 --echo
 --echo # Inserting and flushing one more time for compatibility with 5.5.
 INSERT INTO t1 VALUES (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
@@ -86,11 +100,15 @@ FLUSH TABLES t1;
 SET @@GLOBAL.innodb_log_checkpoint_now=TRUE;
 SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 
+--let $prev_last_bmp_file_name = $last_bmp_file_name
+--let $prev_last_bmp_file_size = $last_bmp_file_size
+--source suite/innodb/include/percona_get_last_bmp_file_name_size.inc
+
 --echo
---echo # Listing .xdb files after the flush.
---echo # The output must show 6 .xdb files: ib_modified_log_1_0.xdb to ib_modified_log_7_nnn.xdb.
---replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
---list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+--echo # Checking if bitmap files updated after the second flush
+if (`SELECT "$last_bmp_file_name" = "$prev_last_bmp_file_name" AND $last_bmp_file_size = $prev_last_bmp_file_size`) {
+    --die "Bitmap files should be updated after the flush"
+}
 
 --echo
 --echo # Purging changed page bitmaps (tracking enabled).
@@ -100,10 +118,15 @@ SET @@GLOBAL.innodb_track_redo_log_now=TRUE;
 eval PURGE CHANGED_PAGE_BITMAPS BEFORE $previous_lsn;
 
 --echo
---echo # Listing .xdb files after the purge (tracking enabled).
---echo # The output must show only one .xdb file - ib_modified_log_7_nnn.xdb.
---replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
---list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+--echo # Checking .xdb files after the purge (tracking enabled).
+--echo # There must be only one file.
+--let $prev_last_bmp_file_name = $last_bmp_file_name
+--let $prev_last_bmp_file_size = $last_bmp_file_size
+--source suite/innodb/include/percona_get_last_bmp_file_name_size.inc
+
+if (`SELECT "$last_bmp_file_name" != "$prev_last_bmp_file_name" AND $bmp_files_count != 1`) {
+    --die "There must stay only one last file after purge"
+}
 
 --echo
 --echo # Restarting with redo log tracking disabled.
@@ -116,23 +139,31 @@ eval PURGE CHANGED_PAGE_BITMAPS BEFORE $previous_lsn;
 --source include/assert.inc
 
 --echo
---echo # Listing .xdb files after the restart with tracking disabled.
---echo # The output must show the same and a new .xdb file: ib_modified_log_7_nnn.xdb and ib_modified_log_8_nnn.xdb.
---replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
---list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+--echo # Checking .xdb files after the restart with tracking disabled.
+--echo # There must stay some .xdb files.
+--let $prev_last_bmp_file_name = $last_bmp_file_name
+--source suite/innodb/include/percona_get_last_bmp_file_name_size.inc
+
+if (`SELECT $bmp_files_count = 0`) {
+    --die "There must stay some .xdb files after restart (tracking enabled)"
+}
 
 --echo
 --echo # Purging changed page bitmaps (tracking disabled).
---echo # The next-to-last one .xdb file (ib_modified_log_7_nnn.xdb) must be deleted.
+--echo # The next-to-last one .xdb file must be deleted.
 --let $previous_lsn = query_get_value(SHOW STATUS LIKE 'innodb_lsn_current', Value, 1)
 --replace_regex /[[:digit:]]+/PREVIOUS_LSN/
 eval PURGE CHANGED_PAGE_BITMAPS BEFORE $previous_lsn;
 
 --echo
---echo # Listing .xdb files after the purge (tracking disabled).
---echo # The output must show only the last one .xdb file - ib_modified_log_7_nnn.xdb.
---replace_regex /_[[:digit:]]+\.xdb$/_<nnn>.xdb/
---list_files $CUSTOM_INNODB_DATA_HOME_DIR *.xdb
+--echo # Checking .xdb files after the purge (tracking disabled).
+--echo # There must stay only the last one .xdb file.
+--let $prev_last_bmp_file_name = $last_bmp_file_name
+--source suite/innodb/include/percona_get_last_bmp_file_name_size.inc
+
+if (`SELECT "$last_bmp_file_name" != "$prev_last_bmp_file_name" AND $bmp_files_count != 1`) {
+    --die "There must stay only the last one .xdb file"
+}
 
 --echo
 --echo # Dropping the table.


### PR DESCRIPTION
The test used bitmap files number after each action to find out if
that action actually took place and bitmap data is updated.
This approach became not relaiable. The amount of data written
to bitmap files during each test run is the same but checkpoints
are generated at different LSN positions. As a result number of
generated bitmap files may be different.

To make test stable instead of just comparing results with the
predefined bitmap file names check how currently active file
name and its size changes after each action. Added separate
.inc file which checks current state of bitmap files.