### PR TITLE
PS-7698 Docs lack info about init scripts for Docker image (8.0)

### DIFF
--- a/doc/source/installation/docker.rst
+++ b/doc/source/installation/docker.rst
@@ -280,3 +280,7 @@ and collation for all databases::
    --character-set-server=utf8 \
    --collation-server=utf8_general_ci
 
+.. seealso:: 
+
+    `Docker Hub MySQL <https://hub.docker.com/_/mysql>`__ 
+


### PR DESCRIPTION
Merge remote-tracking branch 'ps-5.7-7698' into ps-8.0-7698
Changes to be committed:
  modified:   source/installation/docker.rst