### PR TITLE
PS-7652: Enable WITH_KEYRING_VAULT_TEST cmake option for TravisCI builds (5.7)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -329,6 +329,7 @@ script:
       -DDOWNLOAD_BOOST=1
       -DWITH_BOOST=../deps
       -DWITH_KEYRING_VAULT=ON
+      -DWITH_KEYRING_VAULT_TEST=ON
       -DWITH_PAM=ON
     ";
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7652