### PR TITLE
PS-7518: Backport default shutdown timeout fix for MTR tests (5.7)

### DIFF
--- a/mysql-test/lib/My/SafeProcess.pm
+++ b/mysql-test/lib/My/SafeProcess.pm
@@ -267,8 +267,6 @@ sub shutdown {
     else {
       $shutdown_status{failed}= 1 if $? >> 8 != 0 and $? >> 8 != 62;
     }
-    # Only wait for the first process with shutdown timeout
-    $shutdown_timeout= 0;
   }
 
   # Wait infinitely for those process


### PR DESCRIPTION
BUG#28861140 MTR TESTING ON WINDOWS EMITS FREQUENT "COULDN'T DELETE FILE..." ERROR MESSAGES

Increase the mysql-test-run.pl default shutdown timeout and
modify the shutdown subroutine to apply this timeout to all
processes in a collection, not just the first. This is because
the first process in a collection may shut down more quickly
than subsequent processes, and killing processes should
remain a last resort.

(cherry picked from commit 956f452e8c80f8f6ee77249eadd93af8c60d5403)