### PR TITLE
Fixed PS-7275 (Status variable Innodb_checkpoint_max_age missed from …

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -1165,6 +1165,8 @@ static SHOW_VAR innodb_status_variables[] = {
      SHOW_SCOPE_GLOBAL},
     {"checkpoint_age", (char *)&export_vars.innodb_checkpoint_age, SHOW_LONG,
      SHOW_SCOPE_GLOBAL},
+    {"checkpoint_max_age", (char *)&export_vars.innodb_checkpoint_max_age,
+     SHOW_LONG, SHOW_SCOPE_GLOBAL},
     {"data_fsyncs", (char *)&export_vars.innodb_data_fsyncs, SHOW_LONG,
      SHOW_SCOPE_GLOBAL},
     {"data_pending_fsyncs", (char *)&export_vars.innodb_data_pending_fsyncs,

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1389,6 +1389,7 @@ struct export_var_t {
 #endif                                /* UNIV_DEBUG */
   // Percona-added status variables
   ulint innodb_checkpoint_age;
+  ulint innodb_checkpoint_max_age;
   ulint innodb_ibuf_free_list;
   ulint innodb_ibuf_segment_size;
   lsn_t innodb_lsn_current;

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1746,6 +1746,8 @@ void srv_export_innodb_status(void) {
   }
   export_vars.innodb_checkpoint_age =
       (log_get_lsn(*log_sys) - log_sys->last_checkpoint_lsn);
+
+  export_vars.innodb_checkpoint_max_age = log_get_free_check_capacity(*log_sys);
   ibuf_export_ibuf_status(&export_vars.innodb_ibuf_free_list,
                           &export_vars.innodb_ibuf_segment_size);
   export_vars.innodb_lsn_current = log_get_lsn(*log_sys);


### PR DESCRIPTION
…version 8.0)

https://jira.percona.com/browse/PS-7275

Innodb_checkpoint_max_age is the same value as log_capacity and
has been removed from 8.0. There is no way to currently get
log_capacity value from a user point of view.
Adding back Innodb_checkpoint_max_age as a status variable and
as part of SHOW ENGINE INNODB STATUS.