### PR TITLE
PS-7883 : Server crashes with ALTER query when --rocksdb_write_disable_wal is enabled

### DIFF
--- a/mysql-test/suite/rocksdb/r/locking_issues.result
+++ b/mysql-test/suite/rocksdb/r/locking_issues.result
@@ -1,3 +1,5 @@
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
 
 -----------------------------------------------------------------------
 - Locking issues case 1.1:
@@ -429,3 +431,4 @@ COMMIT;
 DROP TABLE t1;
 DROP TABLE t2;
 SET GLOBAL rocksdb_lock_scanned_rows=0;
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;

--- a/mysql-test/suite/rocksdb/r/rocksdb_bug7883.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_bug7883.result
@@ -1,0 +1,8 @@
+call mtr.add_suppression("Plugin rocksdb reported:");
+call mtr.add_suppression("Plugin 'ROCKSDB'");
+CREATE TABLE tt_12 (ipkey INT AUTO_INCREMENT, i1 INT, d2 DOUBLE,
+PRIMARY KEY(ipkey), INDEX tt_12i0(d2, i1 ASC, ipkey),
+INDEX tt_12i1(ipkey, i1, d2))
+ROW_FORMAT=DYNAMIC ENGINE=RocksDB;
+ERROR 42000: Unknown storage engine 'RocksDB'
+Pattern found.

--- a/mysql-test/suite/rocksdb/r/rocksdb_bug7883_2.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_bug7883_2.result
@@ -1,0 +1,37 @@
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @rocksdb_write_disable_wal_saved = @@session.rocksdb_write_disable_wal;
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
+SET @@session.rocksdb_write_disable_wal=ON;
+SET @@session.rocksdb_write_disable_wal=OFF;
+SET @@global.rocksdb_flush_log_at_trx_commit = 1;
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+Variable_name	Value
+rocksdb_write_disable_wal	ON
+CREATE TABLE tt_12 (ipkey INT AUTO_INCREMENT, i1 INT, d2 DOUBLE,
+PRIMARY KEY(ipkey), INDEX tt_12i0(d2, i1 ASC, ipkey),
+INDEX tt_12i1(ipkey, i1, d2))
+ROW_FORMAT=DYNAMIC ENGINE=RocksDB;
+REPLACE INTO tt_12  (ipkey, i1, d2) VALUES(2097, 6145, 0.00000);
+call mtr.add_suppression("Sync writes has to enable WAL. Switching to rocksdb_write_disable_wal = false for the time when sync writes are enabled.");
+ALTER TABLE tt_12 MODIFY COLUMN  ipkey INT(14), LOCK=DEFAULT, ALGORITHM=DEFAULT;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Pattern found.
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+Variable_name	Value
+rocksdb_write_disable_wal	OFF
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+Variable_name	Value
+rocksdb_write_disable_wal	OFF
+call mtr.add_suppression("Sync writes disabled. Switching back to rocksdb_write_disable_wal = true");
+ALTER TABLE tt_12 MODIFY COLUMN  ipkey INT(15), LOCK=DEFAULT, ALGORITHM=DEFAULT;
+Warnings:
+Warning	1681	Integer display width is deprecated and will be removed in a future release.
+Pattern found.
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+Variable_name	Value
+rocksdb_write_disable_wal	ON
+DROP TABLE tt_12;
+SET @@session.rocksdb_write_disable_wal = @rocksdb_write_disable_wal_saved;
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;

--- a/mysql-test/suite/rocksdb/t/locking_issues.test
+++ b/mysql-test/suite/rocksdb/t/locking_issues.test
@@ -1,5 +1,11 @@
 --source include/have_rocksdb.inc
 
+# rocksdb_write_disable_wal=ON is incompatible with
+# synchronous writes (rocksdb_flush_log_at_trx_commit=1).
+# See https://jira.percona.com/browse/PS-7883 for details.
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
+
 let $isolation_level = REPEATABLE READ;
 --source suite/rocksdb/include/locking_issues_case1_1.inc
 
@@ -71,3 +77,5 @@ let $isolation_level = REPEATABLE READ;
 
 let $isolation_level = READ COMMITTED;
 --source suite/rocksdb/include/locking_issues_case7.inc
+
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;

--- a/mysql-test/suite/rocksdb/t/rocksdb_bug7883-master.opt
+++ b/mysql-test/suite/rocksdb/t/rocksdb_bug7883-master.opt
@@ -1,0 +1,1 @@
+--loose-rocksdb_write_disable_wal=ON

--- a/mysql-test/suite/rocksdb/t/rocksdb_bug7883.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_bug7883.test
@@ -1,0 +1,19 @@
+--source include/have_rocksdb.inc
+
+# rocksdb_write_disable_wal=ON is incompatible with
+# synchronous writes (rocksdb_flush_log_at_trx_commit=1).
+# See https://jira.percona.com/browse/PS-7883 for details.
+
+call mtr.add_suppression("Plugin rocksdb reported:");
+call mtr.add_suppression("Plugin 'ROCKSDB'");
+
+--error ER_UNKNOWN_STORAGE_ENGINE
+CREATE TABLE tt_12 (ipkey INT AUTO_INCREMENT, i1 INT, d2 DOUBLE,
+                    PRIMARY KEY(ipkey), INDEX tt_12i0(d2, i1 ASC, ipkey),
+                    INDEX tt_12i1(ipkey, i1, d2))
+                   ROW_FORMAT=DYNAMIC ENGINE=RocksDB;
+
+--let $grep_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $grep_pattern=\[ERROR\] .* Plugin rocksdb reported: 'Invalid argument: Sync writes \(rocksdb_flush_log_at_trx_commit == 1\) has to enable WAL'
+--let $grep_output=boolean
+--source include/grep_pattern.inc

--- a/mysql-test/suite/rocksdb/t/rocksdb_bug7883_2.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_bug7883_2.test
@@ -1,0 +1,71 @@
+--source include/have_rocksdb.inc
+
+--connect(con1, localhost, root,,)
+--connect(con2, localhost, root,,)
+
+--connection con1
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @rocksdb_write_disable_wal_saved = @@session.rocksdb_write_disable_wal;
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
+SET @@session.rocksdb_write_disable_wal=ON;
+
+--connection con2
+SET @@session.rocksdb_write_disable_wal=OFF;
+SET @@global.rocksdb_flush_log_at_trx_commit = 1;
+
+--connection con1
+# Now rocksdb_flush_log_at_trx_commit = 1 and rocksdb_write_disable_wal=ON
+# The following statements have caused crash as
+# rocksdb_write_disable_wal=ON is incompatible with
+# synchronous writes (rocksdb_flush_log_at_trx_commit=1).
+# See https://jira.percona.com/browse/PS-7883 for details.
+
+# The incompatible value (ON) is retained until the variable is used and the
+# incompatible value will not be temporarily hidden by the compatible
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+
+CREATE TABLE tt_12 (ipkey INT AUTO_INCREMENT, i1 INT, d2 DOUBLE,
+                    PRIMARY KEY(ipkey), INDEX tt_12i0(d2, i1 ASC, ipkey),
+                    INDEX tt_12i1(ipkey, i1, d2))
+                   ROW_FORMAT=DYNAMIC ENGINE=RocksDB;
+
+REPLACE INTO tt_12  (ipkey, i1, d2) VALUES(2097, 6145, 0.00000);
+
+call mtr.add_suppression("Sync writes has to enable WAL. Switching to rocksdb_write_disable_wal = false for the time when sync writes are enabled.");
+ALTER TABLE tt_12 MODIFY COLUMN  ipkey INT(14), LOCK=DEFAULT, ALGORITHM=DEFAULT;
+
+--let $grep_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $grep_pattern=\[Warning\] .* Plugin rocksdb reported: 'Sync writes has to enable WAL. Switching to rocksdb_write_disable_wal = false for the time when sync writes are enabled.'
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+# The compatible value (OFF) hides incompatible (ON) after ALTER TABLE
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+
+--connection con2
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
+
+--connection con1
+
+# The compatible value (OFF) that hides a previously incompatible value (ON) is
+# retained until the variable is used
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+
+call mtr.add_suppression("Sync writes disabled. Switching back to rocksdb_write_disable_wal = true");
+ALTER TABLE tt_12 MODIFY COLUMN  ipkey INT(15), LOCK=DEFAULT, ALGORITHM=DEFAULT;
+
+--let $grep_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $grep_pattern=\[Warning\] .* Plugin rocksdb reported: 'Sync writes disabled. Switching back to rocksdb_write_disable_wal = true'
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+# The originally incompatible value (ON) is now compatible and we see and use it
+SHOW SESSION VARIABLES LIKE "rocksdb_write_disable_wal";
+
+DROP TABLE tt_12;
+
+SET @@session.rocksdb_write_disable_wal = @rocksdb_write_disable_wal_saved;
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;
+
+--disconnect con1
+--disconnect con2

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_flush_log_at_trx_commit_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_flush_log_at_trx_commit_basic.result
@@ -1,3 +1,5 @@
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @rocksdb_write_disable_wal_saved = @@session.rocksdb_write_disable_wal;
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO valid_values VALUES(2);
 INSERT INTO valid_values VALUES(1);
@@ -55,3 +57,9 @@ SELECT @@global.ROCKSDB_FLUSH_LOG_AT_TRX_COMMIT;
 1
 DROP TABLE valid_values;
 DROP TABLE invalid_values;
+SET @@global.rocksdb_flush_log_at_trx_commit=0;
+SET @@session.rocksdb_write_disable_wal = ON;
+SET @@global.rocksdb_flush_log_at_trx_commit=1;
+ERROR HY000: Got error 513 'rocksdb_flush_log_at_trx_commit = 1 and rocksdb_write_disable_wal = ON are not compatible' from ROCKSDB
+SET @@session.rocksdb_write_disable_wal = @rocksdb_write_disable_wal_saved;
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;

--- a/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_write_disable_wal_basic.result
+++ b/mysql-test/suite/rocksdb_sys_vars/r/rocksdb_write_disable_wal_basic.result
@@ -1,3 +1,6 @@
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @rocksdb_write_disable_wal_saved = @@session.rocksdb_write_disable_wal;
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO valid_values VALUES(1);
 INSERT INTO valid_values VALUES(0);
@@ -112,3 +115,9 @@ SELECT @@session.ROCKSDB_WRITE_DISABLE_WAL;
 0
 DROP TABLE valid_values;
 DROP TABLE invalid_values;
+SET @@session.rocksdb_write_disable_wal=OFF;
+SET @@global.rocksdb_flush_log_at_trx_commit = 1;
+SET @@session.rocksdb_write_disable_wal=ON;
+ERROR HY000: Got error 513 'rocksdb_flush_log_at_trx_commit = 1 and rocksdb_write_disable_wal = ON are not compatible' from ROCKSDB
+SET @@session.rocksdb_write_disable_wal = @rocksdb_write_disable_wal_saved;
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_flush_log_at_trx_commit_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_flush_log_at_trx_commit_basic.test
@@ -1,6 +1,9 @@
 --source include/have_rocksdb.inc
 --source include/have_myisam.inc
 
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @rocksdb_write_disable_wal_saved = @@session.rocksdb_write_disable_wal;
+
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO valid_values VALUES(2);
 INSERT INTO valid_values VALUES(1);
@@ -16,3 +19,17 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;
+
+################################################################################
+# Change the value of rocksdb_flush_log_at_trx_commit to an incompatible value #
+################################################################################
+# rocksdb_write_disable_wal=ON is incompatible with
+# synchronous writes (rocksdb_flush_log_at_trx_commit=1).
+# See https://jira.percona.com/browse/PS-7883 for details.
+SET @@global.rocksdb_flush_log_at_trx_commit=0;
+SET @@session.rocksdb_write_disable_wal = ON;
+--error ER_GET_ERRMSG
+SET @@global.rocksdb_flush_log_at_trx_commit=1;
+
+SET @@session.rocksdb_write_disable_wal = @rocksdb_write_disable_wal_saved;
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;

--- a/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_write_disable_wal_basic.test
+++ b/mysql-test/suite/rocksdb_sys_vars/t/rocksdb_write_disable_wal_basic.test
@@ -1,6 +1,13 @@
 --source include/have_rocksdb.inc
 --source include/have_myisam.inc
 
+# rocksdb_write_disable_wal=ON is incompatible with
+# synchronous writes (rocksdb_flush_log_at_trx_commit=1).
+# See https://jira.percona.com/browse/PS-7883 for details.
+SET @rocksdb_flush_log_at_trx_commit_saved = @@global.rocksdb_flush_log_at_trx_commit;
+SET @rocksdb_write_disable_wal_saved = @@session.rocksdb_write_disable_wal;
+SET @@global.rocksdb_flush_log_at_trx_commit = 2;
+
 CREATE TABLE valid_values (value varchar(255)) ENGINE=myisam;
 INSERT INTO valid_values VALUES(1);
 INSERT INTO valid_values VALUES(0);
@@ -17,3 +24,17 @@ INSERT INTO invalid_values VALUES('\'aaa\'');
 
 DROP TABLE valid_values;
 DROP TABLE invalid_values;
+
+##########################################################################
+# Change the value of rocksdb_write_disable_wal to an incompatible value #
+##########################################################################
+# rocksdb_write_disable_wal=ON is incompatible with
+# synchronous writes (rocksdb_flush_log_at_trx_commit=1).
+# See https://jira.percona.com/browse/PS-7883 for details.
+SET @@session.rocksdb_write_disable_wal=OFF;
+SET @@global.rocksdb_flush_log_at_trx_commit = 1;
+--error ER_GET_ERRMSG
+SET @@session.rocksdb_write_disable_wal=ON;
+
+SET @@session.rocksdb_write_disable_wal = @rocksdb_write_disable_wal_saved;
+SET @@global.rocksdb_flush_log_at_trx_commit = @rocksdb_flush_log_at_trx_commit_saved;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7883

Sync writes has to enable WAL. Output a warning if wal is disabled and
sync writes is enabled, and ignore wal disabled