### PR TITLE
PS-7988: Fix BiDiScan Azure job to properly handle empty changed files list (5.7)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,10 +13,9 @@ jobs:
 
       if [ -z "${CHANGED_FILES}" ]; then
           echo --- No changed files
-          ##vso[task.complete result=Succeeded;]DONE
+      else
+          python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v ${CHANGED_FILES}
       fi
-
-      python $(Build.SourcesDirectory)/scripts/find_unicode_control.py -p bidi -v ${CHANGED_FILES}
 
 - job:
   timeoutInMinutes: 240


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7988