### PR TITLE
PS-7574: Improve communication between MTR test worker and main process (5.7)

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -879,8 +879,10 @@ sub run_test_server ($$$) {
 	      # Test has failed, force is off
 	      push(@$completed, $result);
 	      return $completed unless $result->{'dont_kill_server'};
-	      # Prevent kill of server, to get valgrind report
-	      print $sock "BYE\n";
+          # Prevent kill of server, to get shutdown/valgrind report from the
+          # worker, BYE should be sent to the worker for complete exit once
+          # report is received.
+          print $sock "GETREPORTS\n";
 	      next;
 	    }
 	    elsif ($opt_max_test_fail > 0 and
@@ -950,9 +952,14 @@ sub run_test_server ($$$) {
 	  add_total_times($line);
 	}
 	elsif ($line eq 'SHUTDOWN_REPORT') {
-      # Mysqld detected crash during shutdown
+      # Shutdown/valgrind report received
       $shutdown_report = 1;
       push(@$completed, My::Test::read_test($sock));
+
+      # Shutdown worker
+      print $sock "BYE\n";
+      $sock->shutdown(SHUT_WR);
+      next;
 	}
 	else {
 	  mtr_error("Unknown response: '$line' from client");
@@ -1039,9 +1046,9 @@ sub run_test_server ($$$) {
 	  $num_ndb_tests++ if ($next->{ndb_test});
 	}
 	else {
-	  # No more test, tell child to exit
-	  #mtr_report("Saying BYE to child");
-	  print $sock "BYE\n";
+      # No more test, get shutdown/valgrind reports from the worker, BYE
+      # should be sent to the worker for complete exit once report is received.
+      print $sock "GETREPORTS\n";
 	}
       }
     }
@@ -1107,6 +1114,8 @@ sub run_worker ($) {
 
   mark_time_used('init');
 
+  my $exit_code = 0;
+
   while (my $line= <$server>){
     chomp($line);
     if ($line eq 'TESTCASE'){
@@ -1132,36 +1141,37 @@ sub run_worker ($) {
       $test->write_test($server, 'TESTRESULT');
       mark_time_used('restart');
     }
-    elsif ($line eq 'BYE'){
-      mtr_report("Server said BYE");
-      my $found_err = 0;
-      my $valgrind_report_text = '';
-
+    elsif ($line eq 'GETREPORTS'){
       stop_all_servers($opt_shutdown_timeout);
-
-      if ($opt_valgrind || $opt_sanitize) {
-        $valgrind_report_text = valgrind_exit_reports();
-      }
-
-      if ($shutdown_report || $valgrind_report_text) {
-        my $test = My::Test->new(
-          name => 'shutdown_report',
-          comment => $shutdown_report_text,
-          valgrind_comment => $valgrind_report_text,
-        );
-        $test->write_test($server, "SHUTDOWN_REPORT");
-        $found_err = 1;
-      }
-
       mark_time_used('restart');
 
       if ( $opt_gprof ) {
         gprof_collect(find_mysqld($basedir), keys %gprof_dirs);
       }
 
+      my $valgrind_report_text = '';
+      if ($opt_valgrind || $opt_sanitize) {
+        $valgrind_report_text = valgrind_exit_reports();
+      }
+
+      if ($shutdown_report || $valgrind_report_text) {
+        $exit_code = 1;
+      }
+
+      # Send reports as the last message from the worker
+      my $test = My::Test->new(
+        name => 'shutdown_report',
+        comment => $shutdown_report_text ? $shutdown_report_text : '',
+        valgrind_comment => $valgrind_report_text ? $valgrind_report_text : '',
+      );
       mark_time_used('admin');
+
       print_times_used($server, $thread_num);
-      exit($found_err);
+      $test->write_test($server, "SHUTDOWN_REPORT");
+    }
+    elsif ($line eq 'BYE') {
+      mtr_report("Server said BYE");
+      exit($exit_code);
     }
     else {
       mtr_error("Could not understand server, '$line'");


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7574

This is a follow up improvement for
https://github.com/percona/percona-server/pull/3899.

When MTR worker finishes its job it sends shutdown and valgrind
reports to main process. It exits right after that. Two issues
are possible at this point:
- main process may lose last sent data from a worker;
- from time to time main MTR ptocess may silently exit right
  after closing a worker.

To solve both these issues communication protocol between
main MTR process and workers is modified in this change.
The following changes are done:
- Worker shutdown process is split into two steps - collecting
  and sending shutdown/valgrind reports, actual worker process shutdown.
- The GETREPORTS message gets sent to a worker to make it collect and
  send shutdown reports. Worker process stays active at this point.
- Once main process receives all reports it sends BYE to a worker.
  Worker process exits after receiving this message.
Above changes make sure main MTR process has time to collect
all data from a worker before it exits.