### PR TITLE
PS-7929 : Wrong row lock number in SEIS

### DIFF
--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -1842,7 +1842,9 @@ lock_rec_add_to_queue(
 
 		if (lock != NULL) {
 
-			lock_rec_set_nth_bit(lock, heap_no);
+			if (!lock_rec_get_nth_bit(lock, heap_no)) {
+				lock_rec_set_nth_bit(lock, heap_no);
+			}
 
 			return;
 		}


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7929

Problem:
--------

The number of row locks in "SHOW ENGINE INNODB STATUS" OUTPUT is wrong.
When the trx inserts many duplicate records, the number of row locks
in, "SHOW ENGINE INNODB STATUS" output is wrong.

InnoDB maintains this locks as a counter in trx->lock.n_rec_locks. They are
incremented on lock acquisition and decremented on lock release.

In case of duplicate records, some lock acquisitions increment the counter
for the lock which is already acquired/set

Fix
---
Set the lock bit only if it is not already set/acquired.