### PR TITLE
PS-7684: Add GCC-10 support for EL7 and EL8

### DIFF
--- a/build-ps/percona-server-8.0_builder.sh
+++ b/build-ps/percona-server-8.0_builder.sh
@@ -359,8 +359,17 @@ install_deps() {
             yum -y install libevent-devel
         fi
         if [ "x$RHEL" = "x7" ]; then
+            yum -y --enablerepo=centos-sclo-rh-testing install devtoolset-10-gcc-c++ devtoolset-10-binutils devtoolset-10-valgrind devtoolset-10-valgrind-devel devtoolset-10-libatomic-devel
+            yum -y --enablerepo=centos-sclo-rh-testing install devtoolset-10-libasan-devel devtoolset-10-libubsan-devel
             rm -f /usr/bin/cmake
 	    cp -p /usr/bin/cmake3 /usr/bin/cmake
+        fi
+        if [ "x$RHEL" = "x8" ]; then
+            yum -y install centos-release-stream
+            yum -y install gcc-toolset-10-gcc-c++ gcc-toolset-10-binutils
+            yum -y install gcc-toolset-10-valgrind gcc-toolset-10-valgrind-devel gcc-toolset-10-libatomic-devel
+            yum -y install gcc-toolset-10-libasan-devel gcc-toolset-10-libubsan-devel
+            yum -y remove centos-release-stream
         fi
     else
         apt-get -y install dirmngr || true


### PR DESCRIPTION
Logs:
```
gcc-toolset-10-binutils.x86_64        2.35-6.el8                                 @Stream-AppStream
gcc-toolset-10-gcc.x86_64             10.2.1-8.2.el8                             @Stream-AppStream
gcc-toolset-10-gcc-c++.x86_64         10.2.1-8.2.el8                             @Stream-AppStream
gcc-toolset-10-libasan-devel.x86_64   10.2.1-8.2.el8                             @Stream-AppStream
gcc-toolset-10-libatomic-devel.x86_64 10.2.1-8.2.el8                             @Stream-AppStream
gcc-toolset-10-libstdc++-devel.x86_64 10.2.1-8.2.el8                             @Stream-AppStream
gcc-toolset-10-libubsan-devel.x86_64  10.2.1-8.2.el8                             @Stream-AppStream
gcc-toolset-10-runtime.x86_64         10.1-0.el8                                 @Stream-AppStream
gcc-toolset-10-valgrind.x86_64        1:3.16.0-4.el8                             @Stream-AppStream
gcc-toolset-10-valgrind-devel.x86_64  1:3.16.0-4.el8                             @Stream-AppStream
libgcc.x86_64                         8.3.1-5.1.el8                              @BaseOS
[root@cent8-ps-7684 mnt]#


devtoolset-10-binutils.x86_64        2.35-3.el7                  @centos-sclo-rh-testing
devtoolset-10-gcc.x86_64             10.2.1-2.1.el7              @centos-sclo-rh-testing
devtoolset-10-gcc-c++.x86_64         10.2.1-2.1.el7              @centos-sclo-rh-testing
devtoolset-10-libasan-devel.x86_64   10.2.1-2.1.el7              @centos-sclo-rh-testing
devtoolset-10-libatomic-devel.x86_64 10.2.1-2.1.el7              @centos-sclo-rh-testing
devtoolset-10-libstdc++-devel.x86_64 10.2.1-2.1.el7              @centos-sclo-rh-testing
devtoolset-10-libubsan-devel.x86_64  10.2.1-2.1.el7              @centos-sclo-rh-testing
devtoolset-10-runtime.x86_64         10.0-0.el7                  @centos-sclo-rh-testing
devtoolset-10-valgrind.x86_64        1:3.16.1-5.el7              @centos-sclo-rh-testing
devtoolset-10-valgrind-devel.x86_64  1:3.16.1-5.el7              @centos-sclo-rh-testing
devtoolset-8-binutils.x86_64         2.30-55.el7.2               @centos-sclo-rh
devtoolset-8-gcc.x86_64              8.3.1-3.2.el7               @centos-sclo-rh
devtoolset-8-gcc-c++.x86_64          8.3.1-3.2.el7               @centos-sclo-rh
devtoolset-8-libasan-devel.x86_64    8.3.1-3.2.el7               @centos-sclo-rh
devtoolset-8-libstdc++-devel.x86_64  8.3.1-3.2.el7               @centos-sclo-rh
devtoolset-8-libubsan-devel.x86_64   8.3.1-3.2.el7               @centos-sclo-rh
devtoolset-8-runtime.x86_64          8.1-1.el7                   @centos-sclo-rh
devtoolset-8-valgrind.x86_64         1:3.14.0-16.el7             @centos-sclo-rh
devtoolset-8-valgrind-devel.x86_64   1:3.14.0-16.el7             @centos-sclo-rh
[root@cent7-ps-7684 mnt]#
```