### PR TITLE
PS-7722: Multiple-Column Index using Column Prefix Key Parts fails with Index Condition Pushdown in MyRocks

### DIFF
--- a/mysql-test/suite/rocksdb/r/type_varchar.result
+++ b/mysql-test/suite/rocksdb/r/type_varchar.result
@@ -833,3 +833,12 @@ select t_vers from t1 where t_vers = '7.6';
 t_vers
 7.6 
 drop table t1;
+# PS-7722: Multiple-Column Index using Column Prefix Key Parts fails with Index Condition Pushdown in MyRocks
+CREATE TABLE t1 (
+f1 varchar(255) CHARSET utf8mb4 COLLATE utf8mb4_general_ci,
+f2 date,
+KEY idx (f2, f1(200))
+) ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES ('63bab075', '2021-05-20');
+include/assert.inc [query should return an empty set]
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/type_varchar.test
+++ b/mysql-test/suite/rocksdb/t/type_varchar.test
@@ -101,3 +101,15 @@ create table t1(
 insert into t1 values ('7.6 ');
 select t_vers from t1 where t_vers = '7.6';
 drop table t1;
+
+--echo # PS-7722: Multiple-Column Index using Column Prefix Key Parts fails with Index Condition Pushdown in MyRocks
+CREATE TABLE t1 (
+  f1 varchar(255) CHARSET utf8mb4 COLLATE utf8mb4_general_ci,
+  f2 date,
+  KEY idx (f2, f1(200))
+) ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES ('63bab075', '2021-05-20');
+--let $assert_text = query should return an empty set
+--let $assert_cond = [SELECT COUNT(*) FROM t1 WHERE f1 = \'63bab075\' AND f2 < \'2021-05-19\'] = 0
+--source include/assert.inc
+DROP TABLE t1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -8032,6 +8032,16 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
   int rc = 0;
   uint pk_size;
 
+  // Due to MRR, now an index-only scan have pushed index condition.
+  // (If it does, we follow non-index only code path here, except that
+  //  we don't fetch the row).
+  bool have_icp = (pushed_idx_cond && pushed_idx_cond_keyno == active_index);
+  if (have_icp) {
+    if (kd.m_is_reverse_cf) move_forward = !move_forward;
+    rc = find_icp_matching_index_rec(move_forward, buf);
+    if (rc) return (rc);
+  }
+
   /* Get the key columns and primary key value */
   const rocksdb::Slice &rkey = m_scan_it->key();
   const rocksdb::Slice &value = m_scan_it->value();


### PR DESCRIPTION
1. Fix the issue using code from https://github.com/facebook/mysql-5.6/commit/48dfd8c710b
2. Add MTR test case to cover the issue.