### PR TITLE
PS-7626 - Remove lock when reading net_buffer_shrink_time

### DIFF
--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -1217,9 +1217,9 @@ void bind_fields(Item *first) {
  */
 static bool net_buffer_shrink_interval_is_over(
     const THD *const thd, unsigned long long net_buffer_shrink_time) {
-  mysql_mutex_lock(&LOCK_global_system_variables);
+  // N.B. Make a copy to use the same variable during all the function
+  // as it could be modified in another session.
   auto interval = net_buffer_shrink_interval;
-  mysql_mutex_unlock(&LOCK_global_system_variables);
 
   return interval != 0 &&
          thd->start_utime / 1000000 > net_buffer_shrink_time + interval;


### PR DESCRIPTION
LOCK_global_system_variables is not owned when reading other
global variables.

As the type of net_buffer_shrink_interval is `ulong` the read/writes
are atomic but there still the hazards of using stale values.

As this is a mild problem, the risk is accepted.