### PR TITLE
PS-7492: Update slow log formatting for tmp tables related stats (8.0)

### DIFF
--- a/mysql-test/include/percona_slow_log_verbosity_grep.inc
+++ b/mysql-test/include/percona_slow_log_verbosity_grep.inc
@@ -2,16 +2,14 @@
 --let grep_pattern = ^# Schema: .+  Last_errno: \d+  Killed: \d+\$
 --let log_expected_matches = $log_slow_verbosity_expected_matches
 --source include/log_grep.inc
---let grep_pattern = ^#.*Rows_affected: \d+\$
---source include/log_grep.inc
---let grep_pattern = ^# Bytes_sent: \d+.*\$
+--let grep_pattern = ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+\$
 --source include/log_grep.inc
 # InnoDB
 --let log_expected_matches = $log_slow_verbosity_innodb_expected_matches
 --let grep_pattern = ^# InnoDB_trx_id: [0-9a-fA-F]+\$
 --source include/log_grep.inc
 # Query plan
---let grep_pattern = ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+\$
+--let grep_pattern = ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+\$
 --source include/log_grep.inc
 --let grep_pattern = ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)\$
 --source include/log_grep.inc

--- a/mysql-test/r/percona_bug643149.result
+++ b/mysql-test/r/percona_bug643149.result
@@ -7,13 +7,11 @@ SELECT 1;
 [log_stop.inc] percona_bug643149_slow
 # User@Host: root[root] @ localhost []  Id: X
 # Schema: test  Last_errno: X  Killed: X
-# Query_time: X.X  Lock_time: X.X  Rows_sent: X  Rows_examined: X  Rows_affected: X
-# Bytes_sent: X
+# Query_time: X.X  Lock_time: X.X  Rows_sent: X  Rows_examined: X  Rows_affected: X  Bytes_sent: X
 # Profile_starting: X.X Profile_starting_cpu: X.X Profile_Opening_tables: X.X Profile_Opening_tables_cpu: X.X Profile_Opening_tables: X.X Profile_Opening_tables_cpu: X.X Profile_System_lock: X.X Profile_System_lock_cpu: X.X Profile_query_end: X.X Profile_query_end_cpu: X.X Profile_closing_tables: X.X Profile_closing_tables_cpu: X.X Profile_freeing_items: X.X Profile_freeing_items_cpu: X.X Profile_logging_slow_query: X.X Profile_logging_slow_query_cpu: X.X 
 # Profile_total: X.X Profile_total_cpu: X.X 
 # User@Host: root[root] @ localhost []  Id: X
 # Schema: test  Last_errno: X  Killed: X
-# Query_time: X.X  Lock_time: X.X  Rows_sent: X  Rows_examined: X  Rows_affected: X
-# Bytes_sent: X
+# Query_time: X.X  Lock_time: X.X  Rows_sent: X  Rows_examined: X  Rows_affected: X  Bytes_sent: X
 # Profile_starting: X.X Profile_starting_cpu: X.X Profile_checking_permissions: X.X Profile_checking_permissions_cpu: X.X Profile_Opening_tables: X.X Profile_Opening_tables_cpu: X.X Profile_init: X.X Profile_init_cpu: X.X Profile_optimizing: X.X Profile_optimizing_cpu: X.X Profile_executing: X.X Profile_executing_cpu: X.X Profile_end: X.X Profile_end_cpu: X.X Profile_query_end: X.X Profile_query_end_cpu: X.X Profile_closing_tables: X.X Profile_closing_tables_cpu: X.X Profile_freeing_items: X.X Profile_freeing_items_cpu: X.X Profile_logging_slow_query: X.X Profile_logging_slow_query_cpu: X.X 
 # Profile_total: X.X Profile_total_cpu: X.X 

--- a/mysql-test/r/percona_log_slow_query_plan.result
+++ b/mysql-test/r/percona_log_slow_query_plan.result
@@ -194,7 +194,7 @@ SELECT COUNT(*) FROM t1;
 COUNT(*)
 2
 [log_stop.inc] percona_slow_query_log.query_plan_8
-[log_grep.inc] file: percona_slow_query_log.query_plan_8 pattern: ^#.*Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0$ expected_matches: 2
+[log_grep.inc] file: percona_slow_query_log.query_plan_8 pattern: ^# Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
 [log_grep.inc] file: percona_slow_query_log.query_plan_8 pattern: ^#.*Tmp_table: No  Tmp_table_on_disk: No$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
@@ -216,7 +216,7 @@ COUNT(*)
 1
 1
 [log_stop.inc] percona_slow_query_log.query_plan_9
-[log_grep.inc] file: percona_slow_query_log.query_plan_9 pattern: ^#.*Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*$ expected_matches: 1
+[log_grep.inc] file: percona_slow_query_log.query_plan_9 pattern: ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*$ expected_matches: 1
 [log_grep.inc] found expected match count: 1
 [log_grep.inc] file: percona_slow_query_log.query_plan_9 pattern: ^#.*Tmp_table: Yes  Tmp_table_on_disk: No$ expected_matches: 1
 [log_grep.inc] found expected match count: 1
@@ -233,7 +233,7 @@ COUNT(*)
 1
 1
 [log_stop.inc] percona_slow_query_log.query_plan_9a
-[log_grep.inc] file: percona_slow_query_log.query_plan_9a pattern: ^#.*Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*$
+[log_grep.inc] file: percona_slow_query_log.query_plan_9a pattern: ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona_slow_query_log.query_plan_9a pattern: ^#.*Tmp_table: Yes  Tmp_table_on_disk: No$
 [log_grep.inc] lines:   0
@@ -261,7 +261,7 @@ COUNT(*)
 1
 1
 [log_stop.inc] percona_slow_query_log.query_plan_10
-[log_grep.inc] file: percona_slow_query_log.query_plan_10 pattern: ^#.*Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*$ expected_matches: 1
+[log_grep.inc] file: percona_slow_query_log.query_plan_10 pattern: ^# Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*$ expected_matches: 1
 [log_grep.inc] found expected match count: 1
 [log_grep.inc] file: percona_slow_query_log.query_plan_10 pattern: ^#.*Tmp_table: Yes  Tmp_table_on_disk: Yes$ expected_matches: 1
 [log_grep.inc] found expected match count: 1
@@ -278,7 +278,7 @@ COUNT(*)
 1
 1
 [log_stop.inc] percona_slow_query_log.query_plan_10a
-[log_grep.inc] file: percona_slow_query_log.query_plan_10a pattern: ^#.*Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*$
+[log_grep.inc] file: percona_slow_query_log.query_plan_10a pattern: ^# Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona_slow_query_log.query_plan_10a pattern: ^#.*Tmp_table: Yes  Tmp_table_on_disk: Yes$
 [log_grep.inc] lines:   0

--- a/mysql-test/r/percona_log_slow_verbosity.result
+++ b/mysql-test/r/percona_log_slow_verbosity.result
@@ -11,13 +11,11 @@ a
 log_slow_verbosity='microtime,innodb,query_plan':
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Bytes_sent: \d+.*$
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   1
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_0 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   2
@@ -50,13 +48,11 @@ SELECT 1;
 log_slow_verbosity='microtime,innodb,query_plan':
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^#.*Rows_affected: \d+$ expected_matches: 2
-[log_grep.inc] found expected match count: 2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Bytes_sent: \d+.*$ expected_matches: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_1 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   2
@@ -87,13 +83,11 @@ INSERT INTO t1 VALUE(1);
 log_slow_verbosity='microtime':
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^#.*Rows_affected: \d+$ expected_matches: 2
-[log_grep.inc] found expected match count: 2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Bytes_sent: \d+.*$ expected_matches: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_2 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   0
@@ -124,13 +118,11 @@ INSERT INTO t1 VALUE(2);
 log_slow_verbosity='query_plan':
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^#.*Rows_affected: \d+$ expected_matches: 2
-[log_grep.inc] found expected match count: 2
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Bytes_sent: \d+.*$ expected_matches: 2
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$ expected_matches: 2
 [log_grep.inc] found expected match count: 2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_verbosity_3 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   2

--- a/mysql-test/suite/innodb/r/percona_log_slow_innodb.result
+++ b/mysql-test/suite/innodb/r/percona_log_slow_innodb.result
@@ -12,13 +12,11 @@ SUM(a)
 [log_stop.inc] percona.slow_extended.innodb_0
 [log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^# Bytes_sent: \d+.*$
+[log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   1
-[log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_0 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   0
@@ -49,13 +47,11 @@ SELECT 5;
 [log_stop.inc] percona.slow_extended.innodb_2
 [log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# Bytes_sent: \d+.*$
+[log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_2 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   0
@@ -92,13 +88,11 @@ UNLOCK TABLES;
 [log_stop.inc] percona.slow_extended.innodb_3
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Bytes_sent: \d+.*$
+[log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_3 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   0
@@ -136,13 +130,11 @@ COMMIT;
 [log_stop.inc] percona.slow_extended.innodb_4
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Bytes_sent: \d+.*$
+[log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   1
-[log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_4 pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   0

--- a/mysql-test/suite/innodb/r/percona_log_slow_innodb_debug.result
+++ b/mysql-test/suite/innodb/r/percona_log_slow_innodb_debug.result
@@ -17,13 +17,11 @@ SET DEBUG_SYNC = 'reset';
 [log_stop.inc] percona.slow_extended.innodb_debug
 [log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^# Bytes_sent: \d+.*$
+[log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   1
-[log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.innodb_debug pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   0

--- a/mysql-test/suite/rpl/r/percona_log_slow_slave_statements_innodb.result
+++ b/mysql-test/suite/rpl/r/percona_log_slow_slave_statements_innodb.result
@@ -26,13 +26,11 @@ include/sync_slave_sql_with_master.inc
 [log_stop.inc] percona.slow_extended.log_slow_slave_statements-innodb
 [log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^# Schema: .+  Last_errno: \d+  Killed: \d+$
 [log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^#.*Rows_affected: \d+$
-[log_grep.inc] lines:   2
-[log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^# Bytes_sent: \d+.*$
+[log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^# Query_time: \d+\.\d+  Lock_time: \d+\.\d+  Rows_sent: \d+  Rows_examined: \d+  Rows_affected: \d+  Bytes_sent: \d+$
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^# InnoDB_trx_id: [0-9a-fA-F]+$
 [log_grep.inc] lines:   1
-[log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^# Bytes_sent: \d+  Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
+[log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^# Tmp_tables: \d+  Tmp_disk_tables: \d+  Tmp_table_sizes: \d+$
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.log_slow_slave_statements-innodb pattern: ^# QC_Hit: (Yes|No)  Full_scan: (Yes|No)  Full_join: (Yes|No)  Tmp_table: (Yes|No)  Tmp_table_on_disk: (Yes|No)$
 [log_grep.inc] lines:   0

--- a/mysql-test/t/percona_log_slow_query_plan.test
+++ b/mysql-test/t/percona_log_slow_query_plan.test
@@ -231,7 +231,7 @@ EXPLAIN SELECT COUNT(*) FROM t1;
 --source include/log_start.inc
 SELECT COUNT(*) FROM t1;
 --source include/log_stop.inc
---let grep_pattern = ^#.*Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\$
+--let grep_pattern = ^# Tmp_tables: 0  Tmp_disk_tables: 0  Tmp_table_sizes: 0\$
 --let log_expected_matches= 2
 --source include/log_grep.inc
 --let grep_pattern = ^#.*Tmp_table: No  Tmp_table_on_disk: No\$
@@ -249,7 +249,7 @@ EXPLAIN SELECT COUNT(*) FROM t1, t3 WHERE t1.a = t3.a GROUP BY t3.a;
 --source include/log_start.inc
 SELECT COUNT(*) FROM t1, t3 WHERE t1.a = t3.a GROUP BY t3.a;
 --source include/log_stop.inc
---let grep_pattern = ^#.*Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*\$
+--let grep_pattern = ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*\$
 --let log_expected_matches= 1
 --source include/log_grep.inc
 --let grep_pattern = ^#.*Tmp_table: Yes  Tmp_table_on_disk: No\$
@@ -268,7 +268,7 @@ SET SESSION log_slow_filter='full_join,tmp_table_on_disk,filesort_on_disk';
 --source include/log_start.inc
 SELECT COUNT(*) FROM t1, t3 WHERE t1.a = t3.a GROUP BY t3.a;
 --source include/log_stop.inc
---let grep_pattern = ^#.*Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*\$
+--let grep_pattern = ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*\$
 --let log_expected_matches= 0
 --source include/log_grep.inc
 --let grep_pattern = ^#.*Tmp_table: Yes  Tmp_table_on_disk: No\$
@@ -293,7 +293,7 @@ EXPLAIN SELECT COUNT(*) FROM t1, t4 WHERE t1.a = t4.a GROUP BY t4.a;
 --source include/log_start.inc
 SELECT COUNT(*) FROM t1, t4 WHERE t1.a = t4.a GROUP BY t4.b;
 --source include/log_stop.inc
---let grep_pattern = ^#.*Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*\$
+--let grep_pattern = ^# Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*\$
 --let log_expected_matches= 1
 --source include/log_grep.inc
 --let grep_pattern = ^#.*Tmp_table: Yes  Tmp_table_on_disk: Yes\$
@@ -312,7 +312,7 @@ SET SESSION log_slow_filter='full_join,filesort_on_disk';
 --source include/log_start.inc
 SELECT COUNT(*) FROM t1, t4 WHERE t1.a = t4.a GROUP BY t4.b;
 --source include/log_stop.inc
---let grep_pattern = ^#.*Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*\$
+--let grep_pattern = ^# Tmp_tables: 1  Tmp_disk_tables: 1  Tmp_table_sizes: [1-9][0-9]*\$
 --let log_expected_matches= 0
 --source include/log_grep.inc
 --let grep_pattern = ^#.*Tmp_table: Yes  Tmp_table_on_disk: Yes\$

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -896,8 +896,8 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
   if (my_b_printf(&log_file,
                   "# Schema: %s  Last_errno: %u  Killed: %u\n"
                   "# Query_time: %s  Lock_time: %s  Rows_sent: %llu"
-                  "  Rows_examined: %llu  Rows_affected: %llu\n"
-                  "# Bytes_sent: %lu",
+                  "  Rows_examined: %llu  Rows_affected: %llu"
+                  "  Bytes_sent: %lu\n",
                   (thd->db().str ? thd->db().str : ""),
                   thd->last_errno, (uint) thd->killed,
                   query_time_buff, lock_time_buff,
@@ -911,14 +911,11 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
 
   if (thd->variables.log_slow_verbosity & (1ULL << SLOG_V_QUERY_PLAN))
     if (my_b_printf(&log_file,
-                    "  Tmp_tables: %lu  Tmp_disk_tables: %lu  "
-                    "Tmp_table_sizes: %llu",
+                    "# Tmp_tables: %lu  Tmp_disk_tables: %lu  "
+                    "Tmp_table_sizes: %llu\n",
                     thd->tmp_tables_used, thd->tmp_tables_disk_used,
                     thd->tmp_tables_size) == (uint) -1)
       goto err;
-
-  if (my_b_write(&log_file, (uchar*) "\n", 1))
-    goto err;
 
   if (opt_log_slow_sp_statements == 1 && thd->sp_runtime_ctx &&
       my_b_printf(&log_file,


### PR DESCRIPTION
Depending on slow log config it is possible that stats for tmp
tables will be printed on a separate line without "#" symbol
in front of it.
Update log format so that tmp tables related stats will allways be
printed on a separate line.