### PR TITLE
PS-7229: Improve stability of rocksdb.add_index_inplace_sstfilewriter

### DIFF
--- a/mysql-test/suite/rocksdb/r/add_index_inplace_sstfilewriter.result
+++ b/mysql-test/suite/rocksdb/r/add_index_inplace_sstfilewriter.result
@@ -1,4 +1,3 @@
-set rocksdb_max_row_locks=6000000;
 CREATE TABLE t1(pk CHAR(5) PRIMARY KEY, a char(30), b char(30)) ENGINE=ROCKSDB COLLATE 'latin1_bin';
 set rocksdb_bulk_load=1;
 set rocksdb_bulk_load_size=100000;
@@ -6,15 +5,19 @@ LOAD DATA INFILE <input_file> INTO TABLE t1;
 set rocksdb_bulk_load=0;
 select count(pk) from t1;
 count(pk)
-3000000
+1500000
 select count(a) from t1;
 count(a)
-3000000
+1500000
 select count(b) from t1;
 count(b)
-3000000
+1500000
 ALTER TABLE t1 ADD INDEX kb(b), ALGORITHM=INPLACE;
 ALTER TABLE t1 ADD INDEX kb_copy(b), ALGORITHM=COPY;
+ERROR HY000: Got error 10 'Operation aborted: Failed to acquire lock due to rocksdb_max_row_locks limit' from ROCKSDB
+set session rocksdb_bulk_load=1;
+ALTER TABLE t1 ADD INDEX kb_copy(b), ALGORITHM=COPY;
+set session rocksdb_bulk_load=0;
 SELECT COUNT(*) as c FROM
 (SELECT COALESCE(LOWER(CONV(BIT_XOR(CAST(CRC32(CONCAT_WS('#', `b`, CONCAT(ISNULL(`b`)))) AS UNSIGNED)), 10, 16)), 0) AS crc FROM `t1` FORCE INDEX(`kb`)
 UNION DISTINCT
@@ -25,22 +28,22 @@ c
 1
 select count(*) from t1 FORCE INDEX(kb);
 count(*)
-3000000
+1500000
 select count(*) from t1 FORCE INDEX(kb_copy);
 count(*)
-3000000
+1500000
 select count(*) from t1 FORCE INDEX(PRIMARY);
 count(*)
-3000000
+1500000
 ALTER TABLE t1 DROP INDEX kb, ALGORITHM=INPLACE;
 ALTER TABLE t1 DROP INDEX kb_copy, ALGORITHM=INPLACE;
 ALTER TABLE t1 ADD INDEX kb(b), ADD INDEX kab(a,b), ALGORITHM=INPLACE;
 SELECT COUNT(*) FROM t1 FORCE INDEX(kab);
 COUNT(*)
-3000000
+1500000
 SELECT COUNT(*) FROM t1 FORCE INDEX(kb);
 COUNT(*)
-3000000
+1500000
 SHOW CREATE TABLE t1;
 Table	Create Table
 t1	CREATE TABLE `t1` (

--- a/mysql-test/suite/rocksdb/t/add_index_inplace_sstfilewriter.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace_sstfilewriter.test
@@ -1,8 +1,6 @@
 --source include/big_test.inc
 --source include/have_rocksdb.inc
 
-set rocksdb_max_row_locks=6000000;
-
 # Create a table with a primary key and one secondary key as well as one
 # more column
 CREATE TABLE t1(pk CHAR(5) PRIMARY KEY, a char(30), b char(30)) ENGINE=ROCKSDB COLLATE 'latin1_bin';
@@ -15,7 +13,7 @@ CREATE TABLE t1(pk CHAR(5) PRIMARY KEY, a char(30), b char(30)) ENGINE=ROCKSDB C
 perl;
 my $fn = $ENV{'ROCKSDB_INFILE'};
 open(my $fh, '>>', $fn) || die "perl open($fn): $!";
-my $max = 3000000;
+my $max = 1500000;
 my @chars = ("A".."Z", "a".."z", "0".."9");
 my @lowerchars = ("a".."z");
 my @powers_of_26 = (26 * 26 * 26 * 26, 26 * 26 * 26, 26 * 26, 26, 1);
@@ -61,7 +59,12 @@ ALTER TABLE t1 ADD INDEX kb(b), ALGORITHM=INPLACE;
 # disable duplicate index warning
 --disable_warnings
 # now do same index using copy algorithm
+# hitting max row locks (1M)
+--error ER_GET_ERRMSG
 ALTER TABLE t1 ADD INDEX kb_copy(b), ALGORITHM=COPY;
+set session rocksdb_bulk_load=1;
+ALTER TABLE t1 ADD INDEX kb_copy(b), ALGORITHM=COPY;
+set session rocksdb_bulk_load=0;
 --enable_warnings
 
 # checksum testing


### PR DESCRIPTION
Port improved `rocksdb.add_index_inplace_sstfilewriter` from https://github.com/facebook/mysql-5.6/commits/fb-mysql-5.6.35