### PR TITLE
PS-7694 [5.7]: Fix compilation issues with gcc-11

### DIFF
--- a/libmysqld/CMakeLists.txt
+++ b/libmysqld/CMakeLists.txt
@@ -186,6 +186,14 @@ IF(HAVE_MISLEADING_INDENTATION)
     COMPILE_FLAGS "-Wno-misleading-indentation")
 ENDIF()
 
+# Suppress warnings for gcc-11 or newer
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-array-bounds FILES ../sql/spatial.cc)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-stringop-overflow FILES ../sql/spatial.cc)
+  # a false positive with a bison-generated file (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-free-nonheap-object FILES ${CMAKE_CURRENT_BINARY_DIR}/sql_hints.yy.cc)
+ENDIF()
+
 # Handle out-of-source build from source package with possibly broken 
 # bison. Copy bison output to from source to build directory, if not already 
 # there

--- a/mysys/thr_lock.c
+++ b/mysys/thr_lock.c
@@ -1389,6 +1389,7 @@ static void *test_thread(void *arg)
   THR_LOCK_DATA *multi_locks[MAX_LOCK_COUNT];
   my_thread_id id;
   mysql_cond_t COND_thr_lock;
+  memset(&COND_thr_lock, 0, sizeof(COND_thr_lock));
 
   id= param + 1; /* Main thread uses value 0. */
   mysql_cond_init(0, &COND_thr_lock);

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -407,6 +407,14 @@ IF (WIN32 AND OPENSSL_APPLINK_C)
   )
 ENDIF()
 
+# Suppress warnings for gcc-11 or newer
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-array-bounds FILES spatial.cc)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-stringop-overflow FILES spatial.cc)
+  # a false positive with a bison-generated file (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-free-nonheap-object FILES ${CMAKE_CURRENT_BINARY_DIR}/sql_hints.yy.cc)
+ENDIF()
+
 ADD_CONVENIENCE_LIBRARY(sql ${SQL_SOURCE})
 ADD_DEPENDENCIES(sql GenServerSource)
 ADD_DEPENDENCIES(sql GenDigestServerSource)

--- a/sql/item_geofunc_internal.cc
+++ b/sql/item_geofunc_internal.cc
@@ -124,8 +124,7 @@ merge_components(my_bool *pnull_value)
   if (is_comp_no_overlapped())
     return;
 
-  POS pos;
-  Item_func_spatial_operation ifso(pos, NULL, NULL,
+  Item_func_spatial_operation ifso(POS(), NULL, NULL,
                                    Item_func_spatial_operation::op_union);
   bool do_again= true;
   uint32 last_composition[6]= {0}, num_unchanged_composition= 0;

--- a/sql/opt_range.cc
+++ b/sql/opt_range.cc
@@ -14904,7 +14904,7 @@ static void append_range_all_keyparts(Opt_trace_array *range_trace,
       range_string and the string becomes too long. Printing very long
       range conditions normally doesn't make sense either.
      */
-    if (!append_to_trace && range_string->length() > 500)
+    if (!append_to_trace && range_string && range_string->length() > 500)
     {
       range_string->append(STRING_WITH_LEN("..."));
       break;
@@ -14942,7 +14942,7 @@ static void append_range_all_keyparts(Opt_trace_array *range_trace,
       if (append_to_trace)
         range_trace->add_utf8(range_so_far->ptr(),
                               range_so_far->length());
-      else
+      else if (range_string)
       {
         if (range_string->length() == 0)
           range_string->append(STRING_WITH_LEN("("));

--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -196,6 +196,12 @@ IF(HAVE_CAST_FUNCTION_TYPE)
     COMPILE_FLAGS "-Wno-cast-function-type")
 ENDIF()
 
+# Suppress warnings for gcc-11 or newer
+IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 11)
+  # a false positive with a bison-generated file (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-free-nonheap-object FILES pars/pars0grm.cc)
+ENDIF()
+
 # A GCC bug causes crash when compiling these files on ARM64 with -O1+
 # Compile them with -O0 as a workaround.
 IF(CMAKE_COMPILER_IS_GNUCXX AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")

--- a/storage/innobase/include/mem0mem.ic
+++ b/storage/innobase/include/mem0mem.ic
@@ -597,6 +597,8 @@ mem_strdupl(
 	ulint		len)	/*!< in: length of str, in bytes */
 {
 	char*	s = static_cast<char*>(ut_malloc_nokey(len + 1));
+	if (!s) return NULL;
+
 	s[len] = 0;
 	if (len > 0) {
 		memcpy(s, str, len);

--- a/testclients/mysql_client_test.c
+++ b/testclients/mysql_client_test.c
@@ -18146,9 +18146,9 @@ static void test_bug40365(void)
     if (!opt_silent)
       fprintf(stdout, "\ntime[%d]: %02d-%02d-%02d ",
               i, tm[i].year, tm[i].month, tm[i].day);
-      DIE_UNLESS(tm[i].year == 0);
-      DIE_UNLESS(tm[i].month == 0);
-      DIE_UNLESS(tm[i].day == 0);
+    DIE_UNLESS(tm[i].year == 0);
+    DIE_UNLESS(tm[i].month == 0);
+    DIE_UNLESS(tm[i].day == 0);
   }
   mysql_stmt_close(stmt);
   rc= mysql_commit(mysql);

--- a/unittest/gunit/strings_utf8-t.cc
+++ b/unittest/gunit/strings_utf8-t.cc
@@ -189,6 +189,7 @@ TEST_F(StringsUTF8Test, MyIsmbcharUtf8)
 
   /* valid utf8 charaters, testing for boundry values */
   utf8_src[0]= '\x00';
+  utf8_src[1]= '\x00';
   EXPECT_EQ(0U, system_charset_info->cset->ismbchar(system_charset_info,
                                                     utf8_src, utf8_src + 1));
 
@@ -366,6 +367,7 @@ TEST_F(StringsUTF8mb4Test, MyIsmbcharUtf8mb4)
 
   /* valid utf8mb4 charaters, testing for boundry values */
   utf8_src[0]= '\x00';
+  utf8_src[1]= '\x00';
   EXPECT_EQ(0U, system_charset_info->cset->ismbchar(system_charset_info,
                                                     utf8_src,utf8_src + 1));
   utf8_src[0]= '\x7f';


### PR DESCRIPTION
Fix the following 5.7 Debug issues:
```
pars0grm.cc: In function ‘int yyparse()’:
pars0grm.cc:3028:18: error: ‘void free(void*)’ called on unallocated object ‘yyssa’ [-Werror=free-nonheap-object]
pars0grm.cc:1766:16: note: declared here
cc1plus: all warnings being treated as errors
storage/innobase/CMakeFiles/innobase.dir/build.make:1910: recipe for target 'storage/innobase/CMakeFiles/innobase.dir/pars/pars0grm.cc.o' failed

/data/mysql-server/percona-5.7-deb-gcc11-rocks-toku/libmysqld/sql_hints.yy.cc: In function ‘int HINT_PARSER_parse(THD*, Hint_scanner*, PT_hint_list**)’:
/data/mysql-server/percona-5.7-deb-gcc11-rocks-toku/libmysqld/sql_hints.yy.cc:1947:18: error: ‘void free(void*)’ called on unallocated object ‘yyssa’ [-Werror=free-nonheap-object]
 1947 |     YYSTACK_FREE (yyss);
/data/mysql-server/percona-5.7-deb-gcc11-rocks-toku/libmysqld/sql_hints.yy.cc:1113:18: note: declared here
 1113 |     yytype_int16 yyssa[YYINITDEPTH];

/data/mysql-server/percona-5.7/testclients/mysql_client_test.c: In function ‘test_bug40365’:
/data/mysql-server/percona-5.7/testclients/mysql_client_test.c:18146:5: error: this ‘if’ clause does not guard... [-Werror=misleading-indentation]
18146 |     if (!opt_silent)
      |     ^~
In file included from /data/mysql-server/percona-5.7/testclients/mysql_client_test.c:34:
/data/mysql-server/percona-5.7/testclients/mysql_client_fw.c:133:1: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  133 | ((void) ((expr) ? 0 : (die(__FILE__, __LINE__, #expr), 0)))
      | ^
/data/mysql-server/percona-5.7/testclients/mysql_client_test.c:18149:7: note: in expansion of macro ‘DIE_UNLESS’
18149 |       DIE_UNLESS(tm[i].year == 0);

In file included from /data/mysql-server/_deps/googletest-release-1.8.0/googletest/include/gtest/gtest.h:1874,
                 from /data/mysql-server/percona-5.7/unittest/gunit/copy_info-t.cc:26,
                 from /data/mysql-server/percona-5.7-deb-gcc11-rocks-toku/unittest/gunit/merge_large_tests.cc:2:
/data/mysql-server/percona-5.7/unittest/gunit/strings_utf8-t.cc: In member function ‘virtual void strings_utf8_unittest::StringsUTF8Test_MyIsmbcharUtf8_Test::TestBody()’:
/data/mysql-server/percona-5.7/unittest/gunit/strings_utf8-t.cc:192:52: error: ‘<unknown>’ may be used uninitialized [-Werror=maybe-uninitialized]
  192 |   EXPECT_EQ(0U, system_charset_info->cset->ismbchar(system_charset_info,
      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
  193 |                                                     utf8_src, utf8_src + 1));
```

Fix the following 5.7 RelWithDebInfo issues:
```
In file included from /data/mysql-server/percona-5.7/include/mysql/psi/mysql_thread.h:68,
                 from /data/mysql-server/percona-5.7/mysys/mysys_priv.h:32,
                 from /data/mysql-server/percona-5.7/mysys/thr_lock.c:82:
In function ‘inline_mysql_cond_init’,
    inlined from ‘test_thread’ at /data/mysql-server/percona-5.7/mysys/thr_lock.c:1394:3:
/data/mysql-server/percona-5.7/include/mysql/psi/psi.h:3005:29: error: ‘COND_thr_lock’ may be used uninitialized [-Werror=maybe-uninitialized]
 3005 | #define PSI_DYNAMIC_CALL(M) PSI_server->M
/data/mysql-server/percona-5.7/include/mysql/psi/mysql_thread.h:84:26: note: in expansion of macro ‘PSI_DYNAMIC_CALL’
   84 | #define PSI_COND_CALL(M) PSI_DYNAMIC_CALL(M)
      |                          ^~~~~~~~~~~~~~~~
/data/mysql-server/percona-5.7/include/mysql/psi/mysql_thread.h:1147:16: note: in expansion of macro ‘PSI_COND_CALL’
 1147 |   that->m_psi= PSI_COND_CALL(init_cond)(key, &that->m_cond);

In function ‘char* mem_strdupl(const char*, ulint)’,
    inlined from ‘ulint dict_check_sys_tables(bool)’ at /data/mysql-server/percona-5.7/storage/innobase/dict/dict0load.cc:1548:34,
    inlined from ‘void dict_check_tablespaces_and_store_max_id(bool)’ at /data/mysql-server/percona-5.7/storage/innobase/dict/dict0load.cc:1696:36:
/data/mysql-server/percona-5.7/storage/innobase/include/mem0mem.ic:600:16: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
  600 |         s[len] = 0;

/data/mysql-server/percona-5.7/sql/opt_range.cc: In function ‘void append_range_all_keyparts(Opt_trace_array*, String*, String*, SEL_ARG*, const KEY_PART_INFO*, bool)’:
/data/mysql-server/percona-5.7/sql/opt_range.cc:14909:27: error: ‘this’ pointer is null [-Werror=nonnull]
14909 |       range_string->append(STRING_WITH_LEN("..."));

In function ‘void* memset(void*, int, size_t)’,
    inlined from ‘Geometry::Flags_t::Flags_t()’ at /data/mysql-server/percona-5.7/sql/spatial.h:832:13,
    inlined from ‘Geometry::Geometry(const void*, size_t, const Geometry::Flags_t&, Geometry::srid_t)’ at /data/mysql-server/percona-5.7/sql/spatial.h:877:3,
    inlined from ‘Gis_point::Gis_point(bool)’ at /data/mysql-server/percona-5.7/sql/spatial.h:1316:59,
    inlined from ‘objtype* Inplace_vector<objtype, array_size>::append_object() [with objtype = Gis_point; long unsigned int array_size = 16]’ at /data/mysql-server/percona-5.7/sql/inplace_vector.h:161:12,
    inlined from ‘void Gis_wkb_vector<T>::shallow_push(const Geometry*) [with T = Gis_point]’ at /data/mysql-server/percona-5.7/sql/spatial.cc:4718:51:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:71:33: error: ‘void* __builtin_memset(void*, int, long unsigned int)’ offset [0, 7] is out of the bounds [0, 0] [-Werror=array-bounds]
   71 |   return __builtin___memset_chk (__dest, __ch, __len, __bos0 (__dest));

In function ‘void* memset(void*, int, size_t)’,
    inlined from ‘Geometry::Flags_t::Flags_t()’ at /data/mysql-server/percona-5.7/sql/spatial.h:832:13,
    inlined from ‘Geometry::Geometry(const void*, size_t, const Geometry::Flags_t&, Geometry::srid_t)’ at /data/mysql-server/percona-5.7/sql/spatial.h:877:3,
    inlined from ‘Gis_point::Gis_point(bool)’ at /data/mysql-server/percona-5.7/sql/spatial.h:1316:59,
    inlined from ‘objtype* Inplace_vector<objtype, array_size>::append_object() [with objtype = Gis_point; long unsigned int array_size = 16]’ at /data/mysql-server/percona-5.7/sql/inplace_vector.h:161:12,
    inlined from ‘void Gis_wkb_vector<T>::shallow_push(const Geometry*) [with T = Gis_point]’ at /data/mysql-server/percona-5.7/sql/spatial.cc:4718:51:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:71:33: error: ‘void* __builtin_memset(void*, int, long unsigned int)’ writing 8 bytes into a region of size 0 overflows the destination [-Werror=stringop-overflow=]
   71 |   return __builtin___memset_chk (__dest, __ch, __len, __bos0 (__dest));
```