### PR TITLE
PS-7694: Fix compilation issues with gcc-11

### DIFF
--- a/client/mysqldump.cc
+++ b/client/mysqldump.cc
@@ -1550,6 +1550,7 @@ static char *cover_definer_clause(char *stmt_str, size_t stmt_length,
 
   char *query_str = nullptr;
   char *query_ptr;
+  LEX_CSTRING comment = {STRING_WITH_LEN("*/ /*!")};
 
   if (!definer_begin) return nullptr;
 
@@ -1565,11 +1566,11 @@ static char *cover_definer_clause(char *stmt_str, size_t stmt_length,
   query_str = alloc_query_str(stmt_length + 23);
 
   query_ptr = my_stpncpy(query_str, stmt_str, definer_begin - stmt_str);
-  query_ptr = my_stpncpy(query_ptr, STRING_WITH_LEN("*/ /*!"));
+  query_ptr = my_stpncpy(query_ptr, comment.str, comment.length + 1);
   query_ptr =
       my_stpncpy(query_ptr, definer_version_str, definer_version_length);
   query_ptr = my_stpncpy(query_ptr, definer_begin, definer_end - definer_begin);
-  query_ptr = my_stpncpy(query_ptr, STRING_WITH_LEN("*/ /*!"));
+  query_ptr = my_stpncpy(query_ptr, comment.str, comment.length + 1);
   query_ptr = my_stpncpy(query_ptr, stmt_version_str, stmt_version_length);
   query_ptr = strxmov(query_ptr, definer_end, NullS);
 

--- a/include/m_string.h
+++ b/include/m_string.h
@@ -40,6 +40,7 @@
 
 #include "decimal.h"
 #include "lex_string.h"
+#include "my_compiler.h"  // unlikely
 #include "my_config.h"
 #include "my_inttypes.h"
 #include "my_macros.h"
@@ -198,6 +199,30 @@ static inline char *my_stpncpy(char *dst, const char *src, size_t n) {
   /* Fallback to implementation supporting overlap. */
   return my_stpnmov(dst, src, n);
 #endif
+}
+
+/**
+   Copies strlen(src) characters of source to destination.
+   If strlen(src) is equal or bigger than num then dst will be truncated.
+   The null-character is always appended at the end of destination.
+   Destination is not padded with zeros until a total of num characters.
+
+   @param dst   Destination
+   @param src   Source
+   @param n     Maximum number of characters to copy.
+
+   @return pointer to Destination is returned.
+*/
+static inline char *my_strncpy_trunc(char *dst, const char *src, size_t num) {
+  size_t len = strlen(src);
+  if (unlikely(len >= num)) {
+    len = num - 1;
+    memcpy(dst, src, len);
+    dst[len] = '\0';
+  } else {
+    memcpy(dst, src, len + 1);
+  }
+  return dst;
 }
 
 static inline longlong my_strtoll(const char *nptr, char **endptr, int base) {

--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -2522,7 +2522,7 @@ bool rename_foreign_keys(THD *thd MY_ATTRIBUTE((unused)),
     if (is_generated_foreign_key_name(old_table_name_norm,
                                       old_table_name_norm_len, hton, *fk)) {
       char table_name[NAME_LEN + 1];
-      my_stpncpy(table_name, new_tab->name().c_str(), sizeof(table_name));
+      my_strncpy_trunc(table_name, new_tab->name().c_str(), sizeof(table_name));
       if (lower_case_table_names == 2)
         my_casedn_str(system_charset_info, table_name);
       dd::String_type new_name(table_name);


### PR DESCRIPTION
Fix the following issues:
```
In function ‘char* stpncpy(char*, const char*, size_t)’,
    inlined from ‘char* my_stpncpy(char*, const char*, size_t)’ at /data/mysql-server/8.0/include/m_string.h:197:17,
    inlined from ‘char* cover_definer_clause(char*, size_t, const char*, size_t, const char*, size_t, const char*, size_t)’ at /data/mysql-server/8.0/client/mysqldump.cc:1568:25:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:103:34: error: ‘char* __builtin_stpncpy(char*, const char*, long unsigned int)’ output truncated before terminating nul copying 6 bytes from a string of the same length [-Werror=stringop-truncation]
  103 |   return __builtin___stpncpy_chk (__dest, __src, __n,
```

```
In function ‘char* stpncpy(char*, const char*, size_t)’,
    inlined from ‘char* my_stpncpy(char*, const char*, size_t)’ at /data/mysql-server/8.0/include/m_string.h:197:17,
    inlined from ‘bool dd::rename_foreign_keys(THD*, const char*, const char*, handlerton*, const char*, dd::Table*)’ at /data/mysql-server/8.0/sql/dd/dd_table.cc:2525:17:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:103:34: error: ‘char* __builtin_stpncpy(char*, const char*, long unsigned int)’ specified bound 193 equals destination size [-Werror=stringop-truncation]
  103 |   return __builtin___stpncpy_chk (__dest, __src, __n,
```