### PR TITLE
PS-7995: Update macOS version used for Azure builds to latest (5.7)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,14 +36,14 @@ jobs:
 
   strategy:
     matrix:
-      macOS 10.14 Release:
-        imageName: 'macOS-10.14'
+      macOS 10.15 Release:
+        imageName: 'macOS-10.15'
         Compiler: clang
         BuildType: RelWithDebInfo
 
       ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
-        macOS 10.14 Debug:
-          imageName: 'macOS-10.14'
+        macOS 10.15 Debug:
+          imageName: 'macOS-10.15'
           Compiler: clang
           BuildType: Debug
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7995

The macOS-10.14 environment is going to be deprecated soon.
Use macOS-10.15 instead.