### PR TITLE
PS-7296: Fix existing bitmap files processing during initialization (8.0)

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp.result
@@ -80,6 +80,7 @@ SELECT @@innodb_track_changed_pages;
 12th restart
 # restart:--innodb-data-home-dir=tmpdatadir --datadir=MYSQLD_DATADIR1
 ib_modified_log_1
+ib_modified_log_2
 include/assert.inc [INFORMATION_SCHEMA.INNODB_CHANGED_PAGES is not empty]
 13th restart
 # restart:--innodb-track-changed-pages=TRUE

--- a/storage/innobase/log/log0online.cc
+++ b/storage/innobase/log/log0online.cc
@@ -934,11 +934,8 @@ void log_online_read_init(void) {
         bitmap_dir->dir_entry[i].mystat->st_size > 0) {
       log_bmp_sys->out_seq_num = file_seq_num;
       last_file_start_lsn = file_start_lsn;
-      /* No dir component (log_bmp_sys->bmp_file_home) here, because
-that's the cwd */
-      strncpy(log_bmp_sys->out.name, bitmap_dir->dir_entry[i].name,
-              FN_REFLEN - 1);
-      log_bmp_sys->out.name[FN_REFLEN - 1] = '\0';
+      snprintf(log_bmp_sys->out.name, sizeof(log_bmp_sys->out.name), "%s%s",
+               log_bmp_sys->bmp_file_home, bitmap_dir->dir_entry[i].name);
     }
   }
   my_dirend(bitmap_dir);


### PR DESCRIPTION
In log_online_read_init there is an attempt to check the most recent
bitmap file and continue writing it or rotate if needed. At the moment
server fails to open the most recent bitmap file in case
--innodb-data-home-dir and --datadir are set to different directories.

With such configuration current working directory differs from innodb
data home directory. At the same time during initialization
log_bmp_sys->bmp_file_home isn't taken into account when trying
to open existing bitmap file. As a result it tries to find it
in current working directory.