### PR TITLE
Fixed PS-7297 (proxy_protocol_admin_port test failing on 8.0.21)

### DIFF
--- a/mysql-test/r/proxy_protocol_admin_port.result
+++ b/mysql-test/r/proxy_protocol_admin_port.result
@@ -1,4 +1,4 @@
-# restart: --skip-name-resolve --admin-address=::ffff:127.0.0.1 --admin_port=ADMIN_PORT --proxy_protocol_networks=*
+# restart: --skip-name-resolve --admin-address=::ffff:127.0.0.1 --admin_port=ADMIN_PORT --admin-ssl=OFF --proxy_protocol_networks=*
 # An unproxied client connection should be accepted when connection to an extra_port if proxying enabled on the server
 SHOW GLOBAL STATUS LIKE 'Threads_connected';
 Variable_name	Value

--- a/mysql-test/t/proxy_protocol_admin_port.test
+++ b/mysql-test/t/proxy_protocol_admin_port.test
@@ -5,7 +5,7 @@
 
 --let $PORT_OFFSET = 100
 --expr $ADMIN_PORT = $MASTER_MYPORT + $PORT_OFFSET
---let $restart_parameters=restart: --skip-name-resolve --admin-address=::ffff:127.0.0.1 --admin_port=$ADMIN_PORT --proxy_protocol_networks=*
+--let $restart_parameters=restart: --skip-name-resolve --admin-address=::ffff:127.0.0.1 --admin_port=$ADMIN_PORT --admin-ssl=OFF --proxy_protocol_networks=*
 --replace_result $ADMIN_PORT ADMIN_PORT
 --source include/restart_mysqld.inc
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7297

MySQL 8.0.21 introduced a new SSL context for the admin port. This allows
the admin interface has its own SSL configuration. In case you do not
specify SSL certificates for the admin interface, a new warning will
be displayed indicating the missing SSL certs and the main SSL context will
also be used for the admin interface. This was causing the MTR test to fail due
to the new warning.
To fix it the test now disables SSL.