### PR TITLE
PS-7772: Fix rocksdb_stress MTR tests to work with old python connectors

### DIFF
--- a/mysql-test/suite/rocksdb_stress/include/rocksdb_stress.inc
+++ b/mysql-test/suite/rocksdb_stress/include/rocksdb_stress.inc
@@ -6,13 +6,16 @@
 --connection master
 --let $master_host = 127.0.0.1
 
+CREATE USER 'rocksdb_stress_test'@'localhost' IDENTIFIED WITH 'mysql_native_password';
+GRANT ALL ON *.* TO 'rocksdb_stress_test'@'localhost';
+
 let $exec =
   python $MYSQL_TEST_DIR/suite/rocksdb_stress/t/load_generator.py
   -L $MYSQL_TMP_DIR/load_generator.log -H $master_host -t $table
   -P $MASTER_MYPORT -n $num_records -m $max_records
   -l $num_loaders -c $num_checkers -r $num_requests
   -E $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-  -D $reap_delay;
+  -D $reap_delay -u rocksdb_stress_test;
 
 exec $exec;
 
@@ -38,6 +41,7 @@ if ($not_same)
 
 # Cleanup
 --connection master
+DROP USER 'rocksdb_stress_test'@'localhost';
 --let $cleanup = DROP TABLE $table
 eval $cleanup;
 

--- a/mysql-test/suite/rocksdb_stress/r/drop_cf_stress.result
+++ b/mysql-test/suite/rocksdb_stress/r/drop_cf_stress.result
@@ -1,3 +1,5 @@
+CREATE USER 'drop_cf_test'@'localhost' IDENTIFIED WITH 'mysql_native_password';
+GRANT ALL ON *.* TO 'drop_cf_test'@'localhost';
 CREATE TABLE tables (
 table_id int NOT NULL,
 created BOOLEAN NOT NULL,
@@ -39,3 +41,4 @@ INSERT INTO cfs VALUES(6, 0, 0);
 INSERT INTO cfs VALUES(7, 0, 0);
 DROP TABLE tables;
 DROP TABLE cfs;
+DROP USER 'drop_cf_test'@'localhost';

--- a/mysql-test/suite/rocksdb_stress/r/rocksdb_stress.result
+++ b/mysql-test/suite/rocksdb_stress/r/rocksdb_stress.result
@@ -12,12 +12,15 @@ msg_length int,
 msg_checksum varchar(128),
 KEY msg_i(msg(255), zero_sum))
 ENGINE=RocksDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
+CREATE USER 'rocksdb_stress_test'@'localhost' IDENTIFIED WITH 'mysql_native_password';
+GRANT ALL ON *.* TO 'rocksdb_stress_test'@'localhost';
 stop slave;
 Warnings:
 Warning	1287	'STOP SLAVE' is deprecated and will be removed in a future release. Please use STOP REPLICA instead
 start slave;
 Warnings:
 Warning	1287	'START SLAVE' is deprecated and will be removed in a future release. Please use START REPLICA instead
+DROP USER 'rocksdb_stress_test'@'localhost';
 DROP TABLE t1;
 stop slave;
 Warnings:

--- a/mysql-test/suite/rocksdb_stress/r/rocksdb_stress_crash.result
+++ b/mysql-test/suite/rocksdb_stress/r/rocksdb_stress_crash.result
@@ -12,12 +12,15 @@ msg_length int,
 msg_checksum varchar(128),
 KEY msg_i(msg(255), zero_sum))
 ENGINE=RocksDB DEFAULT CHARSET=latin1 COLLATE=latin1_bin;
+CREATE USER 'rocksdb_stress_test'@'localhost' IDENTIFIED WITH 'mysql_native_password';
+GRANT ALL ON *.* TO 'rocksdb_stress_test'@'localhost';
 stop slave;
 Warnings:
 Warning	1287	'STOP SLAVE' is deprecated and will be removed in a future release. Please use STOP REPLICA instead
 start slave;
 Warnings:
 Warning	1287	'START SLAVE' is deprecated and will be removed in a future release. Please use START REPLICA instead
+DROP USER 'rocksdb_stress_test'@'localhost';
 DROP TABLE t1;
 stop slave;
 Warnings:

--- a/mysql-test/suite/rocksdb_stress/t/drop_cf_stress.test
+++ b/mysql-test/suite/rocksdb_stress/t/drop_cf_stress.test
@@ -22,7 +22,10 @@ call mtr.add_suppression("Could not get index information for Index Number");
 --let $drop_cf_weight = 9
 --let $manual_compaction_weight = 1
 
-connect (conn1,localhost,root,,);
+CREATE USER 'drop_cf_test'@'localhost' IDENTIFIED WITH 'mysql_native_password';
+GRANT ALL ON *.* TO 'drop_cf_test'@'localhost';
+
+connect (conn1,localhost,drop_cf_test,,);
 --connection conn1
 
 --let $local_host = 127.0.0.1
@@ -64,7 +67,7 @@ let $exec =
   python $MYSQL_TEST_DIR/suite/rocksdb_stress/t/drop_cf_stress.py
   -L $MYSQL_TMP_DIR/drop_cf_stress.log -H $local_host
   -P $MASTER_MYPORT
-  -w $num_workers -r $num_requests -v
+  -w $num_workers -r $num_requests -v -u drop_cf_test
   --ct-weight $create_table_weight --dt-weight $drop_table_weight
   --ai-weight $add_index_weight --di-weight $drop_index_weight
   --dc-weight $drop_cf_weight --mc-weight $manual_compaction_weight;
@@ -75,3 +78,4 @@ exec $exec;
 
 DROP TABLE tables;
 DROP TABLE cfs;
+DROP USER 'drop_cf_test'@'localhost';


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7772

In PS 8.0 default authentication plugin was changed to
caching_sha2_password. Python connector installed on most of the
platforms tested on Jenkins doesn't support this plugin and as a result
tests fail to run.
Updated rocksdb stress tests to use separate user with mysql_native_password
auth plugin for Python scripts.