### PR TITLE
PS-7856: update on partition tables crashes the server

### DIFF
--- a/mysql-test/suite/innodb/r/partition_autoinc.result
+++ b/mysql-test/suite/innodb/r/partition_autoinc.result
@@ -1,0 +1,5 @@
+# PS-7856: update on partition tables crashes the server
+CREATE TABLE t1(ip_col INT, i1 INT AUTO_INCREMENT, INDEX tt_2_pi1(i1)) PARTITION BY HASH (ip_col);
+INSERT INTO t1(ip_col) VALUES(1);
+UPDATE t1 SET i1 = 1 WHERE ip_col = 1;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/partition_autoinc.test
+++ b/mysql-test/suite/innodb/t/partition_autoinc.test
@@ -1,0 +1,9 @@
+--source include/have_innodb.inc
+
+#################################
+--echo # PS-7856: update on partition tables crashes the server
+#################################
+CREATE TABLE t1(ip_col INT, i1 INT AUTO_INCREMENT, INDEX tt_2_pi1(i1)) PARTITION BY HASH (ip_col);
+INSERT INTO t1(ip_col) VALUES(1);
+UPDATE t1 SET i1 = 1 WHERE ip_col = 1;
+DROP TABLE t1;

--- a/sql/partitioning/partition_handler.cc
+++ b/sql/partitioning/partition_handler.cc
@@ -669,12 +669,12 @@ int Partition_helper::ph_update_row(const uchar *old_data, uchar *new_data,
     index)
     mysql_update does not set table->next_number_field, so we use
     table->found_next_number_field instead.
-    Also checking that the field is marked in the write set.
+    Also checking that the field is marked in the read set.
   */
   if (m_table->found_next_number_field &&
       new_data == m_table->record[0] &&
       !m_table->s->next_number_keypart &&
-      bitmap_is_set(m_table->write_set,
+      bitmap_is_set(m_table->read_set,
                     m_table->found_next_number_field->field_index))
   {
     set_auto_increment_if_higher();


### PR DESCRIPTION
`write_set` wasn't used here, probably this is mistake. Replacing with `read_set` solves the problem, but is it correct that we skip `set_auto_increment_if_higher` when read_set is reseted? Or maybe we need to mark autoincrement column used in some appropriate place. I need an advice here.

Also bug is reproduced in 8.0, but binlog should be disabled, otherwise bitmap is set and no assertion error is produced. I created a PR for that branch too.