### PR TITLE
PS-7290: Using RocksDB as a temp table can lead to an assertion on the debug build (8.0)

### DIFF
--- a/mysql-test/suite/rocksdb/r/PS-7290.result
+++ b/mysql-test/suite/rocksdb/r/PS-7290.result
@@ -1,0 +1,7 @@
+#
+# PS-7290: Using RocksDB as a temp table can lead to an assertion on the debug build
+#
+CREATE TEMPORARY TABLE t0(ID INT);
+ALTER TABLE t0 ENGINE=RocksDB;
+ERROR HY000: Table storage engine 'ROCKSDB' does not support the create option 'TEMPORARY'
+DROP TABLE t0;

--- a/mysql-test/suite/rocksdb/t/PS-7290.test
+++ b/mysql-test/suite/rocksdb/t/PS-7290.test
@@ -1,0 +1,11 @@
+--source include/have_rocksdb.inc
+
+--echo #
+--echo # PS-7290: Using RocksDB as a temp table can lead to an assertion on the debug build
+--echo #
+
+CREATE TEMPORARY TABLE t0(ID INT);
+--error ER_ILLEGAL_HA_CREATE_OPTION
+ALTER TABLE t0 ENGINE=RocksDB;
+
+DROP TABLE t0;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7570,6 +7570,12 @@ int ha_rocksdb::create(const char *const name, TABLE *const table_arg,
     DBUG_RETURN(HA_WRONG_CREATE_OPTION);
   }
 
+  if (unlikely(create_info->options & HA_LEX_CREATE_TMP_TABLE)) {
+    my_error(ER_ILLEGAL_HA_CREATE_OPTION, MYF(0),
+             ha_resolve_storage_engine_name(create_info->db_type), "TEMPORARY");
+    DBUG_RETURN(HA_ERR_ROCKSDB_INVALID_TABLE);
+  }
+
   int err;
   /*
     Construct dbname.tablename ourselves, because parititioning


### PR DESCRIPTION
MySQL 8.0.21 moves a check for `HA_LEX_CREATE_TMP_TABLE` from `check_engine()` to `get_viability()`.
This patch adds a similar check for MyRocks in `ha_rocksdb::create`.