### PR TITLE
PS-7566: [5.7] Fix changelog error for RHEL Software certification utility

### DIFF
--- a/build-ps/percona-server-5.7_builder.sh
+++ b/build-ps/percona-server-5.7_builder.sh
@@ -469,6 +469,9 @@ build_srpm(){
     cd ${WORKDIR}/rpmbuild/SPECS
     tar vxzf ${WORKDIR}/${TARFILE} --wildcards '*/build-ps/*.spec' --strip=2
     #
+    sed -i "/^%changelog/a - Release ${VERSION}-${RELEASE}" percona-server.spec
+    sed -i "/^%changelog/a * $(date "+%a") $(date "+%b") $(date "+%d") $(date "+%Y") Percona Development Team <info@percona.com> - ${VERSION}-${RELEASE}" percona-server.spec
+    #
     cd ${WORKDIR}/rpmbuild/SOURCES
     #wget http://downloads.sourceforge.net/boost/${BOOST_PACKAGE_NAME}.tar.bz2
     wget http://jenkins.percona.com/downloads/boost/${BOOST_PACKAGE_NAME}.tar.gz

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -1106,6 +1106,9 @@ fi
 
 
 %changelog
+* Mon Feb 22 2021 Percona Development Team <info@percona.com> - 5.7.33-36
+- Release 5.7.33-36
+
 * Wed Aug  2 2017 Evgeniy Patlan <evgeniy.patlan@percona.com>
 - Added RocksDB
 


### PR DESCRIPTION
Builds: https://rel.cd.percona.com/job/percona-server-57-rpm/7/