### PR TITLE
PS-7582 - Check module data_masking loaded when calling its functions

### DIFF
--- a/mysql-test/suite/data_masking/r/error_not_loaded_module.result
+++ b/mysql-test/suite/data_masking/r/error_not_loaded_module.result
@@ -1,3 +1,3 @@
 CREATE FUNCTION gen_blacklist RETURNS STRING SONAME 'data_masking.so';
 select gen_blacklist();
-ERROR HY000: Can't initialize function 'gen_blacklist'; This function requires data_masking plugin which is not installed. Please instal
+ERROR HY000: Can't initialize function 'gen_blacklist'; It requires the data_masking plugin installed. Please, install it and try again.

--- a/mysql-test/suite/data_masking/r/error_not_loaded_module.result
+++ b/mysql-test/suite/data_masking/r/error_not_loaded_module.result
@@ -1,0 +1,3 @@
+CREATE FUNCTION gen_blacklist RETURNS STRING SONAME 'data_masking.so';
+select gen_blacklist();
+ERROR HY000: Can't initialize function 'gen_blacklist'; This function requires data_masking plugin which is not installed. Please instal

--- a/mysql-test/suite/data_masking/t/error_not_loaded_module.test
+++ b/mysql-test/suite/data_masking/t/error_not_loaded_module.test
@@ -1,0 +1,4 @@
+CREATE FUNCTION gen_blacklist RETURNS STRING SONAME 'data_masking.so';
+
+--error 1123
+select gen_blacklist();

--- a/plugin/data_masking/include/plugin.h
+++ b/plugin/data_masking/include/plugin.h
@@ -40,7 +40,7 @@ extern mysql_rwlock_t g_data_masking_dict_rwlock;
 extern void init_data_masking_memory();
 extern void deinit_data_masking_memory();
 
-// Returns true and populates the msg with an error if the module has not been initialized
-extern bool data_masking_validate_status(char *msg, size_t msg_len);
+// Returns false and populates the msg with an error if the module has not been initialized
+extern bool data_masking_is_inited(char *msg, size_t msg_len);
 
 #endif  //_PLUGIN_DATA_MASKING_PLUGIN_H

--- a/plugin/data_masking/include/plugin.h
+++ b/plugin/data_masking/include/plugin.h
@@ -40,4 +40,7 @@ extern mysql_rwlock_t g_data_masking_dict_rwlock;
 extern void init_data_masking_memory();
 extern void deinit_data_masking_memory();
 
+// Returns true and populates the msg with an error if the module has not been initialized
+extern bool data_masking_validate_status(char *msg, size_t msg_len);
+
 #endif  //_PLUGIN_DATA_MASKING_PLUGIN_H

--- a/plugin/data_masking/src/plugin.cc
+++ b/plugin/data_masking/src/plugin.cc
@@ -75,15 +75,14 @@ mysql_declare_plugin(data_masking){
     0,                               // flags
 } mysql_declare_plugin_end;
 
-// Returns true and populates the msg with an error if the module has not been initialized
-bool data_masking_validate_status(char *msg, size_t msg_len) {
+// Returns false and populates the msg with an error if the module has not been initialized
+bool data_masking_is_inited(char *msg, size_t msg_len) {
   if (!data_masking_init) {
-    strncpy(
+    std::snprintf(
         msg,
-        "It requires the data_masking plugin installed. Please, install it and try again.",
-        msg_len - 1);
-    msg[msg_len - 1]= '\0';
+        msg_len,
+        "It requires the data_masking plugin installed. Please, install it and try again.");
   }
 
-  return !data_masking_init;
+  return data_masking_init;
 }

--- a/plugin/data_masking/src/plugin.cc
+++ b/plugin/data_masking/src/plugin.cc
@@ -80,8 +80,7 @@ bool data_masking_validate_status(char *msg, size_t msg_len) {
   if (!data_masking_init) {
     strncpy(
         msg,
-        "This function requires data_masking plugin which is not installed."
-        " Please install keyring_udf plugin and try again.",
+        "It requires the data_masking plugin installed. Please, install it and try again.",
         msg_len - 1);
     msg[msg_len - 1]= '\0';
   }

--- a/plugin/data_masking/src/plugin.cc
+++ b/plugin/data_masking/src/plugin.cc
@@ -15,6 +15,8 @@
 
 #include "../include/plugin.h"
 
+static bool data_masking_init = false;
+
 static int data_masking_plugin_init(void *p) {
   DBUG_ENTER("data_masking_plugin_init");
 
@@ -31,11 +33,16 @@ static int data_masking_plugin_init(void *p) {
   struct st_plugin_int *plugin = (struct st_plugin_int *)p;
   plugin->data = (void *)g_data_masking_dict;
 
+  data_masking_init = true;
+
   DBUG_RETURN(0);
 }
 
 static int data_masking_plugin_deinit(void *p) {
   DBUG_ENTER("data_masking_plugin_deinit");
+
+  data_masking_init = false;
+
   sql_print_information(
       "DataMasking Plugin: Deinitializing plugin memory structures");
 
@@ -67,3 +74,17 @@ mysql_declare_plugin(data_masking){
     NULL,                            // config options
     0,                               // flags
 } mysql_declare_plugin_end;
+
+// Returns true and populates the msg with an error if the module has not been initialized
+bool data_masking_validate_status(char *msg, size_t msg_len) {
+  if (!data_masking_init) {
+    strncpy(
+        msg,
+        "This function requires data_masking plugin which is not installed."
+        " Please install keyring_udf plugin and try again.",
+        msg_len - 1);
+    msg[msg_len - 1]= '\0';
+  }
+
+  return !data_masking_init;
+}

--- a/plugin/data_masking/src/plugin_memory.cc
+++ b/plugin/data_masking/src/plugin_memory.cc
@@ -15,7 +15,7 @@
 
 #include "../include/plugin_memory.h"
 
-void init_data_masking_psi_keys() {
+static void init_data_masking_psi_keys() {
   PSI_rwlock_info all_data_masking_rwlock[] = {
       {&key_data_masking_rwlock, "data_masking::rwlock", PSI_FLAG_GLOBAL}};
 

--- a/plugin/data_masking/src/udf/udf_gen_blacklist.cc
+++ b/plugin/data_masking/src/udf/udf_gen_blacklist.cc
@@ -31,7 +31,7 @@ my_bool gen_blacklist_init(UDF_INIT *initid, UDF_ARGS *args,
                         char *message) {
   DBUG_ENTER("gen_blacklist_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_blacklist.cc
+++ b/plugin/data_masking/src/udf/udf_gen_blacklist.cc
@@ -13,6 +13,7 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
@@ -20,15 +21,19 @@
 #include <algorithm>
 
 extern "C" {
-  bool gen_blacklist_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_blacklist_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_blacklist_deinit(UDF_INIT *initid);
   char *gen_blacklist(UDF_INIT *, UDF_ARGS *args, char *result,
                       unsigned long *length, char *is_null, char *);
 }
 
-bool gen_blacklist_init(UDF_INIT *initid, UDF_ARGS *args,
+my_bool gen_blacklist_init(UDF_INIT *initid, UDF_ARGS *args,
                         char *message) {
   DBUG_ENTER("gen_blacklist_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 3) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_gen_dictionary.cc
+++ b/plugin/data_masking/src/udf/udf_gen_dictionary.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool gen_dictionary_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_dictionary_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_dictionary.cc
+++ b/plugin/data_masking/src/udf/udf_gen_dictionary.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool gen_dictionary_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_dictionary_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_dictionary_deinit(UDF_INIT *initid);
   char *gen_dictionary(UDF_INIT *initid, UDF_ARGS *args, char *,
                        unsigned long *length, char *is_null, char *);
 }
 
-bool gen_dictionary_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool gen_dictionary_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_dictionary_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 1) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_gen_dictionary_drop.cc
+++ b/plugin/data_masking/src/udf/udf_gen_dictionary_drop.cc
@@ -38,7 +38,7 @@ my_bool gen_dictionary_drop_init(UDF_INIT *initid, UDF_ARGS *args,
                                      char *message) {
   DBUG_ENTER("gen_dictionary_drop_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_dictionary_drop.cc
+++ b/plugin/data_masking/src/udf/udf_gen_dictionary_drop.cc
@@ -21,21 +21,26 @@
 #include "utils_string.h"
 */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool  gen_dictionary_drop_init(UDF_INIT *initid, UDF_ARGS *args,
+  my_bool  gen_dictionary_drop_init(UDF_INIT *initid, UDF_ARGS *args,
                                  char *message);
   void  gen_dictionary_drop_deinit(UDF_INIT *initid);
   char *gen_dictionary_drop(UDF_INIT *, UDF_ARGS *args, char *result,
                             unsigned long *length, char *, char *);
 }
 
-bool gen_dictionary_drop_init(UDF_INIT *initid, UDF_ARGS *args,
+my_bool gen_dictionary_drop_init(UDF_INIT *initid, UDF_ARGS *args,
                                      char *message) {
-  DBUG_ENTER("gen_blacklist_init");
+  DBUG_ENTER("gen_dictionary_drop_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 1) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_gen_dictionary_load.cc
+++ b/plugin/data_masking/src/udf/udf_gen_dictionary_load.cc
@@ -21,6 +21,7 @@
 #include "utils_string.h"
 */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
@@ -29,14 +30,18 @@
 #include <iostream>
 
 extern "C" {
-  bool gen_dictionary_load_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_dictionary_load_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_dictionary_load_deinit(UDF_INIT *initid);
   char *gen_dictionary_load(UDF_INIT *, UDF_ARGS *args, char *result,
                             unsigned long *length, char *, char *);
 }
 
-bool gen_dictionary_load_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool gen_dictionary_load_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_dictionary_load_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 2) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_gen_dictionary_load.cc
+++ b/plugin/data_masking/src/udf/udf_gen_dictionary_load.cc
@@ -39,7 +39,7 @@ extern "C" {
 my_bool gen_dictionary_load_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_dictionary_load_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_range.cc
+++ b/plugin/data_masking/src/udf/udf_gen_range.cc
@@ -13,6 +13,7 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
@@ -20,14 +21,18 @@
 #include <iostream>
 
 extern "C" {
-  bool gen_range_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_range_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_range_deinit(UDF_INIT *initid);
   long long gen_range(UDF_INIT *initid, UDF_ARGS *args, char *is_null,
                       char *is_error);
 }
 
-bool gen_range_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool gen_range_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_range_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 2) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_gen_range.cc
+++ b/plugin/data_masking/src/udf/udf_gen_range.cc
@@ -30,7 +30,7 @@ extern "C" {
 my_bool gen_range_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_range_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_rnd_email.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_email.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool gen_rnd_email_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_email_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_rnd_email.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_email.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool gen_rnd_email_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_rnd_email_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_rnd_email_deinit(UDF_INIT *initid);
   char *gen_rnd_email(UDF_INIT *initid, UDF_ARGS *args, char *result,
                       unsigned long *length, char *is_null, char *is_error);
 }
 
-bool gen_rnd_email_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool gen_rnd_email_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_email_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count > 2) {
     std::snprintf(

--- a/plugin/data_masking/src/udf/udf_gen_rnd_pan.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_pan.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool gen_rnd_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_pan_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_rnd_pan.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_pan.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool gen_rnd_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_rnd_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_rnd_pan_deinit(UDF_INIT *initid);
   char *gen_rnd_pan(UDF_INIT *initid, UDF_ARGS *args, char *result,
                     unsigned long *length, char *is_null, char *is_error);
 }
 
-bool gen_rnd_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool gen_rnd_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_pan_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 0) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_gen_rnd_ssn.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_ssn.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool gen_rnd_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_ssn_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_rnd_ssn.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_ssn.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool gen_rnd_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_rnd_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_rnd_ssn_deinit(UDF_INIT *initid);
   char *gen_rnd_ssn(UDF_INIT *initid, UDF_ARGS *args, char *result,
                     unsigned long *length, char *, char *);
 }
 
-bool gen_rnd_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool gen_rnd_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_ssn_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 0) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_gen_rnd_us_phone.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_us_phone.cc
@@ -30,7 +30,7 @@ extern "C" {
 my_bool gen_rnd_us_phone_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_us_phone_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_gen_rnd_us_phone.cc
+++ b/plugin/data_masking/src/udf/udf_gen_rnd_us_phone.cc
@@ -13,6 +13,7 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
@@ -20,14 +21,18 @@
 #include <iostream>
 
 extern "C" {
-  bool gen_rnd_us_phone_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool gen_rnd_us_phone_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void gen_rnd_us_phone_deinit(UDF_INIT *initid);
   char *gen_rnd_us_phone(UDF_INIT *initid, UDF_ARGS *args, char *result,
                          unsigned long *length, char *is_null, char *is_error);
 }
 
-bool gen_rnd_us_phone_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool gen_rnd_us_phone_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("gen_rnd_us_phone_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 0) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_mask_inner.cc
+++ b/plugin/data_masking/src/udf/udf_mask_inner.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool mask_inner_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_inner_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_mask_inner.cc
+++ b/plugin/data_masking/src/udf/udf_mask_inner.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool mask_inner_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool mask_inner_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void mask_inner_deinit(UDF_INIT *initid);
   const char *mask_inner(UDF_INIT *initid, UDF_ARGS *args, char *result,
                          unsigned long *length, char *is_null, char *);
 }
 
-bool mask_inner_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool mask_inner_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_inner_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count < 3 || args->arg_count > 4) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_mask_outer.cc
+++ b/plugin/data_masking/src/udf/udf_mask_outer.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool mask_outer_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_outer_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_mask_outer.cc
+++ b/plugin/data_masking/src/udf/udf_mask_outer.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool mask_outer_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool mask_outer_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void mask_outer_deinit(UDF_INIT *initid);
   const char *mask_outer(UDF_INIT *initid, UDF_ARGS *args, char *result,
                          unsigned long *length, char *is_null, char *);
 }
 
-bool mask_outer_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool mask_outer_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_outer_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count < 3 || args->arg_count > 4) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_mask_pan.cc
+++ b/plugin/data_masking/src/udf/udf_mask_pan.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool mask_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool mask_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void mask_pan_deinit(UDF_INIT *initid);
   const char *mask_pan(UDF_INIT *initid, UDF_ARGS *args, char *result,
                        unsigned long *length, char *is_null, char *);
 }
 
-bool mask_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool mask_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_pan_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 1) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_mask_pan.cc
+++ b/plugin/data_masking/src/udf/udf_mask_pan.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool mask_pan_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_pan_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_mask_pan_relaxed.cc
+++ b/plugin/data_masking/src/udf/udf_mask_pan_relaxed.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool mask_pan_relaxed_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool mask_pan_relaxed_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void mask_pan_relaxed_deinit(UDF_INIT *initid);
   const char *mask_pan_relaxed(UDF_INIT *initid, UDF_ARGS *args, char *result,
                                unsigned long *length, char *is_null, char *);
 }
 
-bool mask_pan_relaxed_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool mask_pan_relaxed_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_pan_relaxed_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 1) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,

--- a/plugin/data_masking/src/udf/udf_mask_pan_relaxed.cc
+++ b/plugin/data_masking/src/udf/udf_mask_pan_relaxed.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool mask_pan_relaxed_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_pan_relaxed_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_mask_ssn.cc
+++ b/plugin/data_masking/src/udf/udf_mask_ssn.cc
@@ -28,7 +28,7 @@ extern "C" {
 my_bool mask_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_ssn_init");
 
-  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+  if (!data_masking_is_inited(message, MYSQL_ERRMSG_SIZE)) {
     DBUG_RETURN(true);
   }
 

--- a/plugin/data_masking/src/udf/udf_mask_ssn.cc
+++ b/plugin/data_masking/src/udf/udf_mask_ssn.cc
@@ -13,19 +13,24 @@
    along with this program; if not, write to the Free Software Foundation,
    51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
 
+#include <my_global.h>
 #include "../../include/plugin.h"
 #include "../../include/udf/udf_utils.h"
 #include "../../include/udf/udf_utils_string.h"
 
 extern "C" {
-  bool mask_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+  my_bool mask_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
   void mask_ssn_deinit(UDF_INIT *initid);
   const char *mask_ssn(UDF_INIT *initid, UDF_ARGS *args, char *result,
                        unsigned long *length, char *is_null, char *);
 }
 
-bool mask_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+my_bool mask_ssn_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   DBUG_ENTER("mask_ssn_init");
+
+  if (data_masking_validate_status(message, MYSQL_ERRMSG_SIZE)) {
+    DBUG_RETURN(true);
+  }
 
   if (args->arg_count != 1) {
     std::snprintf(message, MYSQL_ERRMSG_SIZE,


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7582
https://ps57.cd.percona.com/view/5.7/job/percona-server-5.7-param/468/

---

**Bug:**

If a function of the data_masking module is called without the module
has been loaded, it generates an exception.

**Solution:**

As it is done with other modules, use a variable to check if
data_masking has been initialized. This condition is checked when the
function is invoked.

**Extra work:**

- Use `my_bool` instead of bool for `extern "C" functions`.