### PR TITLE
PS-7811 merge: Merge MySQL 8.0.26 (partition_base inline fixes)

### DIFF
--- a/sql/partitioning/partition_base.cc
+++ b/sql/partitioning/partition_base.cc
@@ -4558,7 +4558,7 @@ void Partition_base::cancel_pushed_idx_cond() {
   Also sets stats.auto_increment_value.
 */
 
-inline int Partition_base::initialize_auto_increment(bool no_lock) {
+int Partition_base::initialize_auto_increment(bool no_lock) {
   DBUG_ENTER("Partition_base::initialize_auto_increment");
 #ifndef NDEBUG
   if (table_share->tmp_table == NO_TMP_TABLE) {

--- a/sql/partitioning/partition_handler.cc
+++ b/sql/partitioning/partition_handler.cc
@@ -782,7 +782,7 @@ void Partition_helper::get_auto_increment_first_field(
   *nb_reserved_values = nb_desired_values;
 }
 
-inline void Partition_helper::set_auto_increment_if_higher() {
+void Partition_helper::set_auto_increment_if_higher() {
   Field_num *field = static_cast<Field_num *>(m_table->found_next_number_field);
   ulonglong nr =
       (field->is_unsigned() || field->val_int() > 0) ? field->val_int() : 0;
@@ -1395,7 +1395,7 @@ err:
   Set table->read_set taking partitioning expressions into account.
 */
 
-inline void Partition_helper::set_partition_read_set() {
+void Partition_helper::set_partition_read_set() {
   /*
     For operations that may need to change data, we may need to extend
     read_set.

--- a/sql/partitioning/partition_handler.h
+++ b/sql/partitioning/partition_handler.h
@@ -141,12 +141,12 @@ class Partition_share : public Handler_share {
                                     const ulonglong max_reserved);
 
   /** lock mutex protecting auto increment value next_auto_inc_val. */
-  inline void lock_auto_inc() {
+  void lock_auto_inc() {
     assert(auto_inc_mutex);
     mysql_mutex_lock(auto_inc_mutex);
   }
   /** unlock mutex protecting auto increment value next_auto_inc_val. */
-  inline void unlock_auto_inc() {
+  void unlock_auto_inc() {
     assert(auto_inc_mutex);
     mysql_mutex_unlock(auto_inc_mutex);
   }
@@ -643,7 +643,7 @@ class Partition_helper {
   /**
     unlock auto increment.
   */
-  inline void unlock_auto_increment() {
+  void unlock_auto_increment() {
     /*
       If m_auto_increment_safe_stmt_log_lock is true, we have to keep the lock.
       It will be set to false and thus unlocked at the end of the statement by
@@ -930,7 +930,7 @@ class Partition_helper {
   /**
     Update auto increment value if current row contains a higher value.
   */
-  inline void set_auto_increment_if_higher();
+  void set_auto_increment_if_higher();
   /**
     Common routine to set up index scans.
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7811

Fixed an issue with some functions in Native Partitioning base
code declared 'inline' and then defined externally in a '.cc'
file.

This used to cause 'undefined symbol' errors when loading
'ha_rocksdb.so' on some platforms (Ubuntu 21.04 Hirsute,
GCC 10.3.0, RelWithDebInfo configuration).

***************************************************************
2021-10-13T15:33:09.033629Z 0 [ERROR] [MY-010901] [Server] Can't open shared library
'/tmp/results/PS/plugin_output_directory/ha_rocksdb.so'
(errno: 0 /tmp/results/PS/plugin_output_directory/ha_rocksdb.so:
undefined symbol: _ZN11native_part14Partition_base25initialize_auto_incre).
***************************************************************