### PR TITLE
PS-7162 hotfix: UDF functions for PITR in PXC operator (custom --log-bin)

### DIFF
--- a/mysql-test/r/percona_binlog_utils_udf.result
+++ b/mysql-test/r/percona_binlog_utils_udf.result
@@ -31,7 +31,7 @@ ERROR HY000: Can't initialize function 'get_last_gtid_from_binlog'; Function req
 SELECT get_last_gtid_from_binlog('blah', 'blah');
 ERROR HY000: Can't initialize function 'get_last_gtid_from_binlog'; Function requires exactly one argument
 SELECT get_last_gtid_from_binlog('non_existing.000001');
-ERROR HY000: File './non_existing.000001' not found (OS errno 2 - No such file or directory)
+ERROR HY000: File 'non_existing.000001' not found (OS errno 2 - No such file or directory)
 include/assert.inc ['GTID extracted via get_last_gtid_from_binlog() for stage 1 should match the recorded value']
 include/assert.inc ['GTID extracted via get_last_gtid_from_binlog() for stage 2 should match the recorded value']
 include/assert.inc ['GTID extracted via get_last_gtid_from_binlog() for stage 3 should match the recorded value']
@@ -320,6 +320,8 @@ SELECT get_gtid_set_by_binlog();
 ERROR HY000: Can't initialize function 'get_gtid_set_by_binlog'; Function requires exactly one argument
 SELECT get_gtid_set_by_binlog('blah', 'blah');
 ERROR HY000: Can't initialize function 'get_gtid_set_by_binlog'; Function requires exactly one argument
+SELECT get_gtid_set_by_binlog('non_existing.000001');
+ERROR HY000: get_gtid_set_by_binlog<string> UDF failed; Binary log does not exist
 include/assert.inc ['GTID set extracted via get_gtid_set_by_binlog() for stage 1 should match the recorded value']
 include/assert.inc ['GTID set extracted via get_gtid_set_by_binlog() for stage 2 should match the recorded value']
 include/assert.inc ['GTID set extracted via get_gtid_set_by_binlog() for stage 3 should match the recorded value']
@@ -1532,6 +1534,8 @@ SELECT get_first_record_timestamp_by_binlog();
 ERROR HY000: Can't initialize function 'get_first_record_timestamp_by_binlog'; Function requires exactly one argument
 SELECT get_first_record_timestamp_by_binlog('blah', 'blah');
 ERROR HY000: Can't initialize function 'get_first_record_timestamp_by_binlog'; Function requires exactly one argument
+SELECT get_first_record_timestamp_by_binlog('non_existing.000001');
+ERROR HY000: File 'non_existing.000001' not found (OS errno 2 - No such file or directory)
 DELETE FROM loaded_ts;
 LOAD DATA LOCAL INFILE 'MYSQLTEST_VARDIR/filtered_binlog_file' INTO TABLE loaded_ts;
 include/assert.inc ['first record timestamp extracted via get_first_record_timestamp_by_binlog() for stage 1 should match the value extracted via mysqlbinlog']
@@ -1588,6 +1592,8 @@ SELECT get_last_record_timestamp_by_binlog();
 ERROR HY000: Can't initialize function 'get_last_record_timestamp_by_binlog'; Function requires exactly one argument
 SELECT get_last_record_timestamp_by_binlog('blah', 'blah');
 ERROR HY000: Can't initialize function 'get_last_record_timestamp_by_binlog'; Function requires exactly one argument
+SELECT get_last_record_timestamp_by_binlog('non_existing.000001');
+ERROR HY000: File 'non_existing.000001' not found (OS errno 2 - No such file or directory)
 DELETE FROM loaded_ts;
 LOAD DATA LOCAL INFILE 'MYSQLTEST_VARDIR/filtered_binlog_file' INTO TABLE loaded_ts;
 include/assert.inc ['last record timestamp extracted via get_last_record_timestamp_by_binlog() for stage 1 should match the value extracted via mysqlbinlog']

--- a/mysql-test/t/percona_binlog_utils_udf.test
+++ b/mysql-test/t/percona_binlog_utils_udf.test
@@ -10,7 +10,11 @@ if(`SELECT CONVERT(@@version_compile_os USING latin1) IN ("Win32", "Win64", "Win
 {
   SET @path_separator = '\\';
 }
+--let $binlog_base_dir = `SELECT LEFT(@@global.log_bin_basename, CHAR_LENGTH(@@global.log_bin_basename) - CHAR_LENGTH(SUBSTRING_INDEX(@@global.log_bin_basename, @path_separator, -1)))`
 --enable_query_log
+
+--let $non_existing_binlog_name = non_existing.000001
+--let $non_existing_binlog_name_regex = /'.*($non_existing_binlog_name)'/'\1'/
 
 --echo
 --echo *** creating a table that will be used to generate binlog events
@@ -101,13 +105,14 @@ SELECT get_last_gtid_from_binlog();
 SELECT get_last_gtid_from_binlog('blah', 'blah');
 
 # EE_FILENOTFOUND 29
+--replace_regex $non_existing_binlog_name_regex
 --error 29
-SELECT get_last_gtid_from_binlog('non_existing.000001');
+eval SELECT get_last_gtid_from_binlog('$non_existing_binlog_name');
 
 --let $stage = 1
 while($stage <= $number_of_stages)
 {
-  --let $current_binlog_name = `SELECT CONCAT('.', @path_separator, binlog_name) FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
+  --let $current_binlog_name = `SELECT binlog_name FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
   --let $current_gtid_value = `SELECT gtid_value FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
 
   --let $assert_text = 'GTID extracted via get_last_gtid_from_binlog() for stage $stage should match the recorded value'
@@ -133,7 +138,7 @@ SELECT get_binlog_by_gtid('blah', 'blah');
 --let $stage = 1
 while($stage <= $number_of_stages)
 {
-  --let $current_binlog_name = `SELECT CONCAT('.', @path_separator, binlog_name) FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
+  --let $current_binlog_name = `SELECT binlog_name FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
   --let $substage = 1
   while($substage <= $number_of_substages)
   {
@@ -161,10 +166,13 @@ SELECT get_gtid_set_by_binlog();
 --error ER_CANT_INITIALIZE_UDF
 SELECT get_gtid_set_by_binlog('blah', 'blah');
 
+--error ER_UDF_ERROR
+eval SELECT get_gtid_set_by_binlog('$non_existing_binlog_name');
+
 --let $stage = 1
 while($stage <= $number_of_stages)
 {
-  --let $current_binlog_name = `SELECT CONCAT('.', @path_separator, binlog_name) FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
+  --let $current_binlog_name = `SELECT binlog_name FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
   # use GTID_SUBTRACT() here to normalize concatenated GTIDs
   --let $current_gtid_set = `SELECT GTID_SUBTRACT(GROUP_CONCAT(gtid_value ORDER BY substage SEPARATOR ','), '') FROM captured_gtid WHERE stage = $stage`
 
@@ -197,7 +205,7 @@ while($outer_index < $number_of_iterations)
   --let $outer_stage = `SELECT ($outer_index DIV 3) + 1`
   --let $outer_substage = `SELECT ELT(($outer_index MOD 3) + 1, 1, $number_of_substages DIV 2, $number_of_substages)`
   --let $lower_bound = `SELECT ($outer_stage - 1) * $number_of_substages + $outer_substage - 1`
-  --let $current_binlog_name = `SELECT CONCAT('.', @path_separator, binlog_name) FROM captured_gtid WHERE stage = $outer_stage AND substage = $number_of_substages`
+  --let $current_binlog_name = `SELECT binlog_name FROM captured_gtid WHERE stage = $outer_stage AND substage = $number_of_substages`
 
   --let $inner_index = $outer_index
   while($inner_index < $number_of_iterations)
@@ -235,13 +243,18 @@ SELECT get_first_record_timestamp_by_binlog();
 --error ER_CANT_INITIALIZE_UDF
 SELECT get_first_record_timestamp_by_binlog('blah', 'blah');
 
+# EE_FILENOTFOUND 29
+--replace_regex $non_existing_binlog_name_regex
+--error 29
+eval SELECT get_first_record_timestamp_by_binlog('$non_existing_binlog_name');
+
 --let $filtered_binlog_file = $MYSQLTEST_VARDIR/filtered_binlog_file
 
 --let $stage = 1
 while($stage <= $number_of_stages)
 {
-  --let $current_binlog_name_for_utility = `SELECT CONCAT(@@datadir, @path_separator, binlog_name) FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
-  --let $current_binlog_name = `SELECT CONCAT('.', @path_separator, binlog_name) FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
+  --let $current_binlog_name = `SELECT binlog_name FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
+  --let $current_binlog_name_for_utility = $binlog_base_dir$current_binlog_name
 
   # Extracting lines with timestamps (e.g. "#201116 20:54:02") from the mysqlbinlog output
   --exec $MYSQL_BINLOG $current_binlog_name_for_utility | grep -Eo '^#[[:digit:]]+[[:blank:]]+[[:digit:]]+:[[:digit:]]+:[[:digit:]]+' | head -n 1 > $filtered_binlog_file
@@ -274,13 +287,18 @@ SELECT get_last_record_timestamp_by_binlog();
 --error ER_CANT_INITIALIZE_UDF
 SELECT get_last_record_timestamp_by_binlog('blah', 'blah');
 
+# EE_FILENOTFOUND 29
+--replace_regex $non_existing_binlog_name_regex
+--error 29
+eval SELECT get_last_record_timestamp_by_binlog('$non_existing_binlog_name');
+
 --let $filtered_binlog_file = $MYSQLTEST_VARDIR/filtered_binlog_file
 
 --let $stage = 1
 while($stage <= $number_of_stages)
 {
-  --let $current_binlog_name_for_utility = `SELECT CONCAT(@@datadir, @path_separator, binlog_name) FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
-  --let $current_binlog_name = `SELECT CONCAT('.', @path_separator, binlog_name) FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
+  --let $current_binlog_name = `SELECT binlog_name FROM captured_gtid WHERE stage = $stage AND substage = $number_of_substages`
+  --let $current_binlog_name_for_utility = $binlog_base_dir$current_binlog_name
 
   # Extracting lines with timestamps (e.g. "#201116 20:54:02") from the mysqlbinlog output
   --exec $MYSQL_BINLOG $current_binlog_name_for_utility | grep -Eo '^#[[:digit:]]+[[:blank:]]+[[:digit:]]+:[[:digit:]]+:[[:digit:]]+' | tail -n 1 > $filtered_binlog_file


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7162

Fixed problem with Binary Log UDFs not working properly when MySQL Server is
started with non-default '--log-bin' option.

Functions accepting binlog name now expect it to be in short form, meaning
that they will be read from the current binary log directory. If a name with
the path separator '/' is provided, an error is returned.

Functions returning binlog name now always return a name in short form
(without path component). If necessary, users can always prepend it with
'@@global.log_bin_basename'.

'main.percona_binlog_utils_udf' MTR test case updated to reflect the changes
 mentioned above. It was also extended with a few additional checks for
calling functions on non-existing binary logs.