### PR TITLE
PS-7388: CircleCI: avoid Docker Hub rate limits (8.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ jobs:
   build:
     docker:
       - image: circleci/buildpack-deps:bionic
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - run:


### PR DESCRIPTION
On November 1st, 2020 Docker Hub will begin limiting anonymous image pulls.

This change will influence our clang-format validation with CircleCI.
But a simple workaround is to create a dummy Docker Hub account and use it within `.circleci/config.yml`.