### PR TITLE
PS-7622 merge: Merge MySQL 8.0.24 (fix sys_vars.innodb_log_writer_thr…

### DIFF
--- a/storage/innobase/log/log0write.cc
+++ b/storage/innobase/log/log0write.cc
@@ -2667,6 +2667,11 @@ void log_write_notifier(log_t *log_ptr) {
       log.write_notifier_resume_lsn.store(0, std::memory_order_release);
 
       log_write_notifier_mutex_enter(log);
+    } else if (UNIV_UNLIKELY(log.write_notifier_resume_lsn.load(
+                   std::memory_order_acquire)) != 0) {
+      /* There might be the case there has occurred an unset/set
+       * and log_resume_writer_threads is waiting for Ack */
+      log.write_notifier_resume_lsn.store(0, std::memory_order_release);
     }
 
     LOG_SYNC_POINT("log_write_notifier_before_check");
@@ -2785,6 +2790,11 @@ void log_flush_notifier(log_t *log_ptr) {
       log.flush_notifier_resume_lsn.store(0, std::memory_order_release);
 
       log_flush_notifier_mutex_enter(log);
+    } else if (UNIV_UNLIKELY(log.flush_notifier_resume_lsn.load(
+                   std::memory_order_acquire)) != 0) {
+      /* There might be the case there has occurred an unset/set
+       * and log_resume_writer_threads is waiting for Ack */
+      log.flush_notifier_resume_lsn.store(0, std::memory_order_release);
     }
 
     LOG_SYNC_POINT("log_flush_notifier_before_check");


### PR DESCRIPTION
…eads_basic)

The thread running `log_resume_writer_threads` might get waiting
indefinitely for an ack if an unset followed by a set of
`global.innodb_log_writer_threads` occurrs.

The functions `log_write_notifier` and `log_flush_notifier` might not
notice the unset and set of the variable and consider there has
been no change but `log_resume_writer_threads` is waiting for ack.

The solution is checking if log_resume_writer_threads is waiting for an
ack although the `log.writer_threads_paused` is false and, in that case,
signal an ack.