### PR TITLE
PS-7949 Fix main.mtr_unit_tests

### DIFF
--- a/mysql-test/lib/t/testMyConfigFactory.t
+++ b/mysql-test/lib/t/testMyConfigFactory.t
@@ -72,6 +72,7 @@ my $config= My::ConfigFactory->new_config
   vardir => "/path/to/var",
   baseport => 10987,
   #hosts => [ 'host1', 'host2' ],
+  worker => 1,
  }
 );
 
@@ -117,6 +118,7 @@ my $config2= My::ConfigFactory->new_config
   vardir => "/path/to/var",
   baseport => 10987,
   #hosts => [ 'host1', 'host2' ],
+  worker => 1,
  }
 );
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7949

This is a fix to a regression introduced in the implementation of WDCZEN-9
"Allow running rocksdb MTR test cases on ZenFS storage in parallel"
(https://jira.percona.com/browse/WDCZEN-9)
(commit 15fb7ac).

'My::ConfigFactory->new_config()' now requires one additional argument
'worker'.

(cherry picked from commit e4646eb468ac96d26ee1e8cc53bf7c70adf532a9)