### PR TITLE
Bug#33341623: SHOW PROCESSLIST with terminology_use_previous hits fai…

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -352,7 +352,7 @@ const char *THD::proc_info(const System_variables &sysvars) const {
       static_cast<terminology_use_previous::enum_compatibility_version>(
           sysvars.terminology_use_previous);
   DBUG_PRINT("info", ("session.terminology_use_previous=%d", (int)version));
-  if (version != terminology_use_previous::NONE) {
+  if ((ret != nullptr) && (version != terminology_use_previous::NONE)) {
     auto compatible_name_info =
         terminology_use_previous::lookup(PFS_CLASS_STAGE, ret, false);
 #ifndef NDEBUG


### PR DESCRIPTION
…lsafe in race condition

SHOW PROCESSLIST may inspect a given thread from another at pretty much any time. If proc_info() is NULL at this point and @@global.terminology_use_previous is set (e.g. to BEFORE_8_0_26), the look-up for alternative terminology is attempted using said nullptr. Wrapping the look-up in an if() testing whether there actually is anything to look up prevents failsafes from triggering.

Change-Id: Ic30ebf1742ddc9403136c9ac040566567e0ce7b4
(cherry picked from commit 4bff15b94917c4996e2a54beb92c99d474cfb656)