### PR TITLE
PS-7298: Fix assertion in Fil_shard::close_file during fast shutdown

### DIFF
--- a/mysql-test/suite/innodb/r/percona_fast_shutdown_crash.result
+++ b/mysql-test/suite/innodb/r/percona_fast_shutdown_crash.result
@@ -1,0 +1,33 @@
+CREATE TABLE t1 (x INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+CREATE TABLE t2 (x INT) ENGINE=InnoDB;
+INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
+SET GLOBAL INNODB_FAST_SHUTDOWN=2;
+# restart
+SELECT * FROM t1;
+x
+1
+2
+3
+4
+5
+1
+2
+3
+4
+5
+1
+2
+3
+4
+5
+SELECT * FROM t2;
+x
+1
+2
+3
+4
+5
+DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/t/percona_fast_shutdown_crash.test
+++ b/mysql-test/suite/innodb/t/percona_fast_shutdown_crash.test
@@ -1,0 +1,22 @@
+#
+# Make sure server doesn't crash while doing fast shutdown
+# (with innobase_fast_shutdown=2)
+#
+
+--source include/have_debug.inc
+
+CREATE TABLE t1 (x INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+INSERT INTO t1 VALUES (1),(2),(3),(4),(5);
+CREATE TABLE t2 (x INT) ENGINE=InnoDB;
+INSERT INTO t2 VALUES (1),(2),(3),(4),(5);
+
+SET GLOBAL INNODB_FAST_SHUTDOWN=2;
+
+--source include/restart_mysqld.inc
+
+SELECT * FROM t1;
+SELECT * FROM t2;
+
+DROP TABLE t1, t2;

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -3960,6 +3960,12 @@ void Fil_shard::close_all_files() {
 
     for (auto &file : space->files) {
       if (file.is_open) {
+        while (file.n_pending_flushes > 0) {
+          mutex_release();
+          os_thread_sleep(10000);
+          mutex_acquire();
+        }
+
         close_file(&file, false);
       }
     }


### PR DESCRIPTION
The assertion ut_a(file->n_pending_flushes == 0) in Fil_shard::close_file
failes in case fast server shutdown is done with INNODB_FAST_SHUTDOWN=2.
The reason for this is that IO threads are still active at the time
all files are being closed. Those threads may start checking pending
flushes at any time.
To fix this wait for any active flushes on a file to finish before
actually closing it.