### PR TITLE
PS-7322 : Datamasking: mask_outer() doesn't work if the right mask le…

### DIFF
--- a/mysql-test/suite/data_masking/r/mask_outer.result
+++ b/mysql-test/suite/data_masking/r/mask_outer.result
@@ -28,3 +28,9 @@ Xhis is a string
 SELECT mask_outer('This is a string', 100, 500);
 mask_outer('This is a string', 100, 500)
 XXXXXXXXXXXXXXXX
+SELECT mask_outer('abcdef', 0, 5);
+mask_outer('abcdef', 0, 5)
+aXXXXX
+SELECT mask_outer('abcdef', 0, 5, '#');
+mask_outer('abcdef', 0, 5, '#')
+a#####

--- a/mysql-test/suite/data_masking/t/mask_outer.test
+++ b/mysql-test/suite/data_masking/t/mask_outer.test
@@ -10,3 +10,5 @@ SELECT mask_outer('This is a string', -1, 5);
 SELECT mask_outer('This is a string', 1, -5);
 SELECT mask_outer('This is a string', 1, 25);
 SELECT mask_outer('This is a string', 100, 500);
+SELECT mask_outer('abcdef', 0, 5);
+SELECT mask_outer('abcdef', 0, 5, '#');

--- a/plugin/data_masking/src/udf/udf_utils_string.cc
+++ b/plugin/data_masking/src/udf/udf_utils_string.cc
@@ -100,7 +100,7 @@ std::string mask_outer(const char *str, const unsigned long str_length,
                   maskchar);
 
   // Mask right
-  if (static_cast<unsigned long>(margin2) < (str_length - 1))
+  if (static_cast<unsigned long>(margin2) < str_length)
     std::generate_n(str_masked.end() - margin2, margin2, maskchar);
 
   return str_masked;


### PR DESCRIPTION
…ngth is string length - 1

Problem:
--------
mask_outer() the input string as is if the right mask length is string length - 1

ie. SELECT mask_outer('abcdef',0, 5); returns original string as is

Fix:
----
Fix the right mask length calculation to handle up to string length