### PR TITLE
PS-5168: Set stats.data_file_length in temptable SE

### DIFF
--- a/mysql-test/r/percona_log_slow_query_plan.result
+++ b/mysql-test/r/percona_log_slow_query_plan.result
@@ -216,7 +216,7 @@ COUNT(*)
 1
 1
 [log_stop.inc] percona_slow_query_log.query_plan_9
-[log_grep.inc] file: percona_slow_query_log.query_plan_9 pattern: ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [0-9]*$ expected_matches: 1
+[log_grep.inc] file: percona_slow_query_log.query_plan_9 pattern: ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*$ expected_matches: 1
 [log_grep.inc] found expected match count: 1
 [log_grep.inc] file: percona_slow_query_log.query_plan_9 pattern: ^#.*Tmp_table: Yes  Tmp_table_on_disk: No$ expected_matches: 1
 [log_grep.inc] found expected match count: 1

--- a/mysql-test/t/percona_log_slow_query_plan.test
+++ b/mysql-test/t/percona_log_slow_query_plan.test
@@ -248,9 +248,7 @@ EXPLAIN SELECT COUNT(*) FROM t1, t3 WHERE t1.a = t3.a GROUP BY t3.a;
 --source include/log_start.inc
 SELECT COUNT(*) FROM t1, t3 WHERE t1.a = t3.a GROUP BY t3.a;
 --source include/log_stop.inc
-# The pattern below should also check for "Tmp_table_sizes: [1-9][0-9]*", but
-# this is disabled because of https://jira.percona.com/browse/PS-5168
---let grep_pattern = ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [0-9]*\$
+--let grep_pattern = ^# Tmp_tables: 1  Tmp_disk_tables: 0  Tmp_table_sizes: [1-9][0-9]*\$
 --let log_expected_matches= 1
 --source include/log_grep.inc
 --let grep_pattern = ^#.*Tmp_table: Yes  Tmp_table_on_disk: No\$

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -2371,7 +2371,6 @@ void close_tmp_table(TABLE *table) {
   DBUG_TRACE;
   DBUG_PRINT("enter", ("table: %s", table->alias));
 
-  // Possibly use current_thd instead of table->in_use
   if (table->file && table->in_use != nullptr)
     table->in_use->tmp_tables_size += table->file->stats.data_file_length;
 

--- a/storage/temptable/include/temptable/allocator.h
+++ b/storage/temptable/include/temptable/allocator.h
@@ -277,6 +277,12 @@ struct AllocatorState {
    * new block needs to be created.
    */
   size_t number_of_blocks = 0;
+
+  /**
+   * Allocated memory size counter. Used for statistics to determine
+   * maximum allocated memory space for a table.
+   */
+  size_t allocated_mem_counter;
 };
 
 /** Custom memory allocator. All dynamic memory used by the TempTable engine
@@ -413,6 +419,10 @@ class Allocator {
    * before other methods. */
   static void init();
 
+  uint64_t get_allocated_mem_counter() const {
+    return m_state->allocated_mem_counter;
+  }
+
   /**
     Shared state between all the copies and rebinds of this allocator.
     See AllocatorState for details.
@@ -499,6 +509,7 @@ inline T *Allocator<T, AllocationScheme>::allocate(size_t n_elements) {
   T *chunk_data =
       reinterpret_cast<T *>(block->allocate(n_bytes_requested).data());
   assert(reinterpret_cast<uintptr_t>(chunk_data) % alignof(T) == 0);
+  m_state->allocated_mem_counter += n_bytes_requested;
   return chunk_data;
 }
 

--- a/storage/temptable/include/temptable/table.h
+++ b/storage/temptable/include/temptable/table.h
@@ -69,6 +69,8 @@ class Table {
 
   size_t number_of_rows() const;
 
+  uint64_t get_mem_counter() const;
+
   const Index &index(size_t i) const;
 
   const Column &column(size_t i) const;
@@ -184,6 +186,10 @@ inline size_t Table::number_of_columns() const { return m_columns.size(); }
 inline const Columns &Table::columns() const { return m_columns; }
 
 inline size_t Table::number_of_rows() const { return m_rows.size(); }
+
+inline uint64_t Table::get_mem_counter() const {
+  return m_allocator.get_allocated_mem_counter();
+}
 
 inline const Index &Table::index(size_t i) const {
   return *m_index_entries[i].m_index;

--- a/storage/temptable/src/handler.cc
+++ b/storage/temptable/src/handler.cc
@@ -205,6 +205,8 @@ int Handler::open(const char *table_name, int, uint, const dd::Table *) {
     ret = Result::OUT_OF_MEM;
   }
 
+  info(HA_STATUS_VARIABLE);
+
   DBUG_PRINT("temptable_api", ("this=%p %s; return=%s", this, table_name,
                                result_to_string(ret)));
 
@@ -650,6 +652,8 @@ int Handler::write_row(uchar *mysql_row) {
 
   const Result ret = m_opened_table->insert(mysql_row);
 
+  info(HA_STATUS_VARIABLE);
+
   DBUG_RET(ret);
 }
 
@@ -672,6 +676,8 @@ int Handler::update_row(const uchar *mysql_row_old, uchar *mysql_row_new) {
 
   const Result ret =
       m_opened_table->update(mysql_row_old, mysql_row_new, target_row);
+
+  info(HA_STATUS_VARIABLE);
 
   DBUG_RET(ret);
 }
@@ -736,6 +742,7 @@ int Handler::info(uint) {
   stats.deleted = m_deleted_rows;
   stats.records = m_opened_table->number_of_rows();
   stats.table_in_mem_estimate = 1.0;
+  stats.data_file_length = m_opened_table->get_mem_counter();
 
   for (uint i = 0; i < table->s->keys; ++i) {
     KEY *key = &table->key_info[i];


### PR DESCRIPTION
https://jira.percona.com/browse/PS-5168

The stats.data_file_length isn't set in temptable storage
engine. As a result of this we always get "Tmp_table_sizes: 0"
in slow query log even in case temporary table was actually
used during query processing.

To fix the issue the Handler::info() for temptable was updated
to set stats.data_file_length. Needed info is fetched from the
allocator instance wich handles all memory allocations for
the temptable storage engine.
In addition invocation of Handler::info() added in Handler::open()
to properly update memory usage after table is opened.