### PR TITLE
PS-7748: Implement buffered error logging ability

### DIFF
--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -42,7 +42,7 @@ include/assert.inc [Expect 500+ variables in the table. Due to open Bugs, we are
 
 # Test SET PERSIST
 
-include/assert.inc [Expect 497 persisted variables in the table.]
+include/assert.inc [Expect 499 persisted variables in the table.]
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -50,9 +50,9 @@ include/assert.inc [Expect 497 persisted variables in the table.]
 ************************************************************
 # restart
 
-include/assert.inc [Expect 497 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 497 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 497 persisted variables with matching peristed and global values.]
+include/assert.inc [Expect 499 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 499 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 499 persisted variables with matching peristed and global values.]
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/r/buffered_error_log.result
+++ b/mysql-test/r/buffered_error_log.result
@@ -1,0 +1,5 @@
+call mtr.add_suppression("Attempting backtrace. You can use the following information to");
+Sending kill signal 11 to mysqld ...
+# restart:
+Testing that buffered_error_log log contains something logged
+# restart:

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -245,6 +245,10 @@ The following options may be given as the first argument:
  values are COMMIT_ORDER, WRITESET and WRITESET_SESSION.
  --block-encryption-mode=name 
  mode for AES_ENCRYPT/AES_DECRYPT
+ --buffered-error-log-filename=name 
+ Filename of the buffered error log
+ --buffered-error-log-size=# 
+ Size of the buffered error log (kB)
  --bulk-insert-buffer-size=# 
  Size of tree cache used in bulk insert optimisation. Note
  that this is a limit per thread!
@@ -1755,6 +1759,8 @@ binlog-transaction-compression-level-zstd 3
 binlog-transaction-dependency-history-size 25000
 binlog-transaction-dependency-tracking COMMIT_ORDER
 block-encryption-mode aes-128-ecb
+buffered-error-log-filename 
+buffered-error-log-size 0
 bulk-insert-buffer-size 8388608
 caching-sha2-password-digest-rounds 5000
 caching-sha2-password-private-key-path private_key.pem

--- a/mysql-test/suite/sys_vars/r/buffered_error_log_filename_basic.result
+++ b/mysql-test/suite/sys_vars/r/buffered_error_log_filename_basic.result
@@ -1,0 +1,20 @@
+SET @start_value = @@global.buffered_error_log_filename;
+SELECT @start_value;
+@start_value
+
+SET @@global.buffered_error_log_filename = "/tmp/bar.txt";
+SELECT @@global.buffered_error_log_filename;
+@@global.buffered_error_log_filename
+/tmp/bar.txt
+SET @@global.buffered_error_log_filename = '';
+SELECT @@global.buffered_error_log_filename;
+@@global.buffered_error_log_filename
+
+SET @@session.buffered_error_log_filename = OFF;
+ERROR HY000: Variable 'buffered_error_log_filename' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.buffered_error_log_filename;
+ERROR HY000: Variable 'buffered_error_log_filename' is a GLOBAL variable
+SET @@global.buffered_error_log_filename = @start_value;
+SELECT @@global.buffered_error_log_filename;
+@@global.buffered_error_log_filename
+

--- a/mysql-test/suite/sys_vars/r/buffered_error_log_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/buffered_error_log_size_basic.result
@@ -1,0 +1,31 @@
+SET @start_value = @@global.buffered_error_log_size;
+SELECT @start_value;
+@start_value
+0
+SET @@global.buffered_error_log_size = 420;
+SELECT @@global.buffered_error_log_size;
+@@global.buffered_error_log_size
+420
+SET @@global.buffered_error_log_size = 0;
+SELECT @@global.buffered_error_log_size;
+@@global.buffered_error_log_size
+0
+SET @@session.buffered_error_log_size = 0;
+ERROR HY000: Variable 'buffered_error_log_size' is a GLOBAL variable and should be set with SET GLOBAL
+SELECT @@session.buffered_error_log_size;
+ERROR HY000: Variable 'buffered_error_log_size' is a GLOBAL variable
+SET @@global.buffered_error_log_size = -10;
+Warnings:
+Warning	1292	Truncated incorrect buffered_error_log_size value: '-10'
+SELECT @@global.buffered_error_log_size;
+@@global.buffered_error_log_size
+0
+SET @@global.buffered_error_log_size = "/foo/bar.txt";
+ERROR 42000: Incorrect argument type to variable 'buffered_error_log_size'
+SELECT @@global.buffered_error_log_size;
+@@global.buffered_error_log_size
+0
+SET @@global.buffered_error_log_size = @start_value;
+SELECT @@global.buffered_error_log_size;
+@@global.buffered_error_log_size
+0

--- a/mysql-test/suite/sys_vars/t/buffered_error_log_filename_basic.test
+++ b/mysql-test/suite/sys_vars/t/buffered_error_log_filename_basic.test
@@ -1,0 +1,19 @@
+SET @start_value = @@global.buffered_error_log_filename;
+SELECT @start_value;
+
+
+SET @@global.buffered_error_log_filename = "/tmp/bar.txt";
+SELECT @@global.buffered_error_log_filename;
+SET @@global.buffered_error_log_filename = '';
+SELECT @@global.buffered_error_log_filename;
+
+
+--Error ER_GLOBAL_VARIABLE
+SET @@session.buffered_error_log_filename = OFF;
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.buffered_error_log_filename;
+
+
+SET @@global.buffered_error_log_filename = @start_value;
+SELECT @@global.buffered_error_log_filename;
+

--- a/mysql-test/suite/sys_vars/t/buffered_error_log_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/buffered_error_log_size_basic.test
@@ -1,0 +1,26 @@
+SET @start_value = @@global.buffered_error_log_size;
+SELECT @start_value;
+
+
+SET @@global.buffered_error_log_size = 420;
+SELECT @@global.buffered_error_log_size;
+SET @@global.buffered_error_log_size = 0;
+SELECT @@global.buffered_error_log_size;
+
+
+--Error ER_GLOBAL_VARIABLE
+SET @@session.buffered_error_log_size = 0;
+--Error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SELECT @@session.buffered_error_log_size;
+
+# No error, truncation
+SET @@global.buffered_error_log_size = -10;
+SELECT @@global.buffered_error_log_size;
+
+--Error ER_WRONG_TYPE_FOR_VAR
+SET @@global.buffered_error_log_size = "/foo/bar.txt";
+SELECT @@global.buffered_error_log_size;
+
+SET @@global.buffered_error_log_size = @start_value;
+SELECT @@global.buffered_error_log_size;
+

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -43,7 +43,7 @@ call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* Changing innodb_extend_and_i
 call mtr.add_suppression("Failed to initialize TLS for channel: mysql_main");
 
 let $total_global_vars=`SELECT COUNT(*) FROM performance_schema.global_variables where variable_name NOT LIKE 'ndb_%'`;
-let $total_persistent_vars=497;
+let $total_persistent_vars=499;
 
 --echo ***************************************************************
 --echo * 0. Verify that variables present in performance_schema.global

--- a/mysql-test/t/buffered_error_log-master.opt
+++ b/mysql-test/t/buffered_error_log-master.opt
@@ -1,0 +1,2 @@
+--debug="d,redirect_message_to_buffered_error_log"
+--buffered_error_log-size=2048

--- a/mysql-test/t/buffered_error_log.test
+++ b/mysql-test/t/buffered_error_log.test
@@ -1,0 +1,24 @@
+call mtr.add_suppression("Attempting backtrace. You can use the following information to");
+
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+
+--disable_query_log
+--let SEARCH_FILE= $MYSQLTEST_VARDIR/log/buffered_error_log.err
+--eval SET GLOBAL buffered_error_log_filename="$SEARCH_FILE"
+--enable_query_log
+
+# Send a kill -11 to mysqld, should cause a buffered_error_log log
+--let $_kill_signal = 11
+--source include/send_kill_to_mysqld.inc
+
+--let $restart_parameters=restart:
+--source include/start_mysqld.inc
+
+--echo Testing that buffered_error_log log contains something logged
+--let ABORT_ON = NOT_FOUND
+--let SEARCH_PATTERN=Server socket created on IP
+--source include/search_pattern_in_file.inc
+
+--let $restart_parameters=restart:
+--source include/start_mysqld.inc

--- a/mysys/CMakeLists.txt
+++ b/mysys/CMakeLists.txt
@@ -30,6 +30,7 @@ INCLUDE_DIRECTORIES(SYSTEM ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})
 
 SET(MYSYS_SOURCES
   array.cc
+  buffered_error_log.cc
   charset.cc
   charset-def.cc
   dbug.cc

--- a/mysys/buffered_error_log.cc
+++ b/mysys/buffered_error_log.cc
@@ -1,0 +1,69 @@
+
+#include "buffered_error_log.h"
+
+Buffered_error_logger buffered_error_log;
+char *buffered_error_log_filename = nullptr;
+
+void Buffered_error_logger::resize(std::size_t buffer_size) {
+  std::lock_guard<std::mutex> lk{data_mtx};
+
+  if (data.get() != nullptr && buffer_size == data->capacity()) {
+    return;
+  }
+
+  // Write out what we have currently, that way we don't have
+  // to deal with old data in the buffer
+  write_to_disk_();
+
+  if (buffer_size == 0) {
+    data.reset();
+    return;
+  }
+
+  data_t new_buffer(new std::string());
+  new_buffer->reserve(buffer_size);
+  data.swap(new_buffer);
+}
+
+Buffered_error_logger::~Buffered_error_logger() { write_to_disk(); }
+
+void Buffered_error_logger::log(const char *msg, size_t len) {
+  std::lock_guard<std::mutex> lk{data_mtx};
+  if (data.get() == nullptr || data->capacity() == 0) return;
+  const auto msg_end = data->size() + len;
+  if (msg_end > data->capacity() - 1) {
+    write_to_disk_();
+  }
+  *data += msg;
+  *data += '\n';
+}
+
+void Buffered_error_logger::write_to_disk() {
+  std::lock_guard<std::mutex> lk{data_mtx};
+  write_to_disk_();
+}
+
+bool Buffered_error_logger::is_enabled() {
+  std::lock_guard<std::mutex> lk{data_mtx};
+  return data.get() != nullptr && data->size() != 0;
+}
+
+void Buffered_error_logger::write_to_disk_() {
+  if (buffered_error_log_filename == nullptr ||
+      strlen(buffered_error_log_filename) == 0) {
+    return;
+  }
+  if (data.get() == nullptr || data->size() == 0) {
+    return;
+  }
+  auto fdd = fopen(buffered_error_log_filename, "a");
+  fwrite(data->data(), data->size(), 1, fdd);
+  fclose(fdd);
+
+  // the C++ standard doesn't guarantee that clear doesn't deallocate the
+  // buffer but it seems to be the case in libstdc++ and libc++ just to be on
+  // the safe side, we call reserve after clear
+  const auto curr_size = data->capacity();
+  data->clear();
+  data->reserve(curr_size);
+}

--- a/mysys/buffered_error_log.h
+++ b/mysys/buffered_error_log.h
@@ -1,0 +1,43 @@
+
+#pragma once
+
+#include <stdio.h>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+extern char *buffered_error_log_filename;
+
+/** Stores log messages in a fixed size buffer, which can be dumped by large
+ * chunks instead of line by line, to increase performance for high throughput
+ * scenarios.
+ *
+ * The buffer is also dumped by the crash reporting code and during shutdown to
+ * ensure that nothing is lost, only delayed.
+ */
+class Buffered_error_logger {
+  // We are using a pointer to string to guarantee that we can decrease the size
+  // of the buffer
+  using data_t = std::unique_ptr<std::string>;
+  // memory buffer storing the log messages
+  std::mutex data_mtx;
+  data_t data;
+
+ public:
+  void resize(std::size_t buffer_size);
+
+  ~Buffered_error_logger();
+
+  void log(const char *msg, size_t len);
+
+  void write_to_disk();
+
+  bool is_enabled();
+
+ private:
+  // requires holding data_mtx
+  void write_to_disk_();
+};
+
+extern Buffered_error_logger buffered_error_log;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -714,6 +714,7 @@ MySQL clients support the protocol:
 #include "my_time.h"
 #include "my_timer.h"  // my_timer_initialize
 #include "myisam.h"
+#include "mysql/components/services/bits/psi_bits.h"
 #include "mysql/components/services/log_builtins.h"
 #include "mysql/components/services/log_shared.h"
 #include "mysql/components/services/mysql_runtime_error_service.h"
@@ -728,7 +729,6 @@ MySQL clients support the protocol:
 #include "mysql/psi/mysql_stage.h"
 #include "mysql/psi/mysql_statement.h"
 #include "mysql/psi/mysql_thread.h"
-#include "mysql/components/services/bits/psi_bits.h"
 #include "mysql/psi/psi_cond.h"
 #include "mysql/psi/psi_data_lock.h"
 #include "mysql/psi/psi_error.h"
@@ -752,6 +752,7 @@ MySQL clients support the protocol:
 #include "mysql_time.h"
 #include "mysql_version.h"
 #include "mysqld_error.h"
+#include "mysys/buffered_error_log.h"
 #include "mysys_err.h"  // EXIT_OUT_OF_MEMORY
 #include "pfs_thread_provider.h"
 #include "print_version.h"
@@ -802,11 +803,11 @@ MySQL clients support the protocol:
 #include "sql/persisted_variable.h"               // Persisted_variables_cache
 #include "sql/plugin_table.h"
 #include "sql/protocol.h"
-#include "sql/sql_profile.h"
 #include "sql/psi_memory_key.h"  // key_memory_MYSQL_RELAY_LOG_index
 #include "sql/query_options.h"
 #include "sql/replication.h"                        // thd_enter_cond
 #include "sql/resourcegroups/resource_group_mgr.h"  // init, post_init
+#include "sql/sql_profile.h"
 #ifdef _WIN32
 #include "sql/restart_monitor_win.h"
 #endif
@@ -6072,6 +6073,8 @@ static int setup_error_log_components() {
 }
 
 static int init_server_components() {
+  buffered_error_log.resize(buffered_error_log_size * 1024);
+
   DBUG_TRACE;
   /*
     We need to call each of these following functions to ensure that

--- a/sql/server_component/log_sink_trad.cc
+++ b/sql/server_component/log_sink_trad.cc
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 #include "log_sink_trad.h"
 #include "log_sink_perfschema.h"  // log_sink_pfs_event
 #include "my_systime.h"           // my_micro_time()
+#include "mysys/buffered_error_log.h"
 #include "sql/log.h"  // log_write_errstream(), log_prio_from_label()
 
 extern int log_item_inconsistent(log_item *li);
@@ -387,8 +388,23 @@ int log_sink_trad(void *instance [[maybe_unused]], log_line *ll) {
         log_sink_trad_last = microtime;
       }
 
+      bool log_to_buffered_error_log = false;
+      bool log_only_to_buffered_error_log = false;
+
+      // Add product specific buffered_error_log logic based on subsys & prio
+      // here
+      DBUG_EXECUTE_IF("redirect_message_to_buffered_error_log", {
+        log_to_buffered_error_log = true;
+        // also log to the normal log for MTR
+      });
+
+      if (log_to_buffered_error_log) {
+        buffered_error_log.log(buff_line, len);
+      }
+
       // write log-event to log-file
-      log_write_errstream(buff_line, len);
+      if (!log_only_to_buffered_error_log || !buffered_error_log.is_enabled())
+        log_write_errstream(buff_line, len);
     }
   }
 

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -30,6 +30,7 @@
 
 #include "lex_string.h"
 #include "my_inttypes.h"
+#include "mysys/buffered_error_log.h"
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -176,6 +177,8 @@ extern "C" void handle_fatal_signal(int sig) {
       "in the manual which will help you identify the cause of the crash.\n");
 
 #endif /* HAVE_STACKTRACE */
+
+  buffered_error_log.write_to_disk();
 
   if (test_flags & TEST_CORE_ON_SIGNAL) {
 #if HAVE_LIBCOREDUMPER

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -52,6 +52,7 @@
 #include <limits>
 
 #include "include/compression.h"
+#include "mysys/buffered_error_log.h"
 
 #include "my_loglevel.h"
 #include "mysql/components/services/log_builtins.h"
@@ -5993,6 +5994,18 @@ static bool check_log_path(sys_var *self, THD *, set_var *var) {
   return false;
 }
 
+static bool check_log_path_allow_empty(sys_var *self, THD *thd, set_var *var) {
+  if (!var->value) return false;
+
+  if (!var->save_result.string_value.str) return false;
+
+  if (strlen(var->save_result.string_value.str) == 0) return false;
+
+  if (!check_log_path(self, thd, var)) return false;
+
+  return true;
+}
+
 static bool fix_general_log_file(sys_var *, THD *, enum_var_type) {
   bool res;
 
@@ -8010,6 +8023,26 @@ static Sys_var_enum Sys_terminology_use_previous(
     terminology_use_previous_names, DEFAULT(terminology_use_previous::NONE),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr),
     DEPRECATED_VAR(""));
+
+std::size_t buffered_error_log_size;
+
+static bool buffered_error_log_size_update(sys_var *, THD *, enum_var_type) {
+  buffered_error_log.resize(buffered_error_log_size * 1024);
+  return false;
+}
+
+static Sys_var_charptr Sys_var_buffered_error_log_filename(
+    "buffered_error_log_filename", "Filename of the buffered error log",
+    GLOBAL_VAR(buffered_error_log_filename), CMD_LINE(REQUIRED_ARG),
+    IN_FS_CHARSET, DEFAULT(""), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+    ON_CHECK(check_log_path_allow_empty));
+
+static Sys_var_ulonglong Sys_var_buffered_error_log_size(
+    "buffered_error_log_size", "Size of the buffered error log (kB)",
+    GLOBAL_VAR(buffered_error_log_size), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(0, ULLONG_MAX), DEFAULT(0), BLOCK_SIZE(1), NO_MUTEX_GUARD,
+    NOT_IN_BINLOG, ON_CHECK(nullptr),
+    ON_UPDATE(buffered_error_log_size_update));
 
 #ifndef NDEBUG
 Debug_shutdown_actions Debug_shutdown_actions::instance;

--- a/sql/sys_vars.h
+++ b/sql/sys_vars.h
@@ -3088,4 +3088,6 @@ class Sys_var_errors_set : public sys_var {
   }
 };
 
+extern std::size_t buffered_error_log_size;
+
 #endif /* SYS_VARS_H_INCLUDED */


### PR DESCRIPTION
This commits adds two new variables, buffered_error_log_filename and
buffered_error_log_size.

When buffered_error_log_size is specified and non zero, a buffer is
allocated with the specified size, and certain (debug) log messages are
written there.

When this buffer gets full, the server shuts down, or crashes, the
buffer is written to buffered_error_log_filename.

This is useful in situations where debug logs create lots of output and
slow down normal server operation, but are helpful for figuring out
issues, as writing to a memory buffer has less overhead.