### PR TITLE
PS-7940 ON DELETE CASCADE with generated column crashes in innobase_g…

### DIFF
--- a/mysql-test/suite/innodb/r/foreign_key.result
+++ b/mysql-test/suite/innodb/r/foreign_key.result
@@ -297,3 +297,23 @@ date_sent
 2020-10-22 13:32:41
 DROP TABLE `email_stats`;
 DROP TABLE `emails`;
+#
+# PS-7940 :ON DELETE CASCADE with generated column crashes in innobase_get_computed_value
+#
+CREATE TABLE `t1` (`t1_id` int unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY(`t1_id`)) ENGINE=InnoDB;
+INSERT INTO `t1` VALUES (10);
+CREATE TABLE `t2` (
+`t2_id` int unsigned NOT NULL AUTO_INCREMENT,
+`c1` decimal(14,2) NOT NULL DEFAULT '0.00',
+`t1_id` int unsigned DEFAULT NULL,
+`testycol` bit(1) GENERATED ALWAYS AS (`c1` <> 0) VIRTUAL,
+PRIMARY KEY (`t2_id`),
+UNIQUE KEY `t1_id` (`t1_id`),
+KEY `testycol` (`testycol`),
+CONSTRAINT `t2_ibfk_3` FOREIGN KEY (`t1_id`) REFERENCES `t1` (`t1_id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+INSERT INTO `t2` (`t2_id`, `c1`, `t1_id`) VALUES (1,5.00,10);
+# restart
+DELETE FROM `t1` WHERE `t1_id`=10;
+DROP TABLE `t2`;
+DROP TABLE `t1`;

--- a/mysql-test/suite/innodb/t/foreign_key.test
+++ b/mysql-test/suite/innodb/t/foreign_key.test
@@ -253,3 +253,28 @@ SELECT `date_sent` FROM `email_stats` WHERE `generated_sent_email` = '2020-';
 #clean up.
 DROP TABLE `email_stats`;
 DROP TABLE `emails`;
+
+--echo #
+--echo # PS-7940 :ON DELETE CASCADE with generated column crashes in innobase_get_computed_value
+--echo #
+
+CREATE TABLE `t1` (`t1_id` int unsigned NOT NULL AUTO_INCREMENT, PRIMARY KEY(`t1_id`)) ENGINE=InnoDB;
+INSERT INTO `t1` VALUES (10);
+CREATE TABLE `t2` (
+  `t2_id` int unsigned NOT NULL AUTO_INCREMENT,
+  `c1` decimal(14,2) NOT NULL DEFAULT '0.00',
+  `t1_id` int unsigned DEFAULT NULL,
+  `testycol` bit(1) GENERATED ALWAYS AS (`c1` <> 0) VIRTUAL,
+  PRIMARY KEY (`t2_id`),
+  UNIQUE KEY `t1_id` (`t1_id`),
+  KEY `testycol` (`testycol`),
+  CONSTRAINT `t2_ibfk_3` FOREIGN KEY (`t1_id`) REFERENCES `t1` (`t1_id`) ON DELETE CASCADE
+) ENGINE=InnoDB;
+INSERT INTO `t2` (`t2_id`, `c1`, `t1_id`) VALUES (1,5.00,10);
+
+--source include/restart_mysqld.inc
+
+DELETE FROM `t1` WHERE `t1_id`=10;
+
+DROP TABLE `t2`;
+DROP TABLE `t1`;

--- a/storage/innobase/row/row0ins.cc
+++ b/storage/innobase/row/row0ins.cc
@@ -1306,8 +1306,13 @@ row_ins_foreign_check_on_constraint(
 						 clust_index, tmp_heap);
 	}
 
-	if (cascade->is_delete && foreign->v_cols != NULL
-	    && foreign->v_cols->size() > 0
+	/* A cascade delete from the parent table triggers delete on the child
+	table. Before a clustered index record is deleted in the child table,
+	a copy of row is built to remove secondary index records. This copy of
+	the row requires virtual columns to be materialized. Hence, if child
+	table has any virtual columns, we have to initialize virtual column
+	template */
+	if (cascade->is_delete && dict_table_get_n_v_cols(table) > 0
 	    && table->vc_templ == NULL) {
 		innobase_init_vc_templ(table);
 	}


### PR DESCRIPTION
…et_computed_value

https://jira.percona.com/browse/PS-7940

Problem:
Virtual column template of child table is not populated when cascade
delete happened on parent table.  Failing to initliaze it causes a crash
when we are trying remove the secondary index rows defined on virtual column .

Fix:

As part of fix e5e8c9d1b2e0 MySQL handle case when child virtual column
depends on forign key. To extend the fix we are now initliazing virtual column template
if child table has any virtual column.