### PR TITLE
PS-7659: The test `main.bug84640` fails when run with --mem

### DIFF
--- a/mysql-test/t/bug84640.test
+++ b/mysql-test/t/bug84640.test
@@ -3,6 +3,8 @@
 # lp:1654256 "MyISAM CREATE TABLE DATA DIRECTORY check race"
 #
 
+# This test does not work with var being a softlink.
+--source include/not_var_link.inc
 --source include/have_myisam.inc
 --source include/have_debug_sync.inc
 --source include/count_sessions.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7659

Fix: Disable the test when var is a softlink.

Note:
The test fails with
```
[ 50%] main.bug84640                             [ fail ]
        Test ended at 2021-04-21 19:31:44

CURRENT_TEST: main.bug84640
mysqltest: At line 59: Command "remove_file" failed with error 1. my_errno=2.

The result from queries just before the failure was:
#
# Tests for MyISAM handling of symlinks
#
#
# Bug 1654256: symlinks in CREATE TABLE ... DATA DIRECTORY, last path component
#
CREATE TABLE t1 (a INT) ENGINE=MyISAM DATA DIRECTORY='custom_data_directory';
INSERT INTO t1 VALUES (1), (2);
FLUSH TABLES;
SET DEBUG_SYNC="before_opening_datafile SIGNAL open_ready WAIT_FOR finish_open";
SELECT * FROM t1;
SET DEBUG_SYNC="now WAIT_FOR open_ready";
SET DEBUG_SYNC="now SIGNAL finish_open";
ERROR HY000: File '/dev/shm/var_auto_NU5U/tmp/mysqld.1/bug84640/t1.MYD' not found (OS errno 40 - Too many levels of symbolic links)
SET DEBUG_SYNC= 'RESET';
DROP TABLE t1;
safe_process[260649]: Child process: 260650, exit: 1

```