### PR TITLE
PS-7363: Release MDL when UNDO truncate is cancelled because of LTFB

### DIFF
--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -1553,11 +1553,13 @@ static bool trx_purge_truncate_marked_undo() {
 
   // Acquire Percona's LOCK TABLES FOR BACKUP lock
   if (current_thd->backup_tables_lock.is_acquired()) {
+    dd_release_mdl(mdl_ticket);
     ib::info(ER_IB_MSG_UNDO_TRUNCATE_DELAY_BY_LTFB, space_name.c_str());
     return (false);
   }
   if (current_thd->backup_tables_lock.acquire_protection(current_thd,
                                                          MDL_TRANSACTION, 0)) {
+    dd_release_mdl(mdl_ticket);
     ib::info(ER_IB_MSG_UNDO_TRUNCATE_DELAY_BY_LTFB, space_name.c_str());
     return (false);
   }


### PR DESCRIPTION
Issue: executing drop undo tablespace while LTFB + UNLOCK TABLES is
executed on another session could result in DROP UNDO TABLESPACE getting
stuck.

This is caused by the undo truncation thread: when undo truncation is
cancelled because of LTFB, the purge thread doesn't release the MDL
locks held for truncation.

Fix: locks are correctly released on failure.