### PR TITLE
PXC-3809: Server crashes with Assertion `m_prebuilt->table->n_ref_cou…

### DIFF
--- a/storage/innobase/handler/ha_innopart.cc
+++ b/storage/innobase/handler/ha_innopart.cc
@@ -197,7 +197,14 @@ Ha_innopart_share::open_one_table_part(
 		&& (m_table_share->fields
 		    != dict_table_get_n_user_cols(ib_table)
 		       + dict_table_get_n_v_cols(ib_table) - 1))) {
-		ib::warn() << "Partition `" << get_partition_name(part_id)
+        /* We may end up here when doing ha_innopart::open(), so before
+           populate_partition_name_hash() was called. In such a case
+           get_partition_name() returns nullptr. Fall back to any other
+           informative string instead of trying to print nullptr. */
+        const char *part_name = get_partition_name(part_id)
+                                ? get_partition_name(part_id)
+                                : ib_table->name.m_name;
+		ib::warn() << "Partition `" << (part_name ? part_name : "nullptr")
 			<< "` contains " << dict_table_get_n_user_cols(ib_table)
 			<< " user defined columns in InnoDB, but "
 			<< m_table_share->fields
@@ -459,7 +466,10 @@ Ha_innopart_share::close_table_parts()
 	mutex_enter(&dict_sys->mutex);
 	if (m_table_parts != NULL) {
 		for (uint i = 0; i < m_tot_parts; i++) {
-			if (m_table_parts[i] != NULL) {
+            // If the partition is corrupted, it was not opened.
+            ut_a(m_table_parts[i] == NULL || m_table_parts[i]->n_ref_count > 0
+                 || m_table_parts[i]->corrupted);
+			if (m_table_parts[i] != NULL && !m_table_parts[i]->corrupted)  {
 				dict_table_close(m_table_parts[i], TRUE, TRUE);
 			}
 		}
@@ -1055,6 +1065,11 @@ share_error:
 	m_pcur_parts = NULL;
 	m_clust_pcur_parts = NULL;
 	m_pcur_map = NULL;
+
+    if (ib_table->corrupted) {
+        close();
+        DBUG_RETURN(HA_ERR_TABLE_CORRUPT);
+    }
 
 	/* TODO: Handle mismatching #P# vs #p# in upgrading to new DD instead!
 	See bug#58406, The problem exists when moving partitioned tables


### PR DESCRIPTION
…nt > 0' failed

https://jira.percona.com/browse/PXC-3809

This issue was reported to PXC, but the reason is not PXC specific.
This commit is the proposal of the fix for PS.

Cause:
5.7 does not support atomic DDL. It may happen that MySql's frm file is
out of sync with InnodDB dictionary. In such a case the table that is
part of InnoDB partitioned table is not opened.

Fix:
We are not able to fix this case automatically, but we can improve
the error handling. If the partitioned table cannot be opened, and its
1st partition is marked as corrupted, return error without proceeding
with further opening.

Also, logging was improved as it may happen that when the inconsistency
is detected, partition names are not initialized yet, which resulted with the
spoiled log like:
```
2022-01-03T20:48:59.780793Z 14 [Warning] InnoDB: Partition `
2022-01-03T20:48:59.782633Z 14 [Warning] InnoDB: Partition `
2022-01-03T20:48:59.784170Z 14 [Warning] InnoDB: Partition `
```