### PR TITLE
PS-8028: Server crashes with Assertion `m_prebuilt->table->n_ref_coun…

### DIFF
--- a/mysql-test/suite/innodb/r/partition_fmt_inconsistency.result
+++ b/mysql-test/suite/innodb/r/partition_fmt_inconsistency.result
@@ -1,0 +1,16 @@
+CREATE TABLE t1 (id INT)
+PARTITION BY RANGE(id) (
+PARTITION p0 VALUES LESS THAN (100),
+PARTITION p1 VALUES LESS THAN (200),
+PARTITION p2 VALUES LESS THAN (300),
+PARTITION p3 VALUES LESS THAN (400)
+);
+SET SESSION DEBUG = '+d,alter_table_crash_before_frm_replace';
+ALTER TABLE t1 ADD a INT;
+ERROR HY000: Lost connection to MySQL server during query
+# Restart mysqld after the crash and reconnect.
+# restart
+SELECT * FROM t1;
+ERROR 42S02: Table 'test.t1' doesn't exist
+include/assert_grep.inc [InnoDB vs MySql columns mismatch.]
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/partition_fmt_inconsistency.test
+++ b/mysql-test/suite/innodb/t/partition_fmt_inconsistency.test
@@ -1,0 +1,41 @@
+#
+# Test the case when server is aborted after updating InnoDB dictionary,
+# but before fmt file gets updated. This leads to the inconsistency which
+# cannot be auto healied. Informative error message should be printed
+# and there should be possible to drop such a table.
+#
+--source include/have_innodb.inc
+
+--disable_query_log
+call mtr.add_suppression('InnoDB: Partition .* contains 2 user defined columns in InnoDB, but 1 columns in MySQL');
+--enable_query_log
+
+CREATE TABLE t1 (id INT)
+  PARTITION BY RANGE(id) (
+    PARTITION p0 VALUES LESS THAN (100),
+    PARTITION p1 VALUES LESS THAN (200),
+    PARTITION p2 VALUES LESS THAN (300),
+    PARTITION p3 VALUES LESS THAN (400)
+);
+
+SET SESSION DEBUG = '+d,alter_table_crash_before_frm_replace';
+
+--source include/expect_crash.inc
+
+--error 2013
+ALTER TABLE t1 ADD a INT;
+
+--echo # Restart mysqld after the crash and reconnect.
+--source include/start_mysqld.inc
+
+--error ER_NO_SUCH_TABLE
+SELECT * FROM t1;
+
+# Check that the error log contains the information about corrupted table
+--let $assert_file = $MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_count = 4
+--let $assert_select = InnoDB: Partition .* contains 2 user defined columns in InnoDB, but 1 columns in MySQL.
+--let $assert_text = InnoDB vs MySql columns mismatch.
+--source include/assert_grep.inc
+
+DROP TABLE t1;

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -7931,6 +7931,9 @@ static bool mysql_inplace_alter_table(THD *thd,
   table_list->table= table= NULL;
   close_temporary_table(thd, altered_table, true, false);
 
+  DBUG_EXECUTE_IF("alter_table_crash_before_frm_replace", {
+    DBUG_SUICIDE();
+  });
   /*
     Replace the old .FRM with the new .FRM, but keep the old name for now.
     Rename to the new name (if needed) will be handled separately below.


### PR DESCRIPTION
…t > 0' failed

https://jira.percona.com/browse/PS-8028

Cause:
5.7 does not support atomic DDL. It may happen that MySql's frm file is
out of sync with InnodDB dictionary. In such a case the table that is
part of InnoDB partitioned table is not opened which causes asserts.

Fix:
We are not able to recover from this case automatically, but we can
improve the error handling.
If the partitioned table cannot be opened, and its 1st partition is
marked as corrupted, return error without proceeding with further
opening.

Also, logging was improved as it may happen that when the inconsistency
is detected (opening the table), partition names are not initialized
yet, which results with the spoiled log.