### PR TITLE
PS-7549: Illegal mix of collation on 8.0.22 and 8.0.23

### DIFF
--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -618,10 +618,6 @@ class Item_func_user : public Item_func_sysconst {
     str_value.set("", 0, system_charset_info);
   }
 
-  table_map get_initial_pseudo_tables() const override {
-    return INNER_TABLE_BIT;
-  }
-
   bool itemize(Parse_context *pc, Item **res) override;
 
   bool check_function_as_value_generator(uchar *checker_args) override {


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7549

Problem:
Execution of
select * from mysql.user u where u.host=SUBSTRING_INDEX(CURRENT_USER(),'@',-1);
fails with ERROR 1267 (HY000): Illegal mix of collations (ascii, utf8).
The same works on 8.0.21.

Cause:
1. mysql.user Host is ASCII
2. Commit 67c3c70e4895874d43434f1df556f9f30d781b48 introduced
Item_func_user::get_initial_pseudo_tables() method, which causes
Item_func_current_user object having INNER_TABLE_BIT bit set.

We've got the following Item object tree (only 'where' part):

Item_func_eq (item_bool_func2)     (1)
    |-Item_field                   (2)
    |-Item_func_substr_index       (3)
        |-Item_func_current_user   (4)
        |-Item_string              (5)
        |-Item_func_neg            (6)
            |-Item_Int             (7)

(2) ascii / DERIVIATION_IMPLICIT
(3) utf8 / DERIVIATION_SYSCONST  / INNER_TABLE_BIT (inherited from (4))
(4) utf8/ DERIVIATION_SYSCONST/ INNER_TABLE_BIT

Why it doesn't work?

1. Item_bool_func2::resolve_type() (1) attempts to determine charset for
comparison of 2 strings (this is Item_func_eq object) (call to
agg_arg_charsets_for_comparison() which internally sets
cmp.cmp_collation which is collation that will be used for comparison).
Type is resolved between (2) and (3).
2. By default the collation of (2) is used (agg_item_collations()), then
the function checks if we can convert to collation of (3) (call to
DTCollation::aggregate()
3. DTCollation::aggregate() implements the logic that decides
considering actual collation (repertoire and derivation). Collation of
(3) is the superset of the collation of (2), but the derivation of (3)
is weaker, so (2) wins.
So we do a comparison using ASCII
4. After deciding which collation will be used for comparison,
agg_item_charsets() attempts to create item's converters to convert
items to needed collation (call to agg_item_set_converter())
5. (2) does not need conversion, so a converter is not created
6. (3) needs converter, so we try to create converter (call to
agg_item_set_converter(), Item_func_conv_charset object creation)
7. (3) cannot be immediately evaluated, because it has INNER_TABLE_BIT
flag set (flag originates from (4) and is propagated to (3)
during fixing phase), and query execution is not marked as 'started'
yet.
8. As we cannot evaluate immediately, we decide that there is no
possible safe conversion utf8 -> ASCII and we raise the error.

Why it worked before?

INNER_TABLE_BIT was not set in (4). As the consequence, during converter
creation we tried to immediately do the conversion. As the conversion is
possible because the host part always contains only ASCII characters,
the converter was created, and an error was not raised.

Solution:
Remove Item_func_user::get_initial_pseudo_tables() method which causes
the logic to work as it was in 8.0.21