### PR TITLE
Fixed PS-7325 - SELECT missing data from MyRocks table when GROUP BY …

### DIFF
--- a/mysql-test/suite/rocksdb/r/select.result
+++ b/mysql-test/suite/rocksdb/r/select.result
@@ -349,4 +349,38 @@ a	b
 200	bar
 200	bar
 200	bar
-DROP TABLE t1, t2;
+CREATE TABLE `t3` (
+`col1` bigint unsigned NOT NULL AUTO_INCREMENT,
+`col2` varbinary(16) NOT NULL,
+`col3` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+`col4` bigint NOT NULL,
+`col5` mediumblob NOT NULL,
+PRIMARY KEY (`col1`),
+UNIQUE KEY `uc_key` (`col2`,`col3`,`col4`)
+) ENGINE=ROCKSDB;
+insert into t3 (col2,col3,col4,col5) values('aa', 'aa', 100, 'aa');
+insert into t3 (col2,col3,col4,col5) values('aa', 'bb', 100, 'bb');
+insert into t3 (col2,col3,col4,col5) values('aa', 'cc', 100, 'cc');
+insert into t3 (col2,col3,col4,col5) values('aa', 'dd', 100, 'dd');
+insert into t3 (col2,col3,col4,col5) values('aa', 'cc', 99, 'cc');
+SELECT col2, col3, max(col4) AS col4 FROM t3 WHERE col2 IN (x'6161') AND col3 IN ('aa','bb','cc','dd') GROUP BY col2, col3;
+col2	col3	col4
+aa	aa	100
+aa	bb	100
+aa	cc	100
+aa	dd	100
+ALTER TABLE t3 ENGINE=ROCKSDB;
+SELECT col2, col3, max(col4) AS col4 FROM t3 WHERE col2 IN (x'6161') AND col3 IN ('aa','bb','cc','dd') GROUP BY col2, col3;
+col2	col3	col4
+aa	aa	100
+aa	bb	100
+aa	cc	100
+aa	dd	100
+ALTER TABLE t3 ENGINE=ROCKSDB;
+SELECT col2, col3, max(col4) AS col4 FROM t3 WHERE col2 IN (x'6161') AND col3 IN ('aa','bb','cc','dd') GROUP BY col2, col3;
+col2	col3	col4
+aa	aa	100
+aa	bb	100
+aa	cc	100
+aa	dd	100
+DROP TABLE t1, t2, t3;

--- a/mysql-test/suite/rocksdb/t/select.test
+++ b/mysql-test/suite/rocksdb/t/select.test
@@ -185,6 +185,26 @@ SELECT a,b FROM t1 UNION SELECT a,b FROM t2 UNION DISTINCT SELECT a,b FROM t1;
 --sorted_result
 SELECT a,b FROM t1 UNION SELECT a,b FROM t2 UNION ALL SELECT a,b FROM t1;
 
+# PS-7325 - SELECT missing data from MyRocks table when GROUP BY is used
+CREATE TABLE `t3` (
+`col1` bigint unsigned NOT NULL AUTO_INCREMENT,
+`col2` varbinary(16) NOT NULL,
+`col3` varchar(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+`col4` bigint NOT NULL,
+`col5` mediumblob NOT NULL,
+PRIMARY KEY (`col1`),
+UNIQUE KEY `uc_key` (`col2`,`col3`,`col4`)
+) ENGINE=ROCKSDB;
+insert into t3 (col2,col3,col4,col5) values('aa', 'aa', 100, 'aa');
+insert into t3 (col2,col3,col4,col5) values('aa', 'bb', 100, 'bb');
+insert into t3 (col2,col3,col4,col5) values('aa', 'cc', 100, 'cc');
+insert into t3 (col2,col3,col4,col5) values('aa', 'dd', 100, 'dd');
+insert into t3 (col2,col3,col4,col5) values('aa', 'cc', 99, 'cc');
+SELECT col2, col3, max(col4) AS col4 FROM t3 WHERE col2 IN (x'6161') AND col3 IN ('aa','bb','cc','dd') GROUP BY col2, col3;
+ALTER TABLE t3 ENGINE=ROCKSDB;
+SELECT col2, col3, max(col4) AS col4 FROM t3 WHERE col2 IN (x'6161') AND col3 IN ('aa','bb','cc','dd') GROUP BY col2, col3;
+ALTER TABLE t3 ENGINE=ROCKSDB;
+SELECT col2, col3, max(col4) AS col4 FROM t3 WHERE col2 IN (x'6161') AND col3 IN ('aa','bb','cc','dd') GROUP BY col2, col3;
 
 # Cleanup
-DROP TABLE t1, t2;
+DROP TABLE t1, t2, t3;

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -11010,12 +11010,27 @@ int QUICK_RANGE_SELECT::get_next_prefix(uint prefix_length,
       DBUG_ASSERT(cur_prefix != nullptr);
       result = file->ha_index_read_map(record, cur_prefix, keypart_map,
                                        HA_READ_AFTER_KEY);
-      if (result || last_range->max_keypart_map == 0) return result;
-
-      key_range previous_endpoint;
-      last_range->make_max_endpoint(&previous_endpoint, prefix_length,
-                                    keypart_map);
-      if (file->compare_key(&previous_endpoint) <= 0) return 0;
+      if (result || last_range->max_keypart_map == 0) {
+        /*
+          Only return if actual failure occurred. For HA_ERR_KEY_NOT_FOUND
+          or HA_ERR_END_OF_FILE, we just want to continue to reach the next
+          set of ranges. It is possible for the storage engine to return
+         HA_ERR_KEY_NOT_FOUND/HA_ERR_END_OF_FILE even when there are more
+          keys if it respects the end range set by the read_range_first call
+          below.
+        */
+        if (result != HA_ERR_KEY_NOT_FOUND && result != HA_ERR_END_OF_FILE)
+          return result;
+      } else {
+        /*
+          For storage engines that don't respect end range, check if we've
+          moved past the current range.
+        */
+        key_range previous_endpoint;
+        last_range->make_max_endpoint(&previous_endpoint, prefix_length,
+                                      keypart_map);
+        if (file->compare_key(&previous_endpoint) <= 0) return 0;
+      }
     }
 
     const size_t count = ranges.size() - (cur_range - ranges.begin());


### PR DESCRIPTION
…is used

https://jira.percona.com/browse/PS-7325

Cherry-picked facebook commit[1] and ported to 8.0. Added a MTR
test case.

[1]:
commit 98b0d40af27051ded465a5ca81fac8e3110cc2c1
Author: Manuel Ung <mung@fb.com>
Date:   Tue Mar 19 07:44:54 2019 -0700

    Fix error handling in group by plans

    Summary:
    For certain GROUP BY plans, the QUICK_RANGE_SELECT class is used to iterate through all possible prefixes that form a group. The current iteration process calls read_range_first with both a start and end range, and then iterates until we've moved past the end range. However, the storage engine may choose to honour the end range (because of index condition pushdown, rocksdb iterator bounds, or rocksdb prefix seek mode) and return HA_ERR_KEY_NOT_FOUND or HA_ERR_END_OF_FILE instead. Instead of moving onto the next range, this causes the QUICK_RANGE_SELECT::get_next_prefix to return early without actually advancing onto the next prefix. This can cause an infinite loop in QUICK_GROUP_MIN_MAX_SELECT::get_next, or QUICK_GROUP_MIN_MAX_SELECT::get_next to return HA_ERR_END_OF_FILE too early.

    The fix is to detect if HA_ERR_KEY_NOT_FOUND or HA_ERR_END_OF_FILE is returned, and continue onto the next range instead of returning early.

    Reviewed By: hermanlee

    Differential Revision: D14521084

    fbshipit-source-id: 6963b17081f