### PR TITLE
PS-7328: Block CREATE/ALTER/DROP UNDO TABLESPACE with LTFB

### DIFF
--- a/mysql-test/suite/innodb_undo/r/undo_tablespace.result
+++ b/mysql-test/suite/innodb_undo/r/undo_tablespace.result
@@ -277,6 +277,24 @@ undo_004	NULL	./undo_004.ibu
 Warnings:
 Warning	1812	Tablespace is missing for table undo_004.
 DROP UNDO TABLESPACE undo_004;
+LOCK TABLES FOR BACKUP;
+CREATE UNDO TABLESPACE undo_003 ADD DATAFILE 'undo3.ibu';
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+SET @@session.lock_wait_timeout=1;
+CREATE UNDO TABLESPACE undo_003 ADD DATAFILE 'undo3.ibu';
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+UNLOCK TABLES;
+CREATE UNDO TABLESPACE undo_003 ADD DATAFILE 'undo3.ibu';
+LOCK TABLES FOR BACKUP;
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+UNLOCK TABLES;
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+LOCK TABLES FOR BACKUP;
+DROP UNDO TABLESPACE undo_003;
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+UNLOCK TABLES;
+DROP UNDO TABLESPACE undo_003;
 #
 # Cleanup
 #

--- a/mysql-test/suite/innodb_undo/t/undo_tablespace.test
+++ b/mysql-test/suite/innodb_undo/t/undo_tablespace.test
@@ -3,6 +3,7 @@
 --echo #
 
 --source include/have_innodb_default_undo_tablespaces.inc
+--source include/count_sessions.inc
 
 # Do a slow shutdown and restart to clear out the undo logs
 SET GLOBAL innodb_fast_shutdown = 0;
@@ -245,6 +246,43 @@ SELECT TABLESPACE_NAME, FILE_TYPE, FILE_NAME FROM INFORMATION_SCHEMA.FILES
        WHERE FILE_NAME LIKE '%undo%' ORDER BY TABLESPACE_NAME;
 DROP UNDO TABLESPACE undo_004;
 
+
+# Check that it won't work with LTFB
+LOCK TABLES FOR BACKUP;
+
+--error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
+CREATE UNDO TABLESPACE undo_003 ADD DATAFILE 'undo3.ibu';
+
+--connect (con1,'localhost','root',,)
+SET @@session.lock_wait_timeout=1;
+
+--error ER_LOCK_WAIT_TIMEOUT
+CREATE UNDO TABLESPACE undo_003 ADD DATAFILE 'undo3.ibu';
+
+--connection default
+--disconnect con1
+
+UNLOCK TABLES;
+
+CREATE UNDO TABLESPACE undo_003 ADD DATAFILE 'undo3.ibu';
+
+LOCK TABLES FOR BACKUP;
+
+ --error ER_CANT_EXECUTE_WITH_BACKUP_LOCK 
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+
+UNLOCK TABLES;
+ALTER UNDO TABLESPACE undo_003 SET INACTIVE;
+--let $inactive_undo_space = undo_003
+--source include/wait_until_undo_space_is_empty.inc
+
+LOCK TABLES FOR BACKUP;
+
+ --error ER_CANT_EXECUTE_WITH_BACKUP_LOCK 
+DROP UNDO TABLESPACE undo_003;
+UNLOCK TABLES;
+DROP UNDO TABLESPACE undo_003;
+
 --echo #
 --echo # Cleanup
 --echo #
@@ -255,6 +293,8 @@ ALTER UNDO TABLESPACE undo_005 SET INACTIVE;
 let $inactive_undo_space = undo_005;
 source include/wait_until_undo_space_is_empty.inc;
 DROP UNDO TABLESPACE undo_005;
+
+--source include/wait_until_count_sessions.inc
 
 --disable_query_log
 call mtr.add_suppression("\\[Warning\\] .* Log writer is waiting for checkpointer to to catch up lag");

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11155,6 +11155,9 @@ ER_REDO_TABLESPACE_ENCRYPTION_MISSING_KEY_VERSIONS
 ER_REDO_TABLESPACE_ENCRYPTION_CORRUPTED_KEYS
   eng "Tablespace id %u is encrypted. Although server managed to find all needed versions of key_id=%u in keyring to decrypt it, the provided versions are either incorrect or corrupted. Can't continue reading table. Please provide the correct keyring."
 
+ER_IB_MSG_UNDO_TRUNCATE_DELAY_BY_LTFB
+  eng "Delaying truncate of undo tablespace %s due to lock tables for backup."
+
 #
 # End of Percona Server 8.0 server error log messages
 #

--- a/sql/sql_tablespace.cc
+++ b/sql/sql_tablespace.cc
@@ -1378,6 +1378,13 @@ bool Sql_cmd_create_undo_tablespace::execute(THD *thd) {
     return true;
   }
 
+  // Acquire Percona's LOCK TABLES FOR BACKUP lock
+  if (thd->backup_tables_lock.abort_if_acquired() ||
+      thd->backup_tables_lock.acquire_protection(
+          thd, MDL_TRANSACTION, thd->variables.lock_wait_timeout)) {
+    return true;
+  }
+
   handlerton *hton = nullptr;
   if (get_stmt_hton(thd, m_options->engine_name, m_undo_tablespace_name.str,
                     "CREATE UNDO TABLESPACE", &hton)) {
@@ -1525,6 +1532,13 @@ bool Sql_cmd_alter_undo_tablespace::execute(THD *thd) {
     return true;
   }
 
+  // Acquire Percona's LOCK TABLES FOR BACKUP lock
+  if (thd->backup_tables_lock.abort_if_acquired() ||
+      thd->backup_tables_lock.acquire_protection(
+          thd, MDL_TRANSACTION, thd->variables.lock_wait_timeout)) {
+    return true;
+  }
+
   handlerton *hton = nullptr;
   if (get_stmt_hton(thd, m_options->engine_name, m_undo_tablespace_name.str,
                     "ALTER UNDO TABLESPACE", &hton)) {
@@ -1613,6 +1627,13 @@ bool Sql_cmd_drop_undo_tablespace::execute(THD *thd) {
   Rollback_guard rollback_on_return{thd};
 
   if (check_global_access(thd, CREATE_TABLESPACE_ACL)) {
+    return true;
+  }
+
+  // Acquire Percona's LOCK TABLES FOR BACKUP lock
+  if (thd->backup_tables_lock.abort_if_acquired() ||
+      thd->backup_tables_lock.acquire_protection(
+          thd, MDL_TRANSACTION, thd->variables.lock_wait_timeout)) {
     return true;
   }
 

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -33,6 +33,8 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include <sys/types.h>
 #include <new>
 
+#include <current_thd.h>
+#include <sql_class.h>
 #include "clone0api.h"
 #include "clone0clone.h"
 #include "dict0dd.h"
@@ -1548,6 +1550,17 @@ static bool trx_purge_truncate_marked_undo() {
     return (false);
   }
   ut_ad(mdl_ticket != nullptr);
+
+  // Acquire Percona's LOCK TABLES FOR BACKUP lock
+  if (current_thd->backup_tables_lock.is_acquired()) {
+    ib::info(ER_IB_MSG_UNDO_TRUNCATE_DELAY_BY_LTFB, space_name.c_str());
+    return (false);
+  }
+  if (current_thd->backup_tables_lock.acquire_protection(current_thd,
+                                                         MDL_TRANSACTION, 0)) {
+    ib::info(ER_IB_MSG_UNDO_TRUNCATE_DELAY_BY_LTFB, space_name.c_str());
+    return (false);
+  }
 
   /* Re-check for clone after acquiring MDL. The Backup MDL from clone
   is released by clone during shutdown while provisioning. We should


### PR DESCRIPTION
Issue: changing the undo tablespaces could result in failed backups.

Fix: block these statements while the backup lock is available, and hold
the lock until the operation is completed.