### PR TITLE
PS-7865 [8.0]: Dropping a table with discarded tablespace crashes the server

### DIFF
--- a/mysql-test/suite/innodb/r/discard_tablespace.result
+++ b/mysql-test/suite/innodb/r/discard_tablespace.result
@@ -1,4 +1,10 @@
 #
+# PS-7865: Dropping a table with discarded tablespace crashes the server
+#
+CREATE TABLE t1(a INT)ENGINE=innodb;
+ALTER TABLE t1 DISCARD TABLESPACE;
+DROP TABLE t1;
+#
 # Bug #29793800 ASSERT AFTER DISCARD TABLESPACE, RENAME TABLE AND
 # CREATE TABLE USING SAME NAME.
 #

--- a/mysql-test/suite/innodb/t/discard_tablespace.test
+++ b/mysql-test/suite/innodb/t/discard_tablespace.test
@@ -1,4 +1,24 @@
 --echo #
+--echo # PS-7865: Dropping a table with discarded tablespace crashes the server
+--echo #
+
+CREATE TABLE t1(a INT) ENGINE=innodb;
+
+--disable_query_log
+--let $n=2048
+BEGIN;
+while ($n)
+{
+INSERT INTO t1 VALUES (10);
+--dec $n
+}
+COMMIT;
+--enable_query_log
+
+ALTER TABLE t1 DISCARD TABLESPACE;
+DROP TABLE t1;
+
+--echo #
 --echo # Bug #29793800 ASSERT AFTER DISCARD TABLESPACE, RENAME TABLE AND
 --echo # CREATE TABLE USING SAME NAME.
 --echo #

--- a/storage/innobase/btr/btr0sea.cc
+++ b/storage/innobase/btr/btr0sea.cc
@@ -1120,7 +1120,7 @@ retry:
   ut_ad(!index->disable_ahi);
   ut_ad(btr_search_enabled);
 
-  ut_ad(block->page.id.space() == index->space);
+  ut_ad(block->page.was_stale() || block->page.id.space() == index->space);
   ut_a(index_id == index->id);
   ut_a(!dict_index_is_ibuf(index));
 #ifdef UNIV_DEBUG


### PR DESCRIPTION
This is how the bug occurs:
1. If table have a lot of data, these conditions are satisfied and `btr_search_update_block_hash_info` returns true: https://github.com/percona/percona-server/blob/8.0/storage/innobase/btr/btr0sea.cc#L588 on one of `LOAD DATA` commands execution. This causes the creation of a hash index.
2. On discarding table this line is reached: https://github.com/percona/percona-server/blob/8.0/storage/innobase/row/row0mysql.cc#L3994. This will be the problematic index on which assert fails because of `index->space == FIL_NULL` but `block->page.id.space()` stays the same.
3. This erros occurs only on a lot amount of data, otherwise a hash index will not be created and hence will not be droped.

I suppose that solution can be in widening assert condition to include `index->space == FIL_NULL` case. But I'am not sure, is it okay that we drop the reseted index in `btr_search_drop_page_hash_index`? But early returning from the function probably is not an option, because in that case `assert_block_ahi_empty(block)` is failed:
```
  if (block->index == nullptr ||
      block->index->space == FIL_NULL) {
    rw_lock_s_unlock(latch);
    assert_block_ahi_empty(block);
    return;
  }
```

Assert was originally added in https://github.com/percona/percona-server/commit/195760a57028 commit. Probably it's not good idea to widen other same asserts because other cases are not related with dropping index, but with creating, updating etc. But I'am also not sure.

I added a little faster version of a testcase. It differs from the original one, but works in the same way.