### PR TITLE
PS-7591 Document new variables global.net_buffer_shrink_interval and …

### DIFF
--- a/doc/source/performance/xtradb_performance_improvements_for_io-bound_highly-concurrent_workloads.rst
+++ b/doc/source/performance/xtradb_performance_improvements_for_io-bound_highly-concurrent_workloads.rst
@@ -101,22 +101,38 @@ compiled with ``UNIV_PERF_DEBUG`` C preprocessor define.
 .. variable:: innodb_sched_priority_master
 
    :cli: Yes
-   :conf: Yes
    :scope: Global
    :dyn: Yes
    :vartype: Boolean
 
+This variable can be added to the configuration file.
 
-Version Specific Information
-============================
+ .. _adaptive_network_buffers:
 
-  * :rn:`8.0.12-1`
-    Feature ported from |Percona Server| 5.7
+Adaptive Network Buffers 
+-------------------------
+
+To find the buffer size of the current connection, use the ``network_buffer_length`` status variable. Add ``SHOW GLOBAL`` to review the cumulative buffer sizes for all connections. This variable can help to estimate the maximum size of the network buffer's overhead.
+
+Network buffers grow towards the `max_allowed_packet <https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet>`_ size and do not shrink until the connection is terminated. For example, if the connections are selected at random from the pool, an occasional big query eventually increases the buffers of all connections. The combination of `max_allowed packet` set to a value between 64MB to 128MB and the connection number between 256 to 1024 can create a large memory overhead.
+
+Percona Server| version 8.0.23-14 introduces the :variable:`net_buffer_shrink_interval` variable to solve this issue. The default value is 0 (zero). If you set the value higher than 0, Percona Server records the network buffer's maximum use size for the number of seconds set by `net_buffer_shrink_interval`. When the next interval starts, the network buffer is set to the recorded size. This action removes spikes in the buffer size.
+
+You can achieve similar results by disconnecting and reconnecting the TCP connections, but this solution is a heavier process. This process disconnects and reconnects connections with small buffers. 
+
+.. variable:: net_buffer_shrink_interval
+
+   :cli: --net-buffer-shrink-interval=#
+   :dyn: Yes
+   :scope: Global
+   :vartype: integer 
+   :default: 0
+
+The interval is measured in seconds. The default value is 0, which disables the functionality. The minimum value is 0, and the maximum value is 31536000. 
 
 Other Reading
 =============
 
-* :ref:`page_cleaner_tuning`
 * Bug :mysqlbug:`74637` - make dirty page flushing more adaptive
 * Bug :mysqlbug:`67808` - in innodb engine, double write and multi-buffer pool
   instance reduce concurrency


### PR DESCRIPTION
…net_buffer_length (8.0)

 Changes to be committed:
	modified:   source/performance/xtradb_performance_improvements_for_io-bound_highly-concurrent_workloads.rst