### PR TITLE
PS-1346: Reset enable_slow_log thd variable once log query is applied for replica thread (8.0)

### DIFF
--- a/mysql-test/suite/rpl/r/percona_log_slow_slave_statements.result
+++ b/mysql-test/suite/rpl/r/percona_log_slow_slave_statements.result
@@ -31,7 +31,7 @@ include/sync_slave_sql_with_master.inc
 [log_grep.inc] file: percona.slow_extended.log_slow_slave_statements pattern: INSERT INTO t VALUES \(3\)
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona.slow_extended.log_slow_slave_statements pattern: ^# User@Host: skip-grants user\[SQL_SLAVE\] @  \[\]
-[log_grep.inc] lines:   2
+[log_grep.inc] lines:   1
 DROP TABLE t;
 SET GLOBAL log_slow_slave_statements=@saved_log_slow_slave_statements;
 SET GLOBAL long_query_time=@saved_long_query_time;

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -4932,7 +4932,17 @@ int Query_log_event::do_apply_event(Relay_log_info const *rli,
 
       thd->variables.option_bits &= ~OPTION_MASTER_SQL_ERROR;
 
-      thd->enable_slow_log = true;
+      /*
+        Resetting the enable_slow_log thd variable.
+
+        We need to reset it back to the opt_log_slow_slave_statements
+        value after the statement execution (and slow logging
+        is done). It might have changed if the statement was an
+        admin statement (in which case, down in dispatch_sql_command execution
+        thd->enable_slow_log is set to the value of
+        opt_log_slow_admin_statements).
+      */
+      thd->enable_slow_log = opt_log_slow_slave_statements;
     } else {
       /*
         The query got a really bad error on the master (thread killed etc),

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -5000,7 +5000,7 @@ int Query_log_event::do_apply_event(Relay_log_info const *rli,
         thd->enable_slow_log is set to the value of
         opt_log_slow_admin_statements).
       */
-      thd->enable_slow_log= TRUE;
+      thd->enable_slow_log= opt_log_slow_slave_statements;
     }
     else
     {

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -225,7 +225,6 @@ extern bool opt_old_style_user_limits, trust_function_creators;
 extern bool check_proxy_users, mysql_native_password_proxy_users,
     sha256_password_proxy_users;
 extern bool opt_userstat, opt_thread_statistics;
-extern bool opt_log_slow_slave_statements;
 extern ulonglong opt_slow_query_log_use_global_control;
 extern ulong opt_slow_query_log_rate_type;
 #ifdef _WIN32


### PR DESCRIPTION
https://jira.percona.com/browse/PS-1346

In Query_log_event::do_apply_event() thd->enable_slow_log is
unconditionally set to TRUE after log query is applied on replica
server. As a result of this the log_slow_applicable() function will not
be able to properly detect if next applied record should be logged to a
slow log. It will be able to find this out only in
Query_logger::slow_log_write() after checking
opt_log_slow_slave_statements value.

To fix this the code which is supposed to reset enable_slow_log thd
variable is reverted back to upstream state.