### PR TITLE
PS-7360: clang-4.0 compilation fails from '-Winconsistent-missing-destructor-override'

### DIFF
--- a/router/src/protobuf/src/protobuf_plugin.cc
+++ b/router/src/protobuf/src/protobuf_plugin.cc
@@ -28,8 +28,10 @@
 
 MY_COMPILER_DIAGNOSTIC_PUSH()
 MY_COMPILER_CLANG_DIAGNOSTIC_IGNORE("-Wdeprecated-dynamic-exception-spec")
+#if !defined(__clang__) || (__clang_major__ >= 5)
 MY_COMPILER_CLANG_DIAGNOSTIC_IGNORE(
     "-Winconsistent-missing-destructor-override")
+#endif
 #include <google/protobuf/message_lite.h>  // ShutdownProtobufLibrary()
 MY_COMPILER_DIAGNOSTIC_POP()
 


### PR DESCRIPTION
Don't call `MY_COMPILER_CLANG_DIAGNOSTIC_IGNORE("-Winconsistent-missing-destructor-override")` for clang-4.0 or older.