### PR TITLE
PS-6730: Use Last_errno in slow query log for errors only

### DIFF
--- a/mysql-test/r/percona_slow_extended_log_error.result
+++ b/mysql-test/r/percona_slow_extended_log_error.result
@@ -11,4 +11,15 @@ ERROR 42S01: Table 't1' already exists
 [log_stop.inc] percona.slow_extended.log_error_2
 [log_grep.inc] file: percona.slow_extended.log_error_2 pattern: ^.*Last_errno: 1050 .*$
 [log_grep.inc] lines:   1
-DROP TABLE t1;
+
+# PS-6730 - Field 'Last_errno:' should be used for errors only
+
+[log_start.inc] percona.slow_extended.log_error_3
+CREATE TABLE t2(f1 DECIMAL(5, 2) NOT NULL);
+INSERT INTO t2(f1) VALUES (31.400191);
+Warnings:
+Note	1265	Data truncated for column 'f1' at row 1
+[log_stop.inc] percona.slow_extended.log_error_3
+[log_grep.inc] file: percona.slow_extended.log_error_3 pattern: ^.*Last_errno: 0 .*$
+[log_grep.inc] lines:   4
+DROP TABLE t1, t2;

--- a/mysql-test/t/percona_slow_extended_log_error.test
+++ b/mysql-test/t/percona_slow_extended_log_error.test
@@ -22,6 +22,17 @@ CREATE TABLE t1(a INT);
 --let grep_pattern = ^.*Last_errno: 1050 .*\$
 --source include/log_grep.inc
 
-DROP TABLE t1;
+--echo
+--echo # PS-6730 - Field 'Last_errno:' should be used for errors only
+--echo
+--let log_file=percona.slow_extended.log_error_3
+--source include/log_start.inc
+CREATE TABLE t2(f1 DECIMAL(5, 2) NOT NULL);
+INSERT INTO t2(f1) VALUES (31.400191);
+--source include/log_stop.inc
+--let grep_pattern = ^.*Last_errno: 0 .*\$
+--source include/log_grep.inc
+
+DROP TABLE t1, t2;
 
 --source include/log_cleanup.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -894,12 +894,14 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
   sprintf(query_time_buff, "%.6f", ulonglong2double(query_utime)/1000000.0);
   sprintf(lock_time_buff,  "%.6f", ulonglong2double(lock_utime)/1000000.0);
   if (my_b_printf(&log_file,
-                  "# Schema: %s  Last_errno: %u  Killed: %u\n"
+                  "# Schema: %s  Last_errno: %lu  Killed: %u\n"
                   "# Query_time: %s  Lock_time: %s  Rows_sent: %llu"
                   "  Rows_examined: %llu  Rows_affected: %llu"
                   "  Bytes_sent: %lu\n",
                   (thd->db().str ? thd->db().str : ""),
-                  thd->last_errno, (uint) thd->killed,
+                  static_cast<ulong>(
+                      thd->is_error() ? thd->get_stmt_da()->mysql_errno() : 0),
+                  (uint) thd->killed,
                   query_time_buff, lock_time_buff,
                   (ulonglong) thd->get_sent_row_count(),
                   (ulonglong) thd->get_examined_row_count(),


### PR DESCRIPTION
https://jira.percona.com/browse/PS-6730

Query execution warning gets added as Last_errno in slow query log.
Fix is based on upstream change mysql/mysql-server@0ae6ced.
The thd->last_errno may contain not actual data at the moment when
slow log is printed. It also gets updated with warnings if there
are any during query execution.
Populate Last_errno with info from statement Diagnostics Area instead.