### PR TITLE
PS-2346: Implement logging certain errors into slow query log

### DIFF
--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -42,7 +42,7 @@ include/assert.inc [Expect 500+ variables in the table. Due to open Bugs, we are
 
 # Test SET PERSIST
 
-include/assert.inc [Expect 492 persisted variables in the table.]
+include/assert.inc [Expect 493 persisted variables in the table.]
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -50,9 +50,9 @@ include/assert.inc [Expect 492 persisted variables in the table.]
 ************************************************************
 # restart
 
-include/assert.inc [Expect 492 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 492 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 492 persisted variables with matching peristed and global values.]
+include/assert.inc [Expect 493 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 493 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 493 persisted variables with matching peristed and global values.]
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -589,6 +589,11 @@ The following options may be given as the first argument:
  --log-queries-not-using-indexes 
  Log queries that are executed without benefit of any
  index to the slow log if it is open
+ --log-query-errors=# 
+ Log queries which failed with the specified error code.
+ Multiple error codes are allowed in comma-separated
+ string. Can be set to ALL to match all possible error
+ codes.
  --log-raw           Log to general log before any rewriting of the query. For
  use in debugging, not production as sensitive information
  may be logged.
@@ -1499,7 +1504,7 @@ The following options may be given as the first argument:
  Multiple flags allowed in a comma-separated string.
  [none, log_slow_filter, log_slow_rate_limit,
  log_slow_verbosity, long_query_time,
- min_examined_row_limit, all]
+ min_examined_row_limit, log_query_errors, all]
  --socket=name       Socket file to use for connection
  --sort-buffer-size=# 
  Each thread that needs to do a sort allocates a buffer of
@@ -1823,6 +1828,7 @@ log-error-verbosity 2
 log-isam myisam.log
 log-output FILE
 log-queries-not-using-indexes FALSE
+log-query-errors (Disabled)
 log-raw FALSE
 log-replica-updates FALSE
 log-short-format FALSE

--- a/mysql-test/r/percona_log_slow_query_errors.result
+++ b/mysql-test/r/percona_log_slow_query_errors.result
@@ -1,0 +1,14 @@
+SELECT * FROM t1;
+ERROR 42S02: Table 'test.t1' doesn't exist
+SET SESSION log_query_errors="1146";
+SELECT * FROM t1;
+ERROR 42S02: Table 'test.t1' doesn't exist
+CREATE TABLE t1 (i int);
+SET SESSION log_query_errors="ALL";
+SELECT j from t1;
+ERROR 42S22: Unknown column 'j' in 'field list'
+[log_grep.inc] file: mysqld-slow.log pattern: SELECT \* FROM t1
+[log_grep.inc] lines:   1
+[log_grep.inc] file: mysqld-slow.log pattern: SELECT j from t1
+[log_grep.inc] lines:   1
+DROP TABLE t1;

--- a/mysql-test/suite/sys_vars/r/log_query_errors_basic.result
+++ b/mysql-test/suite/sys_vars/r/log_query_errors_basic.result
@@ -1,0 +1,245 @@
+SET @old_log_query_errors = @@global.log_query_errors;
+# check default empty value
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	
+
+# set global to ALL, session is unset
+SET GLOBAL log_query_errors=all;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+ALL
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	ALL
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	ALL
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	
+
+# unset global, set session to ALL
+SET GLOBAL log_query_errors="";
+SET SESSION log_query_errors=all;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+ALL
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	ALL
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	ALL
+
+# set both to ALL
+SET GLOBAL log_query_errors=all;
+SET SESSION log_query_errors=all;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+ALL
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+ALL
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	ALL
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+Variable_name	Value
+log_query_errors	ALL
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	ALL
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+VARIABLE_NAME	VARIABLE_VALUE
+log_query_errors	ALL
+
+# set to default
+SET SESSION log_query_errors=default;
+SET GLOBAL log_query_errors=default;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+
+
+# set some codes
+SET GLOBAL log_query_errors="1010,1011,1012";
+SET SESSION log_query_errors="2010,2011,2012";
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+1010,1011,1012
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+2010,2011,2012
+
+# set one code
+SET GLOBAL log_query_errors="1000";
+SET SESSION log_query_errors="2000";
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+1000
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+2000
+
+# set max allowed number of codes
+SET GLOBAL log_query_errors="1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012,1013,1014,1015,1016,1017,1018,1019,1020,1021,1022,1023,1024,1025,1026,1027,1028,1029,1030,1031,1032,1033,1034,1035,1036,1037,1038,1039,1040,1041,1042,1043,1044,1045,1046,1047,1048,1049,1050,1051,1052,1053,1054,1055,1056,1057,1058,1059,1060,1061,1062,1063,1064";
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012,1013,1014,1015,1016,1017,1018,1019,1020,1021,1022,1023,1024,1025,1026,1027,1028,1029,1030,1031,1032,1033,1034,1035,1036,1037,1038,1039,1040,1041,1042,1043,1044,1045,1046,1047,1048,1049,1050,1051,1052,1053,1054,1055,1056,1057,1058,1059,1060,1061,1062,1063,1064
+
+# set more than max allowed number of codes
+SET GLOBAL log_query_errors="1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012,1013,1014,1015,1016,1017,1018,1019,1020,1021,1022,1023,1024,1025,1026,1027,1028,1029,1030,1031,1032,1033,1034,1035,1036,1037,1038,1039,1040,1041,1042,1043,1044,1045,1046,1047,1048,1049,1050,1051,1052,1053,1054,1055,1056,1057,1058,1059,1060,1061,1062,1063,1064,1065";
+ERROR HY000: The number of provided error codes exceeds the maximum allowed 64
+
+# check ALL in upper and in lower case is accepted
+SET GLOBAL log_query_errors=all;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+ALL
+SET GLOBAL log_query_errors=ALL;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+ALL
+
+# check it fails with non-numeric code added to the list
+SET GLOBAL log_query_errors="1010,aaaa,1012";
+ERROR 42000: Variable 'log_query_errors' can't be set to the value of '1010,aaaa,1012'
+SET GLOBAL log_query_errors="1-34,23-13";
+ERROR 42000: Variable 'log_query_errors' can't be set to the value of '1-34,23-13'
+
+# check spaces only string, should be processed as empty string
+SET GLOBAL log_query_errors=' ';
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SET GLOBAL log_query_errors="  ";
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+
+# check negative code
+SET GLOBAL log_query_errors="-1000";
+ERROR 42000: Variable 'log_query_errors' can't be set to the value of '-1000'
+SET GLOBAL log_query_errors=" / ";
+ERROR 42000: Variable 'log_query_errors' can't be set to the value of ' / '
+
+# check some wrong types
+SET GLOBAL log_query_errors=1.1;
+ERROR 42000: Incorrect argument type to variable 'log_query_errors'
+SET GLOBAL log_query_errors=1e1;
+ERROR 42000: Incorrect argument type to variable 'log_query_errors'
+SET GLOBAL log_query_errors=-7;
+ERROR 42000: Incorrect argument type to variable 'log_query_errors'
+SET GLOBAL log_query_errors=0;
+ERROR 42000: Incorrect argument type to variable 'log_query_errors'
+
+# check too big number
+SET GLOBAL log_query_errors="92233720368547758070,123";
+ERROR HY000: Provided error code is bigger than maximum allowed 9223372036854775807
+SET GLOBAL log_query_errors="123,92233720368547758070";
+ERROR HY000: Provided error code is bigger than maximum allowed 9223372036854775807
+SET GLOBAL log_query_errors="92233720368547758070";
+ERROR HY000: Provided error code is bigger than maximum allowed 9223372036854775807
+
+# check SET PERSIST
+SET GLOBAL log_query_errors="1000";
+SET SESSION log_query_errors="2000";
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+1000
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+2000
+SET PERSIST log_query_errors="3000";
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+3000
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+2000
+# restart
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+3000
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+3000
+SET PERSIST log_query_errors=default;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+3000
+# restart
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+
+
+# check SET PERSIST_ONLY
+SET PERSIST_ONLY log_query_errors="4000";
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+
+# restart
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+4000
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+4000
+SET PERSIST_ONLY log_query_errors=default;
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+4000
+# restart
+SELECT @@global.log_query_errors;
+@@global.log_query_errors
+
+SELECT @@session.log_query_errors;
+@@session.log_query_errors
+
+RESET PERSIST;
+SET @@global.log_query_errors = @old_log_query_errors;

--- a/mysql-test/suite/sys_vars/r/slow_query_log_use_global_control_basic.result
+++ b/mysql-test/suite/sys_vars/r/slow_query_log_use_global_control_basic.result
@@ -23,7 +23,7 @@ slow_query_log_use_global_control
 SET GLOBAL slow_query_log_use_global_control=all;
 SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
 Variable_name	Value
-slow_query_log_use_global_control	log_slow_filter,log_slow_rate_limit,log_slow_verbosity,long_query_time,min_examined_row_limit
+slow_query_log_use_global_control	log_slow_filter,log_slow_rate_limit,log_slow_verbosity,long_query_time,min_examined_row_limit,log_query_errors
 SET GLOBAL slow_query_log_use_global_control='';
 SHOW VARIABLES LIKE 'slow_query_log_use_global_control';
 Variable_name	Value

--- a/mysql-test/suite/sys_vars/t/log_query_errors_basic.test
+++ b/mysql-test/suite/sys_vars/t/log_query_errors_basic.test
@@ -1,0 +1,170 @@
+SET @old_log_query_errors = @@global.log_query_errors;
+
+--echo # check default empty value
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+--disable_warnings
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+--enable_warnings
+
+--echo
+--echo # set global to ALL, session is unset
+SET GLOBAL log_query_errors=all;
+
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+--disable_warnings
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+--enable_warnings
+
+--echo
+--echo # unset global, set session to ALL
+SET GLOBAL log_query_errors="";
+SET SESSION log_query_errors=all;
+
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+--disable_warnings
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+--enable_warnings
+
+--echo
+--echo # set both to ALL
+SET GLOBAL log_query_errors=all;
+SET SESSION log_query_errors=all;
+
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+SHOW GLOBAL VARIABLES LIKE 'log_query_errors';
+SHOW SESSION VARIABLES LIKE 'log_query_errors';
+--disable_warnings
+SELECT * FROM performance_schema.global_variables WHERE variable_name='log_query_errors';
+SELECT * FROM performance_schema.session_variables WHERE variable_name='log_query_errors';
+--enable_warnings
+
+--echo
+--echo # set to default
+SET SESSION log_query_errors=default;
+SET GLOBAL log_query_errors=default;
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+
+--echo
+--echo # set some codes
+SET GLOBAL log_query_errors="1010,1011,1012";
+SET SESSION log_query_errors="2010,2011,2012";
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+
+--echo
+--echo # set one code
+SET GLOBAL log_query_errors="1000";
+SET SESSION log_query_errors="2000";
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+
+--echo
+--echo # set max allowed number of codes
+SET GLOBAL log_query_errors="1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012,1013,1014,1015,1016,1017,1018,1019,1020,1021,1022,1023,1024,1025,1026,1027,1028,1029,1030,1031,1032,1033,1034,1035,1036,1037,1038,1039,1040,1041,1042,1043,1044,1045,1046,1047,1048,1049,1050,1051,1052,1053,1054,1055,1056,1057,1058,1059,1060,1061,1062,1063,1064";
+SELECT @@global.log_query_errors;
+
+--echo
+--echo # set more than max allowed number of codes
+--error ER_TOO_MANY_ERROR_CODES
+SET GLOBAL log_query_errors="1001,1002,1003,1004,1005,1006,1007,1008,1009,1010,1011,1012,1013,1014,1015,1016,1017,1018,1019,1020,1021,1022,1023,1024,1025,1026,1027,1028,1029,1030,1031,1032,1033,1034,1035,1036,1037,1038,1039,1040,1041,1042,1043,1044,1045,1046,1047,1048,1049,1050,1051,1052,1053,1054,1055,1056,1057,1058,1059,1060,1061,1062,1063,1064,1065";
+
+--echo
+--echo # check ALL in upper and in lower case is accepted
+SET GLOBAL log_query_errors=all;
+SELECT @@global.log_query_errors;
+SET GLOBAL log_query_errors=ALL;
+SELECT @@global.log_query_errors;
+
+--echo
+--echo # check it fails with non-numeric code added to the list
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_query_errors="1010,aaaa,1012";
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_query_errors="1-34,23-13";
+
+--echo
+--echo # check spaces only string, should be processed as empty string
+SET GLOBAL log_query_errors=' ';
+SELECT @@global.log_query_errors;
+SET GLOBAL log_query_errors="  ";
+SELECT @@global.log_query_errors;
+
+--echo
+--echo # check negative code
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_query_errors="-1000";
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL log_query_errors=" / ";
+
+--echo
+--echo # check some wrong types
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL log_query_errors=1.1;
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL log_query_errors=1e1;
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL log_query_errors=-7;
+--error ER_WRONG_TYPE_FOR_VAR
+SET GLOBAL log_query_errors=0;
+
+--echo
+--echo # check too big number
+--error ER_TOO_BIG_ERROR_CODE
+SET GLOBAL log_query_errors="92233720368547758070,123";
+--error ER_TOO_BIG_ERROR_CODE
+SET GLOBAL log_query_errors="123,92233720368547758070";
+--error ER_TOO_BIG_ERROR_CODE
+SET GLOBAL log_query_errors="92233720368547758070";
+
+--echo
+--echo # check SET PERSIST
+SET GLOBAL log_query_errors="1000";
+SET SESSION log_query_errors="2000";
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+SET PERSIST log_query_errors="3000";
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+--source include/restart_mysqld.inc
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+
+SET PERSIST log_query_errors=default;
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+--source include/restart_mysqld.inc
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+
+--echo
+--echo # check SET PERSIST_ONLY
+SET PERSIST_ONLY log_query_errors="4000";
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+--source include/restart_mysqld.inc
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+
+SET PERSIST_ONLY log_query_errors=default;
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+--source include/restart_mysqld.inc
+SELECT @@global.log_query_errors;
+SELECT @@session.log_query_errors;
+
+RESET PERSIST;
+SET @@global.log_query_errors = @old_log_query_errors;

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -43,7 +43,7 @@ call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* Changing innodb_extend_and_i
 call mtr.add_suppression("Failed to initialize TLS for channel: mysql_main");
 
 let $total_global_vars=`SELECT COUNT(*) FROM performance_schema.global_variables where variable_name NOT LIKE 'ndb_%'`;
-let $total_persistent_vars=492;
+let $total_persistent_vars=493;
 
 --echo ***************************************************************
 --echo * 0. Verify that variables present in performance_schema.global

--- a/mysql-test/t/percona_log_slow_query_errors-master.opt
+++ b/mysql-test/t/percona_log_slow_query_errors-master.opt
@@ -1,0 +1,1 @@
+--slow-query-log=1

--- a/mysql-test/t/percona_log_slow_query_errors.test
+++ b/mysql-test/t/percona_log_slow_query_errors.test
@@ -1,0 +1,30 @@
+#
+# Checking that queries failing with error code set in log_query_errors
+# are getting added into slow query log.
+#
+
+--let log_file = mysqld-slow.log
+--let log_file_full_path = `SELECT Variable_value FROM performance_schema.global_variables WHERE Variable_name = 'slow_query_log_file';`
+
+# Shouldn't be logged
+--error ER_NO_SUCH_TABLE
+SELECT * FROM t1;
+
+# Should be printed to slow log
+SET SESSION log_query_errors="1146";
+--error ER_NO_SUCH_TABLE
+SELECT * FROM t1;
+
+# Should be printed to slow log as well
+CREATE TABLE t1 (i int);
+SET SESSION log_query_errors="ALL";
+--error ER_BAD_FIELD_ERROR
+SELECT j from t1;
+
+--let grep_pattern = SELECT \* FROM t1
+--source include/log_grep.inc
+
+--let grep_pattern = SELECT j from t1
+--source include/log_grep.inc
+
+DROP TABLE t1;

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -9696,6 +9696,12 @@ ER_WRAPPED_UDF_EXCEPTION
 ER_DROP_MULTI_TABLE
   eng "Multi table drop is not supported when '%s' option is enabled"
 
+ER_TOO_MANY_ERROR_CODES
+  eng "The number of provided error codes exceeds the maximum allowed %lu"
+
+ER_TOO_BIG_ERROR_CODE
+  eng "Provided error code is bigger than maximum allowed %lu"
+
 #
 # End of Percona Server 8.0 client messages
 #

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -306,7 +306,7 @@ ER_VERBOSE_REQUIRES_HELP
   eng "--verbose is for use with --help; did you mean --log-error-verbosity?"
 
 ER_POINTLESS_WITHOUT_SLOWLOG
-  eng "options --log-slow-admin-statements, --log-queries-not-using-indexes and --log-slow-replica-statements have no effect if --slow-query-log is not set"
+  eng "options --log-slow-admin-statements, --log-queries-not-using-indexes, --log-slow-replica-statements and --log-query-errors have no effect if --slow-query-log is not set"
 
 ER_WASTEFUL_NET_BUFFER_SIZE
   eng "net_buffer_length (%lu) is set to be larger than max_allowed_packet (%lu). Please rectify."

--- a/sql/log.h
+++ b/sql/log.h
@@ -94,6 +94,10 @@ struct TABLE_LIST;
     Values: ON, OFF
     Control slow query logging of queries that do not use indexes.
 
+  --log-query-errors
+    Values: ALL, comma separated list of code errors
+    Control slow query logging of queries failed with the specified error code.
+
   --log-raw
     Values: ON, OFF
     Control query rewrite of passwords to the general log.

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -10915,7 +10915,8 @@ static int get_options(int *argc_ptr, char ***argv_ptr) {
   if (!opt_help && opt_verbose) LogErr(ERROR_LEVEL, ER_VERBOSE_REQUIRES_HELP);
 
   if ((opt_log_slow_admin_statements || opt_log_queries_not_using_indexes ||
-       opt_log_slow_replica_statements) &&
+       opt_log_slow_replica_statements ||
+       global_system_variables.log_query_errors.check_variable_set()) &&
       !opt_slow_log)
     LogErr(WARNING_LEVEL, ER_POINTLESS_WITHOUT_SLOWLOG);
 

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -186,6 +186,7 @@ enum enum_slow_query_log_use_global_control {
   SLOG_UG_LOG_SLOW_VERBOSITY,
   SLOG_UG_LONG_QUERY_TIME,
   SLOG_UG_MIN_EXAMINED_ROW_LIMIT,
+  SLOG_UG_LOG_QUERY_ERRORS,
   SLOG_UG_ALL
 };
 enum enum_log_slow_verbosity {

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6032,6 +6032,14 @@ static Sys_var_set Sys_log_slow_filter(
     SESSION_VAR(log_slow_filter), CMD_LINE(REQUIRED_ARG), log_slow_filter_name,
     DEFAULT(0));
 
+static Sys_var_errors_set Sys_log_query_errors(
+    "log_query_errors",
+    "Log queries which failed with the specified error code. "
+    "Multiple error codes are allowed in comma-separated string. "
+    "Can be set to ALL to match all possible error codes.",
+    SESSION_VAR(log_query_errors), CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET,
+    NO_MUTEX_GUARD, NOT_IN_BINLOG);
+
 static Sys_var_ulong sys_log_slow_rate_limit(
     "log_slow_rate_limit",
     "Rate limit statement writes to slow log to only those from every "
@@ -6142,6 +6150,7 @@ static const char *slow_query_log_use_global_control_name[] = {
     "log_slow_verbosity",
     "long_query_time",
     "min_examined_row_limit",
+    "log_query_errors",
     "all",
     nullptr};
 
@@ -6153,7 +6162,8 @@ static bool update_slow_query_log_use_global_control(sys_var *, THD *,
         (1ULL << SLOG_UG_LOG_SLOW_RATE_LIMIT) |
         (1ULL << SLOG_UG_LOG_SLOW_VERBOSITY) |
         (1ULL << SLOG_UG_LONG_QUERY_TIME) |
-        (1ULL << SLOG_UG_MIN_EXAMINED_ROW_LIMIT);
+        (1ULL << SLOG_UG_MIN_EXAMINED_ROW_LIMIT) |
+        (1ULL << SLOG_UG_LOG_QUERY_ERRORS);
   }
   return false;
 }
@@ -6201,7 +6211,7 @@ static Sys_var_set_none Sys_slow_query_log_use_global_control(
     "Choose flags, wich always use the global variables. Multiple flags "
     "allowed in a comma-separated string. [none, log_slow_filter, "
     "log_slow_rate_limit, log_slow_verbosity, long_query_time, "
-    "min_examined_row_limit, all]",
+    "min_examined_row_limit, log_query_errors, all]",
     GLOBAL_VAR(opt_slow_query_log_use_global_control), CMD_LINE(REQUIRED_ARG),
     slow_query_log_use_global_control_name, DEFAULT(0), NO_MUTEX_GUARD,
     NOT_IN_BINLOG, ON_CHECK(0),

--- a/sql/sys_vars.h
+++ b/sql/sys_vars.h
@@ -3012,4 +3012,81 @@ class Sys_var_binlog_encryption : public Sys_var_bool {
   bool global_update(THD *thd, set_var *var) override;
 };
 
+class Sys_var_errors_set : public sys_var {
+ public:
+  Sys_var_errors_set(
+      const char *name_arg, const char *comment, int flag_args, ptrdiff_t off,
+      size_t size MY_ATTRIBUTE((unused)), CMD_LINE getopt,
+      enum charset_enum is_os_charset_arg, PolyLock *lock = nullptr,
+      enum binlog_status_enum binlog_status_arg = VARIABLE_NOT_IN_BINLOG,
+      on_check_function on_check_func = nullptr,
+      on_update_function on_update_func = nullptr,
+      const char *substitute = nullptr, int parse_flag = PARSE_NORMAL)
+      : sys_var(&all_sys_vars, name_arg, comment, flag_args, off, getopt.id,
+                getopt.arg_type, SHOW_CHAR, 0, lock, binlog_status_arg,
+                on_check_func, on_update_func, substitute, parse_flag) {
+    is_os_charset = is_os_charset_arg == IN_FS_CHARSET;
+    assert(size == sizeof(Query_errors_set));
+    static_cast<Query_errors_set *>(option.value)->clear_all();
+  }
+
+  void saved_value_to_string(THD *, set_var *var, char *dest) override {
+    if (var->value != nullptr) {
+      String str;
+      String *val_str = var->value->val_str(&str);
+      strncpy(dest, val_str->ptr(), val_str->length());
+    }
+  }
+  void persist_only_to_string(THD *, set_var *var, String *dest) override {
+    if (var->value != nullptr) {
+      String str;
+      String *val_str = var->value->val_str(&str);
+      dest->copy(val_str->ptr(), val_str->length(), system_charset_info);
+    }
+  }
+  bool check_update_type(Item_result type) override {
+    return type != STRING_RESULT;
+  }
+  bool do_check(THD *, set_var *var) override {
+    String str;
+    String *val = var->value->val_str(&str);
+    return !Query_errors_set::check(val);
+  }
+  void session_save_default(THD *thd, set_var *) override {
+    ((Query_errors_set *)session_var_ptr(thd))->clear_all();
+  }
+  void global_save_default(THD *, set_var *) override {
+    ((Query_errors_set *)global_var_ptr())->clear_all();
+  }
+  bool session_update(THD *thd, set_var *var) override {
+    if (var->value != nullptr) {
+      String str;
+      String *val = var->value->val_str(&str);
+      return !((Query_errors_set *)session_var_ptr(thd))->set_codes(val);
+    }
+    return false;
+  }
+  bool global_update(THD *, set_var *var) override {
+    if (var->value != nullptr) {
+      String str;
+      String *val = var->value->val_str(&str);
+      return !((Query_errors_set *)global_var_ptr())->set_codes(val);
+    }
+    return false;
+  }
+  const uchar *session_value_ptr(THD *running_thd, THD *target_thd,
+                                 LEX_STRING *) override {
+    char buf[Query_errors_set::MAX_TEXT_LENGTH + 1];
+    ((Query_errors_set *)session_var_ptr(target_thd))->to_string(buf);
+    char *ret = running_thd->mem_strdup(buf);
+    return (uchar *)ret;
+  }
+  const uchar *global_value_ptr(THD *thd, LEX_STRING *) override {
+    char buf[Query_errors_set::MAX_TEXT_LENGTH + 1];
+    ((Query_errors_set *)global_var_ptr())->to_string(buf);
+    char *ret = thd->mem_strdup(buf);
+    return (uchar *)ret;
+  }
+};
+
 #endif /* SYS_VARS_H_INCLUDED */

--- a/sql/system_variables.cc
+++ b/sql/system_variables.cc
@@ -94,3 +94,5 @@ void add_diff_to_status(System_status_var *to_var, System_status_var *from_var,
 void reset_system_status_vars(System_status_var *status_vars) {
   memset(status_vars, 0, sizeof(*status_vars));
 }
+
+const String Query_errors_set::LOG_ALL = String("ALL", system_charset_info);

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -31,8 +31,10 @@
 #include "my_inttypes.h"
 #include "my_sqlcommand.h"
 #include "my_thread_local.h"     // my_thread_id
+#include "mysqld_error.h"
 #include "sql/rpl_gtid.h"        // Gitd_specification
 #include "sql/sql_plugin_ref.h"  // plugin_ref
+#include "sql_string.h"
 
 class MY_LOCALE;
 class Time_zone;
@@ -199,6 +201,160 @@ struct fragmentation_stats_t {
                                               query (in bytes) */
 };
 
+class Query_errors_set {
+ public:
+  static constexpr uint8_t MAX_CODES_NUM = 64;
+  static constexpr uint32_t MAX_TEXT_LENGTH =
+      std::numeric_limits<uint32_t>::digits10 * MAX_CODES_NUM + MAX_CODES_NUM;
+  static const String LOG_ALL;
+
+ private:
+  bool is_all_set;
+  uint32_t codes[MAX_CODES_NUM];
+
+  void set_all() {
+    if (!is_all_set) {
+      clear_all();
+      is_all_set = true;
+    }
+  }
+
+ public:
+  void clear_all() {
+    is_all_set = false;
+    for (uint32_t &code : codes) {
+      code = 0;
+    }
+  }
+
+  static bool check(const String *str) {
+    if (str == nullptr || str->is_empty()) {
+      return true;
+    }
+    if (stringcmp(str, &LOG_ALL) == 0) {
+      return true;
+    }
+
+    const char *val = str->ptr();
+
+    for (; my_isspace(system_charset_info, *val); ++val) /* empty */
+      ;
+
+    uint8_t codes_count = 0;
+    uint8_t digits_count = 0;
+
+    for (const char *p = val; *p; ++p) {
+      if (!my_isdigit(system_charset_info, *p) && *p != ',') {
+        return false;
+      }
+
+      if (*p == ',' && ++codes_count == MAX_CODES_NUM) {
+        my_error(ER_TOO_MANY_ERROR_CODES, MYF(0), MAX_CODES_NUM);
+        return false;
+      }
+
+      if (my_isdigit(system_charset_info, *p)) {
+        ++digits_count;
+      }
+      if ((*p == ',' || static_cast<size_t>(p - val) + 1 == str->length()) &&
+          digits_count > 0) {
+        long err_code = 0;
+        const char *code_start =
+            (*p == ',') ? p - digits_count : p - digits_count + 1;
+        if (!str2int(code_start, 10, 0, LONG_MAX, &err_code)) {
+          my_error(ER_TOO_BIG_ERROR_CODE, MYF(0), LONG_MAX);
+          return false;
+        }
+        digits_count = 0;
+      }
+    }
+
+    return true;
+  }
+
+  bool set_codes(const String *str) {
+    if (str == nullptr || str->is_empty()) {
+      clear_all();
+      return true;
+    }
+    if (stringcmp(str, &LOG_ALL) == 0) {
+      set_all();
+      return true;
+    }
+
+    const char *val = str->ptr();
+
+    for (; my_isspace(system_charset_info, *val); ++val) /* empty */
+      ;
+
+    clear_all();
+    uint8_t error_index = 0;
+
+    for (const char *p = val; *p;) {
+      long err_code;
+      if (!(p = str2int(p, 10, 0, LONG_MAX, &err_code))) {
+        break;
+      }
+
+      if (error_index == MAX_CODES_NUM) {
+        // Too many codes, should have been detected in check()
+        return true;
+      }
+
+      codes[error_index] = err_code;
+      ++error_index;
+
+      while (!my_isdigit(system_charset_info, *p) && *p) {
+        p++;
+      }
+    }
+
+    return true;
+  }
+
+  size_t to_string(char *buf) const {
+    char *p = buf;
+
+    if (is_all_set) {
+      p += sprintf(p, "%s", LOG_ALL.ptr());
+    } else {
+      for (int i = 0; i < MAX_CODES_NUM; ++i) {
+        if (codes[i] != 0) {
+          if (i > 0) {
+            p += sprintf(p, ",%d", codes[i]);
+          } else {
+            p += sprintf(p, "%d", codes[i]);
+          }
+        }
+      }
+    }
+
+    *p = '\0';
+
+    return p - buf;
+  }
+
+  bool check_error_set(const uint32_t code) const {
+    if (is_all_set) {
+      return true;
+    }
+
+    for (const uint32_t &c : codes) {
+      if (c == 0) {
+        // unused slots reached
+        break;
+      }
+      if (code == c) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool check_variable_set() const { return is_all_set || codes[0] != 0; }
+};
+
 struct System_variables {
   /*
     How dynamically allocated system variables are handled:
@@ -348,6 +504,7 @@ struct System_variables {
   ulong log_slow_rate_limit;
   ulonglong log_slow_filter;
   ulonglong log_slow_verbosity;
+  Query_errors_set log_query_errors;
 
   ulong innodb_io_reads;
   ulonglong innodb_io_read;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-2346

Added an option log_query_errors which enables logging queries failing
with certain error codes into a slow query log independently of their
execution time. The log_query_errors can be passed a comma separated list
of error codes: log_query_errors=code1,code2,code3. It can be set to
'all' to log all failing queries with nonzero error code.