### PR TITLE
PS-7289: Fix min/max value check for innodb_encryption_threads (5.7)

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_encryption_threads_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_encryption_threads_basic.result
@@ -1,3 +1,52 @@
+SET GLOBAL innodb_file_per_table = ON;
+INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
+SET GLOBAL innodb_encryption_threads = 10;
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+10
+SET GLOBAL innodb_encryption_threads = 1000;
+Warnings:
+Warning	1292	Truncated incorrect innodb_encryption_threads value: '1000'
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+255
+SET GLOBAL innodb_encryption_threads = -1000;
+Warnings:
+Warning	1292	Truncated incorrect innodb_encryption_threads value: '-1000'
 SELECT @@global.innodb_encryption_threads;
 @@global.innodb_encryption_threads
 0
+SET GLOBAL innodb_encryption_threads = 10.5;
+ERROR 42000: Incorrect argument type to variable 'innodb_encryption_threads'
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+0
+SET GLOBAL innodb_encryption_threads = ON;
+ERROR 42000: Incorrect argument type to variable 'innodb_encryption_threads'
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+0
+SET GLOBAL innodb_encryption_threads = 'a';
+ERROR 42000: Incorrect argument type to variable 'innodb_encryption_threads'
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+0
+SET GLOBAL innodb_encryption_threads = "abc";
+ERROR 42000: Incorrect argument type to variable 'innodb_encryption_threads'
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+0
+SET SESSION sql_mode = 'STRICT_ALL_TABLES';
+SET GLOBAL innodb_encryption_threads = 10;
+SET GLOBAL innodb_encryption_threads = 1000;
+ERROR 42000: Variable 'innodb_encryption_threads' can't be set to the value of '1000'
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+10
+SET GLOBAL innodb_encryption_threads = -1000;
+ERROR 42000: Variable 'innodb_encryption_threads' can't be set to the value of '-1000'
+SELECT @@global.innodb_encryption_threads;
+@@global.innodb_encryption_threads
+10
+SET GLOBAL innodb_encryption_threads = 0;
+UNINSTALL PLUGIN keyring_file;

--- a/mysql-test/suite/sys_vars/t/innodb_encryption_threads_basic-master.opt
+++ b/mysql-test/suite/sys_vars/t/innodb_encryption_threads_basic-master.opt
@@ -1,0 +1,3 @@
+$KEYRING_PLUGIN_OPT
+--innodb-encryption-threads=0
+--loose-keyring-file-data=$MYSQL_TMP_DIR/mydummy_key

--- a/mysql-test/suite/sys_vars/t/innodb_encryption_threads_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_encryption_threads_basic.test
@@ -1,5 +1,49 @@
---source include/have_innodb.inc
+--disable_warnings
+SET GLOBAL innodb_file_per_table = ON;
+INSTALL PLUGIN keyring_file SONAME 'keyring_file.so';
+--enable_warnings
 
---skip Not implemented
-
+SET GLOBAL innodb_encryption_threads = 10;
 SELECT @@global.innodb_encryption_threads;
+
+SET GLOBAL innodb_encryption_threads = 1000;
+SELECT @@global.innodb_encryption_threads;
+
+SET GLOBAL innodb_encryption_threads = -1000;
+SELECT @@global.innodb_encryption_threads;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL innodb_encryption_threads = 10.5;
+SELECT @@global.innodb_encryption_threads;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL innodb_encryption_threads = ON;
+SELECT @@global.innodb_encryption_threads;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL innodb_encryption_threads = 'a';
+SELECT @@global.innodb_encryption_threads;
+
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL innodb_encryption_threads = "abc";
+SELECT @@global.innodb_encryption_threads;
+
+--disable_warnings
+SET SESSION sql_mode = 'STRICT_ALL_TABLES';
+--enable_warnings
+SET GLOBAL innodb_encryption_threads = 10;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_encryption_threads = 1000;
+SELECT @@global.innodb_encryption_threads;
+
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL innodb_encryption_threads = -1000;
+SELECT @@global.innodb_encryption_threads;
+
+# cleanup
+SET GLOBAL innodb_encryption_threads = 0;
+
+UNINSTALL PLUGIN keyring_file;
+--replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
+--remove_file $MYSQL_TMP_DIR/mydummy_key

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -57,6 +57,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include <sql_table.h>
 #include <sql_tablespace.h>
 #include <sql_thd_internal_api.h>
+#include <sys_vars_shared.h>
 #include <my_check_opt.h>
 #include <my_bitmap.h>
 #include <mysql/service_thd_alloc.h>
@@ -21320,8 +21321,24 @@ innodb_encryption_threads_validate(
 		DBUG_RETURN(1);
 	}
 
-	if (srv_n_fil_crypt_threads == 0 && intbuf > 0) { // We are starting encryption threads, we must lock
-							  // the keyring plugins
+	bool is_val_fixed = false;
+	long long requested_threads = intbuf;
+	if (intbuf < 0) {
+		requested_threads = 0;
+		is_val_fixed = true;
+	}
+	else if (intbuf > MAX_ENCRYPTION_THREADS) {
+		requested_threads = MAX_ENCRYPTION_THREADS;
+		is_val_fixed = true;
+	}
+
+	if (throw_bounds_warning(thd, "innodb_encryption_threads", is_val_fixed, intbuf)) {
+		DBUG_RETURN(1);
+	}
+
+	if (srv_n_fil_crypt_threads == 0 && requested_threads > 0) {
+		// We are starting encryption threads, we must lock
+		// the keyring plugins
 		uint number_of_keyrings_locked= lock_keyrings(NULL);
 
 		if (number_of_keyrings_locked == 0) {
@@ -21335,11 +21352,12 @@ innodb_encryption_threads_validate(
 			unlock_keyrings(NULL);
 			DBUG_RETURN(1);
 		}
-	} else if (intbuf == 0 && srv_n_fil_crypt_threads > 0) {// We are disabling encryption threads, unlock the keyrings
+	} else if (requested_threads == 0 && srv_n_fil_crypt_threads > 0) {
+		// We are disabling encryption threads, unlock the keyrings
 		unlock_keyrings(NULL);  
 	}
 
-	*reinterpret_cast<ulong*>(save) = static_cast<ulong>(intbuf);
+	*reinterpret_cast<ulong*>(save) = static_cast<ulong>(requested_threads);
 
 	DBUG_RETURN(0);
 }


### PR DESCRIPTION
The min and max variable value provided with variable definition
don't take effect in case there is a custom validator for a variable.
Added min and max allowed value check into custom validator
for innodb_encryption_threads variable.