### PR TITLE
PS-7232 Multithreaded Slave hangs when slave_transaction_retries=0

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_mts_spco_deadlock_slave_trans_retries_assertion.result
+++ b/mysql-test/suite/rpl/r/rpl_mts_spco_deadlock_slave_trans_retries_assertion.result
@@ -46,8 +46,8 @@ include/start_slave_sql.inc
 [connection slave]
 ROLLBACK;
 #
-# 5. Wait till the co-ordinator thread to error out with ER_SLAVE_WORKER_STOPPED_PREVIOUS_THD_ERROR.
-include/wait_for_slave_sql_error.inc [errno=3030]
+# 5. Wait till the co-ordinator thread to error out with ER_LOCK_DEADLOCK.
+include/wait_for_slave_sql_error.inc [errno=1213]
 # Removing debug point 'simulate_exhausted_trans_retries' from @@GLOBAL.debug
 include/start_slave_sql.inc
 #

--- a/mysql-test/suite/rpl/t/rpl_mts_spco_deadlock_slave_trans_retries_assertion.test
+++ b/mysql-test/suite/rpl/t/rpl_mts_spco_deadlock_slave_trans_retries_assertion.test
@@ -119,8 +119,8 @@ INSERT INTO t1 VALUES(11, 11);
 ROLLBACK;
 
 --echo #
---echo # 5. Wait till the co-ordinator thread to error out with ER_SLAVE_WORKER_STOPPED_PREVIOUS_THD_ERROR.
---let $slave_sql_errno = convert_error(ER_SLAVE_WORKER_STOPPED_PREVIOUS_THD_ERROR)
+--echo # 5. Wait till the co-ordinator thread to error out with ER_LOCK_DEADLOCK.
+--let $slave_sql_errno = convert_error(ER_LOCK_DEADLOCK)
 --source include/wait_for_slave_sql_error.inc
 
 # Remove the debug point


### PR DESCRIPTION
This is a post-push fix of PS-7232.

Problem
-------
The test rpl_mts_spco_deadlock_slave_trans_retries_assertion.test failed with
with wrong error code for the slave SQL thread.

CURRENT_TEST: rpl.rpl_mts_spco_deadlock_slave_trans_retries_assertion
mysqltest: At line 80: Slave stopped with wrong error code
In included file ./include/wait_for_slave_sql_error.inc: 81
included from
/home/venki/work/ps/7197/80-7232/mysql-test/suite/rpl/t/rpl_mts_spco_deadlock_slave_trans_retries_assertion.test:
125

Analysis
--------
The test was introduced as part of PS-7231 and started failing after PS-7232
was merged into 8.0.

When there is a deadlock among the slave worker threads and if slave
transaction retries are exhausted, the slave SQL/coordinator thread failed with
ER_SLAVE_WORKER_STOPPED_PREVIOUS_THD_ERROR before the fix for PS-7232.

But, after the fix for PS-7232, it fails with the ER_LOCK_DEADLOCK. However
this was not caught during the test run for PS-7232.

Fix
---
Modify the test to wait for the SQL thread to fail with ER_LOCK_DEADLOCK,
instead of ER_SLAVE_WORKER_STOPPED_PREVIOUS_THD_ERROR.