### PR TITLE
PS-7558: Assertion `innodb_trx_id == 0 || innodb_trx_id == trx_id || …

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -898,6 +898,8 @@ extern "C" void thd_report_innodb_stat(THD *thd, unsigned long long trx_id,
                                        enum mysql_trx_stat_type type,
                                        unsigned long long       value)
 {
+  if (thd_log_slow_verbosity(thd) && (thd->innodb_trx_id != trx_id)) thd->innodb_trx_id = 0;
+
   thd->mark_innodb_used(trx_id);
   switch (type)
   {


### PR DESCRIPTION
…trx_id == 0' during CHANGE MASTER

https://jira.percona.com/browse/PS-7558

Analysis
Assertion happned as innodb_trx_id in thd class not equal to trx_id

Fix
reseted innodb_trx_id before call to mark_innodb_used