### PR TITLE
PS-7410: Auto-detect and set performance-related RocksDB flags (5.7)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/percona/Percona-TokuBackup.git
 [submodule "storage/rocksdb/rocksdb"]
 	path = storage/rocksdb/rocksdb
-	url = https://github.com/percona/rocksdb.git
+	url = https://github.com/facebook/rocksdb.git
 [submodule "storage/rocksdb/third_party/zstd"]
 	path = storage/rocksdb/third_party/zstd
 	url = https://github.com/facebook/zstd

--- a/cmake/compiler_features.cmake
+++ b/cmake/compiler_features.cmake
@@ -1,0 +1,276 @@
+# Copyright (c) 2020, Percona and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+
+# Functions to detect features supported by compiler
+
+include(CheckCXXSourceCompiles)
+
+set(CMAKE_REQUIRED_FLAGS "-msse4.2 --std=c++11 -Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+#include <nmmintrin.h>
+int main() {
+  auto x = _mm_crc32_u32(0, 0);
+}
+" HAVE_SSE42)
+
+
+set(CMAKE_REQUIRED_FLAGS "-mpclmul --std=c++11 -Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+#include <wmmintrin.h>
+int main() {
+  const auto a = _mm_set_epi64x(0, 0);
+  const auto b = _mm_set_epi64x(0, 0);
+  const auto c = _mm_clmulepi64_si128(a, b, 0x00);
+  auto d = _mm_cvtsi128_si64(c);
+}
+" HAVE_PCLMUL)
+
+
+set(CMAKE_REQUIRED_FLAGS "-mavx2 --std=c++11 -Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+#include <immintrin.h>
+int main() {
+  const auto a = _mm256_setr_epi32(0, 1, 2, 3, 4, 7, 6, 5);
+  const auto b = _mm256_permutevar8x32_epi32(a, a);
+}
+" HAVE_AVX2)
+
+
+set(CMAKE_REQUIRED_FLAGS "-mbmi --std=c++11 -Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+#include <immintrin.h>
+#include <cstdint>
+#include <immintrin.h>
+int main(int argc, char *argv[]) {
+  return (int)_tzcnt_u64((uint64_t)argc);
+}
+" HAVE_BMI)
+
+
+set(CMAKE_REQUIRED_FLAGS "-mlzcnt --std=c++11 -Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+#include <immintrin.h>
+int main(int argc, char *argv[]) {
+  return (int)_lzcnt_u64((uint64_t)argc);
+}
+" HAVE_LZCNT)
+
+
+set(CMAKE_REQUIRED_FLAGS "-faligned-new -Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+struct alignas(1024) t {int a;};
+int main() {}
+" HAVE_ALIGNED_NEW)
+
+
+set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+#include <cstdint>
+int main() {
+  uint64_t a = 0xffffFFFFffffFFFF;
+  __uint128_t b = __uint128_t(a) * a;
+  a = static_cast<uint64_t>(b >> 64);
+}
+" HAVE_UINT128_EXTENSION)
+
+
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_LINK_FLAGS} -Wno-error")
+FIND_LIBRARY(URING_LIBRARY NAMES uring)
+IF (URING_LIBRARY)
+	set(CMAKE_REQUIRED_LIBRARIES ${URING_LIBRARY})
+	CHECK_CXX_SOURCE_COMPILES("
+	#include <liburing.h>
+	int main() {
+	  struct io_uring ring;
+	  io_uring_queue_init(1, &ring, 0);
+	  return 0;
+	}
+	" HAVE_URING)
+ENDIF()
+
+
+FIND_LIBRARY(MEMKIND_LIBRARY NAMES memkind)
+IF (MEMKIND_LIBRARY)
+	set(CMAKE_REQUIRED_LIBRARIES ${MEMKIND_LIBRARY})
+	CHECK_CXX_SOURCE_COMPILES("
+	#include <memkind.h>
+	int main() {
+	  memkind_malloc(MEMKIND_DAX_KMEM, 1024);
+	  return 0;
+	}
+	" HAVE_MEMKIND)
+ENDIF()
+
+unset(CMAKE_REQUIRED_LIBRARIES)
+
+
+set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+CHECK_CXX_SOURCE_COMPILES("
+#if defined(_MSC_VER) && !defined(__thread)
+#define __thread __declspec(thread)
+#endif
+int main() {
+  static __thread int tls;
+}
+" HAVE_THREAD_LOCAL)
+
+
+CHECK_CXX_SOURCE_COMPILES("
+#include <fcntl.h>
+#include <linux/falloc.h>
+int main() {
+  int fd = open(\"/dev/null\", 0);
+  fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1024);
+}
+" HAVE_FALLOCATE)
+
+
+CHECK_CXX_SOURCE_COMPILES("
+#include <pthread.h>
+int main() {
+  int x = PTHREAD_MUTEX_ADAPTIVE_NP;
+}
+" HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
+
+
+CHECK_CXX_SOURCE_COMPILES("
+#include <pthread.h>
+#include <execinfo.h>
+int main() {
+  void* frames[1];
+  backtrace_symbols(frames, backtrace(frames, 1));
+  return 0;
+}
+" HAVE_BACKTRACE_SYMBOLS)
+
+
+CHECK_CXX_SOURCE_COMPILES("
+#include <fcntl.h>
+int main() {
+  int fd = open(\"/dev/null\", 0);
+  sync_file_range(fd, 0, 1024, SYNC_FILE_RANGE_WRITE);
+}
+" HAVE_SYNC_FILE_RANGE_WRITE)
+
+unset(CMAKE_REQUIRED_FLAGS)
+
+
+include(CheckCXXSymbolExists)
+
+if(CMAKE_SYSTEM_NAME MATCHES "^FreeBSD")
+  check_cxx_symbol_exists(malloc_usable_size malloc_np.h HAVE_MALLOC_USABLE_SIZE)
+else()
+  check_cxx_symbol_exists(malloc_usable_size malloc.h HAVE_MALLOC_USABLE_SIZE)
+endif()
+
+check_cxx_symbol_exists(sched_getcpu sched.h ROCKSDB_SCHED_GETCPU_PRESENT)
+check_cxx_symbol_exists(getauxval sys/auxv.h HAVE_AUXV_GETAUXVAL)
+
+
+MACRO(ROCKSDB_SET_DEFINTIONS)
+	if(HAVE_SSE42)
+	  add_definitions(-DHAVE_SSE42)
+	endif()
+
+	IF (HAVE_PCLMUL)
+	  add_definitions(-DHAVE_PCLMUL)
+	ENDIF ()
+
+	if(HAVE_AVX2)
+	  add_definitions(-DHAVE_AVX2)
+	endif()
+
+	if(HAVE_BMI)
+	  add_definitions(-DHAVE_BMI)
+	endif()
+
+	if(HAVE_LZCNT)
+	  add_definitions(-DHAVE_LZCNT)
+	endif()
+
+	if(HAVE_ALIGNED_NEW AND NOT ROCKSDB_DISABLE_ALIGNED_NEW)
+	  add_definitions(-DHAVE_ALIGNED_NEW)
+	endif()
+
+	if(HAVE_UINT128_EXTENSION)
+	  add_definitions(-DHAVE_UINT128_EXTENSION)
+	endif()
+
+	if(HAVE_URING)
+	  if (ROCKSDB_USE_IO_URING)
+	     add_definitions(-DROCKSDB_IOURING_PRESENT)
+	   else()
+	     message(STATUS "uring library detected but not used as ROCKSDB_USE_IO_URING is not defined")
+	   endif()
+	endif()
+
+	if(HAVE_MEMKIND)
+	  if (ROCKSDB_USE_MEMKIND)
+	     add_definitions(-DMEMKIND)
+	   else()
+	     message(STATUS "memkind library detected but not used as ROCKSDB_USE_MEMKIND is not defined")
+	   endif()
+	endif()
+
+	if(HAVE_MALLOC_USABLE_SIZE)
+	  if (ROCKSDB_USE_MALLOC_USABLE_SIZE)
+	     add_definitions(-DROCKSDB_MALLOC_USABLE_SIZE)
+	   else()
+	     message(STATUS "malloc_usable_size() function detected but not used as ROCKSDB_USE_MALLOC_USABLE_SIZE is not defined")
+	   endif()
+	endif()
+
+	if(HAVE_THREAD_LOCAL)
+	  add_definitions(-DROCKSDB_SUPPORT_THREAD_LOCAL)
+	endif()
+
+	if(HAVE_FALLOCATE AND NOT ROCKSDB_DISABLE_FALLOCATE)
+	  add_definitions(-DROCKSDB_FALLOCATE_PRESENT)
+	endif()
+
+	if(WITH_NUMA)
+	  add_definitions(-DNUMA)
+	endif()
+
+	if(WITH_JEMALLOC)
+	  add_definitions(-DROCKSDB_JEMALLOC)
+	endif()
+
+	if(HAVE_SYNC_FILE_RANGE_WRITE AND NOT ROCKSDB_DISABLE_SYNC_FILE_RANGE)
+	  add_definitions(-DROCKSDB_RANGESYNC_PRESENT)
+	endif()
+
+	if(HAVE_PTHREAD_MUTEX_ADAPTIVE_NP AND NOT ROCKSDB_DISABLE_PTHREAD_MUTEX_ADAPTIVE_NP)
+	  add_definitions(-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX)
+	endif()
+
+	if(HAVE_BACKTRACE_SYMBOLS AND NOT ROCKSDB_DISABLE_BACKTRACE)
+	  add_definitions(-DROCKSDB_BACKTRACE)
+	endif()
+
+	if(ROCKSDB_SCHED_GETCPU_PRESENT AND NOT ROCKSDB_DISABLE_SCHED_GETCPU)
+	  add_definitions(-DROCKSDB_SCHED_GETCPU_PRESENT -DHAVE_SCHED_GETCPU=1)
+	endif()
+
+	if(HAVE_AUXV_GETAUXVAL AND NOT ROCKSDB_DISABLE_AUXV_GETAUXVAL)
+	  add_definitions(-DROCKSDB_AUXV_GETAUXVAL_PRESENT)
+	endif()
+ENDMACRO()

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -35,50 +35,12 @@ IF ((CMAKE_CXX_COMPILER_ID STREQUAL GNU) AND
   RETURN ()
 ENDIF ()
 
-
-# Suppress warnings for clang-10 or newer
-IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-range-loop-construct FILES rocksdb/db/db_impl/db_impl_compaction_flush.cc rocksdb/options/options_parser.cc rocksdb/options/options_helper.cc)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-copy FILES rocksdb/db/db_impl/db_impl.cc)
-ENDIF()
-
-# Suppress warnings for gcc-9 or newer
-IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-copy FILES rocksdb/db/db_impl/db_impl.cc)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-maybe-uninitialized FILES rocksdb/table/block_based/block_based_table_builder.cc)
-ENDIF()
-
-# Suppress warnings for gcc-4.8.x
-IF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-missing-field-initializers FILES rocksdb/db/db_impl/db_impl_compaction_flush.cc rocksdb/utilities/blob_db/blob_db_impl.cc)
-ENDIF()
-
-
-# Suppress warnings for gcc ASan build
-IF(CMAKE_COMPILER_IS_GNUCXX AND WITH_ASAN)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-error=maybe-uninitialized FILES rocksdb/util/bloom.cc)
-ENDIF()
-
-
 # check that compiler supports cxx11 and set options
 INCLUDE (check_stdcxx11)
 IF (!HAVE_STDCXX11)
   MESSAGE (${MYROCKS_STATUS_MODE} "${CMAKE_CXX_COMPILER} doesn't support -std=c++11, you need one that does. Not building MyRocks")
   RETURN ()
 ENDIF ()
-
-CHECK_FUNCTION_EXISTS(sched_getcpu  HAVE_SCHED_GETCPU)
-IF(HAVE_SCHED_GETCPU)
-  ADD_DEFINITIONS(-DHAVE_SCHED_GETCPU=1 -DROCKSDB_SCHED_GETCPU_PRESENT)
-ENDIF()
-
-# This is a strong requirement coming from RocksDB. No conditional checks here.
-ADD_DEFINITIONS(-DROCKSDB_PLATFORM_POSIX -DROCKSDB_LIB_IO_POSIX -DZLIB -DLZ4 -DZSTD)
-
-IF(ROCKSDB_CUSTOM_NAMESPACE)
-  ADD_DEFINITIONS(-DROCKSDB_NAMESPACE=${ROCKSDB_CUSTOM_NAMESPACE})
-  ADD_DEFINITIONS(-DROCKSDB_CUSTOM_NAMESPACE=${ROCKSDB_CUSTOM_NAMESPACE})
-ENDIF()
 
 IF(HAVE_EXTERNAL_ROCKSDB)
   MESSAGE(STATUS "MyRocks: Using external RocksDB")
@@ -108,6 +70,88 @@ ELSE()
   )
 ENDIF()
 
+# This is a strong requirement coming from RocksDB. No conditional checks here.
+add_definitions(-DROCKSDB_PLATFORM_POSIX -DROCKSDB_LIB_IO_POSIX -DZLIB -DLZ4 -DZSTD)
+
+IF (ROCKSDB_CUSTOM_NAMESPACE)
+  ADD_DEFINITIONS(-DROCKSDB_NAMESPACE=${ROCKSDB_CUSTOM_NAMESPACE})
+  ADD_DEFINITIONS(-DROCKSDB_CUSTOM_NAMESPACE=${ROCKSDB_CUSTOM_NAMESPACE})
+ENDIF()
+
+include(compiler_features)
+
+IF (NOT HAVE_THREAD_LOCAL)
+  MESSAGE(FATAL_ERROR "No '__thread' support found. Not building MyRocks")
+ENDIF()
+
+IF (HAVE_SSE42 AND HAVE_PCLMUL)
+  add_compile_flags(${ROCKSDB_ROOT}/util/crc32c.cc COMPILE_FLAGS "-msse4.2 -mpclmul")
+  MESSAGE(STATUS "MyRocks: SSE42 support found")
+ELSE()
+  IF (ALLOW_NO_SSE42)
+    MESSAGE(WARNING "No SSE42 support found and ALLOW_NO_SSE42 specified, building MyRocks but without SSE42/FastCRC32 support")
+  ELSE()
+    MESSAGE(FATAL_ERROR "No SSE42 support found. Not building MyRocks")
+  ENDIF()
+ENDIF()
+
+IF (HAVE_AVX2)
+  add_compile_flags(${ROCKSDB_ROOT}/table/block_based/filter_policy.cc COMPILE_FLAGS "-mavx2")
+ENDIF()
+
+IF (HAVE_URING AND ROCKSDB_USE_IO_URING)
+  SET(rocksdb_static_libs ${rocksdb_static_libs} ${URING_LIBRARY})
+ENDIF()
+
+IF (HAVE_MEMKIND AND ROCKSDB_USE_MEMKIND)
+  SET(rocksdb_static_libs ${rocksdb_static_libs} ${MEMKIND_LIBRARY})
+ENDIF()
+
+IF (HAVE_ALIGNED_NEW AND NOT ROCKSDB_DISABLE_ALIGNED_NEW)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
+ENDIF()
+
+IF (CMAKE_COMPILER_IS_GNUCXX)
+  add_compile_options(-fno-builtin-memcmp)
+ENDIF()
+
+IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  add_compile_options(-march=native)
+ENDIF()
+
+IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  add_definitions(-DOS_LINUX)
+ENDIF()
+
+ROCKSDB_SET_DEFINTIONS()
+get_directory_property(COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
+list(SORT COMPILE_DEFINITIONS)
+message(STATUS "MyRocks compile definitions: ${COMPILE_DEFINITIONS}")
+
+
+# Suppress warnings for clang-10 or newer
+IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 10.0)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-range-loop-construct FILES rocksdb/db/db_impl/db_impl_compaction_flush.cc rocksdb/options/options_parser.cc rocksdb/options/options_helper.cc)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-copy FILES rocksdb/db/db_impl/db_impl.cc)
+ENDIF()
+
+# Suppress warnings for gcc-9 or newer
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-copy FILES rocksdb/db/db_impl/db_impl.cc)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-maybe-uninitialized FILES rocksdb/table/block_based/block_based_table_builder.cc)
+ENDIF()
+
+# Suppress warnings for gcc-4.8.x
+IF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-missing-field-initializers FILES rocksdb/db/db_impl/db_impl_compaction_flush.cc rocksdb/utilities/blob_db/blob_db_impl.cc)
+ENDIF()
+
+# Suppress warnings for gcc ASan build
+IF(CMAKE_COMPILER_IS_GNUCXX AND WITH_ASAN)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-error=maybe-uninitialized FILES rocksdb/util/bloom.cc)
+ENDIF()
+
+
 INCLUDE_DIRECTORIES(
   ${ROCKSDB_ROOT}
   ${ROCKSDB_ROOT}/include
@@ -118,59 +162,6 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_SOURCE_DIR}/third_party/zstd/lib/dictBuilder
   ${LZ4_INCLUDE_DIR}
 )
-
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2 -mpclmul")
-SET(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_FLAGS} --std=c++11")
-INCLUDE(CheckCXXSourceCompiles)
-CHECK_CXX_SOURCE_COMPILES("
-#include <cstdint>
-#include <nmmintrin.h>
-#include <wmmintrin.h>
-int main() {
-  volatile uint32_t x __attribute__((unused)) = _mm_crc32_u32(0, 0);
-  const auto a = _mm_set_epi64x(0, 0);
-  const auto b = _mm_set_epi64x(0, 0);
-  const auto c = _mm_clmulepi64_si128(a, b, 0x00);
-  auto d __attribute__((unused)) = _mm_cvtsi128_si64(c);
-}
-" HAVE_SSE42)
-IF (HAVE_SSE42)
-  ADD_DEFINITIONS(-DHAVE_SSE42)
-  MESSAGE(STATUS "MyRocks: SSE42 support found")
-ELSE ()
-  IF (ALLOW_NO_SSE42)
-    MESSAGE(WARNING "No SSE42 support found and ALLOW_NO_SSE42 specified, building MyRocks but without SSE42/FastCRC32 support")
-  ELSE ()
-    MESSAGE(FATAL_ERROR "No SSE42 support found. Not building MyRocks")
-  ENDIF ()
-ENDIF ()
-
-IF(UNIX)
-  IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    ADD_DEFINITIONS(-DOS_LINUX)
-
-    CHECK_INCLUDE_FILES(linux/falloc.h HAVE_LINUX_FALLOC_H)
-    CHECK_FUNCTION_EXISTS(fallocate HAVE_FALLOCATE)
-
-    IF(HAVE_FALLOCATE AND HAVE_LINUX_FALLOC_H)
-      ADD_DEFINITIONS(-DROCKSDB_FALLOCATE_PRESENT)
-    ENDIF()
-  ENDIF()
-ENDIF()
-
-CHECK_CXX_SOURCE_COMPILES("
-#if defined(_MSC_VER) && !defined(__thread)
-#define __thread __declspec(thread)
-#endif
-int main() {
-  static __thread int tls __attribute__((unused));
-}
-" HAVE_THREAD_LOCAL)
-if(HAVE_THREAD_LOCAL)
-  ADD_DEFINITIONS(-DROCKSDB_SUPPORT_THREAD_LOCAL)
-else()
-  MESSAGE(FATAL_ERROR "No '__thread' support found. Not building MyRocks")
-endif()
 
 # add bundled compression code
 SET(ZSTD_SOURCES
@@ -233,7 +224,7 @@ ELSE()
 ENDIF()
 
 IF(HAVE_EXTERNAL_ROCKSDB)
-  SET(rocksdb_static_libs "${ROCKSDB_LIB_PATH}/${ROCKSDB_LIB_NAME}")
+  SET(rocksdb_static_libs ${rocksdb_static_libs} "${ROCKSDB_LIB_PATH}/${ROCKSDB_LIB_NAME}")
 ENDIF()
 
 SET(rocksdb_static_libs ${rocksdb_static_libs} ${ZLIB_LIBRARY} ${LZ4_LIBRARY} "-lrt" "-ldl")


### PR DESCRIPTION
This patch adds `cmake/compiler_features.cmake` to auto-detect a compiler support for the following flags:
```
-DHAVE_AVX2
-DHAVE_BMI
-DHAVE_LZCNT
-DHAVE_PCLMUL
-DHAVE_SSE42
-DHAVE_ALIGNED_NEW
-DHAVE_UINT128_EXTENSION
-DNUMA
-DMEMKIND
-DROCKSDB_IOURING_PRESENT
-DROCKSDB_BACKTRACE
-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX
-DROCKSDB_RANGESYNC_PRESENT
-DROCKSDB_AUXV_GETAUXVAL_PRESENT
-DROCKSDB_SUPPORT_THREAD_LOCAL
-DROCKSDB_FALLOCATE_PRESENT
-DROCKSDB_MALLOC_USABLE_SIZE
-DROCKSDB_SCHED_GETCPU_PRESENT
```