### PR TITLE
PS-7581: Allow to disable HAVE_AVX2 and -march=native RocksDB flags (5.7)

### DIFF
--- a/cmake/compiler_features.cmake
+++ b/cmake/compiler_features.cmake
@@ -194,7 +194,7 @@ MACRO(ROCKSDB_SET_DEFINTIONS)
 	  add_definitions(-DHAVE_PCLMUL)
 	ENDIF ()
 
-	if(HAVE_AVX2)
+	if(HAVE_AVX2 AND NOT ROCKSDB_DISABLE_AVX2)
 	  add_definitions(-DHAVE_AVX2)
 	endif()
 

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -95,7 +95,7 @@ ELSE()
   ENDIF()
 ENDIF()
 
-IF (HAVE_AVX2)
+IF (HAVE_AVX2 AND NOT ROCKSDB_DISABLE_AVX2)
   add_compile_flags(${ROCKSDB_ROOT}/table/block_based/filter_policy.cc COMPILE_FLAGS "-mavx2")
 ENDIF()
 
@@ -115,7 +115,7 @@ IF (CMAKE_COMPILER_IS_GNUCXX)
   add_compile_options(-fno-builtin-memcmp)
 ENDIF()
 
-IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" AND NOT ROCKSDB_DISABLE_MARCH_NATIVE)
   add_compile_options(-march=native)
 ENDIF()
 


### PR DESCRIPTION
It will allow to build packages for machines without support for given CPU features.