### PR TITLE
PS-7778 Wrongly handled definer for triggers when PS used

### DIFF
--- a/mysql-test/r/ps_trigger_access_check_regression.result
+++ b/mysql-test/r/ps_trigger_access_check_regression.result
@@ -1,0 +1,106 @@
+CREATE USER 'logger'@'%' IDENTIFIED BY '';
+CREATE USER 'user'@'%' IDENTIFIED BY '';
+CREATE DATABASE test1;
+USE test1;
+CREATE TABLE logger_internal (data VARCHAR(100));
+INSERT INTO logger_internal SET data = 'secret';
+GRANT ALL PRIVILEGES ON logger_internal TO 'logger'@'%';
+CREATE TABLE forbidden_for_everyone (data VARCHAR(100));
+INSERT INTO forbidden_for_everyone SET data = '______';
+CREATE TABLE log (val VARCHAR(100));
+GRANT ALL PRIVILEGES ON log TO 'logger'@'%';
+# -----------------------------------------------------------------------
+# 1. Trigger SELECTs a table that 'user' can't access, but 'logger' can.
+#
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+AFTER UPDATE ON data
+FOR EACH ROW
+INSERT INTO log (val)
+(SELECT CONCAT('trg/1/', data) FROM logger_internal LIMIT 1);
+USE test1;
+UPDATE data SET val = 'new-data';
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+EXECUTE s;
+# -----------------------------------------------------------------------
+# 2. Trigger SELECTs something both 'user' and 'logger' cannot read.
+#
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+AFTER UPDATE ON data
+FOR EACH ROW
+INSERT INTO log (val)
+(SELECT CONCAT('trg/2/', data) FROM forbidden_for_everyone LIMIT 1);
+UPDATE data SET val = 'new-data';
+ERROR 42000: SELECT command denied to user 'logger'@'%' for table 'forbidden_for_everyone'
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+EXECUTE s;
+ERROR 42000: SELECT command denied to user 'logger'@'%' for table 'forbidden_for_everyone'
+# -----------------------------------------------------------------------
+# 3. Trigger uses OLD.val, but definer has no SELECT priviledge.
+#
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+AFTER UPDATE ON data
+FOR EACH ROW
+INSERT INTO log (val) (SELECT CONCAT('trg/3/', OLD.val));
+UPDATE data SET val = 'new-data';
+ERROR 42000: SELECT command denied to user 'logger'@'%' for column 'val' in table 'data'
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+EXECUTE s;
+ERROR 42000: SELECT command denied to user 'logger'@'%' for column 'val' in table 'data'
+# -----------------------------------------------------------------------
+# 4. Before-update trigger tries to set new value, but has no UPDATE privilege.
+#
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+BEFORE UPDATE ON data
+FOR EACH ROW
+SET NEW.val = 'str';
+UPDATE data SET val = 'new-data';
+ERROR 42000: UPDATE command denied to user 'logger'@'%' for column 'val' in table 'data'
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+EXECUTE s;
+ERROR 42000: UPDATE command denied to user 'logger'@'%' for column 'val' in table 'data'
+# -----------------------------------------------------------------------
+# 5. Definer gets TRIGGER priviledge revoked after trigger definition.
+#
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+AFTER UPDATE ON data
+FOR EACH ROW
+INSERT INTO log (val)
+(SELECT CONCAT('trg/5/', data) FROM logger_internal LIMIT 1);
+REVOKE TRIGGER ON data FROM 'logger'@'%';
+UPDATE data SET val = 'new-data';
+ERROR 42000: TRIGGER command denied to user 'logger'@'%' for table 'data'
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+EXECUTE s;
+ERROR 42000: TRIGGER command denied to user 'logger'@'%' for table 'data'
+# -----------------------------------------------------------------------
+SELECT * FROM log;
+val
+trg/1/secret
+trg/1/secret
+DROP DATABASE test1;
+DROP USER user;
+DROP USER logger;

--- a/mysql-test/t/ps_trigger_access_check_regression.test
+++ b/mysql-test/t/ps_trigger_access_check_regression.test
@@ -1,0 +1,154 @@
+#
+# PS-7778  Wrongly handled definer for triggers when prepared statements are used
+#
+
+CREATE USER 'logger'@'%' IDENTIFIED BY '';
+CREATE USER 'user'@'%' IDENTIFIED BY '';
+
+CREATE DATABASE test1;
+USE test1;
+
+# A table that only 'logger' can access.
+CREATE TABLE logger_internal (data VARCHAR(100));
+INSERT INTO logger_internal SET data = 'secret';
+GRANT ALL PRIVILEGES ON logger_internal TO 'logger'@'%';
+
+# A table that nobody can access.
+CREATE TABLE forbidden_for_everyone (data VARCHAR(100));
+INSERT INTO forbidden_for_everyone SET data = '______';
+
+# A table 'logger' logs to.
+CREATE TABLE log (val VARCHAR(100));
+GRANT ALL PRIVILEGES ON log TO 'logger'@'%';
+
+--echo # -----------------------------------------------------------------------
+--echo # 1. Trigger SELECTs a table that 'user' can't access, but 'logger' can.
+--echo #
+
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+  AFTER UPDATE ON data
+  FOR EACH ROW
+    INSERT INTO log (val)
+      (SELECT CONCAT('trg/1/', data) FROM logger_internal LIMIT 1);
+
+--connect (con_user, localhost, user, , )
+USE test1;
+
+UPDATE data SET val = 'new-data';
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+EXECUTE s;
+
+--echo # -----------------------------------------------------------------------
+--echo # 2. Trigger SELECTs something both 'user' and 'logger' cannot read.
+--echo #
+
+--connection default
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+  AFTER UPDATE ON data
+  FOR EACH ROW
+    INSERT INTO log (val)
+      (SELECT CONCAT('trg/2/', data) FROM forbidden_for_everyone LIMIT 1);
+
+--connection con_user
+
+--error ER_TABLEACCESS_DENIED_ERROR
+UPDATE data SET val = 'new-data';
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+--error ER_TABLEACCESS_DENIED_ERROR
+EXECUTE s;
+
+--echo # -----------------------------------------------------------------------
+--echo # 3. Trigger uses OLD.val, but definer has no SELECT priviledge.
+--echo #
+
+--connection default
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+
+GRANT TRIGGER ON data TO 'logger'@'%';  # No SELECT privilege.
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+  AFTER UPDATE ON data
+  FOR EACH ROW
+    INSERT INTO log (val) (SELECT CONCAT('trg/3/', OLD.val));
+
+--connection con_user
+
+--error ER_COLUMNACCESS_DENIED_ERROR
+UPDATE data SET val = 'new-data';
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+--error ER_COLUMNACCESS_DENIED_ERROR
+EXECUTE s;
+
+--echo # -----------------------------------------------------------------------
+--echo # 4. Before-update trigger tries to set new value, but has no UPDATE privilege.
+--echo #
+
+--connection default
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+
+GRANT TRIGGER ON data TO 'logger'@'%';  # No UPDATE privilege.
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+  BEFORE UPDATE ON data
+  FOR EACH ROW
+    SET NEW.val = 'str';
+
+--connection con_user
+
+--error ER_COLUMNACCESS_DENIED_ERROR
+UPDATE data SET val = 'new-data';
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+--error ER_COLUMNACCESS_DENIED_ERROR
+EXECUTE s;
+
+--echo # -----------------------------------------------------------------------
+--echo # 5. Definer gets TRIGGER priviledge revoked after trigger definition.
+--echo #
+
+--connection default
+DROP TABLE data;
+CREATE TABLE data (val VARCHAR(100));
+INSERT INTO data (val) VALUES ('original-data');
+GRANT ALL PRIVILEGES ON data TO 'user'@'%';
+
+GRANT TRIGGER ON data TO 'logger'@'%';
+CREATE DEFINER = 'logger'@'%' TRIGGER trg
+  AFTER UPDATE ON data
+  FOR EACH ROW
+    INSERT INTO log (val)
+      (SELECT CONCAT('trg/5/', data) FROM logger_internal LIMIT 1);
+
+REVOKE TRIGGER ON data FROM 'logger'@'%';
+
+--connection con_user
+
+--error ER_TABLEACCESS_DENIED_ERROR
+UPDATE data SET val = 'new-data';
+PREPARE s FROM 'UPDATE data SET val = \'new-data\'';
+--error ER_TABLEACCESS_DENIED_ERROR
+EXECUTE s;
+--echo # -----------------------------------------------------------------------
+
+--connection default
+--disconnect con_user
+
+SELECT * FROM log;
+
+DROP DATABASE test1;
+DROP USER user;
+DROP USER logger;

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -929,9 +929,10 @@ bool Sql_cmd_select::check_privileges(THD *thd) {
 
 bool Sql_cmd_dml::check_all_table_privileges(THD *thd) {
   // Check for all possible DML privileges
+  TABLE_LIST *first_not_own_table = lex->first_not_own_table();
 
-  for (TABLE_LIST *tr = lex->query_tables; tr != nullptr;
-       tr = tr->next_global) {
+  for (TABLE_LIST *tr = lex->query_tables;
+       tr != nullptr && tr != first_not_own_table; tr = tr->next_global) {
     if (tr->is_internal())  // No privilege check required for internal tables
       continue;
     // Calculated wanted privilege based on how table/view is used:


### PR DESCRIPTION
It's possible to get spurious access denied errors when a query causes a trigger to execute, and is executed as a prepared statement. Access checking logic tries to check if the current user has access to all tables that a trigger touches, even if that trigger is bound to run in a context of another user.

As all additional tables are added to the list after all own tables of a query, it's enough to stop traversing the table list once any of non-own tables are met.

This regression was introduced in 67c3c70e4895874d43434f1df556f9f30d781b48.
