### PR TITLE
PS-7902 fix 8.0: Conditional jump or move depends on uninitialised value in myrocks::Rdb_tbl_def::get_create_time()

### DIFF
--- a/storage/rocksdb/rdb_datadic.h
+++ b/storage/rocksdb/rdb_datadic.h
@@ -1270,7 +1270,8 @@ class Rdb_tbl_def {
         m_mtcache_lock(0),
         m_mtcache_count(0),
         m_mtcache_size(0),
-        m_mtcache_last_update(0) {
+        m_mtcache_last_update(0),
+        m_create_time(CREATE_TIME_UNKNOWN) {
     set_name(name);
     m_auto_incr_val = other.m_auto_incr_val.load(std::memory_order_relaxed);
     m_hidden_pk_val = other.m_hidden_pk_val.load(std::memory_order_relaxed);


### PR DESCRIPTION
Fixed problem with one of the 'myrocks::Rdb_tbl_def' constructors not
initializing 'm_create_time' field properly (Discovered by Valgrind).