### PR TITLE
PS-1108: Changing a column from uncompressed to compressed for JSON c…

### DIFF
--- a/mysql-test/suite/innodb/r/xtradb_compressed_columns_alter_table.result
+++ b/mysql-test/suite/innodb/r/xtradb_compressed_columns_alter_table.result
@@ -1403,3 +1403,51 @@ modified_dictionary_references_cleaned
 
 DROP COMPRESSION_DICTIONARY dict1;
 DROP COMPRESSION_DICTIONARY dict2;
+#
+# Bug PS-1108 : Changing a column from uncompressed to compressed for JSON crashes the server
+#
+CREATE TABLE t1 (json_variables JSON);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED;
+SELECT * FROM t1;
+json_variables
+{"name": "json test"}
+DROP TABLE t1;
+CREATE TABLE t2 (a TEXT);
+INSERT INTO t2 VALUES('test value');
+ALTER TABLE t2 MODIFY a TEXT COLUMN_FORMAT COMPRESSED;
+SELECT * FROM t2;
+a
+test value
+DROP TABLE t2;
+CREATE TABLE t1 (json_variables JSON,t VARCHAR(3) AS (CONCAT(SUBSTRING(json_variables,1,1)))) PARTITION BY KEY(t) PARTITIONS 4;
+INSERT INTO t1 VALUES('{"name":"json test"}',DEFAULT);
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED;
+SELECT json_variables FROM t1;
+json_variables
+{"name": "json test"}
+DROP TABLE t1;
+SET @dictionary_data='"name"';
+CREATE COMPRESSION_DICTIONARY test_dictionary (@dictionary_data);
+CREATE TABLE t1 (json_variables JSON);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY test_dictionary;
+SELECT * FROM t1;
+json_variables
+{"name": "json test"}
+DROP TABLE t1;
+CREATE TABLE t1 (json_variables JSON COLUMN_FORMAT COMPRESSED);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY test_dictionary;
+SELECT * FROM t1;
+json_variables
+{"name": "json test"}
+DROP TABLE t1;
+CREATE TABLE t1 (json_variables JSON COLUMN_FORMAT COMPRESSED);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON;
+SELECT * FROM t1;
+json_variables
+{"name": "json test"}
+DROP TABLE t1;
+DROP COMPRESSION_DICTIONARY test_dictionary;

--- a/mysql-test/suite/innodb/t/xtradb_compressed_columns_alter_table.test
+++ b/mysql-test/suite/innodb/t/xtradb_compressed_columns_alter_table.test
@@ -85,3 +85,48 @@ eval ALTER TABLE $original_table_name DISCARD TABLESPACE;
 # cleaning created compression dictionaries
 --eval DROP COMPRESSION_DICTIONARY $dict1_name
 --eval DROP COMPRESSION_DICTIONARY $dict2_name
+
+--echo #
+--echo # Bug PS-1108 : Changing a column from uncompressed to compressed for JSON crashes the server
+--echo #
+
+CREATE TABLE t1 (json_variables JSON);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t2 (a TEXT);
+INSERT INTO t2 VALUES('test value');
+ALTER TABLE t2 MODIFY a TEXT COLUMN_FORMAT COMPRESSED;
+SELECT * FROM t2;
+DROP TABLE t2;
+
+CREATE TABLE t1 (json_variables JSON,t VARCHAR(3) AS (CONCAT(SUBSTRING(json_variables,1,1)))) PARTITION BY KEY(t) PARTITIONS 4;
+INSERT INTO t1 VALUES('{"name":"json test"}',DEFAULT);
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED;
+SELECT json_variables FROM t1;
+DROP TABLE t1;
+
+SET @dictionary_data='"name"';
+CREATE COMPRESSION_DICTIONARY test_dictionary (@dictionary_data);
+
+CREATE TABLE t1 (json_variables JSON);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY test_dictionary;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (json_variables JSON COLUMN_FORMAT COMPRESSED);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON COLUMN_FORMAT COMPRESSED WITH COMPRESSION_DICTIONARY test_dictionary;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+CREATE TABLE t1 (json_variables JSON COLUMN_FORMAT COMPRESSED);
+INSERT INTO t1 VALUES('{"name":"json test"}');
+ALTER TABLE t1 MODIFY json_variables JSON;
+SELECT * FROM t1;
+DROP TABLE t1;
+
+DROP COMPRESSION_DICTIONARY test_dictionary;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -8854,7 +8854,8 @@ Field_json *Field_json::clone() const
 uint Field_json::is_equal(Create_field *new_field)
 {
   // All JSON fields are compatible with each other.
-  return (new_field->sql_type == real_type());
+  return (new_field->sql_type == real_type() &&
+          !has_different_compression_attributes_with(*new_field));
 }
 
 


### PR DESCRIPTION
…rashes the server

https://jira.percona.com/browse/PS-1108

Analysis
A Table with JSON column is converted to a column with compressed column.
ALTER is successful but the table is unusable state. SELECT crashes the
server.

When ALTER finishes, it ignores the fact that COLUMN type changed to
compressed and does a metadata change only ALTER. Data remain same.

So we now have table which thinks it is compressed column and the
actual data that is not compressed.

SELECTs when they try to decompress on wrong data
(data which was not compressed), crashes the server.

Fix
Fix the ALTER to detect column type changes. When the column modifies to
COMPRESSED or COMPRESSED WITH Dictionary, detect the type change and
ensure that ALTER rebuilds the data.