### PR TITLE
PS-7495 Block Tablespace DDL with Lock Tables for backup

### DIFF
--- a/mysql-test/suite/innodb/r/tablespace_encrypt_1.result
+++ b/mysql-test/suite/innodb/r/tablespace_encrypt_1.result
@@ -47,6 +47,41 @@ SELECT @@innodb_file_per_table;
 1
 ALTER TABLESPACE innodb_system ENCRYPTION='Y';
 ERROR 42000: InnoDB: `innodb_system` is a reserved tablespace name.
+LOCK TABLES FOR BACKUP;
+CREATE TABLESPACE tbs01 ADD DATAFILE 'tbs01.ibd' ENCRYPTION='y';
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+SET @@session.lock_wait_timeout=1;
+CREATE TABLESPACE tbs01 ADD DATAFILE 'tbs01.ibd' ENCRYPTION='y';
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+UNLOCK TABLES;
+CREATE TABLESPACE tbs01 ADD DATAFILE 'tbs01.ibd' ENCRYPTION='y';
+CREATE TABLE t1(i int) TABLESPACE=tbs01 ENCRYPTION='y';
+LOCK TABLES FOR BACKUP;
+ALTER TABLESPACE tbs01 ENCRYPTION='n';
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+INSERT into t1 values(100);
+SET @@session.lock_wait_timeout=1;
+ALTER TABLESPACE tbs01 ENCRYPTION='n';
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+UNLOCK TABLES;
+ALTER TABLESPACE tbs01 ENCRYPTION='n';
+LOCK TABLES FOR BACKUP;
+ALTER TABLESPACE tbs01 rename to tbs01_renamed;
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+SET @@session.lock_wait_timeout=1;
+ALTER TABLESPACE tbs01 rename to tbs01_renamed;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+UNLOCK TABLES;
+ALTER TABLESPACE tbs01 rename to tbs01_renamed;
+DROP TABLE t1;
+LOCK TABLES FOR BACKUP;
+DROP TABLESPACE tbs01_renamed;
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+SET @@session.lock_wait_timeout=1;
+DROP TABLESPACE tbs01_renamed;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+UNLOCK TABLES;
+DROP TABLESPACE tbs01_renamed;
 ---------------------------
 TEMPORARY TABLESPACE
 ---------------------------

--- a/mysql-test/suite/innodb/t/tablespace_encrypt_1.test
+++ b/mysql-test/suite/innodb/t/tablespace_encrypt_1.test
@@ -114,6 +114,79 @@ SELECT @@innodb_file_per_table;
 --error ER_WRONG_TABLESPACE_NAME
 ALTER TABLESPACE innodb_system ENCRYPTION='Y';
 
+# Check that it won't work with LTFB
+LOCK TABLES FOR BACKUP;
+
+--error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
+CREATE TABLESPACE tbs01 ADD DATAFILE 'tbs01.ibd' ENCRYPTION='y';
+
+--connect (con1,'localhost','root',,)
+SET @@session.lock_wait_timeout=1;
+
+--error ER_LOCK_WAIT_TIMEOUT
+CREATE TABLESPACE tbs01 ADD DATAFILE 'tbs01.ibd' ENCRYPTION='y';
+
+--connection default
+--disconnect con1
+
+UNLOCK TABLES;
+
+CREATE TABLESPACE tbs01 ADD DATAFILE 'tbs01.ibd' ENCRYPTION='y';
+CREATE TABLE t1(i int) TABLESPACE=tbs01 ENCRYPTION='y';
+
+LOCK TABLES FOR BACKUP;
+
+--error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
+ALTER TABLESPACE tbs01 ENCRYPTION='n';
+
+--connect (con1,'localhost','root',,)
+INSERT into t1 values(100);
+SET @@session.lock_wait_timeout=1;
+
+--error ER_LOCK_WAIT_TIMEOUT
+ALTER TABLESPACE tbs01 ENCRYPTION='n';
+
+--connection default
+--disconnect con1
+
+UNLOCK TABLES;
+ALTER TABLESPACE tbs01 ENCRYPTION='n';
+
+LOCK TABLES FOR BACKUP;
+
+--error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
+ALTER TABLESPACE tbs01 rename to tbs01_renamed;
+
+--connect (con1,'localhost','root',,)
+SET @@session.lock_wait_timeout=1;
+
+--error ER_LOCK_WAIT_TIMEOUT
+ALTER TABLESPACE tbs01 rename to tbs01_renamed;
+
+--connection default
+--disconnect con1
+
+UNLOCK TABLES;
+ALTER TABLESPACE tbs01 rename to tbs01_renamed;
+DROP TABLE t1;
+
+LOCK TABLES FOR BACKUP;
+
+--error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
+DROP TABLESPACE tbs01_renamed;
+
+--connect (con1,'localhost','root',,)
+SET @@session.lock_wait_timeout=1;
+
+--error ER_LOCK_WAIT_TIMEOUT
+DROP TABLESPACE tbs01_renamed;
+
+--connection default
+--disconnect con1
+
+UNLOCK TABLES;
+DROP TABLESPACE tbs01_renamed;
+
 --echo ---------------------------
 --echo TEMPORARY TABLESPACE
 --echo ---------------------------

--- a/sql/sql_tablespace.cc
+++ b/sql/sql_tablespace.cc
@@ -247,6 +247,13 @@ bool lock_tablespace_names(THD *thd, Names... names) {
     return true;
   }
 
+  // Acquire Percona's LOCK TABLES FOR BACKUP lock
+  if (thd->backup_tables_lock.abort_if_acquired() ||
+      thd->backup_tables_lock.acquire_protection(
+          thd, MDL_TRANSACTION, thd->variables.lock_wait_timeout)) {
+    return true;
+  }
+
   if (lock_rec(thd, &mdl_requests, names...)) {
     return true;
   }
@@ -1378,13 +1385,6 @@ bool Sql_cmd_create_undo_tablespace::execute(THD *thd) {
     return true;
   }
 
-  // Acquire Percona's LOCK TABLES FOR BACKUP lock
-  if (thd->backup_tables_lock.abort_if_acquired() ||
-      thd->backup_tables_lock.acquire_protection(
-          thd, MDL_TRANSACTION, thd->variables.lock_wait_timeout)) {
-    return true;
-  }
-
   handlerton *hton = nullptr;
   if (get_stmt_hton(thd, m_options->engine_name, m_undo_tablespace_name.str,
                     "CREATE UNDO TABLESPACE", &hton)) {
@@ -1532,13 +1532,6 @@ bool Sql_cmd_alter_undo_tablespace::execute(THD *thd) {
     return true;
   }
 
-  // Acquire Percona's LOCK TABLES FOR BACKUP lock
-  if (thd->backup_tables_lock.abort_if_acquired() ||
-      thd->backup_tables_lock.acquire_protection(
-          thd, MDL_TRANSACTION, thd->variables.lock_wait_timeout)) {
-    return true;
-  }
-
   handlerton *hton = nullptr;
   if (get_stmt_hton(thd, m_options->engine_name, m_undo_tablespace_name.str,
                     "ALTER UNDO TABLESPACE", &hton)) {
@@ -1627,13 +1620,6 @@ bool Sql_cmd_drop_undo_tablespace::execute(THD *thd) {
   Rollback_guard rollback_on_return{thd};
 
   if (check_global_access(thd, CREATE_TABLESPACE_ACL)) {
-    return true;
-  }
-
-  // Acquire Percona's LOCK TABLES FOR BACKUP lock
-  if (thd->backup_tables_lock.abort_if_acquired() ||
-      thd->backup_tables_lock.acquire_protection(
-          thd, MDL_TRANSACTION, thd->variables.lock_wait_timeout)) {
     return true;
   }
 


### PR DESCRIPTION
   PS-7495 Block Tablespace DDL with Lock Table For Backup

    Block CREATE/ALTER/DROP TABLESPACE statements when the backup lock
    is taken, and hold the lock until the operation is completed.
