### PR TITLE
Support for RocksDB filesystem plugins

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -50,9 +50,30 @@ ELSE()
   # split the list into lines
   STRING(REGEX MATCHALL "[^\n]+" ROCKSDB_LIB_SOURCES ${SCRIPT_OUTPUT})
 
+  LIST(APPEND PLUGINS ${ROCKSDB_PLUGINS})
+  FOREACH(PLUGIN IN LISTS PLUGINS)
+    SET(PLUGIN_ROOT "${ROCKSDB_ROOT}/plugin/${PLUGIN}/")
+    MESSAGE(STATUS "MyRocks: Building RocksDB plugin: ${PLUGIN}")
+    FILE(GLOB PLUGINMKFILE "${PLUGIN_ROOT}${PLUGIN}*.mk")
+    IF (NOT EXISTS ${PLUGINMKFILE})
+      MESSAGE(SEND_ERROR "Missing RocksDB plugin makefile in ${PLUGIN_ROOT}")
+    ELSE()
+      FILE(READ ${PLUGINMKFILE} PLUGINMK)
+      STRING(REGEX MATCH "SOURCES[ ]*=[ ]*([^\n]*)" FOO ${PLUGINMK})
+      SET(MK_SOURCES ${CMAKE_MATCH_1})
+      SEPARATE_ARGUMENTS(MK_SOURCES)
+      FOREACH(MK_FILE IN LISTS MK_SOURCES)
+        LIST(APPEND PLUGIN_SOURCES "${PLUGIN_ROOT}${MK_FILE}")
+      ENDFOREACH()
+      STRING(REGEX MATCH "LDFLAGS[ ]*=[ ]*([^\n]*)" FOO ${PLUGINMK})
+      LIST(APPEND PLUGIN_LD ${CMAKE_MATCH_1} )
+    ENDIF()
+  ENDFOREACH()
+
   # Statically include all RocksDB source
   SET(ROCKSDB_SOURCES
     ${ROCKSDB_LIB_SOURCES}
+    ${PLUGIN_SOURCES}
   )
 ENDIF()
 
@@ -217,7 +238,7 @@ IF(HAVE_EXTERNAL_ROCKSDB)
   SET(rocksdb_static_libs ${rocksdb_static_libs} "${ROCKSDB_LIB_PATH}/${ROCKSDB_LIB_NAME}")
 ENDIF()
 
-SET(rocksdb_static_libs ${rocksdb_static_libs} ${ZLIB_LIBRARY} ${ZSTD_LIBRARY} ${LZ4_LIBRARY} "-lrt" "-ldl")
+SET(rocksdb_static_libs ${rocksdb_static_libs} ${ZLIB_LIBRARY} ${ZSTD_LIBRARY} ${LZ4_LIBRARY} "-lrt" "-ldl" ${PLUGIN_LD})
 
 MYSQL_ADD_PLUGIN(rocksdb ${ROCKSDB_SOURCES} STORAGE_ENGINE DEFAULT MODULE_ONLY
   LINK_LIBRARIES ${rocksdb_static_libs}

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -637,6 +637,7 @@ static uint32_t rocksdb_validate_tables = 1;
 #endif  // defined(ROCKSDB_INCLUDE_VALIDATE_TABLES) &&
         // ROCKSDB_INCLUDE_VALIDATE_TABLES
 static char *rocksdb_datadir = nullptr;
+static char *rocksdb_fs_uri;
 static uint32_t rocksdb_max_bottom_pri_background_compactions = 0;
 static uint32_t rocksdb_table_stats_sampling_pct =
     RDB_DEFAULT_TBL_STATS_SAMPLE_PCT;
@@ -817,6 +818,12 @@ rdb_init_rocksdb_tbl_options(void) {
       new rocksdb::BlockBasedTableOptions());
   o->block_size = RDB_DEFAULT_BLOCK_SIZE;
   return o;
+}
+
+static rocksdb::Env *GetCompositeEnv(std::shared_ptr<rocksdb::FileSystem> fs)
+{
+  static std::shared_ptr<rocksdb::Env> composite_env = rocksdb::NewCompositeEnv(fs);
+  return composite_env.get();
 }
 
 /* DBOptions contains Statistics and needs to be destructed last */
@@ -2033,6 +2040,11 @@ static MYSQL_SYSVAR_STR(datadir, rocksdb_datadir,
                         "RocksDB data directory", nullptr, nullptr,
                         "./.rocksdb");
 
+static MYSQL_SYSVAR_STR(fs_uri, rocksdb_fs_uri,
+                        PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
+                        "Custom filesystem URI", nullptr,
+                        nullptr, nullptr);
+
 static MYSQL_SYSVAR_UINT(
     table_stats_sampling_pct, rocksdb_table_stats_sampling_pct,
     PLUGIN_VAR_RQCMDARG,
@@ -2306,6 +2318,7 @@ static struct SYS_VAR *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(print_snapshot_conflict_queries),
 
     MYSQL_SYSVAR(datadir),
+    MYSQL_SYSVAR(fs_uri),
     MYSQL_SYSVAR(create_checkpoint),
     MYSQL_SYSVAR(create_temporary_checkpoint),
     MYSQL_SYSVAR(disable_file_deletions),
@@ -5198,6 +5211,19 @@ static int rocksdb_init_internal(void *const p) {
         "Can't enable both use_direct_reads and allow_mmap_reads\n");
     deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
+  }
+
+  if (rocksdb_fs_uri) {
+    std::shared_ptr<rocksdb::FileSystem> fs;
+    s = rocksdb::FileSystem::Load(rocksdb_fs_uri, &fs);
+    if (fs == nullptr) {
+        LogPluginErrMsg(ERROR_LEVEL, 0,
+                        "Loading custom file system failed: %s\n",
+                        s.ToString().c_str());
+        deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
+        DBUG_RETURN(HA_EXIT_FAILURE);
+    }
+    rocksdb_db_options->env = GetCompositeEnv(fs);
   }
 
   // Check whether the filesystem backing rocksdb_datadir allows O_DIRECT


### PR DESCRIPTION
### This is a port to percona-server from upstream myrocks PR https://github.com/facebook/mysql-5.6/pull/1160. The upstream change will trickle down eventually, but this gives a heads up on the coming support for custom file system support in rocksdb. It would be great to get feedback on the build integration (especially any percona-server-specifics - the port required some changes)

RocksDB now supports building plugins from external repos (https://github.com/facebook/rocksdb/pull/7918) and this pull request adds the needed cmake magic to include these in percona server builds. The plugins to include are specified by ROCKSDB_PLUGINS: 

```
mkdir storage/rocksdb/plugin
git clone https://github.com/ajkr/dedupfs storage/rocksdb/plugin/dedupfs
mkdir build
cd build
cmake .. <build flags> -DROCKSDB_PLUGINS=dedupfs
```

Note: as this branch is not yet including the above pull request, the plugin directory does not exist, but can be created manually and the above example will work.

A configuration parameter, rocksdb_fs_uri is also added to allow the user to specify custom file systems.
```
rocksdb_fs_uri=dedupfs
```

These two changes allows external file systems to be included and used in myrocks. I've tested using dedupfs and a custom filesystem that I've developed for zoned block devices: zenfs (https://github.com/westerndigitalcorporation/zenfs)




