### PR TITLE
Crash when auto incremented column updated in partitioned table

### DIFF
--- a/mysql-test/suite/innodb/r/partition_autoinc.result
+++ b/mysql-test/suite/innodb/r/partition_autoinc.result
@@ -1,0 +1,5 @@
+# PS-7856: update on partition tables crashes the server
+CREATE TABLE t1(ip_col INT, i1 INT AUTO_INCREMENT, INDEX tt_2_pi1(i1)) PARTITION BY HASH (ip_col);
+INSERT INTO t1(ip_col) VALUES(1);
+UPDATE t1 SET i1 = 1 WHERE ip_col = 1;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/partition_autoinc-master.opt
+++ b/mysql-test/suite/innodb/t/partition_autoinc-master.opt
@@ -1,0 +1,1 @@
+--disable-log-bin

--- a/mysql-test/suite/innodb/t/partition_autoinc.test
+++ b/mysql-test/suite/innodb/t/partition_autoinc.test
@@ -1,0 +1,7 @@
+#################################
+--echo # PS-7856: update on partition tables crashes the server
+#################################
+CREATE TABLE t1(ip_col INT, i1 INT AUTO_INCREMENT, INDEX tt_2_pi1(i1)) PARTITION BY HASH (ip_col);
+INSERT INTO t1(ip_col) VALUES(1);
+UPDATE t1 SET i1 = 1 WHERE ip_col = 1;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/partition_autoinc.test
+++ b/mysql-test/suite/innodb/t/partition_autoinc.test
@@ -1,3 +1,5 @@
+--source include/have_innodb.inc
+
 #################################
 --echo # PS-7856: update on partition tables crashes the server
 #################################

--- a/sql/partitioning/partition_handler.cc
+++ b/sql/partitioning/partition_handler.cc
@@ -677,7 +677,9 @@ int Partition_helper::ph_update_row(const uchar *old_data, uchar *new_data,
       bitmap_is_set(m_table->write_set,
                     m_table->found_next_number_field->field_index))
   {
+    my_bitmap_map *old_map = dbug_tmp_use_all_columns(m_table, m_table->read_set);
     set_auto_increment_if_higher();
+    dbug_tmp_restore_column_map(m_table->read_set, old_map);
   }
   DBUG_RETURN(error);
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7856

Use dbug_tmp_use_all_columns/dbug_tmp_restore_column_map as described in 74cc73d as a workaround, because autoincremented column is not used in the query.

This is new PR instead of https://github.com/percona/percona-server/pull/4567 to comply GCA process.