### PR TITLE
[5.7] PS-8030: Multithreaded replica crashes inside Relay_log_info::cannot_safely_rollback()

### DIFF
--- a/sql/rpl_rli.cc
+++ b/sql/rpl_rli.cc
@@ -431,7 +431,8 @@ bool Relay_log_info::cannot_safely_rollback() const
   {
     Slave_worker *worker= *it;
     mysql_mutex_lock(&worker->jobs_lock);
-    ret= worker->info_thd->get_transaction()->cannot_safely_rollback(Transaction_ctx::SESSION);
+    const Transaction_ctx *trx= worker->info_thd->get_transaction();
+    ret= trx ? trx->cannot_safely_rollback(Transaction_ctx::SESSION) : false;
     mysql_mutex_unlock(&worker->jobs_lock);
   }
   return ret;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8030

This issue backports PS-7147 (MTA Replica crashes inside
Transaction_ctx::THD_TRANS::cannot_safely_rollback())

(https://jira.percona.com/browse/PS-7147)

Problem & Analysis
------------------
As part of the bugfix for PS-5824 (commit 205b48f017a9842c736d3), the
co-ordinator thread was made to check for the safeness of the ongoing
transactions and if found that all transactions executed by the worker
threads are safe to rollback, then it immediately would stop all the worker
threads making the STOP SLAVE to execute faster.

However, while checking for the safeness, it doesn't take into account that
the transaction objects can be empty if the worker thread had performed the
clean up of the transaction objects.

This caused the the function call to
`worker->info_thd->get_transaction()->cannot_safely_rollback(Transaction_ctx::SESSION);`
result in dereferencing a null pointer and caused the mysqld to crash.

Fix
---
Added a check for null pointer.

(cherry picked from 8.0 commit b68dffffa46ab16f94da7f380cba492d48041f11)

Note:
This is a GCA based commit.

The 8.0 null merge PR can be found https://github.com/percona/percona-server/pull/4605