### PR TITLE
PS-7742: Enabling binlog encryption breaks basic replication setup on PS

### DIFF
--- a/mysys/mf_iocache.cc
+++ b/mysys/mf_iocache.cc
@@ -387,11 +387,6 @@ bool reinit_io_cache(IO_CACHE *info, enum cache_type type, my_off_t seek_offset,
   info->error = 0;
   init_functions(info);
 
-  if (info->m_encryptor != nullptr)
-    info->m_encryptor->set_stream_offset(seek_offset);
-  if (info->m_decryptor != nullptr)
-    info->m_decryptor->set_stream_offset(seek_offset);
-
   if (DBUG_EVALUATE_IF("fault_injection_reinit_io_cache", true, false))
     return true;
   return false;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7742

Problem:
When binlog encryption is enabled, malformed binlog events can be
written into it.

Cause:
Commit 1f1fe241ffc1f5841f40be0eacde8a5a154f9a9b introduced the change in
reinit_io_cache() function adding the code which sets encryptor and
decryptor stream offset.
However, this causes that in case of reusing cache page that is
currently loaded into the memory, encryptor position is out of sync with
the position of the file. If after this reinit_io_cache() is called
again and it triggers cache buffer to be flushed to the file, the buffer
is encrypted with wrong keys.

Example:
1. Transaction starts
2. Events are added to binlog cache
3. At some point the cache is full and needs to be flushed to the file.
my_b_flush_io_cache() is called. It flushes current content of the cache
into file + part of current event (_my_b_write() logic)
4. Other events are added to the cache
5. ROLLBACK TO SAVEPOINT is executed. This causes reinit_io_cache() to
the point that is currently in memory. If we adjust encryptor here, it
will be out of sync of underlaying file
6. COMMIT is executed. This causes reinit_io_cache() call again. As the
cache is reinitialized from write to read, the buffer needs to be
flushed to file. File position and encryptor are not synchronized, so
data are written to the proper file position, but encrypted with the
wrong key.

Solution:
Remove encryptor/decryptor position adjustment code to be aligned with
upstream implementation.