### PR TITLE
WIP Fixed PS-7923 (Assertion `owned_gtids.is_owned_by(thd->owned_gtid, thd->thread_id())' failed)

### DIFF
--- a/mysql-test/r/bug_ps7923.result
+++ b/mysql-test/r/bug_ps7923.result
@@ -1,0 +1,10 @@
+CREATE PROCEDURE my_infinite_alter_ts()
+BEGIN
+WHILE TRUE DO
+ALTER TABLESPACE mysql ENCRYPTION='Y';
+ALTER TABLESPACE mysql ENCRYPTION='N';
+END WHILE;
+END//
+CALL my_infinite_alter_ts();
+# Kill and restart:<hidden args>
+DROP PROCEDURE my_infinite_alter_ts;

--- a/mysql-test/t/bug_ps7923-master.opt
+++ b/mysql-test/t/bug_ps7923-master.opt
@@ -1,0 +1,5 @@
+--early-plugin-load="keyring_file=$KEYRING_PLUGIN"
+--loose-keyring_file_data=$MYSQL_TMP_DIR/keyring
+$KEYRING_PLUGIN_OPT
+--gtid-mode=ON --enforce-gtid-consistency=ON
+--innodb-use_native_aio=OFF

--- a/mysql-test/t/bug_ps7923.test
+++ b/mysql-test/t/bug_ps7923.test
@@ -1,0 +1,36 @@
+--source include/count_sessions.inc
+
+--connect (con1,localhost,root,,)
+--connect (con2,localhost,root,,)
+
+--connection default
+
+DELIMITER //;
+
+CREATE PROCEDURE my_infinite_alter_ts()
+BEGIN
+  WHILE TRUE DO
+    ALTER TABLESPACE mysql ENCRYPTION='Y';
+    ALTER TABLESPACE mysql ENCRYPTION='N';
+  END WHILE;
+END//
+
+DELIMITER ;//
+
+--connection con1
+--send CALL my_infinite_alter_ts()
+
+--sleep 5
+
+--connection default
+
+--let $do_not_echo_parameters = 1
+--let $restart_parameters = restart: --gtid-mode=ON --enforce-gtid-consistency=ON --early-plugin-load=keyring_file=$KEYRING_PLUGIN --loose-keyring_file_data=$MYSQL_TMP_DIR/keyring $KEYRING_PLUGIN_OPT
+--source include/kill_and_restart_mysqld.inc
+
+--disconnect con1
+--disconnect con2
+
+DROP PROCEDURE my_infinite_alter_ts;
+
+--source include/wait_until_count_sessions.inc

--- a/sql/conn_handler/connection_handler_manager.cc
+++ b/sql/conn_handler/connection_handler_manager.cc
@@ -282,6 +282,14 @@ void Connection_handler_manager::process_new_connection(
   }
 }
 
+void Connection_handler_manager::pause_new_connections() {
+  mysql_mutex_lock(&LOCK_connection_count);
+}
+
+void Connection_handler_manager::resume_new_connections() {
+  mysql_mutex_unlock(&LOCK_connection_count);
+}
+
 THD *create_thd(Channel_info *channel_info) {
   THD *thd = channel_info->create_thd();
   if (thd == nullptr)

--- a/sql/conn_handler/connection_handler_manager.h
+++ b/sql/conn_handler/connection_handler_manager.h
@@ -233,5 +233,8 @@ class Connection_handler_manager {
     wat till connection_count to become zero.
   */
   static void wait_till_no_connection();
+
+  static void pause_new_connections();
+  static void resume_new_connections();
 };
 #endif  // CONNECTION_HANDLER_MANAGER_INCLUDED.

--- a/sql/rpl_gtid_owned.cc
+++ b/sql/rpl_gtid_owned.cc
@@ -72,6 +72,7 @@ enum_return_status Owned_gtids::add_gtid_owner(const Gtid &gtid,
   assert(gtid.sidno <= get_max_sidno());
   assert(gtid.gno > 0);
   assert(gtid.gno < GNO_END);
+  assert(owner != 0);
   Node *n =
       (Node *)my_malloc(key_memory_Sid_map_Node, sizeof(Node), MYF(MY_WME));
   if (n == nullptr) RETURN_REPORTED_ERROR;
@@ -89,6 +90,7 @@ void Owned_gtids::remove_gtid(const Gtid &gtid, const my_thread_id owner) {
   DBUG_TRACE;
   // printf("Owned_gtids::remove(sidno=%d gno=%lld)\n", sidno, gno);
   // assert(contains_gtid(sidno, gno)); // allow group not owned
+  assert(owner != 0);
   malloc_unordered_multimap<rpl_gno, unique_ptr_my_free<Node>> *hash =
       get_hash(gtid.sidno);
   auto it_range = hash->equal_range(gtid.gno);

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -4828,6 +4828,8 @@ void fsp_init_resume_alter_encrypt_tablespace() {
   THD *thd = create_thd(false, true, true, 0);
 #endif
 
+  thd->set_new_thread_id();
+
   resume_alter_encrypt_tablespace(thd);
 
   destroy_thd(thd);


### PR DESCRIPTION
 Fixed PS-7923 (Assertion `owned_gtids.is_owned_by(thd->owned_gtid, thd->thread_id())' failed)

https://jira.percona.com/browse/PS-7923

Problem:
1) InnoDB creates a thread to resume encryption but does not assign it an ID. By default threads have ID of 0, which is a magic value that changes what `Owned_gtids::is_owned_by()` actually checks for.

2) There is a race condition window that is opened by initiating "mysql" tablespace encryption. Concurrent threads may execute queries that need to access data dictionary tables in "mysql" tablespace. Exclusive locks during tablespace encryption may cause unexpected rollbacks in attachable transactions which are expected to never cause rollbacks. The destructor of `THD::Attachable_trx` class has an assertion that triggers when that happens.

Fix:
1) Assign an ID to an encryption thread. Add assertions to `Owned_gtids::add_gtid_owner()` and `Owned_gtids::remove_gtid()` to catch similar errors earlier where it's easier to reason about.

2) Refuse to encrypt/decrypt "mysql" tablespace if there are other connections. Prevent new connections from happening while encryption/decryption is in progress.
Here is why. There is no way of knowing if some other client runs a transaction that may later try to access "mysql" tablespace and fail if encryption happens to lock all names in "mysql" tablespace. While it's possible to introduce another read lock that all threads have to acquire to process further with a query, this will incur a performance penalty on every query. Since encryption of "mysql" tablespace is not expected to happen more than even once, it's decided to impose a responsibility of looking after existence of concurrent connections onto database administrators instead.