### PR TITLE
PS-4894: Virtual column support for MyRocks

### DIFF
--- a/mysql-test/suite/rocksdb/r/virtual_basic.result
+++ b/mysql-test/suite/rocksdb/r/virtual_basic.result
@@ -1,0 +1,1388 @@
+CREATE TABLE t (a INT, b INT GENERATED ALWAYS AS (a), c CHAR(10), d CHAR(20), e CHAR(10) GENERATED ALWAYS AS (c), g INT) ENGINE=RocksDB;
+INSERT INTO t VALUES(10, DEFAULT, "aa", "bb", DEFAULT, 20);
+INSERT INTO t VALUES(11, DEFAULT, "jj", "kk", DEFAULT, 21);
+CREATE INDEX idx ON t(e) algorithm=inplace;
+INSERT INTO t VALUES(12, DEFAULT, 'mm', "nn", DEFAULT, 22);
+SELECT e FROM t;
+e
+aa
+jj
+mm
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (null, null, DEFAULT, 'mm');
+CREATE INDEX idx ON t(c);
+SELECT c FROM t;
+c
+NULL
+14
+19
+29
+UPDATE t SET a = 10 WHERE a = 11;
+SELECT c FROM t;
+c
+NULL
+13
+19
+29
+SELECT * FROM t;
+a	b	c	h
+10	3	13	mm
+18	1	19	mm
+28	1	29	mm
+NULL	NULL	NULL	mm
+DELETE FROM t WHERE a = 18;
+SELECT c FROM t;
+c
+NULL
+13
+29
+START TRANSACTION;
+INSERT INTO t VALUES (128, 22, DEFAULT, "xx");
+INSERT INTO t VALUES (1290, 212, DEFAULT, "xmx");
+ROLLBACK;
+SELECT c FROM t;
+c
+NULL
+13
+29
+SELECT * FROM t;
+a	b	c	h
+10	3	13	mm
+28	1	29	mm
+NULL	NULL	NULL	mm
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + j), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+INSERT INTO t VALUES(11, 22, DEFAULT, "AAA", 8, DEFAULT, "XXX", DEFAULT);
+INSERT INTO t VALUES(1, 2, DEFAULT, "uuu", 9, DEFAULT, "uu", DEFAULT);
+INSERT INTO t VALUES(3, 4, DEFAULT, "uooo", 1, DEFAULT, "umm", DEFAULT);
+SELECT c FROM t;
+c
+3
+7
+33
+SELECT m FROM t;
+m
+5
+11
+30
+SELECT p FROM t;
+p
+XXXAAA
+uuuuu
+ummuooo
+SELECT * FROM t;
+a	b	c	h	j	m	n	p
+11	22	33	AAA	8	30	XXX	XXXAAA
+1	2	3	uuu	9	11	uu	uuuuu
+3	4	7	uooo	1	5	umm	ummuooo
+update t set a = 13 where a =11;
+delete from t where a =13;
+DROP INDEX idx1 ON t;
+DROP INDEX idx2 ON t;
+DROP TABLE t;
+/* Test large BLOB data */
+CREATE TABLE `t` (
+`a` BLOB,
+`b` BLOB,
+`c` BLOB GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+`h` VARCHAR(10) NOT NULL,
+PRIMARY KEY (h) # Primary key added by RocksDB test to avoid gap lock detection error
+) ENGINE=RocksDB;
+INSERT INTO t VALUES (REPEAT('g', 16000), REPEAT('x', 16000), DEFAULT, "kk");
+CREATE INDEX idx ON t(c(100));
+SELECT length(c) FROM t;
+length(c)
+32000
+START TRANSACTION;
+INSERT INTO t VALUES (REPEAT('a', 16000), REPEAT('b', 16000), DEFAULT, 'mm');
+ROLLBACK;
+INSERT INTO t VALUES (REPEAT('a', 16000), REPEAT('b', 16000), DEFAULT, 'mm');
+START TRANSACTION;
+UPDATE t SET a = REPEAT('m', 16000) WHERE h = 'mm';
+ROLLBACK;
+SELECT COUNT(*) FROM t WHERE c like "aaa%";
+COUNT(*)
+1
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), PRIMARY KEY(a)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+CREATE INDEX idx ON t(c);
+START TRANSACTION;
+UPDATE t SET a = 100 WHERE a = 11;
+UPDATE t SET a =22 WHERE a = 18;
+UPDATE t SET a = 33 WHERE a = 22;
+SELECT c FROM t;
+c
+29
+34
+103
+ROLLBACK;
+SELECT c FROM t;
+c
+14
+19
+29
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+CREATE INDEX idx ON t(c);
+SELECT c FROM t;
+c
+14
+19
+29
+START TRANSACTION;
+SELECT c FROM t;
+c
+14
+19
+29
+UPDATE t SET a = 19 WHERE a = 11;
+SELECT c FROM t;
+c
+14
+19
+29
+ROLLBACK;
+SELECT c FROM t;
+c
+19
+22
+29
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + x), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, y)), x INT, y CHAR(20), z INT, PRIMARY KEY(a), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+INSERT INTO t VALUES(1, 2, DEFAULT, "hhh", 3, DEFAULT, "nnn", DEFAULT, 4, "yyy", 5);
+INSERT INTO t VALUES(2, 3, DEFAULT, "hhha", 4, DEFAULT, "nnna", DEFAULT, 5, "yyya", 6);
+INSERT INTO t VALUES(12, 13, DEFAULT, "hhhb", 14, DEFAULT, "nnnb", DEFAULT, 15, "yyyb", 16);
+CREATE INDEX idx6 ON t(p, c);
+SELECT p, c FROM t;
+p	c
+nnnayyya	5
+nnnbyyyb	25
+nnnyyy	3
+START TRANSACTION;
+INSERT INTO t VALUES(32, 33, DEFAULT, "hhhb", 34, DEFAULT, "nnnb", DEFAULT, 35, "yyyb", 36);
+ROLLBACK;
+UPDATE t SET a = 100 WHERE a = 1;
+START TRANSACTION;
+UPDATE t SET a = 1 WHERE a = 100;
+ROLLBACK;
+Drop TABLE t;
+CREATE TABLE t1(a INT) ENGINE=RocksDB;
+ALTER TABLE t1 add COLUMN (b INT generated always as (a+1) virtual, c INT as(5) virtual);
+ALTER TABLE t1 add COLUMN (d INT generated always as (a+1) virtual, e INT as(5) virtual);
+ALTER TABLE t1 add COLUMN (f INT generated always as (a+1) virtual, g INT as(5) virtual), DROP COLUMN e;
+DROP TABLE t1;
+CREATE TABLE t1(a INT) ENGINE=RocksDB;
+ALTER TABLE t1 add COLUMN (b INT generated always as (a+1) virtual, c INT as(5) virtual);
+ALTER TABLE t1 change b x INT generated always as (a+1) virtual;
+DROP TABLE t1;
+CREATE TABLE t (a INT DEFAULT 1, b INT DEFAULT 2, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), PRIMARY KEY (a)) ENGINE=RocksDB;
+CREATE INDEX idx ON t(c);
+INSERT INTO t(h)VALUES ('mm');
+SELECT c FROM t;
+c
+3
+CREATE unique INDEX idx1 ON t(c);
+INSERT INTO t(h)VALUES ('mm');
+ERROR 23000: Duplicate entry '1' for key 't.PRIMARY'
+DROP TABLE t;
+CREATE TABLE `t1` ( `a` INT DEFAULT NULL,   `b` INT DEFAULT NULL,   `c` INT GENERATED ALWAYS AS (a+b) VIRTUAL,   `x` INT NOT NULL,   `h` VARCHAR(10) DEFAULT NULL,   PRIMARY KEY (`x`),   KEY `idx` (`c`) ) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+INSERT INTO t1 VALUES (1, 2, DEFAULT, 3, 'mm');
+INSERT INTO t1 VALUES (11, 22, DEFAULT, 23, 'mm');
+UPDATE t1 SET x = 4 WHERE x =3;
+DROP TABLE t1;
+CREATE TABLE `t1` ( `a` INT NOT NULL,   `b` INT  DEFAULT NULL,   `c` INT GENERATED ALWAYS AS (a+b) VIRTUAL,   `x` INT NOT NULL,   `h` VARCHAR(10) DEFAULT NULL,   PRIMARY KEY (a), KEY `idx` (`c`) ) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+INSERT INTO t1 VALUES (1, 2, DEFAULT, 3, 'mm');
+INSERT INTO t1 VALUES (11, 22, DEFAULT, 23, 'mm');
+START TRANSACTION;
+SELECT * FROM t1;
+a	b	c	x	h
+1	2	3	3	mm
+11	22	33	23	mm
+START TRANSACTION;
+UPDATE t1 SET a = 15 WHERE a = 1;
+UPDATE t1 SET a = 10 WHERE a=15;
+ROLLBACK;
+SELECT c FROM t1;
+c
+3
+33
+DROP TABLE t1;
+CREATE TABLE `t` (
+`a` INT DEFAULT NULL,
+`b` INT DEFAULT NULL,
+`c` INT GENERATED ALWAYS AS (a+b) VIRTUAL,
+`d` INT GENERATED ALWAYS AS (a) VIRTUAL,
+`h` INT NOT NULL,
+PRIMARY KEY (`h`),
+KEY `idx` (`c`)
+) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (18, 1, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (28, 1, DEFAULT, DEFAULT, 3);
+INSERT INTO t VALUES (null, null, DEFAULT, DEFAULT, 4);
+CREATE PROCEDURE UPDATE_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 2000) DO
+UPDATE t SET a = 100 + i WHERE h = 1;
+SET i = i + 1;
+END WHILE;
+END|
+CREATE PROCEDURE DELETE_insert_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 2000) DO
+UPDATE t SET a = 100 + i WHERE h = 1;
+SET i = i + 1;
+END WHILE;
+END|
+CALL UPDATE_t();
+SELECT c FROM t;
+c
+NULL
+19
+29
+2103
+CALL DELETE_insert_t();
+SELECT c FROM t;
+c
+NULL
+19
+29
+2103
+DROP INDEX idx ON t;
+CALL UPDATE_t();
+SELECT c FROM t;
+c
+2103
+19
+29
+NULL
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+DROP TABLE t;
+# Bug#20767937: WL8149:ASSERTION FAILED IN ROW_UPD_SEC_INDEX_ENTRY
+CREATE TABLE b (
+col_INT_nokey INTEGER NOT NULL,
+col_INT_key INTEGER GENERATED ALWAYS AS (col_INT_nokey) VIRTUAL,
+col_date_nokey DATE,
+col_date_key DATE GENERATED ALWAYS AS (DATE_ADD(col_date_nokey,
+INTerval 30 day)) VIRTUAL,
+col_datetime_nokey DATETIME NOT NULL,
+col_time_nokey TIME NOT NULL,
+col_datetime_key DATETIME GENERATED ALWAYS AS (ADDTIME(col_datetime_nokey,
+col_time_nokey)),
+col_time_key TIME GENERATED ALWAYS AS (ADDTIME(col_datetime_nokey,
+col_time_nokey)),
+col_VARCHAR_nokey VARCHAR(1) NOT NULL,
+col_VARCHAR_key VARCHAR(2) GENERATED ALWAYS AS(CONCAT(col_VARCHAR_nokey,
+col_VARCHAR_nokey)),
+KEY (col_INT_key),
+KEY (col_VARCHAR_key),
+KEY (col_date_key),
+KEY (col_time_key),
+KEY (col_datetime_key),
+KEY (col_INT_key, col_VARCHAR_key),
+KEY (col_INT_key, col_VARCHAR_key, col_date_key,
+col_time_key, col_datetime_key)
+) ENGINE=RocksDB;
+INSERT INTO b (
+col_INT_nokey,
+col_date_nokey,
+col_time_nokey,
+col_datetime_nokey,
+col_VARCHAR_nokey
+) VALUES
+(0, NULL, '21:22:34.025509', '2002-02-13 17:30:06.013935', 'j'),
+(8, '2004-09-18', '10:50:38.059966', '2008-09-27
+00:34:58.026613', 'v');
+EXPLAIN SELECT col_INT_key FROM b;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	b	NULL	index	NULL	col_INT_key	5	NULL	3	100.00	Using index
+Warnings:
+Note	1003	/* select#1 */ select `test`.`b`.`col_INT_key` AS `col_INT_key` from `test`.`b`
+SELECT col_INT_key FROM b;
+col_INT_key
+0
+8
+SELECT col_INT_nokey, col_INT_key FROM b;
+col_INT_nokey	col_INT_key
+0	0
+8	8
+DELETE FROM b;
+DROP TABLE b;
+CREATE TABLE `t` (
+`a` VARCHAR(10000),   `b` VARCHAR(3000),
+`c` VARCHAR(14000) GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+`d` VARCHAR(5000) GENERATED ALWAYS AS (b) VIRTUAL,
+`e` INT(11) GENERATED ALWAYS AS (10) VIRTUAL,
+`h` INT(11) NOT NULL,
+PRIMARY KEY (`h`) ) ROW_FORMAT=COMPACT  ENGINE=InnoDB charset latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` varchar(10000) DEFAULT NULL,
+  `b` varchar(3000) DEFAULT NULL,
+  `c` varchar(14000) GENERATED ALWAYS AS (concat(`a`,`b`)) VIRTUAL,
+  `d` varchar(5000) GENERATED ALWAYS AS (`b`) VIRTUAL,
+  `e` int GENERATED ALWAYS AS (10) VIRTUAL,
+  `h` int NOT NULL,
+  PRIMARY KEY (`h`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPACT
+INSERT INTO t VALUES (REPEAT('g', 10000), REPEAT('x', 2800), DEFAULT, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (REPEAT('a', 9000), REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (REPEAT('m', 8000), REPEAT('n', 3000), DEFAULT, DEFAULT, DEFAULT, 3);
+CREATE INDEX idx ON t(c(100), d(20));
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 2000) WHERE h = 1;
+CREATE PROCEDURE UPDATE_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+UPDATE t SET a = REPEAT(CAST(i AS CHAR), 2000) WHERE h = 1;
+SET i = i + 1;
+END WHILE;
+END|
+CREATE PROCEDURE DELETE_insert_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+DELETE FROM t WHERE h = 1;
+INSERT INTO t VALUES (REPEAT(CAST(i AS CHAR), 2000) ,  REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 1);
+SET i = i + 1;
+END WHILE;
+END|
+CALL UPDATE_t();
+CALL DELETE_insert_t();
+UPDATE t SET a = NULL WHERE h=1;
+START TRANSACTION;
+CALL UPDATE_t();
+ROLLBACK;
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+DROP TABLE t;
+CREATE TABLE `t` (
+`a` BLOB,
+`b` BLOB,
+`c` BLOB GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+`d` BLOB GENERATED ALWAYS AS (b) VIRTUAL,
+`e` INT GENERATED ALWAYS AS (10) VIRTUAL,
+`h` INT NOT NULL,
+PRIMARY KEY (`h`)
+) ENGINE=RocksDB;
+INSERT INTO t VALUES (REPEAT('g', 16000), REPEAT('x', 16000), DEFAULT, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (REPEAT('a', 32000), REPEAT('b', 11000), DEFAULT, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (REPEAT('m', 18000), REPEAT('n', 46000), DEFAULT, DEFAULT, DEFAULT, 3);
+CREATE INDEX idx ON t(c(100), d(20));
+UPDATE t SET a = NULL WHERE h=1;
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 2000) WHERE h = 1;
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 1000) WHERE h = 1;
+CREATE PROCEDURE UPDATE_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 200) DO
+UPDATE t SET a = REPEAT(CAST(i AS CHAR), 2000) WHERE h = 1;
+SET i = i + 1;
+END WHILE;
+END|
+CREATE PROCEDURE DELETE_insert_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 200) DO
+DELETE FROM t WHERE h = 1;
+INSERT INTO t VALUES (REPEAT(CAST(i AS CHAR), 2000) ,  REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 1);
+SET i = i + 1;
+END WHILE;
+END|
+CALL UPDATE_t();
+CALL DELETE_insert_t();
+UPDATE t SET a = NULL WHERE h=1;
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+DROP TABLE t;
+CREATE TABLE `t` (
+`m1` INT DEFAULT NULL,
+`m2` INT DEFAULT NULL,
+`m3` INT GENERATED ALWAYS AS (m1 + m2) VIRTUAL,
+`m4` INT DEFAULT NULL,
+`m5` CHAR(10) DEFAULT NULL,
+`m6` CHAR(12) GENERATED ALWAYS AS (m5) VIRTUAL,
+`a` VARCHAR(10000) DEFAULT NULL,
+`b` VARCHAR(3000) DEFAULT NULL,
+`c` VARCHAR(14000) GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+`d` VARCHAR(5000) GENERATED ALWAYS AS (b) VIRTUAL,
+`e` INT GENERATED ALWAYS AS (10) VIRTUAL,
+`h` INT NOT NULL,
+PRIMARY KEY (`h`),
+KEY `m3` (`m3`),
+KEY `c` (`c`(100)),
+KEY `e` (`e`,`d`(20))
+) ENGINE=RocksDB charset latin1;
+INSERT INTO t VALUES (1, 2, DEFAULT, 3, "aaa", DEFAULT, REPEAT('g', 10000), REPEAT('x', 2800), DEFAULT, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (11, 21, DEFAULT, 31, "bbb", DEFAULT, REPEAT('a', 9000), REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (21, 31, DEFAULT, 41, "zzz", DEFAULT, REPEAT('m', 8000), REPEAT('n', 3000), DEFAULT, DEFAULT, DEFAULT, 3);
+ALTER TABLE t DROP COLUMN c;
+DELETE FROM t;
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), PRIMARY KEY(a)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (1, null, DEFAULT, 'mm');
+CREATE INDEX idx ON t(a, c);
+SELECT a, c FROM t;
+a	c
+1	NULL
+11	14
+18	19
+28	29
+START TRANSACTION;
+UPDATE t SET a = 13 where a = 11;
+ROLLBACK;
+DELETE FROM t;
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), m int, PRIMARY KEY(a)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, "a", 1);
+INSERT INTO t VALUES (18, 1, DEFAULT, "b", 2);
+INSERT INTO t VALUES (28, 1, DEFAULT, "c", 3 );
+INSERT INTO t VALUES (1, null, DEFAULT, "d", 4);
+CREATE INDEX idx ON t(a, c, h);
+SELECT a, c FROM t;
+a	c
+1	NULL
+11	14
+18	19
+28	29
+START TRANSACTION;
+UPDATE t SET a =10 WHERE a = 11;
+ROLLBACK;
+SELECT a, c, h FROM t;
+a	c	h
+1	NULL	d
+11	14	a
+18	19	b
+28	29	c
+DROP TABLE t;
+CREATE TABLE `t1` (
+`col1` int(11) NOT NULL,
+`col2` int(11) NOT NULL,
+`col3` int(11) NOT NULL,
+`col4` int(11) DEFAULT NULL,
+`col5` int(11) GENERATED ALWAYS AS (col2 % col3) VIRTUAL,
+`col7` int(11) GENERATED ALWAYS AS (col5 * col5) VIRTUAL,
+`col8` int(11) GENERATED ALWAYS AS (col5 % col5) VIRTUAL,
+`col9` text,
+`extra` int(11) DEFAULT NULL,
+UNIQUE KEY `uidx` (`col5`)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+ALTER TABLE t1 CHANGE COLUMN extra col6 INT;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `col1` int NOT NULL,
+  `col2` int NOT NULL,
+  `col3` int NOT NULL,
+  `col4` int DEFAULT NULL,
+  `col5` int GENERATED ALWAYS AS ((`col2` % `col3`)) VIRTUAL,
+  `col7` int GENERATED ALWAYS AS ((`col5` * `col5`)) VIRTUAL,
+  `col8` int GENERATED ALWAYS AS ((`col5` % `col5`)) VIRTUAL,
+  `col9` text,
+  `col6` int DEFAULT NULL,
+  UNIQUE KEY `uidx` (`col5`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+DROP TABLE t1;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + j), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+INSERT INTO t VALUES(11, 22, DEFAULT, "AAA", 8, DEFAULT, "XXX", DEFAULT);
+INSERT INTO t VALUES(1, 2, DEFAULT, "uuu", 9, DEFAULT, "uu", DEFAULT);
+INSERT INTO t VALUES(3, 4, DEFAULT, "uooo", 1, DEFAULT, "umm", DEFAULT);
+alter table t add  x int, add xx int generated ALWAYS AS(x);
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + j), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+INSERT INTO t VALUES(11, 22, DEFAULT, "AAA", 8, DEFAULT, "XXX", DEFAULT);
+INSERT INTO t VALUES(1, 2, DEFAULT, "uuu", 9, DEFAULT, "uu", DEFAULT);
+INSERT INTO t VALUES(3, 4, DEFAULT, "uooo", 1, DEFAULT, "umm", DEFAULT);
+ALTER TABLE t DROP COLUMN c;
+ALTER TABLE t DROP COLUMN p, ADD COLUMN s VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h));
+SELECT s FROM t;
+s
+XXXAAA
+uuuuu
+ummuooo
+ALTER TABLE t ADD  x VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), ADD INDEX idx (x);
+DROP TABLE t;
+CREATE TABLE `t1` (
+`col1` int(11) DEFAULT NULL,
+`col2` int(11) DEFAULT NULL,
+`col3` int(11) DEFAULT NULL,
+`col4` int(11) DEFAULT NULL,
+`col5` int(11) GENERATED ALWAYS AS (col4 * col2) VIRTUAL,
+`col6` int(11) GENERATED ALWAYS AS (col2 % col4) VIRTUAL,
+`col7` int(11) GENERATED ALWAYS AS (col5 / col6) VIRTUAL,
+`col8` int(11) GENERATED ALWAYS AS (col5 + col5) VIRTUAL,
+`col9` text,
+`extra` int(11) DEFAULT NULL
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+ALTER TABLE t1 DROP COLUMN col7;
+DROP TABLE t1;
+CREATE TABLE t1 (
+col1 INTEGER NOT NULL,
+col2 INTEGER NOT NULL,
+col3 INTEGER DEFAULT NULL,
+col4 INTEGER DEFAULT NULL,
+col5 INTEGER DEFAULT NULL,
+col6 INTEGER DEFAULT NULL,
+col7 INTEGER DEFAULT NULL,
+col8 INTEGER DEFAULT NULL,
+col9 INTEGER DEFAULT NULL,
+col10 INTEGER DEFAULT NULL,
+col11 INTEGER DEFAULT NULL,
+col12 INTEGER DEFAULT NULL,
+col13 INTEGER DEFAULT NULL,
+col14 INTEGER DEFAULT NULL,
+col15 INTEGER DEFAULT NULL,
+col16 INTEGER DEFAULT NULL,
+col17 INTEGER DEFAULT NULL,
+col18 INTEGER DEFAULT NULL,
+col19 INTEGER DEFAULT NULL,
+col20 INTEGER DEFAULT NULL,
+col21 INTEGER DEFAULT NULL,
+col22 INTEGER DEFAULT NULL,
+col23 INTEGER DEFAULT NULL,
+col24 INTEGER DEFAULT NULL,
+col25 INTEGER DEFAULT NULL,
+col26 INTEGER DEFAULT NULL,
+col27 INTEGER DEFAULT NULL,
+col28 INTEGER DEFAULT NULL,
+col29 INTEGER DEFAULT NULL,
+col30 INTEGER DEFAULT NULL,
+col31 INTEGER DEFAULT NULL,
+col32 INTEGER DEFAULT NULL,
+col33 INTEGER DEFAULT NULL,
+gcol1 INTEGER GENERATED ALWAYS AS (col1 + col2) VIRTUAL,
+KEY idx1 (gcol1)
+) ENGINE=RocksDB;
+INSERT INTO t1 (col1, col2)
+VALUES (0,1), (1,2), (2,3), (3,4), (4,5);
+SELECT gcol1 FROM t1 FORCE INDEX(idx1);
+gcol1
+1
+3
+5
+7
+9
+ALTER TABLE t1 ADD COLUMN extra INTEGER;
+SELECT gcol1 FROM t1 FORCE INDEX(idx1);
+gcol1
+1
+3
+5
+7
+9
+DROP TABLE t1;
+CREATE TABLE t1 (
+id INT NOT NULL,
+store_id INT NOT NULL,
+x INT GENERATED ALWAYS AS (id + store_id)
+) ENGINE=RocksDB
+PARTITION BY RANGE (store_id) (
+PARTITION p0 VALUES LESS THAN (6),
+PARTITION p1 VALUES LESS THAN (11),
+PARTITION p2 VALUES LESS THAN (16),
+PARTITION p3 VALUES LESS THAN (21)
+);
+INSERT INTO t1 VALUES(1, 2, default);
+INSERT INTO t1 VALUES(3, 4, default);
+INSERT INTO t1 VALUES(3, 12, default);
+INSERT INTO t1 VALUES(4, 18, default);
+CREATE INDEX idx ON t1(x);
+SELECT x FROM t1;
+x
+3
+7
+15
+22
+DROP TABLE t1;
+CREATE TABLE t1 (
+id INT NOT NULL,
+store_id INT NOT NULL,
+x INT GENERATED ALWAYS AS (id + store_id)
+) ENGINE=RocksDB
+PARTITION BY RANGE (x) (
+PARTITION p0 VALUES LESS THAN (6),
+PARTITION p1 VALUES LESS THAN (11),
+PARTITION p2 VALUES LESS THAN (16),
+PARTITION p3 VALUES LESS THAN (21)
+);
+insert into t1 values(1, 2, default);
+insert into t1 values(3, 4, default);
+insert into t1 values(3, 12, default);
+insert into t1 values(4, 18, default);
+ERROR HY000: Table has no partition for value 22
+CREATE INDEX idx ON t1(x);
+SELECT x FROM t1;
+x
+3
+7
+15
+DROP TABLE t1;
+CREATE TABLE t1 (a INT, b INT GENERATED ALWAYS AS (a+1) ,c int) ENGINE=RocksDB PARTITION BY RANGE (b) (
+PARTITION p0 VALUES LESS THAN (6),
+PARTITION p1 VALUES LESS THAN (11),
+PARTITION p2 VALUES LESS THAN (16),
+PARTITION p3 VALUES LESS THAN (21) );
+INSERT INTO t1 VALUES (10,DEFAULT,2);
+INSERT INTO t1 VALUES (19,DEFAULT,8);
+CREATE INDEX idx ON t1 (b);
+INSERT INTO t1 VALUES (5,DEFAULT,9);
+SELECT * FROM t1;
+a	b	c
+5	6	9
+10	11	2
+19	20	8
+ALTER TABLE t1 REMOVE PARTITIONING;
+DROP TABLE t1;
+CREATE TABLE `t#P#1` (a INT, bt INT GENERATED ALWAYS AS (a+1) ,c int) ENGINE=RocksDB
+PARTITION BY RANGE (bt)
+subpartition by hash (bt)
+(
+PARTITION p0 VALUES LESS THAN (6) (
+SUBPARTITION s0,
+SUBPARTITION s1),
+PARTITION p1 VALUES LESS THAN (11) (
+SUBPARTITION s2,
+SUBPARTITION s3),
+PARTITION p2 VALUES LESS THAN (16) (
+SUBPARTITION s4,
+SUBPARTITION s5),
+PARTITION p3 VALUES LESS THAN (21) (
+SUBPARTITION s6,
+SUBPARTITION s7)
+);
+insert into `t#P#1` values (10,DEFAULT,2);
+insert into `t#P#1` values (19,DEFAULT,8);
+create index idx on `t#P#1` (bt);
+insert into `t#P#1` values (5,DEFAULT,9);
+select * from `t#P#1`;
+a	bt	c
+5	6	9
+10	11	2
+19	20	8
+alter table `t#P#1` remove partitioning;
+drop table `t#P#1`;
+CREATE TABLE `t` (
+`a` VARCHAR(10000),   `b` VARCHAR(3000),
+`c` VARCHAR(14000) GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+`d` VARCHAR(5000) GENERATED ALWAYS AS (b) VIRTUAL,
+`e` INT(11) GENERATED ALWAYS AS (10) VIRTUAL,
+`h` INT(11) NOT NULL,
+PRIMARY KEY (`h`) ) ROW_FORMAT=DYNAMIC  ENGINE=InnoDB charset latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` varchar(10000) DEFAULT NULL,
+  `b` varchar(3000) DEFAULT NULL,
+  `c` varchar(14000) GENERATED ALWAYS AS (concat(`a`,`b`)) VIRTUAL,
+  `d` varchar(5000) GENERATED ALWAYS AS (`b`) VIRTUAL,
+  `e` int GENERATED ALWAYS AS (10) VIRTUAL,
+  `h` int NOT NULL,
+  PRIMARY KEY (`h`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=DYNAMIC
+INSERT INTO t VALUES (REPEAT('g', 10000), REPEAT('x', 2800), DEFAULT, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (REPEAT('a', 9000), REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (REPEAT('m', 8000), REPEAT('n', 3000), DEFAULT, DEFAULT, DEFAULT, 3);
+CREATE INDEX idx ON t(c(100), d(20));
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 2000) WHERE h = 1;
+CREATE PROCEDURE UPDATE_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+UPDATE t SET a = REPEAT(CAST(i AS CHAR), 2000) WHERE h = 1;
+SET i = i + 1;
+END WHILE;
+END|
+CREATE PROCEDURE DELETE_insert_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+DELETE FROM t WHERE h = 1;
+INSERT INTO t VALUES (REPEAT(CAST(i AS CHAR), 2000) ,  REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 1);
+SET i = i + 1;
+END WHILE;
+END|
+CALL UPDATE_t();
+CALL DELETE_insert_t();
+UPDATE t SET a = NULL WHERE h=1;
+START TRANSACTION;
+CALL UPDATE_t();
+ROLLBACK;
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+DROP TABLE t;
+CREATE TABLE `t` (
+`a` VARCHAR(10000),   `b` VARCHAR(3000),
+`c` VARCHAR(14000) GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+`d` VARCHAR(5000) GENERATED ALWAYS AS (b) VIRTUAL,
+`e` INT(11) GENERATED ALWAYS AS (10) VIRTUAL,
+`h` INT(11) NOT NULL,
+PRIMARY KEY (`h`) ) ROW_FORMAT=REDUNDANT  ENGINE=InnoDB charset latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` varchar(10000) DEFAULT NULL,
+  `b` varchar(3000) DEFAULT NULL,
+  `c` varchar(14000) GENERATED ALWAYS AS (concat(`a`,`b`)) VIRTUAL,
+  `d` varchar(5000) GENERATED ALWAYS AS (`b`) VIRTUAL,
+  `e` int GENERATED ALWAYS AS (10) VIRTUAL,
+  `h` int NOT NULL,
+  PRIMARY KEY (`h`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=REDUNDANT
+INSERT INTO t VALUES (REPEAT('g', 10000), REPEAT('x', 2800), DEFAULT, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (REPEAT('a', 9000), REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (REPEAT('m', 8000), REPEAT('n', 3000), DEFAULT, DEFAULT, DEFAULT, 3);
+CREATE INDEX idx ON t(c(100), d(20));
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 2000) WHERE h = 1;
+CREATE PROCEDURE UPDATE_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+UPDATE t SET a = REPEAT(CAST(i AS CHAR), 2000) WHERE h = 1;
+SET i = i + 1;
+END WHILE;
+END|
+CREATE PROCEDURE DELETE_insert_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+DELETE FROM t WHERE h = 1;
+INSERT INTO t VALUES (REPEAT(CAST(i AS CHAR), 2000) ,  REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 1);
+SET i = i + 1;
+END WHILE;
+END|
+CALL UPDATE_t();
+CALL DELETE_insert_t();
+UPDATE t SET a = NULL WHERE h=1;
+START TRANSACTION;
+CALL UPDATE_t();
+ROLLBACK;
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+DROP TABLE t;
+CREATE TABLE `t` (
+`a` VARCHAR(10000),   `b` VARCHAR(3000),
+`c` VARCHAR(14000) GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+`d` VARCHAR(5000) GENERATED ALWAYS AS (b) VIRTUAL,
+`e` INT(11) GENERATED ALWAYS AS (10) VIRTUAL,
+`h` INT(11) NOT NULL,
+PRIMARY KEY (`h`) ) ROW_FORMAT=COMPRESSED  ENGINE=InnoDB charset latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` varchar(10000) DEFAULT NULL,
+  `b` varchar(3000) DEFAULT NULL,
+  `c` varchar(14000) GENERATED ALWAYS AS (concat(`a`,`b`)) VIRTUAL,
+  `d` varchar(5000) GENERATED ALWAYS AS (`b`) VIRTUAL,
+  `e` int GENERATED ALWAYS AS (10) VIRTUAL,
+  `h` int NOT NULL,
+  PRIMARY KEY (`h`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1 ROW_FORMAT=COMPRESSED
+INSERT INTO t VALUES (REPEAT('g', 10000), REPEAT('x', 2800), DEFAULT, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (REPEAT('a', 9000), REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (REPEAT('m', 8000), REPEAT('n', 3000), DEFAULT, DEFAULT, DEFAULT, 3);
+CREATE INDEX idx ON t(c(100), d(20));
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 2000) WHERE h = 1;
+CREATE PROCEDURE UPDATE_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+UPDATE t SET a = REPEAT(CAST(i AS CHAR), 2000) WHERE h = 1;
+SET i = i + 1;
+END WHILE;
+END|
+CREATE PROCEDURE DELETE_insert_t()
+begin
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 100) DO
+DELETE FROM t WHERE h = 1;
+INSERT INTO t VALUES (REPEAT(CAST(i AS CHAR), 2000) ,  REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 1);
+SET i = i + 1;
+END WHILE;
+END|
+CALL UPDATE_t();
+CALL DELETE_insert_t();
+UPDATE t SET a = NULL WHERE h=1;
+START TRANSACTION;
+CALL UPDATE_t();
+ROLLBACK;
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+DROP TABLE t;
+create table t (a int,b int,c int,d int,e int,
+f int generated always as (a+b) virtual,
+g int,h blob,i int,unique key (d,h(25))) engine=RocksDB;
+select h from t where d is null;
+h
+drop table t;
+create table t(a blob not null) engine=RocksDB;
+alter table t add column b int;
+alter table t add column c varbinary (1000) generated always as (a) virtual;
+alter table t add unique index (c(39));
+replace into t set a = 'a',b =1;
+replace into t set a = 'a',b =1;
+drop table t;
+CREATE TABLE t (a INT, b INT,  h VARCHAR(10)) ENGINE=RocksDB;
+INSERT INTO t VALUES (12, 3,  "ss");
+INSERT INTO t VALUES (13, 4,  "ss");
+INSERT INTO t VALUES (14, 0,  "ss");
+alter table t add  c INT GENERATED ALWAYS AS(a/b);
+ERROR 22012: Division by 0
+DROP TABLE t;
+CREATE TABLE t (
+pk INTEGER AUTO_INCREMENT,
+col_int_nokey INTEGER /*! NULL */,
+col_int INT GENERATED ALWAYS AS (col_int_nokey +
+col_int_nokey) STORED not null,
+col_int_key INTEGER GENERATED ALWAYS AS (col_int +
+col_int_nokey) VIRTUAL not null,
+col_date_nokey DATE /*! NULL */,
+col_date DATE GENERATED ALWAYS AS
+(DATE_ADD(col_date_nokey,interval 30 day)) STORED not null,
+col_date_key DATE GENERATED ALWAYS AS
+(DATE_ADD(col_date,interval 30 day)) VIRTUAL not null,
+col_datetime_nokey DATETIME /*! NULL */,
+col_time_nokey TIME /*! NULL */,
+col_datetime DATETIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime_nokey, col_time_nokey)) STORED not null,
+col_time TIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime_nokey, col_time_nokey)) STORED not null,
+col_datetime_key DATETIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime, col_time_nokey)) VIRTUAL not null,
+col_time_key TIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime_nokey, col_time)) VIRTUAL not null,
+col_varchar_nokey VARCHAR(1) /*! NULL */,
+col_varchar VARCHAR(2) GENERATED ALWAYS AS
+(CONCAT(col_varchar_nokey,col_varchar_nokey)) STORED not null,
+col_varchar_key VARCHAR(2) GENERATED ALWAYS AS
+(CONCAT(col_varchar, 'x')) VIRTUAL not null,
+unique KEY (pk,col_int_key),
+KEY(col_int),
+KEY(col_date),
+KEY(col_datetime),
+KEY(col_time),
+KEY(col_varchar),
+UNIQUE KEY (col_int_key),
+KEY (col_time_key),
+KEY (col_datetime_key),
+UNIQUE KEY (col_int_key, col_varchar_key),
+KEY (col_int_key, col_int_nokey),
+KEY(col_int_key,col_date_key),
+KEY(col_int_key, col_time_key),
+KEY(col_int_key, col_datetime_key),
+KEY(col_date_key,col_time_key,col_datetime_key),
+KEY (col_varchar_key, col_varchar_nokey),
+UNIQUE KEY (col_int_key, col_varchar_key,
+col_date_key, col_time_key, col_datetime_key)
+)  AUTO_INCREMENT=10 ENGINE=RocksDB PARTITION BY
+KEY(col_int_key) PARTITIONS 3;
+ALTER TABLE t DROP COLUMN `pk`;
+Warnings:
+Warning	1831	Duplicate index 'pk' defined on the table 'test.t'. This is deprecated and will be disallowed in a future release.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `col_int_nokey` int DEFAULT NULL,
+  `col_int` int GENERATED ALWAYS AS ((`col_int_nokey` + `col_int_nokey`)) STORED NOT NULL,
+  `col_int_key` int GENERATED ALWAYS AS ((`col_int` + `col_int_nokey`)) VIRTUAL NOT NULL,
+  `col_date_nokey` date DEFAULT NULL,
+  `col_date` date GENERATED ALWAYS AS ((`col_date_nokey` + interval 30 day)) STORED NOT NULL,
+  `col_date_key` date GENERATED ALWAYS AS ((`col_date` + interval 30 day)) VIRTUAL NOT NULL,
+  `col_datetime_nokey` datetime DEFAULT NULL,
+  `col_time_nokey` time DEFAULT NULL,
+  `col_datetime` datetime GENERATED ALWAYS AS (addtime(`col_datetime_nokey`,`col_time_nokey`)) STORED NOT NULL,
+  `col_time` time GENERATED ALWAYS AS (addtime(`col_datetime_nokey`,`col_time_nokey`)) STORED NOT NULL,
+  `col_datetime_key` datetime GENERATED ALWAYS AS (addtime(`col_datetime`,`col_time_nokey`)) VIRTUAL NOT NULL,
+  `col_time_key` time GENERATED ALWAYS AS (addtime(`col_datetime_nokey`,`col_time`)) VIRTUAL NOT NULL,
+  `col_varchar_nokey` varchar(1) DEFAULT NULL,
+  `col_varchar` varchar(2) GENERATED ALWAYS AS (concat(`col_varchar_nokey`,`col_varchar_nokey`)) STORED NOT NULL,
+  `col_varchar_key` varchar(2) GENERATED ALWAYS AS (concat(`col_varchar`,_utf8mb4'x')) VIRTUAL NOT NULL,
+  UNIQUE KEY `pk` (`col_int_key`),
+  UNIQUE KEY `col_int_key` (`col_int_key`),
+  UNIQUE KEY `col_int_key_2` (`col_int_key`,`col_varchar_key`),
+  UNIQUE KEY `col_int_key_7` (`col_int_key`,`col_varchar_key`,`col_date_key`,`col_time_key`,`col_datetime_key`),
+  KEY `col_int` (`col_int`),
+  KEY `col_date` (`col_date`),
+  KEY `col_datetime` (`col_datetime`),
+  KEY `col_time` (`col_time`),
+  KEY `col_varchar` (`col_varchar`),
+  KEY `col_time_key` (`col_time_key`),
+  KEY `col_datetime_key` (`col_datetime_key`),
+  KEY `col_int_key_3` (`col_int_key`,`col_int_nokey`),
+  KEY `col_int_key_4` (`col_int_key`,`col_date_key`),
+  KEY `col_int_key_5` (`col_int_key`,`col_time_key`),
+  KEY `col_int_key_6` (`col_int_key`,`col_datetime_key`),
+  KEY `col_date_key` (`col_date_key`,`col_time_key`,`col_datetime_key`),
+  KEY `col_varchar_key` (`col_varchar_key`,`col_varchar_nokey`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+/*!50100 PARTITION BY KEY (col_int_key)
+PARTITIONS 3 */
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (null, null, DEFAULT, 'mm');
+ALTER TABLE t ADD COLUMN xs INT GENERATED ALWAYS AS(a+b), ADD COLUMN mm INT
+GENERATED ALWAYS AS(a+b) STORED, ALGORITHM = INPLACE;
+ERROR 0A000: ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.
+ALTER TABLE t ADD COLUMN x INT GENERATED ALWAYS AS(a+b);
+ALTER TABLE t DROP COLUMN x;
+ALTER TABLE t ADD COLUMN x1 INT GENERATED ALWAYS AS(a+b), DROP COLUMN c;
+DROP TABLE t;
+CREATE TABLE t (a INT GENERATED ALWAYS AS(1) VIRTUAL,KEY(a)) ENGINE=RocksDB;
+INSERT INTO t VALUES(default);
+SELECT a FROM t FOR UPDATE;
+a
+1
+DROP TABLE t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (null, null, DEFAULT, 'mm');
+ALTER TABLE t ADD COLUMN x INT GENERATED ALWAYS AS(a+b), ADD INDEX idx (x);
+affected rows: 4
+info: Records: 4  Duplicates: 0  Warnings: 0
+SELECT x FROM t;
+x
+NULL
+14
+19
+29
+DROP TABLE t;
+CREATE TABLE t1 (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t1 VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t1 VALUES (28, 1, DEFAULT, 'mm');
+ALTER TABLE t1 ADD INDEX idx12 (c) , FORCE;
+ALTER TABLE t1 DROP COLUMN h,  ADD INDEX idx (c) , FORCE;
+Warnings:
+Warning	1831	Duplicate index 'idx' defined on the table 'test.t1'. This is deprecated and will be disallowed in a future release.
+DROP TABLE t1 ;
+create table t(a int) engine=RocksDB;
+insert into t set a=1;
+alter table t add column c int generated always as (1) virtual;
+insert into t set a=2;
+alter table t add unique index(c);
+ERROR 23000: Duplicate entry '1' for key 't.c'
+insert into t set a=1;
+drop table t;
+create table t (
+x int,
+a int generated always as (x) virtual not null,
+b int generated always as (1) stored,
+c int not null,
+unique (b),
+unique (a,b)
+) engine=RocksDB;
+insert into t(x, c) values(1, 3);
+replace into t(x, c) values(1, 0);
+drop table t;
+CREATE TABLE `t` (
+`col1` int(11) DEFAULT NULL,
+`col2` int(11) DEFAULT NULL,
+`col4` int(11) DEFAULT NULL,
+`col5` int(11) GENERATED ALWAYS AS ((`col2` % `col4`)) VIRTUAL,
+`col6` int(11) GENERATED ALWAYS AS ((`col2` - `col2`)) VIRTUAL,
+`col5x` int(11) GENERATED ALWAYS AS ((`col1` / `col1`)) VIRTUAL,
+`col6x` int(11) GENERATED ALWAYS AS ((`col2` / `col4`)) VIRTUAL,
+`col7x` int(11) GENERATED ALWAYS AS ((`col6` % `col6x`)) VIRTUAL,
+`col8x` int(11) GENERATED ALWAYS AS ((`col6` / `col6`)) VIRTUAL,
+`col9` text,
+`col7c` int(11) GENERATED ALWAYS AS ((`col6x` % `col6x`)) VIRTUAL,
+`col1b` varchar(20) GENERATED ALWAYS AS (`col1`) VIRTUAL,
+`col3` int(11) DEFAULT NULL,
+`col7` int(11) DEFAULT NULL,
+`col5c` int(11) GENERATED ALWAYS AS ((`col5x` * `col6`)) VIRTUAL,
+`col6c` varchar(20) GENERATED ALWAYS AS (`col5x`) VIRTUAL,
+`col3b` bigint(20) GENERATED ALWAYS AS ((`col6x` * `col6`)) VIRTUAL,
+`col1a` varchar(20) GENERATED ALWAYS AS (`col1`) VIRTUAL,
+`col8` int(11) DEFAULT NULL,
+UNIQUE KEY `col5` (`col5`),
+UNIQUE KEY `col6x` (`col6x`),
+UNIQUE KEY `col5_2` (`col5`),
+KEY `idx2` (`col9`(10)),
+KEY `idx4` (`col2`),
+KEY `idx8` (`col9`(10),`col5`),
+KEY `idx9` (`col6`),
+KEY `idx6` (`col6`)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1831	Duplicate index 'col5_2' defined on the table 'test.t'. This is deprecated and will be disallowed in a future release.
+Warning	1831	Duplicate index 'idx6' defined on the table 'test.t'. This is deprecated and will be disallowed in a future release.
+ALTER TABLE t CHANGE COLUMN col3b col8a BIGINT GENERATED ALWAYS AS
+(col6x * col6) VIRTUAL, ADD UNIQUE KEY uidx ( col8a );
+DROP TABLE t;
+#
+# Bug 22141031 - GCOLS: PURGED THREAD DIES: TRIED TO PURGE
+# NON-DELETE-MARKED RECORD IN INDEX
+#
+create table t (
+a int,b int,c text,d int,e int,f int,g int,
+h text generated always as ('1') virtual,
+i int,j int,k int,l int,m int,
+primary key (c(1)),unique key (c(1)),
+key (i),key (h(1))
+) engine=RocksDB default charset latin1;
+replace into t(c) values ('');
+replace into t(c) values ('');
+alter table t drop column d ;
+drop table t;
+#
+# Bug 22139917 - ASSERTION: DICT_TABLE_GET_NTH_COL(USER_TABLE, NTH_COL)
+# ->LEN < NEW_LEN
+#
+create table t (
+a int generated always as (1) virtual,
+b varbinary(1),
+c varbinary(1) generated always as (b) virtual
+) engine=RocksDB;
+alter table t change column b b varbinary(2);
+alter table t change column c c varbinary(2) generated always as (b) virtual;
+drop table t;
+SET @@SESSION.sql_mode=0;
+CREATE TABLE t(
+c1 INT AUTO_INCREMENT,
+c2 INT,
+c3 INT GENERATED ALWAYS AS(c2 + c2)VIRTUAL,
+c3k INT GENERATED ALWAYS AS(c2 + c3)VIRTUAL,
+c4 DATE,
+c5 DATE GENERATED ALWAYS AS(DATE_ADD(c4,interval 30 day)) VIRTUAL,
+c5k DATE GENERATED ALWAYS AS(DATE_ADD(c4,interval 30 day)) VIRTUAL,
+c5time_gckey DATE,
+c6 TIME,
+c5time DATE GENERATED ALWAYS AS(ADDTIME(c5time_gckey,c6)) VIRTUAL,
+c7 TIME GENERATED ALWAYS AS(ADDTIME(c5time_gckey,c6)) VIRTUAL,
+c5timek DATE GENERATED ALWAYS AS(ADDTIME(c5time_gckey,c7)) VIRTUAL,
+c7k TIME GENERATED ALWAYS AS(ADDTIME(c5time,c6)) VIRTUAL,
+c8 CHAR(10),
+c9 CHAR(20)GENERATED ALWAYS AS (CONCAT(c8,c8)) VIRTUAL,
+c9k CHAR(15)GENERATED ALWAYS AS (CONCAT(c8,0)) VIRTUAL,
+PRIMARY KEY(c1),
+KEY(c3),
+KEY(c9(10)),
+UNIQUE KEY(c9k),
+UNIQUE KEY(c3k,c9k(5),c5k,c7k,c5timek,c3,c9(5),c5,c7,c5time)
+)ENGINE=RocksDB;
+INSERT INTO
+t(c2,c4,c6,c5time_gckey,c8)VALUES(1,0,0,0,0),(0,0,0,0,'ityzg'),(0,0,1,0,'tyzgk
+t'),(0,1,0,1,'yzgktb'),(0,0,0,0,'zgktb'),(0,0,0,0,'gktbkj'),(0,0,0,0,0),(0,0,1
+,0,1),(0,0,0,0,1),(0,0,0,0,'tbkjrkm'),(0,0,0,0,'bkjr'),(0,0,0,0,0),(0,0,0,0,0)
+,(0,0,0,0,'rk'),(0,0,0,0,'kmqmknbtoe'),(1,0,0,0,'mqmknbt'),(0,1,0,0,'qmknb'),(
+0,0,0,0,'mkn'),(0,0,0,0,'knbtoervql'),(0,0,1,0,1),(0,0,0,0,'nbtoerv'),(0,0,0,0
+,'btoerv'),(0,0,1,0,'toer'),(1,0,0,0,0),(0,0,0,0,'ervq'),(0,0,0,0,'rvqlzsvasu'
+),(0,0,0,0,'vqlzs'),(0,0,0,0,0),(0,1,0,0,'lzsvasu'),(0,0,0,0,'zsvasurq');
+ERROR 23000: Duplicate entry '00' for key 't.c9k'
+SELECT
+DISTINCT * FROM t
+FORCE KEY(PRIMARY,c3k,c3,c9k,c9)
+WHERE
+(c9 IS NULL AND (c9=0))
+OR(
+(c9k NOT IN ('ixfq','xfq','New Mexico','fq')OR c9 IS NULL)
+)
+OR(c9 BETWEEN 'hwstqua' AND 'wstquadcji' OR (c9k=0))
+AND(c3 IS NULL OR c3 IN (0,0,0));
+c1	c2	c3	c3k	c4	c5	c5k	c5time_gckey	c6	c5time	c7	c5timek	c7k	c8	c9	c9k
+drop table t;
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), d INT
+GENERATED ALWAYS AS(a+b+b), e INT  GENERATED ALWAYS AS(a), h VARCHAR(10)) ENGINE=RocksDB;
+INSERT INTO t VALUES (11, 3, DEFAULT, DEFAULT, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, DEFAULT, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, DEFAULT, DEFAULT, 'mm');
+INSERT INTO t VALUES (null, null, DEFAULT, DEFAULT, DEFAULT, 'mm');
+CREATE INDEX idx ON t(c, d);
+CREATE INDEX idx1 ON t(c);
+CREATE INDEX idx2 ON t(e, c, d);
+ALTER TABLE t DROP COLUMN c;
+SELECT d FROM t;
+d
+NULL
+17
+20
+30
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `d` int GENERATED ALWAYS AS (((`a` + `b`) + `b`)) VIRTUAL,
+  `e` int GENERATED ALWAYS AS (`a`) VIRTUAL,
+  `h` varchar(10) DEFAULT NULL,
+  KEY `idx` (`d`),
+  KEY `idx2` (`e`,`d`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t DROP COLUMN d, ADD COLUMN c INT GENERATED ALWAYS AS(a+b), ADD INDEX idx (e);
+Warnings:
+Warning	1831	Duplicate index 'idx2' defined on the table 'test.t'. This is deprecated and will be disallowed in a future release.
+Warning	1831	Duplicate index 'idx' defined on the table 'test.t'. This is deprecated and will be disallowed in a future release.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `e` int GENERATED ALWAYS AS (`a`) VIRTUAL,
+  `h` varchar(10) DEFAULT NULL,
+  `c` int GENERATED ALWAYS AS ((`a` + `b`)) VIRTUAL,
+  KEY `idx2` (`e`),
+  KEY `idx` (`e`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t ADD INDEX idx4(c, e), ADD COLUMN x VARCHAR(10) GENERATED ALWAYS AS(h), DROP INDEX idx;
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `e` int GENERATED ALWAYS AS (`a`) VIRTUAL,
+  `h` varchar(10) DEFAULT NULL,
+  `c` int GENERATED ALWAYS AS ((`a` + `b`)) VIRTUAL,
+  `x` varchar(10) GENERATED ALWAYS AS (`h`) VIRTUAL,
+  KEY `idx2` (`e`),
+  KEY `idx4` (`c`,`e`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t ADD COLUMN i INT GENERATED ALWAYS AS(a+a+b), ADD COLUMN j INT;
+ALTER TABLE t ADD INDEX (x), ADD COLUMN k INT;
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `e` int GENERATED ALWAYS AS (`a`) VIRTUAL,
+  `h` varchar(10) DEFAULT NULL,
+  `c` int GENERATED ALWAYS AS ((`a` + `b`)) VIRTUAL,
+  `x` varchar(10) GENERATED ALWAYS AS (`h`) VIRTUAL,
+  `i` int GENERATED ALWAYS AS (((`a` + `a`) + `b`)) VIRTUAL,
+  `j` int DEFAULT NULL,
+  `k` int DEFAULT NULL,
+  KEY `idx2` (`e`),
+  KEY `idx4` (`c`,`e`),
+  KEY `x` (`x`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ALTER TABLE t ADD COLUMN l INT GENERATED ALWAYS AS(a+a+b), ADD INDEX (l);
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `a` int DEFAULT NULL,
+  `b` int DEFAULT NULL,
+  `e` int GENERATED ALWAYS AS (`a`) VIRTUAL,
+  `h` varchar(10) DEFAULT NULL,
+  `c` int GENERATED ALWAYS AS ((`a` + `b`)) VIRTUAL,
+  `x` varchar(10) GENERATED ALWAYS AS (`h`) VIRTUAL,
+  `i` int GENERATED ALWAYS AS (((`a` + `a`) + `b`)) VIRTUAL,
+  `j` int DEFAULT NULL,
+  `k` int DEFAULT NULL,
+  `l` int GENERATED ALWAYS AS (((`a` + `a`) + `b`)) VIRTUAL,
+  KEY `idx2` (`e`),
+  KEY `idx4` (`c`,`e`),
+  KEY `x` (`x`),
+  KEY `l` (`l`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT l FROM t;
+l
+NULL
+25
+37
+57
+SELECT * FROM t;
+a	b	e	h	c	x	i	j	k	l
+11	3	11	mm	14	mm	25	NULL	NULL	25
+18	1	18	mm	19	mm	37	NULL	NULL	37
+28	1	28	mm	29	mm	57	NULL	NULL	57
+NULL	NULL	NULL	mm	NULL	mm	NULL	NULL	NULL	NULL
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT GENERATED ALWAYS AS(a+b),
+d INT GENERATED ALWAYS AS(a+b+b),
+KEY vidx (c, d)
+)ENGINE=RocksDB;
+INSERT INTO t (a,b) VALUES (0, 0), (1, NULL), (NULL, 2), (NULL, NULL);
+SELECT c, d FROM t;
+c	d
+NULL	NULL
+NULL	NULL
+NULL	NULL
+0	0
+SELECT * FROM t;
+a	b	c	d
+0	0	0	0
+1	NULL	NULL	NULL
+NULL	2	NULL	NULL
+NULL	NULL	NULL	NULL
+ALTER TABLE t DROP COLUMN c;
+SELECT d FROM t;
+d
+NULL
+NULL
+NULL
+0
+SELECT * FROM t;
+a	b	d
+0	0	0
+1	NULL	NULL
+NULL	2	NULL
+NULL	NULL	NULL
+DROP TABLE t;
+CREATE TABLE t (
+a INT,
+b INT,
+c INT GENERATED ALWAYS AS(a+b),
+d INT GENERATED ALWAYS AS(a+b+b)
+)ENGINE=RocksDB;
+INSERT INTO t (a,b) VALUES (0, 0), (1, NULL), (NULL, 2), (NULL, NULL);
+SELECT * FROM t;
+a	b	c	d
+0	0	0	0
+1	NULL	NULL	NULL
+NULL	2	NULL	NULL
+NULL	NULL	NULL	NULL
+ALTER TABLE t DROP COLUMN c, ADD INDEX vidx(d);
+SELECT d FROM t;
+d
+NULL
+NULL
+NULL
+0
+SELECT * FROM t;
+a	b	d
+0	0	0
+1	NULL	NULL
+NULL	2	NULL
+NULL	NULL	NULL
+DROP TABLE t;
+#
+# Bug #22162200 MEMORY LEAK IN HA_INNOPART_SHARE
+# ::SET_V_TEMPL PARTITIONED ON VIRTUAL COLUMN
+#
+create table t (
+c tinyint,
+d longblob generated always as (c) virtual
+) engine=RocksDB partition by key (c) partitions 2;
+select d in(select d from t)from t group by d;
+d in(select d from t)
+drop table t;
+#
+# BUG#23052231 - ASSERTION FAILURE: ROW0MERGE.CC:2100:ADD_AUTOINC
+# < DICT_TABLE_GET_N_USER_COLS
+#
+CREATE TABLE `t` (
+`a` int(11) NOT NULL,
+`d` int(11) NOT NULL,
+`b` varchar(198) NOT NULL,
+`c` char(177) DEFAULT NULL,
+`vadcol` int(11) GENERATED ALWAYS AS ((`a` + length(`d`))) STORED,
+`vbcol` char(2) GENERATED ALWAYS AS (substr(`b`,2,2)) VIRTUAL,
+`vbidxcol` char(3) GENERATED ALWAYS AS (substr(`b`,1,3)) VIRTUAL,
+PRIMARY KEY (`b`(10),`a`,`d`),
+KEY `d` (`d`),
+KEY `a` (`a`),
+KEY `c_renamed` (`c`(99),`b`(35)),
+KEY `b` (`b`(5),`c`(10),`a`),
+KEY `vbidxcol` (`vbidxcol`),
+KEY `a_2` (`a`,`vbidxcol`),
+KEY `vbidxcol_2` (`vbidxcol`,`d`)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+INSERT INTO t values (11, 1, "11", "aa", default, default, default);
+ALTER TABLE t ADD COLUMN nc01128 BIGINT  AUTO_INCREMENT NOT NULL, ADD KEY auto_nc01128(nc01128);
+DROP TABLE t;
+#
+#Bug #22965271 NEEDS REBUILD FOR COLUMN LENGTH CHANGE THAT IS
+#PART OF VIRTUAL INDEX.
+#
+CREATE TABLE t1(
+a VARCHAR(45) CHARACTER SET LATIN1,
+b VARCHAR(115) CHARACTER SET UTF8 GENERATED ALWAYS AS ('f1') VIRTUAL,
+UNIQUE KEY (b,a))ENGINE=RocksDB;
+Warnings:
+Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
+INSERT INTO t1(a) VALUES ('');
+ALTER TABLE t1 CHANGE COLUMN a a VARCHAR(85);
+SELECT * FROM t1;
+a	b
+	f1
+DROP TABLE t1;
+#
+# BUG#27712812 - ALTER TABLE TO ADD AND(OR) DROP VIRTUAL COLUMNS SHOULD BE INSTANT
+#
+CREATE TABLE t1 (a INT NOT NULL AUTO_INCREMENT PRIMARY KEY, b INT) ENGINE=RocksDB;
+INSERT INTO t1 VALUES(0, 1), (0, 2), (0, 3), (0, 4), (0, 5);
+ALTER TABLE t1 ADD COLUMN c INT NOT NULL, ADD COLUMN d INT GENERATED ALWAYS AS ((b * 2)) VIRTUAL;
+ALTER TABLE t1 ADD COLUMN e INT GENERATED ALWAYS AS ((b * 2)) VIRTUAL;
+DROP TABLE t1;
+#
+# BUG#27755892 - CRASH IN ROW_SEL_FIELD_STORE_IN_MYSQL_FORMAT_FUNC
+#
+CREATE TABLE t1 (b DATE, c CHAR(100) CHARACTER SET utf32 GENERATED ALWAYS AS (concat(1, b, 1)) VIRTUAL, UNIQUE KEY(c(16))) ENGINE=RocksDB;
+INSERT INTO t1(b) VALUES('2018-04-01');
+SELECT c LIKE 1 FROM t1;
+c LIKE 1
+0
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/virtual_index.result
+++ b/mysql-test/suite/rocksdb/r/virtual_index.result
@@ -1,0 +1,155 @@
+#
+# Bug 21922176 - PREBUILT->SEARCH_TUPLE CREATED WITHOUT INCLUDING
+# THE NUMBER OF VIRTUAL COLUMNS
+#
+CREATE TABLE t1 (a INT, a1 INT GENERATED ALWAYS AS (a) VIRTUAL, a2 INT
+GENERATED ALWAYS AS (a) VIRTUAL, a3 INT GENERATED ALWAYS AS (a) VIRTUAL, a4
+INT GENERATED ALWAYS AS (a) VIRTUAL, a5 INT GENERATED ALWAYS AS (a) VIRTUAL,
+a6 INT GENERATED ALWAYS AS (a) VIRTUAL, a7 INT GENERATED ALWAYS AS (a)
+VIRTUAL, a8 INT GENERATED ALWAYS AS (a) VIRTUAL, a9 INT GENERATED ALWAYS AS
+(a) VIRTUAL, INDEX(a1, a2, a3, a4, a5, a6, a7, a8, a9)) ENGINE=RocksDB;
+INSERT INTO t1(a) VALUES(10);
+SELECT * FROM t1 WHERE a1=10 AND a2 = 10 AND a3 =10 AND a4 = 10 AND a5=10 AND
+a6=10 AND a7=10 AND a8=10 AND a9=10;
+a	a1	a2	a3	a4	a5	a6	a7	a8	a9
+10	10	10	10	10	10	10	10	10	10
+DROP TABLE t1;
+#
+# Bug 23014521 - GCOL:INNODB: FAILING ASSERTION: !IS_V
+#
+CREATE TABLE t1 (
+col1 int NOT NULL,
+col2 int DEFAULT NULL,
+col3 int NOT NULL,
+col4 int DEFAULT NULL,
+col5 int GENERATED ALWAYS AS ((col1 % col4)) VIRTUAL,
+col6 int GENERATED ALWAYS AS ((col2 - col4)) VIRTUAL,
+col5x int GENERATED ALWAYS AS ((col3 / col2)) VIRTUAL,
+col6b varchar(20) GENERATED ALWAYS AS (col2) VIRTUAL,
+col6x int GENERATED ALWAYS AS ((col2 % col1)) VIRTUAL,
+col7 int GENERATED ALWAYS AS ((col6x + col5x)) VIRTUAL,
+col8 int GENERATED ALWAYS AS ((col5x / col5)) VIRTUAL,
+col7x int GENERATED ALWAYS AS ((col5x + col5)) VIRTUAL,
+col8x int GENERATED ALWAYS AS ((col5 / col5x)) VIRTUAL,
+col9 text,
+col2b varchar(20) GENERATED ALWAYS AS (col4) VIRTUAL,
+col8a int GENERATED ALWAYS AS (col2) VIRTUAL,
+col4b varchar(20) GENERATED ALWAYS AS (col4) VIRTUAL,
+col1c int GENERATED ALWAYS AS ((col2 * col1)) VIRTUAL,
+extra int DEFAULT NULL,
+col5c int GENERATED ALWAYS AS ((col1 / col1)) VIRTUAL,
+col6a bigint GENERATED ALWAYS AS ((col3 / col1)) VIRTUAL,
+col1a varchar(20) GENERATED ALWAYS AS (col6) VIRTUAL,
+col6c int GENERATED ALWAYS AS ((col2 % col2)) VIRTUAL,
+col7c bigint GENERATED ALWAYS AS ((col2 / col1)) VIRTUAL,
+col2c int GENERATED ALWAYS AS ((col5 % col5)) VIRTUAL,
+col1b int GENERATED ALWAYS AS ((col1 / col2)) VIRTUAL,
+col3b bigint GENERATED ALWAYS AS ((col6x % col6)) VIRTUAL,
+UNIQUE KEY idx7 (col1,col3,col2),
+UNIQUE KEY uidx (col9(10)),
+KEY idx15 (col9(10),col2),
+KEY idx10 (col9(10),col1),
+KEY idx11 (col6x),
+KEY idx6 (col9(10),col7),
+KEY idx14 (col6)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+DROP TABLE t1;
+CREATE TABLE t1 (
+col1 int NOT NULL,
+col2 int DEFAULT NULL,
+col3 int NOT NULL,
+col4 int DEFAULT NULL) ENGINE=RocksDB;
+ALTER TABLE t1 ADD COLUMN col7a INT GENERATED ALWAYS AS (col1 % col2)
+VIRTUAL, ADD UNIQUE index idx (col1);
+DROP TABLE t1;
+CREATE TABLE t1 (
+col1 int NOT NULL,
+col2 int DEFAULT NULL,
+col3 int NOT NULL,
+col4 int DEFAULT NULL,
+col5 int GENERATED ALWAYS AS ((col2 - col4)) VIRTUAL,
+col6 int GENERATED ALWAYS AS ((col5 + col1)) VIRTUAL,
+col7 bigint GENERATED ALWAYS AS ((col2 / col1)) VIRTUAL,
+col8 int GENERATED ALWAYS AS ((col5 % col5)) VIRTUAL,
+col9 text,
+KEY idx1 (col5),
+KEY idx2 (col6)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `col1` int NOT NULL,
+  `col2` int DEFAULT NULL,
+  `col3` int NOT NULL,
+  `col4` int DEFAULT NULL,
+  `col5` int GENERATED ALWAYS AS ((`col2` - `col4`)) VIRTUAL,
+  `col6` int GENERATED ALWAYS AS ((`col5` + `col1`)) VIRTUAL,
+  `col7` bigint GENERATED ALWAYS AS ((`col2` / `col1`)) VIRTUAL,
+  `col8` int GENERATED ALWAYS AS ((`col5` % `col5`)) VIRTUAL,
+  `col9` text,
+  KEY `idx1` (`col5`),
+  KEY `idx2` (`col6`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=latin1
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+INSERT INTO t1(col1, col2, col3, col4, col9) VALUES (10, 50, 40, 300, "lope");
+INSERT INTO t1(col1, col2, col3, col4, col9) VALUES (100, 3240, 4000, 11, "dskf");
+INSERT INTO t1(col1, col2, col3, col4, col9) VALUES (5, 400, 20, 900, "hqal");
+SELECT * FROM t1;
+col1	col2	col3	col4	col5	col6	col7	col8	col9
+10	50	40	300	-250	-240	5	0	lope
+100	3240	4000	11	3229	3329	32	0	dskf
+5	400	20	900	-500	-495	80	0	hqal
+SELECT col5 FROM t1;
+col5
+-500
+-250
+3229
+SELECT col6 FROM t1;
+col6
+-495
+-240
+3329
+SELECT col7 FROM t1;
+col7
+5
+32
+80
+ALTER TABLE t1 ADD INDEX idx3 (col7);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SELECT col7 FROM t1;
+col7
+5
+32
+80
+SELECT col7 FROM t1;
+col7
+5
+32
+80
+ALTER TABLE t1 DROP INDEX idx3, ADD INDEX idx3 (col7 ASC);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+SELECT col7 FROM t1;
+col7
+5
+32
+80
+DROP TABLE t1;
+#
+# Bug 25899959 - SERVER CRASH WHILE TRYING TO ADD A VIRTUAL COLUMN AND ADD INDEX ON IT
+#
+CREATE TABLE t1 (doc json DEFAULT NULL) ENGINE=RocksDB;
+ALTER TABLE t1 ADD Name char(52) AS (doc->>"$.Name"), ADD INDEX n (Name);
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `doc` json DEFAULT NULL,
+  `Name` char(52) GENERATED ALWAYS AS (json_unquote(json_extract(`doc`,_utf8mb4'$.Name'))) VIRTUAL,
+  KEY `n` (`Name`)
+) ENGINE=ROCKSDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/virtual_basic.test
+++ b/mysql-test/suite/rocksdb/t/virtual_basic.test
@@ -1,0 +1,1156 @@
+--source include/have_rocksdb.inc
+
+--source include/count_sessions.inc
+
+--disable_query_log
+call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* Compute virtual");
+--enable_query_log
+
+CREATE TABLE t (a INT, b INT GENERATED ALWAYS AS (a), c CHAR(10), d CHAR(20), e CHAR(10) GENERATED ALWAYS AS (c), g INT) ENGINE=RocksDB;
+INSERT INTO t VALUES(10, DEFAULT, "aa", "bb", DEFAULT, 20);
+INSERT INTO t VALUES(11, DEFAULT, "jj", "kk", DEFAULT, 21);
+
+CREATE INDEX idx ON t(e) algorithm=inplace;
+INSERT INTO t VALUES(12, DEFAULT, 'mm', "nn", DEFAULT, 22);
+
+SELECT e FROM t;
+
+DROP TABLE t;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (null, null, DEFAULT, 'mm');
+
+CREATE INDEX idx ON t(c);
+SELECT c FROM t;
+
+UPDATE t SET a = 10 WHERE a = 11;
+SELECT c FROM t;
+
+SELECT * FROM t;
+
+DELETE FROM t WHERE a = 18;
+
+SELECT c FROM t;
+
+START TRANSACTION;
+
+INSERT INTO t VALUES (128, 22, DEFAULT, "xx");
+INSERT INTO t VALUES (1290, 212, DEFAULT, "xmx");
+ROLLBACK;
+
+SELECT c FROM t;
+SELECT * FROM t;
+
+DROP TABLE t;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + j), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES(11, 22, DEFAULT, "AAA", 8, DEFAULT, "XXX", DEFAULT);
+INSERT INTO t VALUES(1, 2, DEFAULT, "uuu", 9, DEFAULT, "uu", DEFAULT);
+INSERT INTO t VALUES(3, 4, DEFAULT, "uooo", 1, DEFAULT, "umm", DEFAULT);
+
+SELECT c FROM t;
+SELECT m FROM t;
+SELECT p FROM t;
+SELECT * FROM t;
+
+update t set a = 13 where a =11;
+
+delete from t where a =13;
+
+DROP INDEX idx1 ON t;
+DROP INDEX idx2 ON t;
+DROP TABLE t;
+
+/* Test large BLOB data */
+CREATE TABLE `t` (
+  `a` BLOB,
+  `b` BLOB,
+  `c` BLOB GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+  `h` VARCHAR(10) NOT NULL,
+  PRIMARY KEY (h) # Primary key added by RocksDB test to avoid gap lock detection error
+) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (REPEAT('g', 16000), REPEAT('x', 16000), DEFAULT, "kk");
+
+CREATE INDEX idx ON t(c(100));
+
+SELECT length(c) FROM t;
+
+START TRANSACTION;
+
+INSERT INTO t VALUES (REPEAT('a', 16000), REPEAT('b', 16000), DEFAULT, 'mm');
+
+ROLLBACK;
+
+INSERT INTO t VALUES (REPEAT('a', 16000), REPEAT('b', 16000), DEFAULT, 'mm');
+
+START TRANSACTION;
+
+# Changed condition: was a like 'aaa%' originally, not possible with rocksdb
+UPDATE t SET a = REPEAT('m', 16000) WHERE h = 'mm';
+
+ROLLBACK;
+
+# This SELECT did not give correct answer, even though InnoDB return
+# all qualified rows
+SELECT COUNT(*) FROM t WHERE c like "aaa%";
+
+DROP TABLE t;
+
+# Primary key added for gap lock detection
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), PRIMARY KEY(a)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+CREATE INDEX idx ON t(c);
+
+START TRANSACTION;
+
+UPDATE t SET a = 100 WHERE a = 11;
+
+UPDATE t SET a =22 WHERE a = 18;
+
+UPDATE t SET a = 33 WHERE a = 22;
+
+SELECT c FROM t;
+
+ROLLBACK;
+
+SELECT c FROM t;
+DROP TABLE t;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+CREATE INDEX idx ON t(c);
+SELECT c FROM t;
+
+CONNECT(con1,localhost,root,,test);
+START TRANSACTION;
+SELECT c FROM t;
+
+CONNECTION default;
+UPDATE t SET a = 19 WHERE a = 11;
+
+# this should report the same value as previous ONe (14, 19, 29).
+CONNECTiON con1;
+SELECT c FROM t;
+
+ROLLBACK;
+
+SELECT c FROM t;
+
+CONNECTION default;
+DISCONNECT con1;
+
+DROP TABLE t;
+
+# CREATE a more complex TABLE
+# Primary key added to avoid gap lock issue
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + x), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, y)), x INT, y CHAR(20), z INT, PRIMARY KEY(a), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES(1, 2, DEFAULT, "hhh", 3, DEFAULT, "nnn", DEFAULT, 4, "yyy", 5);
+
+
+INSERT INTO t VALUES(2, 3, DEFAULT, "hhha", 4, DEFAULT, "nnna", DEFAULT, 5, "yyya", 6);
+
+
+INSERT INTO t VALUES(12, 13, DEFAULT, "hhhb", 14, DEFAULT, "nnnb", DEFAULT, 15, "yyyb", 16);
+
+# CREATE an INDEX ON multiple virtual COLUMN
+CREATE INDEX idx6 ON t(p, c);
+
+SELECT p, c FROM t;
+
+START TRANSACTION;
+INSERT INTO t VALUES(32, 33, DEFAULT, "hhhb", 34, DEFAULT, "nnnb", DEFAULT, 35, "yyyb", 36);
+ROLLBACK;
+
+UPDATE t SET a = 100 WHERE a = 1;
+
+START TRANSACTION;
+UPDATE t SET a = 1 WHERE a = 100;
+ROLLBACK;
+
+
+Drop TABLE t;
+
+CREATE TABLE t1(a INT) ENGINE=RocksDB;
+ALTER TABLE t1 add COLUMN (b INT generated always as (a+1) virtual, c INT as(5) virtual);
+ALTER TABLE t1 add COLUMN (d INT generated always as (a+1) virtual, e INT as(5) virtual);
+
+#--error ER_UNSUPPORTED_ACTION_ON_GENERATED_COLUMN
+ALTER TABLE t1 add COLUMN (f INT generated always as (a+1) virtual, g INT as(5) virtual), DROP COLUMN e;
+
+DROP TABLE t1;
+
+
+CREATE TABLE t1(a INT) ENGINE=RocksDB;
+ALTER TABLE t1 add COLUMN (b INT generated always as (a+1) virtual, c INT as(5) virtual);
+
+ALTER TABLE t1 change b x INT generated always as (a+1) virtual;
+
+DROP TABLE t1;
+
+#test DEFAULT value
+CREATE TABLE t (a INT DEFAULT 1, b INT DEFAULT 2, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), PRIMARY KEY (a)) ENGINE=RocksDB;
+CREATE INDEX idx ON t(c);
+INSERT INTO t(h)VALUES ('mm');
+SELECT c FROM t;
+
+CREATE unique INDEX idx1 ON t(c);
+
+--error ER_DUP_ENTRY
+INSERT INTO t(h)VALUES ('mm');
+
+DROP TABLE t;
+
+
+CREATE TABLE `t1` ( `a` INT DEFAULT NULL,   `b` INT DEFAULT NULL,   `c` INT GENERATED ALWAYS AS (a+b) VIRTUAL,   `x` INT NOT NULL,   `h` VARCHAR(10) DEFAULT NULL,   PRIMARY KEY (`x`),   KEY `idx` (`c`) ) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+
+INSERT INTO t1 VALUES (1, 2, DEFAULT, 3, 'mm');
+INSERT INTO t1 VALUES (11, 22, DEFAULT, 23, 'mm');
+
+CONNECT(con1,localhost,root,,test);
+UPDATE t1 SET x = 4 WHERE x =3;
+DROP TABLE t1;
+
+CREATE TABLE `t1` ( `a` INT NOT NULL,   `b` INT  DEFAULT NULL,   `c` INT GENERATED ALWAYS AS (a+b) VIRTUAL,   `x` INT NOT NULL,   `h` VARCHAR(10) DEFAULT NULL,   PRIMARY KEY (a), KEY `idx` (`c`) ) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+
+INSERT INTO t1 VALUES (1, 2, DEFAULT, 3, 'mm');
+INSERT INTO t1 VALUES (11, 22, DEFAULT, 23, 'mm');
+
+START TRANSACTION;
+SELECT * FROM t1;
+
+CONNECTiON con1;
+START TRANSACTION;
+UPDATE t1 SET a = 15 WHERE a = 1;
+
+UPDATE t1 SET a = 10 WHERE a=15;
+ROLLBACK;
+
+CONNECTION default;
+SELECT c FROM t1;
+
+DISCONNECT con1;
+
+DROP TABLE t1;
+
+CREATE TABLE `t` (
+  `a` INT DEFAULT NULL,
+  `b` INT DEFAULT NULL,
+  `c` INT GENERATED ALWAYS AS (a+b) VIRTUAL,
+  `d` INT GENERATED ALWAYS AS (a) VIRTUAL,
+  `h` INT NOT NULL,
+  PRIMARY KEY (`h`),
+  KEY `idx` (`c`)
+) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (18, 1, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (28, 1, DEFAULT, DEFAULT, 3);
+INSERT INTO t VALUES (null, null, DEFAULT, DEFAULT, 4);
+
+
+delimiter |;
+CREATE PROCEDURE UPDATE_t()
+begin
+        DECLARE i INT DEFAULT 1;
+        WHILE (i <= 2000) DO
+		UPDATE t SET a = 100 + i WHERE h = 1;
+                SET i = i + 1;
+        END WHILE;
+END|
+
+CREATE PROCEDURE DELETE_insert_t()
+begin
+        DECLARE i INT DEFAULT 1;
+        WHILE (i <= 2000) DO
+		UPDATE t SET a = 100 + i WHERE h = 1;
+                SET i = i + 1;
+        END WHILE;
+END|
+delimiter ;|
+
+CALL UPDATE_t();
+SELECT c FROM t;
+
+CALL DELETE_insert_t();
+SELECT c FROM t;
+
+DROP INDEX idx ON t;
+CALL UPDATE_t();
+SELECT c FROM t;
+
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+
+DROP TABLE t;
+
+--echo # Bug#20767937: WL8149:ASSERTION FAILED IN ROW_UPD_SEC_INDEX_ENTRY
+CREATE TABLE b (
+col_INT_nokey INTEGER NOT NULL,
+col_INT_key INTEGER GENERATED ALWAYS AS (col_INT_nokey) VIRTUAL,
+col_date_nokey DATE,
+col_date_key DATE GENERATED ALWAYS AS (DATE_ADD(col_date_nokey,
+        INTerval 30 day)) VIRTUAL,
+
+col_datetime_nokey DATETIME NOT NULL,
+col_time_nokey TIME NOT NULL,
+
+col_datetime_key DATETIME GENERATED ALWAYS AS (ADDTIME(col_datetime_nokey,
+      col_time_nokey)),
+col_time_key TIME GENERATED ALWAYS AS (ADDTIME(col_datetime_nokey,
+      col_time_nokey)),
+
+col_VARCHAR_nokey VARCHAR(1) NOT NULL,
+col_VARCHAR_key VARCHAR(2) GENERATED ALWAYS AS(CONCAT(col_VARCHAR_nokey,
+      col_VARCHAR_nokey)),
+
+KEY (col_INT_key),
+KEY (col_VARCHAR_key),
+KEY (col_date_key),
+KEY (col_time_key),
+KEY (col_datetime_key),
+KEY (col_INT_key, col_VARCHAR_key),
+KEY (col_INT_key, col_VARCHAR_key, col_date_key,
+col_time_key, col_datetime_key)
+) ENGINE=RocksDB;
+INSERT INTO b (
+  col_INT_nokey,
+  col_date_nokey,
+  col_time_nokey,
+  col_datetime_nokey,
+  col_VARCHAR_nokey
+) VALUES
+(0, NULL, '21:22:34.025509', '2002-02-13 17:30:06.013935', 'j'),
+(8, '2004-09-18', '10:50:38.059966', '2008-09-27
+00:34:58.026613', 'v');
+
+EXPLAIN SELECT col_INT_key FROM b;
+SELECT col_INT_key FROM b;
+SELECT col_INT_nokey, col_INT_key FROM b;
+DELETE FROM b;
+
+DROP TABLE b;
+
+
+LET $row_format=COMPACT;
+--source suite/innodb/include/innodb_v_large_col.inc
+
+CREATE TABLE `t` (
+  `a` BLOB,
+  `b` BLOB,
+  `c` BLOB GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+  `d` BLOB GENERATED ALWAYS AS (b) VIRTUAL,
+  `e` INT GENERATED ALWAYS AS (10) VIRTUAL,
+  `h` INT NOT NULL,
+  PRIMARY KEY (`h`)
+) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (REPEAT('g', 16000), REPEAT('x', 16000), DEFAULT, DEFAULT, DEFAULT, 1);
+INSERT INTO t VALUES (REPEAT('a', 32000), REPEAT('b', 11000), DEFAULT, DEFAULT, DEFAULT, 2);
+INSERT INTO t VALUES (REPEAT('m', 18000), REPEAT('n', 46000), DEFAULT, DEFAULT, DEFAULT, 3);
+
+CREATE INDEX idx ON t(c(100), d(20));
+
+UPDATE t SET a = NULL WHERE h=1;
+
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 2000) WHERE h = 1;
+
+UPDATE t SET a = REPEAT(CAST(1 AS CHAR), 1000) WHERE h = 1;
+
+delimiter |;
+
+CREATE PROCEDURE UPDATE_t()
+begin
+        DECLARE i INT DEFAULT 1;
+        WHILE (i <= 200) DO
+                UPDATE t SET a = REPEAT(CAST(i AS CHAR), 2000) WHERE h = 1;
+                SET i = i + 1;
+        END WHILE;
+END|
+
+CREATE PROCEDURE DELETE_insert_t()
+begin
+        DECLARE i INT DEFAULT 1;
+        WHILE (i <= 200) DO
+                DELETE FROM t WHERE h = 1;
+                INSERT INTO t VALUES (REPEAT(CAST(i AS CHAR), 2000) ,  REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 1);
+                SET i = i + 1;
+        END WHILE;
+END|
+delimiter ;|
+
+CALL UPDATE_t();
+CALL DELETE_insert_t();
+
+UPDATE t SET a = NULL WHERE h=1;
+
+
+DROP PROCEDURE DELETE_insert_t;
+DROP PROCEDURE UPDATE_t;
+DROP TABLE t;
+
+CREATE TABLE `t` (
+  `m1` INT DEFAULT NULL,
+  `m2` INT DEFAULT NULL,
+  `m3` INT GENERATED ALWAYS AS (m1 + m2) VIRTUAL,
+  `m4` INT DEFAULT NULL,
+  `m5` CHAR(10) DEFAULT NULL,
+  `m6` CHAR(12) GENERATED ALWAYS AS (m5) VIRTUAL,
+  `a` VARCHAR(10000) DEFAULT NULL,
+  `b` VARCHAR(3000) DEFAULT NULL,
+  `c` VARCHAR(14000) GENERATED ALWAYS AS (CONCAT(a,b)) VIRTUAL,
+  `d` VARCHAR(5000) GENERATED ALWAYS AS (b) VIRTUAL,
+  `e` INT GENERATED ALWAYS AS (10) VIRTUAL,
+  `h` INT NOT NULL,
+  PRIMARY KEY (`h`),
+  KEY `m3` (`m3`),
+  KEY `c` (`c`(100)),
+  KEY `e` (`e`,`d`(20))
+) ENGINE=RocksDB charset latin1;
+
+INSERT INTO t VALUES (1, 2, DEFAULT, 3, "aaa", DEFAULT, REPEAT('g', 10000), REPEAT('x', 2800), DEFAULT, DEFAULT, DEFAULT, 1);
+
+INSERT INTO t VALUES (11, 21, DEFAULT, 31, "bbb", DEFAULT, REPEAT('a', 9000), REPEAT('b', 2000), DEFAULT, DEFAULT, DEFAULT, 2);
+
+INSERT INTO t VALUES (21, 31, DEFAULT, 41, "zzz", DEFAULT, REPEAT('m', 8000), REPEAT('n', 3000), DEFAULT, DEFAULT, DEFAULT, 3);
+
+ALTER TABLE t DROP COLUMN c;
+
+DELETE FROM t;
+
+DROP TABLE t;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), PRIMARY KEY(a)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (1, null, DEFAULT, 'mm');
+
+CREATE INDEX idx ON t(a, c);
+SELECT a, c FROM t;
+
+START TRANSACTION;
+
+UPDATE t SET a = 13 where a = 11;
+
+ROLLBACK;
+DELETE FROM t;
+
+DROP TABLE t;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), m int, PRIMARY KEY(a)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, "a", 1);
+INSERT INTO t VALUES (18, 1, DEFAULT, "b", 2);
+INSERT INTO t VALUES (28, 1, DEFAULT, "c", 3 );
+INSERT INTO t VALUES (1, null, DEFAULT, "d", 4);
+
+CREATE INDEX idx ON t(a, c, h);
+SELECT a, c FROM t;
+
+START TRANSACTION;
+UPDATE t SET a =10 WHERE a = 11;
+ROLLBACK;
+SELECT a, c, h FROM t;
+
+DROP TABLE t;
+
+# bug#21065137 - WL8149:FAILING ASSERTION: NAME_OFS < FULL_LEN 
+CREATE TABLE `t1` (
+  `col1` int(11) NOT NULL,
+  `col2` int(11) NOT NULL,
+  `col3` int(11) NOT NULL,
+  `col4` int(11) DEFAULT NULL,
+  `col5` int(11) GENERATED ALWAYS AS (col2 % col3) VIRTUAL,
+  `col7` int(11) GENERATED ALWAYS AS (col5 * col5) VIRTUAL,
+  `col8` int(11) GENERATED ALWAYS AS (col5 % col5) VIRTUAL,
+  `col9` text,
+  `extra` int(11) DEFAULT NULL,
+  UNIQUE KEY `uidx` (`col5`)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+
+ALTER TABLE t1 CHANGE COLUMN extra col6 INT;
+
+SHOW CREATE TABLE t1;
+DROP TABLE t1;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + j), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES(11, 22, DEFAULT, "AAA", 8, DEFAULT, "XXX", DEFAULT);
+INSERT INTO t VALUES(1, 2, DEFAULT, "uuu", 9, DEFAULT, "uu", DEFAULT);
+INSERT INTO t VALUES(3, 4, DEFAULT, "uooo", 1, DEFAULT, "umm", DEFAULT);
+
+alter table t add  x int, add xx int generated ALWAYS AS(x);
+
+DROP TABLE t;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT  GENERATED ALWAYS AS(b + j), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES(11, 22, DEFAULT, "AAA", 8, DEFAULT, "XXX", DEFAULT);
+INSERT INTO t VALUES(1, 2, DEFAULT, "uuu", 9, DEFAULT, "uu", DEFAULT);
+INSERT INTO t VALUES(3, 4, DEFAULT, "uooo", 1, DEFAULT, "umm", DEFAULT);
+
+ALTER TABLE t DROP COLUMN c;
+ALTER TABLE t DROP COLUMN p, ADD COLUMN s VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h));
+
+# This should fail
+#ALTER TABLE t ADD  x INT, DROP COLUMN m, algorithm=inplace;
+SELECT s FROM t;
+
+ALTER TABLE t ADD  x VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), ADD INDEX idx (x);
+DROP TABLE t;
+
+
+CREATE TABLE `t1` (
+  `col1` int(11) DEFAULT NULL,
+  `col2` int(11) DEFAULT NULL,
+  `col3` int(11) DEFAULT NULL,
+  `col4` int(11) DEFAULT NULL,
+  `col5` int(11) GENERATED ALWAYS AS (col4 * col2) VIRTUAL,
+  `col6` int(11) GENERATED ALWAYS AS (col2 % col4) VIRTUAL,
+  `col7` int(11) GENERATED ALWAYS AS (col5 / col6) VIRTUAL,
+  `col8` int(11) GENERATED ALWAYS AS (col5 + col5) VIRTUAL,
+  `col9` text,
+  `extra` int(11) DEFAULT NULL
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+
+ALTER TABLE t1 DROP COLUMN col7;
+
+DROP TABLE t1;
+
+CREATE TABLE t1 (
+  col1 INTEGER NOT NULL,
+  col2 INTEGER NOT NULL,
+  col3 INTEGER DEFAULT NULL,
+  col4 INTEGER DEFAULT NULL,
+  col5 INTEGER DEFAULT NULL,
+  col6 INTEGER DEFAULT NULL,
+  col7 INTEGER DEFAULT NULL,
+  col8 INTEGER DEFAULT NULL,
+  col9 INTEGER DEFAULT NULL,
+  col10 INTEGER DEFAULT NULL,
+  col11 INTEGER DEFAULT NULL,
+  col12 INTEGER DEFAULT NULL,
+  col13 INTEGER DEFAULT NULL,
+  col14 INTEGER DEFAULT NULL,
+  col15 INTEGER DEFAULT NULL,
+  col16 INTEGER DEFAULT NULL,
+  col17 INTEGER DEFAULT NULL,
+  col18 INTEGER DEFAULT NULL,
+  col19 INTEGER DEFAULT NULL,
+  col20 INTEGER DEFAULT NULL,
+  col21 INTEGER DEFAULT NULL,
+  col22 INTEGER DEFAULT NULL,
+  col23 INTEGER DEFAULT NULL,
+  col24 INTEGER DEFAULT NULL,
+  col25 INTEGER DEFAULT NULL,
+  col26 INTEGER DEFAULT NULL,
+  col27 INTEGER DEFAULT NULL,
+  col28 INTEGER DEFAULT NULL,
+  col29 INTEGER DEFAULT NULL,
+  col30 INTEGER DEFAULT NULL,
+  col31 INTEGER DEFAULT NULL,
+  col32 INTEGER DEFAULT NULL,
+  col33 INTEGER DEFAULT NULL,
+  gcol1 INTEGER GENERATED ALWAYS AS (col1 + col2) VIRTUAL,
+  KEY idx1 (gcol1)
+) ENGINE=RocksDB;
+
+INSERT INTO t1 (col1, col2)
+  VALUES (0,1), (1,2), (2,3), (3,4), (4,5);
+
+SELECT gcol1 FROM t1 FORCE INDEX(idx1);
+
+ALTER TABLE t1 ADD COLUMN extra INTEGER;
+
+SELECT gcol1 FROM t1 FORCE INDEX(idx1);
+
+DROP TABLE t1;
+
+CREATE TABLE t1 (
+    id INT NOT NULL,
+    store_id INT NOT NULL,
+    x INT GENERATED ALWAYS AS (id + store_id)
+) ENGINE=RocksDB
+PARTITION BY RANGE (store_id) (
+    PARTITION p0 VALUES LESS THAN (6),
+    PARTITION p1 VALUES LESS THAN (11),
+    PARTITION p2 VALUES LESS THAN (16),
+    PARTITION p3 VALUES LESS THAN (21)
+);
+
+INSERT INTO t1 VALUES(1, 2, default);
+INSERT INTO t1 VALUES(3, 4, default);
+
+INSERT INTO t1 VALUES(3, 12, default);
+INSERT INTO t1 VALUES(4, 18, default);
+
+CREATE INDEX idx ON t1(x);
+
+SELECT x FROM t1;
+
+DROP TABLE t1;
+
+CREATE TABLE t1 (
+    id INT NOT NULL,
+    store_id INT NOT NULL,
+    x INT GENERATED ALWAYS AS (id + store_id)
+) ENGINE=RocksDB
+PARTITION BY RANGE (x) (
+    PARTITION p0 VALUES LESS THAN (6),
+    PARTITION p1 VALUES LESS THAN (11),
+    PARTITION p2 VALUES LESS THAN (16),
+    PARTITION p3 VALUES LESS THAN (21)
+);
+
+insert into t1 values(1, 2, default);
+insert into t1 values(3, 4, default);
+
+insert into t1 values(3, 12, default);
+--error ER_NO_PARTITION_FOR_GIVEN_VALUE
+insert into t1 values(4, 18, default);
+
+CREATE INDEX idx ON t1(x);
+SELECT x FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (a INT, b INT GENERATED ALWAYS AS (a+1) ,c int) ENGINE=RocksDB PARTITION BY RANGE (b) (
+PARTITION p0 VALUES LESS THAN (6),
+PARTITION p1 VALUES LESS THAN (11),
+PARTITION p2 VALUES LESS THAN (16),
+PARTITION p3 VALUES LESS THAN (21) );
+
+INSERT INTO t1 VALUES (10,DEFAULT,2);
+INSERT INTO t1 VALUES (19,DEFAULT,8);
+
+CREATE INDEX idx ON t1 (b);
+
+INSERT INTO t1 VALUES (5,DEFAULT,9);
+
+SELECT * FROM t1;
+
+ALTER TABLE t1 REMOVE PARTITIONING;
+
+DROP TABLE t1;
+
+CREATE TABLE `t#P#1` (a INT, bt INT GENERATED ALWAYS AS (a+1) ,c int) ENGINE=RocksDB
+PARTITION BY RANGE (bt)
+subpartition by hash (bt)
+ (
+    PARTITION p0 VALUES LESS THAN (6) (
+        SUBPARTITION s0,
+        SUBPARTITION s1),
+    PARTITION p1 VALUES LESS THAN (11) (
+        SUBPARTITION s2,
+        SUBPARTITION s3),
+    PARTITION p2 VALUES LESS THAN (16) (
+        SUBPARTITION s4,
+        SUBPARTITION s5),
+    PARTITION p3 VALUES LESS THAN (21) (
+        SUBPARTITION s6,
+        SUBPARTITION s7)
+ );
+insert into `t#P#1` values (10,DEFAULT,2);
+insert into `t#P#1` values (19,DEFAULT,8);
+create index idx on `t#P#1` (bt);
+insert into `t#P#1` values (5,DEFAULT,9);
+select * from `t#P#1`;
+alter table `t#P#1` remove partitioning;
+drop table `t#P#1`;
+
+LET $row_format=DYNAMIC;
+--source suite/innodb/include/innodb_v_large_col.inc
+
+LET $row_format=REDUNDANT;
+--source suite/innodb/include/innodb_v_large_col.inc
+
+LET $row_format=COMPRESSED;
+--source suite/innodb/include/innodb_v_large_col.inc
+
+# Test uses ICP on column h and d
+create table t (a int,b int,c int,d int,e int,
+f int generated always as (a+b) virtual,
+g int,h blob,i int,unique key (d,h(25))) engine=RocksDB;
+
+select h from t where d is null;
+drop table t;
+
+# Test Add virtual column of MySQL long true type
+create table t(a blob not null) engine=RocksDB;
+alter table t add column b int;
+alter table t add column c varbinary (1000) generated always as (a) virtual;
+alter table t add unique index (c(39));
+replace into t set a = 'a',b =1;
+replace into t set a = 'a',b =1;
+drop table t;
+
+CREATE TABLE t (a INT, b INT,  h VARCHAR(10)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (12, 3,  "ss");
+
+INSERT INTO t VALUES (13, 4,  "ss");
+
+INSERT INTO t VALUES (14, 0,  "ss");
+
+--error ER_DIVISION_BY_ZERO
+alter table t add  c INT GENERATED ALWAYS AS(a/b);
+
+DROP TABLE t;
+
+CREATE TABLE t (
+                        pk INTEGER AUTO_INCREMENT,
+                        col_int_nokey INTEGER /*! NULL */,
+                        col_int INT GENERATED ALWAYS AS (col_int_nokey +
+col_int_nokey) STORED not null,
+                        col_int_key INTEGER GENERATED ALWAYS AS (col_int +
+col_int_nokey) VIRTUAL not null,
+
+                        col_date_nokey DATE /*! NULL */,
+                        col_date DATE GENERATED ALWAYS AS
+(DATE_ADD(col_date_nokey,interval 30 day)) STORED not null,
+                        col_date_key DATE GENERATED ALWAYS AS
+(DATE_ADD(col_date,interval 30 day)) VIRTUAL not null,
+
+                        col_datetime_nokey DATETIME /*! NULL */,
+                        col_time_nokey TIME /*! NULL */,
+
+                        col_datetime DATETIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime_nokey, col_time_nokey)) STORED not null,
+                        col_time TIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime_nokey, col_time_nokey)) STORED not null,
+
+                        col_datetime_key DATETIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime, col_time_nokey)) VIRTUAL not null,
+                        col_time_key TIME GENERATED ALWAYS AS
+(ADDTIME(col_datetime_nokey, col_time)) VIRTUAL not null,
+
+                        col_varchar_nokey VARCHAR(1) /*! NULL */,
+                        col_varchar VARCHAR(2) GENERATED ALWAYS AS
+(CONCAT(col_varchar_nokey,col_varchar_nokey)) STORED not null,
+                        col_varchar_key VARCHAR(2) GENERATED ALWAYS AS
+(CONCAT(col_varchar, 'x')) VIRTUAL not null,
+
+                        unique KEY (pk,col_int_key),
+                        KEY(col_int),
+                        KEY(col_date),
+                        KEY(col_datetime),
+                        KEY(col_time),
+                        KEY(col_varchar),
+                        UNIQUE KEY (col_int_key),
+                        KEY (col_time_key),
+                        KEY (col_datetime_key),
+                        UNIQUE KEY (col_int_key, col_varchar_key),
+                        KEY (col_int_key, col_int_nokey),
+                        KEY(col_int_key,col_date_key),
+                        KEY(col_int_key, col_time_key),
+                        KEY(col_int_key, col_datetime_key),
+                        KEY(col_date_key,col_time_key,col_datetime_key),
+                        KEY (col_varchar_key, col_varchar_nokey),
+                        UNIQUE KEY (col_int_key, col_varchar_key,
+col_date_key, col_time_key, col_datetime_key)
+                )  AUTO_INCREMENT=10 ENGINE=RocksDB PARTITION BY
+KEY(col_int_key) PARTITIONS 3;
+
+ALTER TABLE t DROP COLUMN `pk`;
+
+SHOW CREATE TABLE t;
+
+DROP TABLE t;
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+INSERT INTO t VALUES (null, null, DEFAULT, 'mm');
+
+--error ER_ALTER_OPERATION_NOT_SUPPORTED
+ALTER TABLE t ADD COLUMN xs INT GENERATED ALWAYS AS(a+b), ADD COLUMN mm INT
+GENERATED ALWAYS AS(a+b) STORED, ALGORITHM = INPLACE;
+
+ALTER TABLE t ADD COLUMN x INT GENERATED ALWAYS AS(a+b);
+
+ALTER TABLE t DROP COLUMN x;
+
+ALTER TABLE t ADD COLUMN x1 INT GENERATED ALWAYS AS(a+b), DROP COLUMN c;
+
+DROP TABLE t;
+
+CREATE TABLE t (a INT GENERATED ALWAYS AS(1) VIRTUAL,KEY(a)) ENGINE=RocksDB;
+INSERT INTO t VALUES(default);
+SELECT a FROM t FOR UPDATE;
+DROP TABLE t;
+
+# Test add virtual column and add index at the same time
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, 'mm');
+
+INSERT INTO t VALUES (18, 1, DEFAULT, 'mm');
+
+INSERT INTO t VALUES (28, 1, DEFAULT, 'mm');
+
+INSERT INTO t VALUES (null, null, DEFAULT, 'mm');
+
+--enable_info
+ALTER TABLE t ADD COLUMN x INT GENERATED ALWAYS AS(a+b), ADD INDEX idx (x);
+--disable_info
+
+SELECT x FROM t;
+
+DROP TABLE t;
+
+CREATE TABLE t1 (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10)) ENGINE=RocksDB;
+
+INSERT INTO t1 VALUES (11, 3, DEFAULT, 'mm');
+
+INSERT INTO t1 VALUES (18, 1, DEFAULT, 'mm');
+
+INSERT INTO t1 VALUES (28, 1, DEFAULT, 'mm');
+
+ALTER TABLE t1 ADD INDEX idx12 (c) , FORCE;
+ALTER TABLE t1 DROP COLUMN h,  ADD INDEX idx (c) , FORCE;
+
+DROP TABLE t1 ;
+
+# Bug 21941320 - GCOLS: FAILING ASSERTION: N_IDX > 0
+create table t(a int) engine=RocksDB;
+insert into t set a=1;
+alter table t add column c int generated always as (1) virtual;
+insert into t set a=2;
+
+# Following will cause create index fail, we need to make sure the column
+# ord_part is reset
+--error ER_DUP_ENTRY
+alter table t add unique index(c);
+insert into t set a=1;
+drop table t;
+
+# Bug 21875974 - VCOL : READ OF FREED MEMORY IN DTUPLE_GET_N_FIELDS
+# CAUSE CRASH
+
+create table t (
+  x int,
+  a int generated always as (x) virtual not null,
+  b int generated always as (1) stored,
+  c int not null,
+  unique (b),
+  unique (a,b)
+) engine=RocksDB;
+
+insert into t(x, c) values(1, 3);
+
+# This will exercise row_vers_impl_x_locked_low() for virtual columns
+replace into t(x, c) values(1, 0);
+
+drop table t;
+
+# Bug22111464	VCOL:INNODB: FAILING ASSERTION: I < TABLE->N_DEF
+
+CREATE TABLE `t` (
+  `col1` int(11) DEFAULT NULL,
+  `col2` int(11) DEFAULT NULL,
+  `col4` int(11) DEFAULT NULL,
+  `col5` int(11) GENERATED ALWAYS AS ((`col2` % `col4`)) VIRTUAL,
+  `col6` int(11) GENERATED ALWAYS AS ((`col2` - `col2`)) VIRTUAL,
+  `col5x` int(11) GENERATED ALWAYS AS ((`col1` / `col1`)) VIRTUAL,
+  `col6x` int(11) GENERATED ALWAYS AS ((`col2` / `col4`)) VIRTUAL,
+  `col7x` int(11) GENERATED ALWAYS AS ((`col6` % `col6x`)) VIRTUAL,
+  `col8x` int(11) GENERATED ALWAYS AS ((`col6` / `col6`)) VIRTUAL,
+  `col9` text,
+  `col7c` int(11) GENERATED ALWAYS AS ((`col6x` % `col6x`)) VIRTUAL,
+  `col1b` varchar(20) GENERATED ALWAYS AS (`col1`) VIRTUAL,
+  `col3` int(11) DEFAULT NULL,
+  `col7` int(11) DEFAULT NULL,
+  `col5c` int(11) GENERATED ALWAYS AS ((`col5x` * `col6`)) VIRTUAL,
+  `col6c` varchar(20) GENERATED ALWAYS AS (`col5x`) VIRTUAL,
+  `col3b` bigint(20) GENERATED ALWAYS AS ((`col6x` * `col6`)) VIRTUAL,
+  `col1a` varchar(20) GENERATED ALWAYS AS (`col1`) VIRTUAL,
+  `col8` int(11) DEFAULT NULL,
+  UNIQUE KEY `col5` (`col5`),
+  UNIQUE KEY `col6x` (`col6x`),
+  UNIQUE KEY `col5_2` (`col5`),
+  KEY `idx2` (`col9`(10)),
+  KEY `idx4` (`col2`),
+  KEY `idx8` (`col9`(10),`col5`),
+  KEY `idx9` (`col6`),
+  KEY `idx6` (`col6`)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+
+ALTER TABLE t CHANGE COLUMN col3b col8a BIGINT GENERATED ALWAYS AS
+(col6x * col6) VIRTUAL, ADD UNIQUE KEY uidx ( col8a );
+
+DROP TABLE t;
+
+--echo #
+--echo # Bug 22141031 - GCOLS: PURGED THREAD DIES: TRIED TO PURGE
+--echo # NON-DELETE-MARKED RECORD IN INDEX
+--echo #
+create table t (
+  a int,b int,c text,d int,e int,f int,g int,
+  h text generated always as ('1') virtual,
+  i int,j int,k int,l int,m int,
+  primary key (c(1)),unique key (c(1)),
+  key (i),key (h(1))
+) engine=RocksDB default charset latin1;
+
+replace into t(c) values ('');
+replace into t(c) values ('');
+alter table t drop column d ;
+
+drop table t;
+
+--echo #
+--echo # Bug 22139917 - ASSERTION: DICT_TABLE_GET_NTH_COL(USER_TABLE, NTH_COL)
+--echo # ->LEN < NEW_LEN
+--echo #
+
+create table t (
+  a int generated always as (1) virtual,
+  b varbinary(1),
+  c varbinary(1) generated always as (b) virtual
+) engine=RocksDB;
+alter table t change column b b varbinary(2);
+alter table t change column c c varbinary(2) generated always as (b) virtual;
+
+drop table t;
+
+# Bug22202788	GCOL:ASSERTION:0 IN ROW_SEL_GET_CLUST_REC_FOR_MYSQL AT
+# ROW0SEL.CC
+SET @@SESSION.sql_mode=0;
+
+CREATE TABLE t(
+	c1 INT AUTO_INCREMENT,
+	c2 INT,
+	c3 INT GENERATED ALWAYS AS(c2 + c2)VIRTUAL,
+	c3k INT GENERATED ALWAYS AS(c2 + c3)VIRTUAL,
+	c4 DATE,
+	c5 DATE GENERATED ALWAYS AS(DATE_ADD(c4,interval 30 day)) VIRTUAL,
+	c5k DATE GENERATED ALWAYS AS(DATE_ADD(c4,interval 30 day)) VIRTUAL,
+	c5time_gckey DATE,
+	c6 TIME,
+	c5time DATE GENERATED ALWAYS AS(ADDTIME(c5time_gckey,c6)) VIRTUAL,
+	c7 TIME GENERATED ALWAYS AS(ADDTIME(c5time_gckey,c6)) VIRTUAL,
+	c5timek DATE GENERATED ALWAYS AS(ADDTIME(c5time_gckey,c7)) VIRTUAL,
+	c7k TIME GENERATED ALWAYS AS(ADDTIME(c5time,c6)) VIRTUAL,
+	c8 CHAR(10),
+	c9 CHAR(20)GENERATED ALWAYS AS (CONCAT(c8,c8)) VIRTUAL,
+	c9k CHAR(15)GENERATED ALWAYS AS (CONCAT(c8,0)) VIRTUAL,
+	PRIMARY KEY(c1),
+	KEY(c3),
+	KEY(c9(10)),
+	UNIQUE KEY(c9k),
+	UNIQUE KEY(c3k,c9k(5),c5k,c7k,c5timek,c3,c9(5),c5,c7,c5time)
+)ENGINE=RocksDB;
+
+--error ER_DUP_ENTRY
+INSERT INTO
+t(c2,c4,c6,c5time_gckey,c8)VALUES(1,0,0,0,0),(0,0,0,0,'ityzg'),(0,0,1,0,'tyzgk
+t'),(0,1,0,1,'yzgktb'),(0,0,0,0,'zgktb'),(0,0,0,0,'gktbkj'),(0,0,0,0,0),(0,0,1
+,0,1),(0,0,0,0,1),(0,0,0,0,'tbkjrkm'),(0,0,0,0,'bkjr'),(0,0,0,0,0),(0,0,0,0,0)
+,(0,0,0,0,'rk'),(0,0,0,0,'kmqmknbtoe'),(1,0,0,0,'mqmknbt'),(0,1,0,0,'qmknb'),(
+0,0,0,0,'mkn'),(0,0,0,0,'knbtoervql'),(0,0,1,0,1),(0,0,0,0,'nbtoerv'),(0,0,0,0
+,'btoerv'),(0,0,1,0,'toer'),(1,0,0,0,0),(0,0,0,0,'ervq'),(0,0,0,0,'rvqlzsvasu'
+),(0,0,0,0,'vqlzs'),(0,0,0,0,0),(0,1,0,0,'lzsvasu'),(0,0,0,0,'zsvasurq');
+
+SELECT
+DISTINCT * FROM t
+FORCE KEY(PRIMARY,c3k,c3,c9k,c9)
+WHERE
+(c9 IS NULL AND (c9=0))
+OR(
+(c9k NOT IN ('ixfq','xfq','New Mexico','fq')OR c9 IS NULL)
+)
+OR(c9 BETWEEN 'hwstqua' AND 'wstquadcji' OR (c9k=0))
+AND(c3 IS NULL OR c3 IN (0,0,0));
+
+drop table t;
+
+#
+# BUG#22082762 RE-ENABLE SUPPORT FOR ADDING VIRTUAL INDEX WHILE DROPPING VIRTUAL COLUMN
+#
+
+CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), d INT
+GENERATED ALWAYS AS(a+b+b), e INT  GENERATED ALWAYS AS(a), h VARCHAR(10)) ENGINE=RocksDB;
+
+INSERT INTO t VALUES (11, 3, DEFAULT, DEFAULT, DEFAULT, 'mm');
+INSERT INTO t VALUES (18, 1, DEFAULT, DEFAULT, DEFAULT, 'mm');
+INSERT INTO t VALUES (28, 1, DEFAULT, DEFAULT, DEFAULT, 'mm');
+INSERT INTO t VALUES (null, null, DEFAULT, DEFAULT, DEFAULT, 'mm');
+CREATE INDEX idx ON t(c, d);
+CREATE INDEX idx1 ON t(c);
+CREATE INDEX idx2 ON t(e, c, d);
+
+# This will drop column c, drop index idx1 on column c, and build index
+# idx and idx2, so they become idx(d) and idx2(e, d) respectively.
+ALTER TABLE t DROP COLUMN c;
+
+SELECT d FROM t;
+
+SHOW CREATE TABLE t;
+
+# Add an index on existing column along with dropping a column is allowed
+ALTER TABLE t DROP COLUMN d, ADD COLUMN c INT GENERATED ALWAYS AS(a+b), ADD INDEX idx (e);
+SHOW CREATE TABLE t;
+
+# Add an index on existing column along with adding a virtual column and droping a virtual index
+ALTER TABLE t ADD INDEX idx4(c, e), ADD COLUMN x VARCHAR(10) GENERATED ALWAYS AS(h), DROP INDEX idx;
+SHOW CREATE TABLE t;
+
+# With instant ADD COLUMN, adding a regular column along with virtual column is allowed
+ALTER TABLE t ADD COLUMN i INT GENERATED ALWAYS AS(a+a+b), ADD COLUMN j INT;
+
+# Add an index along with adding a regular column is allowed.
+ALTER TABLE t ADD INDEX (x), ADD COLUMN k INT;
+SHOW CREATE TABLE t;
+
+ALTER TABLE t ADD COLUMN l INT GENERATED ALWAYS AS(a+a+b), ADD INDEX (l);
+SHOW CREATE TABLE t;
+
+SELECT l FROM t;
+
+SELECT * FROM t;
+
+DROP TABLE t;
+
+#
+# BUG#22469459 WRONG VALUES IN ADDED INDEX WHILE DROPPING VIRTUAL COLUMN
+#
+
+# Drop column with existing index on it.
+CREATE TABLE t (
+  a INT,
+  b INT,
+  c INT GENERATED ALWAYS AS(a+b),
+  d INT GENERATED ALWAYS AS(a+b+b),
+  KEY vidx (c, d)
+)ENGINE=RocksDB;
+
+INSERT INTO t (a,b) VALUES (0, 0), (1, NULL), (NULL, 2), (NULL, NULL);
+
+SELECT c, d FROM t;
+
+SELECT * FROM t;
+
+ALTER TABLE t DROP COLUMN c;
+
+SELECT d FROM t;
+
+SELECT * FROM t;
+
+DROP TABLE t;
+
+# Drop column with a new index.
+CREATE TABLE t (
+  a INT,
+  b INT,
+  c INT GENERATED ALWAYS AS(a+b),
+  d INT GENERATED ALWAYS AS(a+b+b)
+)ENGINE=RocksDB;
+
+INSERT INTO t (a,b) VALUES (0, 0), (1, NULL), (NULL, 2), (NULL, NULL);
+
+SELECT * FROM t;
+
+ALTER TABLE t DROP COLUMN c, ADD INDEX vidx(d);
+
+SELECT d FROM t;
+
+SELECT * FROM t;
+
+DROP TABLE t;
+
+--echo #
+--echo # Bug #22162200 MEMORY LEAK IN HA_INNOPART_SHARE
+--echo # ::SET_V_TEMPL PARTITIONED ON VIRTUAL COLUMN
+--echo #
+create table t (
+  c tinyint,
+  d longblob generated always as (c) virtual
+) engine=RocksDB partition by key (c) partitions 2;
+
+select d in(select d from t)from t group by d;
+drop table t;
+
+--echo #
+--echo # BUG#23052231 - ASSERTION FAILURE: ROW0MERGE.CC:2100:ADD_AUTOINC
+--echo # < DICT_TABLE_GET_N_USER_COLS
+--echo #
+CREATE TABLE `t` (
+  `a` int(11) NOT NULL,
+  `d` int(11) NOT NULL,
+  `b` varchar(198) NOT NULL,
+  `c` char(177) DEFAULT NULL,
+  `vadcol` int(11) GENERATED ALWAYS AS ((`a` + length(`d`))) STORED,
+  `vbcol` char(2) GENERATED ALWAYS AS (substr(`b`,2,2)) VIRTUAL,
+  `vbidxcol` char(3) GENERATED ALWAYS AS (substr(`b`,1,3)) VIRTUAL,
+  PRIMARY KEY (`b`(10),`a`,`d`),
+  KEY `d` (`d`),
+  KEY `a` (`a`),
+  KEY `c_renamed` (`c`(99),`b`(35)),
+  KEY `b` (`b`(5),`c`(10),`a`),
+  KEY `vbidxcol` (`vbidxcol`),
+  KEY `a_2` (`a`,`vbidxcol`),
+  KEY `vbidxcol_2` (`vbidxcol`,`d`)
+) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+
+INSERT INTO t values (11, 1, "11", "aa", default, default, default);
+
+ALTER TABLE t ADD COLUMN nc01128 BIGINT  AUTO_INCREMENT NOT NULL, ADD KEY auto_nc01128(nc01128);
+
+DROP TABLE t;
+--source include/wait_until_count_sessions.inc
+
+--echo #
+--echo #Bug #22965271 NEEDS REBUILD FOR COLUMN LENGTH CHANGE THAT IS
+--echo #PART OF VIRTUAL INDEX.
+--echo #
+
+CREATE TABLE t1(
+a VARCHAR(45) CHARACTER SET LATIN1,
+b VARCHAR(115) CHARACTER SET UTF8 GENERATED ALWAYS AS ('f1') VIRTUAL,
+UNIQUE KEY (b,a))ENGINE=RocksDB;
+INSERT INTO t1(a) VALUES ('');
+ALTER TABLE t1 CHANGE COLUMN a a VARCHAR(85);
+SELECT * FROM t1;
+DROP TABLE t1;
+
+
+--echo #
+--echo # BUG#27712812 - ALTER TABLE TO ADD AND(OR) DROP VIRTUAL COLUMNS SHOULD BE INSTANT
+--echo #
+
+CREATE TABLE t1 (a INT NOT NULL AUTO_INCREMENT PRIMARY KEY, b INT) ENGINE=RocksDB;
+
+INSERT INTO t1 VALUES(0, 1), (0, 2), (0, 3), (0, 4), (0, 5);
+
+ALTER TABLE t1 ADD COLUMN c INT NOT NULL, ADD COLUMN d INT GENERATED ALWAYS AS ((b * 2)) VIRTUAL;
+ALTER TABLE t1 ADD COLUMN e INT GENERATED ALWAYS AS ((b * 2)) VIRTUAL;
+
+DROP TABLE t1;
+
+
+--echo #
+--echo # BUG#27755892 - CRASH IN ROW_SEL_FIELD_STORE_IN_MYSQL_FORMAT_FUNC
+--echo #
+
+CREATE TABLE t1 (b DATE, c CHAR(100) CHARACTER SET utf32 GENERATED ALWAYS AS (concat(1, b, 1)) VIRTUAL, UNIQUE KEY(c(16))) ENGINE=RocksDB;
+
+INSERT INTO t1(b) VALUES('2018-04-01');
+
+SELECT c LIKE 1 FROM t1;
+
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/virtual_index.test
+++ b/mysql-test/suite/rocksdb/t/virtual_index.test
@@ -1,0 +1,117 @@
+--source include/have_rocksdb.inc
+--echo #
+--echo # Bug 21922176 - PREBUILT->SEARCH_TUPLE CREATED WITHOUT INCLUDING
+--echo # THE NUMBER OF VIRTUAL COLUMNS
+--echo #
+
+CREATE TABLE t1 (a INT, a1 INT GENERATED ALWAYS AS (a) VIRTUAL, a2 INT
+GENERATED ALWAYS AS (a) VIRTUAL, a3 INT GENERATED ALWAYS AS (a) VIRTUAL, a4
+INT GENERATED ALWAYS AS (a) VIRTUAL, a5 INT GENERATED ALWAYS AS (a) VIRTUAL,
+a6 INT GENERATED ALWAYS AS (a) VIRTUAL, a7 INT GENERATED ALWAYS AS (a)
+VIRTUAL, a8 INT GENERATED ALWAYS AS (a) VIRTUAL, a9 INT GENERATED ALWAYS AS
+(a) VIRTUAL, INDEX(a1, a2, a3, a4, a5, a6, a7, a8, a9)) ENGINE=RocksDB;
+
+INSERT INTO t1(a) VALUES(10);
+
+SELECT * FROM t1 WHERE a1=10 AND a2 = 10 AND a3 =10 AND a4 = 10 AND a5=10 AND
+a6=10 AND a7=10 AND a8=10 AND a9=10;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Bug 23014521 - GCOL:INNODB: FAILING ASSERTION: !IS_V
+--echo #
+CREATE TABLE t1 (
+     col1 int NOT NULL,
+     col2 int DEFAULT NULL,
+     col3 int NOT NULL,
+     col4 int DEFAULT NULL,
+     col5 int GENERATED ALWAYS AS ((col1 % col4)) VIRTUAL,
+     col6 int GENERATED ALWAYS AS ((col2 - col4)) VIRTUAL,
+     col5x int GENERATED ALWAYS AS ((col3 / col2)) VIRTUAL,
+     col6b varchar(20) GENERATED ALWAYS AS (col2) VIRTUAL,
+     col6x int GENERATED ALWAYS AS ((col2 % col1)) VIRTUAL,
+     col7 int GENERATED ALWAYS AS ((col6x + col5x)) VIRTUAL,
+     col8 int GENERATED ALWAYS AS ((col5x / col5)) VIRTUAL,
+     col7x int GENERATED ALWAYS AS ((col5x + col5)) VIRTUAL,
+     col8x int GENERATED ALWAYS AS ((col5 / col5x)) VIRTUAL,
+     col9 text,
+     col2b varchar(20) GENERATED ALWAYS AS (col4) VIRTUAL,
+     col8a int GENERATED ALWAYS AS (col2) VIRTUAL,
+     col4b varchar(20) GENERATED ALWAYS AS (col4) VIRTUAL,
+     col1c int GENERATED ALWAYS AS ((col2 * col1)) VIRTUAL,
+     extra int DEFAULT NULL,
+     col5c int GENERATED ALWAYS AS ((col1 / col1)) VIRTUAL,
+     col6a bigint GENERATED ALWAYS AS ((col3 / col1)) VIRTUAL,
+     col1a varchar(20) GENERATED ALWAYS AS (col6) VIRTUAL,
+     col6c int GENERATED ALWAYS AS ((col2 % col2)) VIRTUAL,
+     col7c bigint GENERATED ALWAYS AS ((col2 / col1)) VIRTUAL,
+     col2c int GENERATED ALWAYS AS ((col5 % col5)) VIRTUAL,
+     col1b int GENERATED ALWAYS AS ((col1 / col2)) VIRTUAL,
+     col3b bigint GENERATED ALWAYS AS ((col6x % col6)) VIRTUAL,
+     UNIQUE KEY idx7 (col1,col3,col2),
+     UNIQUE KEY uidx (col9(10)),
+     KEY idx15 (col9(10),col2),
+     KEY idx10 (col9(10),col1),
+     KEY idx11 (col6x),
+     KEY idx6 (col9(10),col7),
+     KEY idx14 (col6)
+   ) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (
+	col1 int NOT NULL,
+	col2 int DEFAULT NULL,
+	col3 int NOT NULL,
+	col4 int DEFAULT NULL) ENGINE=RocksDB;
+
+ALTER TABLE t1 ADD COLUMN col7a INT GENERATED ALWAYS AS (col1 % col2)
+VIRTUAL, ADD UNIQUE index idx (col1);
+
+DROP TABLE t1;
+
+CREATE TABLE t1 (
+     col1 int NOT NULL,
+     col2 int DEFAULT NULL,
+     col3 int NOT NULL,
+     col4 int DEFAULT NULL,
+     col5 int GENERATED ALWAYS AS ((col2 - col4)) VIRTUAL,
+     col6 int GENERATED ALWAYS AS ((col5 + col1)) VIRTUAL,
+     col7 bigint GENERATED ALWAYS AS ((col2 / col1)) VIRTUAL,
+     col8 int GENERATED ALWAYS AS ((col5 % col5)) VIRTUAL,
+     col9 text,
+     KEY idx1 (col5),
+     KEY idx2 (col6)
+   ) ENGINE=RocksDB DEFAULT CHARSET=latin1;
+SHOW CREATE TABLE t1;
+CHECK TABLE t1;
+
+INSERT INTO t1(col1, col2, col3, col4, col9) VALUES (10, 50, 40, 300, "lope");
+INSERT INTO t1(col1, col2, col3, col4, col9) VALUES (100, 3240, 4000, 11, "dskf");
+INSERT INTO t1(col1, col2, col3, col4, col9) VALUES (5, 400, 20, 900, "hqal");
+
+SELECT * FROM t1;
+SELECT col5 FROM t1;
+SELECT col6 FROM t1;
+
+SELECT col7 FROM t1;
+ALTER TABLE t1 ADD INDEX idx3 (col7);
+CHECK TABLE t1;
+SELECT col7 FROM t1;
+
+SELECT col7 FROM t1;
+ALTER TABLE t1 DROP INDEX idx3, ADD INDEX idx3 (col7 ASC);
+CHECK TABLE t1;
+SELECT col7 FROM t1;
+
+DROP TABLE t1;
+
+--echo #
+--echo # Bug 25899959 - SERVER CRASH WHILE TRYING TO ADD A VIRTUAL COLUMN AND ADD INDEX ON IT
+--echo #
+
+CREATE TABLE t1 (doc json DEFAULT NULL) ENGINE=RocksDB;
+ALTER TABLE t1 ADD Name char(52) AS (doc->>"$.Name"), ADD INDEX n (Name);
+SHOW CREATE TABLE t1;
+
+DROP TABLE t1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8841,6 +8841,12 @@ int ha_rocksdb::get_row_by_rowid(uchar *const buf, const char *const rowid,
 
     m_last_rowkey.copy((const char *)rowid, rowid_size, &my_charset_bin);
     rc = convert_record_from_storage_format(&key_slice, buf);
+
+    if (rc) {
+      DBUG_RETURN(rc);
+    }
+
+    rc = fill_virtual_columns();
   } else {
     /*
       Note: we don't need to unlock the row. It is intentional that we keep
@@ -12742,6 +12748,32 @@ bool ha_rocksdb::inplace_alter_table(
   DBUG_RETURN(HA_EXIT_SUCCESS);
 }
 
+int ha_rocksdb::fill_virtual_columns() {
+  /* Specify the columns the server should evaluate */
+  MY_BITMAP column_map;
+  bool bitmap_inited = false;
+  my_bitmap_map col_map_storage[bitmap_buffer_size(1023)];
+  for (uint i = 0; i < table->s->fields; i++) {
+    auto &field = table->field[i];
+    if (field->is_virtual_gcol()) {
+      if (!bitmap_inited) {
+        bitmap_init(&column_map, col_map_storage, 1023);
+        bitmap_inited = true;
+      }
+      bitmap_set_bit(&column_map, i);
+    }
+  }
+  if (bitmap_inited) {
+    THD *const thd = my_core::thd_get_current_thd();
+    int ret = handler::my_eval_gcolumn_expr(
+        thd, const_cast<TABLE *>(table), &column_map,
+        const_cast<uchar *>(table->record[0]), nullptr, nullptr);
+
+    return ret;
+  }
+  return 0;
+}
+
 /**
  Scan the Primary Key index entries and populate the new secondary keys.
 */
@@ -12873,6 +12905,11 @@ int ha_rocksdb::inplace_populate_sk(
       if (hidden_pk_exists &&
           (res = read_hidden_pk_id_from_rowkey(&hidden_pk_id))) {
         LogPluginErrMsg(ERROR_LEVEL, 0, "Error retrieving hidden pk id.");
+        ha_index_end();
+        DBUG_RETURN(res);
+      }
+
+      if ((res = fill_virtual_columns())) {
         ha_index_end();
         DBUG_RETURN(res);
       }

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -355,6 +355,8 @@ class ha_rocksdb : public my_core::handler {
                                  const rocksdb::Slice &key,
                                  rocksdb::PinnableSlice *value) const;
 
+  int fill_virtual_columns();
+
   int get_row_by_rowid(uchar *const buf, const char *const rowid,
                        const uint rowid_size, const bool skip_ttl_check = true,
                        const bool skip_lookup = false)
@@ -466,7 +468,8 @@ class ha_rocksdb : public my_core::handler {
                 HA_CAN_INDEX_BLOBS |
                 (m_pk_can_be_decoded ? HA_PRIMARY_KEY_IN_READ_INDEX : 0) |
                 HA_PRIMARY_KEY_REQUIRED_FOR_POSITION | HA_NULL_IN_KEY |
-                HA_PARTIAL_COLUMN_READ | HA_ONLINE_ANALYZE);
+                HA_PARTIAL_COLUMN_READ | HA_ONLINE_ANALYZE |
+                HA_GENERATED_COLUMNS | HA_CAN_INDEX_VIRTUAL_GENERATED_COLUMN);
   }
 
   bool init_with_fields() override;


### PR DESCRIPTION
This commit adds indexed virtual commit support to MyRocks, along with
tests adapted from the innodb suite. Parts of the tests which relied on
features not supported by MyRocks (inplace alter, fulltext, spatial)
were removed, and parts that failed because of gap lock issues were
modifed.