### PR TITLE
PS-8.0 compilation fails on latest OSX due to unknown data type uint

### DIFF
--- a/plugin/data_masking/include/udf/udf_utils.h
+++ b/plugin/data_masking/include/udf/udf_utils.h
@@ -16,6 +16,7 @@
 
 #define _UTILS_H
 
+#include <my_inttypes.h>
 #include <mysql/components/services/registry.h>
 #include <mysql/components/services/udf_metadata.h>
 #include <mysql/udf_registration_types.h>


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8027

Fixed compilation error unknown type name 'uint'