### PR TITLE
PS-7666: Assertion failure: fil0fil.cc:13097:fil_system->shard_by_id(…

### DIFF
--- a/mysql-test/suite/innodb/r/drop_table_crash_debug.result
+++ b/mysql-test/suite/innodb/r/drop_table_crash_debug.result
@@ -1,0 +1,23 @@
+#
+# PS-7666 : Assertion failure: fil0fil.cc:13097:fil_system->shard_by_id(id)->mutex_owned()
+#
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+SET GLOBAL innodb_checkpoint_disabled=true;
+SET GLOBAL innodb_page_cleaner_disabled_debug=true;
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+SET DEBUG='+d, delete_crash';
+DROP TABLE t1;
+ERROR HY000: Lost connection to MySQL server during query
+# restart

--- a/mysql-test/suite/innodb/t/drop_table_crash_debug.test
+++ b/mysql-test/suite/innodb/t/drop_table_crash_debug.test
@@ -1,0 +1,32 @@
+--echo #
+--echo # PS-7666 : Assertion failure: fil0fil.cc:13097:fil_system->shard_by_id(id)->mutex_owned()
+--echo #
+
+--source include/have_debug.inc
+--source include/not_valgrind.inc
+
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+SET GLOBAL innodb_checkpoint_disabled=true;
+SET GLOBAL innodb_page_cleaner_disabled_debug=true;
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 VALUES (1),(2),(3),(4);
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+INSERT INTO t1 SELECT * FROM t1;
+--source include/expect_crash.inc
+SET DEBUG='+d, delete_crash';
+--error 2013
+DROP TABLE t1;
+
+--source include/wait_until_disconnected.inc
+--source include/start_mysqld.inc
+assert(`SELECT COUNT(*)=0 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA='test' AND TABLE_NAME='t1'`);
+

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -3382,7 +3382,10 @@ static bool fil_space_free(space_id_t space_id, bool x_latched) {
     rw_lock_x_unlock(&space->latch);
   }
 
+  shard->mutex_acquire();
   Fil_shard::space_free_low(space);
+  shard->mutex_release();
+
   ut_a(space == nullptr);
 
   return true;
@@ -4970,6 +4973,9 @@ dberr_t Fil_shard::space_delete(space_id_t space_id, buf_remove_t buf_remove) {
     fil_op_write_log(MLOG_FILE_DELETE, space_id, path, nullptr, 0, &mtr);
 
     mtr.commit();
+
+    DBUG_EXECUTE_IF("delete_crash", log_buffer_flush_to_disk();
+                    DBUG_SUICIDE(););
 
     /* Even if we got killed shortly after deleting the
     tablespace file, the record must have already been


### PR DESCRIPTION
…id)->mutex_owned()

https://jira.percona.com/browse/PS-7666

Problem:
--------
On debug builds, a crash during DROP TABLE operation, makes the database unusable.
InnoDB will enter crash recovery but it will keep crashing with the
same assertion failure

For the DROP TABLE operation, InnoDB writes MLOG_FILE_DELETE redo log entry.
A subsequent start, InnoDB will enter crash recovery and tries to replay the
operation. During this replay, it tries to delete the file again and remove
the in-memory tablespace object (fil_space_t).

Removal of the in-memory tablespace object fails with assertion failure as
it expect the Fil_system->Fil_shard mutex to be taken.

Fix:
----
Acquire Fil_system->Fil_shard mutex for the in-memory space removal and release
after it is done with removal