### PR TITLE
PS-7596 [5.7]: Suppress gcc-11 compilation warning after update of RocksDB submodule pointer

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -138,7 +138,7 @@ ENDIF()
 # Suppress warnings for gcc-9 or newer
 IF(CMAKE_COMPILER_IS_GNUCXX AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
   ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-deprecated-copy FILES rocksdb/db/db_impl/db_impl.cc)
-  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-maybe-uninitialized FILES rocksdb/table/block_based/block_based_table_builder.cc)
+  ADD_CXX_COMPILE_FLAGS_TO_FILES(-Wno-maybe-uninitialized FILES rocksdb/env/env.cc rocksdb/table/block_based/block_based_table_builder.cc)
 ENDIF()
 
 # Suppress warnings for gcc-4.8.x


### PR DESCRIPTION
Suppress gcc-11 compilation warning after update of RocksDB submodule pointer:
```
/home/travis/build/percona/percona-server/storage/rocksdb/rocksdb/env/env.cc: In member function ‘virtual rocksdb::Status rocksdb::Env::GetHostNameString(std::string*)’:
/home/travis/build/percona/percona-server/storage/rocksdb/rocksdb/env/env.cc:144:66: error: ‘hostname_buf’ may be used uninitialized [-Werror=maybe-uninitialized]
  144 |   Status s = GetHostName(hostname_buf.data(), hostname_buf.size());
      |                                                                  ^
In file included from /usr/include/c++/11/tuple:39,
                 from /usr/include/c++/11/functional:54,
                 from /home/travis/build/percona/percona-server/storage/rocksdb/rocksdb/include/rocksdb/env.h:21,
                 from /home/travis/build/percona/percona-server/storage/rocksdb/rocksdb/env/env.cc:10:
/usr/include/c++/11/array:176:7: note: by argument 1 of type ‘const std::array<char, 256>*’ to ‘constexpr std::array<_Tp, _Nm>::size_type std::array<_Tp, _Nm>::size() const [with _Tp = char; long unsigned int _Nm = 256]’ declared here
  176 |       size() const noexcept { return _Nm; }
      |       ^~~~
/home/travis/build/percona/percona-server/storage/rocksdb/rocksdb/env/env.cc:143:37: note: ‘hostname_buf’ declared here
  143 |   std::array<char, kMaxHostNameLen> hostname_buf;
```