### PR TITLE
Add support for increasing the max supported key length of RocksDB ta…

### DIFF
--- a/mysql-test/suite/rocksdb/include/index.inc
+++ b/mysql-test/suite/rocksdb/include/index.inc
@@ -123,7 +123,9 @@ DROP TABLE t1;
 # Test index prefix length limits.
 #
 set @orig_rocksdb_large_prefix=@@global.rocksdb_large_prefix;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
 set @@global.rocksdb_large_prefix=0;
+set @@global.rocksdb_xlarge_prefix=0;
 
 CREATE TABLE t1 (
   a BLOB(1024),
@@ -138,6 +140,7 @@ CREATE TABLE t1 (
 ) ENGINE=ROCKSDB;
 
 set @@global.rocksdb_large_prefix=1;
+set @@global.rocksdb_xlarge_prefix=0;
 
 CREATE TABLE t1 (
   a BLOB(4096),
@@ -152,3 +155,19 @@ CREATE TABLE t1 (
 ) ENGINE=ROCKSDB;
 
 set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
+
+set @@global.rocksdb_xlarge_prefix=1;
+
+CREATE TABLE t1 (
+    a BLOB(4096),
+KEY (a(4000))
+) ENGINE=ROCKSDB;
+DROP TABLE t1;
+
+--error ER_TOO_LONG_KEY
+CREATE TABLE t1 (
+    a BLOB(65535),
+KEY (a(49153))
+) ENGINE=ROCKSDB;
+
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;

--- a/mysql-test/suite/rocksdb/r/dup_key_update.result
+++ b/mysql-test/suite/rocksdb/r/dup_key_update.result
@@ -367,3 +367,194 @@ id1	id2	id3
 9	17	9
 DROP TABLE t1;
 DROP TABLE t2;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+CREATE TABLE t1 (id1 varchar(2048) CHARACTER SET latin1 COLLATE latin1_bin,
+id2 varchar(2048) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin,
+id3 varchar(2048) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+PRIMARY KEY (id1, id2, id3),
+UNIQUE KEY (id3, id1)) ENGINE=ROCKSDB;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+CREATE TABLE t2 (id1 varchar(2048) CHARACTER SET latin1 COLLATE latin1_bin,
+id2 varchar(2048) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin,
+id3 varchar(2048) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+PRIMARY KEY (id1, id2, id3),
+UNIQUE KEY (id3, id1) COMMENT 'cfname=rev:cf') ENGINE=ROCKSDB;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+Warning	3778	'utf8_bin' is a collation of the deprecated character set UTF8MB3. Please consider using UTF8MB4 with an appropriate collation instead.
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;
+INSERT INTO t1 VALUES (1, 1, 1) ON DUPLICATE KEY UPDATE id2 = 9;
+SELECT * FROM t1 WHERE id1 = 1;
+id1	id2	id3
+1	1	1
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 1;
+id1	id2	id3
+1	1	1
+INSERT INTO t1 VALUES (1, 1, 1) ON DUPLICATE KEY UPDATE id2 = 10;
+SELECT * FROM t1 WHERE id1 = 1;
+id1	id2	id3
+1	10	1
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 1;
+id1	id2	id3
+1	10	1
+INSERT INTO t1 VALUES (1, 1, 1) ON DUPLICATE KEY UPDATE id2 = 11;
+SELECT * FROM t1 WHERE id1 = 1;
+id1	id2	id3
+1	11	1
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 1;
+id1	id2	id3
+1	11	1
+INSERT INTO t1 VALUES (5, 5, 5) ON DUPLICATE KEY UPDATE id2 = 12;
+SELECT * FROM t1 WHERE id1 = 5;
+id1	id2	id3
+5	12	5
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 5;
+id1	id2	id3
+5	12	5
+INSERT INTO t1 VALUES (5, 5, 5) ON DUPLICATE KEY UPDATE id2 = 13;
+SELECT * FROM t1 WHERE id1 = 5;
+id1	id2	id3
+5	13	5
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 5;
+id1	id2	id3
+5	13	5
+INSERT INTO t1 VALUES (5, 5, 5) ON DUPLICATE KEY UPDATE id2 = 14;
+SELECT * FROM t1 WHERE id1 = 5;
+id1	id2	id3
+5	14	5
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 5;
+id1	id2	id3
+5	14	5
+INSERT INTO t1 VALUES (9, 9, 9) ON DUPLICATE KEY UPDATE id2 = 15;
+SELECT * FROM t1 WHERE id1 = 9;
+id1	id2	id3
+9	15	9
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 9;
+id1	id2	id3
+9	15	9
+INSERT INTO t1 VALUES (9, 9, 9) ON DUPLICATE KEY UPDATE id2 = 16;
+SELECT * FROM t1 WHERE id1 = 9;
+id1	id2	id3
+9	16	9
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 9;
+id1	id2	id3
+9	16	9
+INSERT INTO t1 VALUES (9, 9, 9) ON DUPLICATE KEY UPDATE id2 = 17;
+SELECT * FROM t1 WHERE id1 = 9;
+id1	id2	id3
+9	17	9
+SELECT * FROM t1 FORCE INDEX (id3) WHERE id3 = 9;
+id1	id2	id3
+9	17	9
+SELECT * FROM t1;
+id1	id2	id3
+1	11	1
+2	2	2
+3	3	3
+4	4	4
+5	14	5
+6	6	6
+7	7	7
+8	8	8
+9	17	9
+SELECT * FROM t1 FORCE INDEX (id3);
+id1	id2	id3
+1	11	1
+2	2	2
+3	3	3
+4	4	4
+5	14	5
+6	6	6
+7	7	7
+8	8	8
+9	17	9
+INSERT INTO t2 VALUES (1, 1, 1) ON DUPLICATE KEY UPDATE id2 = 9;
+SELECT * FROM t2 WHERE id1 = 1;
+id1	id2	id3
+1	1	1
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 1;
+id1	id2	id3
+1	1	1
+INSERT INTO t2 VALUES (1, 1, 1) ON DUPLICATE KEY UPDATE id2 = 10;
+SELECT * FROM t2 WHERE id1 = 1;
+id1	id2	id3
+1	10	1
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 1;
+id1	id2	id3
+1	10	1
+INSERT INTO t2 VALUES (1, 1, 1) ON DUPLICATE KEY UPDATE id2 = 11;
+SELECT * FROM t2 WHERE id1 = 1;
+id1	id2	id3
+1	11	1
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 1;
+id1	id2	id3
+1	11	1
+INSERT INTO t2 VALUES (5, 5, 5) ON DUPLICATE KEY UPDATE id2 = 12;
+SELECT * FROM t2 WHERE id1 = 5;
+id1	id2	id3
+5	12	5
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 5;
+id1	id2	id3
+5	12	5
+INSERT INTO t2 VALUES (5, 5, 5) ON DUPLICATE KEY UPDATE id2 = 13;
+SELECT * FROM t2 WHERE id1 = 5;
+id1	id2	id3
+5	13	5
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 5;
+id1	id2	id3
+5	13	5
+INSERT INTO t2 VALUES (5, 5, 5) ON DUPLICATE KEY UPDATE id2 = 14;
+SELECT * FROM t2 WHERE id1 = 5;
+id1	id2	id3
+5	14	5
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 5;
+id1	id2	id3
+5	14	5
+INSERT INTO t2 VALUES (9, 9, 9) ON DUPLICATE KEY UPDATE id2 = 15;
+SELECT * FROM t2 WHERE id1 = 9;
+id1	id2	id3
+9	15	9
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 9;
+id1	id2	id3
+9	15	9
+INSERT INTO t2 VALUES (9, 9, 9) ON DUPLICATE KEY UPDATE id2 = 16;
+SELECT * FROM t2 WHERE id1 = 9;
+id1	id2	id3
+9	16	9
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 9;
+id1	id2	id3
+9	16	9
+INSERT INTO t2 VALUES (9, 9, 9) ON DUPLICATE KEY UPDATE id2 = 17;
+SELECT * FROM t2 WHERE id1 = 9;
+id1	id2	id3
+9	17	9
+SELECT * FROM t2 FORCE INDEX (id3) WHERE id3 = 9;
+id1	id2	id3
+9	17	9
+SELECT * FROM t2;
+id1	id2	id3
+1	11	1
+2	2	2
+3	3	3
+4	4	4
+5	14	5
+6	6	6
+7	7	7
+8	8	8
+9	17	9
+SELECT * FROM t2 FORCE INDEX (id3);
+id1	id2	id3
+1	11	1
+2	2	2
+3	3	3
+4	4	4
+5	14	5
+6	6	6
+7	7	7
+8	8	8
+9	17	9
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/r/index.result
+++ b/mysql-test/suite/rocksdb/r/index.result
@@ -42,7 +42,9 @@ t1	1	a	1	a	A	#	NULL	NULL	YES	SE_SPECIFIC		simple index on a	YES	NULL
 ALTER TABLE t1 DROP KEY a;
 DROP TABLE t1;
 set @orig_rocksdb_large_prefix=@@global.rocksdb_large_prefix;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
 set @@global.rocksdb_large_prefix=0;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(1024),
 KEY (a(767))
@@ -54,6 +56,7 @@ KEY (a(768))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 767 bytes
 set @@global.rocksdb_large_prefix=1;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(4096),
 KEY (a(3072))
@@ -65,6 +68,18 @@ KEY (a(3073))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 3072 bytes
 set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+CREATE TABLE t1 (
+a BLOB(4096),
+KEY (a(4000))
+) ENGINE=ROCKSDB;
+DROP TABLE t1;
+CREATE TABLE t1 (
+a BLOB(65535),
+KEY (a(49153))
+) ENGINE=ROCKSDB;
+ERROR 42000: Specified key was too long; max key length is 49152 bytes
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;
 #
 # Issue #376: MyRocks: ORDER BY optimizer is unable to use the index extension
 #

--- a/mysql-test/suite/rocksdb/r/index_primary.result
+++ b/mysql-test/suite/rocksdb/r/index_primary.result
@@ -46,7 +46,9 @@ Table	Non_unique	Key_name	Seq_in_index	Column_name	Collation	Cardinality	Sub_par
 t1	0	PRIMARY	1	b	A	#	NULL	NULL		SE_SPECIFIC			YES	NULL
 DROP TABLE t1;
 set @orig_rocksdb_large_prefix=@@global.rocksdb_large_prefix;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
 set @@global.rocksdb_large_prefix=0;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(1024),
 PRIMARY KEY (a(767))
@@ -58,6 +60,7 @@ PRIMARY KEY (a(768))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 767 bytes
 set @@global.rocksdb_large_prefix=1;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(4096),
 PRIMARY KEY (a(3072))
@@ -69,3 +72,15 @@ PRIMARY KEY (a(3073))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 3072 bytes
 set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+CREATE TABLE t1 (
+a BLOB(4096),
+PRIMARY KEY (a(4000))
+) ENGINE=ROCKSDB;
+DROP TABLE t1;
+CREATE TABLE t1 (
+a BLOB(65535),
+PRIMARY KEY (a(49153))
+) ENGINE=ROCKSDB;
+ERROR 42000: Specified key was too long; max key length is 49152 bytes
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;

--- a/mysql-test/suite/rocksdb/r/index_type_btree.result
+++ b/mysql-test/suite/rocksdb/r/index_type_btree.result
@@ -50,7 +50,9 @@ t1	1	a	1	a	A	#	NULL	NULL	YES	SE_SPECIFIC		simple index on a	YES	NULL
 ALTER TABLE t1 DROP KEY a;
 DROP TABLE t1;
 set @orig_rocksdb_large_prefix=@@global.rocksdb_large_prefix;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
 set @@global.rocksdb_large_prefix=0;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(1024),
 KEY (a(767))
@@ -62,6 +64,7 @@ KEY (a(768))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 767 bytes
 set @@global.rocksdb_large_prefix=1;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(4096),
 KEY (a(3072))
@@ -73,3 +76,15 @@ KEY (a(3073))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 3072 bytes
 set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+CREATE TABLE t1 (
+a BLOB(4096),
+KEY (a(4000))
+) ENGINE=ROCKSDB;
+DROP TABLE t1;
+CREATE TABLE t1 (
+a BLOB(65535),
+KEY (a(49153))
+) ENGINE=ROCKSDB;
+ERROR 42000: Specified key was too long; max key length is 49152 bytes
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;

--- a/mysql-test/suite/rocksdb/r/index_type_hash.result
+++ b/mysql-test/suite/rocksdb/r/index_type_hash.result
@@ -50,7 +50,9 @@ t1	1	a	1	a	A	#	NULL	NULL	YES	SE_SPECIFIC		simple index on a	YES	NULL
 ALTER TABLE t1 DROP KEY a;
 DROP TABLE t1;
 set @orig_rocksdb_large_prefix=@@global.rocksdb_large_prefix;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
 set @@global.rocksdb_large_prefix=0;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(1024),
 KEY (a(767))
@@ -62,6 +64,7 @@ KEY (a(768))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 767 bytes
 set @@global.rocksdb_large_prefix=1;
+set @@global.rocksdb_xlarge_prefix=0;
 CREATE TABLE t1 (
 a BLOB(4096),
 KEY (a(3072))
@@ -73,3 +76,15 @@ KEY (a(3073))
 ) ENGINE=ROCKSDB;
 ERROR 42000: Specified key was too long; max key length is 3072 bytes
 set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+CREATE TABLE t1 (
+a BLOB(4096),
+KEY (a(4000))
+) ENGINE=ROCKSDB;
+DROP TABLE t1;
+CREATE TABLE t1 (
+a BLOB(65535),
+KEY (a(49153))
+) ENGINE=ROCKSDB;
+ERROR 42000: Specified key was too long; max key length is 49152 bytes
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;

--- a/mysql-test/suite/rocksdb/r/rocksdb.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb.result
@@ -966,6 +966,7 @@ rocksdb_info_log_level	error_level
 rocksdb_is_fd_close_on_exec	ON
 rocksdb_keep_log_file_num	1000
 rocksdb_large_prefix	ON
+rocksdb_xlarge_prefix	OFF
 rocksdb_lock_scanned_rows	OFF
 rocksdb_lock_wait_timeout	1
 rocksdb_log_file_time_to_roll	0
@@ -2456,6 +2457,33 @@ set @orig_rocksdb_large_prefix=@@global.rocksdb_large_prefix;
 set @@global.rocksdb_large_prefix=1;
 create table t1 (a int, b text, c varchar(255), Primary Key(a), Key(b(255))) engine=rocksdb;
 set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
+insert into t1 values (1, '1abcde', '1abcde'), (2, '2abcde', '2abcde'), (3, '3abcde', '3abcde');
+select * from t1;
+a	b	c
+1	1abcde	1abcde
+2	2abcde	2abcde
+3	3abcde	3abcde
+explain select * from t1 where b like '1%';
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	range	b	b	1023	NULL	#	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t1`.`a` AS `a`,`test`.`t1`.`b` AS `b`,`test`.`t1`.`c` AS `c` from `test`.`t1` where (`test`.`t1`.`b` like '1%')
+explain select b, a from t1 where b like '1%';
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t1	NULL	range	b	b	1023	NULL	#	100.00	Using where
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t1`.`b` AS `b`,`test`.`t1`.`a` AS `a` from `test`.`t1` where (`test`.`t1`.`b` like '1%')
+update t1 set b= '12345' where b = '2abcde';
+select * from t1;
+a	b	c
+1	1abcde	1abcde
+2	12345	2abcde
+3	3abcde	3abcde
+drop table t1;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+create table t1 (a int, b text, c varchar(255), Primary Key(a), Key(b(4000))) engine=rocksdb;
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;
 insert into t1 values (1, '1abcde', '1abcde'), (2, '2abcde', '2abcde'), (3, '3abcde', '3abcde');
 select * from t1;
 a	b	c

--- a/mysql-test/suite/rocksdb/t/dup_key_update.test
+++ b/mysql-test/suite/rocksdb/t/dup_key_update.test
@@ -37,3 +37,24 @@ set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
 # Cleanup
 DROP TABLE t1;
 DROP TABLE t2;
+
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+CREATE TABLE t1 (id1 varchar(2048) CHARACTER SET latin1 COLLATE latin1_bin,
+                 id2 varchar(2048) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin,
+                 id3 varchar(2048) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+                 PRIMARY KEY (id1, id2, id3),
+                 UNIQUE KEY (id3, id1)) ENGINE=ROCKSDB;
+
+CREATE TABLE t2 (id1 varchar(2048) CHARACTER SET latin1 COLLATE latin1_bin,
+                 id2 varchar(2048) CHARACTER SET utf8mb3 COLLATE utf8mb3_bin,
+                 id3 varchar(2048) CHARACTER SET latin1 COLLATE latin1_swedish_ci,
+                 PRIMARY KEY (id1, id2, id3),
+                 UNIQUE KEY (id3, id1) COMMENT 'cfname=rev:cf') ENGINE=ROCKSDB;
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;
+
+--source suite/rocksdb/include/dup_key_update.inc
+
+# Cleanup
+DROP TABLE t1;
+DROP TABLE t2;

--- a/mysql-test/suite/rocksdb/t/index_primary.test
+++ b/mysql-test/suite/rocksdb/t/index_primary.test
@@ -62,7 +62,9 @@ DROP TABLE t1;
 # Test index prefix length limits.
 #
 set @orig_rocksdb_large_prefix=@@global.rocksdb_large_prefix;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
 set @@global.rocksdb_large_prefix=0;
+set @@global.rocksdb_xlarge_prefix=0;
 
 CREATE TABLE t1 (
   a BLOB(1024),
@@ -77,6 +79,7 @@ CREATE TABLE t1 (
 ) ENGINE=ROCKSDB;
 
 set @@global.rocksdb_large_prefix=1;
+set @@global.rocksdb_xlarge_prefix=0;
 
 CREATE TABLE t1 (
   a BLOB(4096),
@@ -91,3 +94,19 @@ CREATE TABLE t1 (
 ) ENGINE=ROCKSDB;
 
 set @@global.rocksdb_large_prefix=@orig_rocksdb_large_prefix;
+
+set @@global.rocksdb_xlarge_prefix=1;
+
+CREATE TABLE t1 (
+    a BLOB(4096),
+PRIMARY KEY (a(4000))
+) ENGINE=ROCKSDB;
+DROP TABLE t1;
+
+--error ER_TOO_LONG_KEY
+CREATE TABLE t1 (
+  a BLOB(65535),
+  PRIMARY KEY (a(49153))
+) ENGINE=ROCKSDB;
+
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;

--- a/mysql-test/suite/rocksdb/t/rocksdb.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb.test
@@ -1739,6 +1739,19 @@ explain select b, a from t1 where b like '1%';
 update t1 set b= '12345' where b = '2abcde';
 select * from t1;
 drop table t1;
+set @orig_rocksdb_xlarge_prefix=@@global.rocksdb_xlarge_prefix;
+set @@global.rocksdb_xlarge_prefix=1;
+create table t1 (a int, b text, c varchar(255), Primary Key(a), Key(b(4000))) engine=rocksdb;
+set @@global.rocksdb_xlarge_prefix=@orig_rocksdb_xlarge_prefix;
+insert into t1 values (1, '1abcde', '1abcde'), (2, '2abcde', '2abcde'), (3, '3abcde', '3abcde');
+select * from t1;
+--replace_column 10 #
+explain select * from t1 where b like '1%';
+--replace_column 10 #
+explain select b, a from t1 where b like '1%';
+update t1 set b= '12345' where b = '2abcde';
+select * from t1;
+drop table t1;
 --error ER_TOO_LONG_KEY
 create table t1 (a int, b text, c varchar(400), Primary Key(a), Key(b(2255))) engine=rocksdb;
 SET sql_mode = @old_mode;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_xlarge_prefix_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_xlarge_prefix_basic.result
@@ -1,0 +1,64 @@
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+INSERT INTO valid_values VALUES('on');
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+INSERT INTO invalid_values VALUES('\'bbb\'');
+SET @start_global_value = @@global.ROCKSDB_XLARGE_PREFIX;
+SELECT @start_global_value;
+@start_global_value
+0
+'# Setting to valid values in global scope#'
+"Trying to set variable @@global.ROCKSDB_XLARGE_PREFIX to 1"
+SET @@global.ROCKSDB_XLARGE_PREFIX   = 1;
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_XLARGE_PREFIX = DEFAULT;
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+0
+"Trying to set variable @@global.ROCKSDB_XLARGE_PREFIX to 0"
+SET @@global.ROCKSDB_XLARGE_PREFIX   = 0;
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+0
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_XLARGE_PREFIX = DEFAULT;
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+0
+"Trying to set variable @@global.ROCKSDB_XLARGE_PREFIX to on"
+SET @@global.ROCKSDB_XLARGE_PREFIX   = on;
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+1
+"Setting the global scope variable back to default"
+SET @@global.ROCKSDB_XLARGE_PREFIX = DEFAULT;
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+0
+"Trying to set variable @@session.ROCKSDB_XLARGE_PREFIX to 444. It should fail because it is not session."
+SET @@session.ROCKSDB_XLARGE_PREFIX   = 444;
+ERROR HY000: Variable 'rocksdb_xlarge_prefix' is a GLOBAL variable and should be set with SET GLOBAL
+'# Testing with invalid values in global scope #'
+"Trying to set variable @@global.ROCKSDB_XLARGE_PREFIX to 'aaa'"
+SET @@global.ROCKSDB_XLARGE_PREFIX   = 'aaa';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+0
+"Trying to set variable @@global.ROCKSDB_XLARGE_PREFIX to 'bbb'"
+SET @@global.ROCKSDB_XLARGE_PREFIX   = 'bbb';
+Got one of the listed errors
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+0
+SET @@global.ROCKSDB_XLARGE_PREFIX = @start_global_value;
+SELECT @@global.ROCKSDB_XLARGE_PREFIX;
+@@global.ROCKSDB_XLARGE_PREFIX
+0
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_xlarge_prefix_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_xlarge_prefix_basic.test
@@ -1,0 +1,19 @@
+--source include/have_rocksdb.inc
+--source include/have_myisam.inc
+
+CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO valid_values VALUES(1);
+INSERT INTO valid_values VALUES(0);
+INSERT INTO valid_values VALUES('on');
+
+CREATE TABLE invalid_values (value varchar(255)) ENGINE=myisam;
+INSERT INTO invalid_values VALUES('\'aaa\'');
+INSERT INTO invalid_values VALUES('\'bbb\'');
+
+--let $sys_var=ROCKSDB_XLARGE_PREFIX
+--let $read_only=0
+--let $session=0
+--source ../include/rocksdb_sys_var.inc
+
+DROP TABLE valid_values;
+DROP TABLE invalid_values;

--- a/sql/sql_const.h
+++ b/sql/sql_const.h
@@ -50,7 +50,7 @@
 #define MAX_SYS_VAR_LENGTH 32
 #define MAX_KEY MAX_INDEXES  /* Max used keys */
 #define MAX_REF_PARTS 16U    /* Max parts used as ref */
-#define MAX_KEY_LENGTH 3072U /* max possible key */
+#define MAX_KEY_LENGTH 49152U /* max possible key */
 #define MAX_REFLENGTH 8      /* Max length for record ref */
 
 #define MAX_MBWIDTH 3 /* Max multibyte sequence */

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -185,10 +185,10 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "ut0mem.h"
 #include "ut0test.h"
 #include "xtradb_i_s.h"
+#include "univ.i"
 #else
 #include <typelib.h>
 #include "buf0types.h"
-#include "univ.i"
 #endif /* !UNIV_HOTBACKUP */
 
 #include "json_binary.h"
@@ -6996,7 +6996,7 @@ uint ha_innobase::max_supported_key_length() const {
     case 8192:
       return (1536);
     default:
-      return (3500);
+      return (INNODB_MAX_KEY_SIZE);
   }
 }
 

--- a/storage/innobase/include/dict0mem.h
+++ b/storage/innobase/include/dict0mem.h
@@ -67,8 +67,6 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "dict/mem.h"
 #include "ut0new.h"
 
-#include "sql/sql_const.h" /* MAX_KEY_LENGTH */
-
 #include <algorithm>
 #include <iterator>
 #include <memory> /* std::unique_ptr */
@@ -904,8 +902,8 @@ struct dict_index_t {
   in a clustered index record, if the fields
   before it are known to be of a fixed size,
   0 otherwise */
-#if (1 << MAX_KEY_LENGTH_BITS) < MAX_KEY_LENGTH
-#error(1<<MAX_KEY_LENGTH_BITS) < MAX_KEY_LENGTH
+#if (1 << MAX_KEY_LENGTH_BITS) < INNODB_MAX_KEY_SIZE
+#error(1<<MAX_KEY_LENGTH_BITS) < INNODB_MAX_KEY_SIZE
 #endif
   unsigned n_user_defined_cols : 10;
   /*!< number of columns the user defined to

--- a/storage/innobase/include/univ.i
+++ b/storage/innobase/include/univ.i
@@ -383,6 +383,10 @@ database name and table name. In addition, 14 bytes is added for:
 only (NONE | ZLIB | LZ4). */
 #define MAX_COMPRESSION_LEN 4
 
+/** The maximum key size allowed in bytes. InnoDB has historically reported
+3500 bytes as the maximum key length allowed. */
+#define INNODB_MAX_KEY_SIZE 3500
+
 /*
                         UNIVERSAL TYPE DEFINITIONS
                         ==========================

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -686,6 +686,7 @@ static bool rocksdb_enable_remove_orphaned_dropped_cfs = true;
 static bool rpl_skip_tx_api_var = false;
 static bool rocksdb_print_snapshot_conflict_queries = false;
 static bool rocksdb_large_prefix = true;
+static bool rocksdb_xlarge_prefix = false;
 static bool rocksdb_allow_to_start_after_corruption = false;
 static uint64_t rocksdb_write_policy =
     rocksdb::TxnDBWritePolicy::WRITE_COMMITTED;
@@ -2223,6 +2224,13 @@ static MYSQL_SYSVAR_BOOL(
     nullptr, nullptr, true);
 
 static MYSQL_SYSVAR_BOOL(
+    xlarge_prefix, rocksdb_xlarge_prefix, PLUGIN_VAR_RQCMDARG,
+    "Support extra large index prefix length of 49152 bytes. If off, the "
+    "maximum index prefix length is 3072 bytes if large prefix is enabled or "
+    "767 bytes.",
+    nullptr, nullptr, false);
+
+static MYSQL_SYSVAR_BOOL(
     allow_to_start_after_corruption, rocksdb_allow_to_start_after_corruption,
     PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_READONLY,
     "Allow server to start successfully when RocksDB corruption is detected.",
@@ -2462,6 +2470,7 @@ static struct SYS_VAR *rocksdb_system_variables[] = {
     MYSQL_SYSVAR(table_stats_background_thread_nice_value),
 
     MYSQL_SYSVAR(large_prefix),
+    MYSQL_SYSVAR(xlarge_prefix),
     MYSQL_SYSVAR(allow_to_start_after_corruption),
     MYSQL_SYSVAR(error_on_suboptimal_collation),
     MYSQL_SYSVAR(no_create_column_family),
@@ -9473,8 +9482,15 @@ bool ha_rocksdb::is_pk(const uint index, const TABLE *const table_arg,
 uint ha_rocksdb::max_supported_key_part_length(
     HA_CREATE_INFO *create_info MY_ATTRIBUTE((__unused__))) const {
   DBUG_ENTER_FUNC();
-  DBUG_RETURN(rocksdb_large_prefix ? MAX_INDEX_COL_LEN_LARGE
-                                   : MAX_INDEX_COL_LEN_SMALL);
+
+  int idx_len = MAX_INDEX_COL_LEN_SMALL;
+  if (rocksdb_xlarge_prefix) {
+      idx_len = MAX_INDEX_COL_LEN_XLARGE;
+  } else if (rocksdb_large_prefix) {
+      idx_len = MAX_INDEX_COL_LEN_LARGE;
+  }
+
+  DBUG_RETURN(idx_len);
 }
 
 const char *ha_rocksdb::get_key_name(const uint index,

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -582,7 +582,7 @@ class ha_rocksdb : public my_core::handler {
   uint max_supported_key_length() const override {
     DBUG_ENTER_FUNC();
 
-    DBUG_RETURN(16 * 1024); /* just to return something*/
+    DBUG_RETURN(ROCKSDB_MAX_KEY_LENGTH);
   }
 
   /**

--- a/storage/rocksdb/rdb_global.h
+++ b/storage/rocksdb/rdb_global.h
@@ -241,9 +241,12 @@ const constexpr uint64_t DEFAULT_SST_MGR_RATE_BYTES_PER_SEC = 0;
 
 #define ROCKSDB_SIZEOF_AUTOINC_VALUE sizeof(longlong)
 
+#define ROCKSDB_MAX_KEY_LENGTH 49152 /* Max key length in bytes */
+
 /*
   Maximum index prefix length in bytes.
 */
+const constexpr uint MAX_INDEX_COL_LEN_XLARGE = 49152;
 const constexpr uint MAX_INDEX_COL_LEN_LARGE = 3072;
 const constexpr uint MAX_INDEX_COL_LEN_SMALL = 767;
 


### PR DESCRIPTION
…ble to 48KB

Summary:
Add support for increasing the max supported key length of RocksDB table to
48KB. Changes:
- Add a variable rocksdb_xlarge_prefix which enables support for key length of
  size up to 48KB. This is disabled by default.
- MySQL had a hard limit of 3072 bytes being the max allowed limit irrespective
  of storage engine - refactored it to be able to increase the limit for
  RocksDB
- InnoDB had some checks that were enforcing the allowed max key size limit
  reported by MySQL to not be more than 4096 - refactored it to be able to
  increase the server level allowed limit