### PR TITLE
AUDITLOG - use log_timestamps

### DIFF
--- a/plugin/audit_log/audit_log.cc
+++ b/plugin/audit_log/audit_log.cc
@@ -1358,7 +1358,7 @@ static int audit_log_exclude_accounts_validate(
 static void audit_log_exclude_accounts_update(
     MYSQL_THD thd MY_ATTRIBUTE((unused)), SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  const char *new_val = *(const char * const*)(save);
+  const char *new_val = *(const char *const *)(save);
 
   DBUG_ASSERT(audit_log_include_accounts == nullptr);
 
@@ -1400,7 +1400,7 @@ static int audit_log_include_accounts_validate(
 static void audit_log_include_accounts_update(
     MYSQL_THD thd MY_ATTRIBUTE((unused)), SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  const char *new_val = *(const char * const*)(save);
+  const char *new_val = *(const char *const *)(save);
 
   DBUG_ASSERT(audit_log_exclude_accounts == nullptr);
 
@@ -1441,7 +1441,7 @@ static int audit_log_exclude_databases_validate(
 static void audit_log_exclude_databases_update(
     MYSQL_THD thd MY_ATTRIBUTE((unused)), SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  const char *new_val = *(const char * const*)(save);
+  const char *new_val = *(const char *const *)(save);
 
   DBUG_ASSERT(audit_log_include_databases == nullptr);
 
@@ -1483,7 +1483,7 @@ static int audit_log_include_databases_validate(
 static void audit_log_include_databases_update(
     MYSQL_THD thd MY_ATTRIBUTE((unused)), SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  const char *new_val = *(const char * const*)(save);
+  const char *new_val = *(const char *const *)(save);
 
   DBUG_ASSERT(audit_log_exclude_databases == nullptr);
 
@@ -1524,7 +1524,7 @@ static int audit_log_exclude_commands_validate(
 static void audit_log_exclude_commands_update(
     MYSQL_THD thd MY_ATTRIBUTE((unused)), SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  const char *new_val = *(const char * const*)(save);
+  const char *new_val = *(const char *const *)(save);
 
   DBUG_ASSERT(audit_log_include_commands == nullptr);
 
@@ -1566,7 +1566,7 @@ static int audit_log_include_commands_validate(
 static void audit_log_include_commands_update(
     MYSQL_THD thd MY_ATTRIBUTE((unused)), SYS_VAR *var MY_ATTRIBUTE((unused)),
     void *var_ptr MY_ATTRIBUTE((unused)), const void *save) {
-  const char *new_val = *(const char * const*)(save);
+  const char *new_val = *(const char *const *)(save);
 
   DBUG_ASSERT(audit_log_exclude_commands == nullptr);
 

--- a/plugin/audit_log/tests/mtr/audit_log_timestamps_basic.result
+++ b/plugin/audit_log/tests/mtr/audit_log_timestamps_basic.result
@@ -1,0 +1,20 @@
+SET @old_audit_log_timestamps     = @@global.audit_log_timestamps;
+SET GLOBAL  audit_log_timestamps=UTC;
+SELECT      @@global.audit_log_timestamps;
+@@global.audit_log_timestamps
+UTC
+SET GLOBAL  audit_log_timestamps=SYSTEM;
+SELECT      @@global.audit_log_timestamps;
+@@global.audit_log_timestamps
+SYSTEM
+SET SESSION audit_log_timestamps=UTC;
+ERROR HY000: Variable 'audit_log_timestamps' is a GLOBAL variable and should be set with SET GLOBAL
+SET GLOBAL  audit_log_timestamps=ON;
+ERROR 42000: Variable 'audit_log_timestamps' can't be set to the value of 'ON'
+SET GLOBAL  audit_log_timestamps=2;
+ERROR 42000: Variable 'audit_log_timestamps' can't be set to the value of '2'
+SET GLOBAL  audit_log_timestamps=DEFAULT;
+SELECT      @@global.audit_log_timestamps;
+@@global.audit_log_timestamps
+UTC
+SET GLOBAL audit_log_timestamps      = @old_audit_log_timestamps;

--- a/plugin/audit_log/tests/mtr/audit_log_timestamps_basic.test
+++ b/plugin/audit_log/tests/mtr/audit_log_timestamps_basic.test
@@ -1,0 +1,24 @@
+SET @old_audit_log_timestamps     = @@global.audit_log_timestamps;
+
+# audit_log_timestamps -- values UTC|SYSTEM
+SET GLOBAL  audit_log_timestamps=UTC;
+SELECT      @@global.audit_log_timestamps;
+SET GLOBAL  audit_log_timestamps=SYSTEM;
+SELECT      @@global.audit_log_timestamps;
+
+# sess var
+--error ER_GLOBAL_VARIABLE
+SET SESSION audit_log_timestamps=UTC;
+
+# wrong value
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL  audit_log_timestamps=ON;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL  audit_log_timestamps=2;
+
+
+# log_timestamps -- default UTC
+SET GLOBAL  audit_log_timestamps=DEFAULT;
+SELECT      @@global.audit_log_timestamps;
+
+SET GLOBAL audit_log_timestamps      = @old_audit_log_timestamps;


### PR DESCRIPTION
Use log_timestamps global variable to format audit log timestamp record.
This will make it easier to analyse when we have servers in non-UTC and we use log_timestamps = SYSTEM
Reuse existing mysql timestamps functions, this will also add usec to the audit. 