### PR TITLE
PS-2433: Add slow and general query log file creation time to log header (8.0)

### DIFF
--- a/mysql-test/r/percona_log_creation_timestamp.result
+++ b/mysql-test/r/percona_log_creation_timestamp.result
@@ -1,0 +1,4 @@
+[log_grep.inc] file: mysqld-slow.log pattern: , Time:
+[log_grep.inc] lines:   1
+[log_grep.inc] file: mysqld.log pattern: , Time:
+[log_grep.inc] lines:   1

--- a/mysql-test/t/percona_log_creation_timestamp-master.opt
+++ b/mysql-test/t/percona_log_creation_timestamp-master.opt
@@ -1,0 +1,1 @@
+--log-output=FILE --general-log=1 --slow-query-log=1

--- a/mysql-test/t/percona_log_creation_timestamp.test
+++ b/mysql-test/t/percona_log_creation_timestamp.test
@@ -1,0 +1,16 @@
+#
+# Checking that file creation timestamp is present in slow query log and
+# generic log files header.
+#
+
+--let log_file = mysqld-slow.log
+--let log_file_full_path = `SELECT Variable_value FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE Variable_name = 'slow_query_log_file';`
+
+--let grep_pattern = , Time:
+--source include/log_grep.inc
+
+--let log_file = mysqld.log
+--let log_file_full_path = `SELECT Variable_value FROM INFORMATION_SCHEMA.GLOBAL_VARIABLES WHERE Variable_name = 'general_log_file';`
+
+--let grep_pattern = , Time:
+--source include/log_grep.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -709,19 +709,23 @@ bool File_query_log::open()
     goto err;
 
   {
+    char log_creation_time[iso8601_size];
+    make_iso8601_timestamp(log_creation_time);
+
     char *end;
-    size_t len=my_snprintf(buff, sizeof(buff), "%s, Version: %s (%s). "
+    size_t len=my_snprintf(buff, sizeof(buff), "%s, Version: %s (%s), Time: %s. "
 #ifdef EMBEDDED_LIBRARY
                         "embedded library\n",
-                        my_progname, server_version, MYSQL_COMPILATION_COMMENT
+                        my_progname, server_version, MYSQL_COMPILATION_COMMENT,
+                        log_creation_time
 #elif _WIN32
                         "started with:\nTCP Port: %d, Named Pipe: %s\n",
                         my_progname, server_version, MYSQL_COMPILATION_COMMENT,
-                        mysqld_port, mysqld_unix_port
+                        log_creation_time, mysqld_port, mysqld_unix_port
 #else
                         "started with:\nTcp port: %d  Unix socket: %s\n",
                         my_progname, server_version, MYSQL_COMPILATION_COMMENT,
-                        mysqld_port, mysqld_unix_port
+                        log_creation_time, mysqld_port, mysqld_unix_port
 #endif
                         );
     end= my_stpncpy(buff + len, "Time                 Id Command    Argument\n",


### PR DESCRIPTION
Add field named "Time" which contains log file creation timestamp.
The log header at the moment looks like the following:

mysqld, Version: 8.0.23-14 (Source distribution). started with: Tcp port: 13000  Unix socket: /tmp/mysqld.1.sock

With changes introduced in this change it will look like the following:

mysqld, Version: 8.0.23-14 (Source distribution), Time: 2021-07-12T10:19:56.373448Z. started with:
Tcp port: 13000  Unix socket: /tmp/mysqld.1.sock