### PR TITLE
PS-7507: Update boost version for Azure pipelines to 1.73.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
 
   variables:
     UBUNTU_CODE_NAME: bionic
-    BOOST_VERSION: boost_1_72_0
+    BOOST_VERSION: boost_1_73_0
     BOOST_DIR: $(Pipeline.Workspace)/boost
     USE_CCACHE: 1
     CCACHE_DIR: $(Pipeline.Workspace)/ccache


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7507

Boost version was upgraded to 1.73.0 in
https://github.com/mysql/mysql-server/commit/6d2d0a7ac6db78a156270b0abf63acc58239756f.

Upgrade it for Azure pipelines as well.