### PR TITLE
Fixed PS-7990 - mysqldump --single-transaction creates non-consistent…

### DIFF
--- a/mysql-test/r/mysqldump_gtid_state.result
+++ b/mysql-test/r/mysqldump_gtid_state.result
@@ -66,7 +66,34 @@ innodb_table_stats	CREATE TABLE `innodb_table_stats` (
   `sum_of_other_index_sizes` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`database_name`,`table_name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin STATS_PERSISTENT=0
+#
+# PS-7990: mysqldump make a non-consistent backup
+#               with --single-transaction option
+#
+# Restart server.
+# restart: --enforce-gtid-consistency=ON --gtid-mode=ON --log-bin
+CREATE PROCEDURE test_data()
+BEGIN
+DECLARE v_max_rows INT UNSIGNED DEFAULT 1000;
+DECLARE v_counter INT UNSIGNED DEFAULT 1;
+while v_counter <= v_max_rows do
+INSERT INTO t VALUES (v_counter, 1);
+SET v_counter=v_counter+1;
+end while;
+end |
+TRUNCATE TABLE t;
+RESET MASTER;
+USE test;
+call test_data;;
+# Waiting until background connection has executed some inserts
+# Waiting until background connection has executed all inserts
+# RESET
+RESET MASTER;
+# DUMP RESTORE WITH THE DUMP FILE HAVING DATA WRITTEN IN BACKGROUND.
+# Checking rows vs gtid seqno
+include/assert.inc [Committed rows vs gtid seqno]
 #CLEANUP
 DROP TABLE t;
+DROP PROCEDURE test_data;
 RESET MASTER;
-# restart
+# restart: --enforce-gtid-consistency=ON --gtid-mode=ON --log-bin

--- a/mysql-test/t/mysqldump_gtid_state.test
+++ b/mysql-test/t/mysqldump_gtid_state.test
@@ -107,7 +107,70 @@ CALL mtr.add_suppression(".*InnoDB: Table `mysql`.`innodb_table_stats` not found
 
 SHOW CREATE TABLE `mysql`.`innodb_table_stats`;
 
+
+
+--echo #
+--echo # PS-7990: mysqldump make a non-consistent backup
+--echo #               with --single-transaction option
+--echo #
+
+--echo # Restart server.
+--let $restart_parameters= restart: --enforce-gtid-consistency=ON --gtid-mode=ON --log-bin
+--source include/restart_mysqld.inc
+
+
+DELIMITER |;
+CREATE PROCEDURE test_data()
+BEGIN
+
+DECLARE v_max_rows INT UNSIGNED DEFAULT 1000;
+DECLARE v_counter INT UNSIGNED DEFAULT 1;
+
+while v_counter <= v_max_rows do
+  INSERT INTO t VALUES (v_counter, 1);
+  SET v_counter=v_counter+1;
+end while;
+end |
+
+DELIMITER ;|
+
+TRUNCATE TABLE t;
+RESET MASTER;
+
+connect (con2,localhost,root,,);
+connection con2;
+USE test;
+--send call test_data;
+
+connection default;
+
+--echo # Waiting until background connection has executed some inserts
+let $wait_condition=
+  SELECT COUNT(*) >= 1 FROM test.t;
+--source include/wait_condition.inc
+
+--let $gtid_dump = $MYSQLTEST_VARDIR/tmp/gtid_with_trx_running_in_background.sql
+--exec $MYSQL_DUMP --socket=$MASTER_MYSOCK --set-gtid-purged=ON --single-transaction --databases test -uroot > $gtid_dump
+
+--echo # Waiting until background connection has executed all inserts
+connection con2;
+--reap
+
+--echo # RESET
+connection default;
+RESET MASTER;
+--echo # DUMP RESTORE WITH THE DUMP FILE HAVING DATA WRITTEN IN BACKGROUND.
+--exec $MYSQL -h localhost -P $MASTER_MYPORT < $gtid_dump
+
+--let $gtid_seqno= `SELECT COUNT(*) FROM test.t`
+--echo # Checking rows vs gtid seqno
+--let $assert_text= Committed rows vs gtid seqno
+--let $assert_cond= "[SELECT @@GLOBAL.GTID_EXECUTED]" = "$master_uuid:1-$gtid_seqno"
+--source include/assert.inc
+
 --echo #CLEANUP
+disconnect con2;
 DROP TABLE t;
+DROP PROCEDURE test_data;
 RESET MASTER;
 --source include/restart_mysqld.inc


### PR DESCRIPTION
… backups

https://jira.percona.com/browse/PS-7990

Problem:
After 3bc4362 changes, instead of keeping gathering data from GTID in
At the beginning of the backup and only printing it to the end we also
wrongly delayed the query to gather GTID information to the end of the
backup, causing a mismatch between data and SET @@GLOBAL.GTID_PURGED
statement.

Fix:
Continue gathering GTID at the beginning of backup and only delay the
action to print this information.