### PR TITLE
PS-7811 merge: Merge MySQL 8.0.26 (adapt tests to new names of

### DIFF
--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1573,9 +1573,6 @@ The following options may be given as the first argument:
  Use mmap files for temptables. This variable is
  deprecated and will be removed in a future release.
  (Defaults to on; use --skip-temptable-use-mmap to disable.)
- --tf-sequence-table-max-upper-bound=# 
- Maximum number of records SEQUENCE_TABLE() table function
- is allowed to generate.
  --terminology-use-previous=name 
  Make monitoring tables and statements use the identifiers
  that were in use before they were changed in a given
@@ -1591,6 +1588,9 @@ The following options may be given as the first argument:
  BEFORE_8_0_26 as default for the session option, and in
  addition the thread commands that were in use until
  8.0.25 are written to the slow query log.
+ --tf-sequence-table-max-upper-bound=# 
+ Maximum number of records SEQUENCE_TABLE() table function
+ is allowed to generate.
  --thread-cache-size=# 
  How many threads we should keep in a cache for reuse
  --thread-handling=name 
@@ -1825,10 +1825,10 @@ log-short-format FALSE
 log-slave-updates FALSE
 log-slow-admin-statements FALSE
 log-slow-extra FALSE
-log-slow-replica-statements FALSE
 log-slow-filter 
 log-slow-rate-limit 1
 log-slow-rate-type session
+log-slow-replica-statements FALSE
 log-slow-slave-statements FALSE
 log-slow-sp-statements ON
 log-slow-verbosity 

--- a/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_extra_col_slave.result
+++ b/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_extra_col_slave.result
@@ -12,8 +12,8 @@ call mtr.add_suppression("The slave coordinator and worker threads are stopped, 
 STOP SLAVE;
 Warnings:
 Warning	1287	'STOP SLAVE' is deprecated and will be removed in a future release. Please use STOP REPLICA instead
-SET @saved_slave_type_conversions = @@slave_type_conversions;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
+SET @saved_replica_type_conversions = @@replica_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
 CREATE TABLE t1 (a INT, b INT PRIMARY KEY, c CHAR(20),
 d FLOAT DEFAULT '2.00', 
 e CHAR(4) DEFAULT 'TEST') 
@@ -36,7 +36,7 @@ a	b	c	d	e
 1	2	TEXAS	2	TEST
 2	1	AUSTIN	2	TEST
 3	4	QA	2	TEST
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 *** Drop t1  ***
 DROP TABLE t1;
 *** Create t2 on slave  ***

--- a/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_parallel_ddl.result
+++ b/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_parallel_ddl.result
@@ -4,8 +4,8 @@ Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
 include/stop_slave.inc
-set @save.slave_parallel_workers= @@global.slave_parallel_workers;
-set @@global.slave_parallel_workers= 4;
+set @save.replica_parallel_workers= @@global.replica_parallel_workers;
+set @@global.replica_parallel_workers= 4;
 include/start_slave.inc
 include/diff_tables.inc [master:d32.t8, slave:d32.t8]
 include/diff_tables.inc [master:d32.t7, slave:d32.t7]
@@ -521,5 +521,5 @@ t5_XXX.sdi
 t6_XXX.sdi
 t7_XXX.sdi
 t8_XXX.sdi
-set @@global.slave_parallel_workers= @save.slave_parallel_workers;
+set @@global.replica_parallel_workers= @save.replica_parallel_workers;
 include/rpl_end.inc

--- a/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_row_basic.result
+++ b/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_row_basic.result
@@ -373,8 +373,8 @@ X	Q	5	7	R	49	X	Y	2	S	1
 X	Q	5	7	R	49	X	Z	2	S	2
 X	Q	5	9	R	81	X	Y	2	S	1
 X	Q	5	9	R	81	X	Z	2	S	2
-SET @saved_slave_type_conversions = @@SLAVE_TYPE_CONVERSIONS;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_LOSSY';
+SET @saved_replica_type_conversions = @@REPLICA_TYPE_CONVERSIONS;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_LOSSY';
 CREATE TABLE t4 (C1 CHAR(1) PRIMARY KEY, B1 BIT(1), B2 BIT(1) NOT NULL DEFAULT 0, C2 CHAR(1) NOT NULL DEFAULT 'A') ENGINE = 'RocksDB' ;
 INSERT INTO t4 SET C1 = 1;
 SELECT C1,HEX(B1),HEX(B2) FROM t4 ORDER BY C1;
@@ -384,7 +384,7 @@ include/sync_slave_sql_with_master.inc
 SELECT C1,HEX(B1),HEX(B2) FROM t4 ORDER BY C1;
 C1	HEX(B1)	HEX(B2)
 1	NULL	0
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 CREATE TABLE t7 (C1 INT PRIMARY KEY, C2 INT) ENGINE = 'RocksDB' ;
 include/sync_slave_sql_with_master.inc
 --- on slave: original values ---
@@ -394,7 +394,7 @@ C1	C2
 1	3
 2	6
 3	9
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 --- on master: new values inserted ---
 INSERT INTO t7 VALUES (1,2), (2,4), (3,6);
 SELECT * FROM t7 ORDER BY C1;
@@ -403,7 +403,7 @@ C1	C2
 2	4
 3	6
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 --- on slave: old values should be overwritten by replicated values ---
 SELECT * FROM t7 ORDER BY C1;
 C1	C2
@@ -434,11 +434,11 @@ a	b	c
 2	4	6
 3	6	9
 99	99	99
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 --- on master ---
 INSERT INTO t8 VALUES (2,4,8);
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 --- on slave ---
 SELECT * FROM t8 ORDER BY a;
 a	b	c
@@ -455,13 +455,13 @@ include/rpl_reset.inc
 INSERT INTO t1 VALUES ('K','K'), ('L','L'), ('M','M');
 **** On Master ****
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 DELETE FROM t1 WHERE C1 = 'L';
 DELETE FROM t1;
 SELECT COUNT(*) FROM t1 ORDER BY c1,c2;
 COUNT(*)	0
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 include/check_slave_is_running.inc
 SELECT COUNT(*) FROM t1 ORDER BY c1,c2;
 COUNT(*)	0
@@ -529,8 +529,8 @@ c CHAR(255) CHARACTER SET utf8 NOT NULL,
 j INT NOT NULL) ENGINE = 'RocksDB' ;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-SET @saved_slave_type_conversions = @@slave_type_conversions;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
+SET @saved_replica_type_conversions = @@replica_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
 [expecting slave to replicate correctly]
 INSERT INTO t1 VALUES (1, "", 1);
 INSERT INTO t1 VALUES (2, repeat(_utf8'a', 16), 2);
@@ -545,7 +545,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 include/sync_slave_sql_with_master.inc
 include/diff_tables.inc [master:t2, slave:t2]
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 call mtr.add_suppression("Slave SQL.*Table definition on master and slave does not match: Column 1 size mismatch.* Error_code: MY-001535");
 call mtr.add_suppression("Slave SQL.*Could not execute Delete_rows event on table test.t1.* Error_code: MY-001032");
 call mtr.add_suppression("Slave SQL.*Column 1 of table .test.t.. cannot be converted from type.*, Error_code: MY-013146");
@@ -672,8 +672,8 @@ include/sync_slave_sql_with_master.inc
 include/diff_tables.inc [master:t1, slave:t1]
 drop table t1;
 include/sync_slave_sql_with_master.inc
-SET @saved_slave_type_conversions = @@SLAVE_TYPE_CONVERSIONS;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_LOSSY';
+SET @saved_replica_type_conversions = @@REPLICA_TYPE_CONVERSIONS;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_LOSSY';
 CREATE TABLE t1 (a bit) ENGINE='RocksDB';
 INSERT IGNORE INTO t1 VALUES (NULL);
 INSERT INTO t1 ( a ) VALUES ( 0 );
@@ -715,7 +715,7 @@ UPDATE t1 SET a = 8 WHERE a = 5 LIMIT 2;
 INSERT IGNORE INTO t1 ( a ) VALUES ( 1 );
 UPDATE IGNORE t1 SET a = 9 WHERE a < 5 LIMIT 3;
 include/sync_slave_sql_with_master.inc
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 include/diff_tables.inc [master:t1, slave:t1]
 drop table t1;
 include/sync_slave_sql_with_master.inc

--- a/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_row_tabledefs.result
+++ b/mysql-test/suite/rocksdb_rpl/r/rpl_rocksdb_row_tabledefs.result
@@ -38,7 +38,7 @@ ALTER TABLE t8 ADD e1 INT NOT NULL DEFAULT 0, ADD e2 INT NOT NULL DEFAULT 0,
 ADD e3 INT NOT NULL DEFAULT 0, ADD e4 INT NOT NULL DEFAULT 0,
 ADD e5 INT NOT NULL DEFAULT 0, ADD e6 INT NOT NULL DEFAULT 0,
 ADD e7 INT NOT NULL DEFAULT 0, ADD e8 INT NOT NULL DEFAULT 0;
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 INSERT INTO t1_int  VALUES (2, 4, 4711);
 INSERT INTO t1_char VALUES (2, 4, 'Foo is a bar');
 INSERT INTO t1_bit  VALUES (2, 4, b'101', b'11100', b'01');
@@ -62,7 +62,7 @@ a	b
 1	2
 2	5
 **** On Slave ****
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 SELECT a,b,x FROM t1_int ORDER BY a;
 a	b	x
 1	2	42

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_crash_safe.test
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_crash_safe.test
@@ -5,7 +5,7 @@
 --source include/have_debug.inc
 --source include/have_rocksdb.inc
 --source include/have_binlog_format_row.inc
---source include/not_mts_slave_parallel_workers.inc
+--source include/not_mts_replica_parallel_workers.inc
 --source include/master-slave.inc
 
 call mtr.add_suppression('Attempting backtrace');

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_stm_mixed_crash_safe.test
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_stm_mixed_crash_safe.test
@@ -4,7 +4,7 @@
 --source include/have_debug.inc
 --source include/have_rocksdb.inc
 --source include/have_binlog_format_mixed_or_statement.inc
---source include/not_mts_slave_parallel_workers.inc
+--source include/not_mts_replica_parallel_workers.inc
 --source include/master-slave.inc
 
 

--- a/mysql-test/suite/tokudb_rpl/r/rpl_extra_col_slave_tokudb.result
+++ b/mysql-test/suite/tokudb_rpl/r/rpl_extra_col_slave_tokudb.result
@@ -12,8 +12,8 @@ call mtr.add_suppression("The slave coordinator and worker threads are stopped, 
 STOP SLAVE;
 Warnings:
 Warning	1287	'STOP SLAVE' is deprecated and will be removed in a future release. Please use STOP REPLICA instead
-SET @saved_slave_type_conversions = @@slave_type_conversions;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
+SET @saved_replica_type_conversions = @@replica_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
 CREATE TABLE t1 (a INT, b INT PRIMARY KEY, c CHAR(20),
 d FLOAT DEFAULT '2.00', 
 e CHAR(4) DEFAULT 'TEST') 
@@ -36,7 +36,7 @@ a	b	c	d	e
 1	2	TEXAS	2	TEST
 2	1	AUSTIN	2	TEST
 3	4	QA	2	TEST
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 *** Drop t1  ***
 DROP TABLE t1;
 *** Create t2 on slave  ***

--- a/mysql-test/suite/tokudb_rpl/r/rpl_row_basic_3tokudb.result
+++ b/mysql-test/suite/tokudb_rpl/r/rpl_row_basic_3tokudb.result
@@ -373,8 +373,8 @@ X	Q	5	7	R	49	X	Y	2	S	1
 X	Q	5	7	R	49	X	Z	2	S	2
 X	Q	5	9	R	81	X	Y	2	S	1
 X	Q	5	9	R	81	X	Z	2	S	2
-SET @saved_slave_type_conversions = @@SLAVE_TYPE_CONVERSIONS;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_LOSSY';
+SET @saved_replica_type_conversions = @@REPLICA_TYPE_CONVERSIONS;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_LOSSY';
 CREATE TABLE t4 (C1 CHAR(1) PRIMARY KEY, B1 BIT(1), B2 BIT(1) NOT NULL DEFAULT 0, C2 CHAR(1) NOT NULL DEFAULT 'A') ENGINE = 'TokuDB' ;
 INSERT INTO t4 SET C1 = 1;
 SELECT C1,HEX(B1),HEX(B2) FROM t4 ORDER BY C1;
@@ -384,7 +384,7 @@ include/sync_slave_sql_with_master.inc
 SELECT C1,HEX(B1),HEX(B2) FROM t4 ORDER BY C1;
 C1	HEX(B1)	HEX(B2)
 1	NULL	0
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 CREATE TABLE t7 (C1 INT PRIMARY KEY, C2 INT) ENGINE = 'TokuDB' ;
 include/sync_slave_sql_with_master.inc
 --- on slave: original values ---
@@ -394,7 +394,7 @@ C1	C2
 1	3
 2	6
 3	9
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 --- on master: new values inserted ---
 INSERT INTO t7 VALUES (1,2), (2,4), (3,6);
 SELECT * FROM t7 ORDER BY C1;
@@ -403,7 +403,7 @@ C1	C2
 2	4
 3	6
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 --- on slave: old values should be overwritten by replicated values ---
 SELECT * FROM t7 ORDER BY C1;
 C1	C2
@@ -434,11 +434,11 @@ a	b	c
 2	4	6
 3	6	9
 99	99	99
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 --- on master ---
 INSERT INTO t8 VALUES (2,4,8);
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 --- on slave ---
 SELECT * FROM t8 ORDER BY a;
 a	b	c
@@ -455,13 +455,13 @@ include/rpl_reset.inc
 INSERT INTO t1 VALUES ('K','K'), ('L','L'), ('M','M');
 **** On Master ****
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 DELETE FROM t1 WHERE C1 = 'L';
 DELETE FROM t1;
 SELECT COUNT(*) FROM t1 ORDER BY c1,c2;
 COUNT(*)	0
 include/sync_slave_sql_with_master.inc
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 include/check_slave_is_running.inc
 SELECT COUNT(*) FROM t1 ORDER BY c1,c2;
 COUNT(*)	0
@@ -529,8 +529,8 @@ c CHAR(255) CHARACTER SET utf8 NOT NULL,
 j INT NOT NULL) ENGINE = 'TokuDB' ;
 Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
-SET @saved_slave_type_conversions = @@slave_type_conversions;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
+SET @saved_replica_type_conversions = @@replica_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_NON_LOSSY';
 [expecting slave to replicate correctly]
 INSERT INTO t1 VALUES (1, "", 1);
 INSERT INTO t1 VALUES (2, repeat(_utf8'a', 16), 2);
@@ -545,7 +545,7 @@ Warnings:
 Warning	3719	'utf8' is currently an alias for the character set UTF8MB3, but will be an alias for UTF8MB4 in a future release. Please consider using UTF8MB4 in order to be unambiguous.
 include/sync_slave_sql_with_master.inc
 include/diff_tables.inc [master:t2, slave:t2]
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 call mtr.add_suppression("Slave SQL.*Table definition on master and slave does not match: Column 1 size mismatch.* Error_code: MY-001535");
 call mtr.add_suppression("Slave SQL.*Could not execute Delete_rows event on table test.t1.* Error_code: MY-001032");
 call mtr.add_suppression("Slave SQL.*Column 1 of table .test.t.. cannot be converted from type.*, Error_code: MY-013146");
@@ -672,8 +672,8 @@ include/sync_slave_sql_with_master.inc
 include/diff_tables.inc [master:t1, slave:t1]
 drop table t1;
 include/sync_slave_sql_with_master.inc
-SET @saved_slave_type_conversions = @@SLAVE_TYPE_CONVERSIONS;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = 'ALL_LOSSY';
+SET @saved_replica_type_conversions = @@REPLICA_TYPE_CONVERSIONS;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = 'ALL_LOSSY';
 CREATE TABLE t1 (a bit) ENGINE='TokuDB';
 INSERT IGNORE INTO t1 VALUES (NULL);
 INSERT INTO t1 ( a ) VALUES ( 0 );
@@ -715,7 +715,7 @@ UPDATE t1 SET a = 8 WHERE a = 5 LIMIT 2;
 INSERT IGNORE INTO t1 ( a ) VALUES ( 1 );
 UPDATE IGNORE t1 SET a = 9 WHERE a < 5 LIMIT 3;
 include/sync_slave_sql_with_master.inc
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 include/diff_tables.inc [master:t1, slave:t1]
 drop table t1;
 include/sync_slave_sql_with_master.inc

--- a/mysql-test/suite/tokudb_rpl/r/rpl_row_tabledefs_3tokudb.result
+++ b/mysql-test/suite/tokudb_rpl/r/rpl_row_tabledefs_3tokudb.result
@@ -38,7 +38,7 @@ ALTER TABLE t8 ADD e1 INT NOT NULL DEFAULT 0, ADD e2 INT NOT NULL DEFAULT 0,
 ADD e3 INT NOT NULL DEFAULT 0, ADD e4 INT NOT NULL DEFAULT 0,
 ADD e5 INT NOT NULL DEFAULT 0, ADD e6 INT NOT NULL DEFAULT 0,
 ADD e7 INT NOT NULL DEFAULT 0, ADD e8 INT NOT NULL DEFAULT 0;
-set @@global.slave_exec_mode= 'IDEMPOTENT';
+set @@global.replica_exec_mode= 'IDEMPOTENT';
 INSERT INTO t1_int  VALUES (2, 4, 4711);
 INSERT INTO t1_char VALUES (2, 4, 'Foo is a bar');
 INSERT INTO t1_bit  VALUES (2, 4, b'101', b'11100', b'01');
@@ -62,7 +62,7 @@ a	b
 1	2
 2	5
 **** On Slave ****
-set @@global.slave_exec_mode= default;
+set @@global.replica_exec_mode= default;
 SELECT a,b,x FROM t1_int ORDER BY a;
 a	b	x
 1	2	42

--- a/mysql-test/suite/tokudb_rpl/r/rpl_typeconv_tokudb.result
+++ b/mysql-test/suite/tokudb_rpl/r/rpl_typeconv_tokudb.result
@@ -3,11 +3,11 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-SET @saved_slave_type_conversions = @@GLOBAL.SLAVE_TYPE_CONVERSIONS;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = '';
+SET @saved_replica_type_conversions = @@GLOBAL.REPLICA_TYPE_CONVERSIONS;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = '';
 CREATE TABLE t1(b1 BIT(1), b2 BIT(2), b3 BIT(3)) ENGINE=TokuDB;
 INSERT INTO t1 VALUES (b'0', b'01', b'101');
 include/diff_tables.inc [master:t1, slave:t1]
 DROP TABLE t1;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 include/rpl_end.inc

--- a/mysql-test/suite/tokudb_rpl/t/rpl_deadlock_tokudb.test
+++ b/mysql-test/suite/tokudb_rpl/t/rpl_deadlock_tokudb.test
@@ -1,7 +1,7 @@
 -- source include/not_ndb_default.inc
 -- source include/have_tokudb.inc
 -- source include/not_group_replication_plugin.inc
--- source include/not_mts_slave_parallel_workers.inc
+-- source include/not_mts_replica_parallel_workers.inc
 -- source include/not_relay_log_info_table.inc
 -- source include/not_master_info_table.inc
 

--- a/mysql-test/suite/tokudb_rpl/t/rpl_tokudb_row_crash_safe.test
+++ b/mysql-test/suite/tokudb_rpl/t/rpl_tokudb_row_crash_safe.test
@@ -5,7 +5,7 @@
 --source include/have_tokudb.inc
 --source include/not_group_replication_plugin.inc
 --source include/have_binlog_format_row.inc
---source include/not_mts_slave_parallel_workers.inc
+--source include/not_mts_replica_parallel_workers.inc
 --source include/master-slave.inc
 
 call mtr.add_suppression('Attempting backtrace');

--- a/mysql-test/suite/tokudb_rpl/t/rpl_tokudb_stm_mixed_crash_safe.test
+++ b/mysql-test/suite/tokudb_rpl/t/rpl_tokudb_stm_mixed_crash_safe.test
@@ -4,7 +4,7 @@
 --source include/have_tokudb.inc
 --source include/not_group_replication_plugin.inc
 --source include/have_binlog_format_mixed_or_statement.inc
---source include/not_mts_slave_parallel_workers.inc
+--source include/not_mts_replica_parallel_workers.inc
 --source include/master-slave.inc
 
 --connection master

--- a/mysql-test/suite/tokudb_rpl/t/rpl_typeconv_tokudb.test
+++ b/mysql-test/suite/tokudb_rpl/t/rpl_typeconv_tokudb.test
@@ -8,8 +8,8 @@
 #
 
 connection slave;
-SET @saved_slave_type_conversions = @@GLOBAL.SLAVE_TYPE_CONVERSIONS;
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = '';
+SET @saved_replica_type_conversions = @@GLOBAL.REPLICA_TYPE_CONVERSIONS;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = '';
 
 connection master;
 CREATE TABLE t1(b1 BIT(1), b2 BIT(2), b3 BIT(3)) ENGINE=TokuDB;
@@ -23,5 +23,5 @@ connection master;
 DROP TABLE t1;
 sync_slave_with_master;
 
-SET GLOBAL SLAVE_TYPE_CONVERSIONS = @saved_slave_type_conversions;
+SET GLOBAL REPLICA_TYPE_CONVERSIONS = @saved_replica_type_conversions;
 --source include/rpl_end.inc


### PR DESCRIPTION
replication files)

https://jira.percona.com/browse/PS-7811

The upstream commit 4cb39b5da9ec5638e817cc5b8bdb93f3503e920b renames
replication system variables, options and strings.

Therefore, Percona code needs to use the new names.