### PR TITLE
PS-7622 - Fix initialization of lower_case_file_system

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5216,8 +5216,9 @@ int init_common_variables() {
     get corrupted if accesses with names of different case.
   */
   DBUG_PRINT("info", ("lower_case_table_names: %d", lower_case_table_names));
-  lower_case_file_system = test_if_case_insensitive(mysql_real_data_home);
-  if (!lower_case_table_names && lower_case_file_system == 1) {
+  lower_case_file_system =
+      (test_if_case_insensitive(mysql_real_data_home) == 1);
+  if (!lower_case_table_names && lower_case_file_system) {
     if (lower_case_table_names_used) {
       LogErr(ERROR_LEVEL, ER_LOWER_CASE_TABLE_NAMES_CS_DD_ON_CI_FS_UNSUPPORTED);
       return 1;
@@ -5226,15 +5227,10 @@ int init_common_variables() {
              mysql_real_data_home);
       lower_case_table_names = 2;
     }
-  } else if (lower_case_table_names == 2 &&
-             !(lower_case_file_system =
-                   (test_if_case_insensitive(mysql_real_data_home) == 1))) {
+  } else if (lower_case_table_names == 2 && !lower_case_file_system) {
     LogErr(WARNING_LEVEL, ER_LOWER_CASE_TABLE_NAMES_USING_0,
            mysql_real_data_home);
     lower_case_table_names = 0;
-  } else {
-    lower_case_file_system =
-        (test_if_case_insensitive(mysql_real_data_home) == 1);
   }
 
   /* Reset table_alias_charset, now that lower_case_table_names is set. */


### PR DESCRIPTION
https://ps80.cd.percona.com/job/percona-server-8.0-param/951/

---

**Bug:** if `test_if_case_insensitive` returns -1, the `bool` variable
`lower_case_file_system` is assigned `true`.

**Solution:** Just assign true when `test_if_case_insensitive` returns 1.
The same logic is followed in the assignement of `case_insensitive_fs`:

    case_insensitive_fs = (test_if_case_insensitive(datadir_buffer) == 1);

**Extra work:** Remove redundant assignments to `lower_case_file_system`.