### PR TITLE
PS-7710: Azure Pipelines: clang-6 to clang-8 compilation with libstdc++-11

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -344,7 +344,7 @@ jobs:
         '-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2 -g1 -DNDEBUG'
       )
 
-      if [ "$CC" == "clang-5.0" ]; then
+      if [[ "$CC" =~ clang-(5.0|6.0|7|8)$ ]]; then
         COMPILE_OPT+=(
           '-DCMAKE_C_FLAGS=-isystem /usr/include/c++/9 -isystem /usr/include'
           '-DCMAKE_CXX_FLAGS=-isystem /usr/include/c++/9 -isystem /usr/include'


### PR DESCRIPTION
Use libstdc++-9 instead of libstdc++-11 for clang-6 to clang-8.