### PR TITLE
PS-7995: Update macOS version used for Azure builds to latest (8.0)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,14 +30,14 @@ jobs:
 
   strategy:
     matrix:
-      macOS 10.14 Release:
-        imageName: 'macOS-10.14'
+      macOS 10.15 Release:
+        imageName: 'macOS-10.15'
         Compiler: clang
         BuildType: RelWithDebInfo
 
       ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
-        macOS 10.14 Debug:
-          imageName: 'macOS-10.14'
+        macOS 10.15 Debug:
+          imageName: 'macOS-10.15'
           Compiler: clang
           BuildType: Debug
 
@@ -310,7 +310,7 @@ jobs:
         fi
       else
          brew update
-         brew install ccache protobuf lz4 re2 rapidjson
+         brew install ccache protobuf lz4 re2 rapidjson openssl@1.1
       fi
 
       UPDATE_TIME=$SECONDS
@@ -398,6 +398,7 @@ jobs:
           -DWITH_PROTOBUF=system
           -DWITH_SYSTEM_LIBS=ON
           -DWITH_ICU=/usr/local/opt/icu4c
+          -DWITH_SSL=/usr/local/opt/openssl@1.1
         "
       else
         CMAKE_OPT+="


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7995

The macOS-10.14 environment is going to be deprecated soon.
Use macOS-10.15 instead.

(cherry picked from commit ee66a11bc62896e25bc1fd772a7cb72114401c3b)