### PR TITLE
PMM-7137: Fix appending of the Tmp_tables* to the slowlog

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -776,7 +776,7 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
             " Sort_rows: %lu Sort_scan_count: %lu"
             " Created_tmp_disk_tables: %lu"
             " Created_tmp_tables: %lu"
-            " Start: %s End: %s Schema: %s Rows_affected: %llu\n",
+            " Start: %s End: %s Schema: %s Rows_affected: %llu",
             query_time_buff, lock_time_buff, (ulong)thd->get_sent_row_count(),
             (ulong)thd->get_examined_row_count(), (ulong)thd->thread_id(),
             (ulong)(thd->is_classic_protocol()


### PR DESCRIPTION
```
  Tmp_tables: %lu  Tmp_disk_tables: %lu  "
                    "Tmp_table_sizes: %llu
``` 
appended to the slowlog without a `#` sign.

As I can observe, some previous implementation worked since there was no `\n` symbol at the end: https://github.com/percona/percona-server/blob/35365ef8f59216adcca579ec901a8e60f07f180e/sql/log.cc#L724
but then `else` case added with `\n` in the end:  https://github.com/percona/percona-server/blob/ac6ab47e4a6662a64ea5fb2dba0aa18ce5867925/sql/log.cc#L774