### PR TITLE
PS-7988: Improve BiDiScan Azure job to properly handle empty commits (5.7)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,14 @@ jobs:
 
   - script: |
       git fetch origin 5.7
-      python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v $(git diff --name-only --relative --diff-filter AMR origin/5.7 -- . | tr '\n' ' ')
+      CHANGED_FILES=$(git diff --name-only --relative --diff-filter AMR origin/5.7 -- . | tr '\n' ' ')
+
+      if [ -z "${CHANGED_FILES}" ]; then
+          echo --- No changed files
+          ##vso[task.complete result=Succeeded;]DONE
+      fi
+
+      python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v ${CHANGED_FILES}
 
 - job:
   timeoutInMinutes: 240


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7988

It is possible to have PR which doesn't actually change any file
(Null merge for example). Improve BiDiScan Azure job to skip
actual check in case there are not any files changed in PR.