### PR TITLE
PS-7317: Wrong parameter "explicit_default_wait_counter" in "innodb.tablespace_encrypt_*" (5.7)

### DIFF
--- a/mysql-test/include/wait_until_connected_again.inc
+++ b/mysql-test/include/wait_until_connected_again.inc
@@ -1,13 +1,26 @@
 #
 # Include this script to wait until the connection to the
 # server has been restored or timeout occurs
+#
+# $wait_counter - can be set before calling the script, will be reset at the end
+#
+# $explicit_default_counter - can be set before calling the script,
+#                             reset only at the end of the test, overrides $wait_counter
+
 --disable_result_log
 --disable_query_log
-let $counter= 5000;
-if ($VALGRIND_TEST) {
-  let $counter= 30000;
+--let $counter= 5000
+if ($explicit_default_counter)
+{
+  --let $wait_counter= $explicit_default_counter
 }
-let $mysql_errno= 9999;
+if ($VALGRIND_TEST) {
+  --let $wait_counter= 30000
+}
+if ($wait_counter) {
+  --let $counter= $wait_counter
+}
+--let $mysql_errno= 9999
 while ($mysql_errno)
 {
 
@@ -17,20 +30,26 @@ while ($mysql_errno)
   --error 0,1040,1053,2002,2003,2006,2013,1045,ER_CANNOT_FIND_KEY_IN_KEYRING,ER_SECURE_TRANSPORT_REQUIRED
   show session status;
   if ($mysql_errno == 1045){
-    let mysql_errno=0;
+    --let mysql_errno=0
   }
   if ($mysql_errname == ER_SECURE_TRANSPORT_REQUIRED){
-    let mysql_errno=0;
+    --let mysql_errno=0
   }
   if ($mysql_errname == ER_CANNOT_FIND_KEY_IN_KEYRING){
-    let mysql_errno=0;
+    --let mysql_errno=0
   }
-  dec $counter;
+  --dec $counter
   if (!$counter)
   {
     --die Server failed to restart
   }
   --sleep 0.1
+}
+# Reset $wait_counter so that its value won't be used on subsequent
+# calls, and default will be used instead.
+if (!$explicit_default_counter)
+{
+  --let $wait_counter= 0
 }
 --enable_query_log
 --enable_result_log

--- a/mysql-test/suite/innodb/t/table_encrypt_1.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_1.test
@@ -1,2 +1,5 @@
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring_restart_param=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --source include/table_encrypt_1.inc

--- a/mysql-test/suite/innodb/t/table_encrypt_1_rotated_keys_small.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_1_rotated_keys_small.test
@@ -1,3 +1,6 @@
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring_restart_param=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --let $encryption_type=KEYRING
 --source include/table_encrypt_1_small.inc

--- a/mysql-test/suite/innodb/t/table_encrypt_2.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_2.test
@@ -5,6 +5,9 @@
 --source include/have_innodb.inc
 --source include/not_embedded.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring1_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --let $keyring2_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring2 $KEYRING_PLUGIN_OPT
 

--- a/mysql-test/suite/innodb/t/table_encrypt_2_keyring.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_2_keyring.test
@@ -5,6 +5,9 @@
 --source include/have_innodb.inc
 --source include/not_embedded.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring1_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --let $keyring2_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring2 $KEYRING_PLUGIN_OPT
 

--- a/mysql-test/suite/innodb/t/table_encrypt_3.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_3.test
@@ -1,3 +1,6 @@
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring_plugin_name=keyring_file
 --let $keyring_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --let $number_of_MK_rotations=500

--- a/mysql-test/suite/innodb/t/table_encrypt_4.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_4.test
@@ -1,2 +1,5 @@
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring2 $KEYRING_PLUGIN_OPT
 --source include/table_encrypt_4.inc

--- a/mysql-test/suite/innodb/t/table_encrypt_5.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_5.test
@@ -2,6 +2,9 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_file reported: 'Could not c
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_file reported: 'keyring_file initialization failure.");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_file reported: 'File .*keyring' not found .*");
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring_plugin_name=keyring_file
 --let $keyring1_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --let $keyring2_restart_param=restart: --early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring2 $KEYRING_PLUGIN_OPT

--- a/mysql-test/suite/innodb/t/table_encrypt_debug.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_debug.test
@@ -1,3 +1,6 @@
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring_restart_param=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --source include/table_encrypt_debug.inc
 --remove_file $MYSQL_TMP_DIR/mysecret_keyring

--- a/mysql-test/suite/innodb/t/table_encrypt_fts.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_fts.test
@@ -13,7 +13,7 @@
 # Disable in valgrind because of timeout, cf. Bug#22760145
 --source include/not_valgrind.inc
 # Waiting time when (re)starting the server
---let $explicit_default_wait_counter=10000;
+--let $explicit_default_counter=10000
 
 --echo #########
 --echo # SETUP #

--- a/mysql-test/suite/innodb/t/table_encrypt_kill.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_kill.test
@@ -1,3 +1,6 @@
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --let $keyring_restart_param=restart:--early-plugin-load="keyring_file=$KEYRING_PLUGIN" --loose-keyring_file_data=$MYSQL_TMP_DIR/mysecret_keyring $KEYRING_PLUGIN_OPT
 --source include/table_encrypt_kill.inc
 --remove_file $MYSQL_TMP_DIR/mysecret_keyring

--- a/mysql-test/suite/innodb/t/table_encrypt_upgrade.test
+++ b/mysql-test/suite/innodb/t/table_encrypt_upgrade.test
@@ -3,6 +3,9 @@
 --source include/not_embedded.inc
 --source include/have_debug.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 --disable_query_log
 call mtr.add_suppression("\\[Error\\] InnoDB: Encryption can't find master key, please check the keyring plugin is loaded.");
 call mtr.add_suppression("\\[ERROR\\] Function 'keyring_file' already exists");

--- a/mysql-test/suite/innodb/t/table_encryption.test
+++ b/mysql-test/suite/innodb/t/table_encryption.test
@@ -6,6 +6,9 @@
 --source include/have_innodb.inc
 --source include/not_embedded.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 let $innodb_file_per_table = `SELECT @@innodb_file_per_table`;
 
 --echo # Starting server with keyring plugin  

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_1.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_1.test
@@ -4,6 +4,9 @@
 --source is_vault_server_up.inc
 --source include/not_repeat.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_1_directory.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_1_directory.test
@@ -8,6 +8,9 @@
 --source generate_default_directory_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount point
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_2.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_2.test
@@ -10,6 +10,9 @@
 --source generate_default_mount_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_2_directory.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_2_directory.test
@@ -10,6 +10,9 @@
 --source generate_default_directory_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create only one mount point - separation of keyring will be achieved by using separate directories
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_2_keyring.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_2_keyring.test
@@ -10,6 +10,9 @@
 --source generate_default_mount_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_3.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_3.test
@@ -5,6 +5,9 @@
 --source generate_default_mount_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_3_directory.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_3_directory.test
@@ -5,6 +5,9 @@
 --source generate_default_directory_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create only one mount point - separation of keyring will be achieved by using separate directories
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_4.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_4.test
@@ -3,6 +3,9 @@
 --source generate_default_mount_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_2

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_4_directory.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_4_directory.test
@@ -3,6 +3,9 @@
 --source generate_default_directory_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create only one mount point - separation of keyring will be achieved by using separate directories
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_2

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_5.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_5.test
@@ -7,6 +7,9 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' no
 --source generate_default_mount_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_5_directory.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_5_directory.test
@@ -7,6 +7,9 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'File '' no
 --source generate_default_directory_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create only one mount point - separation of keyring will be achieved by using separate directories
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_debug.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_debug.test
@@ -3,6 +3,9 @@
 --source generate_default_mount_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1

--- a/plugin/keyring_vault/tests/mtr/table_encrypt_kill.test
+++ b/plugin/keyring_vault/tests/mtr/table_encrypt_kill.test
@@ -3,6 +3,9 @@
 --source generate_default_mount_conf_files.inc
 --source is_vault_server_up.inc
 
+# Waiting time when (re)starting the server
+--let $explicit_default_counter=10000
+
 # Create mount points
 --let MOUNT_POINT_SERVICE_OP=CREATE
 --let $KEYRING_CONF_FILE=$KEYRING_CONF_FILE_1


### PR DESCRIPTION
This patch:
1. Backports `wait_counter` and `explicit_default_counter` parameters for `include/wait_until_connected_again.inc` from PS-8.0.
2. Adds `explicit_default_counter=10000` to `innodb.tablespace_encrypt_*` MTR tests to make them more stable under heavy load (this was already done in PS-8.0).
3. Fixes occurrences of `explicit_default_wait_counter` with `explicit_default_counter` as `include/wait_until_connected_again.inc` uses the `explicit_default_counter` parameter, not `explicit_default_wait_counter`.