### PR TITLE
release 8.0.26 16

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -5531,7 +5531,6 @@ static int rocksdb_init_internal(void *const p) {
     LogPluginErrMsg(
         ERROR_LEVEL, 0,
         "Can't enable both use_direct_reads and allow_mmap_reads\n");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5576,7 +5575,6 @@ static int rocksdb_init_internal(void *const p) {
     LogPluginErrMsg(ERROR_LEVEL, 0,
                     "Can't enable both use_direct_io_for_flush_and_compaction "
                     "and allow_mmap_writes\n");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5585,7 +5583,6 @@ static int rocksdb_init_internal(void *const p) {
     LogPluginErrMsg(ERROR_LEVEL, 0,
                     "rocksdb_flush_log_at_trx_commit needs to be 0 to use "
                     "allow_mmap_writes");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5696,14 +5693,12 @@ static int rocksdb_init_internal(void *const p) {
     if (!status.ok()) {
       LogPluginErrMsg(ERROR_LEVEL, 0, "Persistent cache returned error: (%s)",
                       status.getState());
-      deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
       DBUG_RETURN(HA_EXIT_FAILURE);
     }
     rocksdb_tbl_options->persistent_cache = pcache;
   } else if (strlen(rocksdb_persistent_cache_path)) {
     LogPluginErrMsg(ERROR_LEVEL, 0,
                     "ust specify rocksdb_persistent_cache_size_mb");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5717,7 +5712,6 @@ static int rocksdb_init_internal(void *const p) {
                             rocksdb_default_cf_options,
                             rocksdb_override_cf_options)) {
     LogPluginErrMsg(ERROR_LEVEL, 0, "Failed to initialize CF options map.");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5806,7 +5800,6 @@ static int rocksdb_init_internal(void *const p) {
                                  rocksdb_enable_remove_orphaned_dropped_cfs);
       })) {
     LogPluginErrMsg(ERROR_LEVEL, 0, "Failed to initialize data dictionary.");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5822,7 +5815,6 @@ static int rocksdb_init_internal(void *const p) {
         // ROCKSDB_INCLUDE_VALIDATE_TABLES
       })) {
     LogPluginErrMsg(ERROR_LEVEL, 0, "Failed to initialize DDL manager.");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5867,7 +5859,6 @@ static int rocksdb_init_internal(void *const p) {
   if (err != 0) {
     LogPluginErrMsg(ERROR_LEVEL, 0,
                     "Couldn't start the background thread: (errno=%d)", err);
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5880,7 +5871,6 @@ static int rocksdb_init_internal(void *const p) {
   if (err != 0) {
     LogPluginErrMsg(ERROR_LEVEL, 0,
                     "Couldn't start the drop index thread: (errno=%d)", err);
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 
@@ -5924,7 +5914,6 @@ static int rocksdb_init_internal(void *const p) {
                           HA_ERR_ROCKSDB_LAST);
   if (err != 0) {
     LogPluginErrMsg(ERROR_LEVEL, 0, "Couldn't initialize error messages");
-    deinit_logging_service_for_plugin(&reg_srv, &log_bi, &log_bs);
     DBUG_RETURN(HA_EXIT_FAILURE);
   }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7811

`deinit_logging_service_for_plugin` must be called after no more calls
to `LogPluginErrMsg` are done.  If not, the calls to `LogPluginErrMsg`
trigger a segmentation fault as `log_bi` is null.

`rocksdb_shutdown` calls `deinit_logging_service_for_plugin` so previous
calls to `deinit_logging_service_for_plugin` must be removed.

This problem occurred when running the test
`rocksdb.use_direct_reads_writes` as `rocksdb_shutdown` called
`LogPluginErrMsg`.