### PR TITLE
PS-7491: [8.0] Add krb5 libs which have krb5_ser_context_init symbol

### DIFF
--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -290,7 +290,7 @@ fi
 )
 
 (
-    LIBLIST="libcrypto.so libssl.so libreadline.so libtinfo.so libsasl2.so libbrotlidec.so libbrotlicommon.so librtmp.so libgssapi.so libkrb5.so libk5crypto.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplc4.so libnspr4.so libssl3.so libplds4.so libncurses.so.5 libtinfo.so.5"
+    LIBLIST="libcrypto.so libssl.so libreadline.so libtinfo.so libsasl2.so libbrotlidec.so libbrotlicommon.so librtmp.so libgssapi_krb5.so libkrb5.so libk5crypto.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplc4.so libnspr4.so libssl3.so libplds4.so libncurses.so.5 libtinfo.so.5"
     DIRLIST="bin lib lib/private lib/plugin lib/mysqlrouter/plugin lib/mysqlrouter/private"
 
     LIBPATH=""

--- a/build-ps/build-binary.sh
+++ b/build-ps/build-binary.sh
@@ -290,7 +290,7 @@ fi
 )
 
 (
-    LIBLIST="libcrypto.so libssl.so libreadline.so libtinfo.so libsasl2.so libbrotlidec.so libbrotlicommon.so libgssapi_krb5.so librtmp.so libgssapi.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplc4.so libnspr4.so libssl3.so libplds4.so libncurses.so.5 libtinfo.so.5"
+    LIBLIST="libcrypto.so libssl.so libreadline.so libtinfo.so libsasl2.so libbrotlidec.so libbrotlicommon.so librtmp.so libgssapi.so libkrb5.so libk5crypto.so libssl3.so libsmime3.so libnss3.so libnssutil3.so libplc4.so libnspr4.so libssl3.so libplds4.so libncurses.so.5 libtinfo.so.5"
     DIRLIST="bin lib lib/private lib/plugin lib/mysqlrouter/plugin lib/mysqlrouter/private"
 
     LIBPATH=""


### PR DESCRIPTION
Builds: https://rel.cd.percona.com/job/percona-server-80/47/
PXB test: https://pxb.cd.percona.com/view/PXB%208.0/job/percona-xtrabackup-8.0-param-medium/19/

PXB test run uses: https://raw.githubusercontent.com/Sudokamikaze/percona-xtrabackup/c3c0d9dba7d103f5553c24f99395f3f5117ec8ec/storage/innobase/xtrabackup/test/bootstrap.sh as bootstrap, this script is modified only to run this test, uses built tarball with this change
