### PR TITLE
PS-7252 : Investigate the unused member least_occupied_workers of Rel…

### DIFF
--- a/sql/rpl_rli.h
+++ b/sql/rpl_rli.h
@@ -1263,7 +1263,7 @@ class Relay_log_info : public Rpl_info {
      The first row of the least occupied Worker is queried at assigning
      a new partition. Is updated at checkpoint commit to the main RLI.
   */
-  Prealloced_array<ulong, 16> least_occupied_workers;
+  Prealloced_array<std::pair<ulong, size_t>, 16> least_occupied_workers;
   time_t mts_last_online_stat;
   /* end of MTS statistics */
 

--- a/sql/rpl_slave.cc
+++ b/sql/rpl_slave.cc
@@ -6516,11 +6516,10 @@ bool mts_checkpoint_routine(Relay_log_info *rli, bool force) {
   /* TODO:
      to turn the least occupied selection in terms of jobs pieces
   */
-  for (Slave_worker **it = rli->workers.begin(); it != rli->workers.begin();
-       ++it) {
-    Slave_worker *w_i = *it;
-    rli->least_occupied_workers[w_i->id] = w_i->jobs.len;
-  };
+  for (size_t i = 0; i < rli->get_worker_count(); i++) {
+    Slave_worker *w_i = rli->workers[i];
+    rli->least_occupied_workers[i] = std::make_pair(w_i->jobs.len, i);
+  }
   std::sort(rli->least_occupied_workers.begin(),
             rli->least_occupied_workers.end());
 
@@ -6642,7 +6641,7 @@ static int slave_start_single_worker(Relay_log_info *rli, ulong i) {
   // Least occupied inited with zero
   {
     ulong jobs_len = w->jobs.len;
-    rli->least_occupied_workers.push_back(jobs_len);
+    rli->least_occupied_workers.push_back(std::make_pair(jobs_len, i));
   }
 err:
   if (error && w) {


### PR DESCRIPTION
…ay_log_info class

https://jira.percona.com/browse/PS-7252

Fix : Refactored code to use least_occupied_workers
      member of Relay_log_info class inside 'get_free_worker'
      method to improve performance, since least_occupied_workers
      is soreted array