### PR TITLE
PS-6774: Add test for Last_errno in case DD table is accessed

### DIFF
--- a/mysql-test/r/percona_slow_extended_log_error.result
+++ b/mysql-test/r/percona_slow_extended_log_error.result
@@ -22,4 +22,18 @@ Note	1265	Data truncated for column 'f1' at row 1
 [log_stop.inc] percona.slow_extended.log_error_3
 [log_grep.inc] file: percona.slow_extended.log_error_3 pattern: ^.*Last_errno: 0 .*$
 [log_grep.inc] lines:   4
+
+# PS-6774 - Unexpected error in Last_errno in case internal DD tables are
+accessed. Statement des not fail in case DD table names
+are submitted as strings in WHERE clause.
+
+[log_start.inc] percona.slow_extended.log_error_4
+SELECT SCHEMA_NAME as Test FROM information_schema.schemata WHERE SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'information_schema');
+Test
+sys
+test
+mtr
+[log_stop.inc] percona.slow_extended.log_error_4
+[log_grep.inc] file: percona.slow_extended.log_error_4 pattern: ^.*Last_errno: 0 .*$
+[log_grep.inc] lines:   2
 DROP TABLE t1, t2;

--- a/mysql-test/t/percona_slow_extended_log_error.test
+++ b/mysql-test/t/percona_slow_extended_log_error.test
@@ -33,6 +33,18 @@ INSERT INTO t2(f1) VALUES (31.400191);
 --let grep_pattern = ^.*Last_errno: 0 .*\$
 --source include/log_grep.inc
 
+--echo
+--echo # PS-6774 - Unexpected error in Last_errno in case internal DD tables are
+--echo             accessed. Statement des not fail in case DD table names
+--echo             are submitted as strings in WHERE clause.
+--echo
+--let log_file=percona.slow_extended.log_error_4
+--source include/log_start.inc
+SELECT SCHEMA_NAME as Test FROM information_schema.schemata WHERE SCHEMA_NAME NOT IN ('mysql', 'performance_schema', 'information_schema');
+--source include/log_stop.inc
+--let grep_pattern = ^.*Last_errno: 0 .*\$
+--source include/log_grep.inc
+
 DROP TABLE t1, t2;
 
 --source include/log_cleanup.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PS-6774

In https://github.com/mysql/mysql-server/commit/a58bf5ef8806941bbd417f8ab17c818c48e21822
access to internal DD tables was prohibited. But SELECT statement
still should not fail in case DD table names are submitted as strings in
WHERE clauses. Add test case to verify Last_errno field in slow query
log doesn't contain any error in this case.
The issue with Last_errno not being empty in this case was previously
fixed in https://github.com/percona/percona-server/pull/4506.