### PR TITLE
PS-7352, PS-7353: Fix LDAP issues on reconfiguration

### DIFF
--- a/plugin/auth_ldap/include/plugin_variables.h
+++ b/plugin/auth_ldap/include/plugin_variables.h
@@ -62,18 +62,21 @@ static MYSQL_SYSVAR_STR(bind_base_dn, bind_base_dn,
                         &update_sysvar<char *> /* update */,
                         nullptr /* default */);
 static MYSQL_SYSVAR_STR(bind_root_dn, bind_root_dn,
-                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
+                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
+                            PLUGIN_VAR_READONLY,
                         "The root distinguished name (DN)", nullptr /* check */,
                         &update_sysvar<char *> /* update */,
                         nullptr /* default */);
 static MYSQL_SYSVAR_STR(bind_root_pwd, bind_root_pwd,
-                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
+                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
+                            PLUGIN_VAR_READONLY,
                         "The password for the "
                         "root distinguished name",
                         nullptr /* check */, &update_pwd_sysvar /* update */,
                         nullptr /* default */);
 static MYSQL_SYSVAR_STR(ca_path, ca_path,
-                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
+                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
+                            PLUGIN_VAR_READONLY,
                         "The absolute path of "
                         "the certificate authority file",
                         nullptr /* check */,
@@ -112,24 +115,26 @@ static MYSQL_SYSVAR_INT(log_status, log_status, PLUGIN_VAR_RQCMDARG,
                         1 /* default */, 1 /*minimum */, 5 /* maximum */,
                         0 /* blocksize */);
 static MYSQL_SYSVAR_STR(server_host, server_host,
-                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
+                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
+                            PLUGIN_VAR_READONLY,
                         "The LDAP server host", nullptr /* check */,
                         &update_sysvar<char *> /* update */,
                         nullptr /* default */);
-static MYSQL_SYSVAR_UINT(server_port, server_port, PLUGIN_VAR_RQCMDARG,
+static MYSQL_SYSVAR_UINT(server_port, server_port,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                          "The LDAP server TCP/IP port number",
                          nullptr /* check */,
                          &update_sysvar<unsigned int> /* update */,
                          389 /* default */, 1 /*minimum */, 32376 /* maximum */,
                          0 /* blocksize */);
 static MYSQL_SYSVAR_BOOL(
-    ssl, ssl, PLUGIN_VAR_RQCMDARG,
+    ssl, ssl, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
     "Whether connections "
     "by the plugin to the LDAP server are using the SSL protocol (ldaps://)",
     nullptr /* check */, &update_sysvar<bool> /* update */,
     false /* default */);
 static MYSQL_SYSVAR_BOOL(
-    tls, tls, PLUGIN_VAR_RQCMDARG,
+    tls, tls, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
     "Whether connections "
     "by the plugin to the LDAP server are secured with STARTTLS (ldap://)",
     nullptr /* check */, &update_sysvar<bool> /* update */,

--- a/plugin/auth_ldap/src/plugin_simple.cc
+++ b/plugin/auth_ldap/src/plugin_simple.cc
@@ -97,11 +97,13 @@ static int auth_ldap_simple_init(MYSQL_PLUGIN plugin_info) {
   auth_ldap_common_init();
   log_srv_dbg("auth_ldap_simple_init()");
 
+  pwd_real_set(bind_root_pwd);
+
   log_srv_dbg("Creating LDAP connection pool");
   connPool = new mysql::plugin::auth_ldap::Pool(
       init_pool_size, max_pool_size, str_or_empty(server_host), server_port,
       ssl, tls, str_or_empty(ca_path), str_or_empty(bind_root_dn),
-      str_or_empty(bind_root_pwd));
+      str_or_empty(bind_root_pwd_real));
   connPool->debug_info();
 
   auth_ldap_simple_plugin_info = plugin_info;

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple-master.opt
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple-master.opt
@@ -1,1 +1,3 @@
 $AUTH_LDAP_OPT $AUTH_LDAP_LOAD
+--authentication_ldap_simple_server_host='$MTR_LDAP_HOST'
+--authentication_ldap_simple_server_port=$MTR_LDAP_PORT

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple.result
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple.result
@@ -13,14 +13,12 @@ authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memb
 authentication_ldap_simple_init_pool_size	10
 authentication_ldap_simple_log_status	1
 authentication_ldap_simple_max_pool_size	1000
-authentication_ldap_simple_server_host	
+authentication_ldap_simple_server_host	<MTR_LDAP_HOST>
 authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
 authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	uid
 SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
-SET GLOBAL authentication_ldap_simple_server_host = '<MTR_LDAP_HOST>';
-SET GLOBAL authentication_ldap_simple_server_port = <MTR_LDAP_PORT>;
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
@@ -57,32 +55,8 @@ authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
 authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	uid
-SET GLOBAL authentication_ldap_simple_server_host = 'badhost';
-ERROR 28000: Access denied for user 'zoidberg'@'localhost' (using password: YES)
-SET GLOBAL authentication_ldap_simple_server_host = '<MTR_LDAP_HOST>';
-SET GLOBAL authentication_ldap_simple_server_port = <BAD_MTR_LDAP_PORT>;
-ERROR 28000: Access denied for user 'zoidberg'@'localhost' (using password: YES)
-SET GLOBAL authentication_ldap_simple_server_port = <MTR_LDAP_PORT>;
-SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
-Variable_name	Value
-authentication_ldap_simple_auth_method_name	SIMPLE
-authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
-authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	
-authentication_ldap_simple_ca_path	
-authentication_ldap_simple_group_search_attr	cn
-authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
-authentication_ldap_simple_init_pool_size	10
-authentication_ldap_simple_log_status	1
-authentication_ldap_simple_max_pool_size	1000
-authentication_ldap_simple_server_host	<MTR_LDAP_HOST>
-authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
-authentication_ldap_simple_ssl	OFF
-authentication_ldap_simple_tls	OFF
-authentication_ldap_simple_user_search_attr	uid
+ERROR 28000: Access denied for user 'nonexistent'@'localhost' (using password: YES)
 DROP USER zoidberg;
 DROP USER nonexistent;
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
-SET GLOBAL authentication_ldap_simple_server_host = '';
-SET GLOBAL authentication_ldap_simple_server_port = 389;
 SET GLOBAL authentication_ldap_simple_log_status = 1;

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple.test
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple.test
@@ -9,13 +9,9 @@ SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_N
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST>
---eval SET GLOBAL authentication_ldap_simple_server_host = '$MTR_LDAP_HOST'
---replace_result $MTR_LDAP_PORT <MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $MTR_LDAP_PORT
 
 # For debugging:
-#SET GLOBAL authentication_ldap_simple_log_status = 4;
+# SET GLOBAL authentication_ldap_simple_log_status = 6;
 
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
@@ -30,39 +26,14 @@ SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 --disconnect con1
 --connection default
 
-SET GLOBAL authentication_ldap_simple_server_host = 'badhost';
 --disable_query_log
 --error ER_ACCESS_DENIED_ERROR
---connect (con1,localhost,zoidberg,zoidberg,,,,CLEARTEXT)
+--connect (con1,localhost,nonexistent,zoidberg,,,,CLEARTEXT)
 --enable_query_log
-
-
---disable_query_log
---let BAD_MTR_LDAP_PORT=`SELECT $MTR_LDAP_PORT+1`
---enable_query_log
-
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST>
---eval SET GLOBAL authentication_ldap_simple_server_host = '$MTR_LDAP_HOST'
---replace_result $BAD_MTR_LDAP_PORT <BAD_MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $BAD_MTR_LDAP_PORT
---disable_query_log
---error ER_ACCESS_DENIED_ERROR
---connect (con1,localhost,zoidberg,zoidberg,,,,CLEARTEXT)
---enable_query_log
-
---replace_result $MTR_LDAP_PORT <MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $MTR_LDAP_PORT
---connect (con1,localhost,zoidberg,zoidberg,,,,CLEARTEXT)
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
-SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
---disconnect con1
---connection default
 
 DROP USER zoidberg;
 DROP USER nonexistent;
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
-SET GLOBAL authentication_ldap_simple_server_host = '';
-SET GLOBAL authentication_ldap_simple_server_port = 389;
 SET GLOBAL authentication_ldap_simple_log_status = 1;
 
 --source include/wait_until_count_sessions.inc

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple_ad-master.opt
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple_ad-master.opt
@@ -1,1 +1,5 @@
 $AUTH_LDAP_OPT $AUTH_LDAP_LOAD
+--authentication_ldap_simple_server_host='$MTR_LDAP_HOST'
+--authentication_ldap_simple_server_port=$MTR_LDAP_PORT
+--authentication_ldap_simple_bind_root_dn='cn=zoidberg,cn=Users,dc=perconatest,dc=com'
+--authentication_ldap_simple_bind_root_pwd='Bergzoid11'

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple_ad.result
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple_ad.result
@@ -5,28 +5,8 @@ SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
 authentication_ldap_simple_bind_base_dn	
-authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	
-authentication_ldap_simple_ca_path	
-authentication_ldap_simple_group_search_attr	cn
-authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
-authentication_ldap_simple_init_pool_size	10
-authentication_ldap_simple_log_status	1
-authentication_ldap_simple_max_pool_size	1000
-authentication_ldap_simple_server_host	
-authentication_ldap_simple_server_port	389
-authentication_ldap_simple_ssl	OFF
-authentication_ldap_simple_tls	OFF
-authentication_ldap_simple_user_search_attr	uid
-SET GLOBAL authentication_ldap_simple_bind_base_dn = 'CN=Users,dc=loctest,dc=hu';
-SET GLOBAL authentication_ldap_simple_server_host = '<MTR_LDAP_HOST>';
-SET GLOBAL authentication_ldap_simple_server_port = <MTR_LDAP_PORT>;
-SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
-Variable_name	Value
-authentication_ldap_simple_auth_method_name	SIMPLE
-authentication_ldap_simple_bind_base_dn	CN=Users,dc=loctest,dc=hu
-authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	
+authentication_ldap_simple_bind_root_dn	cn=zoidberg,cn=Users,dc=perconatest,dc=com
+authentication_ldap_simple_bind_root_pwd	********
 authentication_ldap_simple_ca_path	
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
@@ -38,14 +18,32 @@ authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
 authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	uid
-CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=zoidberg,cn=Users,dc=loctest,dc=hu';
+SET GLOBAL authentication_ldap_simple_bind_base_dn = 'cn=Users,dc=perconatest,dc=com';
+SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
+Variable_name	Value
+authentication_ldap_simple_auth_method_name	SIMPLE
+authentication_ldap_simple_bind_base_dn	cn=Users,dc=perconatest,dc=com
+authentication_ldap_simple_bind_root_dn	cn=zoidberg,cn=Users,dc=perconatest,dc=com
+authentication_ldap_simple_bind_root_pwd	********
+authentication_ldap_simple_ca_path	
+authentication_ldap_simple_group_search_attr	cn
+authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
+authentication_ldap_simple_init_pool_size	10
+authentication_ldap_simple_log_status	1
+authentication_ldap_simple_max_pool_size	1000
+authentication_ldap_simple_server_host	<MTR_LDAP_HOST>
+authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
+authentication_ldap_simple_ssl	OFF
+authentication_ldap_simple_tls	OFF
+authentication_ldap_simple_user_search_attr	uid
+CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=zoidberg,cn=Users,dc=perconatest,dc=com';
 CREATE USER nonexistent IDENTIFIED WITH authentication_ldap_simple BY 'uid=nonexistent';
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
-authentication_ldap_simple_bind_base_dn	CN=Users,dc=loctest,dc=hu
-authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	
+authentication_ldap_simple_bind_base_dn	cn=Users,dc=perconatest,dc=com
+authentication_ldap_simple_bind_root_dn	cn=zoidberg,cn=Users,dc=perconatest,dc=com
+authentication_ldap_simple_bind_root_pwd	********
 authentication_ldap_simple_ca_path	
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
@@ -57,40 +55,16 @@ authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
 authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	uid
-SET GLOBAL authentication_ldap_simple_server_host = 'badhost';
-ERROR 28000: Access denied for user 'zoidberg'@'localhost' (using password: YES)
-SET GLOBAL authentication_ldap_simple_server_host = '<MTR_LDAP_HOST>';
-SET GLOBAL authentication_ldap_simple_server_port = <BAD_MTR_LDAP_PORT>;
-ERROR 28000: Access denied for user 'zoidberg'@'localhost' (using password: YES)
-SET GLOBAL authentication_ldap_simple_server_port = <MTR_LDAP_PORT>;
-SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
-Variable_name	Value
-authentication_ldap_simple_auth_method_name	SIMPLE
-authentication_ldap_simple_bind_base_dn	CN=Users,dc=loctest,dc=hu
-authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	
-authentication_ldap_simple_ca_path	
-authentication_ldap_simple_group_search_attr	cn
-authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
-authentication_ldap_simple_init_pool_size	10
-authentication_ldap_simple_log_status	1
-authentication_ldap_simple_max_pool_size	1000
-authentication_ldap_simple_server_host	<MTR_LDAP_HOST>
-authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
-authentication_ldap_simple_ssl	OFF
-authentication_ldap_simple_tls	OFF
-authentication_ldap_simple_user_search_attr	uid
+ERROR 28000: Access denied for user 'nonexistent'@'localhost' (using password: YES)
 DROP USER zoidberg;
 DROP USER nonexistent;
 SET GLOBAL authentication_ldap_simple_user_search_attr = 'samAccountName';
-SET GLOBAL authentication_ldap_simple_bind_root_dn = 'cn=zoidberg,cn=Users,dc=loctest,dc=hu';
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = 'Bergzoid11';
 CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple;
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
-authentication_ldap_simple_bind_base_dn	CN=Users,dc=loctest,dc=hu
-authentication_ldap_simple_bind_root_dn	cn=zoidberg,cn=Users,dc=loctest,dc=hu
+authentication_ldap_simple_bind_base_dn	cn=Users,dc=perconatest,dc=com
+authentication_ldap_simple_bind_root_dn	cn=zoidberg,cn=Users,dc=perconatest,dc=com
 authentication_ldap_simple_bind_root_pwd	********
 authentication_ldap_simple_ca_path	
 authentication_ldap_simple_group_search_attr	cn
@@ -105,9 +79,5 @@ authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	samAccountName
 DROP USER zoidberg;
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
-SET GLOBAL authentication_ldap_simple_bind_root_dn = '';
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = '';
 SET GLOBAL authentication_ldap_simple_user_search_attr = 'uid';
-SET GLOBAL authentication_ldap_simple_server_host = '';
-SET GLOBAL authentication_ldap_simple_server_port = 389;
 SET GLOBAL authentication_ldap_simple_log_status = 1;

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple_ad.test
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple_ad.test
@@ -7,18 +7,14 @@
 SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME LIKE 'authentication_ldap_simple%';
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
-SET GLOBAL authentication_ldap_simple_bind_base_dn = 'CN=Users,dc=loctest,dc=hu';
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST>
---eval SET GLOBAL authentication_ldap_simple_server_host = '$MTR_LDAP_HOST'
---replace_result $MTR_LDAP_PORT <MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $MTR_LDAP_PORT
+SET GLOBAL authentication_ldap_simple_bind_base_dn = 'cn=Users,dc=perconatest,dc=com';
 
 # For debugging:
-# SET GLOBAL authentication_ldap_simple_log_status = 4;
+#SET GLOBAL authentication_ldap_simple_log_status = 6;
 
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
-CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=zoidberg,cn=Users,dc=loctest,dc=hu';
+CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=zoidberg,cn=Users,dc=perconatest,dc=com';
 CREATE USER nonexistent IDENTIFIED WITH authentication_ldap_simple BY 'uid=nonexistent';
 
 --connect (con1,localhost,zoidberg,Bergzoid11,,,,CLEARTEXT)
@@ -29,41 +25,16 @@ SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 --disconnect con1
 --connection default
 
-SET GLOBAL authentication_ldap_simple_server_host = 'badhost';
 --disable_query_log
 --error ER_ACCESS_DENIED_ERROR
---connect (con1,localhost,zoidberg,Bergzoid11,,,,CLEARTEXT)
+--connect (con1,localhost,nonexistent,Bergzoid11,,,,CLEARTEXT)
 --enable_query_log
-
-
---disable_query_log
---let BAD_MTR_LDAP_PORT=`SELECT $MTR_LDAP_PORT+1`
---enable_query_log
-
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST>
---eval SET GLOBAL authentication_ldap_simple_server_host = '$MTR_LDAP_HOST'
---replace_result $BAD_MTR_LDAP_PORT <BAD_MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $BAD_MTR_LDAP_PORT
---disable_query_log
---error ER_ACCESS_DENIED_ERROR
---connect (con1,localhost,zoidberg,Bergzoid11,,,,CLEARTEXT)
---enable_query_log
-
---replace_result $MTR_LDAP_PORT <MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $MTR_LDAP_PORT
---connect (con1,localhost,zoidberg,Bergzoid11,,,,CLEARTEXT)
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
-SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
---disconnect con1
---connection default
 
 DROP USER zoidberg;
 DROP USER nonexistent;
 
 # Test search mode
 SET GLOBAL authentication_ldap_simple_user_search_attr = 'samAccountName';
-SET GLOBAL authentication_ldap_simple_bind_root_dn = 'cn=zoidberg,cn=Users,dc=loctest,dc=hu';
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = 'Bergzoid11';
 CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple;
 --connect (con1,localhost,zoidberg,Bergzoid11,,,,CLEARTEXT)
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
@@ -74,11 +45,7 @@ SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 DROP USER zoidberg;
 
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
-SET GLOBAL authentication_ldap_simple_bind_root_dn = '';
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = '';
 SET GLOBAL authentication_ldap_simple_user_search_attr = 'uid';
-SET GLOBAL authentication_ldap_simple_server_host = '';
-SET GLOBAL authentication_ldap_simple_server_port = 389;
 SET GLOBAL authentication_ldap_simple_log_status = 1;
 
 --source include/wait_until_count_sessions.inc

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_tls-master.opt
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_tls-master.opt
@@ -1,1 +1,4 @@
 $AUTH_LDAP_OPT $AUTH_LDAP_LOAD
+--authentication_ldap_simple_server_host='$MTR_LDAP_HOST'
+--authentication_ldap_simple_server_port=$MTR_LDAP_PORT
+--authentication_ldap_simple_tls=ON

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_tls.result
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_tls.result
@@ -13,23 +13,18 @@ authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memb
 authentication_ldap_simple_init_pool_size	10
 authentication_ldap_simple_log_status	1
 authentication_ldap_simple_max_pool_size	1000
-authentication_ldap_simple_server_host	
+authentication_ldap_simple_server_host	<MTR_LDAP_HOST>
 authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
 authentication_ldap_simple_ssl	OFF
-authentication_ldap_simple_tls	OFF
+authentication_ldap_simple_tls	ON
 authentication_ldap_simple_user_search_attr	uid
 SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
-SET GLOBAL authentication_ldap_simple_server_host = '<MTR_LDAP_HOST>';
-SET GLOBAL authentication_ldap_simple_server_port = <MTR_LDAP_PORT>;
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = "foo";
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = "bar";
-SET GLOBAL authentication_ldap_simple_tls = ON;
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
 authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
 authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	********
+authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
@@ -48,7 +43,7 @@ Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
 authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
 authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	********
+authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
@@ -60,36 +55,8 @@ authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
 authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	ON
 authentication_ldap_simple_user_search_attr	uid
-SET GLOBAL authentication_ldap_simple_server_host = 'badhost';
-connect(localhost,zoidberg,zoidberg,test,13000,/home/dutow/workspace/topics/ldap-fixup/80-local/mysql-test/var/tmp/mysqld.1.sock);
-ERROR 28000: Access denied for user 'zoidberg'@'localhost' (using password: YES)
-SET GLOBAL authentication_ldap_simple_server_host = '<MTR_LDAP_HOST>';
-SET GLOBAL authentication_ldap_simple_server_port = <BAD_MTR_LDAP_PORT>;
-connect(localhost,zoidberg,zoidberg,test,13000,/home/dutow/workspace/topics/ldap-fixup/80-local/mysql-test/var/tmp/mysqld.1.sock);
-ERROR 28000: Access denied for user 'zoidberg'@'localhost' (using password: YES)
-SET GLOBAL authentication_ldap_simple_server_port = <MTR_LDAP_PORT>;
-SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
-Variable_name	Value
-authentication_ldap_simple_auth_method_name	SIMPLE
-authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
-authentication_ldap_simple_bind_root_dn	
-authentication_ldap_simple_bind_root_pwd	********
-authentication_ldap_simple_ca_path	
-authentication_ldap_simple_group_search_attr	cn
-authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
-authentication_ldap_simple_init_pool_size	10
-authentication_ldap_simple_log_status	1
-authentication_ldap_simple_max_pool_size	1000
-authentication_ldap_simple_server_host	<MTR_LDAP_HOST>
-authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
-authentication_ldap_simple_ssl	OFF
-authentication_ldap_simple_tls	ON
-authentication_ldap_simple_user_search_attr	uid
+ERROR 28000: Access denied for user 'nonexistent'@'localhost' (using password: YES)
 DROP USER zoidberg;
 DROP USER nonexistent;
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
-SET GLOBAL authentication_ldap_simple_server_port = 389;
-SET GLOBAL authentication_ldap_simple_server_host = '';
 SET GLOBAL authentication_ldap_simple_log_status = 1;
-SET GLOBAL authentication_ldap_simple_tls = 0;
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = "";

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_tls.test
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_tls.test
@@ -2,7 +2,6 @@
 # This testcase requires the following ldap structure:
 # https://github.com/rroemhild/docker-test-openldap
 # The easiest way to run it is to use the provided docker image
-# The test also requires the LDAPTLS_REQCERT environment variable set to never
 
 --source include/count_sessions.inc
 
@@ -10,16 +9,9 @@ SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_N
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST>
---eval SET GLOBAL authentication_ldap_simple_server_host = '$MTR_LDAP_HOST'
---replace_result $MTR_LDAP_PORT <MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $MTR_LDAP_PORT
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = "foo";
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = "bar";
-SET GLOBAL authentication_ldap_simple_tls = ON;
 
 # For debugging:
-#SET GLOBAL authentication_ldap_simple_log_status = 4;
+# SET GLOBAL authentication_ldap_simple_log_status = 6;
 
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
@@ -34,36 +26,14 @@ SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 --disconnect con1
 --connection default
 
-SET GLOBAL authentication_ldap_simple_server_host = 'badhost';
---error ER_ACCESS_DENIED_ERROR
---connect (con1,localhost,zoidberg,zoidberg,,,,CLEARTEXT)
-
 --disable_query_log
---let BAD_MTR_LDAP_PORT=`SELECT $MTR_LDAP_PORT+1`
---enable_query_log
-
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST>
---eval SET GLOBAL authentication_ldap_simple_server_host = '$MTR_LDAP_HOST'
---replace_result $BAD_MTR_LDAP_PORT <BAD_MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $BAD_MTR_LDAP_PORT
 --error ER_ACCESS_DENIED_ERROR
---connect (con1,localhost,zoidberg,zoidberg,,,,CLEARTEXT)
-
---replace_result $MTR_LDAP_PORT <MTR_LDAP_PORT>
---eval SET GLOBAL authentication_ldap_simple_server_port = $MTR_LDAP_PORT
---connect (con1,localhost,zoidberg,zoidberg,,,,CLEARTEXT)
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
-SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
---disconnect con1
---connection default
+--connect (con1,localhost,nonexistent,zoidberg,,,,CLEARTEXT)
+--enable_query_log
 
 DROP USER zoidberg;
 DROP USER nonexistent;
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
-SET GLOBAL authentication_ldap_simple_server_port = 389;
-SET GLOBAL authentication_ldap_simple_server_host = '';
 SET GLOBAL authentication_ldap_simple_log_status = 1;
-SET GLOBAL authentication_ldap_simple_tls = 0;
-SET GLOBAL authentication_ldap_simple_bind_root_pwd = "";
 
 --source include/wait_until_count_sessions.inc


### PR DESCRIPTION
Issues:
* Specifying a non existent server with to the LDAP variables could
  result in a slow timeout, making the SET command slow to return,
  blocking connections in the meantime.
* Specifying a non existent CA file for TLS/SSL when there are already
  active connections will result in a crash in the ldap library

Fix: make the variables that requires reconnecting a new server static,
so no runtime reconfiguration is required. These parameters only have to
be changed when the LDAP server is moved, which is not a common event.t