### PR TITLE
PS-7643 Update MyRocks Limitations for support of Default Values (8.0)

### DIFF
--- a/doc/source/myrocks/limitations.rst
+++ b/doc/source/myrocks/limitations.rst
@@ -95,8 +95,7 @@ You should also consider the following:
   error. MyRocks key encoding and comparison does not account for this
   character set attribute.
 
-*  In version 8.0.13-3 and later, MyRocks does not support
-   `explicit DEFAULT value expressions <https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html>`__.
+*  As of |Percona Server| version 8.0.23-14, MyRocks supports `explicit DEFAULT value expressions <https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html>`__. From version 8.0.13-3 to version 8.0.22-13, MyRocks did not support these expressions.
 
 * |Percona Server| 8.0.16 does not support encryption for the MyRocks
   storage engine. At this time, during an ``ALTER TABLE`` operation, MyRocks mistakenly detects all InnoDB tables as encrypted. Therefore, any attempt to ``ALTER`` an InnoDB table to MyRocks fails.


### PR DESCRIPTION
Updated the Default values information to state that as of 8.0.23-14 MyRocks does support Default values.
Based on [https://jira.percona.com/browse/PS-5846](https://jira.percona.com/browse/PS-5846)

 Changes to be committed:
	modified:   source/myrocks/limitations.rst