### PR TITLE
PS-4772: Break down SP stats in slow log per statement

### DIFF
--- a/mysql-test/r/percona_log_slow_admin_statements_sp.result
+++ b/mysql-test/r/percona_log_slow_admin_statements_sp.result
@@ -20,6 +20,8 @@ call test();
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(1\);
 [log_grep.inc] lines:   1
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: Rows_sent: 0  Rows_examined: 0  Rows_affected: 1
+[log_grep.inc] lines:   2
 DROP INDEX i ON t1;
 SET GLOBAL log_slow_admin_statements=ON;
 SET GLOBAL log_slow_sp_statements=OFF;
@@ -32,6 +34,8 @@ call test();
 [log_grep.inc] lines:   0
 [log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: INSERT INTO t1 VALUES\(1\);
 [log_grep.inc] lines:   0
+[log_grep.inc] file: percona_log_slow_admin_stmt_sp_1 pattern: Rows_sent: 0  Rows_examined: 0  Rows_affected: 2
+[log_grep.inc] lines:   1
 DROP INDEX i ON t1;
 SET GLOBAL log_slow_admin_statements=ON;
 SET GLOBAL log_slow_sp_statements=ON;

--- a/mysql-test/r/percona_log_slow_sp_statements.result
+++ b/mysql-test/r/percona_log_slow_sp_statements.result
@@ -1,5 +1,9 @@
 SET SESSION min_examined_row_limit=0;
 SET SESSION long_query_time=0;
+CREATE TABLE t1 (id int);
+CREATE TABLE t2 (id int);
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (3), (4), (5);
 CREATE PROCEDURE test_inner()
 BEGIN
 SELECT 2;
@@ -10,6 +14,11 @@ SELECT 1;
 CALL test_inner();
 END^
 PREPARE stmt FROM "CALL test_outer()";
+CREATE PROCEDURE test_stats()
+BEGIN
+SELECT * FROM t1;
+SELECT * FROM t2;
+END^
 SET @saved_log_slow_sp_statements=@@GLOBAL.log_slow_sp_statements;
 SET GLOBAL log_slow_sp_statements=ON;
 [log_start.inc] percona.slow_extended.sp1
@@ -39,6 +48,24 @@ EXECUTE stmt;
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.sp1 pattern: # Stored_routine: test.test_inner
 [log_grep.inc] lines:   2
+[log_start.inc] percona.slow_extended.sp_stats1
+CALL test_stats();
+id
+1
+2
+id
+3
+4
+5
+[log_stop.inc] percona.slow_extended.sp_stats1
+[log_grep.inc] file: percona.slow_extended.sp_stats1 pattern: SELECT \* FROM t1;
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.sp_stats1 pattern: SELECT \* FROM t2;
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.sp_stats1 pattern: Rows_sent: 2  Rows_examined: 2  Rows_affected: 0
+[log_grep.inc] lines:   1
+[log_grep.inc] file: percona.slow_extended.sp_stats1 pattern: Rows_sent: 3  Rows_examined: 3  Rows_affected: 0
+[log_grep.inc] lines:   1
 SET GLOBAL log_slow_sp_statements=OFF;
 [log_start.inc] percona.slow_extended.sp2
 SELECT "log_always";
@@ -65,6 +92,18 @@ EXECUTE stmt;
 [log_grep.inc] lines:   2
 [log_grep.inc] file: percona.slow_extended.sp2 pattern: # Stored_routine: test.test_
 [log_grep.inc] lines:   0
+[log_start.inc] percona.slow_extended.sp_stats2
+CALL test_stats();
+id
+1
+2
+id
+3
+4
+5
+[log_stop.inc] percona.slow_extended.sp_stats2
+[log_grep.inc] file: percona.slow_extended.sp_stats2 pattern: Rows_sent: 5  Rows_examined: 5  Rows_affected: 0
+[log_grep.inc] lines:   1
 SET GLOBAL log_slow_sp_statements=OFF_NO_CALLS;
 [log_start.inc] percona.slow_extended.sp3
 SELECT "log_always";
@@ -93,4 +132,7 @@ EXECUTE stmt;
 [log_grep.inc] lines:   0
 DROP PROCEDURE test_outer;
 DROP PROCEDURE test_inner;
+DROP PROCEDURE test_stats;
+DROP TABLE t1;
+DROP TABLE t2;
 SET GLOBAL log_slow_sp_statements=@saved_log_slow_sp_statements;

--- a/mysql-test/t/percona_log_slow_admin_statements_sp.test
+++ b/mysql-test/t/percona_log_slow_admin_statements_sp.test
@@ -37,6 +37,10 @@ call test();
 --let grep_pattern=INSERT INTO t1 VALUES\(1\);
 --source include/log_grep.inc
 
+# Check Rows_affected properly logged for each separate statement
+--let grep_pattern=Rows_sent: 0  Rows_examined: 0  Rows_affected: 1
+--source include/log_grep.inc
+
 DROP INDEX i ON t1;
 --source include/log_cleanup.inc
 
@@ -55,6 +59,11 @@ call test();
 --let grep_pattern=CREATE INDEX i ON t1\(a\);
 --source include/log_grep.inc
 --let grep_pattern=INSERT INTO t1 VALUES\(1\);
+--source include/log_grep.inc
+
+# Check Rows_affected reflects all changes done by each individual statement
+# executed within CALL
+--let grep_pattern=Rows_sent: 0  Rows_examined: 0  Rows_affected: 2
 --source include/log_grep.inc
 
 DROP INDEX i ON t1;

--- a/mysql-test/t/percona_log_slow_sp_statements.test
+++ b/mysql-test/t/percona_log_slow_sp_statements.test
@@ -6,6 +6,11 @@
 SET SESSION min_examined_row_limit=0;
 SET SESSION long_query_time=0;
 
+CREATE TABLE t1 (id int);
+CREATE TABLE t2 (id int);
+INSERT INTO t1 VALUES (1), (2);
+INSERT INTO t2 VALUES (3), (4), (5);
+
 delimiter ^;
 CREATE PROCEDURE test_inner()
 BEGIN
@@ -22,6 +27,14 @@ END^
 delimiter ;^
 
 PREPARE stmt FROM "CALL test_outer()";
+
+delimiter ^;
+CREATE PROCEDURE test_stats()
+BEGIN
+   SELECT * FROM t1;
+   SELECT * FROM t2;
+END^
+delimiter ;^
 
 SET @saved_log_slow_sp_statements=@@GLOBAL.log_slow_sp_statements;
 SET GLOBAL log_slow_sp_statements=ON;
@@ -44,12 +57,30 @@ EXECUTE stmt;
 --let grep_pattern=# Stored_routine: test.test_inner
 --source include/log_grep.inc
 
+# Check statistic is properly calculated for each separate statement within a
+# stored procedure when log_slow_sp_statements=ON
+--let log_file=percona.slow_extended.sp_stats1
+--source include/log_start.inc
+CALL test_stats();
+--source include/log_stop.inc
+
+--let grep_pattern=SELECT \* FROM t1;
+--source include/log_grep.inc
+--let grep_pattern=SELECT \* FROM t2;
+--source include/log_grep.inc
+
+--let grep_pattern=Rows_sent: 2  Rows_examined: 2  Rows_affected: 0
+--source include/log_grep.inc
+--let grep_pattern=Rows_sent: 3  Rows_examined: 3  Rows_affected: 0
+--source include/log_grep.inc
+
 SET GLOBAL log_slow_sp_statements=OFF;
 --let log_file=percona.slow_extended.sp2
 --source include/log_start.inc
 SELECT "log_always";
 CALL test_outer();
 EXECUTE stmt;
+
 --source include/log_stop.inc
 --let grep_pattern=log_always
 --source include/log_grep.inc
@@ -60,6 +91,16 @@ EXECUTE stmt;
 --let grep_pattern=CALL test_
 --source include/log_grep.inc
 --let grep_pattern=# Stored_routine: test.test_
+--source include/log_grep.inc
+
+# Check statistic is properly calculated for CALL statement when
+# log_slow_sp_statements=OFF
+--let log_file=percona.slow_extended.sp_stats2
+--source include/log_start.inc
+CALL test_stats();
+--source include/log_stop.inc
+
+--let grep_pattern=Rows_sent: 5  Rows_examined: 5  Rows_affected: 0
 --source include/log_grep.inc
 
 SET GLOBAL log_slow_sp_statements=OFF_NO_CALLS;
@@ -82,6 +123,10 @@ EXECUTE stmt;
 
 DROP PROCEDURE test_outer;
 DROP PROCEDURE test_inner;
+DROP PROCEDURE test_stats;
+
+DROP TABLE t1;
+DROP TABLE t2;
 
 SET GLOBAL log_slow_sp_statements=@saved_log_slow_sp_statements;
 --source include/log_cleanup.inc

--- a/sql/log.cc
+++ b/sql/log.cc
@@ -1791,13 +1791,13 @@ bool log_slow_applicable(THD *thd, int sp_sql_command) {
         assert(sp_sql_command != -1);
         if (sp_sql_command == SQLCOM_CALL) return false;
       } else
-	 return false;
+        return false;
     } else if (thd->lex->sql_command == SQLCOM_EXECUTE) {
       Prepared_statement *stmt;
       LEX_CSTRING *name = &thd->lex->prepared_stmt_name;
       if ((stmt = thd->stmt_map.find_by_name(*name)) != NULL && stmt->lex &&
           stmt->lex->sql_command == SQLCOM_CALL)
-	 return false;
+        return false;
     }
   }
 

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -2220,7 +2220,10 @@ bool sp_head::execute(THD *thd, bool merge_da_on_success) {
     */
     if (thd->rewritten_query().length()) thd->reset_rewritten_query();
 
+    Sub_statement_state statement_state;
+    thd->reset_sub_statement_state_slow_extended(&statement_state);
     err_status = i->execute(thd, &ip);
+    thd->restore_sub_statement_state_slow_extended(statement_state);
 
 #ifdef HAVE_PSI_STATEMENT_INTERFACE
     MYSQL_END_STATEMENT(thd->m_statement_psi, thd->get_stmt_da());

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -690,6 +690,7 @@ class Sub_statement_state {
   Discrete_intervals_list auto_inc_intervals_forced;
   ulonglong current_found_rows;
   ulonglong previous_found_rows;
+  longlong row_count_func;
   ha_rows num_truncated_fields, sent_row_count, examined_row_count;
   ulong client_capabilities;
   uint in_sub_stmt;
@@ -1668,8 +1669,6 @@ class THD : public MDL_context_owner,
   }
   /*** Following methods used in slow_extended.patch ***/
   void clear_slow_extended() noexcept;
-
- private:
   void reset_sub_statement_state_slow_extended(
       Sub_statement_state *backup) noexcept;
   void restore_sub_statement_state_slow_extended(


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4772

In case log_slow_sp_statements=ON stats for each separate statement
within stored procedure continue accumulating for each next statement.
The issue affects Rows_sent, Rows_examined and Rows_affected counters.

To improve this reset slow query log stats before executing each
statement within stored procedure. The following is done in order
to achieve this:
- the statement execution is wrapped with THD::reset_sub_statement_state_slow_extended()
  and THD::restore_sub_statement_state_slow_extended() methods.
- Updated THD::reset_sub_statement_state_slow_extended() and
  THD::restore_sub_statement_state_slow_extended() methods to make them
  safe to use separately from THD::reset_sub_statement_state().
  These methods should handle sent_row_count, examined_row_count
  and row_count_func attrs reset/restore as they are used by slow log.