### PR TITLE
PS-7499 [5.7]: Improve error log when MyRocks fails with rocksdb_validate_tables=1

### DIFF
--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -4580,8 +4580,9 @@ bool Rdb_ddl_manager::validate_auto_incr() {
       sql_print_warning(
           "RocksDB: AUTOINC mismatch - "
           "Index number (%u, %u) found in AUTOINC "
-          "but does not exist as a DDL entry",
-          gl_index_id.cf_id, gl_index_id.index_id);
+          "but does not exist as a DDL entry for table %s",
+          gl_index_id.cf_id, gl_index_id.index_id,
+          safe_get_table_name(gl_index_id).c_str());
       return false;
     }
 
@@ -4592,8 +4593,9 @@ bool Rdb_ddl_manager::validate_auto_incr() {
       sql_print_warning(
           "RocksDB: AUTOINC mismatch - "
           "Index number (%u, %u) found in AUTOINC "
-          "is on unsupported version %d",
-          gl_index_id.cf_id, gl_index_id.index_id, version);
+          "is on unsupported version %d for table %s",
+          gl_index_id.cf_id, gl_index_id.index_id, version,
+          safe_get_table_name(gl_index_id).c_str());
       return false;
     }
   }
@@ -4800,7 +4802,9 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
     }
     if (validate_tables == 1 && !msg.empty()) {
       // NO_LINT_DEBUG
-      sql_print_error("%s", msg.c_str());
+      sql_print_error(
+          "%s. Use \"rocksdb_validate_tables=2\" to ignore this error.",
+          msg.c_str());
       return true;
     }
   }


### PR DESCRIPTION
1. Add a table name for `AUTOINC mismatch` error.
2. Add a suggestion how to ignore `rocksdb_validate_tables=1` errors.