### PR TITLE
PS-7340: Improve value validation for default_table_encryption variable (8.0)

### DIFF
--- a/mysql-test/suite/sys_vars/r/default_table_encryption_basic.result
+++ b/mysql-test/suite/sys_vars/r/default_table_encryption_basic.result
@@ -118,13 +118,15 @@ SELECT @@session.default_table_encryption;
 @@session.default_table_encryption
 OFF
 SET SESSION default_table_encryption=ONLINE_TO_KEYRING;
+ERROR HY000: The default_table_encryption option cannot be changed, keyring plugin is not available
 SELECT @@session.default_table_encryption;
 @@session.default_table_encryption
-ONLINE_TO_KEYRING
+OFF
 SET SESSION default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+ERROR HY000: The default_table_encryption option cannot be changed, keyring plugin is not available
 SELECT @@session.default_table_encryption;
 @@session.default_table_encryption
-ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+OFF
 SET GLOBAL default_table_encryption=OFF;
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
@@ -139,13 +141,15 @@ SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
 ON
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
+ERROR HY000: The default_table_encryption option cannot be changed, keyring plugin is not available
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_TO_KEYRING
+ON
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+ERROR HY000: The default_table_encryption option cannot be changed, keyring plugin is not available
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+ON
 SET PERSIST default_table_encryption=ON;
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
@@ -182,13 +186,15 @@ SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
 OFF
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
+ERROR HY000: The default_table_encryption option cannot be changed, keyring plugin is not available
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_TO_KEYRING
+OFF
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
+ERROR HY000: The default_table_encryption option cannot be changed, keyring plugin is not available
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption
-ONLINE_FROM_KEYRING_TO_UNENCRYPTED
+OFF
 SET PERSIST default_table_encryption=ON;
 SELECT @@global.default_table_encryption;
 @@global.default_table_encryption

--- a/mysql-test/suite/sys_vars/t/default_table_encryption_basic.test
+++ b/mysql-test/suite/sys_vars/t/default_table_encryption_basic.test
@@ -123,9 +123,11 @@ SELECT @@session.default_table_encryption;
 SET SESSION default_table_encryption=KEYRING_ON;
 SELECT @@session.default_table_encryption;
 
+--error ER_WRONG_ARGUMENTS
 SET SESSION default_table_encryption=ONLINE_TO_KEYRING;
 SELECT @@session.default_table_encryption;
 
+--error ER_WRONG_ARGUMENTS
 SET SESSION default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SELECT @@session.default_table_encryption;
 
@@ -139,9 +141,11 @@ SELECT @@global.default_table_encryption;
 SET PERSIST default_table_encryption=KEYRING_ON;
 SELECT @@global.default_table_encryption;
 
+--error ER_WRONG_ARGUMENTS
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
 SELECT @@global.default_table_encryption;
 
+--error ER_WRONG_ARGUMENTS
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SELECT @@global.default_table_encryption;
 
@@ -176,9 +180,11 @@ SELECT @@global.default_table_encryption;
 SET PERSIST default_table_encryption=KEYRING_ON;
 SELECT @@global.default_table_encryption;
 
+--error ER_WRONG_ARGUMENTS
 SET PERSIST default_table_encryption=ONLINE_TO_KEYRING;
 SELECT @@global.default_table_encryption;
 
+--error ER_WRONG_ARGUMENTS
 SET PERSIST default_table_encryption=ONLINE_FROM_KEYRING_TO_UNENCRYPTED;
 SELECT @@global.default_table_encryption;
 

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -1918,7 +1918,7 @@ using fix_default_table_encryption_t = bool (*)(ulong, bool);
  encryption is compliant with current encryption used in
  innodb.
 */
-using check_mk_keyring_exclusions_t = bool (*)(THD *);
+using check_mk_keyring_exclusions_t = bool (*)(THD *, longlong);
 
 using compression_dict_data_vec_t =
     std::vector<std::pair<std::string, std::string>>;

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7184,7 +7184,8 @@ static bool check_set_default_table_encryption_exclusions(THD *thd,
                                                           set_var *var) {
   longlong val = static_cast<longlong>(var->save_result.ulonglong_value);
 
-  if (val == DEFAULT_TABLE_ENC_ONLINE_TO_KEYRING) {
+  if (val == DEFAULT_TABLE_ENC_ONLINE_TO_KEYRING ||
+      val == DEFAULT_TABLE_ENC_ONLINE_FROM_KEYRING_TO_UNENCRYPTED) {
     static const LEX_CSTRING innodb_engine{STRING_WITH_LEN("innodb")};
 
     bool is_online_enc_disallowed = false;
@@ -7192,7 +7193,7 @@ static bool check_set_default_table_encryption_exclusions(THD *thd,
     plugin_ref plugin;
     if ((plugin = ha_resolve_by_name(nullptr, &innodb_engine, false))) {
       handlerton *hton = plugin_data<handlerton *>(plugin);
-      is_online_enc_disallowed = hton->check_mk_keyring_exclusions(thd);
+      is_online_enc_disallowed = hton->check_mk_keyring_exclusions(thd, val);
       plugin_unlock(nullptr, plugin);
     }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -4429,24 +4429,46 @@ bool innobase_fix_default_table_encryption(ulong encryption_option, bool is_serv
   return false;
 }
 
-bool innobase_check_mk_keyring_exclusions(THD *thd) {
-  if (srv_undo_log_encrypt == true) {
-    push_warning_printf(thd, Sql_condition::SL_WARNING, ER_WRONG_ARGUMENTS,
-                        "Online encryption to KEYRING cannot be turned ON"
-                        " as Undo log Master Key encryption is turned ON."
-                        " Please disable the Undo log Master key encryption"
-                        " (innodb_undo_log_encrypt) and try again.");
-    return true;
+bool innobase_check_mk_keyring_exclusions(THD *thd, longlong dte_val) {
+  if (dte_val == DEFAULT_TABLE_ENC_ONLINE_TO_KEYRING ||
+      dte_val == DEFAULT_TABLE_ENC_ONLINE_FROM_KEYRING_TO_UNENCRYPTED) {
+    if (lock_keyrings(nullptr) == 0) {
+      my_printf_error(ER_WRONG_ARGUMENTS,
+                      "The default_table_encryption option cannot be changed, "
+                      "keyring plugin is not available",
+                      MYF(0));
+      return true;
+    }
+    if (!Encryption::is_keyring_alive()) {
+      my_printf_error(ER_WRONG_ARGUMENTS,
+                      "The default_table_encryption option cannot be changed, "
+                      "keyring plugin is installed but it seems it was not "
+                      "properly initialized.",
+                      MYF(0));
+      unlock_keyrings(nullptr);
+      return true;
+    }
   }
-  if (srv_sys_tablespace_encrypt == SYS_TABLESPACE_ENCRYPT_ON) {
-    push_warning_printf(
-        thd, Sql_condition::SL_WARNING, ER_WRONG_ARGUMENTS,
-        "Online encryption to KEYRING cannot be turned ON"
-        " as system tablespace is encrypted with Master Key"
-        " encryption. In case you want system tablespace to"
-        " get re-encrypted with KEYRING encryption set"
-        " --innodb-sys_tablespace_encrypt to RE_ENCRYPTING_TO_KEYRING");
-    return true;
+
+  if (dte_val == DEFAULT_TABLE_ENC_ONLINE_TO_KEYRING) {
+    if (srv_undo_log_encrypt == true) {
+      push_warning_printf(thd, Sql_condition::SL_WARNING, ER_WRONG_ARGUMENTS,
+                          "Online encryption to KEYRING cannot be turned ON"
+                          " as Undo log Master Key encryption is turned ON."
+                          " Please disable the Undo log Master key encryption"
+                          " (innodb_undo_log_encrypt) and try again.");
+      return true;
+    }
+    if (srv_sys_tablespace_encrypt == SYS_TABLESPACE_ENCRYPT_ON) {
+      push_warning_printf(
+          thd, Sql_condition::SL_WARNING, ER_WRONG_ARGUMENTS,
+          "Online encryption to KEYRING cannot be turned ON"
+          " as system tablespace is encrypted with Master Key"
+          " encryption. In case you want system tablespace to"
+          " get re-encrypted with KEYRING encryption set"
+          " --innodb-sys_tablespace_encrypt to RE_ENCRYPTING_TO_KEYRING");
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
Problem:
--------
It's possible to set default_table_encryption to ONLINE_TO_KEYRING or
ONLINE_FROM_KEYRING_TO_UNENCRYPTED in case when keyring plugin isn't
loaded. This leads to server crash when trying to encrypt/decrypt data.
    
Fix:
--------
Add additional validation for default_table_encryption variable.
It can be set to ONLINE_TO_KEYRING or ONLINE_FROM_KEYRING_TO_UNENCRYPTED
only in case keyring plugin is loaded.