### PR TITLE
PS-7792: On replica Master_User should be blank if not storing in slave_master_info

### DIFF
--- a/mysql-test/extra/rpl_tests/rpl_reset_slave.test
+++ b/mysql-test/extra/rpl_tests/rpl_reset_slave.test
@@ -132,4 +132,51 @@ if ($_show_master_host != No such row)
 --eval CHANGE MASTER TO MASTER_HOST= '$_slave_master_host', MASTER_USER= '$_slave_master_user', MASTER_PORT= $_slave_master_port
 --source include/start_slave.inc
 
+#
+# PS-7792: On replica Master_User should be blank if not storing in slave_master_info
+# Bug#27357189 MASTER_USER BECOMES 'TEST' IF IT IS EMPTY WHEN READ FROM REPO
+#
+
+# Clean all the previous info and change the repository type to TABLE.
+
+--source include/stop_slave.inc
+
+--let $save_mi_repo_type=`SELECT @@GLOBAL.master_info_repository`
+--let $save_rli_repo_type=`SELECT @@GLOBAL.relay_log_info_repository`
+SET GLOBAL relay_log_info_repository='TABLE';
+SET GLOBAL master_info_repository='TABLE';
+RESET SLAVE ALL;
+
+--echo # Configure the slave with an empty user
+
+--replace_result $MASTER_MYPORT MASTER_PORT
+--eval CHANGE MASTER TO MASTER_USER='', MASTER_PORT=$MASTER_MYPORT, MASTER_HOST='localhost'
+
+--echo # Issue a RESET SLAVE instruction and try to start the slave IO thread that will error out
+
+RESET SLAVE;
+START SLAVE IO_THREAD;
+
+--let $slave_io_errno= convert_error(ER_SLAVE_FATAL_ERROR)
+--source include/wait_for_slave_io_error.inc
+
+--echo # Check the user is still empty
+
+--let $_user= `SELECT user_name FROM mysql.slave_master_info`
+--let $assert_cond= "$_user" = ""
+--let $assert_text= User_name in slave_master_info is empty
+--source include/assert.inc
+
+--echo # Cleanup
+
+--eval SET @@global.master_info_repository='$save_mi_repo_type'
+--eval SET @@global.relay_log_info_repository='$save_rli_repo_type'
+RESET SLAVE ALL;
+
+--replace_result $MASTER_MYPORT MASTER_PORT
+--eval CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=$MASTER_MYPORT, MASTER_USER='root'
+--source include/start_slave.inc
+
+CALL mtr.add_suppression("Slave I/O for channel '': Fatal error: Invalid .* username when attempting to connect to the master server*");
+
 --source include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_row_reset_slave.result
+++ b/mysql-test/suite/rpl/r/rpl_row_reset_slave.result
@@ -101,4 +101,29 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 include/start_slave.inc
+include/stop_slave.inc
+SET GLOBAL relay_log_info_repository='TABLE';
+SET GLOBAL master_info_repository='TABLE';
+RESET SLAVE ALL;
+# Configure the slave with an empty user
+CHANGE MASTER TO MASTER_USER='', MASTER_PORT=MASTER_PORT, MASTER_HOST='localhost';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+# Issue a RESET SLAVE instruction and try to start the slave IO thread that will error out
+RESET SLAVE;
+START SLAVE IO_THREAD;
+include/wait_for_slave_io_error.inc [errno=1593]
+# Check the user is still empty
+include/assert.inc [User_name in slave_master_info is empty]
+# Cleanup
+SET @@global.master_info_repository='FILE';
+SET @@global.relay_log_info_repository='FILE';
+RESET SLAVE ALL;
+CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=MASTER_PORT, MASTER_USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+include/start_slave.inc
+CALL mtr.add_suppression("Slave I/O for channel '': Fatal error: Invalid .* username when attempting to connect to the master server*");
 include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/rpl_stm_reset_slave.result
+++ b/mysql-test/suite/rpl/r/rpl_stm_reset_slave.result
@@ -103,4 +103,29 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 include/start_slave.inc
+include/stop_slave.inc
+SET GLOBAL relay_log_info_repository='TABLE';
+SET GLOBAL master_info_repository='TABLE';
+RESET SLAVE ALL;
+# Configure the slave with an empty user
+CHANGE MASTER TO MASTER_USER='', MASTER_PORT=MASTER_PORT, MASTER_HOST='localhost';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+# Issue a RESET SLAVE instruction and try to start the slave IO thread that will error out
+RESET SLAVE;
+START SLAVE IO_THREAD;
+include/wait_for_slave_io_error.inc [errno=1593]
+# Check the user is still empty
+include/assert.inc [User_name in slave_master_info is empty]
+# Cleanup
+SET @@global.master_info_repository='FILE';
+SET @@global.relay_log_info_repository='FILE';
+RESET SLAVE ALL;
+CHANGE MASTER TO MASTER_HOST='127.0.0.1', MASTER_PORT=MASTER_PORT, MASTER_USER='root';
+Warnings:
+Note	1759	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	1760	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+include/start_slave.inc
+CALL mtr.add_suppression("Slave I/O for channel '': Fatal error: Invalid .* username when attempting to connect to the master server*");
 include/rpl_end.inc

--- a/sql/rpl_mi.cc
+++ b/sql/rpl_mi.cc
@@ -404,7 +404,7 @@ bool Master_info::read_info(Rpl_info_handler *from)
   if (from->get_info(&temp_master_log_pos,
                      (ulong) BIN_LOG_HEADER_SIZE) ||
       from->get_info(host, sizeof(host), (char *) 0) ||
-      from->get_info(user, sizeof(user), (char *) "test") ||
+      from->get_info(user, sizeof(user), (char *) 0) ||
       from->get_info(password, sizeof(password), (char *) 0) ||
       from->get_info((int *) &port, (int) MYSQL_PORT) ||
       from->get_info((int *) &connect_retry,


### PR DESCRIPTION
PS-7792: On replica Master_User should be blank if not storing in slave_master_info
BUG#27357189: MASTER_USER BECOMES 'TEST' IF IT IS EMPTY WHEN READ FROM REPO

This commit backports the bugfix for Oracle Bug#27357189 to PS-5.7.

When the user for the master connection is empty and there is a read
from the repository information the user becomes 'test'. This happens
as the default value when there is no information is 'test'.

The default value is now empty as well.

ReviewBoard: 24194
(cherry picked from commit 304e920403cecaab9a45834d041bc2ea5a0d2a57)

Testing Done
---
Jenkins: https://ps57.cd.percona.com/job/percona-server-5.7-param/501/console (In Progress)
Failing tests: