### PR TITLE
PS-7518: Backport default shutdown timeout fix for MTR tests (5.6)

### DIFF
--- a/mysql-test/lib/My/SafeProcess.pm
+++ b/mysql-test/lib/My/SafeProcess.pm
@@ -262,8 +262,6 @@ sub shutdown {
     else {
       $shutdown_status{failed}= 1 if $? >> 8 != 0 and $? >> 8 != 62;
     }
-    # Only wait for the first process with shutdown timeout
-    $shutdown_timeout= 0;
   }
 
   # Wait infinitely for those process

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -308,7 +308,7 @@ my $opt_sleep;
 
 my $opt_testcase_timeout= $ENV{MTR_TESTCASE_TIMEOUT} ||  15; # minutes
 my $opt_suite_timeout   = $ENV{MTR_SUITE_TIMEOUT}    || 300; # minutes
-my $opt_shutdown_timeout= $ENV{MTR_SHUTDOWN_TIMEOUT} ||  10; # seconds
+my $opt_shutdown_timeout= $ENV{MTR_SHUTDOWN_TIMEOUT} ||  20; # seconds
 my $opt_start_timeout   = $ENV{MTR_START_TIMEOUT}    || 180; # seconds
 
 sub suite_timeout { return $opt_suite_timeout * 60; };


### PR DESCRIPTION
BUG#28861140 MTR TESTING ON WINDOWS EMITS FREQUENT "COULDN'T DELETE FILE..." ERROR MESSAGES

Increase the mysql-test-run.pl default shutdown timeout and
modify the shutdown subroutine to apply this timeout to all
processes in a collection, not just the first. This is because
the first process in a collection may shut down more quickly
than subsequent processes, and killing processes should
remain a last resort.

(cherry picked from commit 956f452e8c80f8f6ee77249eadd93af8c60d5403)