### PR TITLE
PS-1956: Adjust datatype for some timers used for extended slow query log (5.6)

### DIFF
--- a/include/mysql/plugin.h
+++ b/include/mysql/plugin.h
@@ -587,9 +587,9 @@ void increment_thd_innodb_stats(MYSQL_THD thd,
                     unsigned long long trx_id,
                     long io_reads,
                     long long io_read,
-                    long io_reads_wait_timer,
-                    long lock_que_wait_timer,
-                    long que_wait_timer,
+                    uint64_t io_reads_wait_timer,
+                    uint64_t lock_que_wait_timer,
+                    uint64_t que_wait_timer,
                     long page_access);
 unsigned long thd_log_slow_verbosity(const MYSQL_THD thd);
 int thd_opt_slow_log();

--- a/include/mysql/plugin_audit.h.pp
+++ b/include/mysql/plugin_audit.h.pp
@@ -239,9 +239,9 @@ void increment_thd_innodb_stats(void* thd,
                     unsigned long long trx_id,
                     long io_reads,
                     long long io_read,
-                    long io_reads_wait_timer,
-                    long lock_que_wait_timer,
-                    long que_wait_timer,
+                    uint64_t io_reads_wait_timer,
+                    uint64_t lock_que_wait_timer,
+                    uint64_t que_wait_timer,
                     long page_access);
 unsigned long thd_log_slow_verbosity(const void* thd);
 int thd_opt_slow_log();

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -239,9 +239,9 @@ void increment_thd_innodb_stats(void* thd,
                     unsigned long long trx_id,
                     long io_reads,
                     long long io_read,
-                    long io_reads_wait_timer,
-                    long lock_que_wait_timer,
-                    long que_wait_timer,
+                    uint64_t io_reads_wait_timer,
+                    uint64_t lock_que_wait_timer,
+                    uint64_t que_wait_timer,
                     long page_access);
 unsigned long thd_log_slow_verbosity(const void* thd);
 int thd_opt_slow_log();

--- a/include/mysql/plugin_ftparser.h.pp
+++ b/include/mysql/plugin_ftparser.h.pp
@@ -192,9 +192,9 @@ void increment_thd_innodb_stats(void* thd,
                     unsigned long long trx_id,
                     long io_reads,
                     long long io_read,
-                    long io_reads_wait_timer,
-                    long lock_que_wait_timer,
-                    long que_wait_timer,
+                    uint64_t io_reads_wait_timer,
+                    uint64_t lock_que_wait_timer,
+                    uint64_t que_wait_timer,
                     long page_access);
 unsigned long thd_log_slow_verbosity(const void* thd);
 int thd_opt_slow_log();

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -745,11 +745,11 @@ extern "C"
 void increment_thd_innodb_stats(THD* thd,
                                 unsigned long long trx_id,
                                 long io_reads,
-                                long long  io_read,
-                                long      io_reads_wait_timer,
-                                long      lock_que_wait_timer,
-                                long      que_wait_timer,
-                                long      page_access)
+                                long long io_read,
+                                uint64_t io_reads_wait_timer,
+                                uint64_t lock_que_wait_timer,
+                                uint64_t que_wait_timer,
+                                long page_access)
 {
   thd->innodb_was_used=               TRUE;
   thd->innodb_trx_id=                 trx_id;

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -621,9 +621,9 @@ typedef struct system_variables
 
   ulong      innodb_io_reads;
   ulonglong  innodb_io_read;
-  ulong      innodb_io_reads_wait_timer;
-  ulong      innodb_lock_que_wait_timer;
-  ulong      innodb_innodb_que_wait_timer;
+  uint64_t   innodb_io_reads_wait_timer;
+  uint64_t   innodb_lock_que_wait_timer;
+  uint64_t   innodb_innodb_que_wait_timer;
   ulong      innodb_page_access;
 
   double long_query_time_double;
@@ -1901,9 +1901,9 @@ public:
   bool       innodb_was_used;
   ulong      innodb_io_reads;
   ulonglong  innodb_io_read;
-  ulong      innodb_io_reads_wait_timer;
-  ulong      innodb_lock_que_wait_timer;
-  ulong      innodb_innodb_que_wait_timer;
+  uint64_t   innodb_io_reads_wait_timer;
+  uint64_t   innodb_lock_que_wait_timer;
+  uint64_t   innodb_innodb_que_wait_timer;
   ulong      innodb_page_access;
 
   ulong      query_plan_flags;
@@ -2494,9 +2494,9 @@ public:
   ulonglong  innodb_trx_id;
   ulong      innodb_io_reads;
   ulonglong  innodb_io_read;
-  ulong      innodb_io_reads_wait_timer;
-  ulong      innodb_lock_que_wait_timer;
-  ulong      innodb_innodb_que_wait_timer;
+  uint64_t   innodb_io_reads_wait_timer;
+  uint64_t   innodb_lock_que_wait_timer;
+  uint64_t   innodb_innodb_que_wait_timer;
   ulong      innodb_page_access;
 
   /*

--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -2327,7 +2327,7 @@ got_block:
 		{
 			ut_usectime(&sec, &ms);
 			finish_time = (ib_uint64_t)sec * 1000000 + ms;
-			trx->io_reads_wait_timer += (ulint)(finish_time - start_time);
+			trx->io_reads_wait_timer += finish_time - start_time;
 		}
 	}
 
@@ -2696,8 +2696,7 @@ buf_wait_for_read(buf_block_t* block, trx_t* trx)
 			ut_usectime(&sec, &ms);
 			ib_uint64_t finish_time
 				= (ib_uint64_t)sec * 1000000 + ms;
-			trx->io_reads_wait_timer
-				+= (ulint)(finish_time - start_time);
+			trx->io_reads_wait_timer += finish_time - start_time;
 		}
 
 	}

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -1053,11 +1053,11 @@ struct trx_t{
 	/*------------------------------*/
 	ulint		io_reads;
 	ib_uint64_t	io_read;
-	ulint		io_reads_wait_timer;
+	uint64_t    io_reads_wait_timer;
 	ib_uint64_t	lock_que_wait_ustarted;
-	ulint           lock_que_wait_timer;
-	ulint           innodb_que_wait_timer;
-	ulint           distinct_page_access;
+	uint64_t    lock_que_wait_timer;
+	uint64_t    innodb_que_wait_timer;
+	ulint       distinct_page_access;
 #define	DPAH_SIZE	8192
 	byte*		distinct_page_access_hash;
 	ibool		take_stats;

--- a/storage/innobase/os/os0file.cc
+++ b/storage/innobase/os/os0file.cc
@@ -2655,7 +2655,7 @@ os_file_pread(
 	{
 		ut_usectime(&sec, &ms);
 		finish_time = (ib_uint64_t)sec * 1000000 + ms;
-		trx->io_reads_wait_timer += (ulint)(finish_time - start_time);
+		trx->io_reads_wait_timer += finish_time - start_time;
 	}
 
 	return(n_bytes);
@@ -2720,7 +2720,7 @@ os_file_pread(
 		{
 			ut_usectime(&sec, &ms);
 			finish_time = (ib_uint64_t)sec * 1000000 + ms;
-			trx->io_reads_wait_timer += (ulint)(finish_time - start_time);
+			trx->io_reads_wait_timer += finish_time - start_time;
 		}
 
 		return(ret);

--- a/storage/innobase/que/que0que.cc
+++ b/storage/innobase/que/que0que.cc
@@ -234,8 +234,7 @@ que_thr_end_lock_wait(
 	if (UNIV_UNLIKELY(trx->take_stats)) {
 		ut_usectime(&sec, &ms);
 		now = (ib_uint64_t)sec * 1000000 + ms;
-		trx->lock_que_wait_timer
-			+= (ulint)(now - trx->lock_que_wait_ustarted);
+		trx->lock_que_wait_timer += now - trx->lock_que_wait_ustarted;
 	}
 
 	trx->lock.que_state = TRX_QUE_RUNNING;

--- a/storage/innobase/srv/srv0conc.cc
+++ b/storage/innobase/srv/srv0conc.cc
@@ -506,7 +506,7 @@ retry:
 	if (UNIV_UNLIKELY(start_time != 0)) {
 		ut_usectime(&sec, &ms);
 		finish_time = (ib_uint64_t)sec * 1000000 + ms;
-		trx->innodb_que_wait_timer += (ulint)(finish_time - start_time);
+		trx->innodb_que_wait_timer += finish_time - start_time;
 	}
 
 	os_fast_mutex_lock(&srv_conc_mutex);

--- a/storage/innobase/trx/trx0trx.cc
+++ b/storage/innobase/trx/trx0trx.cc
@@ -1780,9 +1780,7 @@ trx_commit_or_rollback_prepare(
 			if (UNIV_UNLIKELY(trx->take_stats)) {
 				ut_usectime(&sec, &ms);
 				now = (ib_uint64_t)sec * 1000000 + ms;
-				trx->lock_que_wait_timer
-					+= (ulint)
-					(now - trx->lock_que_wait_ustarted);
+				trx->lock_que_wait_timer += now - trx->lock_que_wait_ustarted;
 			}
 
 			trx->lock.que_state = TRX_QUE_RUNNING;


### PR DESCRIPTION
The ulong and ulint are used for such timers as innodb_io_reads_wait_timer,
innodb_lock_que_wait_timer and innodb_innodb_que_wait_timer. They are
32-bit at some platforms which may be not enough in some cases.
Adjust corresponding datatypes to 64-bit.