### PR TITLE
PS-7167: "slice1.compare.slice2" debug assertion (8.0)

### DIFF
--- a/mysql-test/suite/rocksdb/r/percona_assert.result
+++ b/mysql-test/suite/rocksdb/r/percona_assert.result
@@ -1,4 +1,11 @@
 #
+# PS-7167: "slice1.compare.slice2" debug assertion
+#
+CREATE TABLE t0(c1 INT UNSIGNED, PRIMARY KEY(c1)) ENGINE=RocksDB;
+SELECT * FROM t0 WHERE c1<>4294967295;
+c1
+DROP TABLE t0;
+#
 # PS-7290: Using RocksDB as a temp table can lead to an assertion on the debug build
 #
 CREATE TEMPORARY TABLE t0(ID INT);

--- a/mysql-test/suite/rocksdb/t/percona_assert.test
+++ b/mysql-test/suite/rocksdb/t/percona_assert.test
@@ -1,6 +1,16 @@
 --source include/have_rocksdb.inc
 
 --echo #
+--echo # PS-7167: "slice1.compare.slice2" debug assertion
+--echo #
+
+CREATE TABLE t0(c1 INT UNSIGNED, PRIMARY KEY(c1)) ENGINE=RocksDB;
+SELECT * FROM t0 WHERE c1<>4294967295;
+
+DROP TABLE t0;
+
+
+--echo #
 --echo # PS-7290: Using RocksDB as a temp table can lead to an assertion on the debug build
 --echo #
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -11655,7 +11655,7 @@ ha_rows ha_rocksdb::records_in_range(uint inx, key_range *const min_key,
   // right bound being successor() of the left one, e.g. "t.key>10 AND t.key<11"
   if (slice1.compare(slice2) >= 0) {
     // It's not possible to get slice2 > slice1
-    DBUG_ASSERT(slice1.compare(slice2) == 0);
+    DBUG_ASSERT(!min_key || !max_key || slice1.compare(slice2) == 0);
     DBUG_RETURN(HA_EXIT_SUCCESS);
   }
 


### PR DESCRIPTION
Fix assert when `min_key == nullptr` or `max_key == nullptr` in `ha_rocksdb::records_in_range()`.