### PR TITLE
PS-2326: ROW Level replication slow query logging

### DIFF
--- a/mysql-test/suite/rpl/r/percona_log_slow_replica_statements_row.result
+++ b/mysql-test/suite/rpl/r/percona_log_slow_replica_statements_row.result
@@ -1,0 +1,66 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+SET SESSION binlog_rows_query_log_events=1;
+CREATE TABLE t1 (id INT);
+CREATE TABLE t2 (id INT);
+CREATE FUNCTION f1() RETURNS INTEGER
+BEGIN
+INSERT INTO t2 VALUES (1),(2),(3);
+UPDATE t2 SET id=4 WHERE id=3;
+DELETE FROM t2;
+RETURN 1;
+END|
+include/sync_slave_sql_with_master.inc
+SET @saved_min_examined_row_limit=@@GLOBAL.min_examined_row_limit;
+SET GLOBAL min_examined_row_limit=0;
+SET @saved_long_query_time=@@GLOBAL.long_query_time;
+SET GLOBAL long_query_time=0;
+SET @saved_log_slow_replica_statements=@@GLOBAL.log_slow_replica_statements;
+SET GLOBAL log_slow_replica_statements=OFF;
+include/restart_slave.inc
+[log_start.inc] percona.slow_extended.log_slow_replica_statements_rbr
+[connection master]
+INSERT INTO t1 VALUES (1);
+include/sync_slave_sql_with_master.inc
+SET GLOBAL log_slow_replica_statements=ON;
+[connection master]
+BEGIN;
+INSERT INTO t1 VALUES (2);
+UPDATE t1 SET id = 3 WHERE id = 2;
+DELETE FROM t1;
+COMMIT;
+SELECT f1();
+f1()
+1
+include/sync_slave_sql_with_master.inc
+SET GLOBAL log_slow_replica_statements=OFF;
+[connection master]
+INSERT INTO t1 VALUES (3);
+include/sync_slave_sql_with_master.inc
+[log_stop.inc] percona.slow_extended.log_slow_replica_statements_rbr
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_rbr pattern: Write_rows `test`.`t1`
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_rbr pattern: Update_rows `test`.`t1`
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_rbr pattern: Delete_rows `test`.`t1`
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_rbr pattern: Write_rows `test`.`t2`
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_rbr pattern: Update_rows `test`.`t2`
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_rbr pattern: Delete_rows `test`.`t2`
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_rbr pattern: ^# User@Host: skip-grants user\[SQL_SLAVE\] @  \[\]
+[log_grep.inc] lines:   7
+[connection master]
+DROP FUNCTION f1;
+DROP TABLE t1;
+DROP TABLE t2;
+[connection slave]
+SET GLOBAL log_slow_replica_statements=@saved_log_slow_replica_statements;
+SET GLOBAL long_query_time=@saved_long_query_time;
+SET GLOBAL min_examined_row_limit=@saved_min_examined_row_limit;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/r/percona_log_slow_replica_statements_stmt.result
+++ b/mysql-test/suite/rpl/r/percona_log_slow_replica_statements_stmt.result
@@ -12,27 +12,32 @@ SET GLOBAL long_query_time=0;
 SET @saved_log_slow_replica_statements=@@GLOBAL.log_slow_replica_statements;
 SET GLOBAL log_slow_replica_statements=OFF;
 include/restart_slave.inc
-[log_start.inc] percona.slow_extended.log_slow_replica_statements
+[log_start.inc] percona.slow_extended.log_slow_replica_statements_sbr
+[connection master]
 INSERT INTO t VALUES (1);
 include/sync_slave_sql_with_master.inc
 SET GLOBAL log_slow_replica_statements=ON;
+[connection master]
 BEGIN;
 INSERT INTO t VALUES (2);
 COMMIT;
 include/sync_slave_sql_with_master.inc
 SET GLOBAL log_slow_replica_statements=OFF;
+[connection master]
 INSERT INTO t VALUES (3);
 include/sync_slave_sql_with_master.inc
-[log_stop.inc] percona.slow_extended.log_slow_replica_statements
-[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements pattern: INSERT INTO t VALUES \(1\)
+[log_stop.inc] percona.slow_extended.log_slow_replica_statements_sbr
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_sbr pattern: INSERT INTO t VALUES \(1\)
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements pattern: INSERT INTO t VALUES \(2\)
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_sbr pattern: INSERT INTO t VALUES \(2\)
 [log_grep.inc] lines:   1
-[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements pattern: INSERT INTO t VALUES \(3\)
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_sbr pattern: INSERT INTO t VALUES \(3\)
 [log_grep.inc] lines:   0
-[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements pattern: ^# User@Host: skip-grants user\[SQL_SLAVE\] @  \[\]
+[log_grep.inc] file: percona.slow_extended.log_slow_replica_statements_sbr pattern: ^# User@Host: skip-grants user\[SQL_SLAVE\] @  \[\]
 [log_grep.inc] lines:   1
+[connection master]
 DROP TABLE t;
+[connection slave]
 SET GLOBAL log_slow_replica_statements=@saved_log_slow_replica_statements;
 SET GLOBAL long_query_time=@saved_long_query_time;
 SET GLOBAL min_examined_row_limit=@saved_min_examined_row_limit;

--- a/mysql-test/suite/rpl/t/percona_log_slow_replica_statements_row.test
+++ b/mysql-test/suite/rpl/t/percona_log_slow_replica_statements_row.test
@@ -1,0 +1,96 @@
+#
+# Test log_slow_replica_statements with row based replication
+#
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+SET SESSION binlog_rows_query_log_events=1;
+
+CREATE TABLE t1 (id INT);
+CREATE TABLE t2 (id INT);
+
+DELIMITER |;
+CREATE FUNCTION f1() RETURNS INTEGER
+BEGIN
+    INSERT INTO t2 VALUES (1),(2),(3);
+    UPDATE t2 SET id=4 WHERE id=3;
+    DELETE FROM t2;
+    RETURN 1;
+END|
+DELIMITER ;|
+
+--source include/sync_slave_sql_with_master.inc
+
+--source include/log_prepare.inc
+
+SET @saved_min_examined_row_limit=@@GLOBAL.min_examined_row_limit;
+SET GLOBAL min_examined_row_limit=0;
+SET @saved_long_query_time=@@GLOBAL.long_query_time;
+SET GLOBAL long_query_time=0;
+SET @saved_log_slow_replica_statements=@@GLOBAL.log_slow_replica_statements;
+SET GLOBAL log_slow_replica_statements=OFF;
+--source include/restart_slave_sql.inc
+
+--let log_file=percona.slow_extended.log_slow_replica_statements_rbr
+--source include/log_start.inc
+
+#
+# A statement that should not be slow-logged
+#
+--source include/rpl_connection_master.inc
+INSERT INTO t1 VALUES (1);
+--source include/sync_slave_sql_with_master.inc
+
+#
+# A statement that should be slow-logged
+#
+SET GLOBAL log_slow_replica_statements=ON;
+--source include/rpl_connection_master.inc
+# Explicit transaction to avoid slow-logging implicit BEGIN/COMMIT
+BEGIN;
+INSERT INTO t1 VALUES (2);
+UPDATE t1 SET id = 3 WHERE id = 2;
+DELETE FROM t1;
+COMMIT;
+
+SELECT f1();
+
+--source include/sync_slave_sql_with_master.inc
+
+#
+# A statement that should not be slow-logged
+#
+SET GLOBAL log_slow_replica_statements=OFF;
+--source include/rpl_connection_master.inc
+INSERT INTO t1 VALUES (3);
+--source include/sync_slave_sql_with_master.inc
+
+--source include/log_stop.inc
+
+--let grep_pattern= Write_rows `test`.`t1`
+--source include/log_grep.inc
+--let grep_pattern= Update_rows `test`.`t1`
+--source include/log_grep.inc
+--let grep_pattern= Delete_rows `test`.`t1`
+--source include/log_grep.inc
+--let grep_pattern= Write_rows `test`.`t2`
+--source include/log_grep.inc
+--let grep_pattern= Update_rows `test`.`t2`
+--source include/log_grep.inc
+--let grep_pattern= Delete_rows `test`.`t2`
+--source include/log_grep.inc
+--let grep_pattern= ^# User@Host: skip-grants user\[SQL_SLAVE\] @  \[\]
+--source include/log_grep.inc
+
+--source include/rpl_connection_master.inc
+DROP FUNCTION f1;
+DROP TABLE t1;
+DROP TABLE t2;
+
+--source include/rpl_connection_slave.inc
+SET GLOBAL log_slow_replica_statements=@saved_log_slow_replica_statements;
+SET GLOBAL long_query_time=@saved_long_query_time;
+SET GLOBAL min_examined_row_limit=@saved_min_examined_row_limit;
+
+--source include/log_cleanup.inc
+--source include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/percona_log_slow_replica_statements_stmt.test
+++ b/mysql-test/suite/rpl/t/percona_log_slow_replica_statements_stmt.test
@@ -1,5 +1,5 @@
 #
-# Test log_slow_replica_statements
+# Test log_slow_replica_statements with statement based replication
 #
 --source include/have_binlog_format_statement.inc
 --source include/master-slave.inc
@@ -17,13 +17,13 @@ SET @saved_log_slow_replica_statements=@@GLOBAL.log_slow_replica_statements;
 SET GLOBAL log_slow_replica_statements=OFF;
 --source include/restart_slave_sql.inc
 
---let log_file=percona.slow_extended.log_slow_replica_statements
+--let log_file=percona.slow_extended.log_slow_replica_statements_sbr
 --source include/log_start.inc
 
 #
 # A statement that should not be slow-logged
 #
-connection master;
+--source include/rpl_connection_master.inc
 INSERT INTO t VALUES (1);
 --source include/sync_slave_sql_with_master.inc
 
@@ -31,7 +31,7 @@ INSERT INTO t VALUES (1);
 # A statement that should be slow-logged
 #
 SET GLOBAL log_slow_replica_statements=ON;
-connection master;
+--source include/rpl_connection_master.inc
 # Explicit transaction to avoid slow-logging implicit BEGIN/COMMIT
 BEGIN;
 INSERT INTO t VALUES (2);
@@ -42,7 +42,7 @@ COMMIT;
 # A statement that should not be slow-logged
 #
 SET GLOBAL log_slow_replica_statements=OFF;
-connection master;
+--source include/rpl_connection_master.inc
 INSERT INTO t VALUES (3);
 --source include/sync_slave_sql_with_master.inc
 
@@ -57,10 +57,10 @@ INSERT INTO t VALUES (3);
 --let grep_pattern= ^# User@Host: skip-grants user\[SQL_SLAVE\] @  \[\]
 --source include/log_grep.inc
 
-connection master;
+--source include/rpl_connection_master.inc
 DROP TABLE t;
 
-connection slave;
+--source include/rpl_connection_slave.inc
 SET GLOBAL log_slow_replica_statements=@saved_log_slow_replica_statements;
 SET GLOBAL long_query_time=@saved_long_query_time;
 SET GLOBAL min_examined_row_limit=@saved_min_examined_row_limit;

--- a/sql/log.h
+++ b/sql/log.h
@@ -473,6 +473,8 @@ bool log_slow_applicable(THD *thd, int sp_sql_command = -1);
 */
 void log_slow_do(THD *thd, struct System_status_var *query_start_status);
 
+void log_slow_do(THD *thd, const std::string &query);
+
 /**
   Check whether we need to write the current statement to the slow query
   log. If so, do so. This is a wrapper for the two functions above;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-2326

At the moment when row level replication is enabled with
log_slave_slow_statements only BEGIN statements are logged.
This change adds to slow log on replica server a pseudo query
of the following form: row_event_type db_name.table_name.