### PR TITLE
PS-7811 merge: Merge MySQL 8.0.26 (fix shutdown condition of io_handl…

### DIFF
--- a/storage/innobase/srv/srv0start.cc
+++ b/storage/innobase/srv/srv0start.cc
@@ -294,7 +294,8 @@ static void io_handler_thread(ulint segment) {
                << actual_priority;
 
   while (srv_shutdown_state.load() != SRV_SHUTDOWN_EXIT_THREADS ||
-         buf_flush_page_cleaner_is_active() || !os_aio_all_slots_free()) {
+         buf_flush_page_cleaner_is_active() || !os_aio_all_slots_free() ||
+         buf_flush_active_lru_managers() > 0) {
     fil_aio_wait(segment);
   }
 }


### PR DESCRIPTION
…er_thread)

https://jira.percona.com/browse/PS-7811

A thread running `buf_lru_manager_thread` performs async operations and
wait for the results. These async operations are acknowledged by the
threads running `io_handler_thread`.

As long as LRU threads are active, IO threads shouldn't exit and they
should process the IO events.

This issue manifested in the tests:

- innodb.temporary_table
- innodb.temp_table_encrypt

---
<https://ps80.cd.percona.com/job/percona-server-8.0-param/1037/>