### PR TITLE
PS-7959: Update LIBLZ4_VERSION_REQUIRED to 1.9.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -388,7 +388,7 @@ jobs:
           CMAKE_OPT+="
             -DWITH_READLINE=system
             -DWITH_ICU=system
-            -DWITH_LZ4=system
+            -DWITH_LZ4=bundled
             -DWITH_PROTOBUF=system
             -DWITH_ZLIB=system
             -DWITH_NUMA=ON

--- a/cmake/lz4.cmake
+++ b/cmake/lz4.cmake
@@ -23,7 +23,7 @@
 # cmake -DWITH_LZ4=system|bundled
 # bundled is the default
 
-SET(LIBLZ4_VERSION_REQUIRED "1.7.1")
+SET(LIBLZ4_VERSION_REQUIRED "1.9.3")
 
 MACRO (CHECK_LZ4_VERSION)
   SET(PATH_TO_LZ4_H "${ARGV0}/lz4.h")


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7959

The bundled version of liblz4 has been updated to 1.9.3. Therefore,
if `-DWITH_LZ4=system` is provided the minimun required version must
aligned with the bundled one.

(cherry picked from commit 03d1449843d35660a5b2ccc0fcf958924117159d)