### PR TITLE
PS-7568: Exclude coredumper related files from core files search pattern (5.7)

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -422,10 +422,11 @@ sub is_core_dump {
   my $core_path= shift;
   my $core_name= basename($core_path);
   # Name beginning with core, not ending in .gz, .c, nor .log, not belonging to
-  # Boost, or ending with .dmp on Windows
-  return (($core_name =~ /^core/ and $core_name !~ /\.gz$|\.c$|\.log$/
-           and $core_path !~ /\/boost_/)
-          or (IS_WINDOWS and $core_name =~ /\.dmp$/));
+  # Boost, not belonging to a coredumper related files or ending with .dmp on
+  # Windows
+  return (($core_name =~ /^core/ && $core_name !~ /\.gz$|\.c$|\.log$/
+           && $core_path !~ /\/boost_/ && $core_path !~ /\/coredumper/)
+          || (IS_WINDOWS && $core_name =~ /\.dmp$/));
 }
 
 sub main {


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7568

Don't include coredumper related files into a core files
search pattern to avoid false positives when searching core files
in mysql-test-run.