### PR TITLE
PS-7731 [8.0]: Merge percona-202101 to percona-202102 tags from fb-mysql-8.0.20

### DIFF
--- a/mysql-test/suite/rocksdb/r/add_index_inplace.result
+++ b/mysql-test/suite/rocksdb/r/add_index_inplace.result
@@ -508,3 +508,11 @@ t1	CREATE TABLE `t1` (
 include/assert.inc [No new index ids allocated]
 DROP TABLE t1;
 SET global rocksdb_table_stats_sampling_pct = @prior_rocksdb_table_stats_sampling_pct;
+CREATE TABLE t1 (i int primary key, j int, v text) ENGINE=RocksDB CHARSET=latin1;
+INSERT INTO t1 VALUES (1, 1, "1"), (2, 1, "2");
+ALTER TABLE t1 ADD INDEX idx (v(10));
+ALTER TABLE t1 DROP INDEX idx, ADD UNIQUE KEY idx (j);
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/autoinc_crash_safe.result
+++ b/mysql-test/suite/rocksdb/r/autoinc_crash_safe.result
@@ -58,7 +58,7 @@ alter table t modify i int;
 include/rpl_restart_server.inc [server_number=1]
 select table_schema, table_name, auto_increment from information_schema.tables where table_name = 't';
 TABLE_SCHEMA	TABLE_NAME	AUTO_INCREMENT
-test	t	NULL
+test	t	6
 # Add auto_increment property.
 insert into t values (123);
 alter table t modify i int auto_increment;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -951,6 +951,7 @@ rocksdb_enable_ttl_read_filtering	ON
 rocksdb_enable_write_thread_adaptive_yield	OFF
 rocksdb_error_if_exists	OFF
 rocksdb_error_on_suboptimal_collation	OFF
+rocksdb_fault_injection_options	
 rocksdb_flush_log_at_trx_commit	1
 rocksdb_force_compute_memtable_stats	ON
 rocksdb_force_compute_memtable_stats_cachetime	0

--- a/mysql-test/suite/rocksdb/r/rocksdb_fault_injection.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_fault_injection.result
@@ -1,0 +1,14 @@
+call mtr.add_suppression("Error detected in background, Status Code: 5, Status: IO error: IO Error");
+call mtr.add_suppression("BackgroundErrorReason: 5");
+call mtr.add_suppression(".*Waiting after background flush error: IO error: IO ErrorAccumulated background error counts.*");
+CREATE TABLE t1 (i INT, j INT, k INT, PRIMARY KEY (i), KEY(j)) ENGINE=rocksdb;
+select @@global.rocksdb_fault_injection_options;
+@@global.rocksdb_fault_injection_options
+{"retry":true,"failure_ratio":1,"filetypes":["kTableFile"]}
+set global rocksdb_force_flush_memtable_now = 1;
+# restart: --rocksdb_fault_injection_options=
+include/assert_grep.inc [Expect IO errors]
+select @@global.rocksdb_fault_injection_options;
+@@global.rocksdb_fault_injection_options
+
+drop table t1;

--- a/mysql-test/suite/rocksdb/r/stats_during_drop_table.result
+++ b/mysql-test/suite/rocksdb/r/stats_during_drop_table.result
@@ -1,0 +1,33 @@
+set @old_debug = @@global.debug;
+set @@global.debug = '+d,rocksdb_before_delete_table';
+create table t1 (
+id1 int unsigned not null default '0',
+primary key (id1) comment 'cf_primary_key'
+  ) engine=rocksdb;
+drop table t1;
+set debug_sync = "now wait_for ready_to_mark_cf_dropped_before_delete_table";
+SHOW TABLE STATUS LIKE 't1';
+set debug_sync = "now signal mark_cf_dropped_done_before_delete_table";
+show tables;
+Tables_in_test
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	ROCKSDB	10	Fixed	4294967295	0	0	0	0	0	NULL	#	#	NULL	#	NULL		No such table: 'Table is missing'
+Warnings:
+Warning	155	No such table: 'Table is missing'
+set @@global.debug = @old_debug;
+set @@global.debug = '+d,rocksdb_after_delete_table';
+create table t1 (
+id1 int unsigned not null default '0',
+primary key (id1) comment 'cf_primary_key'
+  ) engine=rocksdb;
+drop table t1;
+set debug_sync = "now wait_for ready_to_mark_cf_dropped_after_delete_table";
+SHOW TABLE STATUS LIKE 't1';
+set debug_sync = "now signal mark_cf_dropped_done_after_delete_table";
+show tables;
+Tables_in_test
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	ROCKSDB	10	Fixed	4294967295	0	0	0	0	0	NULL	#	#	NULL	#	NULL		No such table: 'Table is missing'
+Warnings:
+Warning	155	No such table: 'Table is missing'
+set @@global.debug = @old_debug;

--- a/mysql-test/suite/rocksdb/r/truncate_table.result
+++ b/mysql-test/suite/rocksdb/r/truncate_table.result
@@ -8,12 +8,24 @@ DROP TABLE t1;
 CREATE TABLE t1 (a INT KEY AUTO_INCREMENT, c CHAR(8)) ENGINE=ROCKSDB;
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	NULL	#	#	NULL	utf8mb4_0900_ai_ci	NULL		
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+0
+SHOW TABLE STATUS LIKE 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
 t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	1	#	#	#	utf8mb4_0900_ai_ci	NULL		
 INSERT INTO t1 (c) VALUES ('a'),('b'),('c');
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
 t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	4	#	#	#	utf8mb4_0900_ai_ci	NULL		
 TRUNCATE TABLE t1;
+SHOW TABLE STATUS LIKE 't1';
+Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
+t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	NULL	#	#	NULL	utf8mb4_0900_ai_ci	NULL		
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+0
 SHOW TABLE STATUS LIKE 't1';
 Name	Engine	Version	Row_format	Rows	Avg_row_length	Data_length	Max_data_length	Index_length	Data_free	Auto_increment	Create_time	Update_time	Check_time	Collation	Checksum	Create_options	Comment
 t1	ROCKSDB	10	Fixed	#	#	#	0	0	0	1	#	#	#	utf8mb4_0900_ai_ci	NULL		

--- a/mysql-test/suite/rocksdb/t/add_index_inplace.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace.test
@@ -427,3 +427,13 @@ DROP TABLE t1;
 
 # Cleanup
 SET global rocksdb_table_stats_sampling_pct = @prior_rocksdb_table_stats_sampling_pct;
+
+CREATE TABLE t1 (i int primary key, j int, v text) ENGINE=RocksDB CHARSET=latin1;
+INSERT INTO t1 VALUES (1, 1, "1"), (2, 1, "2");
+ALTER TABLE t1 ADD INDEX idx (v(10));
+--disable_result_log
+--error ER_DUP_ENTRY
+ALTER TABLE t1 DROP INDEX idx, ADD UNIQUE KEY idx (j);
+--enable_result_log
+CHECK TABLE t1;
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/t/rocksdb_fault_injection-master.opt
+++ b/mysql-test/suite/rocksdb/t/rocksdb_fault_injection-master.opt
@@ -1,0 +1,1 @@
+--loose-rocksdb_fault_injection_options="{"retry":true,"failure_ratio":1,"filetypes":["kTableFile"]}"

--- a/mysql-test/suite/rocksdb/t/rocksdb_fault_injection.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_fault_injection.test
@@ -1,0 +1,35 @@
+--source include/have_rocksdb.inc
+call mtr.add_suppression("Error detected in background, Status Code: 5, Status: IO error: IO Error");
+call mtr.add_suppression("BackgroundErrorReason: 5");
+call mtr.add_suppression(".*Waiting after background flush error: IO error: IO ErrorAccumulated background error counts.*");
+
+CREATE TABLE t1 (i INT, j INT, k INT, PRIMARY KEY (i), KEY(j)) ENGINE=rocksdb;
+
+# Insert 100 rows that will deterministically reproduce the fault injection error
+--disable_query_log
+let $max = 100;
+let $i = 1;
+while ($i <= $max) {
+  let $insert = INSERT INTO t1 VALUES ($i, $i, $i);
+  inc $i;
+  eval $insert;
+}
+--enable_query_log
+select @@global.rocksdb_fault_injection_options;
+
+set global rocksdb_force_flush_memtable_now = 1;
+
+
+# cleanup
+--let $restart_parameters="restart: --rocksdb_fault_injection_options="
+--source include/restart_mysqld.inc
+
+--let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_only_after = CURRENT_TEST: rocksdb.rocksdb_fault_injection
+--let $assert_select = Error detected in background, Status Code: 5, Status: IO error: IO Error
+--let $assert_match = .*Error detected in background, Status Code: 5, Status: IO error: IO Error.*
+--let $assert_text = Expect IO errors
+--source include/assert_grep.inc
+
+select @@global.rocksdb_fault_injection_options;
+drop table t1;

--- a/mysql-test/suite/rocksdb/t/stats_during_drop_table.test
+++ b/mysql-test/suite/rocksdb/t/stats_during_drop_table.test
@@ -1,0 +1,80 @@
+--source include/have_debug.inc
+--source include/have_debug_sync.inc
+--source include/have_rocksdb.inc
+--source include/count_sessions.inc
+
+set @old_debug = @@global.debug;
+
+connect (conn1,localhost,root,,);
+connect (conn2,localhost,root,,);
+connect (conn3,localhost,root,,);
+
+## test1 ##
+--connection conn1
+set @@global.debug = '+d,rocksdb_before_delete_table';
+create table t1 (
+  id1 int unsigned not null default '0',
+  primary key (id1) comment 'cf_primary_key'
+  ) engine=rocksdb;
+
+send drop table t1;
+
+--connection conn2
+set debug_sync = "now wait_for ready_to_mark_cf_dropped_before_delete_table";
+
+# replace_column is in reap
+send SHOW TABLE STATUS LIKE 't1';
+
+--connection conn3
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
+--source include/wait_condition.inc
+set debug_sync = "now signal mark_cf_dropped_done_before_delete_table";
+
+--connection conn1
+reap;
+show tables;
+
+--connection conn2
+--replace_column 12 # 13 # 15 #
+reap;
+
+set @@global.debug = @old_debug;
+
+## test2 ##
+--connection conn1
+
+set @@global.debug = '+d,rocksdb_after_delete_table';
+create table t1 (
+  id1 int unsigned not null default '0',
+  primary key (id1) comment 'cf_primary_key'
+  ) engine=rocksdb;
+
+send drop table t1;
+
+--connection conn2
+set debug_sync = "now wait_for ready_to_mark_cf_dropped_after_delete_table";
+
+# replace_column is in reap
+send SHOW TABLE STATUS LIKE 't1';
+
+--connection conn3
+let $wait_condition= SELECT count(*) = 1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
+--source include/wait_condition.inc
+
+set debug_sync = "now signal mark_cf_dropped_done_after_delete_table";
+
+--connection conn1
+reap;
+show tables;
+
+--connection conn2
+--replace_column 12 # 13 # 15 #
+reap;
+
+set @@global.debug = @old_debug;
+
+--connection default
+--disconnect conn1
+--disconnect conn2
+--disconnect conn3
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/rocksdb/t/truncate_table.test
+++ b/mysql-test/suite/rocksdb/t/truncate_table.test
@@ -24,6 +24,14 @@ DROP TABLE t1;
 
 CREATE TABLE t1 (a INT KEY AUTO_INCREMENT, c CHAR(8)) ENGINE=ROCKSDB;
 
+# NOTE: Before table open AUTO_INCREMENT will be NULL as table open updates it
+#--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
+--replace_column 5 # 6 # 7 # 12 # 13 #
+SHOW TABLE STATUS LIKE 't1';
+
+# Force open the table to update autoinc number 
+SELECT COUNT(*) FROM t1;
+
 #--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
 --replace_column 5 # 6 # 7 # 12 # 13 # 14 #
 SHOW TABLE STATUS LIKE 't1';
@@ -34,6 +42,15 @@ INSERT INTO t1 (c) VALUES ('a'),('b'),('c');
 SHOW TABLE STATUS LIKE 't1';
 
 TRUNCATE TABLE t1;
+
+# NOTE: Before table open AUTO_INCREMENT will be NULL as table open updates it
+#--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
+--replace_column 5 # 6 # 7 # 12 # 13 #
+
+SHOW TABLE STATUS LIKE 't1';
+# Force open the table to update autoinc number 
+SELECT COUNT(*) FROM t1;
+
 #--replace_column 2 # 3 # 4 # 5 # 6 # 7 # 8 # 9 # 10 # 12 # 13 # 14 # 15 # 16 # 17 # 18 #
 --replace_column 5 # 6 # 7 # 12 # 13 # 14 #
 SHOW TABLE STATUS LIKE 't1';

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_fault_injection_options_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_fault_injection_options_basic.result
@@ -1,0 +1,7 @@
+SET @start_global_value = @@global.ROCKSDB_FAULT_INJECTION_OPTIONS;
+SELECT @start_global_value;
+@start_global_value
+NULL
+"Trying to set variable @@global.ROCKSDB_FAULT_INJECTION_OPTIONS to 444. It should fail because it is readonly."
+SET @@global.ROCKSDB_FAULT_INJECTION_OPTIONS   = 444;
+ERROR HY000: Variable 'rocksdb_fault_injection_options' is a read only variable

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_fault_injection_options_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_fault_injection_options_basic.test
@@ -1,0 +1,6 @@
+--source include/have_rocksdb.inc
+
+--let $sys_var=ROCKSDB_FAULT_INJECTION_OPTIONS
+--let $read_only=1
+--let $session=0
+--source ../include/rocksdb_sys_var.inc

--- a/sql/dd/info_schema/table_stats.cc
+++ b/sql/dd/info_schema/table_stats.cc
@@ -488,7 +488,9 @@ ulonglong Table_statistics::read_stat(
   handlerton *hton = nullptr;
   const bool hton_implements_get_statistics =
       (tmp_plugin && (hton = plugin_data<handlerton *>(tmp_plugin)) &&
-       hton->get_index_column_cardinality && hton->get_table_statistics);
+       (hton->get_index_column_cardinality ||
+        stype != enum_table_stats_type::INDEX_COLUMN_CARDINALITY) &&
+       hton->get_table_statistics);
 
   // Try to get statistics without opening the table.
   if (!partition_name && hton_implements_get_statistics)

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -6931,8 +6931,7 @@ Field_blob::Field_blob(uchar *ptr_arg, uchar *null_ptr_arg, uchar null_bit_arg,
   /* TODO: why do not fill table->s->blob_field array here? */
 }
 
-static void store_blob_length(uchar *i_ptr, uint i_packlength,
-                              uint32 i_number) {
+void store_blob_length(uchar *i_ptr, uint i_packlength, uint32 i_number) {
   switch (i_packlength) {
     case 1:
       i_ptr[0] = (uchar)i_number;
@@ -6948,7 +6947,7 @@ static void store_blob_length(uchar *i_ptr, uint i_packlength,
   }
 }
 
-uint32 Field_blob::get_length(const uchar *pos, uint packlength_arg) const {
+uint32 Field_blob::get_length(const uchar *pos, uint packlength_arg) {
   switch (packlength_arg) {
     case 1:
       return (uint32)pos[0];

--- a/sql/field.h
+++ b/sql/field.h
@@ -3719,7 +3719,7 @@ class Field_blob : public Field_longstr {
     return get_length(row_offset);
   }
   uint32 get_length(ptrdiff_t row_offset = 0) const;
-  uint32 get_length(const uchar *ptr, uint packlength) const;
+  static uint32 get_length(const uchar *ptr, uint packlength);
   uint32 get_length(const uchar *ptr_arg) const;
   /** Get a const pointer to the BLOB data of this field. */
   const uchar *get_blob_data() const { return get_blob_data(ptr + packlength); }
@@ -3876,6 +3876,8 @@ class Field_blob : public Field_longstr {
  private:
   int do_save_field_metadata(uchar *first_byte) const override;
 };
+
+void store_blob_length(uchar *i_ptr, uint i_packlength, uint32 i_number);
 
 class Field_geom final : public Field_blob {
  private:

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -130,14 +130,18 @@ static Rdb_exec_time st_rdb_exec_time;
 /**
   Updates row counters based on the table type and operation type.
 */
-void ha_rocksdb::update_row_stats(const operation_type &type) {
+void ha_rocksdb::update_row_stats(const operation_type &type, ulonglong count) {
   DBUG_ASSERT(type < ROWS_MAX);
   // Find if we are modifying system databases.
   if (table->s && m_tbl_def->m_is_mysql_system_table) {
-    global_stats.system_rows[type].inc();
+    global_stats.system_rows[type].add(count);
   } else {
-    global_stats.rows[type].inc();
+    global_stats.rows[type].add(count);
   }
+}
+
+void ha_rocksdb::update_row_read(ulonglong count) {
+  update_row_stats(ROWS_READ, count);
 }
 
 void dbug_dump_database(rocksdb::DB *db);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -5071,6 +5071,54 @@ static bool rocksdb_rollback_to_savepoint_can_release_mdl(
   return true;
 }
 
+static void rocksdb_get_stats(ha_statistics *stats, Rdb_tbl_def *tbl_def) {
+  stats->records = 0;
+  stats->index_file_length = 0ul;
+  stats->data_file_length = 0ul;
+  stats->mean_rec_length = 0;
+
+  for (uint i = 0; i < tbl_def->m_key_count; i++) {
+    auto key_def = tbl_def->m_key_descr_arr[i];
+    if (key_def->is_primary_key()) {
+      stats->data_file_length = key_def->m_stats.m_actual_disk_size;
+      stats->records = key_def->m_stats.m_rows;
+    } else {
+      stats->index_file_length += key_def->m_stats.m_actual_disk_size;
+    }
+  }
+}
+
+/*
+  This is called for INFORMATION_SCHEMA.TABLES
+*/
+static bool rocksdb_get_table_statistics(
+    const char *db_name, const char *table_name,
+    dd::Object_id /*se_private_id*/,
+    const dd::Properties & /*ts_se_private_data*/,
+    const dd::Properties & /*tbl_se_private_data*/, uint /*stat_flags*/,
+    ha_statistics *stats) {
+  std::string fullname = db_name;
+  fullname.append(".");
+  fullname.append(table_name);
+
+  // We are called from within metadata lock MDL_EXPLICIT, so it should be
+  // safe to access Rdb_tbl_def here
+  auto tbl_def = ddl_manager.find(fullname);
+  if (!tbl_def) {
+    // Table is missing due to a possible race condition
+    my_error(HA_ERR_NO_SUCH_TABLE, MYF(0), "Table is missing");
+    return true;
+  }
+
+  int ret = ha_rocksdb::update_stats(stats, tbl_def);
+  if (ret != HA_EXIT_SUCCESS) {
+    my_error(ret, MYF(0), "Failed to update table stats");
+    return true;
+  }
+
+  return false;
+}
+
 static rocksdb::Status check_rocksdb_options_compatibility(
     const char *const dbpath, const rocksdb::Options &main_opts,
     const std::vector<rocksdb::ColumnFamilyDescriptor> &cf_descr) {
@@ -5340,6 +5388,7 @@ static int rocksdb_init_internal(void *const p) {
   rocksdb_hton->savepoint_rollback = rocksdb_rollback_to_savepoint;
   rocksdb_hton->savepoint_rollback_can_release_mdl =
       rocksdb_rollback_to_savepoint_can_release_mdl;
+  rocksdb_hton->get_table_statistics = rocksdb_get_table_statistics;
   rocksdb_hton->flush_logs = rocksdb_flush_wal;
 
   rocksdb_hton->flags = HTON_TEMPORARY_NOT_SUPPORTED |
@@ -7840,6 +7889,7 @@ int ha_rocksdb::create_table(const std::string &table_name,
 
   m_key_descr_arr = new std::shared_ptr<Rdb_key_def>[n_keys];
   m_tbl_def->m_key_count = n_keys;
+  m_tbl_def->m_pk_index = table_arg->s->primary_key;
   m_tbl_def->m_key_descr_arr = m_key_descr_arr;
 
   err = create_key_defs(table_arg, m_tbl_def, actual_user_table_name);
@@ -11041,51 +11091,86 @@ rocksdb::Status ha_rocksdb::delete_or_singledelete(
   return tx->delete_key(column_family, key, assume_tracked);
 }
 
-void ha_rocksdb::update_stats(void) {
-  DBUG_ENTER_FUNC();
-
-  stats.records = 0;
-  stats.index_file_length = 0ul;
-  stats.data_file_length = 0ul;
-  stats.mean_rec_length = 0;
-
-  for (uint i = 0; i < m_tbl_def->m_key_count; i++) {
-    if (is_pk(i, table, m_tbl_def)) {
-      stats.data_file_length = m_pk_descr->m_stats.m_actual_disk_size;
-      stats.records = m_pk_descr->m_stats.m_rows;
-    } else {
-      stats.index_file_length += m_key_descr_arr[i]->m_stats.m_actual_disk_size;
-    }
-  }
-
-  DBUG_VOID_RETURN;
-}
-
-int ha_rocksdb::adjust_handler_stats_table_scan() {
+int ha_rocksdb::adjust_handler_stats_table_scan(ha_statistics *ha_stats,
+                                                Rdb_tbl_def *tbl_def) {
   DBUG_ENTER_FUNC();
 
   bool should_recalc_stats = false;
-  if (static_cast<longlong>(stats.data_file_length) < 0) {
-    stats.data_file_length = 0;
+  if (static_cast<longlong>(ha_stats->data_file_length) < 0) {
+    ha_stats->data_file_length = 0;
     should_recalc_stats = true;
   }
 
-  if (static_cast<longlong>(stats.index_file_length) < 0) {
-    stats.index_file_length = 0;
+  if (static_cast<longlong>(ha_stats->index_file_length) < 0) {
+    ha_stats->index_file_length = 0;
     should_recalc_stats = true;
   }
 
-  if (static_cast<longlong>(stats.records) < 0) {
-    stats.records = 1;
+  if (static_cast<longlong>(ha_stats->records) < 0) {
+    ha_stats->records = 1;
     should_recalc_stats = true;
   }
 
   if (should_recalc_stats) {
     // If any of the stats is corrupt, add the table to the index stats
     // recalc queue.
-    rdb_is_thread.add_index_stats_request(m_tbl_def->full_tablename());
+    rdb_is_thread.add_index_stats_request(tbl_def->full_tablename());
   }
   DBUG_RETURN(HA_EXIT_SUCCESS);
+}
+
+int ha_rocksdb::update_stats(ha_statistics *ha_stats, Rdb_tbl_def *tbl_def) {
+  /*
+    Test only to simulate corrupted stats
+  */
+  DBUG_EXECUTE_IF("myrocks_simulate_negative_stats", {
+    auto pk_def = tbl_def->get_pk_def();
+    pk_def->m_stats.m_actual_disk_size = -pk_def->m_stats.m_actual_disk_size;
+  });
+
+  rocksdb_get_stats(ha_stats, tbl_def);
+  if (rocksdb_table_stats_use_table_scan) {
+    int ret = adjust_handler_stats_table_scan(ha_stats, tbl_def);
+    if (ret != HA_EXIT_SUCCESS) {
+      return ret;
+    }
+  } else {
+    int ret = adjust_handler_stats_sst_and_memtable(ha_stats, tbl_def);
+    if (ret != HA_EXIT_SUCCESS) {
+      return ret;
+    }
+  }
+
+  if (rocksdb_debug_optimizer_n_rows > 0) {
+    ha_stats->records = rocksdb_debug_optimizer_n_rows;
+  }
+
+  if (ha_stats->records != 0) {
+    ha_stats->mean_rec_length = ha_stats->data_file_length / ha_stats->records;
+  }
+
+  // HA_STATUS_TIME - we always update it as it's cheap
+  ha_stats->update_time = tbl_def->m_update_time;
+
+  // HA_STATUS_AUTO - we always update it as it's cheap
+  // Because we haven't opened the table yet, we need to load auto incr
+  // value here. Note we won't know if the table actually has auto incr
+  // without opening the table, so there is a corner case it'll end up
+  // being NULL if the table has just been created and haven't been
+  // opened yet - InnoDB has the same issue
+  if (tbl_def->m_auto_incr_val == 0) {
+    // Unfortunately in this case we don't know if we actually have auto
+    // increment without opening the table, so we'd have to load the value
+    // always even if the table doesn't have auto increment
+    if (!dict_manager.get_auto_incr_val(tbl_def->get_autoincr_gl_index_id(),
+                                        &ha_stats->auto_increment_value)) {
+      ha_stats->auto_increment_value = 0;
+    }
+  } else {
+    ha_stats->auto_increment_value = tbl_def->m_auto_incr_val;
+  }
+
+  return HA_EXIT_SUCCESS;
 }
 
 /**
@@ -11099,32 +11184,9 @@ int ha_rocksdb::info(uint flag) {
   if (!table) DBUG_RETURN(HA_EXIT_FAILURE);
 
   if (flag & HA_STATUS_VARIABLE) {
-    /*
-      Test only to simulate corrupted stats
-    */
-    DBUG_EXECUTE_IF("myrocks_simulate_negative_stats",
-                    m_pk_descr->m_stats.m_actual_disk_size =
-                        -m_pk_descr->m_stats.m_actual_disk_size;);
-
-    update_stats();
-    if (rocksdb_table_stats_use_table_scan) {
-      int ret = adjust_handler_stats_table_scan();
-      if (ret != HA_EXIT_SUCCESS) {
-        return ret;
-      }
-    } else {
-      int ret = adjust_handler_stats_sst_and_memtable();
-      if (ret != HA_EXIT_SUCCESS) {
-        return ret;
-      }
-    }
-
-    if (rocksdb_debug_optimizer_n_rows > 0) {
-      stats.records = rocksdb_debug_optimizer_n_rows;
-    }
-
-    if (stats.records != 0) {
-      stats.mean_rec_length = stats.data_file_length / stats.records;
+    int ret = update_stats(&stats, m_tbl_def);
+    if (ret != HA_EXIT_SUCCESS) {
+      return ret;
     }
   }
 
@@ -11591,8 +11653,8 @@ static rocksdb::Range get_range(const Rdb_key_def &kd,
   return get_range(kd.get_index_number(), buf, offset1, offset2);
 }
 
-rocksdb::Range get_range(const Rdb_key_def &kd,
-                         uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) {
+rocksdb::Range ha_rocksdb::get_range(
+    const Rdb_key_def &kd, uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) {
   if (kd.m_is_reverse_cf) {
     return myrocks::get_range(kd, buf, 1, 0);
   } else {
@@ -11602,7 +11664,7 @@ rocksdb::Range get_range(const Rdb_key_def &kd,
 
 rocksdb::Range ha_rocksdb::get_range(
     const int i, uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2]) const {
-  return myrocks::get_range(*m_key_descr_arr[i], buf);
+  return get_range(*m_key_descr_arr[i], buf);
 }
 
 /*
@@ -12229,7 +12291,7 @@ static int calculate_cardinality_table_scan(
     Rdb_index_stats &stat = (*stats)[kd->get_gl_index_id()];
 
     uchar r_buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2];
-    auto r = myrocks::get_range(*kd, r_buf);
+    auto r = ha_rocksdb::get_range(*kd, r_buf);
     uint64_t memtableCount;
     uint64_t memtableSize;
     rdb->GetApproximateMemTableStats(kd->get_cf(), r, &memtableCount,
@@ -12368,7 +12430,7 @@ static int read_stats_from_ssts(
   uchar *bufp = buf.data();
   for (const auto &it : to_recalc) {
     auto &kd = it.second;
-    ranges[kd->get_cf()].push_back(myrocks::get_range(*kd, bufp));
+    ranges[kd->get_cf()].push_back(ha_rocksdb::get_range(*kd, bufp));
     bufp += 2 * Rdb_key_def::INDEX_NUMBER_SIZE;
   }
 
@@ -12544,48 +12606,48 @@ int ha_rocksdb::analyze(THD *const thd, HA_CHECK_OPT *const check_opt) {
   DBUG_RETURN(HA_ADMIN_OK);
 }
 
-int ha_rocksdb::adjust_handler_stats_sst_and_memtable() {
+int ha_rocksdb::adjust_handler_stats_sst_and_memtable(ha_statistics *ha_stats,
+                                                      Rdb_tbl_def *tbl_def) {
   DBUG_ENTER_FUNC();
 
   /*
     If any stats are negative due to bad cached stats, re-run analyze table
     and re-retrieve the stats.
   */
-  if (static_cast<longlong>(stats.data_file_length) < 0 ||
-      static_cast<longlong>(stats.index_file_length) < 0 ||
-      static_cast<longlong>(stats.records) < 0) {
-    if (calculate_stats_for_table(m_tbl_def->full_tablename(),
-                                  SCAN_TYPE_NONE)) {
+  if (static_cast<longlong>(ha_stats->data_file_length) < 0 ||
+      static_cast<longlong>(ha_stats->index_file_length) < 0 ||
+      static_cast<longlong>(ha_stats->records) < 0) {
+    if (calculate_stats_for_table(tbl_def->full_tablename(), SCAN_TYPE_NONE)) {
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
 
-    update_stats();
+    rocksdb_get_stats(ha_stats, tbl_def);
   }
 
   // if number of records is hardcoded, we do not want to force computation
   // of memtable cardinalities
-  if (stats.records == 0 || (rocksdb_force_compute_memtable_stats &&
-                             rocksdb_debug_optimizer_n_rows == 0)) {
+  if (ha_stats->records == 0 || (rocksdb_force_compute_memtable_stats &&
+                                 rocksdb_debug_optimizer_n_rows == 0)) {
     // First, compute SST files stats
     uchar buf[Rdb_key_def::INDEX_NUMBER_SIZE * 2];
-    auto r = get_range(pk_index(table, m_tbl_def), buf);
+    std::shared_ptr<Rdb_key_def> pk_def = tbl_def->get_pk_def();
+    auto r = ha_rocksdb::get_range(*pk_def, buf);
     uint64_t sz = 0;
 
     uint8_t include_flags = rocksdb::DB::INCLUDE_FILES;
 
     // recompute SST files stats only if records count is 0
-    if (stats.records == 0) {
-      rdb->GetApproximateSizes(m_pk_descr->get_cf(), &r, 1, &sz, include_flags);
-      stats.records += sz / ROCKSDB_ASSUMED_KEY_VALUE_DISK_SIZE;
-      stats.data_file_length += sz;
+    if (ha_stats->records == 0) {
+      rdb->GetApproximateSizes(pk_def->get_cf(), &r, 1, &sz, include_flags);
+      ha_stats->records += sz / ROCKSDB_ASSUMED_KEY_VALUE_DISK_SIZE;
+      ha_stats->data_file_length += sz;
     }
 
     // Second, compute memtable stats. This call is expensive, so cache
     // values computed for some time.
     uint64_t cachetime = rocksdb_force_compute_memtable_stats_cachetime;
     uint64_t time = (cachetime == 0) ? 0 : my_micro_time();
-    if (cachetime == 0 ||
-        time > m_table_handler->m_mtcache_last_update + cachetime) {
+    if (cachetime == 0 || time > tbl_def->m_mtcache_last_update + cachetime) {
       uint64_t memtableCount;
       uint64_t memtableSize;
 
@@ -12594,26 +12656,26 @@ int ha_rocksdb::adjust_handler_stats_sst_and_memtable() {
       // it also can return 0 for quite a large tables which means that
       // cardinality for memtable only indxes will be reported as 0
 
-      rdb->GetApproximateMemTableStats(m_pk_descr->get_cf(), r, &memtableCount,
+      rdb->GetApproximateMemTableStats(pk_def->get_cf(), r, &memtableCount,
                                        &memtableSize);
 
       // Atomically update all of these fields at the same time
       if (cachetime > 0) {
-        if (m_table_handler->m_mtcache_lock.fetch_add(
-                1, std::memory_order_acquire) == 0) {
-          m_table_handler->m_mtcache_count = memtableCount;
-          m_table_handler->m_mtcache_size = memtableSize;
-          m_table_handler->m_mtcache_last_update = time;
+        if (tbl_def->m_mtcache_lock.fetch_add(1, std::memory_order_acquire) ==
+            0) {
+          tbl_def->m_mtcache_count = memtableCount;
+          tbl_def->m_mtcache_size = memtableSize;
+          tbl_def->m_mtcache_last_update = time;
         }
-        m_table_handler->m_mtcache_lock.fetch_sub(1, std::memory_order_release);
+        tbl_def->m_mtcache_lock.fetch_sub(1, std::memory_order_release);
       }
 
-      stats.records += memtableCount;
-      stats.data_file_length += memtableSize;
+      ha_stats->records += memtableCount;
+      ha_stats->data_file_length += memtableSize;
     } else {
       // Cached data is still valid, so use it instead
-      stats.records += m_table_handler->m_mtcache_count;
-      stats.data_file_length += m_table_handler->m_mtcache_size;
+      ha_stats->records += tbl_def->m_mtcache_count;
+      ha_stats->data_file_length += tbl_def->m_mtcache_size;
     }
   }
 
@@ -12953,6 +13015,7 @@ bool ha_rocksdb::prepare_inplace_alter_table(
     new_tdef = new Rdb_tbl_def(m_tbl_def->full_tablename());
     new_tdef->m_key_descr_arr = new_key_descr;
     new_tdef->m_key_count = new_n_keys;
+    new_tdef->m_pk_index = altered_table->s->primary_key;
     new_tdef->m_auto_incr_val =
         m_tbl_def->m_auto_incr_val.load(std::memory_order_relaxed);
     new_tdef->m_hidden_pk_val =

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -13303,7 +13303,8 @@ int ha_rocksdb::inplace_populate_sk(
       keys.
     */
     const uint pk = pk_index(table, m_tbl_def);
-    ha_index_init(pk, true);
+    res = ha_index_init(pk, true);
+    if (res) DBUG_RETURN(res);
 
     /* Scan each record in the primary key in order */
     for (res = index_first(table->record[0]); res == 0;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -47,6 +47,7 @@
 #include "my_sys.h"
 #include "mysql/thread_pool_priv.h"
 #include "mysys_err.h"
+#include "scope_guard.h"
 #include "sql/debug_sync.h"
 #include "sql/json_dom.h"
 #include "sql/mysqld.h"
@@ -6385,6 +6386,7 @@ ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
       m_pack_buffer(nullptr),
       m_lock_rows(RDB_LOCK_NONE),
       m_keyread_only(false),
+      m_iteration_only(false),
       m_insert_with_update(false),
       m_dup_key_found(false),
 #if defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
@@ -8454,6 +8456,11 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf) {
 
     /* Check if we've ran out of records of this index */
     if (m_key_descr_arr[keyno]->covers_key(key)) {
+      if (m_iteration_only) {
+        table->set_found_row();
+        return 0;
+      }
+
       int rc = 0;
 
       // TODO: We could here check if we have ran out of range we're scanning
@@ -9086,6 +9093,22 @@ int ha_rocksdb::get_row_by_rowid(uchar *const buf, const char *const rowid,
   }
 
   DBUG_RETURN(rc);
+}
+
+int ha_rocksdb::records(ha_rows *num_rows) {
+  m_iteration_only = true;
+  auto iteration_guard =
+      create_scope_guard([this]() { m_iteration_only = false; });
+  int count = handler::records(num_rows);
+  return count;
+}
+
+int ha_rocksdb::records_from_index(ha_rows *num_rows, uint index) {
+  m_iteration_only = true;
+  auto iteration_guard =
+      create_scope_guard([this]() { m_iteration_only = false; });
+  int count = handler::records_from_index(num_rows, index);
+  return count;
 }
 
 /**
@@ -10670,7 +10693,7 @@ int ha_rocksdb::rnd_next(uchar *const buf) {
 int ha_rocksdb::rnd_next_with_direction(uchar *const buf, bool move_forward) {
   DBUG_ENTER_FUNC();
 
-  int rc;
+  int rc = 0;
   THD *thd = ha_thd();
 
   if (!m_scan_it || !is_valid(m_scan_it)) {
@@ -10711,6 +10734,11 @@ int ha_rocksdb::rnd_next_with_direction(uchar *const buf, bool move_forward) {
     const rocksdb::Slice key = m_scan_it->key();
     if (!m_pk_descr->covers_key(key)) {
       rc = HA_ERR_END_OF_FILE;
+      break;
+    }
+
+    if (m_iteration_only) {
+      table->set_found_row();
       break;
     }
 

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -144,6 +144,10 @@ void ha_rocksdb::update_row_read(ulonglong count) {
   update_row_stats(ROWS_READ, count);
 }
 
+void ha_rocksdb::inc_covered_sk_lookup() {
+  global_stats.covered_secondary_key_lookups.inc();
+}
+
 void dbug_dump_database(rocksdb::DB *db);
 static handler *rocksdb_create_handler(my_core::handlerton *hton,
                                        my_core::TABLE_SHARE *table_arg,
@@ -8463,7 +8467,7 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
     } else {
       rc = kd.unpack_record(table, buf, &rkey, &value,
                             m_converter->get_verify_row_debug_checksums());
-      global_stats.covered_secondary_key_lookups.inc();
+      inc_covered_sk_lookup();
     }
   } else {
     if (kd.m_is_reverse_cf) move_forward = !move_forward;
@@ -8588,7 +8592,7 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf) {
         rc = m_key_descr_arr[keyno]->unpack_record(
             table, buf, &key, &value,
             m_converter->get_verify_row_debug_checksums());
-        global_stats.covered_secondary_key_lookups.inc();
+        inc_covered_sk_lookup();
       } else {
         DEBUG_SYNC(ha_thd(), "rocksdb_concurrent_delete_sk");
         rc = get_row_by_rowid(buf, m_pk_packed_tuple, size);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -4235,7 +4235,8 @@ static xa_status_code rocksdb_commit_by_xid(handlerton *const hton,
   DBUG_ASSERT(xid != nullptr);
   DBUG_ASSERT(commit_latency_stats != nullptr);
 
-  rocksdb::StopWatchNano timer(rocksdb::Env::Default(), true);
+  auto clock = rocksdb::Env::Default()->GetSystemClock().get();
+  rocksdb::StopWatchNano timer(clock, true);
 
   const auto name = rdb_xid_to_string(*xid);
   DBUG_ASSERT(!name.empty());
@@ -4352,7 +4353,8 @@ static int rocksdb_commit(handlerton *const hton, THD *const thd,
   DBUG_ASSERT(thd != nullptr);
   DBUG_ASSERT(commit_latency_stats != nullptr);
 
-  rocksdb::StopWatchNano timer(rocksdb::Env::Default(), true);
+  auto clock = rocksdb::Env::Default()->GetSystemClock().get();
+  rocksdb::StopWatchNano timer(clock, true);
 
   /* note: h->external_lock(F_UNLCK) is called after this function is called) */
   Rdb_transaction *tx = get_tx_from_thd(thd);

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -195,6 +195,8 @@ static const char *rdb_get_error_messages(int error);
 static void rocksdb_flush_all_memtables() {
   const Rdb_cf_manager &cf_manager = rdb_get_cf_manager();
 
+  if (!cf_manager.is_initialized()) return;
+
   // RocksDB will fail the flush if the CF is deleted,
   // but here we don't handle return status
   for (const auto &cf_handle : cf_manager.get_all_cf()) {
@@ -5608,6 +5610,8 @@ static int rocksdb_init_internal(void *const p) {
   DBUG_EXECUTE_IF("rocksdb_init_failure_open_db", {
     // Simulate opening TransactionDB failure
     status = rocksdb::Status::Corruption();
+    // fix a memory leak caused by not calling cf_manager.init()
+    for (auto cfh_ptr : cf_handles) delete (cfh_ptr);
   });
 
   if (!status.ok()) {
@@ -5922,16 +5926,6 @@ static int rocksdb_shutdown(bool minimalShutdown) {
   return error;
 }
 
-static int rocksdb_init_func(void *const p) {
-  int ret = rocksdb_init_internal(p);
-  if (ret) {
-    // Ideally we should call rocksdb_done_func but we are not quite
-    // there yet so this only cleans up the safe ones
-    rocksdb_shutdown(/* minimalShutdown = */ true);
-  }
-  return ret;
-}
-
 /*
   Storage Engine deinitialization function, invoked when plugin is unloaded.
 */
@@ -5942,6 +5936,14 @@ static int rocksdb_done_func(void *const p MY_ATTRIBUTE((__unused__))) {
   int error = rocksdb_shutdown(/* minimalShutdown = */ false);
 
   DBUG_RETURN(error);
+}
+
+static int rocksdb_init_func(void *const p) {
+  int ret = rocksdb_init_internal(p);
+  if (ret) {
+    rocksdb_done_func(p);
+  }
+  return ret;
 }
 
 static inline void rocksdb_smart_seek(bool seek_backward,

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -6386,13 +6386,12 @@ ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
       m_lock_rows(RDB_LOCK_NONE),
       m_keyread_only(false),
       m_insert_with_update(false),
-      m_dup_key_found(false)
+      m_dup_key_found(false),
 #if defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
-      ,
       m_in_rpl_delete_rows(false),
-      m_in_rpl_update_rows(false)
+      m_in_rpl_update_rows(false),
 #endif  // defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
-{
+      m_need_build_decoder(false) {
 }
 
 ha_rocksdb::~ha_rocksdb() {
@@ -7952,8 +7951,7 @@ int ha_rocksdb::create(const char *const name, TABLE *const table_arg,
 */
 int ha_rocksdb::truncate_table(Rdb_tbl_def *tbl_def_arg,
                                const std::string &actual_user_table_name,
-                               const TABLE *table_arg,
-                               ulonglong auto_increment_value,
+                               TABLE *table_arg, ulonglong auto_increment_value,
                                dd::Table *table_def) {
   DBUG_ENTER_FUNC();
 
@@ -8039,6 +8037,7 @@ int ha_rocksdb::truncate_table(Rdb_tbl_def *tbl_def_arg,
 
   /* Update the local m_tbl_def reference */
   m_tbl_def = ddl_manager.find(orig_tablename);
+  m_converter.reset(new Rdb_converter(ha_thd(), m_tbl_def, table_arg));
   DBUG_RETURN(err);
 }
 
@@ -8340,8 +8339,9 @@ int ha_rocksdb::read_row_from_secondary_key(uchar *const buf,
 #endif  // !defined(DBUG_OFF)
   DBUG_EXECUTE_IF("dbug.rocksdb.HA_EXTRA_KEYREAD", { m_keyread_only = true; });
 
-  bool covered_lookup = (m_keyread_only && kd.can_cover_lookup()) ||
-                        kd.covers_lookup(&value, &m_lookup_bitmap);
+  bool covered_lookup =
+      (m_keyread_only && kd.can_cover_lookup()) ||
+      kd.covers_lookup(&value, m_converter->get_lookup_bitmap());
 
 #if !defined(DBUG_OFF)
   m_keyread_only = save_keyread_only;
@@ -8469,7 +8469,8 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf) {
       rocksdb::Slice value = m_scan_it->value();
       bool covered_lookup =
           (m_keyread_only && m_key_descr_arr[keyno]->can_cover_lookup()) ||
-          m_key_descr_arr[keyno]->covers_lookup(&value, &m_lookup_bitmap);
+          m_key_descr_arr[keyno]->covers_lookup(
+              &value, m_converter->get_lookup_bitmap());
       if (covered_lookup && m_lock_rows == RDB_LOCK_NONE) {
         rc = m_key_descr_arr[keyno]->unpack_record(
             table, buf, &key, &value,
@@ -8508,6 +8509,8 @@ int ha_rocksdb::index_read_map(uchar *const buf, const uchar *const key,
                                key_part_map keypart_map,
                                enum ha_rkey_function find_flag) {
   DBUG_ENTER_FUNC();
+
+  check_build_decoder();
 
   int rc = 0;
 
@@ -9093,6 +9096,8 @@ int ha_rocksdb::get_row_by_rowid(uchar *const buf, const char *const rowid,
 int ha_rocksdb::index_next(uchar *const buf) {
   DBUG_ENTER_FUNC();
 
+  check_build_decoder();
+
   bool moves_forward = true;
   ha_statistic_increment(&System_status_var::ha_read_next_count);
   if (m_key_descr_arr[active_index]->m_is_reverse_cf) {
@@ -9112,6 +9117,8 @@ int ha_rocksdb::index_next(uchar *const buf) {
 */
 int ha_rocksdb::index_prev(uchar *const buf) {
   DBUG_ENTER_FUNC();
+
+  check_build_decoder();
 
   bool moves_forward = false;
   ha_statistic_increment(&System_status_var::ha_read_prev_count);
@@ -9175,6 +9182,8 @@ int ha_rocksdb::index_next_with_direction(uchar *const buf, bool move_forward) {
 int ha_rocksdb::index_first(uchar *const buf) {
   DBUG_ENTER_FUNC();
 
+  check_build_decoder();
+
   m_sk_match_prefix = nullptr;
   ha_statistic_increment(&System_status_var::ha_read_first_count);
   int rc = m_key_descr_arr[active_index]->m_is_reverse_cf
@@ -9192,6 +9201,8 @@ int ha_rocksdb::index_first(uchar *const buf) {
 */
 int ha_rocksdb::index_last(uchar *const buf) {
   DBUG_ENTER_FUNC();
+
+  check_build_decoder();
 
   m_sk_match_prefix = nullptr;
   ha_statistic_increment(&System_status_var::ha_read_last_count);
@@ -10597,16 +10608,15 @@ void ha_rocksdb::setup_iterator_for_rnd_scan() {
 int ha_rocksdb::rnd_init(bool scan) {
   DBUG_ENTER_FUNC();
 
+  m_need_build_decoder = true;
+  active_index = table->s->primary_key;
+
   THD *thd = ha_thd();
   if (thd && thd->killed) {
     DBUG_RETURN(HA_ERR_QUERY_INTERRUPTED);
   }
 
   Rdb_transaction *const tx = get_or_create_tx(table->in_use);
-
-  // when this table is being updated, decode all fields
-  m_converter->setup_field_decoders(table->read_set,
-                                    m_lock_rows == RDB_LOCK_WRITE);
 
   if (scan) {
     m_rnd_scan_is_new_snapshot = !tx->has_snapshot();
@@ -10630,6 +10640,8 @@ int ha_rocksdb::rnd_init(bool scan) {
 */
 int ha_rocksdb::rnd_next(uchar *const buf) {
   DBUG_ENTER_FUNC();
+
+  check_build_decoder();
 
   int rc;
   ha_statistic_increment(&System_status_var::ha_read_rnd_next_count);
@@ -10763,9 +10775,24 @@ int ha_rocksdb::rnd_next_with_direction(uchar *const buf, bool move_forward) {
 int ha_rocksdb::rnd_end() {
   DBUG_ENTER_FUNC();
 
+  m_need_build_decoder = false;
+
   release_scan_iterator();
 
   DBUG_RETURN(HA_EXIT_SUCCESS);
+}
+
+void ha_rocksdb::build_decoder() {
+  m_converter->setup_field_decoders(table->read_set, active_index,
+                                    m_keyread_only,
+                                    m_lock_rows == RDB_LOCK_WRITE);
+}
+
+void ha_rocksdb::check_build_decoder() {
+  if (m_need_build_decoder) {
+    build_decoder();
+    m_need_build_decoder = false;
+  }
 }
 
 /**
@@ -10776,6 +10803,9 @@ int ha_rocksdb::rnd_end() {
 int ha_rocksdb::index_init(uint idx, bool sorted) {
   DBUG_ENTER_FUNC();
 
+  m_need_build_decoder = true;
+  active_index = idx;
+
   THD *thd = ha_thd();
   if (thd && thd->killed) {
     DBUG_RETURN(HA_ERR_QUERY_INTERRUPTED);
@@ -10784,20 +10814,10 @@ int ha_rocksdb::index_init(uint idx, bool sorted) {
   Rdb_transaction *const tx = get_or_create_tx(table->in_use);
   DBUG_ASSERT(tx != nullptr);
 
-  // when this table is being updated, decode all fields
-  m_converter->setup_field_decoders(table->read_set,
-                                    m_lock_rows == RDB_LOCK_WRITE);
-
-  if (!m_keyread_only) {
-    m_key_descr_arr[idx]->get_lookup_bitmap(table, &m_lookup_bitmap);
-  }
-
   // If m_lock_rows is not RDB_LOCK_NONE then we will be doing a get_for_update
   // when accessing the index, so don't acquire the snapshot right away.
   // Otherwise acquire the snapshot immediately.
   tx->acquire_snapshot(m_lock_rows == RDB_LOCK_NONE);
-
-  active_index = idx;
 
   DBUG_RETURN(HA_EXIT_SUCCESS);
 }
@@ -10809,9 +10829,9 @@ int ha_rocksdb::index_init(uint idx, bool sorted) {
 int ha_rocksdb::index_end() {
   DBUG_ENTER_FUNC();
 
-  release_scan_iterator();
+  m_need_build_decoder = false;
 
-  bitmap_free(&m_lookup_bitmap);
+  release_scan_iterator();
 
   active_index = MAX_KEY;
   in_range_check_pushed_down = false;
@@ -11147,6 +11167,8 @@ void ha_rocksdb::position(const uchar *const record) {
 */
 int ha_rocksdb::rnd_pos(uchar *const buf, uchar *const pos) {
   DBUG_ENTER_FUNC();
+
+  check_build_decoder();
 
   int rc;
   size_t len;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -6374,7 +6374,6 @@ ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
       m_pk_descr(nullptr),
       m_key_descr_arr(nullptr),
       m_pk_can_be_decoded(true),
-      m_pk_tuple(nullptr),
       m_pk_packed_tuple(nullptr),
       m_sk_packed_tuple(nullptr),
       m_end_key_packed_tuple(nullptr),
@@ -6618,37 +6617,17 @@ int ha_rocksdb::alloc_key_buffers(const TABLE *const table_arg,
                                   bool alloc_alter_buffers) {
   DBUG_ENTER_FUNC();
 
-  DBUG_ASSERT(m_pk_tuple == nullptr);
   DBUG_ASSERT(tbl_def_arg != nullptr);
 
   std::shared_ptr<Rdb_key_def> *const kd_arr = tbl_def_arg->m_key_descr_arr;
 
-  uint key_len = 0;
   uint max_packed_sk_len = 0;
   uint pack_key_len = 0;
 
   m_pk_descr = kd_arr[pk_index(table_arg, tbl_def_arg)];
-  if (has_hidden_pk(table_arg)) {
-    m_pk_key_parts = 1;
-  } else {
-    m_pk_key_parts =
-        table->key_info[table->s->primary_key].user_defined_key_parts;
-    key_len = table->key_info[table->s->primary_key].key_length;
-  }
 
   // move this into get_table_handler() ??
   m_pk_descr->setup(table_arg, tbl_def_arg);
-
-#ifdef HAVE_PSI_INTERFACE
-  m_pk_tuple =
-      static_cast<uchar *>(my_malloc(rdb_handler_memory_key, key_len, MYF(0)));
-#else
-  m_pk_tuple =
-      static_cast<uchar *>(my_malloc(PSI_NOT_INSTRUMENTED, key_len, MYF(0)));
-#endif
-  if (m_pk_tuple == nullptr) {
-    goto error;
-  }
 
   pack_key_len = m_pk_descr->max_storage_fmt_length();
 #ifdef HAVE_PSI_INTERFACE
@@ -6743,9 +6722,6 @@ error:
 }
 
 void ha_rocksdb::free_key_buffers() {
-  my_free(m_pk_tuple);
-  m_pk_tuple = nullptr;
-
   my_free(m_pk_packed_tuple);
   m_pk_packed_tuple = nullptr;
 
@@ -8093,7 +8069,6 @@ bool ha_rocksdb::check_keyread_allowed(bool &pk_can_be_decoded,
 
 int ha_rocksdb::read_key_exact(const Rdb_key_def &kd,
                                rocksdb::Iterator *const iter,
-                               const bool /* unused */,
                                const rocksdb::Slice &key_slice,
                                const int64_t ttl_filter_ts) {
   DBUG_ASSERT(iter != nullptr);
@@ -8207,8 +8182,7 @@ int ha_rocksdb::position_to_correct_key(
 
   switch (find_flag) {
     case HA_READ_KEY_EXACT:
-      rc = read_key_exact(kd, m_scan_it, full_key_match, key_slice,
-                          ttl_filter_ts);
+      rc = read_key_exact(kd, m_scan_it, key_slice, ttl_filter_ts);
       break;
     case HA_READ_BEFORE_KEY:
       *move_forward = false;
@@ -8275,8 +8249,7 @@ int ha_rocksdb::calc_eq_cond_len(const Rdb_key_def &kd,
                                  const enum ha_rkey_function &find_flag,
                                  const rocksdb::Slice &slice,
                                  const int bytes_changed_by_succ,
-                                 const key_range *const end_key,
-                                 uint *const end_key_packed_size) {
+                                 const key_range *const end_key) {
   if (find_flag == HA_READ_KEY_EXACT) return slice.size();
 
   if (find_flag == HA_READ_PREFIX_LAST) {
@@ -8289,7 +8262,8 @@ int ha_rocksdb::calc_eq_cond_len(const Rdb_key_def &kd,
   }
 
   if (end_key) {
-    *end_key_packed_size =
+    uint end_key_packed_size = 0;
+    end_key_packed_size =
         kd.pack_index_tuple(table, m_pack_buffer, m_end_key_packed_tuple,
                             end_key->key, end_key->keypart_map);
 
@@ -8303,7 +8277,7 @@ int ha_rocksdb::calc_eq_cond_len(const Rdb_key_def &kd,
        WHERE id1 = 'AAA' and id2 < 3; => eq_cond_len=13 (varchar used 9 bytes)
     */
     rocksdb::Slice end_slice(reinterpret_cast<char *>(m_end_key_packed_tuple),
-                             *end_key_packed_size);
+                             end_key_packed_size);
     return slice.difference_offset(end_slice);
   }
 
@@ -8516,58 +8490,16 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf) {
 }
 
 /*
-  ha_rocksdb::read_range_first overrides handler::read_range_first.
-  The only difference from handler::read_range_first is that
-  ha_rocksdb::read_range_first passes end_key to
-  ha_rocksdb::index_read_map_impl function.
+   See storage/rocksdb/rocksdb-range-access.txt for description of how MySQL
+   index navigation commands are converted into RocksDB lookup commands.
 
-  @return
-    HA_EXIT_SUCCESS  OK
-    other            HA_ERR error code (can be SE-specific)
-*/
-int ha_rocksdb::read_range_first(const key_range *const start_key,
-                                 const key_range *const end_key,
-                                 bool eq_range_arg, bool sorted) {
-  DBUG_ENTER_FUNC();
+   MyRocks needs to decide whether prefix bloom filter can be used or not.
+   To decide to use prefix bloom filter or not, calculating equal condition
+   length is needed. On equal lookups (find_flag == HA_READ_KEY_EXACT), equal
+   condition length is the same as rocksdb::Slice.size() of the start key.
+   On range scan, equal condition length is MIN(start_key, end_key) of the
+   rocksdb::Slice expression, where end_key is taken from end_range.
 
-  int result;
-
-  eq_range = eq_range_arg;
-  set_end_range(end_key, RANGE_SCAN_ASC);
-
-  range_key_part = table->key_info[active_index].key_part;
-
-  if (!start_key)  // Read first record
-    result = ha_index_first(table->record[0]);
-  else {
-    if (is_using_prohibited_gap_locks(
-            table,
-            is_using_full_unique_key(active_index, start_key->keypart_map,
-                                     start_key->flag))) {
-      DBUG_RETURN(HA_ERR_LOCK_DEADLOCK);
-    }
-
-    result =
-        index_read_map_impl(table->record[0], start_key->key,
-                            start_key->keypart_map, start_key->flag, end_key);
-  }
-  if (result) {
-    DBUG_RETURN((result == HA_ERR_KEY_NOT_FOUND) ? HA_ERR_END_OF_FILE : result);
-  }
-
-  if (compare_key(end_range) <= 0) {
-    DBUG_RETURN(HA_EXIT_SUCCESS);
-  } else {
-    /*
-      The last read row does not fall in the range. So request
-      storage engine to release row lock if possible.
-    */
-    unlock_row();
-    DBUG_RETURN(HA_ERR_END_OF_FILE);
-  }
-}
-
-/**
    @return
     HA_EXIT_SUCCESS  OK
     other            HA_ERR error code (can be SE-specific)
@@ -8575,32 +8507,6 @@ int ha_rocksdb::read_range_first(const key_range *const start_key,
 int ha_rocksdb::index_read_map(uchar *const buf, const uchar *const key,
                                key_part_map keypart_map,
                                enum ha_rkey_function find_flag) {
-  DBUG_ENTER_FUNC();
-
-  DBUG_RETURN(index_read_map_impl(buf, key, keypart_map, find_flag, nullptr));
-}
-
-/*
-   See storage/rocksdb/rocksdb-range-access.txt for description of how MySQL
-   index navigation commands are converted into RocksDB lookup commands.
-
-   This function takes end_key as an argument, and it is set on range scan.
-   MyRocks needs to decide whether prefix bloom filter can be used or not.
-   To decide to use prefix bloom filter or not, calculating equal condition
-   length
-   is needed. On equal lookups (find_flag == HA_READ_KEY_EXACT), equal
-   condition length is the same as rocksdb::Slice.size() of the start key.
-   On range scan, equal condition length is MIN(start_key, end_key) of the
-   rocksdb::Slice expression.
-
-   @return
-    HA_EXIT_SUCCESS  OK
-    other            HA_ERR error code (can be SE-specific)
-*/
-int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
-                                    key_part_map keypart_map,
-                                    enum ha_rkey_function find_flag,
-                                    const key_range *end_key) {
   DBUG_ENTER_FUNC();
 
   int rc = 0;
@@ -8616,8 +8522,6 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
   const Rdb_key_def &kd = *m_key_descr_arr[active_index];
   const uint actual_key_parts = kd.get_key_parts();
   bool using_full_key = is_using_full_key(keypart_map, actual_key_parts);
-
-  if (!end_key) end_key = end_range;
 
   /* By default, we don't need the retrieved records to match the prefix */
   m_sk_match_prefix = nullptr;
@@ -8705,10 +8609,8 @@ int ha_rocksdb::index_read_map_impl(uchar *const buf, const uchar *const key,
   rocksdb::Slice slice(reinterpret_cast<const char *>(m_sk_packed_tuple),
                        packed_size);
 
-  uint end_key_packed_size = 0;
   const uint eq_cond_len =
-      calc_eq_cond_len(kd, find_flag, slice, bytes_changed_by_succ, end_key,
-                       &end_key_packed_size);
+      calc_eq_cond_len(kd, find_flag, slice, bytes_changed_by_succ, end_range);
 
   bool use_all_keys = false;
   if (find_flag == HA_READ_KEY_EXACT &&
@@ -10021,8 +9923,8 @@ int ha_rocksdb::check_and_lock_sk(
   */
   DBUG_ASSERT(row_info.tx->has_snapshot() &&
               row_info.tx->m_snapshot_timestamp != 0);
-  *found = !read_key_exact(kd, iter, all_parts_used, new_slice,
-                           row_info.tx->m_snapshot_timestamp);
+  *found =
+      !read_key_exact(kd, iter, new_slice, row_info.tx->m_snapshot_timestamp);
 
   int rc = HA_EXIT_SUCCESS;
 
@@ -11194,7 +11096,6 @@ int ha_rocksdb::info(uint flag) {
       uniqueness violation.
     */
     errkey = m_dupp_errkey;
-    dup_ref = m_pk_tuple;  // TODO(?): this should store packed PK.
   }
 
   if (flag & HA_STATUS_AUTO) {

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -13071,45 +13071,82 @@ bool ha_rocksdb::inplace_alter_table(
   DBUG_ASSERT(ha_alter_info != nullptr);
   DBUG_ASSERT(ha_alter_info->handler_ctx != nullptr);
 
+  bool res = HA_EXIT_SUCCESS;
   Rdb_inplace_alter_ctx *const ctx =
       static_cast<Rdb_inplace_alter_ctx *>(ha_alter_info->handler_ctx);
 
-  if (ha_alter_info->handler_flags &
-      (my_core::Alter_inplace_info::ADD_INDEX |
-       my_core::Alter_inplace_info::ADD_UNIQUE_INDEX)) {
-    /*
-      Buffers need to be set up again to account for new, possibly longer
-      secondary keys.
-    */
-    free_key_buffers();
+  if (!(ha_alter_info->handler_flags &
+        (my_core::Alter_inplace_info::ADD_INDEX |
+         my_core::Alter_inplace_info::ADD_UNIQUE_INDEX))) {
+    DBUG_RETURN(res);
+  }
 
-    DBUG_ASSERT(ctx != nullptr);
+  /*
+    Buffers need to be set up again to account for new, possibly longer
+    secondary keys.
+  */
+  free_key_buffers();
 
-    /*
-      If adding unique index, allocate special buffers for duplicate checking.
-    */
-    int err;
-    if ((err = alloc_key_buffers(
-             altered_table, ctx->m_new_tdef,
-             ha_alter_info->handler_flags &
-                 my_core::Alter_inplace_info::ADD_UNIQUE_INDEX))) {
-      my_error(ER_OUT_OF_RESOURCES, MYF(0));
-      DBUG_RETURN(err);
-    }
+  DBUG_ASSERT(ctx != nullptr);
 
-    /* Populate all new secondary keys by scanning the primary key. */
-    if ((err = inplace_populate_sk(altered_table, ctx->m_added_indexes))) {
-      my_error(ER_SK_POPULATE_DURING_ALTER, MYF(0));
-      DBUG_RETURN(HA_EXIT_FAILURE);
-    }
+  /*
+    If adding unique index, allocate special buffers for duplicate checking.
+  */
+  int err;
+  if ((err = alloc_key_buffers(
+           altered_table, ctx->m_new_tdef,
+           ha_alter_info->handler_flags &
+               my_core::Alter_inplace_info::ADD_UNIQUE_INDEX))) {
+    my_error(ER_OUT_OF_RESOURCES, MYF(0));
+    res = HA_EXIT_FAILURE;
+    goto end;
+  }
+
+  /* Populate all new secondary keys by scanning the primary key. */
+  if ((err = inplace_populate_sk(altered_table, ctx->m_added_indexes))) {
+    my_error(ER_SK_POPULATE_DURING_ALTER, MYF(0));
+    res = HA_EXIT_FAILURE;
+    goto end;
   }
 
   DBUG_EXECUTE_IF("myrocks_simulate_index_create_rollback", {
     dbug_create_err_inplace_alter();
-    DBUG_RETURN(HA_EXIT_FAILURE);
+    res = HA_EXIT_FAILURE;
   };);
 
-  DBUG_RETURN(HA_EXIT_SUCCESS);
+end:
+  // During inplace_populate_sk, we may perform duplicate key checking which
+  // involves calling unpack_record. However, blobs end up being unpacked
+  // using the buffer in altered_table->file, instead of the current handler
+  // object. This handler does not get cleaned up as it was never
+  // opened, so we end up leaking that buffer. To fix, we call free_key_buffers
+  // here.
+  //
+  // In the partitioned case, the altered_table->file is not only unopened, but
+  // also unintialized, but we only unpack on duplicate key errors, and the
+  // error is not possible on partitioned tables because indexes must include
+  // the partitioning key which must include the primary key.
+  //
+  // A better solution would be to pass in the blob buffer from the correct
+  // handler explicitly into the unpack functions, so that
+  // Rdb_key_def::unpack_record does not need to derive it from the TABLE
+  // object, since the Rdb_key_def class are generally unaware of handler
+  // classes anyway.
+  if (err == ER_DUP_ENTRY) {
+    DBUG_ASSERT(ha_alter_info->group_commit_ctx == nullptr);
+    reinterpret_cast<ha_rocksdb *>(altered_table->file)->free_key_buffers();
+  }
+
+  // Try to reallocate key buffers from the old schema.
+  //
+  // A better fix may to save the original buffers to avoid needing to
+  // reallocate here.
+  if (res == HA_EXIT_FAILURE) {
+    free_key_buffers();
+    err = alloc_key_buffers(table, m_tbl_def);
+  }
+
+  DBUG_RETURN(res);
 }
 
 int ha_rocksdb::fill_virtual_columns() {

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -63,6 +63,7 @@
 #include "rocksdb/compaction_filter.h"
 #include "rocksdb/compaction_job_stats.h"
 #include "rocksdb/env.h"
+#include "rocksdb/env/composite_env_wrapper.h"
 #include "rocksdb/memory_allocator.h"
 #include "rocksdb/persistent_cache.h"
 #include "rocksdb/rate_limiter.h"
@@ -71,6 +72,7 @@
 #include "rocksdb/trace_reader_writer.h"
 #include "rocksdb/utilities/checkpoint.h"
 #include "rocksdb/utilities/convenience.h"
+#include "rocksdb/utilities/fault_injection_fs.h"
 #include "rocksdb/utilities/memory_util.h"
 #include "rocksdb/utilities/sim_cache.h"
 #include "rocksdb/utilities/write_batch_with_index.h"
@@ -90,6 +92,13 @@
 #include "./rdb_mutex_wrapper.h"
 #include "./rdb_psi.h"
 #include "./rdb_threads.h"
+
+#ifdef RAPIDJSON_NO_SIZETYPEDEFINE
+// if we build within the server, it will set RAPIDJSON_NO_SIZETYPEDEFINE
+// globally and require to include my_rapidjson_size_t.h
+#include "my_rapidjson_size_t.h"
+#endif
+#include <rapidjson/document.h>
 
 #ifdef FB_HAVE_WSENV
 #include "./ObjectFactory.h"
@@ -368,6 +377,10 @@ static void rocksdb_disable_file_deletions_update(
 static void rocksdb_max_compaction_history_update(
     my_core::THD *const thd, my_core::SYS_VAR *const /* unused */,
     void *const var_ptr, const void *const save);
+
+static bool parse_fault_injection_params(bool *retryable,
+                                         uint32_t *failure_ratio,
+                                         std::vector<rocksdb::FileType> *types);
 
 static void rocksdb_force_flush_memtable_now_stub(
     THD *const thd MY_ATTRIBUTE((__unused__)),
@@ -654,6 +667,7 @@ static uint32_t rocksdb_table_stats_sampling_pct =
 static uint32_t rocksdb_table_stats_recalc_threshold_pct = 10;
 static unsigned long long rocksdb_table_stats_recalc_threshold_count = 100ul;
 static bool rocksdb_table_stats_use_table_scan = 0;
+static char *opt_rocksdb_fault_injection_options = nullptr;
 static int32_t rocksdb_table_stats_background_thread_nice_value =
     THREAD_PRIO_MAX;
 static unsigned long long rocksdb_table_stats_max_num_rows_scanned = 0ul;
@@ -1442,6 +1456,12 @@ static MYSQL_SYSVAR_ULONG(
 static MYSQL_SYSVAR_STR(wsenv_path, rocksdb_wsenv_path,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
                         "Path for RocksDB WSEnv", nullptr, nullptr, "");
+
+static MYSQL_SYSVAR_STR(fault_injection_options,
+                        opt_rocksdb_fault_injection_options,
+                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                        "Fault injection options for running rocksdb tests",
+                        nullptr, nullptr, nullptr);
 
 static MYSQL_SYSVAR_ULONG(
     delete_obsolete_files_period_micros,
@@ -2285,6 +2305,7 @@ static struct SYS_VAR *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(persistent_cache_path),
     MYSQL_SYSVAR(persistent_cache_size_mb),
     MYSQL_SYSVAR(wsenv_path),
+    MYSQL_SYSVAR(fault_injection_options),
     MYSQL_SYSVAR(delete_obsolete_files_period_micros),
     MYSQL_SYSVAR(max_background_jobs),
     MYSQL_SYSVAR(max_background_flushes),
@@ -5223,6 +5244,35 @@ static int rocksdb_init_internal(void *const p) {
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 #endif
+
+  if (opt_rocksdb_fault_injection_options != nullptr &&
+      *opt_rocksdb_fault_injection_options != '\0') {
+    bool retryable = false;
+    uint32_t failure_ratio = 0;
+    std::vector<rocksdb::FileType> types;
+    if (parse_fault_injection_params(&retryable, &failure_ratio, &types)) {
+      DBUG_RETURN(HA_EXIT_FAILURE);
+    }
+
+    auto fs = std::make_shared<rocksdb::FaultInjectionTestFS>(
+        rocksdb_db_options->env->GetFileSystem());
+
+    rocksdb::IOStatus error_msg = rocksdb::IOStatus::IOError("IO Error");
+    error_msg.SetRetryable(retryable);
+
+    uint32_t seed = rand();
+    LogPluginErrMsg(INFORMATION_LEVEL, 0,
+                    "Initializing fault injection with params (retry=%d, "
+                    "failure_ratio=%d, seed=%d)",
+                    retryable, failure_ratio, seed);
+    fs->SetRandomWriteError(seed, failure_ratio, error_msg, types);
+    fs->EnableWriteErrorInjection();
+
+    static auto fault_env_guard =
+        std::make_shared<rocksdb::CompositeEnvWrapper>(rocksdb_db_options->env,
+                                                       fs);
+    rocksdb_db_options->env = fault_env_guard.get();
+  }
 
   // Validate the assumption about the size of ROCKSDB_SIZEOF_HIDDEN_PK_COLUMN.
   static_assert(sizeof(longlong) == 8, "Assuming that longlong is 8 bytes.");
@@ -15591,6 +15641,78 @@ void Rdb_compaction_stats::record_end(rocksdb::CompactionJobInfo info) {
   DBUG_ASSERT(record.end_timestamp != static_cast<time_t>(-1));
   record.info = std::move(info);
   m_history.emplace_back(std::move(record));
+}
+
+static bool parse_fault_injection_file_type(const std::string &type_str,
+                                            rocksdb::FileType *type) {
+  if (type_str == "kWalFile") {
+    *type = rocksdb::FileType::kWalFile;
+    return false;
+  } else if (type_str == "kTableFile") {
+    *type = rocksdb::FileType::kTableFile;
+    return false;
+  } else if (type_str == "kDescriptorFile") {
+    *type = rocksdb::FileType::kDescriptorFile;
+    return false;
+  }
+  return true;
+}
+
+static bool parse_fault_injection_params(
+    bool *retryable, uint32_t *failure_ratio,
+    std::vector<rocksdb::FileType> *types) {
+  rapidjson::Document doc;
+  rapidjson::ParseResult ok = doc.Parse(opt_rocksdb_fault_injection_options);
+  if (!ok) {
+    LogPluginErrMsg(ERROR_LEVEL, 0,
+                    "Parse error (errcode=%d offset=%lu)  "
+                    "rocksdb_fault_injection_options=%s",
+                    ok.Code(), ok.Offset(),
+                    opt_rocksdb_fault_injection_options);
+    return true;
+  }
+
+  auto retry_it = doc.FindMember("retry");
+  auto fr_it = doc.FindMember("failure_ratio");
+  auto ft_it = doc.FindMember("filetypes");
+
+  if (retry_it == doc.MemberEnd() || fr_it == doc.MemberEnd() ||
+      ft_it == doc.MemberEnd()) {
+    LogPluginErrMsg(ERROR_LEVEL, 0,
+                    "rocksdb_fault_injection_options=%s schema not valid",
+                    opt_rocksdb_fault_injection_options);
+    return true;
+  }
+
+  if (!retry_it->value.IsBool() || !fr_it->value.IsInt() ||
+      !ft_it->value.IsArray()) {
+    // NO_LINT_DEBUG
+    LogPluginErrMsg(
+        ERROR_LEVEL, 0,
+        "rocksdb_fault_injection_options=%s schema not valid (wrong "
+        "types)",
+        opt_rocksdb_fault_injection_options);
+    return true;
+  }
+
+  *retryable = retry_it->value.GetBool();
+  *failure_ratio = fr_it->value.GetInt();
+  for (rapidjson::SizeType i = 0; i < ft_it->value.Size(); i++) {
+    rocksdb::FileType type;
+    if (!ft_it->value[i].IsString() ||
+        parse_fault_injection_file_type(ft_it->value[i].GetString(), &type)) {
+      LogPluginErrMsg(ERROR_LEVEL, 0,
+                      "Wrong filetype = %s to  "
+                      "rocksdb_fault_injection_options=%s",
+                      ft_it->value[i].IsString() ? ft_it->value[i].GetString()
+                                                 : "(wrong type)",
+                      opt_rocksdb_fault_injection_options);
+      return true;
+    }
+    types->push_back(type);
+  }
+
+  return false;
 }
 
 }  // namespace myrocks

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -388,7 +388,7 @@ class ha_rocksdb : public my_core::handler {
   bool has_hidden_pk(const TABLE *const table) const
       MY_ATTRIBUTE((__warn_unused_result__));
 
-  void update_row_stats(const operation_type &type);
+  void update_row_stats(const operation_type &type, ulonglong count = 1);
 
   void set_last_rowkey(const uchar *const old_data);
 
@@ -955,6 +955,8 @@ class ha_rocksdb : public my_core::handler {
                                                    Rdb_tbl_def *tbl_def);
   static int adjust_handler_stats_table_scan(ha_statistics *ha_stats,
                                              Rdb_tbl_def *tbl_def);
+
+  void update_row_read(ulonglong count);
 
   void build_decoder();
   void check_build_decoder();

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -175,12 +175,6 @@ class ha_rocksdb : public my_core::handler {
                                     uint part, bool all_parts);
 
   /*
-    Number of key parts in PK. This is the same as
-      table->key_info[table->s->primary_key].keyparts
-  */
-  uint m_pk_key_parts;
-
-  /*
     true <=> Primary Key columns can be decoded from the index. It should be
     enabled by default and may be disabled in init_with_fields() after initial
     keys info is loaded and it turns out the feature isn't supported for
@@ -188,7 +182,6 @@ class ha_rocksdb : public my_core::handler {
   */
   mutable bool m_pk_can_be_decoded;
 
-  uchar *m_pk_tuple;        /* Buffer for storing PK in KeyTupleFormat */
   uchar *m_pk_packed_tuple; /* Buffer for storing PK in StorageFormat */
   // ^^ todo: change it to 'char*'? TODO: ^ can we join this with last_rowkey?
 
@@ -339,9 +332,6 @@ class ha_rocksdb : public my_core::handler {
   int secondary_index_read(const int keyno, uchar *const buf)
       MY_ATTRIBUTE((__warn_unused_result__));
   void setup_iterator_for_rnd_scan();
-  bool is_ascending(const Rdb_key_def &keydef,
-                    enum ha_rkey_function find_flag) const
-      MY_ATTRIBUTE((__nonnull__, __warn_unused_result__));
   void setup_iterator_bounds(const Rdb_key_def &kd,
                              const rocksdb::Slice &eq_cond, size_t bound_len,
                              uchar *const lower_bound, uchar *const upper_bound,
@@ -614,26 +604,13 @@ class ha_rocksdb : public my_core::handler {
     DBUG_RETURN(HA_POS_ERROR);
   }
 
-  /* At the moment, we're ok with default handler::index_init() implementation.
-   */
   int index_read_map(uchar *const buf, const uchar *const key,
                      key_part_map keypart_map,
                      enum ha_rkey_function find_flag) override
       MY_ATTRIBUTE((__warn_unused_result__));
 
-  int index_read_map_impl(uchar *const buf, const uchar *const key,
-                          key_part_map keypart_map,
-                          enum ha_rkey_function find_flag,
-                          const key_range *end_key)
-      MY_ATTRIBUTE((__warn_unused_result__));
-
   int index_read_last_map(uchar *const buf, const uchar *const key,
                           key_part_map keypart_map) override
-      MY_ATTRIBUTE((__warn_unused_result__));
-
-  int read_range_first(const key_range *const start_key,
-                       const key_range *const end_key, bool eq_range,
-                       bool sorted) override
       MY_ATTRIBUTE((__warn_unused_result__));
 
   virtual double scan_time() override {
@@ -812,7 +789,7 @@ class ha_rocksdb : public my_core::handler {
       MY_ATTRIBUTE((__warn_unused_result__));
 
   int read_key_exact(const Rdb_key_def &kd, rocksdb::Iterator *const iter,
-                     const bool using_full_key, const rocksdb::Slice &key_slice,
+                     const rocksdb::Slice &key_slice,
                      const int64_t ttl_filter_ts)
       MY_ATTRIBUTE((__warn_unused_result__));
   int read_before_key(const Rdb_key_def &kd, const bool using_full_key,
@@ -841,8 +818,7 @@ class ha_rocksdb : public my_core::handler {
                        const enum ha_rkey_function &find_flag,
                        const rocksdb::Slice &slice,
                        const int bytes_changed_by_succ,
-                       const key_range *const end_key,
-                       uint *const end_key_packed_size)
+                       const key_range *const end_key)
       MY_ATTRIBUTE((__warn_unused_result__));
 
   Rdb_tbl_def *get_table_if_exists(const char *const tablename)

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -395,13 +395,6 @@ class ha_rocksdb : public my_core::handler {
 
   void set_last_rowkey(const uchar *const old_data);
 
-  /*
-    For the active index, indicates which columns must be covered for the
-    current lookup to be covered. If the bitmap field is null, that means this
-    index does not cover the current lookup for any record.
-   */
-  MY_BITMAP m_lookup_bitmap;
-
   int alloc_key_buffers(const TABLE *const table_arg,
                         const Rdb_tbl_def *const tbl_def_arg,
                         bool alloc_alter_buffers = false)
@@ -913,7 +906,7 @@ class ha_rocksdb : public my_core::handler {
                    dd::Table *table_def);
   int truncate_table(Rdb_tbl_def *tbl_def,
                      const std::string &actual_user_table_name,
-                     const TABLE *table_arg, ulonglong auto_increment_value,
+                     TABLE *table_arg, ulonglong auto_increment_value,
                      dd::Table *table_def);
   bool check_if_incompatible_data(HA_CREATE_INFO *const info,
                                   uint table_changes) override
@@ -962,6 +955,9 @@ class ha_rocksdb : public my_core::handler {
   int adjust_handler_stats_sst_and_memtable();
   int adjust_handler_stats_table_scan();
 
+  void build_decoder();
+  void check_build_decoder();
+
 #if defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
  public:
   virtual void rpl_before_delete_rows() override;
@@ -995,6 +991,9 @@ class ha_rocksdb : public my_core::handler {
   bool m_in_rpl_delete_rows;
   bool m_in_rpl_update_rows;
 #endif  // defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
+
+  /* Need to build decoder on next read operation */
+  bool m_need_build_decoder;
 };
 
 /*

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -280,6 +280,9 @@ class ha_rocksdb : public my_core::handler {
   /* true means we're doing an index-only read. false means otherwise. */
   bool m_keyread_only;
 
+  /* We only iterate but don't need to decode anything */
+  bool m_iteration_only;
+
   bool m_skip_scan_it_next_call;
 
   /* true means we are accessing the first row after a snapshot was created */
@@ -957,6 +960,10 @@ class ha_rocksdb : public my_core::handler {
 
   void build_decoder();
   void check_build_decoder();
+
+ protected:
+  int records(ha_rows *num_rows) override;
+  int records_from_index(ha_rows *num_rows, uint index) override;
 
 #if defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
  public:

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -957,6 +957,7 @@ class ha_rocksdb : public my_core::handler {
                                              Rdb_tbl_def *tbl_def);
 
   void update_row_read(ulonglong count);
+  static void inc_covered_sk_lookup();
 
   void build_decoder();
   void check_build_decoder();

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -109,12 +109,6 @@ struct Rdb_table_handler {
   /* Stores cumulative table statistics */
   my_io_perf_atomic_t m_io_perf_read;
   Rdb_atomic_perf_counters m_table_perf_context;
-
-  /* Stores cached memtable estimate statistics */
-  std::atomic_uint m_mtcache_lock;
-  uint64_t m_mtcache_count;
-  uint64_t m_mtcache_size;
-  uint64_t m_mtcache_last_update;
 };
 
 }  // namespace myrocks
@@ -412,12 +406,14 @@ class ha_rocksdb : public my_core::handler {
   */
   Rdb_io_perf m_io_perf;
 
+ public:
+  static rocksdb::Range get_range(const Rdb_key_def &kd, uchar buf[]);
+
   /*
     Update stats
   */
-  void update_stats(void);
+  static int update_stats(ha_statistics *ha_stats, Rdb_tbl_def *tbl_def);
 
- public:
   /*
     Controls whether writes include checksums. This is updated from the session
     variable
@@ -955,8 +951,10 @@ class ha_rocksdb : public my_core::handler {
       const dd::Table *old_table_def, dd::Table *new_table_def) override;
 
   bool is_read_free_rpl_table() const;
-  int adjust_handler_stats_sst_and_memtable();
-  int adjust_handler_stats_table_scan();
+  static int adjust_handler_stats_sst_and_memtable(ha_statistics *ha_stats,
+                                                   Rdb_tbl_def *tbl_def);
+  static int adjust_handler_stats_table_scan(ha_statistics *ha_stats,
+                                             Rdb_tbl_def *tbl_def);
 
   void build_decoder();
   void check_build_decoder();

--- a/storage/rocksdb/rdb_cf_manager.cc
+++ b/storage/rocksdb/rdb_cf_manager.cc
@@ -64,9 +64,13 @@ void Rdb_cf_manager::init(
     m_cf_name_map[cfh_ptr->GetName()] = cfh;
     m_cf_id_map[cfh_ptr->GetID()] = cfh;
   }
+
+  initialized = true;
 }
 
 void Rdb_cf_manager::cleanup() {
+  if (!initialized) return;
+
   m_cf_name_map.clear();
   m_cf_id_map.clear();
   mysql_mutex_destroy(&m_mutex);

--- a/storage/rocksdb/rdb_cf_manager.h
+++ b/storage/rocksdb/rdb_cf_manager.h
@@ -48,7 +48,7 @@ namespace myrocks {
   - CFs are created in a synchronized way. We can't remove them, yet.
 */
 
-class Rdb_cf_manager {
+class Rdb_cf_manager : public Ensure_initialized {
   std::map<std::string, std::shared_ptr<rocksdb::ColumnFamilyHandle>>
       m_cf_name_map;
   std::map<uint32_t, std::shared_ptr<rocksdb::ColumnFamilyHandle>> m_cf_id_map;

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -631,7 +631,7 @@ int Rdb_converter::convert_record_from_storage_format(
     return err;
   }
 
-  if (!decode_value) {
+  if (!decode_value || get_decode_fields()->size() == 0) {
     // We are done
     return HA_EXIT_SUCCESS;
   }

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -309,6 +309,7 @@ Rdb_converter::~Rdb_converter() {
   m_encoder_arr = nullptr;
   // These are needed to suppress valgrind errors in rocksdb.partition
   m_storage_record.mem_free();
+  bitmap_free(&m_lookup_bitmap);
 }
 
 /*
@@ -333,23 +334,25 @@ void Rdb_converter::get_storage_type(Rdb_field_encoder *const encoder,
     Setup which fields will be unpacked when reading rows
 
   @detail
-    Three special cases when we still unpack all fields:
+    Two special cases when we still unpack all fields:
     - When client requires decode_all_fields, such as this table is being
   updated (m_lock_rows==RDB_LOCK_WRITE).
-    - When @@rocksdb_verify_row_debug_checksums is ON (In this mode, we need to
-  read all fields to find whether there is a row checksum at the end. We could
-  skip the fields instead of decoding them, but currently we do decoding.)
-    - On index merge as bitmap is cleared during that operation
+    - When @@rocksdb_verify_row_debug_checksums is ON (In this mode, we need
+  to read all fields to find whether there is a row checksum at the end. We
+  could skip the fields instead of decoding them, but currently we do
+  decoding.)
 
   @seealso
     Rdb_converter::setup_field_encoders()
     Rdb_converter::convert_record_from_storage_format()
 */
 void Rdb_converter::setup_field_decoders(const MY_BITMAP *field_map,
+                                         uint active_index, bool keyread_only,
                                          bool decode_all_fields) {
   DBUG_TRACE;
   m_key_requested = false;
   m_decoders_vect.clear();
+  bitmap_free(&m_lookup_bitmap);
   int last_useful = 0;
   int skip_size = 0;
 
@@ -361,7 +364,6 @@ void Rdb_converter::setup_field_decoders(const MY_BITMAP *field_map,
   for (uint i = 0; i < m_table->s->fields; i++) {
     const bool field_requested =
         decode_all_fields || m_verify_row_debug_checksums ||
-        bitmap_is_clear_all(field_map) ||
         bitmap_is_set(field_map, m_table->field[i]->field_index());
 
     if (field_requested && m_table->field[i]->is_virtual_gcol()) {
@@ -374,10 +376,8 @@ void Rdb_converter::setup_field_decoders(const MY_BITMAP *field_map,
   }
 
   for (uint i = 0; i < m_table->s->fields; i++) {
-    // bitmap is cleared on index merge, but it still needs to decode columns
     bool field_requested =
         decode_all_fields || m_verify_row_debug_checksums ||
-        bitmap_is_clear_all(field_map) ||
         (bitmap_is_set(field_map, m_table->field[i]->field_index())) ||
         bases[i];
 
@@ -414,6 +414,11 @@ void Rdb_converter::setup_field_decoders(const MY_BITMAP *field_map,
   // skipping. Remove them.
   m_decoders_vect.erase(m_decoders_vect.begin() + last_useful,
                         m_decoders_vect.end());
+
+  if (!keyread_only && active_index != m_table->s->primary_key) {
+    m_tbl_def->m_key_descr_arr[active_index]->get_lookup_bitmap(
+        m_table, &m_lookup_bitmap);
+  }
 }
 
 void Rdb_converter::setup_field_encoders() {
@@ -607,6 +612,11 @@ int Rdb_converter::convert_record_from_storage_format(
     const rocksdb::Slice *const key_slice,
     const rocksdb::Slice *const value_slice, uchar *const dst,
     bool decode_value = true) {
+  bool skip_value = !decode_value || get_decode_fields()->size() == 0;
+  if (!m_key_requested && skip_value) {
+    return HA_EXIT_SUCCESS;
+  }
+
   int err = HA_EXIT_SUCCESS;
 
   Rdb_string_reader value_slice_reader(value_slice);
@@ -628,7 +638,7 @@ int Rdb_converter::convert_record_from_storage_format(
     }
   }
 
-  if (!decode_value || get_decode_fields()->size() == 0) {
+  if (skip_value) {
     // We are done
     return HA_EXIT_SUCCESS;
   }

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -319,6 +319,7 @@ void Rdb_converter::get_storage_type(Rdb_field_encoder *const encoder,
                                      const uint kp) {
   auto pk_descr =
       m_tbl_def->m_key_descr_arr[ha_rocksdb::pk_index(m_table, m_tbl_def)];
+
   // STORE_SOME uses unpack_info.
   if (pk_descr->has_unpack_info(kp)) {
     DBUG_ASSERT(pk_descr->can_unpack(kp));

--- a/storage/rocksdb/rdb_converter.h
+++ b/storage/rocksdb/rdb_converter.h
@@ -134,8 +134,8 @@ class Rdb_converter {
   Rdb_converter &operator=(const Rdb_converter &decoder) = delete;
   ~Rdb_converter();
 
-  void setup_field_decoders(const MY_BITMAP *field_map,
-                            bool decode_all_fields = false);
+  void setup_field_decoders(const MY_BITMAP *field_map, uint active_index,
+                            bool keyread_only, bool decode_all_fields = false);
 
   int decode(const std::shared_ptr<Rdb_key_def> &key_def, uchar *dst,
              const rocksdb::Slice *key_slice, const rocksdb::Slice *value_slice,
@@ -171,6 +171,8 @@ class Rdb_converter {
   const std::vector<READ_FIELD> *get_decode_fields() const {
     return &m_decoders_vect;
   }
+
+  const MY_BITMAP *get_lookup_bitmap() { return &m_lookup_bitmap; }
 
  private:
   int decode_value_header_for_pk(Rdb_string_reader *reader,
@@ -241,5 +243,11 @@ class Rdb_converter {
   my_core::ha_rows m_row_checksums_checked;
   // buffer to hold data during encode_value_slice
   String m_storage_record;
+  /*
+    For the active index, indicates which columns must be covered for the
+    current lookup to be covered. If the bitmap field is null, that means this
+    index does not cover the current lookup for any record.
+   */
+  MY_BITMAP m_lookup_bitmap;
 };
 }  // namespace myrocks

--- a/storage/rocksdb/rdb_converter.h
+++ b/storage/rocksdb/rdb_converter.h
@@ -56,20 +56,21 @@ class Rdb_convert_to_record_value_decoder {
   Rdb_convert_to_record_value_decoder &operator=(
       const Rdb_convert_to_record_value_decoder &decoder) = delete;
 
-  static int decode(uchar *const buf, uint *offset, TABLE *table,
-                    my_core::Field *field, Rdb_field_encoder *field_dec,
-                    Rdb_string_reader *reader, bool decode, bool is_null);
+  static int decode(uchar *const buf, TABLE *table,
+                    Rdb_field_encoder *field_dec, Rdb_string_reader *reader,
+                    bool decode, bool is_null);
 
  private:
-  static int decode_blob(TABLE *table, Field *field, Rdb_string_reader *reader,
-                         bool decode);
-  static int decode_fixed_length_field(Field *const field,
+  static int decode_blob(TABLE *table, uchar *const buf,
+                         Rdb_field_encoder *field_dec,
+                         Rdb_string_reader *reader, bool decode);
+  static int decode_fixed_length_field(uchar *const buf,
                                        Rdb_field_encoder *field_dec,
                                        Rdb_string_reader *const reader,
                                        bool decode);
 
-  static int decode_varchar(Field *const field, Rdb_string_reader *const reader,
-                            bool decode);
+  static int decode_varchar(uchar *const buf, Rdb_field_encoder *field_dec,
+                            Rdb_string_reader *const reader, bool decode);
 };
 
 /**
@@ -118,8 +119,6 @@ class Rdb_value_field_iterator {
   int get_field_index() const;
   // get current field type
   enum_field_types get_field_type() const;
-  // get current field
-  Field *get_field() const;
 };
 
 /**

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2117,7 +2117,7 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
       has_covered_bitmap ? &covered_bitmap : nullptr, buf);
   while (iter.has_next()) {
     err = iter.next();
-    if (err) {
+    if (unlikely(err)) {
       return err;
     }
   }

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -5038,6 +5038,8 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
   delete it;
   LogPluginErrMsg(INFORMATION_LEVEL, 0,
                   "Table_store: loaded DDL data for %d tables", i);
+
+  initialized = true;
   return false;
 }
 
@@ -5380,6 +5382,8 @@ bool Rdb_ddl_manager::rename(const std::string &from, const std::string &to,
 }
 
 void Rdb_ddl_manager::cleanup() {
+  if (!initialized) return;
+
   for (const auto &kv : m_ddl_map) {
     delete kv.second;
   }
@@ -5458,6 +5462,7 @@ bool Rdb_dict_manager::init(rocksdb::TransactionDB *const rdb_dict,
     return HA_EXIT_FAILURE;
   }
 
+  initialized = true;
   return HA_EXIT_SUCCESS;
 }
 

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -4798,6 +4798,7 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
       return true;
     }
     tdef->m_key_count = real_val_size / (Rdb_key_def::PACKED_SIZE * 2);
+    tdef->m_pk_index = MAX_INDEXES;
     tdef->m_key_descr_arr = new std::shared_ptr<Rdb_key_def>[tdef->m_key_count];
 
     ptr = reinterpret_cast<const uchar *>(val.data());
@@ -4871,6 +4872,9 @@ bool Rdb_ddl_manager::init(Rdb_dict_manager *const dict_arg,
           flags & Rdb_key_def::PER_PARTITION_CF_FLAG, "",
           m_dict->get_stats(gl_index_id), index_info.m_index_flags,
           ttl_rec_offset, index_info.m_ttl_duration);
+      if (index_info.m_index_type == Rdb_key_def::INDEX_TYPE_PRIMARY) {
+        tdef->m_pk_index = keyno;
+      }
     }
 
     DBUG_ASSERT(tdef->m_key_count > 0);
@@ -5234,20 +5238,7 @@ bool Rdb_ddl_manager::rename(const std::string &from, const std::string &to,
     return true;
   }
 
-  new_rec = new Rdb_tbl_def(to);
-
-  new_rec->m_key_count = rec->m_key_count;
-  new_rec->m_auto_incr_val =
-      rec->m_auto_incr_val.load(std::memory_order_relaxed);
-  new_rec->m_key_descr_arr = rec->m_key_descr_arr;
-
-  new_rec->m_hidden_pk_val =
-      rec->m_hidden_pk_val.load(std::memory_order_relaxed);
-
-  new_rec->m_tbl_stats = rec->m_tbl_stats;
-
-  // so that it's not free'd when deleting the old rec
-  rec->m_key_descr_arr = nullptr;
+  new_rec = new Rdb_tbl_def(to, std::move(*rec));
 
   // Create a new key
   new_buf_writer.write_index(Rdb_key_def::DDL_ENTRY_INDEX_START_NUMBER);

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -76,28 +76,33 @@ void get_mem_comparable_space(const CHARSET_INFO *cs,
     other              HA_ERR error code
 */
 int Rdb_convert_to_record_key_decoder::decode_field(
-    Rdb_field_packing *fpi, Field *field, Rdb_string_reader *reader,
-    const uchar *const default_value, Rdb_string_reader *unpack_reader) {
-  if (fpi->m_maybe_null) {
+    Rdb_field_packing *fpi, TABLE *table, uchar *buf, Rdb_string_reader *reader,
+    Rdb_string_reader *unpack_reader) {
+  if (fpi->m_field_is_nullable) {
     const char *nullp;
     if (!(nullp = reader->read(1))) {
       return HA_EXIT_FAILURE;
     }
 
-    if (*nullp == 0) {
+    if (likely(*nullp == 1)) {
+      /* Clear the NULL-bit of this field */
+      buf[fpi->m_field_null_offset] &= (uchar) ~(fpi->m_field_null_bit_mask);
+    } else if (*nullp == 0) {
       /* Set the NULL-bit of this field */
-      field->set_null();
+      buf[fpi->m_field_null_offset] |= fpi->m_field_null_bit_mask;
+
       /* Also set the field to its default value */
-      memcpy(field->field_ptr(), default_value, field->pack_length());
+      auto default_value = table->s->default_values + fpi->m_field_offset;
+      memcpy(buf + fpi->m_field_offset, default_value,
+             fpi->m_field_pack_length);
       return HA_EXIT_SUCCESS;
-    } else if (*nullp == 1) {
-      field->set_notnull();
     } else {
       return HA_EXIT_FAILURE;
     }
   }
 
-  return (fpi->m_unpack_func)(fpi, field, field->field_ptr(), reader,
+  Rdb_unpack_func_context ctx = {table};
+  return (fpi->m_unpack_func)(fpi, &ctx, buf + fpi->m_field_offset, reader,
                               unpack_reader);
 }
 
@@ -117,33 +122,19 @@ int Rdb_convert_to_record_key_decoder::decode_field(
     other              HA_ERR error code
 */
 int Rdb_convert_to_record_key_decoder::decode(
-    uchar *const buf, uint *offset, Rdb_field_packing *fpi, TABLE *table,
-    Field *field, bool has_unpack_info, Rdb_string_reader *reader,
+    uchar *const buf, Rdb_field_packing *fpi, TABLE *table,
+    bool has_unpack_info, Rdb_string_reader *reader,
     Rdb_string_reader *unpack_reader) {
   DBUG_ASSERT(buf != nullptr);
-  DBUG_ASSERT(offset != nullptr);
-
-  uint field_offset = field->field_ptr() - table->record[0];
-  *offset = field_offset;
-  uint null_offset = field->null_offset();
-  bool maybe_null = field->is_nullable();
-
-  field->move_field(buf + field_offset,
-                    maybe_null ? buf + null_offset : nullptr, field->null_bit);
 
   // If we need unpack info, but there is none, tell the unpack function
   // this by passing unp_reader as nullptr. If we never read unpack_info
   // during unpacking anyway, then there won't an error.
   bool maybe_missing_unpack = !has_unpack_info && fpi->uses_unpack_info();
 
-  int res =
-      decode_field(fpi, field, reader, table->s->default_values + field_offset,
-                   maybe_missing_unpack ? nullptr : unpack_reader);
+  int res = decode_field(fpi, table, buf, reader,
+                         maybe_missing_unpack ? nullptr : unpack_reader);
 
-  // Restore field->ptr and field->null_ptr
-  field->move_field(table->record[0] + field_offset,
-                    maybe_null ? table->record[0] + null_offset : nullptr,
-                    field->null_bit);
   if (res != UNPACK_SUCCESS) {
     return HA_ERR_ROCKSDB_CORRUPT_DATA;
   }
@@ -162,10 +153,11 @@ int Rdb_convert_to_record_key_decoder::decode(
     other              HA_ERR error code
 */
 int Rdb_convert_to_record_key_decoder::skip(
-    const Rdb_field_packing *fpi, const Field *field, Rdb_string_reader *reader,
-    Rdb_string_reader *unp_reader, bool covered_bitmap_format_enabled) {
+    const Rdb_field_packing *fpi, const Field *field MY_ATTRIBUTE((__unused__)),
+    Rdb_string_reader *reader, Rdb_string_reader *unp_reader,
+    bool covered_bitmap_format_enabled) {
   /* It is impossible to unpack the column. Skip it. */
-  if (fpi->m_maybe_null) {
+  if (fpi->m_field_is_nullable) {
     const char *nullp;
     if (!(nullp = reader->read(1))) {
       return HA_ERR_ROCKSDB_CORRUPT_DATA;
@@ -179,7 +171,7 @@ int Rdb_convert_to_record_key_decoder::skip(
       return HA_ERR_ROCKSDB_CORRUPT_DATA;
     }
   }
-  if ((fpi->m_skip_func)(fpi, field, reader)) {
+  if ((fpi->m_skip_func)(fpi, reader)) {
     return HA_ERR_ROCKSDB_CORRUPT_DATA;
   }
 
@@ -202,9 +194,8 @@ Rdb_key_field_iterator::Rdb_key_field_iterator(
     Rdb_string_reader *reader, Rdb_string_reader *unp_reader, TABLE *table,
     bool has_unpack_info, const MY_BITMAP *covered_bitmap, uchar *const buf) {
   m_key_def = key_def;
-  m_pack_info = pack_info;
-  m_iter_index = 0;
-  m_iter_end = key_def->get_key_parts();
+  m_fpi_next = pack_info;
+  m_fpi_end = pack_info + key_def->get_key_parts();
   m_reader = reader;
   m_unp_reader = unp_reader;
   m_table = table;
@@ -217,68 +208,51 @@ Rdb_key_field_iterator::Rdb_key_field_iterator(
   m_is_hidden_pk =
       (key_def->m_index_type == Rdb_key_def::INDEX_TYPE_HIDDEN_PRIMARY);
   m_curr_bitmap_pos = 0;
-  m_offset = 0;
 }
 
-void *Rdb_key_field_iterator::get_dst() const { return m_buf + m_offset; }
-
-int Rdb_key_field_iterator::get_field_index() const {
-  DBUG_ASSERT(m_field != nullptr);
-  return m_field->field_index();
-}
-
-bool Rdb_key_field_iterator::get_is_null() const { return m_is_null; }
-Field *Rdb_key_field_iterator::get_field() const {
-  DBUG_ASSERT(m_field != nullptr);
-  return m_field;
-}
-
-bool Rdb_key_field_iterator::has_next() { return m_iter_index < m_iter_end; }
+bool Rdb_key_field_iterator::has_next() { return m_fpi_next < m_fpi_end; }
 
 /**
  Iterate each field in the key and decode/skip one by one
 */
 int Rdb_key_field_iterator::next() {
   int status = HA_EXIT_SUCCESS;
-  while (m_iter_index < m_iter_end) {
-    int curr_index = m_iter_index++;
-    m_fpi = &m_pack_info[curr_index];
+  while (m_fpi_next < m_fpi_end) {
+    auto fpi = m_fpi_next++;
+
     /*
       Hidden pk field is packed at the end of the secondary keys, but the SQL
       layer does not know about it. Skip retrieving field if hidden pk.
     */
-    if ((m_secondary_key && m_hidden_pk_exists &&
-         curr_index + 1 == m_iter_end) ||
+    if ((m_secondary_key && m_hidden_pk_exists && fpi + 1 == m_fpi_end) ||
         m_is_hidden_pk) {
-      DBUG_ASSERT(m_fpi->m_unpack_func);
-      if ((m_fpi->m_skip_func)(m_fpi, nullptr, m_reader)) {
+      DBUG_ASSERT(fpi->m_unpack_func);
+      if ((fpi->m_skip_func)(fpi, m_reader)) {
         return HA_ERR_ROCKSDB_CORRUPT_DATA;
       }
       return HA_EXIT_SUCCESS;
     }
 
-    m_field = m_fpi->get_field_in_table(m_table);
-
-    bool covered_column = (m_fpi->m_covered == Rdb_key_def::KEY_COVERED);
+    bool covered_column = (fpi->m_covered == Rdb_key_def::KEY_COVERED);
     if (m_covered_bitmap != nullptr &&
-        Rdb_key_def::is_variable_length_field(m_field->real_type()) &&
-        m_fpi->m_covered == Rdb_key_def::KEY_MAY_BE_COVERED) {
+        Rdb_key_def::is_variable_length_field(fpi->m_field_real_type) &&
+        fpi->m_covered == Rdb_key_def::KEY_MAY_BE_COVERED) {
       covered_column = m_curr_bitmap_pos < MAX_REF_PARTS &&
                        bitmap_is_set(m_covered_bitmap, m_curr_bitmap_pos++);
     }
 
-    if (m_fpi->m_unpack_func && covered_column) {
+    if (fpi->m_unpack_func && covered_column) {
       /* It is possible to unpack this column. Do it. */
       status = Rdb_convert_to_record_key_decoder::decode(
-          m_buf, &m_offset, m_fpi, m_table, m_field, m_has_unpack_info,
-          m_reader, m_unp_reader);
+          m_buf, fpi, m_table, m_has_unpack_info, m_reader, m_unp_reader);
       if (status) {
         return status;
       }
       break;
     } else {
+      auto field = fpi->get_field_in_table(m_table);
       status = Rdb_convert_to_record_key_decoder::skip(
-          m_fpi, m_field, m_reader, m_unp_reader,
+          fpi, field, m_reader, m_unp_reader,
           this->m_key_def->use_covered_bitmap_format());
       if (status) {
         return status;
@@ -867,7 +841,7 @@ int Rdb_key_def::read_memcmp_key_part(const TABLE *table_arg,
                                       Rdb_string_reader *reader,
                                       const uint part_num) const {
   /* It is impossible to unpack the column. Skip it. */
-  if (m_pack_info[part_num].m_maybe_null) {
+  if (m_pack_info[part_num].m_field_is_nullable) {
     const char *nullp;
     if (!(nullp = reader->read(1))) return 1;
     if (*nullp == 0) {
@@ -882,13 +856,7 @@ int Rdb_key_def::read_memcmp_key_part(const TABLE *table_arg,
   Rdb_field_packing *fpi = &m_pack_info[part_num];
   DBUG_ASSERT(table_arg->s != nullptr);
 
-  bool is_hidden_pk_part = (part_num + 1 == m_key_parts) &&
-                           (table_arg->s->primary_key == MAX_INDEXES);
-  Field *field = nullptr;
-  if (!is_hidden_pk_part) {
-    field = fpi->get_field_in_table(table_arg);
-  }
-  if ((fpi->m_skip_func)(fpi, field, reader)) {
+  if ((fpi->m_skip_func)(fpi, reader)) {
     return 1;
   }
   return 0;
@@ -1579,12 +1547,10 @@ void Rdb_key_def::pack_tiny(
 
   const size_t length = fpi->m_max_image_len;
   const uchar *ptr = field->field_ptr();
-  const bool unsigned_flag =
-      dynamic_cast<Field_num *const>(field)->is_unsigned();
   uchar *to = *dst;
 
   DBUG_ASSERT(length >= 1);
-  if (unsigned_flag)
+  if (fpi->m_field_unsigned_flag)
     *to = *ptr;
   else
     to[0] = (char)(ptr[0] ^ (uchar)128); /* Reverse signbit */
@@ -1604,14 +1570,12 @@ void Rdb_key_def::pack_short(
 
   const size_t length = fpi->m_max_image_len;
   const uchar *ptr = field->field_ptr();
-  const bool unsigned_flag =
-      dynamic_cast<Field_num *const>(field)->is_unsigned();
   uchar *to = *dst;
 
   DBUG_ASSERT(length >= 2);
 #ifdef WORDS_BIGENDIAN
   if (!field->table->s->db_low_byte_first) {
-    if (unsigned_flag)
+    if (fpi->m_field_unsigned_flag)
       to[0] = ptr[0];
     else
       to[0] = (char)(ptr[0] ^ 128); /* Revers signbit */
@@ -1619,7 +1583,7 @@ void Rdb_key_def::pack_short(
   } else
 #endif
   {
-    if (unsigned_flag)
+    if (fpi->m_field_unsigned_flag)
       to[0] = ptr[1];
     else
       to[0] = (char)(ptr[1] ^ 128); /* Revers signbit */
@@ -1641,12 +1605,10 @@ void Rdb_key_def::pack_medium(
 
   const size_t length = fpi->m_max_image_len;
   const uchar *ptr = field->field_ptr();
-  const bool unsigned_flag =
-      dynamic_cast<Field_num *const>(field)->is_unsigned();
   uchar *to = *dst;
 
   DBUG_ASSERT(length >= 3);
-  if (unsigned_flag)
+  if (fpi->m_field_unsigned_flag)
     to[0] = ptr[2];
   else
     to[0] = (uchar)(ptr[2] ^ 128); /* Revers signbit */
@@ -1668,14 +1630,12 @@ void Rdb_key_def::pack_long(
 
   const size_t length = fpi->m_max_image_len;
   const uchar *ptr = field->field_ptr();
-  const bool unsigned_flag =
-      dynamic_cast<Field_num *const>(field)->is_unsigned();
   uchar *to = *dst;
 
   DBUG_ASSERT(length >= 4);
 #ifdef WORDS_BIGENDIAN
   if (!field->table->s->db_low_byte_first) {
-    if (unsigned_flag)
+    if (fpi->m_field_unsigned_flag)
       to[0] = ptr[0];
     else
       dst[0] = (char)(ptr[0] ^ 128); /* Revers signbit */
@@ -1685,7 +1645,7 @@ void Rdb_key_def::pack_long(
   } else
 #endif
   {
-    if (unsigned_flag)
+    if (fpi->m_field_unsigned_flag)
       to[0] = ptr[3];
     else
       to[0] = (char)(ptr[3] ^ 128); /* Revers signbit */
@@ -1710,18 +1670,18 @@ void Rdb_key_def::pack_longlong(
   static const int PACK_LENGTH = 8;
   const size_t length = fpi->m_max_image_len;
   const uchar *ptr = field->field_ptr();
-  const bool unsigned_flag =
-      dynamic_cast<Field_num *const>(field)->is_unsigned();
   uchar *to = *dst;
 
   const size_t from_length = PACK_LENGTH;
   const size_t to_length = from_length > length ? from_length : length;
 #ifdef WORDS_BIGENDIAN
   if (field->table == NULL || !field->table->s->db_low_byte_first)
-    copy_integer<true>(to, to_length, ptr, from_length, unsigned_flag);
+    copy_integer<true>(to, to_length, ptr, from_length,
+                       fpi->m_field_unsigned_flag);
   else
 #endif
-    copy_integer<false>(to, to_length, ptr, from_length, unsigned_flag);
+    copy_integer<false>(to, to_length, ptr, from_length,
+                        fpi->m_field_unsigned_flag);
 
   *dst += length;
 }
@@ -1991,7 +1951,7 @@ int Rdb_key_def::compare_keys(const rocksdb::Slice *key1,
 
   for (uint i = 0; i < m_key_parts; i++) {
     const Rdb_field_packing *const fpi = &m_pack_info[i];
-    if (fpi->m_maybe_null) {
+    if (fpi->m_field_is_nullable) {
       const auto nullp1 = reader1.read(1);
       const auto nullp2 = reader2.read(1);
 
@@ -2013,10 +1973,10 @@ int Rdb_key_def::compare_keys(const rocksdb::Slice *key1,
     const auto before_skip1 = reader1.get_current_ptr();
     const auto before_skip2 = reader2.get_current_ptr();
     DBUG_ASSERT(fpi->m_skip_func);
-    if ((fpi->m_skip_func)(fpi, nullptr, &reader1)) {
+    if ((fpi->m_skip_func)(fpi, &reader1)) {
       return HA_EXIT_FAILURE;
     }
-    if ((fpi->m_skip_func)(fpi, nullptr, &reader2)) {
+    if ((fpi->m_skip_func)(fpi, &reader2)) {
       return HA_EXIT_FAILURE;
     }
     const auto size1 = reader1.get_current_ptr() - before_skip1;
@@ -2055,11 +2015,7 @@ size_t Rdb_key_def::key_length(const TABLE *const table,
   }
   for (uint i = 0; i < m_key_parts; i++) {
     const Rdb_field_packing *fpi = &m_pack_info[i];
-    const Field *field = nullptr;
-    if (m_index_type != INDEX_TYPE_HIDDEN_PRIMARY) {
-      field = fpi->get_field_in_table(table);
-    }
-    if ((fpi->m_skip_func)(fpi, field, &reader)) {
+    if ((fpi->m_skip_func)(fpi, &reader)) {
       return size_t(-1);
     }
   }
@@ -2124,7 +2080,7 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
                   !verify_row_debug_checksums);
 
   // Skip the index number
-  if ((!reader.read(INDEX_NUMBER_SIZE))) {
+  if (unlikely(!reader.read(INDEX_NUMBER_SIZE))) {
     return HA_ERR_ROCKSDB_CORRUPT_DATA;
   }
 
@@ -2132,7 +2088,7 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
   bool has_unpack_info;
   int err = HA_EXIT_SUCCESS;
   err = decode_unpack_info(&unp_reader, &has_unpack_info, &unpack_header);
-  if (err) {
+  if (unlikely(err)) {
     return err;
   }
 
@@ -2170,7 +2126,7 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
     Check checksum values if present
   */
   const char *ptr;
-  if ((ptr = unp_reader.read(1)) && *ptr == RDB_CHECKSUM_DATA_TAG) {
+  if (unlikely((ptr = unp_reader.read(1)) && *ptr == RDB_CHECKSUM_DATA_TAG)) {
     if (verify_row_debug_checksums) {
       uint32_t stored_key_chksum = rdb_netbuf_to_uint32(
           (const uchar *)unp_reader.read(RDB_CHECKSUM_SIZE));
@@ -2202,7 +2158,7 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
     handler->m_validated_checksums++;
   }
 
-  if (reader.remaining_bytes()) return HA_ERR_ROCKSDB_CORRUPT_DATA;
+  if (unlikely(reader.remaining_bytes())) return HA_ERR_ROCKSDB_CORRUPT_DATA;
 
   return HA_EXIT_SUCCESS;
 }
@@ -2249,8 +2205,6 @@ bool Rdb_key_def::index_format_min_check(const int pk_min,
 */
 
 int Rdb_key_def::skip_max_length(const Rdb_field_packing *const fpi,
-                                 const Field *const field
-                                     MY_ATTRIBUTE((__unused__)),
                                  Rdb_string_reader *const reader) {
   if (!reader->read(fpi->m_max_image_len)) return HA_EXIT_FAILURE;
   return HA_EXIT_SUCCESS;
@@ -2281,16 +2235,12 @@ static_assert((RDB_ESCAPE_LENGTH - 1) % 2 == 0,
 
 int Rdb_key_def::skip_variable_length_encoding(
     const Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    const Field *const field, Rdb_string_reader *const reader) {
+    Rdb_string_reader *const reader) {
   const uchar *ptr;
   bool finished = false;
 
   size_t dst_len; /* How much data can be there */
-  if (field) {
-    dst_len = fpi->m_max_field_bytes;
-  } else {
-    dst_len = UINT_MAX;
-  }
+  dst_len = fpi->m_max_field_bytes;
 
   bool use_legacy_format = fpi->m_use_legacy_varbinary_format;
 
@@ -2334,16 +2284,11 @@ const int VARCHAR_CMP_GREATER_THAN_SPACES = 3;
 */
 
 int Rdb_key_def::skip_variable_space_pad(const Rdb_field_packing *const fpi,
-                                         const Field *const field,
                                          Rdb_string_reader *const reader) {
   const uchar *ptr;
   bool finished = false;
 
-  size_t dst_len = UINT_MAX; /* How much data can be there */
-
-  if (field) {
-    dst_len = fpi->m_max_field_bytes;
-  }
+  size_t dst_len = fpi->m_max_field_bytes; /* How much data can be there */
 
   if (fpi->m_use_space_pad_lead_byte) {
     uchar encoded_byte = *(const uchar *)reader->read(1);
@@ -2388,7 +2333,6 @@ void Rdb_key_def::pack_unsigned(
     uchar *buf MY_ATTRIBUTE((__unused__)), uchar **dst,
     Rdb_pack_field_context *const pack_ctx MY_ATTRIBUTE((__unused__))) {
   DBUG_ASSERT(fpi != nullptr);
-  DBUG_ASSERT(field != nullptr);
   DBUG_ASSERT(dst != nullptr);
   DBUG_ASSERT(*dst != nullptr);
   DBUG_ASSERT(length == fpi->m_max_image_len);
@@ -2408,7 +2352,8 @@ void Rdb_key_def::pack_unsigned(
 }
 
 int Rdb_key_def::unpack_integer(
-    Rdb_field_packing *const fpi, Field *const field, uchar *const to,
+    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
+    Rdb_unpack_func_context *const, uchar *const to,
     Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   const int length = fpi->m_max_image_len;
@@ -2420,7 +2365,7 @@ int Rdb_key_def::unpack_integer(
 
 #ifdef WORDS_BIGENDIAN
   {
-    if (static_cast<Field_num *>(field)->unsigned_flag) {
+    if (fpi->m_field_unsigned_flag) {
       to[0] = from[0];
     } else {
       to[0] = static_cast<char>(from[0] ^ 128);  // Reverse the sign bit.
@@ -2430,7 +2375,7 @@ int Rdb_key_def::unpack_integer(
 #else
   {
     const int sign_byte = from[0];
-    if (static_cast<Field_num *>(field)->is_unsigned()) {
+    if (fpi->m_field_unsigned_flag) {
       to[length - 1] = sign_byte;
     } else {
       to[length - 1] =
@@ -2444,7 +2389,8 @@ int Rdb_key_def::unpack_integer(
 
 template <int length>
 int Rdb_key_def::unpack_unsigned(
-    Rdb_field_packing *const fpi, Field *const field, uchar *const to,
+    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
+    Rdb_unpack_func_context *const, uchar *const to,
     Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   DBUG_ASSERT(length == fpi->m_max_image_len);
@@ -2559,7 +2505,7 @@ int Rdb_key_def::unpack_floating_point(
 */
 int Rdb_key_def::unpack_double(
     Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-    Field *const field MY_ATTRIBUTE((__unused__)), uchar *const field_ptr,
+    Rdb_unpack_func_context *const, uchar *const field_ptr,
     Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   static double zero_val = 0.0;
@@ -2583,8 +2529,9 @@ int Rdb_key_def::unpack_double(
   allowed in the database.
 */
 int Rdb_key_def::unpack_float(
-    Rdb_field_packing *const fpi, Field *const field MY_ATTRIBUTE((__unused__)),
-    uchar *const field_ptr, Rdb_string_reader *const reader,
+    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
+    Rdb_unpack_func_context *const, uchar *const field_ptr,
+    Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   static float zero_val = 0.0;
   static const uchar zero_pattern[4] = {128, 0, 0, 0};
@@ -2600,8 +2547,9 @@ int Rdb_key_def::unpack_float(
 */
 
 int Rdb_key_def::unpack_newdate(
-    Rdb_field_packing *const fpi, Field *const field MY_ATTRIBUTE((__unused__)),
-    uchar *const field_ptr, Rdb_string_reader *const reader,
+    Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
+    Rdb_unpack_func_context *const, uchar *const field_ptr,
+    Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   const char *from;
   DBUG_ASSERT(fpi->m_max_image_len == 3);
@@ -2636,18 +2584,9 @@ void Rdb_key_def::pack_bit(
   uint length = fpi->m_max_image_len;
   const uchar *ptr = field->field_ptr();
   uchar *to = *dst;
-  auto *field_bit = static_cast<Field_bit *>(field);
 
-  if (field_bit->bit_len) {
-    /* uneven high bits */
-    uchar bits = get_rec_bits(field_bit->bit_ptr, field_bit->bit_ofs,
-                              field_bit->bit_len);
-    *to++ = bits;
-    length--;
-  }
-
-  /* copy the rest */
-  uint data_length = std::min(length, field_bit->bytes_in_rec);
+  /* We don't support uneven high bits / HA_CAN_BIT_FIELD */
+  uint data_length = std::min(length, fpi->m_field_pack_length);
   memcpy(to, ptr, data_length);
 
   *dst += fpi->m_max_image_len;
@@ -2658,27 +2597,19 @@ void Rdb_key_def::pack_bit(
   Unpack the bit by copying it over.
   See Field_bit::unpack_bit for more details.
 */
-int Rdb_key_def::unpack_bit(Rdb_field_packing *const fpi, Field *const field,
-                            uchar *const to, Rdb_string_reader *const reader,
-                            Rdb_string_reader *const unp_reader
-                                MY_ATTRIBUTE((__unused__))) {
+int Rdb_key_def::unpack_bit(
+    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const,
+    uchar *const to, Rdb_string_reader *const reader,
+    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   DBUG_ASSERT(fpi != nullptr);
-  DBUG_ASSERT(field != nullptr);
   const char *from;
   if (!(from = reader->read(fpi->m_max_image_len))) {
     /* Mem-comparable image doesn't have enough bytes */
     return UNPACK_FAILURE;
   }
-  auto *field_bit = static_cast<Field_bit *>(field);
-  if (field_bit->bit_len > 0) {
-    /* uneven high bits */
-    set_rec_bits(*from, field_bit->bit_ptr, field_bit->bit_ofs,
-                 field_bit->bit_len);
-    from++;
-  }
-  /* copy the rest */
+  /* We don't support uneven high bits / HA_CAN_BIT_FIELD */
   uint data_length =
-      std::min((uint)fpi->m_max_image_len, field_bit->bytes_in_rec);
+      std::min((uint)fpi->m_max_image_len, fpi->m_field_pack_length);
   memcpy(to, from, data_length);
   return UNPACK_SUCCESS;
 }
@@ -2690,8 +2621,8 @@ int Rdb_key_def::unpack_bit(Rdb_field_packing *const fpi, Field *const field,
 */
 
 int Rdb_key_def::unpack_binary_str(
-    Rdb_field_packing *const fpi, Field *const field, uchar *const to,
-    Rdb_string_reader *const reader,
+    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const,
+    uchar *const to, Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
   const char *from;
   if (!(from = reader->read(fpi->m_max_image_len))) {
@@ -2710,11 +2641,12 @@ int Rdb_key_def::unpack_binary_str(
 */
 
 template <const int bytes>
-int unpack_utf8_str_templ(Rdb_field_packing *const fpi, Field *const field,
-                          uchar *dst, Rdb_string_reader *const reader,
-                          Rdb_string_reader *const unp_reader
-                              MY_ATTRIBUTE((__unused__))) {
-  my_core::CHARSET_INFO *const cset = (my_core::CHARSET_INFO *)field->charset();
+int unpack_utf8_str_templ(
+    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const, uchar *dst,
+    Rdb_string_reader *const reader,
+    Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
+  my_core::CHARSET_INFO *const cset =
+      (my_core::CHARSET_INFO *)fpi->m_field_charset;
   const uchar *src;
   if (!(src = (const uchar *)reader->read(fpi->m_max_image_len))) {
     /* Mem-comparable image doesn't have enough bytes */
@@ -2722,7 +2654,7 @@ int unpack_utf8_str_templ(Rdb_field_packing *const fpi, Field *const field,
   }
 
   const uchar *const src_end = src + fpi->m_max_image_len;
-  uchar *const dst_end = dst + field->pack_length();
+  uchar *const dst_end = dst + fpi->m_field_pack_length;
 
   while (src < src_end) {
     my_wc_t wc = (bytes == 3) ? (src[0] << 16) | (src[1] << 8) | src[2]
@@ -2864,7 +2796,7 @@ void Rdb_key_def::pack_with_varlength_encoding(
   // Max memcmp byte length with char_length(), in case we need to truncate
   const size_t max_xfrm_len = charset->cset->charpos(
       charset, src, src + value_length,
-      fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen);
+      fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen);
 
   // Trimmed length in code points - this is needed to avoid the padding
   // behavior in strnxfrm for padding collations otherwise strnxfrm would
@@ -2874,9 +2806,8 @@ void Rdb_key_def::pack_with_varlength_encoding(
 
   const size_t xfrm_len = charset->coll->strnxfrm(
       charset, buf, fpi->m_max_image_len_before_encoding,
-      std::min<size_t>(
-          trimmed_codepoints,
-          fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen),
+      std::min<size_t>(trimmed_codepoints,
+                       fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen),
       reinterpret_cast<const uchar *>(src),
       std::min<size_t>(value_length, max_xfrm_len), 0);
 
@@ -3012,13 +2943,13 @@ void Rdb_key_def::pack_with_varlength_space_pad(
   // case we need to truncate for prefix keys
   const size_t max_allowed_len = charset->cset->charpos(
       charset, src, src + value_length,
-      fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen);
+      fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen);
 
   // Max memcmp byte length with char_length(), in case we need to truncate
   // for prefix keys
   const size_t max_xfrm_len = charset->cset->charpos(
       charset, src, src + trimmed_len,
-      fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen);
+      fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen);
 
   // Trimmed length in code points - this is needed to avoid the padding
   // behavior in strnxfrm for padding collations otherwise strnxfrm would
@@ -3028,9 +2959,8 @@ void Rdb_key_def::pack_with_varlength_space_pad(
 
   const size_t xfrm_len = charset->coll->strnxfrm(
       charset, buf, fpi->m_max_image_len_before_encoding,
-      std::min<size_t>(
-          trimmed_codepoints,
-          fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen),
+      std::min<size_t>(trimmed_codepoints,
+                       fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen),
       reinterpret_cast<const uchar *>(src),
       std::min<size_t>(trimmed_len, max_xfrm_len), 0);
 
@@ -3143,26 +3073,24 @@ uint Rdb_key_def::calc_unpack_variable_format(uchar flag, bool *done) {
 }
 
 void Rdb_key_def::store_field(const uchar *data, const size_t length,
-                              Field *field) {
-  if (field->real_type() == MYSQL_TYPE_VARCHAR) {
-    auto field_var = (Field_varstring *)field;
-    auto length_bytes = field_var->get_length_bytes();
+                              uchar *ptr, Rdb_field_packing *const fpi,
+                              Rdb_unpack_func_context *const ctx) {
+  if (fpi->m_field_real_type == MYSQL_TYPE_VARCHAR) {
+    auto length_bytes = fpi->m_varlength_bytes;
     if (length_bytes == 1) {
-      field_var->field_ptr()[0] = length;
+      ptr[0] = length;
     } else {
       DBUG_ASSERT(length_bytes == 2);
-      int2store(field_var->field_ptr(), length);
+      int2store(ptr, length);
     }
     // data is not used for varchar as field->ptr + length_bytes
     // already contains required data.
-  } else if (is_blob(field->real_type())) {
-    auto field_blob = (Field_blob *)field;
-    auto length_bytes = field_blob->pack_length_no_ptr();
-    field_blob->store_length(length);
-    auto blob_data = (char *)data;
-    memset(field_blob->field_ptr() + length_bytes, 0, 8);
-    memcpy(field_blob->field_ptr() + length_bytes, &blob_data,
-           sizeof(uchar **));
+  } else if (is_blob(fpi->m_field_real_type)) {
+    auto length_bytes = fpi->m_varlength_bytes;
+    store_blob_length(ptr, length_bytes, length);
+    auto blob_data = (char *)(data);
+    memset(ptr + length_bytes, 0, 8);
+    memcpy(ptr + length_bytes, &blob_data, sizeof(uchar **));
   } else {
     DBUG_ASSERT(false);
   }
@@ -3186,34 +3114,18 @@ const char *Rdb_key_def::get_data_value(const Field *field) {
   }
 }
 
-uchar *Rdb_key_def::get_data_start_ptr(const Field *field,
-                                       const size_t max_field_length) {
+uchar *Rdb_key_def::get_data_start_ptr(Rdb_field_packing *const fpi, uchar *dst,
+                                       Rdb_unpack_func_context *const ctx) {
   uchar *data_start = nullptr;
-  if (field->real_type() == MYSQL_TYPE_VARCHAR) {
-    const auto field_var = static_cast<const Field_varstring *>(field);
-    data_start = const_cast<uchar *>(field_var->field_ptr()) +
-                 field_var->get_length_bytes();
-  } else if (is_blob(field->real_type())) {
-    auto handler = (ha_rocksdb *)field->table->file;
-    data_start = handler->get_blob_buffer(max_field_length);
+  if (fpi->m_field_real_type == MYSQL_TYPE_VARCHAR) {
+    data_start = dst + fpi->m_varlength_bytes;
+  } else if (is_blob(fpi->m_field_real_type)) {
+    auto handler = static_cast<ha_rocksdb *>(ctx->table->file);
+    data_start = handler->get_blob_buffer(fpi->m_max_field_bytes);
   } else {
     DBUG_ASSERT(false);
   }
   return data_start;
-}
-
-uint16 Rdb_key_def::get_length_bytes(const Field *field) {
-  uint16 length_bytes = 0;
-  if (field->real_type() == MYSQL_TYPE_VARCHAR) {
-    const auto field_var = static_cast<const Field_varstring *>(field);
-    length_bytes = field_var->get_length_bytes();
-  } else if (is_blob(field->real_type())) {
-    const auto field_blob = static_cast<const Field_blob *>(field);
-    length_bytes = field_blob->pack_length_no_ptr();
-  } else {
-    DBUG_ASSERT(false);
-  }
-  return length_bytes;
 }
 
 bool Rdb_key_def::is_varlength_prefix_covering(
@@ -3292,15 +3204,14 @@ bool check_src_len<3>(uint src_len) {
   Function of type rdb_index_field_unpack_t
 */
 int Rdb_key_def::unpack_binary_varlength(
-    Rdb_field_packing *const fpi, Field *const field,
+    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
     uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__))) {
-  DBUG_ASSERT(field->field_ptr() == dst);
-  DBUG_ASSERT(fpi->m_varlength_charset == &my_charset_bin);
+  DBUG_ASSERT(fpi->m_field_charset == &my_charset_bin);
   const uchar *ptr;
   size_t len = 0;
   bool finished = false;
-  uchar *data_start = get_data_start_ptr(field, fpi->m_max_field_bytes);
+  uchar *data_start = get_data_start_ptr(fpi, dst, ctx);
   uchar *data = data_start;
   // How much we can unpack
   size_t data_len = fpi->m_max_field_bytes;
@@ -3341,7 +3252,7 @@ int Rdb_key_def::unpack_binary_varlength(
   if (!finished) {
     return UNPACK_FAILURE;
   }
-  store_field(data_start, len, field);
+  store_field(data_start, len, dst, fpi, ctx);
   return UNPACK_SUCCESS;
 }
 
@@ -3355,14 +3266,13 @@ int Rdb_key_def::unpack_binary_varlength(
 
 template <const int bytes>
 int Rdb_key_def::unpack_binary_or_utf8_varlength_space_pad(
-    Rdb_field_packing *const fpi, Field *const field,
-    uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
+    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
+    uchar *dst, Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader) {
-  DBUG_ASSERT(field->field_ptr() == dst);
   const uchar *ptr;
   size_t len = 0;
   bool finished = false;
-  uchar *data_start = get_data_start_ptr(field, fpi->m_max_field_bytes);
+  uchar *data_start = get_data_start_ptr(fpi, dst, ctx);
   uchar *data = data_start;
   uchar *data_end = data + fpi->m_max_field_bytes;
 
@@ -3421,7 +3331,7 @@ int Rdb_key_def::unpack_binary_or_utf8_varlength_space_pad(
         my_wc_t wc = (bytes == 3) ? (src[0] << 16) | (src[1] << 8) | src[2]
                                   : (src[0] << 8) | src[1];
         src += bytes;
-        const CHARSET_INFO *cset = fpi->m_varlength_charset;
+        const CHARSET_INFO *cset = fpi->m_field_charset;
         int res = cset->cset->wc_mb(cset, wc, data, data_end);
         DBUG_ASSERT(res <= bytes + 1);
         if (res <= 0) return UNPACK_FAILURE;
@@ -3446,10 +3356,10 @@ finished:
     // Both binary and UTF-8 charset store space as ' ',
     // so the following is ok:
     if (data + extra_spaces > data_end) return UNPACK_FAILURE;
-    memset(data, fpi->m_varlength_charset->pad_char, extra_spaces);
+    memset(data, fpi->m_field_charset->pad_char, extra_spaces);
     len += extra_spaces;
   }
-  store_field(data_start, len, field);
+  store_field(data_start, len, dst, fpi, ctx);
   return UNPACK_SUCCESS;
 }
 
@@ -3492,13 +3402,14 @@ void Rdb_key_def::dummy_make_unpack_info(
 */
 
 int Rdb_key_def::unpack_unknown(Rdb_field_packing *const fpi,
-                                Field *const field, uchar *const dst,
+                                Rdb_unpack_func_context *const,
+                                uchar *const dst,
                                 Rdb_string_reader *const reader,
                                 Rdb_string_reader *const unp_reader) {
   const uchar *ptr;
   const uint len = fpi->m_unpack_data_len;
   // We don't use anything from the key, so skip over it.
-  if (skip_max_length(fpi, field, reader)) {
+  if (skip_max_length(fpi, reader)) {
     return UNPACK_FAILURE;
   }
 
@@ -3519,7 +3430,7 @@ void Rdb_key_def::make_unpack_unknown_varlength(
     const Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
     const Field *const field, Rdb_pack_field_context *const pack_ctx) {
   uint len = field->data_length();
-  uint length_bytes = get_length_bytes(field);
+  uint length_bytes = fpi->m_varlength_bytes;
   pack_ctx->writer->write(field->field_ptr(), length_bytes);
   if (field->real_type() == MYSQL_TYPE_VARCHAR) {
     pack_ctx->writer->write(field->field_ptr() + length_bytes, len);
@@ -3545,18 +3456,17 @@ void Rdb_key_def::make_unpack_unknown_varlength(
 */
 
 int Rdb_key_def::unpack_unknown_varlength(Rdb_field_packing *const fpi,
-                                          Field *const field,
-                                          uchar *dst MY_ATTRIBUTE((__unused__)),
+                                          Rdb_unpack_func_context *const ctx,
+                                          uchar *dst,
                                           Rdb_string_reader *const reader,
                                           Rdb_string_reader *const unp_reader) {
-  DBUG_ASSERT(field->field_ptr() == dst);
   const uchar *ptr;
 
-  uchar *data_start = get_data_start_ptr(field, fpi->m_max_field_bytes);
+  uchar *data_start = get_data_start_ptr(fpi, dst, ctx);
   uchar *data = data_start;
-  const uint len_bytes = get_length_bytes(field);
+  const uint len_bytes = fpi->m_varlength_bytes;
   // We don't use anything from the key, so skip over it.
-  if ((fpi->m_skip_func)(fpi, field, reader)) {
+  if ((fpi->m_skip_func)(fpi, reader)) {
     return UNPACK_FAILURE;
   }
 
@@ -3565,15 +3475,14 @@ int Rdb_key_def::unpack_unknown_varlength(Rdb_field_packing *const fpi,
 
   if ((ptr = (uchar *)unp_reader->read(len_bytes))) {
     uint len = 0;
-    if (field->real_type() == MYSQL_TYPE_VARCHAR) {
+    if (fpi->m_field_real_type == MYSQL_TYPE_VARCHAR) {
       len = len_bytes == 1 ? (uint)*ptr : uint2korr(ptr);
     } else {
-      const auto field_blob = static_cast<const Field_blob *>(field);
-      len = field_blob->get_length(ptr);
+      len = Field_blob::get_length(ptr, fpi->m_varlength_bytes);
     }
     if ((ptr = (const uchar *)unp_reader->read(len))) {
       memcpy(data, ptr, len);
-      store_field(data_start, len, field);
+      store_field(data_start, len, dst, fpi, ctx);
       return UNPACK_SUCCESS;
     }
   }
@@ -3630,7 +3539,7 @@ void Rdb_key_def::make_unpack_simple_varlength(
   // mbmaxlen = 1.
   rdb_write_unpack_simple(
       &bit_writer, fpi->m_charset_codec, src,
-      std::min(fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen,
+      std::min(fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen,
                value_length));
 }
 
@@ -3643,19 +3552,18 @@ void Rdb_key_def::make_unpack_simple_varlength(
 */
 
 int Rdb_key_def::unpack_simple_varlength_space_pad(
-    Rdb_field_packing *const fpi, Field *const field,
+    Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
     uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
     Rdb_string_reader *const unp_reader) {
-  DBUG_ASSERT(field->field_ptr() == dst);
   const uchar *ptr;
   size_t len = 0;
   bool finished = false;
-  uchar *data_start = get_data_start_ptr(field, fpi->m_max_field_bytes);
+  uchar *data_start = get_data_start_ptr(fpi, dst, ctx);
   uchar *data = data_start;
 
   // For simple collations, char_length is also number of bytes.
   DBUG_ASSERT((size_t)fpi->m_max_image_len >=
-              (fpi->m_max_field_bytes / fpi->m_varlength_charset->mbmaxlen));
+              (fpi->m_max_field_bytes / fpi->m_field_charset->mbmaxlen));
   uchar *data_end = data + fpi->m_max_field_bytes;
   Rdb_bit_reader bit_reader(unp_reader);
 
@@ -3731,10 +3639,10 @@ finished:
     if (data + extra_spaces > data_end) return UNPACK_FAILURE;
     // pad_char has a 1-byte form in all charsets that
     // are handled by rdb_init_collation_mapping.
-    memset(data, field->charset()->pad_char, extra_spaces);
+    memset(data, fpi->m_field_charset->pad_char, extra_spaces);
     len += extra_spaces;
   }
-  store_field(data_start, len, field);
+  store_field(data_start, len, dst, fpi, ctx);
   return UNPACK_SUCCESS;
 }
 
@@ -3763,8 +3671,7 @@ void Rdb_key_def::make_unpack_simple(const Rdb_field_packing *const fpi,
 */
 
 int Rdb_key_def::unpack_simple(Rdb_field_packing *const fpi,
-                               Field *const field MY_ATTRIBUTE((__unused__)),
-                               uchar *const dst,
+                               Rdb_unpack_func_context *const, uchar *const dst,
                                Rdb_string_reader *const reader,
                                Rdb_string_reader *const unp_reader) {
   const uchar *ptr;
@@ -3967,48 +3874,6 @@ static int get_segment_size_from_collation(const CHARSET_INFO *const cs) {
   return ret;
 }
 
-Rdb_field_packing::Rdb_field_packing(const Rdb_field_packing &o)
-    : m_max_image_len(o.m_max_image_len),
-      m_unpack_data_len(o.m_unpack_data_len),
-      m_unpack_data_offset(o.m_unpack_data_offset),
-      m_maybe_null(o.m_maybe_null),
-      m_varlength_charset(o.m_varlength_charset),
-      m_segment_size(o.m_segment_size),
-      m_unpack_info_uses_two_bytes(o.m_unpack_info_uses_two_bytes),
-      m_covered(o.m_covered),
-      space_xfrm(o.space_xfrm),
-      space_xfrm_len(o.space_xfrm_len),
-      space_mb_len(o.space_mb_len),
-      m_charset_codec(o.m_charset_codec),
-      m_unpack_info_stores_value(o.m_unpack_info_stores_value),
-      m_pack_func(o.m_pack_func),
-      m_make_unpack_info_func(o.m_make_unpack_info_func),
-      m_unpack_func(o.m_unpack_func),
-      m_skip_func(o.m_skip_func),
-      m_keynr(o.m_keynr),
-      m_key_part(o.m_key_part) {}
-
-Rdb_field_packing::Rdb_field_packing()
-    : m_max_image_len(0),
-      m_unpack_data_len(0),
-      m_unpack_data_offset(0),
-      m_maybe_null(false),
-      m_varlength_charset(nullptr),
-      m_segment_size(0),
-      m_unpack_info_uses_two_bytes(false),
-      m_covered(Rdb_key_def::KEY_NOT_COVERED),
-      space_xfrm(nullptr),
-      space_xfrm_len(0),
-      space_mb_len(0),
-      m_charset_codec(nullptr),
-      m_unpack_info_stores_value(false),
-      m_pack_func(nullptr),
-      m_make_unpack_info_func(nullptr),
-      m_unpack_func(nullptr),
-      m_skip_func(nullptr),
-      m_keynr(0),
-      m_key_part(0) {}
-
 /*
   @brief
     Setup packing of index field into its mem-comparable form
@@ -4035,10 +3900,21 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
                               const uint16 key_length) {
   enum_field_types type = field ? field->real_type() : MYSQL_TYPE_LONGLONG;
 
+  m_field_real_type = type;
+  m_field_offset = (key_descr && field)
+                       ? (field->field_ptr() - field->table->record[0])
+                       : -1;
+  m_field_null_offset = (key_descr && field) ? field->null_offset() : -1;
+  m_field_null_bit_mask = (key_descr && field) ? field->null_bit : 0;
+  m_field_pack_length = (key_descr && field) ? field->pack_length() : -1;
+  m_field_charset = (key_descr && field) ? field->charset() : nullptr;
+  m_field_unsigned_flag = field ? field->is_unsigned() : false;
+  m_field_is_nullable = field ? field->is_nullable() : false;
+  m_varlength_bytes = -1;
+
   m_keynr = keynr_arg;
   m_key_part = key_part_arg;
 
-  m_maybe_null = field ? field->is_nullable() : false;
   m_unpack_func = nullptr;
   m_make_unpack_info_func = nullptr;
   m_unpack_data_len = 0;
@@ -4204,6 +4080,8 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
       m_pack_func = Rdb_key_def::pack_bit;
       m_unpack_func = Rdb_key_def::unpack_bit;
       m_covered = Rdb_key_def::KEY_COVERED;
+      // We don't support uneven high bit optimization / HA_CAN_BIT_FIELD
+      SHIP_ASSERT(static_cast<const Field_bit *>(field)->bit_ptr == nullptr);
       return true;
 
     // Obsolete
@@ -4241,7 +4119,15 @@ bool Rdb_field_packing::setup(const Rdb_key_def *const key_descr,
   if (is_varlength) {
     // The default for varchar is variable-length, without space-padding for
     // comparisons
-    m_varlength_charset = cs;
+    m_field_charset = cs;
+
+    if (type == MYSQL_TYPE_VARCHAR) {
+      auto field_var = static_cast<const Field_varstring *>(field);
+      m_varlength_bytes = field_var->get_length_bytes();
+    } else if (is_blob(type)) {
+      const auto field_blob = static_cast<const Field_blob *>(field);
+      m_varlength_bytes = field_blob->pack_length_no_ptr();
+    }
     m_skip_func = Rdb_key_def::skip_variable_length_encoding;
     m_pack_func = Rdb_key_def::pack_with_varlength_encoding;
     if (!key_descr || key_descr->use_legacy_varbinary_format()) {

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -54,18 +54,16 @@ class Rdb_convert_to_record_key_decoder {
       const Rdb_convert_to_record_key_decoder &decoder) = delete;
   Rdb_convert_to_record_key_decoder &operator=(
       const Rdb_convert_to_record_key_decoder &decoder) = delete;
-  static int decode(uchar *const buf, uint *offset, Rdb_field_packing *fpi,
-                    TABLE *table, Field *field, bool has_unpack_info,
-                    Rdb_string_reader *reader,
+  static int decode(uchar *const buf, Rdb_field_packing *fpi, TABLE *table,
+                    bool has_unpack_info, Rdb_string_reader *reader,
                     Rdb_string_reader *unpack_reader);
   static int skip(const Rdb_field_packing *fpi, const Field *field,
                   Rdb_string_reader *reader, Rdb_string_reader *unpack_reader,
                   bool covered_bitmap_format_enabled);
 
  private:
-  static int decode_field(Rdb_field_packing *fpi, Field *field,
+  static int decode_field(Rdb_field_packing *fpi, TABLE *table, uchar *buf,
                           Rdb_string_reader *reader,
-                          const uchar *const default_value,
                           Rdb_string_reader *unpack_reader);
 };
 
@@ -95,11 +93,18 @@ class Rdb_pack_field_context {
   Rdb_string_writer *writer;
 };
 
+/*
+  @brief
+  Field unpacking context being passed to packing helpers
+  This avoids massive changes to all the helpers whenever we need to
+  add/remove arguments
+*/
+struct Rdb_unpack_func_context {
+  TABLE *table;
+};
+
 class Rdb_key_field_iterator {
  private:
-  Rdb_field_packing *m_pack_info;
-  int m_iter_index;
-  int m_iter_end;
   TABLE *m_table;
   Rdb_string_reader *m_reader;
   Rdb_string_reader *m_unp_reader;
@@ -112,9 +117,8 @@ class Rdb_key_field_iterator {
   bool m_hidden_pk_exists;
   bool m_is_hidden_pk;
   bool m_is_null;
-  Field *m_field;
-  uint m_offset;
-  Rdb_field_packing *m_fpi;
+  Rdb_field_packing *m_fpi_next;
+  Rdb_field_packing *m_fpi_end;
 
  public:
   Rdb_key_field_iterator(const Rdb_key_field_iterator &) = delete;
@@ -128,10 +132,6 @@ class Rdb_key_field_iterator {
 
   int next();
   bool has_next();
-  bool get_is_null() const;
-  Field *get_field() const;
-  int get_field_index() const;
-  void *get_dst() const;
 };
 
 struct Rdb_collation_codec;
@@ -144,12 +144,12 @@ struct Rdb_index_info;
 using rdb_make_unpack_info_t = void (*)(const Rdb_field_packing *fpi,
                                         const Field *field,
                                         Rdb_pack_field_context *pack_ctx);
-using rdb_index_field_unpack_t = int (*)(Rdb_field_packing *fpi, Field *field,
+using rdb_index_field_unpack_t = int (*)(Rdb_field_packing *fpi,
+                                         Rdb_unpack_func_context *const ctx,
                                          uchar *field_ptr,
                                          Rdb_string_reader *reader,
                                          Rdb_string_reader *unpack_reader);
 using rdb_index_field_skip_t = int (*)(const Rdb_field_packing *fpi,
-                                       const Field *field,
                                        Rdb_string_reader *reader);
 using rdb_index_field_pack_t = void (*)(Rdb_field_packing *fpi, Field *field,
                                         uchar *buf, uchar **dst,
@@ -772,27 +772,26 @@ class Rdb_key_def {
                             Rdb_pack_field_context *const pack_ctx
                                 MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_integer(Rdb_field_packing *const fpi, Field *const field,
-                            uchar *const to, Rdb_string_reader *const reader,
-                            Rdb_string_reader *const unp_reader
-                                MY_ATTRIBUTE((__unused__)));
+  static int unpack_integer(
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
+      uchar *const to, Rdb_string_reader *const reader,
+      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   template <int length>
-  static int unpack_unsigned(Rdb_field_packing *const fpi, Field *const field,
-                             uchar *const to, Rdb_string_reader *const reader,
-                             Rdb_string_reader *const unp_reader
-                                 MY_ATTRIBUTE((__unused__)));
+  static int unpack_unsigned(
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
+      uchar *const to, Rdb_string_reader *const reader,
+      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   static int unpack_double(
       Rdb_field_packing *const fpi MY_ATTRIBUTE((__unused__)),
-      Field *const field MY_ATTRIBUTE((__unused__)), uchar *const field_ptr,
+      Rdb_unpack_func_context *const ctx, uchar *const field_ptr,
       Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   static int unpack_float(
-      Rdb_field_packing *const fpi,
-      Field *const field MY_ATTRIBUTE((__unused__)), uchar *const field_ptr,
-      Rdb_string_reader *const reader,
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const,
+      uchar *const field_ptr, Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   static void pack_bit(Rdb_field_packing *const fpi, Field *const field,
@@ -800,24 +799,24 @@ class Rdb_key_def {
                        Rdb_pack_field_context *const pack_ctx
                            MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_bit(Rdb_field_packing *const fpi, Field *const field,
-                        uchar *const to, Rdb_string_reader *const reader,
-                        Rdb_string_reader *const unp_reader
-                            MY_ATTRIBUTE((__unused__)));
+  static int unpack_bit(
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
+      uchar *const to, Rdb_string_reader *const reader,
+      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
-  static int unpack_binary_str(Rdb_field_packing *const fpi, Field *const field,
-                               uchar *const to, Rdb_string_reader *const reader,
-                               Rdb_string_reader *const unp_reader
-                                   MY_ATTRIBUTE((__unused__)));
+  static int unpack_binary_str(
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
+      uchar *const to, Rdb_string_reader *const reader,
+      Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   static int unpack_binary_varlength(
-      Rdb_field_packing *const fpi, Field *const field,
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
       uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   template <const int bytes>
   static int unpack_binary_or_utf8_varlength_space_pad(
-      Rdb_field_packing *const fpi, Field *const field,
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
       uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader);
 
@@ -826,31 +825,31 @@ class Rdb_key_def {
   static rdb_index_field_unpack_t unpack_utf8mb4_varlength_space_pad;
 
   static int unpack_newdate(
-      Rdb_field_packing *const fpi,
-      Field *const field MY_ATTRIBUTE((__unused__)), uchar *const field_ptr,
-      Rdb_string_reader *const reader,
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
+      uchar *const field_ptr, Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader MY_ATTRIBUTE((__unused__)));
 
   static rdb_index_field_unpack_t unpack_utf8_str;
   static rdb_index_field_unpack_t unpack_utf8mb4_str;
 
   static int unpack_unknown_varlength(Rdb_field_packing *const fpi,
-                                      Field *const field,
+                                      Rdb_unpack_func_context *const ctx,
                                       uchar *dst MY_ATTRIBUTE((__unused__)),
                                       Rdb_string_reader *const reader,
                                       Rdb_string_reader *const unp_reader);
 
   static int unpack_simple_varlength_space_pad(
-      Rdb_field_packing *const fpi, Field *const field,
+      Rdb_field_packing *const fpi, Rdb_unpack_func_context *const ctx,
       uchar *dst MY_ATTRIBUTE((__unused__)), Rdb_string_reader *const reader,
       Rdb_string_reader *const unp_reader);
 
   static int unpack_simple(Rdb_field_packing *const fpi,
-                           Field *const field MY_ATTRIBUTE((__unused__)),
-                           uchar *const dst, Rdb_string_reader *const reader,
+                           Rdb_unpack_func_context *const ctx, uchar *const dst,
+                           Rdb_string_reader *const reader,
                            Rdb_string_reader *const unp_reader);
 
-  static int unpack_unknown(Rdb_field_packing *const fpi, Field *const field,
+  static int unpack_unknown(Rdb_field_packing *const fpi,
+                            Rdb_unpack_func_context *const ctx,
                             uchar *const dst, Rdb_string_reader *const reader,
                             Rdb_string_reader *const unp_reader);
 
@@ -883,16 +882,12 @@ class Rdb_key_def {
       Rdb_pack_field_context *pack_ctx MY_ATTRIBUTE((__unused__)));
 
   static int skip_max_length(const Rdb_field_packing *const fpi,
-                             const Field *const field
-                                 MY_ATTRIBUTE((__unused__)),
                              Rdb_string_reader *const reader);
 
   static int skip_variable_length_encoding(const Rdb_field_packing *const fpi,
-                                           const Field *const field,
                                            Rdb_string_reader *const reader);
 
   static int skip_variable_space_pad(const Rdb_field_packing *const fpi,
-                                     const Field *const field,
                                      Rdb_string_reader *const reader);
 
   inline bool use_legacy_varbinary_format() const {
@@ -945,8 +940,9 @@ class Rdb_key_def {
     Stores data and len for the given field.
     Currently this support varchar and blob data types.
   */
-  static void store_field(const uchar *data, const size_t length, Field *field);
-
+  static void store_field(const uchar *data, const size_t length, uchar *dst,
+                          Rdb_field_packing *const fpi,
+                          Rdb_unpack_func_context *const ctx);
   /*
     Returns the data pointer from field.
     Currently this support varchar and blob data types.
@@ -957,8 +953,8 @@ class Rdb_key_def {
     Returns the pointer where the field data will be stored.
     Currently this support varchar and blob data types.
   */
-  static uchar *get_data_start_ptr(const Field *field,
-                                   const size_t max_field_length);
+  static uchar *get_data_start_ptr(Rdb_field_packing *const fpi, uchar *dst,
+                                   Rdb_unpack_func_context *const ctx);
 
   /*
     Returns number of bytes used to store the length for field.
@@ -1095,9 +1091,9 @@ extern std::array<const Rdb_collation_codec *, MY_ALL_CHARSETS_SIZE>
 
 class Rdb_field_packing {
  public:
-  Rdb_field_packing(const Rdb_field_packing &);
+  Rdb_field_packing(const Rdb_field_packing &o) = default;
   Rdb_field_packing &operator=(const Rdb_field_packing &) = delete;
-  Rdb_field_packing();
+  Rdb_field_packing() = default;
 
   /* Length of mem-comparable image of the field, in bytes */
   int m_max_image_len;
@@ -1113,11 +1109,23 @@ class Rdb_field_packing {
   int m_unpack_data_offset;
 
   bool m_maybe_null; /* TRUE <=> NULL-byte is stored */
+  /*
+    Cached field information for faster access
+  */
+  bool m_field_is_nullable; /* true <=> NULL-byte is stored */
+  bool m_field_unsigned_flag;
+  enum_field_types m_field_real_type;
+  uchar m_field_null_bit_mask;
+  uint m_field_pack_length;
+  uint m_field_null_offset;
+  ptrdiff_t m_field_offset;
+  const CHARSET_INFO *m_field_charset;
 
   /*
     Valid only for varlength fields i.e varchar and blob.
   */
-  const CHARSET_INFO *m_varlength_charset;
+  uint m_varlength_bytes;
+
   bool m_use_legacy_varbinary_format;
 
   /*

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1251,13 +1251,20 @@ class Rdb_field_encoder {
   STORAGE_TYPE m_storage_type;
 
   uint m_null_offset;
-  uint16 m_field_index;
-
   uchar m_null_mask;  // 0 means the field cannot be null
 
+  /*
+    Cached field information
+  */
   my_core::enum_field_types m_field_type;
-
-  uint m_pack_length_in_rec;
+  uchar m_field_null_mask;
+  uint16 m_field_index;
+  uint m_field_pack_length;
+  uint m_field_length_bytes;
+  uint m_field_length;
+  ptrdiff_t m_field_null_offset;
+  ptrdiff_t m_field_offset;
+  bool m_is_virtual_gcol;
 
   bool maybe_null() const { return m_null_mask != 0; }
 

--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1409,7 +1409,7 @@ interface Rdb_tables_scanner {
   objects are shared among all threads.
 */
 
-class Rdb_ddl_manager {
+class Rdb_ddl_manager : public Ensure_initialized {
   Rdb_dict_manager *m_dict = nullptr;
   Rdb_cf_manager *m_cf_manager = nullptr;
 
@@ -1566,7 +1566,7 @@ class Rdb_ddl_manager {
   begin() and commit() to make it easier to do atomic operations.
 
 */
-class Rdb_dict_manager {
+class Rdb_dict_manager : public Ensure_initialized {
  private:
   mysql_mutex_t m_mutex;
   rocksdb::TransactionDB *m_db = nullptr;
@@ -1608,7 +1608,10 @@ class Rdb_dict_manager {
             Rdb_cf_manager *const cf_manager,
             const bool enable_remove_orphaned_cf_flags);
 
-  inline void cleanup() { mysql_mutex_destroy(&m_mutex); }
+  inline void cleanup() {
+    if (!initialized) return;
+    mysql_mutex_destroy(&m_mutex);
+  }
 
   inline void lock() { RDB_MUTEX_LOCK_CHECK(m_mutex); }
 

--- a/storage/rocksdb/rdb_threads.cc
+++ b/storage/rocksdb/rdb_threads.cc
@@ -51,6 +51,7 @@ void Rdb_thread::init(
   DBUG_ASSERT(!m_run_once);
   mysql_mutex_init(stop_bg_psi_mutex_key, &m_signal_mutex, MY_MUTEX_INIT_FAST);
   mysql_cond_init(stop_bg_psi_cond_key, &m_signal_cond);
+  initialized = true;
 }
 
 void Rdb_thread::uninit() {
@@ -68,11 +69,12 @@ int Rdb_thread::create_thread(const std::string &thread_name
 
   int err = mysql_thread_create(background_psi_thread_key, &m_handle, nullptr,
                                 thread_func, this);
-
   return err;
 }
 
 void Rdb_thread::signal(const bool stop_thread) {
+  if (!initialized) return;
+
   RDB_MUTEX_LOCK_CHECK(m_signal_mutex);
 
   if (stop_thread) {

--- a/storage/rocksdb/rdb_threads.h
+++ b/storage/rocksdb/rdb_threads.h
@@ -37,7 +37,7 @@
 
 namespace myrocks {
 
-class Rdb_thread {
+class Rdb_thread : public Ensure_initialized {
  private:
   // Disable Copying
   Rdb_thread(const Rdb_thread &);
@@ -73,7 +73,10 @@ class Rdb_thread {
 
   void signal(const bool stop_thread = false);
 
-  int join() { return my_thread_join(&m_handle, nullptr); }
+  int join() {
+    if (!m_run_once) return EINVAL;
+    return my_thread_join(&m_handle, nullptr);
+  }
 
   void uninit();
 

--- a/storage/rocksdb/rdb_utils.h
+++ b/storage/rocksdb/rdb_utils.h
@@ -448,4 +448,13 @@ class Ensure_cleanup {
   std::function<void()> m_cleanup;
   bool m_skip_cleanup;
 };
+
+class Ensure_initialized {
+ public:
+  bool is_initialized() const { return initialized; }
+
+ protected:
+  bool initialized = false;
+};
+
 }  // namespace myrocks


### PR DESCRIPTION
1. Update rocksdb submodule to v6.19 [0f8c041ea7bb458caa5ec0dbeef9fa42d0b97482 Remove disabled tests (#8123)](https://github.com/facebook/rocksdb/commit/0f8c041ea7bb458caa5ec0dbeef9fa42d0b97482)

2. Add new MyRocks variable `rocksdb_fault_injection_options`.

3. Cherry-pick the following commits from `percona-202102`:
- [3e41e4e918273832aa295dfee1d89f169c10c6a4 Fix a memory leak in "rocksdb_init_internal"](https://github.com/facebook/mysql-5.6/commit/3e41e4e918273832aa295dfee1d89f169c10c6a4)
- [edce7e9f7518a0a9159a2cf5c63e8e8f340a0481 Fix buffer management issues during online alter](https://github.com/facebook/mysql-5.6/commit/edce7e9f7518a0a9159a2cf5c63e8e8f340a0481)
- [99affe6c5677b2dbdc0aaeb31b8e5182c622fb6d Remove some dead code and unused variables](https://github.com/facebook/mysql-5.6/commit/99affe6c5677b2dbdc0aaeb31b8e5182c622fb6d)
- [0bf45d644729f4beed6280b38c55a557fbad5698 2x integer key decoding perf](https://github.com/facebook/mysql-5.6/commit/0bf45d644729f4beed6280b38c55a557fbad5698)
- [0e45b20a6a7e205f230314e1c6d1d91b752ac372 Faster value decoding](https://github.com/facebook/mysql-5.6/commit/0e45b20a6a7e205f230314e1c6d1d91b752ac372)
- [e025cf1c47e63aada985d78e4083f2e02fba434f Improve count(*) performance and fix index merge bug](https://github.com/facebook/mysql-5.6/commit/e025cf1c47e63aada985d78e4083f2e02fba434f)
- [c059dde397f327982bc6abe555ca63756f4b9fa9 Skip decoding completely during count and improve SK count perf by 20x](https://github.com/facebook/mysql-5.6/commit/c059dde397f327982bc6abe555ca63756f4b9fa9)
- [a69277edd3e9766aead9634dc09253fdff2df908 Bump rocksdb to 6.19](https://github.com/facebook/mysql-5.6/commit/a69277edd3e9766aead9634dc09253fdff2df908)
- [136b9ecdb2427b7468f832be5ef98a8ed057e2fc Integrate rocksdb fault injection framework with myrocks](https://github.com/facebook/mysql-5.6/commit/136b9ecdb2427b7468f832be5ef98a8ed057e2fc)
- [c7c590acbcbfd60b1afbbc90c8162d8b5cadbc67 Check for errors during inplace_populate_sk](https://github.com/facebook/mysql-5.6/commit/c7c590acbcbfd60b1afbbc90c8162d8b5cadbc67)
- [18d7f5ba8304c3bf470b8fc27de601eafe467910 Return stats from storage engine directly without table open](https://github.com/facebook/mysql-5.6/commit/18d7f5ba8304c3bf470b8fc27de601eafe467910)
- [7194dfd7679aa70bda91236d0d6455d5324e615b Refactoring index covering check to match MyRocks and add non-covering SK tests and rocksdb_covering_secondary_key stats](https://github.com/facebook/mysql-5.6/commit/7194dfd7679aa70bda91236d0d6455d5324e615b)

4. Already ported or skipped commits:
- [0c1ecb46e3e5492d0922817052ff21080af3fef2 Adding option to enable global commit ordering on secondaries](https://github.com/facebook/mysql-5.6/commit/0c1ecb46e3e5492d0922817052ff21080af3fef2)
- [718d2c75bc1e92de532e12469d1bddeb86466e39 Fix rocksdb.rqg_runtime in write unprepared](https://github.com/facebook/mysql-5.6/commit/718d2c75bc1e92de532e12469d1bddeb86466e39)
- [acbc0257bae73f898183d7f0bbecd0374f24f78e Change float comparison semantics for BI consistency check](https://github.com/facebook/mysql-5.6/commit/acbc0257bae73f898183d7f0bbecd0374f24f78e)
- [206a691abbca7962cdb9f2160c5d4bed6fb53d2d Fix crash when updating rows with blobs](https://github.com/facebook/mysql-5.6/commit/206a691abbca7962cdb9f2160c5d4bed6fb53d2d)
- [6de27e35d23470045e4bce33667801b64e65bc68 Refactor index_first_intern and index_last_intern into one function](https://github.com/facebook/mysql-5.6/commit/6de27e35d23470045e4bce33667801b64e65bc68)

5. Skipped upstream RocksDB commits:
- [963d0c69bca50c62a213e0b6d944a2b383ec494b Fix test failure in rpl_slave_check_before_image_float_consistency](https://github.com/facebook/mysql-5.6/commit/963d0c69bca50c62a213e0b6d944a2b383ec494b)
- [d6e960627fd12857384d4db562601ae07d934f43 Fix bypass range query](https://github.com/facebook/mysql-5.6/commit/d6e960627fd12857384d4db562601ae07d934f43)
- [2ab629ce89c827fe1d7979d7e829e8540f1a0f66 Better bloom filter / iterator bounds](https://github.com/facebook/mysql-5.6/commit/2ab629ce89c827fe1d7979d7e829e8540f1a0f66)
- [3433a476f09799ff8d5732dcacea49bba8de0c65 Properly fallback if executing unsupported case](https://github.com/facebook/mysql-5.6/commit/3433a476f09799ff8d5732dcacea49bba8de0c65)
- [447a007917f4790bc76e1abf419e1135a7d621cc Add switch to disallow filters](https://github.com/facebook/mysql-5.6/commit/447a007917f4790bc76e1abf419e1135a7d621cc)
- [d8b41a873108003c440ba5d6f241a78f41a38d23 Need to consider all table fields when determine index/value packing](https://github.com/facebook/mysql-5.6/commit/d8b41a873108003c440ba5d6f241a78f41a38d23)
- [8cfd60b4242f246049c24df3da51ff5e179b884d Remove field limit and support VARBINARY](https://github.com/facebook/mysql-5.6/commit/8cfd60b4242f246049c24df3da51ff5e179b884d)
- [f82fbc6ee138babca6fd8bf22716606a58a95fa8 Unique SK Point lookup actually go through point look up path](https://github.com/facebook/mysql-5.6/commit/f82fbc6ee138babca6fd8bf22716606a58a95fa8)
- [4593eb5c537afe2e12d13c7bc57b9f3c0770905a Add db id prefix in MyRocks key format](https://github.com/facebook/mysql-5.6/commit/4593eb5c537afe2e12d13c7bc57b9f3c0770905a)
- [10dad4e940ee51bc5b8b058c15512ec4aa2b46d0 Add max index number per database](https://github.com/facebook/mysql-5.6/commit/10dad4e940ee51bc5b8b058c15512ec4aa2b46d0)
- [1d39dc250a9e683f42b84d6a2062d9d46a1324c5 Fix rocksdb.add_index_inplace](https://github.com/facebook/mysql-5.6/commit/1d39dc250a9e683f42b84d6a2062d9d46a1324c5)
- [e9526144cb3ecc4187867fca5a7fe80b483c488a Revert change to slave_preserve_commit_order and add mts_dependency_order_commits](https://github.com/facebook/mysql-5.6/commit/e9526144cb3ecc4187867fca5a7fe80b483c488a)

6. Skipped upstream commits:
- [ab08a874f4251a7e47166531afa80d5644c85992 recover raft logs by removing partial trxs](https://github.com/facebook/mysql-5.6/commit/ab08a874f4251a7e47166531afa80d5644c85992)
- [247d62293102920f5993b69c585fb97216d0cd6d Checking for inited bool to make sure global_init_info was successful](https://github.com/facebook/mysql-5.6/commit/247d62293102920f5993b69c585fb97216d0cd6d)
- [bad2bac3672ffb95c384a7def9db6b51253cd319 Support for dumping raft logs to vanilla async replicas](https://github.com/facebook/mysql-5.6/commit/bad2bac3672ffb95c384a7def9db6b51253cd319)
- [b93478b6b8cc242c483e33071985fb5e29e14d5c Add server_cpu and warnings to query response attributes](https://github.com/facebook/mysql-5.6/commit/b93478b6b8cc242c483e33071985fb5e29e14d5c)
- [231f238bf8ba0b090c7759024b71144da59c9724 Fixed the flaky raft test suite](https://github.com/facebook/mysql-5.6/commit/231f238bf8ba0b090c7759024b71144da59c9724)
- [858494fa44598e20e699d9a3614b4dca37c5e899 switch back to server1 connection](https://github.com/facebook/mysql-5.6/commit/858494fa44598e20e699d9a3614b4dca37c5e899)
- [ca660cf99d0af5161d2d14eeb3c3b20e9de78822 return error from Raft_replication_delegate when plugin is not available](https://github.com/facebook/mysql-5.6/commit/ca660cf99d0af5161d2d14eeb3c3b20e9de78822)
- [5823346718c11747492f5e8629c3d5e6346fc3bf Fixed issues after refreshing to latest raft plugin.](https://github.com/facebook/mysql-5.6/commit/5823346718c11747492f5e8629c3d5e6346fc3bf)
- [47ccc6539fa676a5bfc89a7467286da3341ff9cf Handle printing of FD event generated by slave SQL thread](https://github.com/facebook/mysql-5.6/commit/47ccc6539fa676a5bfc89a7467286da3341ff9cf)
- [398c3fbf09549bdec7cc2add18b999fb6628e1a8 fix logging verbosity for logs generated during idempotent recovery](https://github.com/facebook/mysql-5.6/commit/398c3fbf09549bdec7cc2add18b999fb6628e1a8)
- [53abaf5a87761b87d82e14ea16ba38610871961b store full gtid set into Previous_gtids_log_event](https://github.com/facebook/mysql-5.6/commit/53abaf5a87761b87d82e14ea16ba38610871961b)
- [8e38b1e6ee8fcad2eaf0d02a91b4f7db4d138fe7 Changes required for MySQL privacy plugin](https://github.com/facebook/mysql-5.6/commit/8e38b1e6ee8fcad2eaf0d02a91b4f7db4d138fe7)
- [405ff5ce339a44f189a9ea244ea006f029d5ddd3 Bump upper limit when searching for build id](https://github.com/facebook/mysql-5.6/commit/405ff5ce339a44f189a9ea244ea006f029d5ddd3)
- [0e6ec622391a68712a3cb26080d43aa43547eb9e Fix main.max_db_connections](https://github.com/facebook/mysql-5.6/commit/0e6ec622391a68712a3cb26080d43aa43547eb9e)
- [cbbf5acca5246856c534e0e37ae0fd91e9c53f3b Adding timestamps for raft rotates which happen in the context of listener thread](https://github.com/facebook/mysql-5.6/commit/cbbf5acca5246856c534e0e37ae0fd91e9c53f3b)
- [e88c598f9fa6c9142bb619aa0c000fa8d709bf2f Raft abrupt stepdown and trim binlog file / gtid test](https://github.com/facebook/mysql-5.6/commit/e88c598f9fa6c9142bb619aa0c000fa8d709bf2f)
- [f03e9394a7a9a24aca9bba5246e2debddeda47fc Port: Fixes around raft log truncation.](https://github.com/facebook/mysql-5.6/commit/f03e9394a7a9a24aca9bba5246e2debddeda47fc)
- [4b2b2239f0a36b16e0daaa8b63d3a3006095717e Fix new slave_preserve_commit_order related failures](https://github.com/facebook/mysql-5.6/commit/4b2b2239f0a36b16e0daaa8b63d3a3006095717e)
- [0cabff1568e54fd0feace67d85b98b1db3feacef rebase due to relay log Format_description_event event size difference](https://github.com/facebook/mysql-5.6/commit/0cabff1568e54fd0feace67d85b98b1db3feacef)
- [0e407d240cbcf84e050da775be0476b49d2ea134 Rebase rpl.rpl_gtid_executed and sys_vars.response_attrs_contain_warnings_bytes_basic](https://github.com/facebook/mysql-5.6/commit/0e407d240cbcf84e050da775be0476b49d2ea134)
- [c3ca0c037c1582b039d59e39e4df26d579d791ee Fixed truncation in rbr_column_type_mismatch_whitelist when log_column_names is enabled](https://github.com/facebook/mysql-5.6/commit/c3ca0c037c1582b039d59e39e4df26d579d791ee)
- [803d19f462aa58f42cb82ca894bfde5b4d0d17ea Support for code coverage](https://github.com/facebook/mysql-5.6/commit/803d19f462aa58f42cb82ca894bfde5b4d0d17ea)
- [c1ef3d4a769c4dbe17577d4c2bd19ee33eac4bab Add max_db_connections for thread_pool plugin](https://github.com/facebook/mysql-5.6/commit/c1ef3d4a769c4dbe17577d4c2bd19ee33eac4bab)
- [c4a171acee47ee8998d2791705bd5b1357f7e388 Porting gradual write throttling and configurable throttle dimensions logic](https://github.com/facebook/mysql-5.6/commit/c4a171acee47ee8998d2791705bd5b1357f7e388)
- [ae565ac78cbc013ce24c97e02d2e32402d0566fe Fix memory bloat in my_core::handler](https://github.com/facebook/mysql-5.6/commit/ae565ac78cbc013ce24c97e02d2e32402d0566fe)
- [e7c691d4c1be05953283850d9cab543ce1d5b62e Add coverage-src-filter option to code coverage](https://github.com/facebook/mysql-5.6/commit/e7c691d4c1be05953283850d9cab543ce1d5b62e)
- [56983c10c9633ae4dee07d297998aeabbf32d00d allow install/uninstall plugin when enable_super_log_bin_read_only is enabled](https://github.com/facebook/mysql-5.6/commit/56983c10c9633ae4dee07d297998aeabbf32d00d)
- [6332aa625aa51b29839af14cb364ca8f71d735b3 fix raft change string metadata event](https://github.com/facebook/mysql-5.6/commit/6332aa625aa51b29839af14cb364ca8f71d735b3)
- [8dbe0d1070d482188e8d7b6dff3366025351a942 Handle flush and analyze commands with enable_super_log_bin_read_only](https://github.com/facebook/mysql-5.6/commit/8dbe0d1070d482188e8d7b6dff3366025351a942)
- [34ac4d4558d40356aad8121855ec4a4bac1e9573 Setting read only during shutdown](https://github.com/facebook/mysql-5.6/commit/34ac4d4558d40356aad8121855ec4a4bac1e9573)
- [f783a119a5e0a960a8762a2be029e3f7d39ea1cb Add exponential backoff for smart restart](https://github.com/facebook/mysql-5.6/commit/f783a119a5e0a960a8762a2be029e3f7d39ea1cb)
- [039eb487c36481e2401af6bb05ca6ffbb99182b7 Backport upstream changes to fix main.mysql_client_test failures](https://github.com/facebook/mysql-5.6/commit/039eb487c36481e2401af6bb05ca6ffbb99182b7)
- [b752731755504a2d0f1f222b798a1b11b5180889 Allocate a server extension structure for slave_stats_daemon](https://github.com/facebook/mysql-5.6/commit/b752731755504a2d0f1f222b798a1b11b5180889)
- [d9a95b38d9f661861827dabae2266d78cd563af2 always release data_lock mutex to avoid deadlock](https://github.com/facebook/mysql-5.6/commit/d9a95b38d9f661861827dabae2266d78cd563af2)
