### PR TITLE
PS-7225: Fix sporadically failing rpl and gr tests on Jenkins

### DIFF
--- a/mysql-test/suite/group_replication/r/gr_primary_mode_group_operations_concurrent_member_shutdown.result
+++ b/mysql-test/suite/group_replication/r/gr_primary_mode_group_operations_concurrent_member_shutdown.result
@@ -12,6 +12,7 @@ SELECT group_replication_switch_to_single_primary_mode("MEMBER1_UUID");
 
 # 2. Unblock the action
 SET DEBUG_SYNC= "now SIGNAL signal.primary_action_continue";
+SET DEBUG_SYNC= "RESET";
 SET @@GLOBAL.DEBUG= '-d,group_replication_block_primary_action_validation';
 
 # 3. Shutdown the server.

--- a/mysql-test/suite/group_replication/t/gr_primary_mode_group_operations_concurrent_member_shutdown.test
+++ b/mysql-test/suite/group_replication/t/gr_primary_mode_group_operations_concurrent_member_shutdown.test
@@ -43,6 +43,7 @@ SET @@GLOBAL.DEBUG= '+d,group_replication_block_primary_action_validation';
 --echo # 2. Unblock the action
 
 SET DEBUG_SYNC= "now SIGNAL signal.primary_action_continue";
+SET DEBUG_SYNC= "RESET";
 SET @@GLOBAL.DEBUG= '-d,group_replication_block_primary_action_validation';
 
 --echo

--- a/mysql-test/suite/rpl_gtid/r/rpl_reset_master_kill.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_reset_master_kill.result
@@ -3,5 +3,6 @@ CALL mtr.add_suppression('The transaction owned GTID is already in the gtid_exec
 CREATE TABLE t1(c1 int);
 RESET MASTER;
 ERROR HY000: Lost connection to MySQL server during query
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
 # Removing debug point 'wait_for_kill_gtid_state_clear' from @@GLOBAL.debug

--- a/mysql-test/suite/rpl_gtid/t/rpl_reset_master_kill.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_reset_master_kill.test
@@ -42,6 +42,7 @@ SET DEBUG_SYNC='now SIGNAL kill_gtid_state_clear';
 
 # 4. Now DROP TABLE t1(any DDL)
 --connection default
+SET DEBUG_SYNC = 'RESET';
 DROP TABLE t1;
 --source include/remove_debug_point.inc
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7225
    
Stabilized the tests `rpl_gtid.rpl_reset_master_kill` and
`gr_primary_mode_group_operations_concurrent_member_shutdown` on Jenkins
by resetting the DEBUG_SYNC in the end of the testcase.


---
Before this patch, the test failed with below error
```
MTR's internal check of the test case 'rpl_gtid.rpl_reset_master_kill' failed.
This means that the test case does not preserve the state that existed
before the test case was executed.  Most likely the test case did not
do a proper clean-up. It could also be caused by the previous test run
by this thread, if the server wasn't restarted.
This is the diff of the states of the servers before and after the
test case was executed:
mysqltest: Results saved in '/home/venki/work/ps/6990/bld/mysql-test/var/4/tmp/check-mysqld_1.result'.
mysqltest: Logging to '/home/venki/work/ps/6990/bld/mysql-test/var/4/tmp/check-mysqld_1.log'.
mysqltest: Connecting to server localhost:13060 (socket /home/venki/work/ps/6990/bld/mysql-test/var/tmp/4/mysqld.1.sock) as 'root', connection 'default', attempt 0 ...
mysqltest: ... Connected.
mysqltest: Start processing test commands from './include/check-testcase.test' ...
mysqltest: ... Done processing test commands.
--- /home/venki/work/ps/6990/bld/mysql-test/var/4/tmp/check-mysqld_1.result	2020-10-30 08:55:49.389510802 +0300
+++ /home/venki/work/ps/6990/bld/mysql-test/var/4/tmp/check-mysqld_1.reject	2020-10-30 08:55:51.001534679 +0300
@@ -1027,7 +1027,7 @@
 windowing_use_high_precision	ON
 VARIABLE_NAME	VARIABLE_VALUE
 VARIABLE_NAME	VARIABLE_VALUE
-debug_sync	ON - signals: ''
+debug_sync	ON - signals: 'kill_gtid_state_clear'
 CATALOG_NAME	SCHEMA_NAME	DEFAULT_CHARACTER_SET_NAME	DEFAULT_COLLATION_NAME	SQL_PATH	DEFAULT_ENCRYPTION
 def	information_schema	utf8	utf8_general_ci	NULL	NO
 def	mtr	utf8mb4	utf8mb4_0900_ai_ci	NULL	NO

mysqltest: Result content mismatch

```

```
2617 [ 12%] group_replication.gr_primary_mode_group_operations_concurrent_member_shutdown w7  [ fail ]
2618     ┆   Test ended at 2020-10-30 21:09:11
2619 
2620 
2621 MTR's internal check of the test case 'group_replication.gr_primary_mode_group_operations_concurrent_member_shutdown' failed.
2622 This means that the test case does not preserve the state that existed
2623 before the test case was executed.  Most likely the test case did not
2624 do a proper clean-up. It could also be caused by the previous test run
2625 by this thread, if the server wasn't restarted.
2626 This is the diff of the states of the servers before and after the
2627 test case was executed:
2628 mysqltest: Results saved in '/home/venki/work/ps/6990/bld/mysql-test/var/7/tmp/check-mysqld_1.result'.
2629 mysqltest: Logging to '/home/venki/work/ps/6990/bld/mysql-test/var/7/tmp/check-mysqld_1.log'.
2630 mysqltest: Connecting to server localhost:13240 (socket /home/venki/work/ps/6990/bld/mysql-test/var/tmp/7/mysqld.1.sock) as 'root', connection 'default', attempt 0 ...
2631 mysqltest: ... Connected.
2632 mysqltest: Start processing test commands from './include/check-testcase.test' ...
2633 mysqltest: ... Done processing test commands.
2634 --- /home/venki/work/ps/6990/bld/mysql-test/var/7/tmp/check-mysqld_1.result 2020-10-30 18:38:29.636855494 +0300
2635 +++ /home/venki/work/ps/6990/bld/mysql-test/var/7/tmp/check-mysqld_1.reject 2020-10-30 18:39:10.942157922 +0300
2636 @@ -1092,7 +1092,7 @@
2637  windowing_use_high_precision   ON
2638  VARIABLE_NAME  VARIABLE_VALUE
2639  VARIABLE_NAME  VARIABLE_VALUE
2640 -debug_sync ON - signals: ''
2641 +debug_sync ON - signals: 'signal.primary_action_continue'
2642  CATALOG_NAME   SCHEMA_NAME DEFAULT_CHARACTER_SET_NAME  DEFAULT_COLLATION_NAME  SQL_PATH    DEFAULT_ENCRYPTION
2643  def    information_schema  utf8    utf8_general_ci NULL    NO
2644  def    mtr utf8mb4 utf8mb4_0900_ai_ci  NULL    NO
2645 
2646 mysqltest: Result content mismatch
```