### PR TITLE
Fixed PS-7827 (partition table created with RocksDB engine crashes on a select query)

### DIFF
--- a/mysql-test/suite/rocksdb/r/bug_ps7827.result
+++ b/mysql-test/suite/rocksdb/r/bug_ps7827.result
@@ -1,0 +1,1 @@
+bug_ps7827.test

--- a/mysql-test/suite/rocksdb/t/bug_ps7827.test
+++ b/mysql-test/suite/rocksdb/t/bug_ps7827.test
@@ -1,0 +1,52 @@
+--source include/have_debug.inc
+--source include/have_rocksdb.inc
+
+# The following statements were triggering memory corruption and subsequent
+# server crash. The defect was caused by dereferencing a pointer to a RocksDB
+# partition handler as a generic RocksDB handler which caused possible
+# writes to other allocations memory areas.
+#
+# See also: https://jira.percona.com/browse/PS-7827
+
+--echo bug_ps7827.test
+--disable_query_log
+--disable_result_log
+
+CREATE TABLE tt_12_p (
+  ip_col INT,
+  i0 INT AUTO_INCREMENT,
+  v1 VARCHAR(28),
+  v2 VARCHAR(11),
+  b3 BLOB,
+  d4 DOUBLE,
+  g5 BLOB,
+  INDEX tt_12_pi0(i0 ASC, v1 ASC, ip_col ASC, g5(3) ASC, v2),
+  INDEX tt_12_pi1(g5(7), v2, ip_col, v1),
+  INDEX tt_12_pi2(v2, v1, i0 ASC, ip_col, b3(1), d4, g5(9)),
+  INDEX tt_12_pi3(v1, i0),
+  INDEX tt_12_pi4(v2, b3(6), g5(16) ASC, d4, v1, i0 ASC),
+  INDEX tt_12_pi5(g5(23), v1, d4 ASC, b3(27), v2),
+  INDEX tt_12_pi6(v1)
+) ROW_FORMAT=REDUNDANT ENGINE=RocksDB
+  PARTITION BY LIST (ip_col)(
+    PARTITION p0 VALUES IN (81, 39, 95, 75),
+    PARTITION p1 VALUES IN (33, 44, 7, 10, 68, 78, 72, 2, 24, 73, 50, 56, 83,
+                            26, 32, 18, 23, 14, 27, 55, 66, 58, 15, 16),
+    PARTITION p2 VALUES IN (90, 11, 87, 25, 97, 93, 47, 41, 92, 37, 67, 20, 43,
+                            42, 53, 62, 13));
+
+--let $i=1
+--while ($i <= 100) {
+INSERT INTO tt_12_p (ip_col, i0, v1, v2, b3, d4, g5) VALUES
+  (32, 4120, '', 'mx',
+   'ojhTJ5vAGzutYnIAVnskLu1lkerGrJBqrXUxT1qMWDmL4oqe4rGzx3iWXyp1OzTYbmGxxOnhv2g9Q9udvYy',
+   0.00000, default);
+SELECT * FROM tt_12_p WHERE v2 >= 'fi9';
+TRUNCATE TABLE tt_12_p;
+--  inc $i
+--}
+
+DROP TABLE tt_12_p;
+
+--enable_query_log
+--enable_result_log

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -15599,7 +15599,7 @@ bool ha_rocksdb::use_read_free_rpl() const {
 }
 #endif  // defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
 
-uchar *ha_rocksdb::get_blob_buffer(uint current_size) {
+uchar *blob_buffer::get_blob_buffer(uint current_size) {
   auto output = m_blob_buffer_current;
   m_blob_buffer_current = m_blob_buffer_current + current_size;
   assert((m_blob_buffer_current - m_blob_buffer_start) <=
@@ -15607,7 +15607,7 @@ uchar *ha_rocksdb::get_blob_buffer(uint current_size) {
   return output;
 }
 
-bool ha_rocksdb::reset_blob_buffer(uint total_size) {
+bool blob_buffer::reset_blob_buffer(uint total_size) {
   if (m_blob_buffer_start == nullptr) {
     m_blob_buffer_start = reinterpret_cast<uchar *>(
         my_malloc(PSI_NOT_INSTRUMENTED, total_size, MYF(0)));
@@ -15623,7 +15623,7 @@ bool ha_rocksdb::reset_blob_buffer(uint total_size) {
   return false;
 }
 
-void ha_rocksdb::release_blob_buffer() {
+void blob_buffer::release_blob_buffer() {
   if (m_blob_buffer_start != nullptr) {
     my_free(m_blob_buffer_start);
     m_blob_buffer_start = nullptr;

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -136,12 +136,52 @@ enum table_cardinality_scan_type {
 
 enum Rdb_lock_type { RDB_LOCK_NONE, RDB_LOCK_READ, RDB_LOCK_WRITE };
 
+class blob_buffer {
+ public:
+  ~blob_buffer() { release_blob_buffer(); }
+  /*
+    Returns the buffer of size(current_size) which will be used
+    to store a blob value while unpacking keys from covering index.
+  */
+  uchar *get_blob_buffer(uint current_size);
+
+  /*
+    Resets the m_blob_buffer_current to m_blob_buffer_start.
+    If m_blob_buffer_start is nullptr, then the buffer of size total_size
+    will be allocated.
+  */
+  bool reset_blob_buffer(uint total_size);
+
+  /*
+    Releases the blob buffer memory
+  */
+  void release_blob_buffer();
+
+ protected:
+  /*
+    In case blob indexes are covering, then this buffer will be used
+    to store the unpacked blob values temporarily.
+    Alocation of m_blob_buffer_start will be done as part of reset_blob_buffer()
+    and deallocation will be done in release_blob_buffer()
+    Use case of below 3 parameters -
+    1) m_blob_buffer_start - stores start pointer of the blob buffer.
+    2) m_blob_buffer_current - stores current pointer where we can store blob
+    data.
+    3) m_total_blob_buffer_allocated - amount of total buffer alocated.
+  */
+  uchar *m_blob_buffer_start = nullptr;
+
+  uchar *m_blob_buffer_current = nullptr;
+
+  uint m_total_blob_buffer_allocated = 0;
+};
+
 /**
   @brief
   Class definition for ROCKSDB storage engine plugin handler
 */
 
-class ha_rocksdb : public my_core::handler {
+class ha_rocksdb : public my_core::handler, public blob_buffer {
   my_core::THR_LOCK_DATA m_db_lock;  ///< MySQL database lock
 
   Rdb_table_handler *m_table_handler;  ///< Open table handler
@@ -230,22 +270,6 @@ class ha_rocksdb : public my_core::handler {
     See also m_insert_with_update.
   */
   rocksdb::PinnableSlice m_dup_key_retrieved_record;
-
-  /*
-    In case blob indexes are covering, then this buffer will be used
-    to store the unpacked blob values temporarily.
-    Alocation of m_blob_buffer_start will be done as part of reset_blob_buffer()
-    and deallocation will be done in release_blob_buffer()
-    Use case of below 3 parameters -
-    1) m_blob_buffer_start - stores start pointer of the blob buffer.
-    2) m_blob_buffer_current - stores current pointer where we can store blob
-    data. 3) m_total_blob_buffer_allocated - amount of total buffer alocated.
-  */
-  uchar *m_blob_buffer_start = nullptr;
-
-  uchar *m_blob_buffer_current = nullptr;
-
-  uint m_total_blob_buffer_allocated = 0;
 
   /* Type of locking to apply to rows */
   Rdb_lock_type m_lock_rows;
@@ -886,24 +910,6 @@ class ha_rocksdb : public my_core::handler {
   virtual bool rpl_lookup_rows() override;
 
   virtual bool use_read_free_rpl() const;  // MyRocks only
-
-  /*
-    Returns the buffer of size(current_size) which will be used
-    to store a blob value while unpacking keys from covering index.
-  */
-  uchar *get_blob_buffer(uint current_size);
-
-  /*
-    Resets the m_blob_buffer_current to m_blob_buffer_start.
-    If m_blob_buffer_start is nullptr, then the buffer of size total_size
-    will be allocated.
-  */
-  bool reset_blob_buffer(uint total_size);
-
-  /*
-    Releases the blob buffer memory
-  */
-  void release_blob_buffer();
 
  private:
   /* Flags tracking if we are inside different replication operation */

--- a/storage/rocksdb/ha_rockspart.h
+++ b/storage/rocksdb/ha_rockspart.h
@@ -17,8 +17,11 @@
 
 #include "sql/partitioning/partition_base.h"
 
+#include "./ha_rocksdb.h"
+
 /* This class must contain engine-specific functions for partitioning */
-class ha_rockspart : public native_part::Partition_base {
+class ha_rockspart : public native_part::Partition_base,
+                     public myrocks::blob_buffer {
  public:
   ha_rockspart(handlerton *hton, TABLE_SHARE *table_arg)
       : Partition_base(hton, table_arg){};

--- a/storage/rocksdb/rdb_datadic.cc
+++ b/storage/rocksdb/rdb_datadic.cc
@@ -2164,10 +2164,10 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
   }
 
   // Reset the blob buffer required for unpacking.
-  auto handler = (ha_rocksdb *)table->file;
   if (this->m_max_blob_length) {
-    auto handler = (ha_rocksdb *)table->file;
-    if (handler->reset_blob_buffer(this->m_max_blob_length)) {
+    auto bb = dynamic_cast<blob_buffer *>(table->file);
+    assert(bb);
+    if (bb->reset_blob_buffer(this->m_max_blob_length)) {
       return HA_ERR_OUT_OF_MEM;
     }
   }
@@ -2226,7 +2226,11 @@ int Rdb_key_def::unpack_record(TABLE *const table, uchar *const buf,
     } else {
       /* The checksums are present but we are not checking checksums */
     }
-    handler->m_validated_checksums++;
+
+    // At this point table->file may point to an instance of either ha_rocksdb
+    // or ha_rockspart, so we must be sure it actually is ha_rocksdb.
+    auto handler = dynamic_cast<ha_rocksdb *>(table->file);
+    if (handler) handler->m_validated_checksums++;
   }
 
   if (unlikely(reader.remaining_bytes())) return HA_ERR_ROCKSDB_CORRUPT_DATA;
@@ -3193,8 +3197,9 @@ uchar *Rdb_key_def::get_data_start_ptr(Rdb_field_packing *const fpi, uchar *dst,
   if (fpi->m_field_real_type == MYSQL_TYPE_VARCHAR) {
     data_start = dst + fpi->m_varlength_bytes;
   } else if (is_blob(fpi->m_field_real_type)) {
-    auto handler = static_cast<ha_rocksdb *>(ctx->table->file);
-    data_start = handler->get_blob_buffer(fpi->m_max_field_bytes);
+    auto bb = dynamic_cast<blob_buffer *>(ctx->table->file);
+    assert(bb);
+    data_start = bb->get_blob_buffer(fpi->m_max_field_bytes);
   } else {
     assert(false);
   }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7827
https://jira.percona.com/browse/PS-7815

Problem:
Code in `Rdb_key_def::unpack_record()` and `Rdb_key_def::get_data_start_ptr()`
in MyRocks casts `handler*` pointers back to `ha_rocksdb*` assuming that
they do point to `ha_rocksdb` instances. However, when partitioning is in
use, `rocksdb_create_handler()` creates instances of `ha_rockspart`, which
cannot be casted to `ha_rocksdb`. Trying to do so results in memory
corruptions, and sometimes crashes.

Fix:
Extract buffer management parts of `ha_rocksdb` into a separate class, add
it as a mixin to both `ha_rocksdb` and `ha_rockspart`, and then recover from
`handler*` pointers with `dynamic_cast` at run time. RTTI is already enabled
and used in MyRocks, so no build flags change is necessary.