### PR TITLE
PS-7734: Fix Wshadow-field build error in keyring_vault-test (8.0)

### DIFF
--- a/plugin/keyring_vault/keyring_vault-test/vault_keys_container_ex.h
+++ b/plugin/keyring_vault/keyring_vault-test/vault_keys_container_ex.h
@@ -26,7 +26,7 @@ namespace keyring {
 
 class Vault_keys_container_ex : public Vault_keys_container {
  public:
-  Vault_keys_container_ex(ILogger *logger) : Vault_keys_container(logger) {}
+  Vault_keys_container_ex(ILogger *logger_) : Vault_keys_container(logger_) {}
 
   void remove_all_keys() {
     std::for_each(


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7734
(cherry picked from commit 219cb19e0a6bc4f82b08abe4e27cebc71be6491e)