### PR TITLE
PS-7958: Fix crash during fulltext search index with special character

### DIFF
--- a/mysql-test/suite/innodb_fts/include/percona_null_character.inc
+++ b/mysql-test/suite/innodb_fts/include/percona_null_character.inc
@@ -1,0 +1,20 @@
+--echo #
+--echo # PS-3851: Crash when SELECT using a fulltext search index with special character
+--echo #
+
+--eval CREATE TABLE tbtest (col1 int(11) NOT NULL AUTO_INCREMENT, col2 varchar(100) COLLATE utf8mb4_bin DEFAULT NULL, col3 text COLLATE utf8mb4_bin, col4 varchar(300) COLLATE utf8mb4_bin DEFAULT NULL, PRIMARY KEY (col1), FULLTEXT KEY FTX_01 (col2, col3, col4) $PARSER, FULLTEXT KEY FTX_02 (col4) $PARSER ) ENGINE=InnoDB AUTO_INCREMENT=100001 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+
+INSERT INTO tbtest (col2, col3, col4)
+SELECT concat(a.column_name,a.column_name) as c1,
+       concat(a.column_name,a.column_name) as c2,
+       concat(a.column_name,a.column_name) as c3
+FROM information_schema.columns a, information_schema.columns b LIMIT 10000;
+
+OPTIMIZE TABLE tbtest;
+
+--echo # Should not crash
+--disable_result_log
+SELECT * FROM tbtest WHERE MATCH(col4) AGAINST('1some_inexistent_file_with_long_name\0.jpg');
+--enable_result_log
+
+DROP TABLE tbtest;

--- a/mysql-test/suite/innodb_fts/r/percona_mecab_null_character.result
+++ b/mysql-test/suite/innodb_fts/r/percona_mecab_null_character.result
@@ -1,0 +1,21 @@
+INSTALL PLUGIN mecab SONAME 'libpluginmecab.so';
+SHOW STATUS LIKE 'mecab_charset';
+Variable_name	Value
+mecab_charset	utf8
+#
+# PS-3851: Crash when SELECT using a fulltext search index with special character
+#
+CREATE TABLE tbtest (col1 int(11) NOT NULL AUTO_INCREMENT, col2 varchar(100) COLLATE utf8mb4_bin DEFAULT NULL, col3 text COLLATE utf8mb4_bin, col4 varchar(300) COLLATE utf8mb4_bin DEFAULT NULL, PRIMARY KEY (col1), FULLTEXT KEY FTX_01 (col2, col3, col4) WITH PARSER MECAB, FULLTEXT KEY FTX_02 (col4) WITH PARSER MECAB ) ENGINE=InnoDB AUTO_INCREMENT=100001 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+INSERT INTO tbtest (col2, col3, col4)
+SELECT concat(a.column_name,a.column_name) as c1,
+concat(a.column_name,a.column_name) as c2,
+concat(a.column_name,a.column_name) as c3
+FROM information_schema.columns a, information_schema.columns b LIMIT 10000;
+OPTIMIZE TABLE tbtest;
+Table	Op	Msg_type	Msg_text
+test.tbtest	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.tbtest	optimize	status	OK
+# Should not crash
+SELECT * FROM tbtest WHERE MATCH(col4) AGAINST('1some_inexistent_file_with_long_name\0.jpg');
+DROP TABLE tbtest;
+UNINSTALL PLUGIN mecab;

--- a/mysql-test/suite/innodb_fts/r/percona_ngram_null_character.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ngram_null_character.result
@@ -1,0 +1,16 @@
+#
+# PS-3851: Crash when SELECT using a fulltext search index with special character
+#
+CREATE TABLE tbtest (col1 int(11) NOT NULL AUTO_INCREMENT, col2 varchar(100) COLLATE utf8mb4_bin DEFAULT NULL, col3 text COLLATE utf8mb4_bin, col4 varchar(300) COLLATE utf8mb4_bin DEFAULT NULL, PRIMARY KEY (col1), FULLTEXT KEY FTX_01 (col2, col3, col4) WITH PARSER NGRAM, FULLTEXT KEY FTX_02 (col4) WITH PARSER NGRAM ) ENGINE=InnoDB AUTO_INCREMENT=100001 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+INSERT INTO tbtest (col2, col3, col4)
+SELECT concat(a.column_name,a.column_name) as c1,
+concat(a.column_name,a.column_name) as c2,
+concat(a.column_name,a.column_name) as c3
+FROM information_schema.columns a, information_schema.columns b LIMIT 10000;
+OPTIMIZE TABLE tbtest;
+Table	Op	Msg_type	Msg_text
+test.tbtest	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.tbtest	optimize	status	OK
+# Should not crash
+SELECT * FROM tbtest WHERE MATCH(col4) AGAINST('1some_inexistent_file_with_long_name\0.jpg');
+DROP TABLE tbtest;

--- a/mysql-test/suite/innodb_fts/r/percona_null_character.result
+++ b/mysql-test/suite/innodb_fts/r/percona_null_character.result
@@ -1,0 +1,16 @@
+#
+# PS-3851: Crash when SELECT using a fulltext search index with special character
+#
+CREATE TABLE tbtest (col1 int(11) NOT NULL AUTO_INCREMENT, col2 varchar(100) COLLATE utf8mb4_bin DEFAULT NULL, col3 text COLLATE utf8mb4_bin, col4 varchar(300) COLLATE utf8mb4_bin DEFAULT NULL, PRIMARY KEY (col1), FULLTEXT KEY FTX_01 (col2, col3, col4) , FULLTEXT KEY FTX_02 (col4)  ) ENGINE=InnoDB AUTO_INCREMENT=100001 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;
+INSERT INTO tbtest (col2, col3, col4)
+SELECT concat(a.column_name,a.column_name) as c1,
+concat(a.column_name,a.column_name) as c2,
+concat(a.column_name,a.column_name) as c3
+FROM information_schema.columns a, information_schema.columns b LIMIT 10000;
+OPTIMIZE TABLE tbtest;
+Table	Op	Msg_type	Msg_text
+test.tbtest	optimize	note	Table does not support optimize, doing recreate + analyze instead
+test.tbtest	optimize	status	OK
+# Should not crash
+SELECT * FROM tbtest WHERE MATCH(col4) AGAINST('1some_inexistent_file_with_long_name\0.jpg');
+DROP TABLE tbtest;

--- a/mysql-test/suite/innodb_fts/t/percona_mecab_null_character-master.opt
+++ b/mysql-test/suite/innodb_fts/t/percona_mecab_null_character-master.opt
@@ -1,0 +1,1 @@
+$MECAB_OPT

--- a/mysql-test/suite/innodb_fts/t/percona_mecab_null_character.test
+++ b/mysql-test/suite/innodb_fts/t/percona_mecab_null_character.test
@@ -1,0 +1,44 @@
+--source include/have_mecab.inc
+
+eval INSTALL PLUGIN mecab SONAME '$MECAB';
+
+let $ipadic_charset=utf-8;
+let $mysql_charset=utf8;
+let $mecab_charset=`SELECT variable_value FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='mecab_charset'`;
+
+if ($mecab_charset == '') {
+  # Restart with package dictionary.
+  let $MYSQL_DATADIR=`select @@datadir`;
+  let $MYSQL_BASEDIR=`select @@basedir`;
+
+  let $mecabrc = $MYSQL_DATADIR/mecabrc;
+  let $dicdir  = $MYSQL_BASEDIR/lib/mecab/dic/ipadic_$ipadic_charset;
+
+  -- exec echo "dicdir=$dicdir" > $mecabrc
+
+  -- source include/shutdown_mysqld.inc
+  -- exec echo "restart: --loose_mecab_rc_file=$mecabrc $MECAB_OPT --innodb_ft_min_token_size=2" >$MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+  -- enable_reconnect
+  -- source include/wait_until_connected_again.inc
+  -- disable_reconnect
+
+  eval INSTALL PLUGIN mecab SONAME '$MECAB';
+
+  let $mecab_charset=`SELECT variable_value FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='mecab_charset'`;
+}
+
+if ($mecab_charset == '') {
+  -- skip Test fail to load mecab parser, please set correct 'loose_mecab_rc_file'.
+}
+
+if ($mecab_charset != $mysql_charset) {
+  UNINSTALL PLUGIN mecab;
+  -- skip Test mecab charset mismatch.
+}
+
+SHOW STATUS LIKE 'mecab_charset';
+
+--let $PARSER=WITH PARSER MECAB
+--source suite/innodb_fts/include/percona_null_character.inc
+
+UNINSTALL PLUGIN mecab;

--- a/mysql-test/suite/innodb_fts/t/percona_ngram_null_character.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ngram_null_character.test
@@ -1,0 +1,4 @@
+--source include/have_ngram.inc
+
+--let $PARSER=WITH PARSER NGRAM
+--source suite/innodb_fts/include/percona_null_character.inc

--- a/mysql-test/suite/innodb_fts/t/percona_null_character.test
+++ b/mysql-test/suite/innodb_fts/t/percona_null_character.test
@@ -1,0 +1,2 @@
+--let $PARSER=
+--source suite/innodb_fts/include/percona_null_character.inc

--- a/plugin/fulltext/ngram_parser/plugin_ngram.cc
+++ b/plugin/fulltext/ngram_parser/plugin_ngram.cc
@@ -68,8 +68,10 @@ ngram_parse(
 		if (next + char_len > end || char_len == 0) {
 			break;
 		} else {
-			/* Skip SPACE */
-			if (char_len == 1 && *next == ' ') {
+			/* Skip SPACE and control characters */
+			int ctype = 0;
+			cs->cset->ctype(cs, &ctype, (uchar*) next, (uchar*) end);
+			if (char_len == 1 && (*next == ' ' || ctype & _MY_CTR)) {
 				start = next + 1;
 				next = start;
 				n_chars = 0;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7958

Server crashes during fulltext search in case there is a null character
symbol in the middle of a search string. The issue reproducible for
NGRAM and MECAB parsers.
Updated ngram_parse() and mecab_parse() method to skip control characters
while parsing a string.