### PR TITLE
PS-7665 : performance_schema.metadata_locks m_column_name_length is u…

### DIFF
--- a/mysql-test/suite/perfschema/r/fk.result
+++ b/mysql-test/suite/perfschema/r/fk.result
@@ -1,0 +1,32 @@
+# Test MDL_key::FOREIGN_KEY
+CREATE TABLE parent (
+id INT NOT NULL,
+PRIMARY KEY (id)
+) ENGINE=INNODB;
+CREATE TABLE child (
+id INT,
+parent_id INT,
+INDEX par_ind (parent_id),
+FOREIGN KEY (parent_id)
+REFERENCES parent(id)
+ON DELETE CASCADE
+) ENGINE=INNODB;
+SET DEBUG_SYNC= 'after_mdl_locks_acquired SIGNAL mdls_acquired WAIT_FOR resume';
+ALTER TABLE child DROP FOREIGN KEY `child_ibfk_1`;;
+SET DEBUG_SYNC= 'now WAIT_FOR mdls_acquired';
+SELECT thd_blocker.processlist_id FROM performance_schema.metadata_locks mdl_blocker JOIN performance_schema.metadata_locks mdl_exclusive ON mdl_exclusive.object_schema=mdl_blocker.object_schema AND mdl_exclusive.object_name=mdl_blocker.object_name AND mdl_exclusive.owner_thread_id!=mdl_blocker.owner_thread_id JOIN performance_schema.metadata_locks mdl_blocked ON mdl_blocked.object_schema=mdl_exclusive.object_schema AND mdl_blocked.object_name=mdl_exclusive.object_name AND mdl_blocked.owner_thread_id!=mdl_exclusive.owner_thread_id JOIN performance_schema.threads thd_blocker ON thd_blocker.thread_id=mdl_blocker.owner_thread_id WHERE mdl_blocker.object_type='TABLE' AND mdl_blocker.lock_type LIKE 'SHARED%' AND mdl_blocker.lock_status='GRANTED' AND mdl_exclusive.object_type='TABLE' AND mdl_exclusive.lock_type='EXCLUSIVE' AND mdl_exclusive.lock_status='PENDING' AND mdl_blocked.object_type='TABLE' AND mdl_blocked.lock_type like 'SHARED%' AND mdl_blocked.lock_status='PENDING' GROUP BY mdl_blocker.owner_thread_id;
+processlist_id
+SET DEBUG_SYNC= 'now SIGNAL resume';
+DROP TABLE child;
+DROP TABLE parent;
+SET DEBUG_SYNC='RESET';
+# Test MDL_key::CHECK_CONSTRAINT
+CREATE TABLE t1 (f1 INT CHECK (f1 < 10), f2 INT, CONSTRAINT t1_ck CHECK(f2 < 10));
+SET DEBUG_SYNC= 'after_acquiring_lock_on_check_constraints_for_rename SIGNAL mdls_acquired WAIT_FOR resume';
+RENAME TABLE t1 to t2;;
+SET DEBUG_SYNC= 'now WAIT_FOR mdls_acquired';
+SELECT thd_blocker.processlist_id FROM performance_schema.metadata_locks mdl_blocker JOIN performance_schema.metadata_locks mdl_exclusive ON mdl_exclusive.object_schema=mdl_blocker.object_schema AND mdl_exclusive.object_name=mdl_blocker.object_name AND mdl_exclusive.owner_thread_id!=mdl_blocker.owner_thread_id JOIN performance_schema.metadata_locks mdl_blocked ON mdl_blocked.object_schema=mdl_exclusive.object_schema AND mdl_blocked.object_name=mdl_exclusive.object_name AND mdl_blocked.owner_thread_id!=mdl_exclusive.owner_thread_id JOIN performance_schema.threads thd_blocker ON thd_blocker.thread_id=mdl_blocker.owner_thread_id WHERE mdl_blocker.object_type='TABLE' AND mdl_blocker.lock_type LIKE 'SHARED%' AND mdl_blocker.lock_status='GRANTED' AND mdl_exclusive.object_type='TABLE' AND mdl_exclusive.lock_type='EXCLUSIVE' AND mdl_exclusive.lock_status='PENDING' AND mdl_blocked.object_type='TABLE' AND mdl_blocked.lock_type like 'SHARED%' AND mdl_blocked.lock_status='PENDING' GROUP BY mdl_blocker.owner_thread_id;
+processlist_id
+SET DEBUG_SYNC= 'now SIGNAL resume';
+DROP TABLE t2;
+SET DEBUG_SYNC='RESET';

--- a/mysql-test/suite/perfschema/t/fk.test
+++ b/mysql-test/suite/perfschema/t/fk.test
@@ -1,0 +1,56 @@
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+connect (con1, localhost, root);
+
+--echo # Test MDL_key::FOREIGN_KEY
+
+CREATE TABLE parent (
+    id INT NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=INNODB;
+
+CREATE TABLE child (
+    id INT,
+    parent_id INT,
+    INDEX par_ind (parent_id),
+    FOREIGN KEY (parent_id)
+        REFERENCES parent(id)
+        ON DELETE CASCADE
+) ENGINE=INNODB;
+
+--connection default
+SET DEBUG_SYNC= 'after_mdl_locks_acquired SIGNAL mdls_acquired WAIT_FOR resume';
+--send ALTER TABLE child DROP FOREIGN KEY `child_ibfk_1`;
+
+--connection con1
+SET DEBUG_SYNC= 'now WAIT_FOR mdls_acquired';
+SELECT thd_blocker.processlist_id FROM performance_schema.metadata_locks mdl_blocker JOIN performance_schema.metadata_locks mdl_exclusive ON mdl_exclusive.object_schema=mdl_blocker.object_schema AND mdl_exclusive.object_name=mdl_blocker.object_name AND mdl_exclusive.owner_thread_id!=mdl_blocker.owner_thread_id JOIN performance_schema.metadata_locks mdl_blocked ON mdl_blocked.object_schema=mdl_exclusive.object_schema AND mdl_blocked.object_name=mdl_exclusive.object_name AND mdl_blocked.owner_thread_id!=mdl_exclusive.owner_thread_id JOIN performance_schema.threads thd_blocker ON thd_blocker.thread_id=mdl_blocker.owner_thread_id WHERE mdl_blocker.object_type='TABLE' AND mdl_blocker.lock_type LIKE 'SHARED%' AND mdl_blocker.lock_status='GRANTED' AND mdl_exclusive.object_type='TABLE' AND mdl_exclusive.lock_type='EXCLUSIVE' AND mdl_exclusive.lock_status='PENDING' AND mdl_blocked.object_type='TABLE' AND mdl_blocked.lock_type like 'SHARED%' AND mdl_blocked.lock_status='PENDING' GROUP BY mdl_blocker.owner_thread_id;
+SET DEBUG_SYNC= 'now SIGNAL resume';
+
+--connection default
+--reap
+
+DROP TABLE child;
+DROP TABLE parent;
+SET DEBUG_SYNC='RESET';
+
+--echo # Test MDL_key::CHECK_CONSTRAINT
+
+CREATE TABLE t1 (f1 INT CHECK (f1 < 10), f2 INT, CONSTRAINT t1_ck CHECK(f2 < 10));
+
+--connection default
+SET DEBUG_SYNC= 'after_acquiring_lock_on_check_constraints_for_rename SIGNAL mdls_acquired WAIT_FOR resume';
+--send RENAME TABLE t1 to t2;
+
+--connection con1
+SET DEBUG_SYNC= 'now WAIT_FOR mdls_acquired';
+SELECT thd_blocker.processlist_id FROM performance_schema.metadata_locks mdl_blocker JOIN performance_schema.metadata_locks mdl_exclusive ON mdl_exclusive.object_schema=mdl_blocker.object_schema AND mdl_exclusive.object_name=mdl_blocker.object_name AND mdl_exclusive.owner_thread_id!=mdl_blocker.owner_thread_id JOIN performance_schema.metadata_locks mdl_blocked ON mdl_blocked.object_schema=mdl_exclusive.object_schema AND mdl_blocked.object_name=mdl_exclusive.object_name AND mdl_blocked.owner_thread_id!=mdl_exclusive.owner_thread_id JOIN performance_schema.threads thd_blocker ON thd_blocker.thread_id=mdl_blocker.owner_thread_id WHERE mdl_blocker.object_type='TABLE' AND mdl_blocker.lock_type LIKE 'SHARED%' AND mdl_blocker.lock_status='GRANTED' AND mdl_exclusive.object_type='TABLE' AND mdl_exclusive.lock_type='EXCLUSIVE' AND mdl_exclusive.lock_status='PENDING' AND mdl_blocked.object_type='TABLE' AND mdl_blocked.lock_type like 'SHARED%' AND mdl_blocked.lock_status='PENDING' GROUP BY mdl_blocker.owner_thread_id;
+SET DEBUG_SYNC= 'now SIGNAL resume';
+
+--connection default
+--reap
+DROP TABLE t2;
+SET DEBUG_SYNC='RESET';
+
+--disconnect con1
+--source include/wait_until_count_sessions.inc

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -16588,6 +16588,8 @@ bool mysql_alter_table(THD *thd, const char *new_db, const char *new_name,
                                        thd->variables.lock_wait_timeout))
       return true;
 
+    DEBUG_SYNC_C("after_mdl_locks_acquired");
+
     /*
       If we are executing ALTER TABLE RENAME under LOCK TABLES we also need
       to check that all previously orphan tables which reference new table

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -16588,7 +16588,7 @@ bool mysql_alter_table(THD *thd, const char *new_db, const char *new_name,
                                        thd->variables.lock_wait_timeout))
       return true;
 
-    DEBUG_SYNC_C("after_mdl_locks_acquired");
+    DEBUG_SYNC(thd, "after_mdl_locks_acquired");
 
     /*
       If we are executing ALTER TABLE RENAME under LOCK TABLES we also need

--- a/storage/perfschema/table_helper.cc
+++ b/storage/perfschema/table_helper.cc
@@ -805,11 +805,13 @@ int PFS_column_row::make_row(const MDL_key *mdl) {
       m_object_type = OBJECT_TYPE_FOREIGN_KEY;
       m_schema_name_length = mdl->db_name_length();
       m_object_name_length = mdl->name_length();
+      m_column_name_length = 0;
       break;
     case MDL_key::CHECK_CONSTRAINT:
       m_object_type = OBJECT_TYPE_CHECK_CONSTRAINT;
       m_schema_name_length = mdl->db_name_length();
       m_object_name_length = mdl->name_length();
+      m_column_name_length = 0;
       break;
     case MDL_key::NAMESPACE_END:
     default:

--- a/storage/perfschema/table_helper.cc
+++ b/storage/perfschema/table_helper.cc
@@ -698,6 +698,12 @@ int PFS_column_row::make_row(const MDL_key *mdl) {
   static_assert(MDL_key::NAMESPACE_END == 19,
                 "Adjust performance schema when changing enum_mdl_namespace");
 
+  /* Reset the row, it can be re-used */
+  m_object_type = NO_OBJECT_TYPE;
+  m_schema_name_length = 0;
+  m_object_name_length = 0;
+  m_column_name_length = 0;
+
   switch (mdl->mdl_namespace()) {
     case MDL_key::GLOBAL:
       m_object_type = OBJECT_TYPE_GLOBAL;
@@ -805,13 +811,11 @@ int PFS_column_row::make_row(const MDL_key *mdl) {
       m_object_type = OBJECT_TYPE_FOREIGN_KEY;
       m_schema_name_length = mdl->db_name_length();
       m_object_name_length = mdl->name_length();
-      m_column_name_length = 0;
       break;
     case MDL_key::CHECK_CONSTRAINT:
       m_object_type = OBJECT_TYPE_CHECK_CONSTRAINT;
       m_schema_name_length = mdl->db_name_length();
       m_object_name_length = mdl->name_length();
-      m_column_name_length = 0;
       break;
     case MDL_key::NAMESPACE_END:
     default:


### PR DESCRIPTION
…ninitialized for MDL_key::FOREIGN_KEY

https://jira.percona.com/browse/PS-7665

Problem:
--------
When a PFS query on performance_schema.metadata_locks is executed, server crashes randomly. This happens
when there are DDLs in progress on a table with foreign key constraints. i.e. MDL with MDL_key::FOREIGN_KEY
should be acquired and not yet released. At this point of time, if we execute the SELECT query on
performance_schema.metadata_locks, there is uninitialized memory access and this causes crashes randomly.

Fix:
----
PFS engine has temporary object(PFS_column_row) to store each row of a query.
Initialize m_column_length to 0. This column name is used only for MDL_key::COLUMN_STATISTICS
So rest all MDL key types should initialize to 0.