### PR TITLE
PS-7493: clang-format checks stopped working on TravisCI and CircleCI (5.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,7 @@ matrix:
         - echo "deb http://apt.llvm.org/$TRAVIS_DIST/ llvm-toolchain-$TRAVIS_DIST-5.0 main" | sudo tee -a /etc/apt/sources.list > /dev/null;
         - sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
         - sudo -E apt-get -yq --no-install-suggests --no-install-recommends install diffstat clang-format-5.0 || travis_terminate 1
-        - wget https://llvm.org/svn/llvm-project/cfe/trunk/tools/clang-format/clang-format-diff.py || travis_terminate 1
-        - chmod a+x clang-format-diff.py
-        - git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | ./clang-format-diff.py -binary=clang-format-5.0 -style=file -p1 >_GIT_DIFF
+        - git diff -U0 --no-color HEAD^1 *.c *.cc *.cpp *.h *.hpp *.i *.ic *.ih | clang-format-diff-5.0 -style=file -p1 >_GIT_DIFF
         - '[ ! -s _GIT_DIFF ] && { echo The last git commit is clang-formatted; travis_terminate 0; } || { diffstat _GIT_DIFF; echo; cat _GIT_DIFF; travis_terminate 1; }'
 
 


### PR DESCRIPTION
Use local `/usr/bin/clang-format-diff-5.0` instead of external `clang-format-diff.py`.