### PR TITLE
PS-7645 : Incorrect strncpy usage

### DIFF
--- a/client/mysql.cc
+++ b/client/mysql.cc
@@ -2706,7 +2706,7 @@ static int not_in_history(const char *line) {
 #if defined(USE_NEW_XLINE_INTERFACE)
 static int fake_magic_space(int, int)
 #else
- static int fake_magic_space(const char *, int)
+static int fake_magic_space(const char *, int)
 #endif
 {
   rl_insert(1, ' ');
@@ -4391,6 +4391,7 @@ static int com_query_attributes(String *buffer MY_ATTRIBUTE((unused)),
     if (!param || !*param) break;
 
     strncpy(name, param, sizeof(name) - 1);
+    name[sizeof(name) - 1] = '\0';
     param = get_arg(param, true);
     if (!param || !*param) {
       return put_info("Usage: query_attributes name1 value1 name2 value2 ...",

--- a/plugin/auth/dialog.cc
+++ b/plugin/auth/dialog.cc
@@ -112,11 +112,12 @@ static int two_questions(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info) {
 static int generate_auth_string_hash(char *outbuf, unsigned int *buflen,
                                      const char *inbuf, unsigned int inbuflen) {
   /*
-    if buffer specified by server is smaller than the buffer given
-    by plugin then return error
+    Check that the buffer from the plugin is large enough to contain
+    the buffer specifed by the server (+1 for null termination of the string).
+    Otherwise return an error.
   */
-  if (*buflen < inbuflen) return 1;
-  strncpy(outbuf, inbuf, inbuflen);
+  if (*buflen <= inbuflen) return 1;
+  strncpy(outbuf, inbuf, inbuflen + 1);
   *buflen = strlen(inbuf);
   return 0;
 }

--- a/plugin/auth/qa_auth_interface.cc
+++ b/plugin/auth/qa_auth_interface.cc
@@ -144,11 +144,12 @@ static int qa_auth_interface(MYSQL_PLUGIN_VIO *vio,
 static int generate_auth_string_hash(char *outbuf, unsigned int *buflen,
                                      const char *inbuf, unsigned int inbuflen) {
   /*
-    if buffer specified by server is smaller than the buffer given
-    by plugin then return error
+    Check that the buffer from the plugin is large enough to contain
+    the buffer specifed by the server (+1 for null termination of the string).
+    Otherwise return an error.
   */
-  if (*buflen < inbuflen) return 1;
-  strncpy(outbuf, inbuf, inbuflen);
+  if (*buflen <= inbuflen) return 1;
+  strncpy(outbuf, inbuf, inbuflen + 1);
   *buflen = strlen(inbuf);
   return 0;
 }

--- a/plugin/auth/qa_auth_server.cc
+++ b/plugin/auth/qa_auth_server.cc
@@ -68,11 +68,12 @@ static int qa_auth_interface(MYSQL_PLUGIN_VIO *vio,
 static int generate_auth_string_hash(char *outbuf, unsigned int *buflen,
                                      const char *inbuf, unsigned int inbuflen) {
   /*
-    if buffer specified by server is smaller than the buffer given
-    by plugin then return error
+    Check that the buffer from the plugin is large enough to contain
+    the buffer specifed by the server (+1 for null termination of the string).
+    Otherwise return an error.
   */
-  if (*buflen < inbuflen) return 1;
-  strncpy(outbuf, inbuf, inbuflen);
+  if (*buflen <= inbuflen) return 1;
+  strncpy(outbuf, inbuf, inbuflen + 1);
   *buflen = strlen(inbuf);
   return 0;
 }

--- a/plugin/auth/test_plugin.cc
+++ b/plugin/auth/test_plugin.cc
@@ -121,11 +121,12 @@ static int auth_test_plugin(MYSQL_PLUGIN_VIO *vio,
 static int generate_auth_string_hash(char *outbuf, unsigned int *buflen,
                                      const char *inbuf, unsigned int inbuflen) {
   /*
-    if buffer specified by server is smaller than the buffer given
-    by plugin then return error
+    Check that the buffer from the plugin is large enough to contain
+    the buffer specifed by the server (+1 for null termination of the string).
+    Otherwise return an error.
   */
-  if (*buflen < inbuflen) return 1;
-  strncpy(outbuf, inbuf, inbuflen);
+  if (*buflen <= inbuflen) return 1;
+  strncpy(outbuf, inbuf, inbuflen + 1);
   *buflen = strlen(inbuf);
   return 0;
 }

--- a/plugin/auth_ldap/src/plugin_common.cc
+++ b/plugin/auth_ldap/src/plugin_common.cc
@@ -90,11 +90,13 @@ int auth_ldap_common_generate_auth_string_hash(char *outbuf,
                                                const char *inbuf,
                                                unsigned int inbuflen) {
   /*
-    fail if buffer specified by server cannot be copied to output buffer
+    Check that the buffer from the plugin is large enough to contain
+    the buffer specifed by the server (+1 for null termination of the string).
+    Otherwise return an error.
   */
-  if (*buflen < inbuflen) return 1; /* error */
-  strncpy(outbuf, inbuf, inbuflen);
-  *buflen = strnlen(inbuf, inbuflen);
+  if (*buflen <= inbuflen) return 1;
+  strncpy(outbuf, inbuf, inbuflen + 1);
+  *buflen = strlen(inbuf);
   return 0; /* success */
 }
 

--- a/plugin/clone/include/clone_status.h
+++ b/plugin/clone/include/clone_status.h
@@ -230,14 +230,16 @@ class Status_pfs : public Table_pfs {
       /* Clone from local instance. */
       if (host == nullptr) {
         strncpy(m_source, &g_local_string[0], sizeof(m_source) - 1);
+        m_source[sizeof(m_source) - 1] = '\0';
       } else {
-        snprintf(m_source, sizeof(m_source) - 1, "%s:%u", host, port);
+        snprintf(m_source, sizeof(m_source), "%s:%u", host, port);
       }
       /* Clone into local instance. */
       if (destination == nullptr) {
         destination = &g_local_string[0];
       }
       strncpy(m_destination, destination, sizeof(m_destination) - 1);
+      m_destination[sizeof(m_destination) - 1] = '\0';
       m_error_number = 0;
       memset(m_error_mesg, 0, sizeof(m_error_mesg));
       m_binlog_pos = 0;
@@ -266,6 +268,7 @@ class Status_pfs : public Table_pfs {
       m_state = Table_pfs::STATE_FAILED;
       m_error_number = err_num;
       strncpy(m_error_mesg, err_mesg, sizeof(m_error_mesg) - 1);
+      m_error_mesg[sizeof(m_error_mesg) - 1] = '\0';
       write(true);
     }
 
@@ -275,6 +278,7 @@ class Status_pfs : public Table_pfs {
     void update_binlog_position(const char *binlog_file, uint64_t position) {
       m_binlog_pos = position;
       strncpy(m_binlog_file, binlog_file, sizeof(m_binlog_file) - 1);
+      m_binlog_file[sizeof(m_binlog_file) - 1] = '\0';
     }
 
     /** Length of variable length character columns. */

--- a/plugin/clone/src/clone_status.cc
+++ b/plugin/clone/src/clone_status.cc
@@ -470,6 +470,7 @@ void Status_pfs::Data::read() {
   /* Set fixed data. */
   m_pid = 0;
   strncpy(m_destination, &g_local_string[0], sizeof(m_destination) - 1);
+  m_destination[sizeof(m_destination) - 1] = '\0';
 
   std::string file_line;
   int line_number = 0;
@@ -494,6 +495,7 @@ void Status_pfs::Data::read() {
       case 3:
         /* read source string */
         strncpy(m_source, file_line.c_str(), sizeof(m_source) - 1);
+        m_source[sizeof(m_source) - 1] = '\0';
         break;
       case 4:
         /* Read error number. */
@@ -502,10 +504,12 @@ void Status_pfs::Data::read() {
       case 5:
         /* read error string */
         strncpy(m_error_mesg, file_line.c_str(), sizeof(m_error_mesg) - 1);
+        m_error_mesg[sizeof(m_error_mesg) - 1] = '\0';
         break;
       case 6:
         /* Read binary log file name. */
         strncpy(m_binlog_file, file_line.c_str(), sizeof(m_binlog_file) - 1);
+        m_binlog_file[sizeof(m_binlog_file) - 1] = '\0';
         break;
       case 7:
         /* Read binary log position. */
@@ -548,6 +552,7 @@ void Status_pfs::Data::recover() {
       case 3:
         /* Read binary log file name. */
         strncpy(m_binlog_file, file_line.c_str(), sizeof(m_binlog_file) - 1);
+        m_binlog_file[sizeof(m_binlog_file) - 1] = '\0';
         break;
       case 4:
         /* Read binary log position. */

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_ssl_transport.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/xcom_ssl_transport.cc
@@ -206,6 +206,7 @@ static long process_tls_version(const char *tls_version) {
   if (strlen(tls_version) - 1 > sizeof(tls_version_option)) return -1;
 
   strncpy(tls_version_option, tls_version, sizeof(tls_version_option));
+  tls_version_option[sizeof(tls_version_option) - 1] = '\0';
   token = xcom_strtok(tls_version_option, separator, &saved_ctx);
   while (token) {
     for (index = 0; index < tls_versions_count; index++) {
@@ -229,7 +230,8 @@ static int PasswordCallBack(char *passwd, int sz, int rw MY_ATTRIBUTE((unused)),
                             void *userdata MY_ATTRIBUTE((unused))) {
   const char *pw = ssl_pw ? ssl_pw : "yassl123";
   strncpy(passwd, pw, (size_t)sz);
-  return (int)strlen(pw);
+  passwd[sz - 1] = '\0';
+  return (int)strlen(passwd);
 }
 /* purecov: end */
 

--- a/plugin/group_replication/libmysqlgcs/src/interface/gcs_logging_system.cc
+++ b/plugin/group_replication/libmysqlgcs/src/interface/gcs_logging_system.cc
@@ -195,6 +195,7 @@ inline void Gcs_async_buffer::produce_events(const char *message,
   char *buffer = entry.get_buffer();
   size_t size = std::min(entry.get_max_buffer_size(), message_size);
   strncpy(buffer, message, size);
+  buffer[size - 1] = '\0';
   entry.set_buffer_size(size);
   notify_entry(entry);
 }

--- a/plugin/innodb_memcached/daemon_memcached/daemon/memcached.c
+++ b/plugin/innodb_memcached/daemon_memcached/daemon/memcached.c
@@ -6077,6 +6077,15 @@ static int server_socket_unix(const char *path, int access_mask) {
         return 1;
     }
 
+    /*
+     * Check that path can fit in the addr.sun_path.  This must be
+     * NULL-terminated so sizeof(addr.sun_path) must be larger than
+     * strlen(path).
+     */
+    if (strlen(path) >= sizeof(addr.sun_path)) {
+      return 1;
+    }
+
     if ((sfd = new_socket_unix()) == -1) {
         return 1;
     }

--- a/plugin/percona-pam-for-mysql/src/auth_pam_common.cc
+++ b/plugin/percona-pam-for-mysql/src/auth_pam_common.cc
@@ -185,12 +185,14 @@ int auth_pam_generate_auth_string_hash(char *outbuf, unsigned int *buflen,
                                        const char *inbuf,
                                        unsigned int inbuflen) {
   /*
-    fail if buffer specified by server cannot be copied to output buffer
+    Check that the buffer from the plugin is large enough to contain
+    the buffer specifed by the server (+1 for null termination of the string).
+    Otherwise return an error.
   */
-  if (*buflen < inbuflen) return 1; /* error */
-  strncpy(outbuf, inbuf, inbuflen);
+  if (*buflen <= inbuflen) return 1;
+  strncpy(outbuf, inbuf, inbuflen + 1);
   *buflen = strlen(inbuf);
-  return 0; /* success */
+  return 0;
 }
 
 int auth_pam_validate_auth_string_hash(char *const buf __attribute__((unused)),

--- a/router/src/harness/src/filesystem-posix.cc
+++ b/router/src/harness/src/filesystem-posix.cc
@@ -304,6 +304,7 @@ std::string get_tmp_dir(const std::string &name) {
   }
   char buf[MAX_LEN];
   strncpy(buf, pattern, sizeof(buf) - 1);
+  buf[sizeof(buf) - 1] = '\0';
   const char *res = mkdtemp(buf);
   if (res == nullptr) {
     throw std::runtime_error("Could not create temporary directory");

--- a/sql/auth/sha2_password.cc
+++ b/sql/auth/sha2_password.cc
@@ -757,6 +757,7 @@ void static inline auth_save_scramble(MYSQL_PLUGIN_VIO *vio,
                                       const char *scramble) {
   MPVIO_EXT *mpvio = (MPVIO_EXT *)vio;
   strncpy(mpvio->scramble, scramble, SCRAMBLE_LENGTH + 1);
+  mpvio->scramble[SCRAMBLE_LENGTH] = '\0';
 }
 
 /**
@@ -1122,8 +1123,7 @@ static int caching_sha2_password_authenticate(MYSQL_PLUGIN_VIO *vio,
 */
 
 int caching_sha2_password_generate(char *outbuf, unsigned int *buflen,
-                                          const char *inbuf,
-                                          unsigned int inbuflen) {
+                                   const char *inbuf, unsigned int inbuflen) {
   DBUG_TRACE;
   std::string digest;
   std::string source(inbuf, inbuflen);

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -4111,6 +4111,7 @@ void static inline auth_save_scramble(MYSQL_PLUGIN_VIO *vio,
                                       const char *scramble) {
   MPVIO_EXT *mpvio = (MPVIO_EXT *)vio;
   strncpy(mpvio->scramble, scramble, SCRAMBLE_LENGTH + 1);
+  mpvio->scramble[SCRAMBLE_LENGTH] = '\0';
 }
 
 /**

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -9013,17 +9013,19 @@ void MYSQL_BIN_LOG::handle_binlog_flush_or_sync_error(THD *thd,
                                                       const char *message) {
   char errmsg[MYSQL_ERRMSG_SIZE] = {0};
   if (message == nullptr)
-    sprintf(
-        errmsg,
+    snprintf(
+        errmsg, sizeof(errmsg),
         "An error occurred during %s stage of the commit. "
         "'binlog_error_action' is set to '%s'.",
         thd->commit_error == THD::CE_FLUSH_ERROR ? "flush" : "sync",
         binlog_error_action == ABORT_SERVER ? "ABORT_SERVER" : "IGNORE_ERROR");
-  else
-    strncpy(errmsg, message, MYSQL_ERRMSG_SIZE - 1);
+  else {
+    strncpy(errmsg, message, sizeof(errmsg) - 1);
+    errmsg[sizeof(errmsg) - 1] = '\0';
+  }
   if (binlog_error_action == ABORT_SERVER) {
     char err_buff[MYSQL_ERRMSG_SIZE + 25];
-    sprintf(err_buff, "%s Server is being stopped.", errmsg);
+    snprintf(err_buff, sizeof(err_buff), "%s Server is being stopped.", errmsg);
     exec_binlog_error_action_abort(err_buff);
   } else {
     DEBUG_SYNC(thd, "before_binlog_closed_due_to_error");

--- a/sql/clone_handler.cc
+++ b/sql/clone_handler.cc
@@ -240,6 +240,7 @@ int Clone_handler::validate_dir(const char *in_dir, char *out_dir) {
   size_t length;
 
   strncpy(tmp_dir, out_dir, FN_REFLEN);
+  tmp_dir[sizeof(tmp_dir) - 1] = '\0';
   length = strlen(out_dir);
 
   /* Loop and remove all non-existent directories from the tail */

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10471,6 +10471,7 @@ bool mysqld_get_one_option(int optid,
 
       /* Save original argument string for error reporting */
       strncpy(orig_argument, argument, PFS_BUFFER_SIZE);
+      orig_argument[sizeof(orig_argument) - 1] = '\0';
 
       /* Split instrument name and value at the equal sign */
       if (!(p = strchr(argument, '='))) goto pfs_error;

--- a/sql/restart_monitor_win.h
+++ b/sql/restart_monitor_win.h
@@ -80,6 +80,7 @@ struct Service_status_msg {
 
   Service_status_msg(const char *msg) {
     strncpy(m_service_msg, msg, sizeof(m_service_msg));
+    m_service_msg[sizeof(m_service_msg) - 1] = '\0';
   }
 
   /**

--- a/sql/rpl_handler.cc
+++ b/sql/rpl_handler.cc
@@ -348,6 +348,7 @@ int get_user_var_str(const char *name, char *value, size_t len,
   }
   it->second->val_str(&null_val, &str, precision);
   strncpy(value, str.c_ptr(), len);
+  value[len - 1] = '\0';
   if (null_value) *null_value = null_val;
   mysql_mutex_unlock(&thd->LOCK_thd_data);
   return 0;

--- a/sql/ssl_acceptor_context_iterator.cc
+++ b/sql/ssl_acceptor_context_iterator.cc
@@ -126,14 +126,17 @@ bool get_tls_status(property_iterator it, TLS_channel_property *property) {
   /* Copy interface */
   copy_size = min(data.interface().length(), MAX_CHANNEL_NAME_SIZE);
   strncpy(property->channel_name, data.interface().c_str(), copy_size);
+  property->channel_name[copy_size] = '\0';
 
   /* Copy property name */
   copy_size = min(data.property().length(), MAX_PROPERTY_NAME_SIZE);
   strncpy(property->property_name, data.property().c_str(), copy_size);
+  property->property_name[copy_size] = '\0';
 
   /* Copy property value */
   copy_size = min(data.value().length(), MAX_PROPERTY_VALUE_SIZE);
   strncpy(property->property_value, data.value().c_str(), copy_size);
+  property->property_value[copy_size] = '\0';
 
   return true;
 }

--- a/sql/table_trigger_dispatcher.h
+++ b/sql/table_trigger_dispatcher.h
@@ -161,6 +161,7 @@ class Table_trigger_dispatcher : public Table_trigger_field_support {
       m_has_unparseable_trigger = true;
       strncpy(m_parse_error_message, error_message,
               sizeof(m_parse_error_message));
+      m_parse_error_message[sizeof(m_parse_error_message) - 1] = '\0';
     }
   }
 

--- a/sql/trigger.h
+++ b/sql/trigger.h
@@ -205,6 +205,7 @@ class Trigger {
     m_has_parse_error = true;
     strncpy(m_parse_error_message, error_message,
             sizeof(m_parse_error_message));
+    m_parse_error_message[sizeof(m_parse_error_message) - 1] = '\0';
   }
 
   /**

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -1728,6 +1728,7 @@ dberr_t dict_table_rename_in_cache(
       in old_name_cs_filename */
 
       strncpy(old_name_cs_filename, old_name, sizeof(old_name_cs_filename));
+      old_name_cs_filename[sizeof(old_name_cs_filename) - 1] = '\0';
       if (strstr(old_name, TEMP_TABLE_PATH_PREFIX) == nullptr) {
         innobase_convert_to_system_charset(
             strchr(old_name_cs_filename, '/') + 1, strchr(old_name, '/') + 1,
@@ -1745,10 +1746,12 @@ dberr_t dict_table_rename_in_cache(
           /* Old name already in
           my_charset_filename */
           strncpy(old_name_cs_filename, old_name, sizeof(old_name_cs_filename));
+          old_name_cs_filename[sizeof(old_name_cs_filename) - 1] = '\0';
         }
       }
 
       strncpy(fkid, foreign->id, MAX_TABLE_NAME_LEN);
+      fkid[MAX_TABLE_NAME_LEN] = '\0';
 
       if (strstr(fkid, TEMP_TABLE_PATH_PREFIX) == nullptr) {
         innobase_convert_to_filename_charset(strchr(fkid, '/') + 1,
@@ -1778,6 +1781,7 @@ dberr_t dict_table_rename_in_cache(
 
         /* Convert the table name to UTF-8 */
         strncpy(table_name, table->name.m_name, MAX_TABLE_NAME_LEN);
+        table_name[MAX_TABLE_NAME_LEN] = '\0';
         innobase_convert_to_system_charset(strchr(table_name, '/') + 1,
                                            strchr(table->name.m_name, '/') + 1,
                                            MAX_TABLE_NAME_LEN, &errors);
@@ -1788,6 +1792,7 @@ dberr_t dict_table_rename_in_cache(
           UTF-8. This means that the table name
           is already in UTF-8 (#mysql#50). */
           strncpy(table_name, table->name.m_name, MAX_TABLE_NAME_LEN);
+          table_name[MAX_TABLE_NAME_LEN] = '\0';
         }
 
         /* Replace the prefix 'databasename/tablename'

--- a/storage/innobase/dict/dict0load.cc
+++ b/storage/innobase/dict/dict0load.cc
@@ -1314,6 +1314,7 @@ static bool dict_sys_tablespaces_rec_read(const rec_t *rec, space_id_t *id,
     return (false);
   }
   strncpy(name, reinterpret_cast<const char *>(field), NAME_LEN);
+  name[NAME_LEN] = '\0';
 
   /* read the 4 byte flags from the TYPE field */
   field = rec_get_nth_field_old(rec, DICT_FLD__SYS_TABLESPACES__FLAGS, &len);

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -12853,7 +12853,9 @@ void Fil_path::convert_to_filename_charset(std::string &name) {
   char filename[MAX_TABLE_NAME_LEN + 20];
 
   strncpy(filename, name.c_str(), sizeof(filename) - 1);
+  filename[sizeof(filename) - 1] = '\0';
   strncpy(old_name, filename, sizeof(old_name));
+  old_name[sizeof(old_name) - 1] = '\0';
 
   innobase_convert_to_filename_charset(filename, old_name, MAX_TABLE_NAME_LEN);
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -3871,9 +3871,10 @@ void Validate_files::check(const Const_iter &begin, const Const_iter &end,
 
     /* It's safe to pass space_name in tablename charset because
     filename is already in filename charset. */
-    dberr_t err = fil_ibd_open(
-        validate || is_enc_in_progress, FIL_TYPE_TABLESPACE, space_id, fsp_flags,
-        space_name, nullptr, filename, false, false, keyring_encryption_info);
+    dberr_t err =
+        fil_ibd_open(validate || is_enc_in_progress, FIL_TYPE_TABLESPACE,
+                     space_id, fsp_flags, space_name, nullptr, filename, false,
+                     false, keyring_encryption_info);
 
     switch (err) {
       case DB_SUCCESS: {
@@ -4485,10 +4486,12 @@ error_exit:
   return (ret);
 }
 
-bool innobase_fix_default_table_encryption(ulong encryption_option, bool is_server_starting) {
+bool innobase_fix_default_table_encryption(ulong encryption_option,
+                                           bool is_server_starting) {
   if (!srv_read_only_mode) {
     return fil_crypt_set_encrypt_tables(
-        static_cast<enum_default_table_encryption>(encryption_option), is_server_starting);
+        static_cast<enum_default_table_encryption>(encryption_option),
+        is_server_starting);
   }
   return false;
 }
@@ -13712,6 +13715,7 @@ int create_table_info_t::parse_table_name(const char *name) {
       m_flags &= ~DICT_TF_MASK_DATA_DIR;
     } else {
       strncpy(m_remote_path, m_create_info->data_file_name, FN_REFLEN - 1);
+      m_remote_path[FN_REFLEN - 1] = '\0';
     }
   }
 
@@ -13725,6 +13729,7 @@ int create_table_info_t::parse_table_name(const char *name) {
   So it only needs to be copied now. */
   if (m_use_shared_space) {
     strncpy(m_tablespace, m_create_info->tablespace, NAME_LEN - 1);
+    m_tablespace[NAME_LEN - 1] = '\0';
   }
 
   return 0;

--- a/storage/innobase/include/clone0clone.h
+++ b/storage/innobase/include/clone0clone.h
@@ -219,6 +219,7 @@ class Clone_Task_Manager {
         ut_ad(m_err_file_len != 0);
 
         strncpy(m_err_file_name, file_name, m_err_file_len);
+        m_err_file_name[m_err_file_len - 1] = '\0';
       }
     }
 

--- a/storage/innobase/os/os0enc.cc
+++ b/storage/innobase/os/os0enc.cc
@@ -84,8 +84,7 @@ Encryption::Encryption(const Encryption &other) noexcept
   memcpy(m_key_id_uuid, other.m_key_id_uuid, SERVER_UUID_LEN + 1);
 }
 
-Encryption::~Encryption() {
-}
+Encryption::~Encryption() {}
 
 void Encryption::set_key(byte *key, ulint key_len) noexcept {
   m_key = key;
@@ -1787,6 +1786,8 @@ bool Encryption::check_keyring() noexcept {
     size_t key_len;
     char *key_type = nullptr;
     char key_name[MASTER_KEY_NAME_MAX_LEN];
+
+    ut_ad(sizeof(DEFAULT_MASTER_KEY) < MASTER_KEY_NAME_MAX_LEN);
 
     key_name[sizeof(DEFAULT_MASTER_KEY)] = 0;
 

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -841,6 +841,7 @@ void Tablespace::set_file_name(const char *file_name) {
   /* Make a copy of the filename and normalize it. */
   char norm_fn[FN_REFLEN];
   strncpy(norm_fn, file_name, FN_REFLEN - 1);
+  norm_fn[FN_REFLEN - 1] = '\0';
   Fil_path::normalize(norm_fn);
   std::string tmp_fn{norm_fn};
 

--- a/storage/innobase/trx/trx0sys.cc
+++ b/storage/innobase/trx/trx0sys.cc
@@ -239,6 +239,7 @@ void trx_sys_read_binlog_position(char *file, uint64_t &offset) {
   }
 
   strncpy(file, current_name, TRX_SYS_MYSQL_LOG_NAME_LEN);
+  file[TRX_SYS_MYSQL_LOG_NAME_LEN] = '\0';
   offset = static_cast<uint64_t>(high);
   offset = (offset << 32);
   offset |= static_cast<uint64_t>(low);

--- a/storage/ndb/nodejs/jones-ndb/impl/include/common/SharedList.h
+++ b/storage/ndb/nodejs/jones-ndb/impl/include/common/SharedList.h
@@ -57,7 +57,7 @@ public:
   void setNote(const char *txt) {
     strncpy(note, txt, LIST_ITEM_NOTE_SIZE);
     /* If txt is too long, strncpy() leaves it unterminated */
-    note[LIST_ITEM_NOTE_SIZE] = '\0';
+    note[LIST_ITEM_NOTE_SIZE - 1] = '\0';
   }
 
   const char * getNote() const {

--- a/storage/ndb/plugin/ndb_conflict.cc
+++ b/storage/ndb/plugin/ndb_conflict.cc
@@ -63,6 +63,7 @@ bool ExceptionsTableWriter::has_prefix_ci(const char *col_name,
   uint prefix_len = strlen(prefix);
   if (col_len < prefix_len) return false;
   char col_name_prefix[FN_HEADLEN];
+  assert(prefix_len < sizeof(col_name_prefix));
   strncpy(col_name_prefix, col_name, prefix_len);
   col_name_prefix[prefix_len] = '\0';
   return (my_strcasecmp(cs, col_name_prefix, prefix) == 0);

--- a/storage/ndb/src/common/logger/LogHandler.cpp
+++ b/storage/ndb/src/common/logger/LogHandler.cpp
@@ -59,7 +59,9 @@ LogHandler::append(const char* pCategory, Logger::LoggerLevel level,
 
     m_last_level= level;
     strncpy(m_last_category, pCategory, sizeof(m_last_category));
+    m_last_category[sizeof(m_last_category) - 1] = '\0';
     strncpy(m_last_message, pMsg, sizeof(m_last_message));
+    m_last_message[sizeof(m_last_message) - 1] = '\0';
   }
   else // repeated message
   {

--- a/storage/ndb/src/common/portlib/NdbTCP.cpp
+++ b/storage/ndb/src/common/portlib/NdbTCP.cpp
@@ -293,6 +293,7 @@ Ndb_split_string_address_port(const char *arg, char *host, size_t hostlen,
       if (*port_colon == ':')
       {
         strncpy(serv, port_colon + 1, servlen);
+        serv[servlen - 1] = '\0';
       }
       else
       {

--- a/storage/ndb/src/common/transporter/Transporter.cpp
+++ b/storage/ndb/src/common/transporter/Transporter.cpp
@@ -99,6 +99,7 @@ Transporter::Transporter(TransporterRegistry &t_reg,
   DBUG_ASSERT(rHostName);
   if (rHostName && strlen(rHostName) > 0){
     strncpy(remoteHostName, rHostName, sizeof(remoteHostName));
+    remoteHostName[sizeof(remoteHostName) - 1] = '\0';
   }
   else
   {
@@ -110,6 +111,7 @@ Transporter::Transporter(TransporterRegistry &t_reg,
     remoteHostName[0]= 0;
   }
   strncpy(localHostName, lHostName, sizeof(localHostName));
+  localHostName[sizeof(localHostName) - 1] = '\0';
 
   DBUG_PRINT("info",("rId=%d lId=%d isServer=%d rHost=%s lHost=%s s_port=%d",
 		     remoteNodeId, localNodeId, isServer,

--- a/storage/ndb/src/common/util/ProcessInfo.cpp
+++ b/storage/ndb/src/common/util/ProcessInfo.cpp
@@ -110,6 +110,7 @@ ProcessInfo * ProcessInfo::forNodeId(Uint16 nodeId)
   ProcessInfo * self = new ProcessInfo();
   self->node_id = nodeId;   // do not copy node id
   strncpy(self->process_name, process->process_name, ProcessNameLength);
+  self->process_name[ProcessNameLength - 1] = '\0';
   self->process_id = process->process_id;
   self->angel_process_id = process->angel_process_id;
   /* Do not copy any of the fields that will be set from set_service_uri() */

--- a/storage/ndb/src/common/util/Properties.cpp
+++ b/storage/ndb/src/common/util/Properties.cpp
@@ -419,9 +419,11 @@ Properties::print(FILE * out, const char * prefix) const{
   char buf[1024];
   if(prefix == 0)
     buf[0] = 0;
-  else
-    strncpy(buf, prefix, 1024);
-  
+  else {
+    strncpy(buf, prefix, sizeof(buf));
+    buf[sizeof(buf) - 1] = '\0';
+  }
+
   for (auto i : impl->content){
     switch(i.second.valueType){
     case PropertiesType_Uint32:

--- a/storage/ndb/src/kernel/blocks/ndbfs/Filename.cpp
+++ b/storage/ndb/src/kernel/blocks/ndbfs/Filename.cpp
@@ -174,6 +174,7 @@ Filename::set(Ndbfs* fs,
     if(buf[0] == DIR_SEPARATOR[0])
     {
       strncpy(theName, buf, PATH_MAX);
+      buf[sizeof(buf) - 1] = '\0';
       m_base_name = theName;
     }
     else

--- a/storage/ndb/src/mgmapi/LocalConfig.cpp
+++ b/storage/ndb/src/mgmapi/LocalConfig.cpp
@@ -123,6 +123,7 @@ LocalConfig::~LocalConfig(){
 void LocalConfig::setError(int lineNumber, const char * _msg) {
   error_line = lineNumber;
   strncpy(error_msg, _msg, sizeof(error_msg));
+  error_msg[sizeof(error_msg) - 1] = '\0';
 }
 
 const char *nodeIdTokens[] = {

--- a/storage/ndb/src/mgmapi/mgmapi.cpp
+++ b/storage/ndb/src/mgmapi/mgmapi.cpp
@@ -3692,6 +3692,7 @@ int ndb_mgm_get_version(NdbMgmHandle handle,
   }
 
   strncpy(str, result.c_str(), len);
+  str[len - 1] = '\0';
 
   delete prop;
   DBUG_RETURN(1);

--- a/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
+++ b/storage/ndb/src/mgmsrv/MgmtSrvr.cpp
@@ -4680,6 +4680,7 @@ MgmtSrvr::startBackup(Uint32& backupId, int waitCompleted,
       epd.password_length = password_length;
       strncpy(epd.encryption_password, encryption_password,
               MAX_BACKUP_ENCRYPTION_PASSWORD_LENGTH);
+      epd.encryption_password[MAX_BACKUP_ENCRYPTION_PASSWORD_LENGTH] = '\0';
 
       ssig.ptr[0].p = (Uint32*)&epd;
       ssig.ptr[0].sz = (sizeof(EncryptionPasswordData) + 3) / 4;

--- a/storage/ndb/tools/ndb_config.cpp
+++ b/storage/ndb/tools/ndb_config.cpp
@@ -428,7 +428,8 @@ print_diff(const Iter& iter)
       }
       else if (iter.get(ConfigInfo::m_ParamInfo[p]._paramId, &config_value) == 0)
       {
-        strncpy(str, config_value,300);
+        strncpy(str, config_value, sizeof(str) - 1);
+        str[sizeof(str) - 1] = '\0';
       }
       else
       {
@@ -446,7 +447,9 @@ print_diff(const Iter& iter)
         uint64 memory_convert = 0;
         uint64 def_value = 0;
         uint len = strlen(ConfigInfo::m_ParamInfo[p]._default) - 1;
-        strncpy(parse_str, ConfigInfo::m_ParamInfo[p]._default,299);
+        strncpy(parse_str, ConfigInfo::m_ParamInfo[p]._default,
+                sizeof(parse_str) - 1);
+        parse_str[sizeof(parse_str) - 1] = '\0';
         if (parse_str[len] == 'M' || parse_str[len] == 'm')
         {
           memory_convert = 1048576;

--- a/storage/perfschema/pfs_prepared_stmt.cc
+++ b/storage/perfschema/pfs_prepared_stmt.cc
@@ -85,6 +85,9 @@ PFS_prepared_stmt *create_prepared_stmt(
     pfs->m_identity = identity;
     /* Set query text if available, else it will be set later. */
     if (sqltext_length > 0) {
+      if (sqltext_length > sizeof(pfs->m_sqltext)) {
+        sqltext_length = sizeof(pfs->m_sqltext);
+      }
       strncpy(pfs->m_sqltext, sqltext, sqltext_length);
     }
 
@@ -92,8 +95,8 @@ PFS_prepared_stmt *create_prepared_stmt(
 
     if (stmt_name != nullptr) {
       pfs->m_stmt_name_length = stmt_name_length;
-      if (pfs->m_stmt_name_length > PS_NAME_LENGTH) {
-        pfs->m_stmt_name_length = PS_NAME_LENGTH;
+      if (pfs->m_stmt_name_length > sizeof(pfs->m_stmt_name)) {
+        pfs->m_stmt_name_length = sizeof(pfs->m_stmt_name);
       }
       strncpy(pfs->m_stmt_name, stmt_name, pfs->m_stmt_name_length);
     } else {
@@ -106,12 +109,21 @@ PFS_prepared_stmt *create_prepared_stmt(
     /* If this statement prepare is called from a SP. */
     if (pfs_program) {
       pfs->m_owner_object_type = pfs_program->m_type;
-      strncpy(pfs->m_owner_object_schema, pfs_program->m_schema_name,
-              pfs_program->m_schema_name_length);
+
       pfs->m_owner_object_schema_length = pfs_program->m_schema_name_length;
-      strncpy(pfs->m_owner_object_name, pfs_program->m_object_name,
-              pfs_program->m_object_name_length);
+      if (pfs->m_owner_object_schema_length >
+          sizeof(pfs->m_owner_object_schema)) {
+        pfs->m_owner_object_schema_length = sizeof(pfs->m_owner_object_schema);
+      }
+      strncpy(pfs->m_owner_object_schema, pfs_program->m_schema_name,
+              pfs->m_owner_object_schema_length);
+
       pfs->m_owner_object_name_length = pfs_program->m_object_name_length;
+      if (pfs->m_owner_object_name_length > sizeof(pfs->m_owner_object_name)) {
+        pfs->m_owner_object_name_length = sizeof(pfs->m_owner_object_name);
+      }
+      strncpy(pfs->m_owner_object_name, pfs_program->m_object_name,
+              pfs->m_owner_object_name_length);
     } else {
       pfs->m_owner_object_type = NO_OBJECT_TYPE;
       pfs->m_owner_object_schema_length = 0;

--- a/storage/perfschema/table_host_cache.cc
+++ b/storage/perfschema/table_host_cache.cc
@@ -196,7 +196,8 @@ int table_host_cache::make_row(Host_entry *entry, row_host_cache *row) {
   strcpy(row->m_ip, entry->ip_key);
   row->m_hostname_length = entry->m_hostname_length;
   if (row->m_hostname_length > 0) {
-    strncpy(row->m_hostname, entry->m_hostname, row->m_hostname_length);
+    DBUG_ASSERT(row->m_hostname_length <= sizeof(row->m_hostname));
+    strncpy(row->m_hostname, entry->m_hostname, sizeof(row->m_hostname));
   }
   row->m_host_validated = entry->m_host_validated;
   row->m_sum_connect_errors = entry->m_errors.m_connect;

--- a/storage/tokudb/ha_tokudb_admin.cc
+++ b/storage/tokudb/ha_tokudb_admin.cc
@@ -29,8 +29,8 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "my_check_opt.h"
 
-#include "sql/sql_class.h"
 #include "sql/protocol.h"
+#include "sql/sql_class.h"
 
 namespace tokudb {
 namespace analyze {
@@ -394,7 +394,8 @@ void standard_t::on_run() {
       rowmsglen = snprintf(rowmsg, sizeof(rowmsg),
                            "rows processed %llu rows deleted %llu", _rows,
                            _deleted_rows);
-      _thd->get_protocol()->store_string(rowmsg, rowmsglen, system_charset_info);
+      _thd->get_protocol()->store_string(rowmsg, rowmsglen,
+                                         system_charset_info);
       _thd->get_protocol()->end_row();
       LogPluginErrMsg(INFORMATION_LEVEL, 0, "Analyze on %.*s %.*s", namelen,
                       name, rowmsglen, rowmsg);
@@ -900,7 +901,8 @@ static void ha_tokudb_check_info(THD *thd, TABLE *table, const char *msg) {
            table->s->db.str, (int)table->s->table_name.length,
            table->s->table_name.str);
   thd->get_protocol()->start_row();
-  thd->get_protocol()->store_string(tablename, strlen(tablename), system_charset_info);
+  thd->get_protocol()->store_string(tablename, strlen(tablename),
+                                    system_charset_info);
   thd->get_protocol()->store_string("check", 5, system_charset_info);
   thd->get_protocol()->store_string("info", 4, system_charset_info);
   thd->get_protocol()->store_string(msg, strlen(msg), system_charset_info);

--- a/storage/tokudb/hatoku_cmp.h
+++ b/storage/tokudb/hatoku_cmp.h
@@ -142,8 +142,8 @@ class KEY_AND_COL_INFO {
   MY_NODISCARD uint32_t get_len_of_offsets(const TABLE_SHARE &table_share,
                                            uint32_t keynr) const;
 
-  MY_NODISCARD inline uint32_t get_max_desc_size(const TABLE &form) const
-      noexcept {
+  MY_NODISCARD inline uint32_t get_max_desc_size(
+      const TABLE &form) const noexcept {
     uint32_t max_row_desc_buff_size;
     // upper bound of key comparison descriptor
     max_row_desc_buff_size = 2 * (form.s->fields * 6) + 10;
@@ -154,8 +154,8 @@ class KEY_AND_COL_INFO {
     return max_row_desc_buff_size;
   }
 
-  MY_NODISCARD inline uint32_t get_max_secondary_key_pack_desc_size() const
-      noexcept {
+  MY_NODISCARD inline uint32_t get_max_secondary_key_pack_desc_size()
+      const noexcept {
     uint32_t ret_val = 0;
     //
     // the fixed stuff:

--- a/unittest/gunit/segfault-t.cc
+++ b/unittest/gunit/segfault-t.cc
@@ -64,10 +64,11 @@ TEST_F(FatalSignalDeathTest, Segfault) {
   */
   EXPECT_DEATH_IF_SUPPORTED(*pint = 42, "");
 #elif defined(HAVE_ASAN)
-/* gcc 4.8.1 with '-fsanitize=address -O1' */
-/* Newer versions of ASAN give other error message, disable it */
+  /* gcc 4.8.1 with '-fsanitize=address -O1' */
+  /* Newer versions of ASAN give other error message, disable it */
   int *pint = nullptr;
-  EXPECT_DEATH_IF_SUPPORTED(*pint= 42, ".*(AddressSanitizer|ASAN):(DEADLYSIGNAL|SIGSEGV).*");
+  EXPECT_DEATH_IF_SUPPORTED(
+          *pint = 42, ".*(AddressSanitizer|ASAN):(DEADLYSIGNAL|SIGSEGV).*");
 #elif defined(HANDLE_FATAL_SIGNALS)
   int *pint = nullptr;
   /*

--- a/utilities/comp_err.cc
+++ b/utilities/comp_err.cc
@@ -1481,6 +1481,7 @@ int compile_messages(const char *messages_to_clients,
 
   char myname[FN_REFLEN];
   strncpy(myname, my_progname, sizeof(myname) - 1);
+  myname[sizeof(myname) - 1] = '\0';
   char *args[1];
   args[0] = myname;
 

--- a/vio/viosslfactories.cc
+++ b/vio/viosslfactories.cc
@@ -556,6 +556,7 @@ long process_tls_version(const char *tls_version) {
   if (strlen(tls_version) - 1 > sizeof(tls_version_option)) return -1;
 
   strncpy(tls_version_option, tls_version, sizeof(tls_version_option));
+  tls_version_option[sizeof(tls_version_option) - 1] = '\0';
   token = my_strtok_r(tls_version_option, separator, &lasts);
   while (token) {
     for (unsigned int i = 0; i < tls_versions_count; i++) {
@@ -776,7 +777,6 @@ static struct st_VioSSLFd *new_VioSSLFd(
 #endif
 
   SSL_CTX_set_options(ssl_fd->ssl_context, ssl_ctx_options);
-
 
 #if OPENSSL_VERSION_NUMBER < 0x10002000L
   {


### PR DESCRIPTION
Issue
Manual code review of strncpy() usage in the MySQL source tree
revealed incorrect usage.  There are instances where the destination
buffer was not being NULL-terminated.

Solution
Ensure that the buffer is being NULL-terminated in the case where
the entire buffer is being filled.