### PR TITLE
PS-7252 : Investigate the unused member `least_occupied_workers` of  `Relay_log_info` class

### DIFF
--- a/sql/rpl_mts_submode.cc
+++ b/sql/rpl_mts_submode.cc
@@ -947,9 +947,10 @@ Mts_submode_logical_clock::get_least_occupied_worker(Relay_log_info *rli,
 Slave_worker*
 Mts_submode_logical_clock::get_free_worker(Relay_log_info *rli)
 {
-  for (Slave_worker **it= rli->workers.begin(); it != rli->workers.end(); ++it)
+  for(std::pair<ulong,size_t> *it = rli->least_occupied_workers.begin(); 
+    it != rli->least_occupied_workers.end(); ++ it)
   {
-    Slave_worker *w_i= *it;
+    Slave_worker *w_i= rli->workers[it->second];
     if (w_i->jobs.len == 0)
       return w_i;
   }

--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -746,7 +746,7 @@ public:
      The first row of the least occupied Worker is queried at assigning
      a new partition. Is updated at checkpoint commit to the main RLI.
   */
-  Prealloced_array<ulong, 16> least_occupied_workers;
+  Prealloced_array<std::pair<ulong,size_t>, 16> least_occupied_workers;
   time_t mts_last_online_stat;
   /* end of MTS statistics */
 

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -6882,12 +6882,12 @@ bool mts_checkpoint_routine(Relay_log_info *rli, ulonglong period,
   /* TODO: 
      to turn the least occupied selection in terms of jobs pieces
   */
-  for (Slave_worker **it= rli->workers.begin();
-       it != rli->workers.begin(); ++it)
+  for(size_t i= 0; i < rli->get_worker_count(); i++)
   {
-    Slave_worker *w_i= *it;
-    rli->least_occupied_workers[w_i->id]= w_i->jobs.len;
+    Slave_worker *w_i= rli->workers[i];
+    rli->least_occupied_workers[i]= std::make_pair(w_i->jobs.len,i);
   };
+
   std::sort(rli->least_occupied_workers.begin(),
             rli->least_occupied_workers.end());
 
@@ -7054,7 +7054,7 @@ int slave_start_single_worker(Relay_log_info *rli, ulong i)
   // Least occupied inited with zero
   {
     ulong jobs_len= w->jobs.len;
-    rli->least_occupied_workers.push_back(jobs_len);
+    rli->least_occupied_workers.push_back(std::make_pair(jobs_len,i));
   }
 err:
   if (error && w)


### PR DESCRIPTION
PS-7252 : Investigate the unused member `least_occupied_workers` of  `Relay_log_info` class

https://jira.percona.com/browse/PS-7252

Fix : Removed least_occupied_workers member from class Relay_log_info
      As it was not used in server code