### PR TITLE
PS-7631 [8.0]: Travis CI and Azure: installation of clang-9 fails on Ubuntu Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -284,8 +284,13 @@ script:
        TIMEOUT_CMD=timeout;
        CC=$CC-$VERSION;
        CXX=$CXX-$VERSION;
+       if [[ "$CC" == "clang-$VERSION" ]]; then
+         PACKAGES="$CC $PACKAGES";
+       else
+         PACKAGES="$CXX $PACKAGES";
+       fi;
        sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
-       sudo -E apt-get -yq --allow-unauthenticated --no-install-suggests --no-install-recommends install $CXX $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libmecab-dev libnuma-dev liblzma-dev libssl-dev || travis_terminate 1;
+       sudo -E apt-get -yq --allow-unauthenticated --no-install-suggests --no-install-recommends install $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libmecab-dev libnuma-dev liblzma-dev libssl-dev || travis_terminate 1;
        if [[ "$INVERTED" != "ON" ]]; then
          sudo -E apt-get -yq --allow-unauthenticated --no-install-suggests --no-install-recommends install libeditline-dev liblz4-dev libre2-dev protobuf-compiler libprotobuf-dev libprotoc-dev libicu-dev || travis_terminate 1;
        fi;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -232,15 +232,17 @@ jobs:
         CC=$(Compiler)-$(CompilerVer)
         if [[ "$(Compiler)" == "clang" ]]; then
           CXX=clang++-$(CompilerVer)
+          PACKAGES="$CC $PACKAGES"
         else
           CXX=g++-$(CompilerVer)
+          PACKAGES="$CXX $PACKAGES"
         fi
       fi
 
       echo CC=$CC CXX=$CXX BuildType=$(BuildType) Ubuntu=$UBUNTU_CODE_NAME OS_NAME=$OS_NAME
       echo --- Configure required LLVM and Ubuntu Toolchain repositories
       if [[ "$OS_NAME" == "Linux" ]] && [[ "$CC" == "clang"* ]]; then
-        PACKAGES="llvm-$(CompilerVer)-dev"
+        PACKAGES="llvm-$(CompilerVer)-dev $PACKAGES"
         curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -
         echo "deb http://apt.llvm.org/$UBUNTU_CODE_NAME/ llvm-toolchain-$UBUNTU_CODE_NAME-$(CompilerVer) main" | sudo tee -a /etc/apt/sources.list > /dev/null
       fi
@@ -249,8 +251,8 @@ jobs:
       if [[ "$OS_NAME" == "Linux" ]]; then
         sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
         sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1
- 
-        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $CXX $PACKAGES cmake cmake-curses-gui ccache bison libncurses5-dev libaio-dev libmecab-dev libnuma-dev liblzma-dev libssl-dev libreadline-dev libpam-dev libcurl4-openssl-dev libldap2-dev || exit 1;
+
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES cmake cmake-curses-gui ccache bison libncurses5-dev libaio-dev libmecab-dev libnuma-dev liblzma-dev libssl-dev libreadline-dev libpam-dev libcurl4-openssl-dev libldap2-dev || exit 1;
         if [[ "$(Inverted)" != "ON" ]]; then
           sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install libevent-dev libeditline-dev liblz4-dev libre2-dev protobuf-compiler libprotobuf-dev libprotoc-dev libicu-dev || exit 1;
         fi


### PR DESCRIPTION
Do not try to install `clang++` what matches a regex.