### PR TITLE
PS-7890 : Unable to install RocksDB engine plugin if server is started with --loose-rocksdb_persistent_cache_size_mb

### DIFF
--- a/mysql-test/suite/rocksdb/r/persistent_cache.result
+++ b/mysql-test/suite/rocksdb/r/persistent_cache.result
@@ -11,3 +11,9 @@ a
 1
 # restart
 DROP TABLE t1;
+call mtr.add_suppression("RocksDB:");
+call mtr.add_suppression("Plugin 'ROCKSDB'");
+# restart:--rocksdb_persistent_cache_path=MYSQLTEST_VARDIR/tmp/roksdb.persistent_cache --rocksdb_persistent_cache_size_mb=12
+Pattern found.
+# restart:--rocksdb_persistent_cache_size_mb=100
+Pattern found.

--- a/mysql-test/suite/rocksdb/t/persistent_cache.test
+++ b/mysql-test/suite/rocksdb/t/persistent_cache.test
@@ -31,3 +31,26 @@ SELECT * FROM t1 WHERE a = 1;
 --exec rm -rf $cache_dir_name
 
 DROP TABLE t1;
+
+call mtr.add_suppression("RocksDB:");
+call mtr.add_suppression("Plugin 'ROCKSDB'");
+
+# rocksdb_persistent_cache_size_mb has to be at least 100
+--let $restart_parameters=restart:--rocksdb_persistent_cache_path=$cache_dir_name --rocksdb_persistent_cache_size_mb=12
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld.inc
+
+--let $grep_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $grep_pattern=\[ERROR\] RocksDB: Invalid value for rocksdb_persistent_cache_size_mb. It has to be at least 100
+--let $grep_output=boolean
+--source include/grep_pattern.inc
+
+# rocksdb_persistent_cache_path required persistent cache parameter if using rocksdb_persistent_cache_size_mb
+--let $restart_parameters=restart:--rocksdb_persistent_cache_size_mb=100
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld.inc
+
+--let $grep_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $grep_pattern=\[ERROR\] RocksDB: Specify rocksdb_persistent_cache_size_path
+--let $grep_output=boolean
+--source include/grep_pattern.inc

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -5235,6 +5235,39 @@ static int rocksdb_init_func(void *const p) {
   }
 
   if (rocksdb_persistent_cache_size_mb > 0) {
+    // TODO: This is the limitations in RocksDB.
+    // 1. Persistent cache size RocksDB has to be at least cache_file_size.
+    //
+    // utilities/persistent_cache/persistent_cache_tier.h:112
+    // Status ValidateSettings() const {
+    // ...
+    // if (cache_size < cache_file_size ...) {
+    // ...
+    // cache_file_size is set here.
+    //
+    // utilities/persistent_cache/persistent_cache_tier.h:165
+    // uint32_t cache_file_size = 100ULL * 1024 * 1024;
+    //
+    // 2. rocksdb_persistent_cache_path required persistent cache parameter
+    //
+    // utilities/persistent_cache/persistent_cache_tier.h:104
+    // Status ValidateSettings() const {
+    // ...
+    // if (!env || path.empty()) {
+    // ...
+    static constexpr int persistent_cache_size_mb_min = 100;
+    if (rocksdb_persistent_cache_size_mb < persistent_cache_size_mb_min) {
+      sql_print_error(
+          "RocksDB: Invalid value for rocksdb_persistent_cache_size_mb. It "
+          "has to be at least %i",
+          persistent_cache_size_mb_min);
+      DBUG_RETURN(HA_EXIT_FAILURE);
+    }
+    if (!strlen(rocksdb_persistent_cache_path)) {
+      sql_print_error("RocksDB: Specify rocksdb_persistent_cache_size_path");
+      DBUG_RETURN(HA_EXIT_FAILURE);
+    }
+
     std::shared_ptr<rocksdb::PersistentCache> pcache;
     uint64_t cache_size_bytes = rocksdb_persistent_cache_size_mb * 1024 * 1024;
     status = rocksdb::NewPersistentCache(


### PR DESCRIPTION
Added checks to bypass RocksDB restrictions

The problem has been dragging on for a long time and there is little chance that it will be fixed.
facebook/mysql-5.6#911
facebook/mysql-5.6#713

I don't see an explanation of why the cache size is limited to 100 Mb. I found a person who wrote the code, but he has one contact through linkedin.com (https://www.linkedin.com/in/karrad/). I asked him a question, but even if he answers, this is third party code and won't affect anything in the near future. Therefore, I propose this patch.