### PR TITLE
PS-7622 merge: Merge MySQL 8.0.24 (fix sys_vars.innodb_log_writer_thr…

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5216,8 +5216,8 @@ int init_common_variables() {
     get corrupted if accesses with names of different case.
   */
   DBUG_PRINT("info", ("lower_case_table_names: %d", lower_case_table_names));
-  lower_case_file_system = test_if_case_insensitive(mysql_real_data_home);
-  if (!lower_case_table_names && lower_case_file_system == 1) {
+  lower_case_file_system = (test_if_case_insensitive(mysql_real_data_home) == 1);
+  if (!lower_case_table_names && lower_case_file_system) {
     if (lower_case_table_names_used) {
       LogErr(ERROR_LEVEL, ER_LOWER_CASE_TABLE_NAMES_CS_DD_ON_CI_FS_UNSUPPORTED);
       return 1;
@@ -5226,15 +5226,10 @@ int init_common_variables() {
              mysql_real_data_home);
       lower_case_table_names = 2;
     }
-  } else if (lower_case_table_names == 2 &&
-             !(lower_case_file_system =
-                   (test_if_case_insensitive(mysql_real_data_home) == 1))) {
+  } else if (lower_case_table_names == 2 && !lower_case_file_system) {
     LogErr(WARNING_LEVEL, ER_LOWER_CASE_TABLE_NAMES_USING_0,
            mysql_real_data_home);
     lower_case_table_names = 0;
-  } else {
-    lower_case_file_system =
-        (test_if_case_insensitive(mysql_real_data_home) == 1);
   }
 
   /* Reset table_alias_charset, now that lower_case_table_names is set. */


### PR DESCRIPTION
…eads_basic)

The thread running `log_resume_writer_threads` might get waiting
indefinitely for an ack if an unset followed by a set of
`global.innodb_log_writer_threads` occurrs.

The functions `log_write_notifier` and `log_flush_notifier` might not
notice the unset and set of the variable and consider there has
been no change but `log_resume_writer_threads` is waiting for ack.

The solution is checking if log_resume_writer_threads is waiting for an
ack although the `log.writer_threads_paused` is false and, in that case,
signal an ack.