### PR TITLE
PS-7931: Implement slow query log rotation (8.0)

### DIFF
--- a/mysql-test/include/assert_number_of_files.inc
+++ b/mysql-test/include/assert_number_of_files.inc
@@ -1,0 +1,38 @@
+# ==== Purpose ====
+#
+# Assert that number of files matching given $file_spec is equal to expected.
+#
+# ==== Usage ====
+#
+# --let file_spec = PATH_REGEX
+# --let expected_number = INTEGER
+# --source include/assert_number_of_files.inc
+#
+# Parameters:
+#   $file_spec
+#     The path with wildcards e.g. $MYSQLTEST_VARDIR/abcd*
+#
+#   $expected_number
+#     The expected number of files
+
+--perl
+  use strict;
+  my $dir = $ENV{'MYSQL_TMP_DIR'} or die "MYSQL_TMP_DIR not set";
+  my $file_spec = $ENV{'file_spec'} or die "file_spec not set";
+  my @files = <$ENV{'file_spec'}>;
+  open (OUTPUT, ">$dir/number_of_files.inc") ;
+  print OUTPUT "--let \$number_of_files = ", scalar(@files), "\n";
+  close (OUTPUT);
+EOF
+--source $MYSQL_TMP_DIR/number_of_files.inc
+--remove_file $MYSQL_TMP_DIR/number_of_files.inc
+
+if ($expected_number != $number_of_files)
+{
+  --echo ====================== Test assertion failed: ======================
+  --echo The number of files ($number_of_files) is different than expected $expected_number
+  --echo ====================================================================
+  --die Test assertion failed in assert_number_of_files.inc
+}
+
+--echo include/assert_number_of_files.inc [The number of files matches expected $expected_number]

--- a/mysql-test/r/all_persisted_variables.result
+++ b/mysql-test/r/all_persisted_variables.result
@@ -42,7 +42,7 @@ include/assert.inc [Expect 500+ variables in the table. Due to open Bugs, we are
 
 # Test SET PERSIST
 
-include/assert.inc [Expect 493 persisted variables in the table.]
+include/assert.inc [Expect 495 persisted variables in the table.]
 
 ************************************************************
 * 3. Restart server, it must preserve the persisted variable
@@ -50,9 +50,9 @@ include/assert.inc [Expect 493 persisted variables in the table.]
 ************************************************************
 # restart
 
-include/assert.inc [Expect 493 persisted variables in persisted_variables table.]
-include/assert.inc [Expect 493 persisted variables shown as PERSISTED in variables_info table.]
-include/assert.inc [Expect 493 persisted variables with matching peristed and global values.]
+include/assert.inc [Expect 495 persisted variables in persisted_variables table.]
+include/assert.inc [Expect 495 persisted variables shown as PERSISTED in variables_info table.]
+include/assert.inc [Expect 495 persisted variables with matching peristed and global values.]
 
 ************************************************************
 * 4. Test RESET PERSIST IF EXISTS. Verify persisted variable

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -742,6 +742,15 @@ The following options may be given as the first argument:
  --max-seeks-for-key=# 
  Limit assumed max number of seeks when looking up rows
  based on a key
+ --max-slowlog-files=# 
+ Maximum number of slow query log files. Used with
+ --max-slowlog-size this can be used to limit the total
+ amount of disk space used for the slow query log. Default
+ is 0, don't limit.
+ --max-slowlog-size=# 
+ Slow query log will be rotated automatically when the
+ size exceeds this value. The default is 0, don't limit
+ the size.
  --max-sort-length=# The number of bytes to use when sorting long values with
  PAD SPACE collations (only the first max_sort_length
  bytes of each value are used; the rest are ignored)
@@ -1873,6 +1882,8 @@ max-points-in-geometry 65536
 max-prepared-stmt-count 16382
 max-relay-log-size 0
 max-seeks-for-key 18446744073709551615
+max-slowlog-files 0
+max-slowlog-size 0
 max-sort-length 1024
 max-sp-recursion-depth 0
 max-user-connections 0

--- a/mysql-test/r/percona_slowlog_size_limits.result
+++ b/mysql-test/r/percona_slowlog_size_limits.result
@@ -1,0 +1,84 @@
+SET @old_slow_query_log = @@global.slow_query_log;
+SET @old_log_output = @@global.log_output;
+SET @old_slow_query_log_file = @@global.slow_query_log_file;
+SET @old_max_slowlog_size = @@global.max_slowlog_size;
+SET @old_max_slowlog_files = @@global.max_slowlog_files;
+SET @old_long_query_time = @@long_query_time;
+SET GLOBAL slow_query_log = 1;
+SET GLOBAL log_output = FILE;
+SET long_query_time = 0;
+# Case 1 (PS-1484): Test if max_slowlog_files is working correctly
+#                   with the default slow query log name
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 3;
+include/assert_number_of_files.inc [The number of files matches expected 3]
+# Case 2 (Bug 1416582): Slow query log is rotated before it should
+#                       when using max_slowlog_size
+SET GLOBAL max_slowlog_size = 10240000;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+FLUSH LOGS;
+FLUSH LOGS;
+FLUSH LOGS;
+include/assert.inc [Slow query log number should not be incremented and log should be abcd.000001]
+# Case 3: Test if each slow_query_log_file call rotates slow log
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/zxcv';
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/zxcv';
+include/assert.inc [Slow query log should be zxcv.000002]
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert.inc [Slow query log should be abcd.000003]
+# Case 4: Test if max_slowlog_files is working correctly
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 5;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 5]
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/zxcv';
+include/assert_number_of_files.inc [The number of files matches expected 5]
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 5]
+# Case 5: Rotating log but should not delete previous logs
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 5]
+# Case 6: Calling "SET max_slowlog_files" should reduce number of logs
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 2;
+include/assert_number_of_files.inc [The number of files matches expected 2]
+# Case 7: Delete all small logs with max_slowlog_size = 0
+SET GLOBAL max_slowlog_size = 0;
+SET GLOBAL max_slowlog_files = 1;
+include/assert_number_of_files.inc [The number of files matches expected 1]
+# Case 8: Rotate log should delete previous log
+SET GLOBAL max_slowlog_size = 10240000;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 1]
+# Case 9: Check if disable max_slowlog_size is working correctly
+SET GLOBAL max_slowlog_size = 0;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/abcd';
+include/assert_number_of_files.inc [The number of files matches expected 2]
+include/assert.inc [Slow query log should stay as abcd]
+# Case 10: Multiple dots in slow query log file name
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 3;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/slow.query.log';
+include/assert_number_of_files.inc [The number of files matches expected 3]
+# Case 11 (Bug 1704056): Enabling and disabling slow query log rotation
+#                        spuriously adds version suffix to the next
+#                        slow query log file name
+SET GLOBAL max_slowlog_size = 10240000;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/bug1704056_1';;
+SET GLOBAL max_slowlog_size = @old_max_slowlog_size;
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+SET GLOBAL slow_query_log_file = 'MYSQLTEST_VARDIR/bug1704056.slog';;
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+bug1704056.slog
+SET @@global.slow_query_log = @old_slow_query_log;
+SET @@global.log_output = @old_log_output;
+SET @@global.slow_query_log_file = @old_slow_query_log_file;
+SET @@global.max_slowlog_size = @old_max_slowlog_size;
+SET @@global.max_slowlog_files = @old_max_slowlog_files;
+SET @@long_query_time = @old_long_query_time;

--- a/mysql-test/suite/sys_vars/r/max_slowlog_files_basic.result
+++ b/mysql-test/suite/sys_vars/r/max_slowlog_files_basic.result
@@ -1,0 +1,30 @@
+SET @old = @@global.max_slowlog_files;
+SET GLOBAL max_slowlog_files = 0;
+SELECT @@global.max_slowlog_files;
+@@global.max_slowlog_files
+0
+SET GLOBAL max_slowlog_files = 4096;
+SELECT @@global.max_slowlog_files;
+@@global.max_slowlog_files
+4096
+SET GLOBAL max_slowlog_files = 1000;
+SELECT @@global.max_slowlog_files;
+@@global.max_slowlog_files
+1000
+SET GLOBAL max_slowlog_files = -1;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_files value: '-1'
+SELECT @@global.max_slowlog_files;
+@@global.max_slowlog_files
+0
+SET GLOBAL max_slowlog_files = 102400;
+SELECT @@global.max_slowlog_files;
+@@global.max_slowlog_files
+102400
+SET GLOBAL max_slowlog_files = 102401;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_files value: '102401'
+SELECT @@global.max_slowlog_files;
+@@global.max_slowlog_files
+102400
+SET @@global.max_slowlog_files = @old;

--- a/mysql-test/suite/sys_vars/r/max_slowlog_size_basic.result
+++ b/mysql-test/suite/sys_vars/r/max_slowlog_size_basic.result
@@ -1,0 +1,32 @@
+SET @old = @@global.max_slowlog_size;
+SET GLOBAL max_slowlog_size = 0;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET GLOBAL max_slowlog_size = 4096;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+4096
+SET GLOBAL max_slowlog_size = 1000;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_size value: '1000'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET GLOBAL max_slowlog_size = -1;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_size value: '-1'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+0
+SET GLOBAL max_slowlog_size = 1024*1024*1024;
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+1073741824
+SET GLOBAL max_slowlog_size = 1024*1024*1024+1;
+Warnings:
+Warning	1292	Truncated incorrect max_slowlog_size value: '1073741825'
+SELECT @@global.max_slowlog_size;
+@@global.max_slowlog_size
+1073741824
+SET @@global.max_slowlog_size = @old;

--- a/mysql-test/suite/sys_vars/t/max_slowlog_files_basic.test
+++ b/mysql-test/suite/sys_vars/t/max_slowlog_files_basic.test
@@ -1,0 +1,18 @@
+#
+# Test max_slowlog_files
+#
+
+SET @old = @@global.max_slowlog_files;
+SET GLOBAL max_slowlog_files = 0;
+SELECT @@global.max_slowlog_files;
+SET GLOBAL max_slowlog_files = 4096;
+SELECT @@global.max_slowlog_files;
+SET GLOBAL max_slowlog_files = 1000;
+SELECT @@global.max_slowlog_files;
+SET GLOBAL max_slowlog_files = -1;
+SELECT @@global.max_slowlog_files;
+SET GLOBAL max_slowlog_files = 102400;
+SELECT @@global.max_slowlog_files;
+SET GLOBAL max_slowlog_files = 102401;
+SELECT @@global.max_slowlog_files;
+SET @@global.max_slowlog_files = @old;

--- a/mysql-test/suite/sys_vars/t/max_slowlog_size_basic.test
+++ b/mysql-test/suite/sys_vars/t/max_slowlog_size_basic.test
@@ -1,0 +1,18 @@
+#
+# Test max_slowlog_size
+#
+
+SET @old = @@global.max_slowlog_size;
+SET GLOBAL max_slowlog_size = 0;
+SELECT @@global.max_slowlog_size;
+SET GLOBAL max_slowlog_size = 4096;
+SELECT @@global.max_slowlog_size;
+SET GLOBAL max_slowlog_size = 1000;
+SELECT @@global.max_slowlog_size;
+SET GLOBAL max_slowlog_size = -1;
+SELECT @@global.max_slowlog_size;
+SET GLOBAL max_slowlog_size = 1024*1024*1024;
+SELECT @@global.max_slowlog_size;
+SET GLOBAL max_slowlog_size = 1024*1024*1024+1;
+SELECT @@global.max_slowlog_size;
+SET @@global.max_slowlog_size = @old;

--- a/mysql-test/t/all_persisted_variables.test
+++ b/mysql-test/t/all_persisted_variables.test
@@ -43,7 +43,7 @@ call mtr.add_suppression("\\[Warning\\] .*MY-\\d+.* Changing innodb_extend_and_i
 call mtr.add_suppression("Failed to initialize TLS for channel: mysql_main");
 
 let $total_global_vars=`SELECT COUNT(*) FROM performance_schema.global_variables where variable_name NOT LIKE 'ndb_%'`;
-let $total_persistent_vars=493;
+let $total_persistent_vars=495;
 
 --echo ***************************************************************
 --echo * 0. Verify that variables present in performance_schema.global

--- a/mysql-test/t/percona_slowlog_size_limits.test
+++ b/mysql-test/t/percona_slowlog_size_limits.test
@@ -1,0 +1,260 @@
+#
+# Test slowlog size limiting and rotation
+#
+
+SET @old_slow_query_log = @@global.slow_query_log;
+SET @old_log_output = @@global.log_output;
+SET @old_slow_query_log_file = @@global.slow_query_log_file;
+SET @old_max_slowlog_size = @@global.max_slowlog_size;
+SET @old_max_slowlog_files = @@global.max_slowlog_files;
+SET @old_long_query_time = @@long_query_time;
+
+SET GLOBAL slow_query_log = 1;
+SET GLOBAL log_output = FILE;
+SET long_query_time = 0;
+
+--echo # Case 1 (PS-1484): Test if max_slowlog_files is working correctly
+--echo #                   with the default slow query log name
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 3;
+
+# avoid 100 selects 1 in .result
+--let $i = 100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let slow_query_base = `SELECT @old_slow_query_log_file`
+--let file_spec = $slow_query_base.*
+--let expected_number = 3
+--source include/assert_number_of_files.inc
+
+--echo # Case 2 (Bug 1416582): Slow query log is rotated before it should
+--echo #                       when using max_slowlog_size
+SET GLOBAL max_slowlog_size = 10240000;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# start/stop slog log should not cause log number increment
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+SET GLOBAL slow_query_log = 0;
+SET GLOBAL slow_query_log = 1;
+
+# FLUSH LOGS should not cause log number increment
+FLUSH LOGS;
+FLUSH LOGS;
+FLUSH LOGS;
+
+--let $assert_text = Slow query log number should not be incremented and log should be abcd.000001
+--let $assert_cond = @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/abcd.000001"
+--source include/assert.inc
+
+--echo # Case 3: Test if each slow_query_log_file call rotates slow log
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/zxcv'
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/zxcv'
+
+--let $assert_text = Slow query log should be zxcv.000002
+--let $assert_cond = @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/zxcv.000002"
+--source include/assert.inc
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--let $assert_text = Slow query log should be abcd.000003
+--let $assert_cond = @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/abcd.000003"
+--source include/assert.inc
+
+--echo # Case 4: Test if max_slowlog_files is working correctly
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 5;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# avoid 100 selects 1 in .result
+--let $i = 100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 5
+--source include/assert_number_of_files.inc
+ 
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/zxcv'
+
+--let $i = 100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/zxcv*
+--let expected_number = 5
+--source include/assert_number_of_files.inc
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# avoid 100 selects 1 in .result
+--let $i = 100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 5
+--source include/assert_number_of_files.inc
+
+--echo # Case 5: Rotating log but should not delete previous logs
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 5
+--source include/assert_number_of_files.inc
+
+--echo # Case 6: Calling "SET max_slowlog_files" should reduce number of logs
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 2;
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 2
+--source include/assert_number_of_files.inc
+
+--echo # Case 7: Delete all small logs with max_slowlog_size = 0
+SET GLOBAL max_slowlog_size = 0;
+SET GLOBAL max_slowlog_files = 1;
+
+# avoid 100 selects 1 in .result
+--let $i = 100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 1
+--source include/assert_number_of_files.inc
+
+--echo # Case 8: Rotate log should delete previous log
+SET GLOBAL max_slowlog_size = 10240000;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 1
+--source include/assert_number_of_files.inc
+
+--echo # Case 9: Check if disable max_slowlog_size is working correctly
+SET GLOBAL max_slowlog_size = 0;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/abcd'
+
+# avoid 100 selects 1 in .result
+--let $i = 100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/abcd*
+--let expected_number = 2
+--source include/assert_number_of_files.inc
+
+--let $assert_text= Slow query log should stay as abcd
+--let $assert_cond= @@GLOBAL.slow_query_log_file = "$MYSQLTEST_VARDIR/abcd"
+--source include/assert.inc
+
+--echo # Case 10: Multiple dots in slow query log file name
+SET GLOBAL max_slowlog_size = 4096;
+SET GLOBAL max_slowlog_files = 3;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/slow.query.log'
+
+# avoid 100 selects 1 in .result
+--let $i = 100
+--disable_query_log
+--disable_result_log
+while($i) {
+  --eval select $i
+  --dec $i
+}
+--enable_query_log
+--enable_result_log
+
+--let file_spec = $MYSQLTEST_VARDIR/slow.query.log*
+--let expected_number = 3
+--source include/assert_number_of_files.inc
+
+--echo # Case 11 (Bug 1704056): Enabling and disabling slow query log rotation
+--echo #                        spuriously adds version suffix to the next
+--echo #                        slow query log file name
+SET GLOBAL max_slowlog_size = 10240000;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/bug1704056_1';
+
+SET GLOBAL max_slowlog_size = @old_max_slowlog_size;
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SET GLOBAL slow_query_log_file = '$MYSQLTEST_VARDIR/bug1704056.slog';
+
+SET GLOBAL slow_query_log_file = @old_slow_query_log_file;
+
+# With the bug present bug1704056.slog.00001 will be created
+list_files $MYSQLTEST_VARDIR bug1704056.slog*;
+
+SET @@global.slow_query_log = @old_slow_query_log;
+SET @@global.log_output = @old_log_output;
+SET @@global.slow_query_log_file = @old_slow_query_log_file;
+SET @@global.max_slowlog_size = @old_max_slowlog_size;
+SET @@global.max_slowlog_files = @old_max_slowlog_files;
+SET @@long_query_time = @old_long_query_time;
+
+--remove_files_wildcard $MYSQLTEST_VARDIR abcd*
+--remove_files_wildcard $MYSQLTEST_VARDIR zxcv*
+--remove_files_wildcard $MYSQLTEST_VARDIR bug1704056*
+--remove_files_wildcard $MYSQLTEST_VARDIR slow.query.log*

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -59,6 +59,7 @@
 #include <string>
 #include <utility>
 
+#include "binlog.h"
 #include "lex_string.h"
 #include "m_ctype.h"
 #include "m_string.h"
@@ -113,6 +114,9 @@
 
 using std::max;
 using std::min;
+
+ulong max_slowlog_size;
+ulong max_slowlog_files;
 
 enum enum_slow_query_log_table_field {
   SQLT_FIELD_START_TIME = 0,
@@ -354,6 +358,14 @@ class File_query_log {
                   size_t sql_text_len, struct System_status_var *query_start);
 
  private:
+  /** slow log rotation and purging functions */
+  bool set_rotated_name(bool need_lock);
+  bool rotate(ulong max_size);
+  bool purge_logs();
+
+  ulong cur_log_ext;
+  ulong last_removed_ext;
+
   /** Type of log file. */
   const enum_log_table_type m_log_type;
 
@@ -387,7 +399,12 @@ class File_query_log {
 };
 
 File_query_log::File_query_log(enum_log_table_type log_type)
-    : m_log_type(log_type), name(nullptr), write_error(false), log_open(false) {
+    : cur_log_ext(0),
+      last_removed_ext(0),
+      m_log_type(log_type),
+      name(nullptr),
+      write_error(false),
+      log_open(false) {
   mysql_mutex_init(key_LOG_LOCK_log, &LOCK_log, MY_MUTEX_INIT_SLOW);
 #ifdef HAVE_PSI_INTERFACE
   if (log_type == QUERY_LOG_GENERAL)
@@ -489,10 +506,13 @@ bool File_query_log::set_file(const char *new_name) {
 
   name = nn;
 
-  // We can do this here since we're not actually resolving symlinks etc.
-  fn_format(log_file_name, name, mysql_data_home, "", MY_UNPACK_FILENAME);
+  mysql_mutex_lock(&LOCK_log);
+  cur_log_ext = 0;
+  last_removed_ext = 0;
+  bool res = set_rotated_name(false) || purge_logs();
+  mysql_mutex_unlock(&LOCK_log);
 
-  return false;
+  return res;
 }
 
 bool File_query_log::open() {
@@ -703,6 +723,8 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
 
   mysql_mutex_lock(&LOCK_log);
   assert(is_open());
+
+  if (max_slowlog_size > 0 && rotate(max_slowlog_size)) goto err;
 
   if (!(specialflag & SPECIAL_SHORT_LOG_FORMAT)) {
     char my_timestamp[iso8601_size];
@@ -943,6 +965,8 @@ bool File_query_log::write_slow(THD *thd, ulonglong current_utime,
       my_b_write(&log_file, pointer_cast<const uchar *>(";\n"), 2) ||
       flush_io_cache(&log_file))
     goto err;
+
+  if (purge_logs()) goto err;
 
   mysql_mutex_unlock(&LOCK_log);
   return false;
@@ -2021,6 +2045,192 @@ bool Slow_log_throttle::log(THD *thd, bool eligible) {
   }
 
   return suppress_current;
+}
+
+/**
+ * Check if string is a n-digit number.
+ *
+ * @param str String to check
+ * @param n_digit Expected number of digits
+ * @param res Returns actual number contained in provided string
+ * @return True in case string is a n-digit number, False otherwise
+ */
+static bool is_n_digit_number(const char *str, int n_digit, ulong *res) {
+  if (!isdigit(*str)) return false;
+
+  const char *start = str++;
+  while (isdigit(*str)) str++;
+  if (*str != 0 || str - start != n_digit) return false;
+
+  if (res) *res = atol(start);
+  return true;
+}
+
+/**
+ * Get biggest known numeric extension for a file name.
+ *
+ * Provided with the full path to the file it searches file's directory for
+ * files with the same name and six digit extension which is preceded by a dot.
+ * Max found extension number is returned. Extension equal to zero is returned
+ * in case there is no such file or there is no such files with numeric
+ * extension yet.
+ *
+ * @param name Full path to the log file name
+ * @return Biggest known numeric extension for the log file name
+ *         or 0 if not found
+ */
+static size_t get_last_extension(const char *const name) {
+  DBUG_ENTER("get_last_extension");
+  char buff[FN_REFLEN];
+  ulong max_found = 0;
+  ulong number = 0;
+  size_t buf_length;
+  size_t length;
+
+  length = dirname_part(buff, name, &buf_length);
+  const char *const start = name + length;
+  const char *const end = strend(start);
+  length = (size_t)(end - start);
+
+  MY_DIR *const dir_info = my_dir(buff, MYF(MY_DONT_SORT));
+  const struct fileinfo *file_info = dir_info->dir_entry;
+
+  for (uint i = dir_info->number_off_files; i--; file_info++) {
+    if (strncmp(file_info->name, start, length) == 0 &&
+        file_info->name[length] == '.' &&
+        is_n_digit_number(file_info->name + length + 1, 6, &number)) {
+      max_found = std::max(max_found, number);
+    }
+  }
+  my_dirend(dir_info);
+  DBUG_RETURN(max_found);
+}
+
+/**
+ * Set rotated log file name.
+ *
+ * Path to log file name updated according to current log file rotation
+ * settings. Numeric extension is added to log file name if needed.
+ * The opt_slow_logname is updated in case log file name has a numeric extension
+ * for the whole server to use proper log file name.
+ *
+ * @param need_lock Shows if LOCK_log mutex should be locked before
+ *                  updating opt_slow_logname
+ * @return False in case log file name updated successfully, True otherwise
+ */
+bool File_query_log::set_rotated_name(const bool need_lock) {
+  DBUG_ENTER("File_query_log::set_rotated_name");
+  if (need_lock) mysql_mutex_assert_owner(&LOCK_log);
+
+  if (!max_slowlog_size) {
+    fn_format(log_file_name, name, mysql_data_home, "", MY_UNPACK_FILENAME);
+    DBUG_RETURN(false);
+  }
+
+  if (cur_log_ext == 0) {
+    fn_format(log_file_name, name, mysql_data_home, "", MY_UNPACK_FILENAME);
+    cur_log_ext = get_last_extension(log_file_name) + 1;
+  } else {
+    cur_log_ext++;
+  }
+
+  if (cur_log_ext > 0) {
+    /* check if reached the maximum possible extension number */
+    if (cur_log_ext >= MAX_LOG_UNIQUE_FN_EXT) {
+      LogErr(ERROR_LEVEL, ER_BINLOG_FILE_EXTENSION_NUMBER_EXHAUSTED,
+             cur_log_ext);
+      DBUG_RETURN(true);
+    }
+
+    if (snprintf(log_file_name, sizeof(log_file_name), "%s.%06lu", name,
+                 cur_log_ext) >= static_cast<int>(sizeof(log_file_name))) {
+      my_printf_error(ER_NO_UNIQUE_LOGFILE,
+                      ER_THD(current_thd, ER_NO_UNIQUE_LOGFILE),
+                      MYF(ME_FATALERROR), name);
+      LogErr(ERROR_LEVEL, ER_NO_UNIQUE_LOGFILE, name);
+      DBUG_RETURN(true);
+    }
+
+    if (need_lock) mysql_mutex_lock(&LOCK_global_system_variables);
+    opt_slow_logname =
+        my_strdup(key_memory_LOG_name, log_file_name, MYF(MY_WME));
+    if (need_lock) mysql_mutex_unlock(&LOCK_global_system_variables);
+  }
+
+  DBUG_RETURN(false);
+}
+
+/**
+ * Rotate log file in case its size exceeds provided value.
+ *
+ * @param max_size Max allowed log file size
+ * @return False in case log is rotated successfully, True otherwise
+ */
+bool File_query_log::rotate(const ulong max_size) {
+  DBUG_ENTER("File_query_log::rotate");
+  mysql_mutex_assert_owner(&LOCK_log);
+
+  if (my_b_tell(&log_file) > max_size) {
+    if (set_rotated_name(true)) DBUG_RETURN(true);
+    close();
+    if (open()) DBUG_RETURN(true);
+  }
+
+  DBUG_RETURN(false);
+}
+
+/**
+ * Purge log files depending on max configured number of log files.
+ *
+ * @return False in case logs purged successfully, True otherwise
+ */
+bool File_query_log::purge_logs() {
+  DBUG_ENTER("File_query_log::purge_logs");
+  mysql_mutex_assert_owner(&LOCK_log);
+
+  if (max_slowlog_files == 0 || cur_log_ext < 1 ||
+      last_removed_ext == cur_log_ext - 1)
+    DBUG_RETURN(false);
+
+  char buff[FN_REFLEN];
+  MY_STAT stat_area;
+  long iter_log_ext = cur_log_ext - 1;
+  ulong total_slowlog_files_count = 1;
+
+  while (true) {
+    if (iter_log_ext > 0) {
+      snprintf(buff, sizeof(buff), "%s.%06lu", name, iter_log_ext);
+    } else {
+      snprintf(buff, sizeof(buff), "%s", name);
+    }
+
+    if (!mysql_file_stat(m_log_file_key, buff, &stat_area, MYF(0))) {
+      last_removed_ext = iter_log_ext;
+      DBUG_RETURN(false);
+    }
+
+    if (++total_slowlog_files_count >= max_slowlog_files) break;
+    if (--iter_log_ext < 0) DBUG_RETURN(false);
+  };
+
+  bool error = false;
+  if (max_slowlog_files > 1) --iter_log_ext;
+
+  while (iter_log_ext >= 0) {
+    if (iter_log_ext > 0) {
+      snprintf(buff, sizeof(buff), "%s.%06lu", name, iter_log_ext);
+    } else {
+      snprintf(buff, sizeof(buff), "%s", name);
+    }
+
+    if ((error = (unlink(buff) != 0))) {
+      if (my_errno() == ENOENT) error = false;
+      break;
+    }
+    --iter_log_ext;
+  }
+
+  DBUG_RETURN(error);
 }
 
 bool Error_log_throttle::log() {

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -245,6 +245,8 @@ extern bool locked_in_memory;
 extern bool opt_using_transactions;
 extern ulong current_pid;
 extern ulong expire_logs_days;
+extern ulong max_slowlog_size;
+extern ulong max_slowlog_files;
 extern ulong binlog_expire_logs_seconds;
 extern ulonglong binlog_space_limit;
 extern uint sync_binlog_period, sync_relaylog_period, sync_relayloginfo_period,

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3048,6 +3048,22 @@ static Sys_var_ulong Sys_max_relay_log_size(
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr),
     ON_UPDATE(fix_max_relay_log_size));
 
+static Sys_var_ulong Sys_max_slowlog_size(
+    "max_slowlog_size",
+    "Slow query log will be rotated automatically when the size exceeds "
+    "this value. The default is 0, don't limit the size.",
+    GLOBAL_VAR(max_slowlog_size), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(0, 1024 * 1024L * 1024L), DEFAULT(0L), BLOCK_SIZE(IO_SIZE));
+
+static Sys_var_ulong Sys_max_slowlog_files(
+    "max_slowlog_files",
+    "Maximum number of slow query log files. Used with --max-slowlog-size "
+    "this can be used to limit the total amount of disk space used for the "
+    "slow query log. "
+    "Default is 0, don't limit.",
+    GLOBAL_VAR(max_slowlog_files), CMD_LINE(REQUIRED_ARG),
+    VALID_RANGE(0, 102400), DEFAULT(0), BLOCK_SIZE(1));
+
 static Sys_var_ulong Sys_max_sort_length(
     "max_sort_length",
     "The number of bytes to use when sorting long values with PAD SPACE "


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7931

The implementation is ported from PS 5.7.

Added the following variables to controll the functionality:
- max_slowlog_size - Slow query log will be rotated automatically when
                     the size exceeds this value. The default is 0,
                     don't limit the size.
- max_slowlog_files - Maximum number of slow query log files. Used with
                      --max-slowlog-size this can be used to limit the total
                      amount of disk space used for the slow query log.
                      Default is 0, don't limit.