### PR TITLE
PS-7894 Wrong error when query interrupted

### DIFF
--- a/mysql-test/suite/rocksdb/r/issue7894.result
+++ b/mysql-test/suite/rocksdb/r/issue7894.result
@@ -1,0 +1,18 @@
+CREATE TABLE test_table_rocksdb(id INT NOT NULL PRIMARY KEY, value CHAR(32)) ENGINE=ROCKSDB;
+INSERT INTO test_table_rocksdb VALUES(1, 'one');
+SET SESSION rocksdb_lock_wait_timeout=10;
+BEGIN;
+SELECT /*+ MAX_EXECUTION_TIME(5) */ * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+id	value
+1	one
+SELECT /*+ MAX_EXECUTION_TIME(5) */ * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+ERROR HY000: Query execution was interrupted, maximum statement execution time exceeded
+SELECT * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+SET SESSION rocksdb_lock_wait_timeout=5;
+SELECT /*+ MAX_EXECUTION_TIME(20000) */ * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+set max_execution_time=2000;
+SELECT * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+ERROR HY000: Query execution was interrupted, maximum statement execution time exceeded
+DROP table test_table_rocksdb;

--- a/mysql-test/suite/rocksdb/t/issue7894.test
+++ b/mysql-test/suite/rocksdb/t/issue7894.test
@@ -1,0 +1,32 @@
+# issue 7894 : Wrong error when query interrupted due to MAX_EXECUTION_TIME
+--source include/have_rocksdb.inc
+
+connect (con1, localhost, root,,);
+connection default;
+
+CREATE TABLE test_table_rocksdb(id INT NOT NULL PRIMARY KEY, value CHAR(32)) ENGINE=ROCKSDB;
+
+INSERT INTO test_table_rocksdb VALUES(1, 'one');
+
+SET SESSION rocksdb_lock_wait_timeout=10;
+
+connection con1;
+BEGIN;
+SELECT /*+ MAX_EXECUTION_TIME(5) */ * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+
+connection default;
+--error ER_QUERY_TIMEOUT
+SELECT /*+ MAX_EXECUTION_TIME(5) */ * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+--error ER_LOCK_WAIT_TIMEOUT
+SELECT * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+
+SET SESSION rocksdb_lock_wait_timeout=5;
+--error ER_LOCK_WAIT_TIMEOUT
+SELECT /*+ MAX_EXECUTION_TIME(20000) */ * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+
+set max_execution_time=2000;
+--error ER_QUERY_TIMEOUT
+SELECT * FROM test_table_rocksdb WHERE id=1 FOR UPDATE;
+
+connection con1;
+DROP table test_table_rocksdb;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -15691,10 +15691,22 @@ double ha_rocksdb::read_time(uint index, uint ranges, ha_rows rows) {
 }
 
 void ha_rocksdb::print_error(int error, myf errflag) {
-  if (error == HA_ERR_ROCKSDB_STATUS_BUSY) {
-    error = HA_ERR_LOCK_DEADLOCK;
+  switch (error) {
+    case HA_ERR_ROCKSDB_STATUS_BUSY:
+      handler::print_error(HA_ERR_LOCK_DEADLOCK, errflag);
+      break;
+    case HA_ERR_LOCK_WAIT_TIMEOUT:
+      if (error == HA_ERR_LOCK_WAIT_TIMEOUT && my_core::thd_killed(ha_thd())) {
+        my_error(ER_QUERY_TIMEOUT, errflag,
+                 table_share->table_name.str /*, error*/);
+      } else {
+        handler::print_error(error, errflag);
+      }
+      break;
+    default:
+      handler::print_error(error, errflag);
+      break;
   }
-  handler::print_error(error, errflag);
 }
 
 std::string rdb_corruption_marker_file_name() {


### PR DESCRIPTION
This PR tries to fix wrong error message when query interrupted and also to introduce changes to MTR test-cases to make them pass with newly returned error messages.