### PR TITLE
[8.0] PS-7578: Replication failure with UPDATE when replica server has a PK and source not

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_add_pk_on_extra_columns_on_replica.inc
+++ b/mysql-test/extra/rpl_tests/rpl_add_pk_on_extra_columns_on_replica.inc
@@ -1,0 +1,145 @@
+# This is an auxiliary file called by
+# `rpl_add_pk_on_extra_columns_on_replica.test` to test the scenarios where a
+# table on replica server has extra columns in addition to the source's table.
+#
+# Parameters:
+# $_CREATE_TABLE_QUERY: CREATE TABLE query to be executed on source server.
+# $_DATA_INSERT_QUERY: INSERT query to be executed on source server.
+# $_ALTER_TABLE_QUERY: ALTER TABLE query to be executed on replica server.
+# $_TEST_QUERY: Query to be executed on source server whose effects need to be checked on replica server.
+# $_DISPLAY_QUERY: Query to be executed to display the contents after validation.
+# $_CLEANUP_ITER_QUERY: Cleanup query to be executed before every iteration.
+# $_CLEANUP_QUERY: Cleanup query to be executed in the end.
+# $table_name: Table name for which consistency check to be performed.
+# $columns_to_be_masked: List of columns that needs to be masked for checking the consistency.
+# $expected_row_count: Expected number of rows for consistency check.
+#
+# How this test works?
+# --------------------
+#
+# 1. Execute $_CREATE_TABLE_QUERY on source server.
+# 2. Sync the replica server with source server.
+# 3. Execute ALTER TABLE on replica server.
+# 4. For each value of slave_rows_search_algorithms, do
+#    4.1. Execute $_DATA_INSERT_QUERY on source server.
+#    4.2. Sync the replica server with source server.
+#    4.3. Execute $_TEST_QUERY on source server.
+#    4.4. Sync replica server with source server.
+#    4.5. Assert that replica table has $expected_row_count rows.
+#    4.6. Verify that both source and replica tables have same rows except the
+#         rows listed in $columns_to_be_masked.
+#    4.7. Execute $_CLEANUP_ITER_QUERY for cleanup before next iteration.
+# 5. Execute $_CLEANUP_QUERY for cleanup.
+#
+# References:
+# PS-7578: Replication failure with UPDATE when replica server has a PK and
+#          source not
+
+--echo
+--echo ##############################################
+--echo # Testing with:
+--echo # CREATE_QUERY: $_CREATE_TABLE_QUERY
+--echo # INSERT_QUERY: $_DATA_INSERT_QUERY
+--echo # ALTER_QUERY: $_ALTER_TABLE_QUERY
+--echo # columns to be mased: $columns_to_be_masked
+--echo ##############################################
+
+--echo #
+--echo # 1. Execute $_CREATE_TABLE_QUERY on source server.
+--echo #
+--source include/rpl_connection_master.inc
+--eval $_CREATE_TABLE_QUERY
+
+--echo #
+--echo # 2. Sync the replica server with source server.
+--echo #
+--source include/sync_slave_sql_with_master.inc
+
+--echo #
+--echo # 3. Execute ALTER TABLE on replica server.
+--echo #
+--eval $_ALTER_TABLE_QUERY
+
+--echo #
+--echo # 4. Test with all combinations of slave_rows_search_algorithms.
+--echo #
+--let $k= 0
+while ($k < 7) {
+
+  if ($k == 0) {
+    SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+  }
+
+  if ($k == 1) {
+    SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+  }
+
+  if ($k == 2) {
+    SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+  }
+
+  if ($k == 3) {
+    SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+  }
+
+  if ($k == 4) {
+    SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+  }
+
+  if ($k == 5) {
+    SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+  }
+
+  if ($k == 6) {
+    SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+  }
+
+  --let $search_algorithm = `SELECT @@GLOBAL.slave_rows_search_algorithms`
+  --echo
+  --echo # Testing with $search_algorithm
+  --echo #
+
+  # Execute $_DATA_INSERT_QUERY on source server.
+  --source include/rpl_connection_master.inc
+  --eval $_DATA_INSERT_QUERY
+
+  # Sync replica server with source server.
+  --source include/sync_slave_sql_with_master.inc
+
+  # Execute $_TEST_QUERY on source server.
+  --source include/rpl_connection_master.inc
+  --eval $_TEST_QUERY
+
+  # Sync replica server with source server.
+  --source include/sync_slave_sql_with_master.inc
+
+  # Assert that replica table has $expected_row_count rows.
+  --let $assert_text= There are exactly $expected_row_count rows on replica server
+  --let $assert_cond= COUNT(*) = $expected_row_count rows FROM $table_name
+  --source include/assert.inc
+
+  # Verify that both source and replica tables have same rows except the rows
+  # listed in $columns_to_be_masked.
+  --let $diff_tables= master:$table_name, slave:$table_name
+  --let $mask_column_list= $columns_to_be_masked
+  --source include/diff_tables.inc
+
+  # Execute $_DISPLAY_QUERY query to display the contents after validation.
+  --source include/rpl_connection_master.inc
+  --eval $_DISPLAY_QUERY
+  --source include/rpl_connection_slave.inc
+  --eval $_DISPLAY_QUERY
+
+  # Execute $_CLEANUP_ITER_QUERY before next iteration.
+  --source include/rpl_connection_master.inc
+  --eval $_CLEANUP_ITER_QUERY
+  --source include/sync_slave_sql_with_master.inc
+
+  --inc $k
+}
+
+--echo #
+--echo # 5. Cleanup
+--echo #
+--source include/rpl_connection_master.inc
+--eval $_CLEANUP_QUERY

--- a/mysql-test/suite/rpl/r/rpl_add_pk_on_extra_columns_on_replica.result
+++ b/mysql-test/suite/rpl/r/rpl_add_pk_on_extra_columns_on_replica.result
@@ -1,0 +1,2643 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+[connection slave]
+SET @saved_slave_rows_search_algorithms= @@global.slave_rows_search_algorithms;
+[connection master]
+SET SQL_LOG_BIN=0;
+CREATE TABLE `queries` (id VARCHAR(10), query VARCHAR(255));
+SET SQL_LOG_BIN=1;
+CREATE FUNCTION update_and_delete_some_rows () RETURNS INT
+BEGIN
+UPDATE t1 SET field1 = "row1-updated" WHERE field1 = "row1";
+DELETE FROM t1 where field1="row2";
+RETURN 0;
+END|
+include/sync_slave_sql_with_master.inc
+[connection master]
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 char(15));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1;
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 char(15)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 char(15));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1;;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 char(15));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL AUTO_INCREMENT PRIMARY KEY;
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 char(15)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 char(15));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL AUTO_INCREMENT PRIMARY KEY;;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 char(15));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1, ADD PRIMARY KEY (field1, extra_col);
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 char(15)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 char(15));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1, ADD PRIMARY KEY (field1, extra_col);;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col
+row1-updated	1
+row3	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 char(15));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col1 INT NOT NULL DEFAULT 100, ADD COLUMN extra_col2 INT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (extra_col2);
+# columns to be mased: extra_col1, extra_col2
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 char(15)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 char(15));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col1 INT NOT NULL DEFAULT 100, ADD COLUMN extra_col2 INT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (extra_col2);;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col1	extra_col2
+row1-updated	100	1
+row3	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col1	extra_col2
+row1-updated	100	1
+row3	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col1	extra_col2
+row1-updated	100	1
+row3	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col1	extra_col2
+row1-updated	100	1
+row3	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col1	extra_col2
+row1-updated	100	1
+row3	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col1	extra_col2
+row1-updated	100	1
+row3	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1
+row1-updated
+row3
+[connection slave]
+SELECT * FROM t1;
+field1	extra_col1	extra_col2
+row1-updated	100	1
+row3	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1;
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1;;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL AUTO_INCREMENT PRIMARY KEY;
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL AUTO_INCREMENT PRIMARY KEY;;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1, ADD PRIMARY KEY (field1, extra_col);
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1, ADD PRIMARY KEY (field1, extra_col);;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col1 INT NOT NULL DEFAULT 100, ADD COLUMN extra_col2 INT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (extra_col2);
+# columns to be mased: extra_col1, extra_col2
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col1 INT NOT NULL DEFAULT 100, ADD COLUMN extra_col2 INT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (extra_col2);;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1;
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1;;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL AUTO_INCREMENT PRIMARY KEY;
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL AUTO_INCREMENT PRIMARY KEY;;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1, ADD PRIMARY KEY (field1, extra_col);
+# columns to be mased: extra_col
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1, ADD PRIMARY KEY (field1, extra_col);;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col
+row1-updated	1010	1
+row3	1010	1
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+
+##############################################
+# Testing with:
+# CREATE_QUERY: CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));
+# INSERT_QUERY: INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');
+# ALTER_QUERY: ALTER TABLE t1 ADD COLUMN extra_col1 INT NOT NULL DEFAULT 100, ADD COLUMN extra_col2 INT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (extra_col2);
+# columns to be mased: extra_col1, extra_col2
+##############################################
+#
+# 1. Execute CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2)); on source server.
+#
+[connection master]
+CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));;
+#
+# 2. Sync the replica server with source server.
+#
+include/sync_slave_sql_with_master.inc
+#
+# 3. Execute ALTER TABLE on replica server.
+#
+ALTER TABLE t1 ADD COLUMN extra_col1 INT NOT NULL DEFAULT 100, ADD COLUMN extra_col2 INT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (extra_col2);;
+#
+# 4. Test with all combinations of slave_rows_search_algorithms.
+#
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN';
+
+# Testing with HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN';
+
+# Testing with TABLE_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'INDEX_SCAN';
+
+# Testing with INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN';
+
+# Testing with TABLE_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,INDEX_SCAN';
+
+# Testing with INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+SET GLOBAL slave_rows_search_algorithms= 'HASH_SCAN,TABLE_SCAN,INDEX_SCAN';
+
+# Testing with TABLE_SCAN,INDEX_SCAN,HASH_SCAN
+#
+[connection master]
+INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');;
+include/sync_slave_sql_with_master.inc
+[connection master]
+SELECT update_and_delete_some_rows();
+update_and_delete_some_rows()
+0
+include/sync_slave_sql_with_master.inc
+include/assert.inc [There are exactly 2 rows on replica server]
+include/diff_tables.inc [master:t1, slave:t1]
+[connection master]
+SELECT * FROM t1;
+field1	field2
+row1-updated	1010
+row3	1010
+[connection slave]
+SELECT * FROM t1;
+field1	field2	extra_col1	extra_col2
+row1-updated	1010	100	1
+row3	1010	100	3
+[connection master]
+TRUNCATE TABLE t1;
+include/sync_slave_sql_with_master.inc
+#
+# 5. Cleanup
+#
+[connection master]
+DROP TABLE t1;
+[connection master]
+DROP FUNCTION update_and_delete_some_rows;
+SET SQL_LOG_BIN=0;
+DROP TABLE queries;
+SET SQL_LOG_BIN=1;
+[connection slave]
+SET GLOBAL slave_rows_search_algorithms= @saved_slave_rows_search_algorithms;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_add_pk_on_extra_columns_on_replica.test
+++ b/mysql-test/suite/rpl/t/rpl_add_pk_on_extra_columns_on_replica.test
@@ -1,0 +1,176 @@
+# ==== Purpose ====
+#
+# This test verifies that update and delete events on a table are properly
+# applied by the replication applier threads when replica table has extra
+# columns, has primary key defined on any of the extra columns.
+#
+# ==== References ====
+#
+# PS-7578: Replication failure with UPDATE when replica server has a PK and
+#          source not
+
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+--source include/rpl_connection_slave.inc
+SET @saved_slave_rows_search_algorithms= @@global.slave_rows_search_algorithms;
+
+# Create an empty helper file which will be later used to load to the server.
+--let $LOAD_FILE= $MYSQLTEST_VARDIR/tmp/query_map.dat
+--write_file $LOAD_FILE
+EOF
+
+################################################################################
+# Here we write queries into the above file in the format
+#
+#          "query_identifier|query"
+#
+# so that this file can be used to load the queries into the table and fetch
+# the queries based on the identifier and execute it on the server for testing.
+#
+# Example: "CREATE_0|CREATE TABLE t1 (field1 char(15));"
+#          query_identifier = CREATE_0
+#          query = CREATE TABLE t1 (field1 char(15));
+#
+################################################################################
+
+############################
+# Variants of CREATE TABLE #
+############################
+# 1. Table with no keys.
+--exec echo "CREATE_0|CREATE TABLE t1 (field1 char(15));" >> $LOAD_FILE
+# 2. Table with a key.
+--exec echo "CREATE_1|CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1));" >> $LOAD_FILE
+# 3. Table with a composite key.
+--exec echo "CREATE_2|CREATE TABLE t1 (field1 CHAR(15), field2 INT DEFAULT 1010, KEY idx (field1, field2));" >> $LOAD_FILE
+
+########################
+# Query to insert data #
+########################
+--exec echo "DATA|INSERT INTO t1(field1) VALUES ('row1'); INSERT INTO t1(field1) VALUES ('row2'); INSERT INTO t1(field1) VALUES ('row3');" >> $LOAD_FILE
+
+###########################
+# Variants of ALTER TABLE #
+###########################
+# 1. No PK.
+--exec echo "ALTER_0|ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1;" >> $LOAD_FILE
+# 2. PK with AUTO_INCREMENT on additional column (adding one column).
+--exec echo "ALTER_1|ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL AUTO_INCREMENT PRIMARY KEY;" >> $LOAD_FILE
+# 3. Composite PK on both source's and additional columns.
+--exec echo "ALTER_2|ALTER TABLE t1 ADD COLUMN extra_col INT NOT NULL DEFAULT 1, ADD PRIMARY KEY (field1, extra_col);" >> $LOAD_FILE
+# 4. PK with AUTO_INCREMENT on additional column (adding two columns).
+--exec echo "ALTER_3|ALTER TABLE t1 ADD COLUMN extra_col1 INT NOT NULL DEFAULT 100, ADD COLUMN extra_col2 INT NOT NULL AUTO_INCREMENT, ADD PRIMARY KEY (extra_col2);" >> $LOAD_FILE
+
+
+################################################################################
+# Create a helper table on source server and load the above created helper file
+# into the table. This table shall be used in later stage of the test to fetch
+# the queries based on the identifier and execute it on the source server.
+################################################################################
+--source include/rpl_connection_master.inc
+SET SQL_LOG_BIN=0;
+CREATE TABLE `queries` (id VARCHAR(10), query VARCHAR(255));
+--disable_query_log
+--eval LOAD DATA LOCAL INFILE "$LOAD_FILE" INTO TABLE `queries` FIELDS TERMINATED BY '|'
+--enable_query_log
+SET SQL_LOG_BIN=1;
+
+################################################################################
+# Create a stored function that generates one Update_rows_log_event and one
+# Delete_row_log_event.
+################################################################################
+--delimiter |
+CREATE FUNCTION update_and_delete_some_rows () RETURNS INT
+BEGIN
+  UPDATE t1 SET field1 = "row1-updated" WHERE field1 = "row1";
+  DELETE FROM t1 where field1="row2";
+  RETURN 0;
+END|
+--delimiter ;
+--source include/sync_slave_sql_with_master.inc
+--source include/rpl_connection_master.inc
+
+################################################################################
+# Test all combinations of CREATE TABLE and ALTER TABLE
+################################################################################
+--let $no_of_create= `SELECT COUNT(*) FROM queries WHERE id like "CREATE%"`
+--let $no_of_alter= `SELECT COUNT(*) FROM queries WHERE id like "ALTER%"`
+--let $i=0
+while ($i < $no_of_create) {
+
+  --let $j=0
+  while ($j < $no_of_alter) {
+
+    # Get next combination of queries.
+    --let $_CREATE_TABLE_QUERY= `SELECT query FROM queries WHERE id="CREATE_$i"`
+    --let $_DATA_INSERT_QUERY= `SELECT query FROM queries WHERE id="DATA"`
+    --let $_ALTER_TABLE_QUERY= `SELECT query FROM queries WHERE id="ALTER_$j"`
+
+    --let $_TEST_QUERY= SELECT update_and_delete_some_rows()
+
+    --let $_DISPLAY_QUERY= SELECT * FROM t1
+    --let $_CLEANUP_ITER_QUERY= TRUNCATE TABLE t1
+    --let $_CLEANUP_QUERY= DROP TABLE t1
+
+    # In every iteration,
+    #
+    # 1. We insert 3 rows.
+    #
+    #    field1
+    #    -----
+    #    row1
+    #    row2
+    #    row3
+    #
+    # 2. We update 1st row
+    #
+    #    field1
+    #    -----
+    #    row1-updated
+    #    row2
+    #    row3
+    #
+    # 3. We delete 2nd row.
+    #    field1
+    #    -----
+    #    row1-updated
+    #    row3
+    #
+    # So, in the end, we expect 2 rows to be present in the table.
+    --let $expected_row_count= 2
+    --let $table_name= t1
+
+    # Define the columns to be masked during validation.
+    if ($j < 3) {
+      --let $columns_to_be_masked= extra_col
+    }
+    if ($j == 3) {
+      --let $columns_to_be_masked= extra_col1, extra_col2
+    }
+
+    # Source rpl_add_pk_on_extra_columns_on_replica.inc to replicate and
+    # validate the data.
+    --source extra/rpl_tests/rpl_add_pk_on_extra_columns_on_replica.inc
+    --inc $j
+  }
+  --inc $i
+}
+
+#
+# Cleanup
+#
+--source include/rpl_connection_master.inc
+DROP FUNCTION update_and_delete_some_rows;
+
+# Drop the helper table.
+SET SQL_LOG_BIN=0;
+DROP TABLE queries;
+SET SQL_LOG_BIN=1;
+
+# Remove the helper file.
+--remove_file $LOAD_FILE
+
+--source include/rpl_connection_slave.inc
+SET GLOBAL slave_rows_search_algorithms= @saved_slave_rows_search_algorithms;
+
+--source include/rpl_end.inc

--- a/sql/rpl_thd_raii.h
+++ b/sql/rpl_thd_raii.h
@@ -1,0 +1,43 @@
+/* Copyright (c) 2021 Percona LLC and/or its affiliates.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+#ifndef RPL_THD_RAII_INCLUDED
+#define RPL_THD_RAII_INCLUDED 1
+#include "sql_class.h" /* THD */
+
+/**
+  RAII class to temporarily disable OPTIMIZER_SWITCH_USE_INDEX_EXTENSIONS
+  optimizer_switch for replication applier threads.
+*/
+class Disable_index_extensions_switch_guard
+{
+public:
+  explicit Disable_index_extensions_switch_guard(THD *thd) : m_thd(thd)
+  {
+    m_save_optimizer_switch = m_thd->variables.optimizer_switch;
+    m_thd->variables.optimizer_switch &= ~OPTIMIZER_SWITCH_USE_INDEX_EXTENSIONS;
+  }
+
+  ~Disable_index_extensions_switch_guard()
+  {
+    m_thd->variables.optimizer_switch = m_save_optimizer_switch;
+  }
+
+private:
+  THD *const m_thd;
+  ulonglong m_save_optimizer_switch;
+};
+#endif /* RPL_THD_RAII_INCLUDED */


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7578

Problem
----
Replication fails with the following error when executing an
UPDATE/DELETE statement in the source(where the table does not have a
PK) and the replica has a PK.

Last_SQL_Errno 1032
Last_SQL_Error Could not execute Update_rows event
on table test.t1; Can't find record in 't1', Error_code: 1032; handler
error HA_ERR_KEY_NOT_FOUND; the event's master log master-bin.000001,
end_log_pos 857

Analysis
----
When there are extra columns on slave server and when any of these
columns are in the key parts of the key used for searching the record in
the replica table, due to the use_index_extensions optimizer switch
(enabled by default even for slave applier threads), the function
`actual_key_parts()` function called from `calculate_key_len()` during
`index_read_map()` considers index_extensions into account and
incorrectly calculates the length of the `KEY::actual_key_parts` instead
of the `KEY::user_defined_key_parts` (in simple, this length the sum of
lengths of secondary key and primary key), and then searches the index
with wrong length, thereby causing "Can't find record in t1" error.

Consider this example.

1. source>  CREATE TABLE t1 (field1 char(5), KEY idx(field1));
2. source>  INSERT INTO t1 VALUES ('abc');
3. replica> ALTER TABLE t1 ADD COLUMN id_pk INT NOT NULL AUTO_INCREMENT PRIMARY KEY;
5. replica> SELECT * FROM t1;
            -------------
            field1  id_pk
            -------------
            abcd    1
            -------------
5. source>  UPDATE t1 SET field1='abcd';
6. Replication breaks.

Since there are extra columns on slave, the applier thread prepares full row
with default values and then merges with the before image row we got from
master and this newly prepared row is then sent to storage engine for updating.
```
Replicated row           : FE 03 61 62 63                <- Writeset from source server.
Prepared row (on replica): FD 61 62 63 20 20 00 00 00 00 <- bytes 7-10 corresponds to default value of INT column
Key data                 : 00 61 62 63 20 20             <- Key prepared from writeset.
Row present in index     : FD 61 62 63 20 20 01 00 00 00 <- bytes 7-10 corresponds to autoinc value 1 of INT column

Key length using actual_key_parts(index extensions) = 10 (1 null byte + 5 bytes for field1 + 4 bytes for id_pk)
Key length using user_defined_key_parts(no index extensions) = 6 (1 null byte + 5 bytes for field1)

Record compare with actual_key_parts (length 10) results in key not found
Prepared row:         FD 61 62 63 20 20 00 00 00 00
Row present in index: FD 61 62 63 20 20 01 00 00 00

Record compare with user_defined_key_parts (length 6) results in successful search
Prepared row:         FD 61 62 63 20 20
Row present in index: FD 61 62 63 20 20
```
Thus in the second case, when used with user_defined_key_parts, the applier
thread will be successfully able to search for the record.

Fix
---
Disable OPTIMIZER_SWITCH_USE_INDEX_EXTENSIONS for Row Based Replication
and make the applier thread to always use `KEY::user_defined_key_parts`
for searching the record.


Testing Done
---
Jenkins: https://ps80.cd.percona.com/job/percona-server-8.0-param/897/testReport/
Failing tests are unrelated to this fix.

Jenkins:https://ps80.cd.percona.com/job/percona-server-8.0-param/898/testReport/