### PR TITLE
PS-1955: Add all possible options to log_slow_verbosity help text (8.0)

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -508,7 +508,7 @@ The following options may be given as the first argument:
  Choose how verbose the messages to your slow log will be.
  Multiple flags allowed in a comma-separated string.
  [microtime, query_plan, innodb, profiling,
- profiling_use_getrusage]
+ profiling_use_getrusage, minimal, standard, full]
  --log-statements-unsafe-for-binlog 
  Log statements considered unsafe when using statement
  based binary logging.

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5512,7 +5512,9 @@ void init_slow_query_log_use_global_control()
 static Sys_var_set Sys_log_slow_verbosity(
         "log_slow_verbosity",
         "Choose how verbose the messages to your slow log will be. "
-        "Multiple flags allowed in a comma-separated string. [microtime, query_plan, innodb, profiling, profiling_use_getrusage]",
+        "Multiple flags allowed in a comma-separated string. "
+        "[microtime, query_plan, innodb, profiling, profiling_use_getrusage, "
+        "minimal, standard, full]",
         SESSION_VAR(log_slow_verbosity), CMD_LINE(REQUIRED_ARG),
         log_slow_verbosity_name, DEFAULT(SLOG_V_MICROTIME),
         NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(0),


### PR DESCRIPTION
https://jira.percona.com/browse/PS-1955

The "minimal", "standard", "full" options were missing in log_slow_verbosity
help text.