### PR TITLE
5.7 PS-8032 Inplace Add index with lock=exclusive doesn’t generate MLOG_A…

### DIFF
--- a/mysql-test/suite/innodb/r/log_inplace_alter_with_exclusiv_lock.result
+++ b/mysql-test/suite/innodb/r/log_inplace_alter_with_exclusiv_lock.result
@@ -1,0 +1,15 @@
+#
+# PS-8032 Inplace Add index with lock=exclusive doesn't generate MLOG_ADD_INDEX redo
+#
+SET GLOBAL innodb_page_cleaner_disabled_debug=1;
+CREATE TABLE t1 (a INT NOT NULL, b INT UNIQUE) ENGINE=InnoDB TABLESPACE=innodb_file_per_table;
+INSERT INTO t1 VALUES (1,2);
+ALTER TABLE t1 ADD INDEX(a), ALGORITHM=INPLACE, LOCK=EXCLUSIVE;
+# Kill the server
+# restart: --debug=d,ib_log
+Pattern "scan .*:.*log rec MLOG_INDEX_LOAD" found
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+# restart
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/log_inplace_alter_with_exclusiv_lock.test
+++ b/mysql-test/suite/innodb/t/log_inplace_alter_with_exclusiv_lock.test
@@ -1,0 +1,33 @@
+--source include/have_debug.inc
+
+--echo #
+--echo # PS-8032 Inplace Add index with lock=exclusive doesn't generate MLOG_ADD_INDEX redo
+--echo #
+
+SET GLOBAL innodb_page_cleaner_disabled_debug=1;
+
+--source include/no_checkpoint_start.inc
+CREATE TABLE t1 (a INT NOT NULL, b INT UNIQUE) ENGINE=InnoDB TABLESPACE=innodb_file_per_table;
+# MLOG_INDEX_LOAD will not be emitted for empty tables. Insert a row.
+INSERT INTO t1 VALUES (1,2);
+ALTER TABLE t1 ADD INDEX(a), ALGORITHM=INPLACE, LOCK=EXCLUSIVE;
+
+--let CLEANUP_IF_CHECKPOINT=DROP TABLE t1;
+--source include/no_checkpoint_end.inc
+
+--let $restart_parameters = restart: --debug=d,ib_log
+--source include/start_mysqld.inc
+
+let SEARCH_FILE = $MYSQLTEST_VARDIR/log/mysqld.1.err;
+# Look for MLOG_INDEX_LOAD in the error log.
+let SEARCH_PATTERN=scan .*:.*log rec MLOG_INDEX_LOAD;
+--source include/search_pattern.inc
+
+CHECK TABLE t1;
+
+# Remove the --debug=d,ib_log setting.
+--let $restart_parameters =
+--source include/restart_mysqld.inc
+
+DROP TABLE t1;
+

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -4725,21 +4725,23 @@ wait_again:
 		if (indexes[i]->type & DICT_FTS) {
 			row_fts_psort_info_destroy(psort_info, merge_info);
 			fts_psort_initiated = false;
-		} else if (error != DB_SUCCESS || !online) {
-			/* Do not apply any online log. */
-		} else if (old_table != new_table) {
-			ut_ad(!sort_idx->online_log);
-			ut_ad(sort_idx->online_status
-			      == ONLINE_INDEX_COMPLETE);
-		} else {
+		} else if (error == DB_SUCCESS &&
+			   !dict_table_is_temporary(indexes[i]->table)) {
 			ut_ad(need_flush_observer);
-
 			flush_observer->flush();
 			row_merge_write_redo(indexes[i]);
 
-			DEBUG_SYNC_C("row_log_apply_before");
-			error = row_log_apply(trx, sort_idx, table, stage);
-			DEBUG_SYNC_C("row_log_apply_after");
+			if (old_table != new_table) {
+				ut_ad(!sort_idx->online_log);
+				ut_ad(sort_idx->online_status
+				      == ONLINE_INDEX_COMPLETE);
+			/* Do not apply any online log if not online. */
+			} else if (online) {
+				DEBUG_SYNC_C("row_log_apply_before");
+				error = row_log_apply(trx, sort_idx, table,
+						stage);
+				DEBUG_SYNC_C("row_log_apply_after");
+			}
 		}
 
 		if (error != DB_SUCCESS) {


### PR DESCRIPTION
…DD_INDEX redo

https://jira.percona.com/browse/PS-8032
Problem:
Server is not generating MLOG_ADD_INDEX in case of inplace add index
with exclusive lock DDL. It is very important for backup tool to know if
any transaction happened without redo logging.
Fix:
Generate MLOG_ADD_INDEX if index was created using btr_blk.