### PR TITLE
PS-8064: Restrict dynamic log file locations

### DIFF
--- a/mysql-test/include/mtr_warnings.sql
+++ b/mysql-test/include/mtr_warnings.sql
@@ -275,6 +275,11 @@ INSERT INTO global_suppressions VALUES
  ("Insecure configuration for --secure-file-priv:*"),
 
  /*
+   Warnings related to --secure-log-path
+ */
+ ("Insecure configuration for --secure-log-path:*"),
+
+ /*
    Bug#26585560, warning related to --pid-file
  */
  ("Insecure configuration for --pid-file:*"),

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1384,6 +1384,9 @@ The following options may be given as the first argument:
  --secure-file-priv=name 
  Limit LOAD DATA, SELECT ... OUTFILE, and LOAD_FILE() to
  files within specified directory
+ --secure-log-path=name 
+ Limit location of general log, slow log and buffered
+ error logwithin specified directory
  --select-into-buffer-size[=#] 
  Buffer size for SELECT INTO OUTFILE/DUMPFILE.
  --select-into-disk-sync 
@@ -2055,6 +2058,7 @@ rpl-stop-slave-timeout 31536000
 safe-user-create FALSE
 schema-definition-cache 256
 secondary-engine-cost-threshold 100000
+secure-log-path 
 select-into-buffer-size 131072
 select-into-disk-sync FALSE
 select-into-disk-sync-delay 0

--- a/mysql-test/r/secure_log_path.result
+++ b/mysql-test/r/secure_log_path.result
@@ -1,0 +1,4 @@
+SET @old_general_log_file = @@global.general_log_file;
+SET GLOBAL general_log_file="DATADIR/log_in_the_datadir";
+ERROR 42000: Variable 'general_log_file' can't be set to the value of 'DATADIR/log_in_the_datadir'
+SET GLOBAL general_log_file="TMPDIR/log_in_the_secure_tmpdir";

--- a/mysql-test/suite/sys_vars/r/secure_log_path_basic.result
+++ b/mysql-test/suite/sys_vars/r/secure_log_path_basic.result
@@ -1,0 +1,21 @@
+select @@global.secure_log_path;
+@@global.secure_log_path
+
+select @@session.secure_log_path;
+ERROR HY000: Variable 'secure_log_path' is a GLOBAL variable
+show global variables like 'secure_log_path';
+Variable_name	Value
+secure_log_path	
+show session variables like 'secure_log_path';
+Variable_name	Value
+secure_log_path	
+select * from performance_schema.global_variables where variable_name='secure_log_path';
+VARIABLE_NAME	VARIABLE_VALUE
+secure_log_path	
+select * from performance_schema.session_variables where variable_name='secure_log_path';
+VARIABLE_NAME	VARIABLE_VALUE
+secure_log_path	
+set global secure_log_path=1;
+ERROR HY000: Variable 'secure_log_path' is a read only variable
+set session secure_log_path=1;
+ERROR HY000: Variable 'secure_log_path' is a read only variable

--- a/mysql-test/suite/sys_vars/t/secure_log_path_basic.test
+++ b/mysql-test/suite/sys_vars/t/secure_log_path_basic.test
@@ -1,0 +1,25 @@
+#
+# only global
+#
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+select @@global.secure_log_path;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+select @@session.secure_log_path;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+show global variables like 'secure_log_path';
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+show session variables like 'secure_log_path';
+--disable_warnings
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+select * from performance_schema.global_variables where variable_name='secure_log_path';
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+select * from performance_schema.session_variables where variable_name='secure_log_path';
+--enable_warnings
+
+#
+# show that it's read-only
+#
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set global secure_log_path=1;
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+set session secure_log_path=1;

--- a/mysql-test/t/secure_log_path-master.opt
+++ b/mysql-test/t/secure_log_path-master.opt
@@ -1,0 +1,1 @@
+--secure_log_path=$MYSQL_TMP_DIR

--- a/mysql-test/t/secure_log_path.test
+++ b/mysql-test/t/secure_log_path.test
@@ -1,0 +1,19 @@
+# Test that general_log_file can't be set outside of secure_log_path
+# if it is set. If it is empty, it should be allowed anywhere, which is
+# tested by other existing general_log_file tests.
+
+SET @old_general_log_file = @@global.general_log_file;
+
+let $datadir= `select @@datadir`;
+--replace_result $datadir DATADIR
+--error ER_WRONG_VALUE_FOR_VAR
+--eval SET GLOBAL general_log_file="$datadir/log_in_the_datadir"
+
+--let $tmpdir= `SELECT @@tmpdir`
+--replace_result $tmpdir TMPDIR
+--eval SET GLOBAL general_log_file="$tmpdir/log_in_the_secure_tmpdir"
+
+--disable_query_log
+SET GLOBAL general_log_file = @old_general_log_file;
+call mtr.add_suppression("Insecure configuration for --secure-log-path");
+--enable_query_log

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -339,28 +339,28 @@ ER_CANT_CREATE_SHUTDOWN_THREAD
   eng "Can't create thread to handle shutdown requests (errno= %d)"
 
 ER_SEC_FILE_PRIV_CANT_ACCESS_DIR
-  eng "Failed to access directory for --secure-file-priv. Please make sure that directory exists and is accessible by MySQL Server. Supplied value : %s"
+  eng "Failed to access directory for --%s. Please make sure that directory exists and is accessible by MySQL Server. Supplied value : %s"
 
 ER_SEC_FILE_PRIV_IGNORED
-  eng "Ignoring --secure-file-priv value as server is running with --initialize(-insecure)."
+  eng "Ignoring --%s value as server is running with --initialize(-insecure)."
 
 ER_SEC_FILE_PRIV_EMPTY
-  eng "Insecure configuration for --secure-file-priv: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path."
+  eng "Insecure configuration for --%s: Current value does not restrict location of generated files. Consider setting it to a valid, non-empty path."
 
 ER_SEC_FILE_PRIV_NULL
-  eng "--secure-file-priv is set to NULL. Operations related to importing and exporting data are disabled"
+  eng "--%s is set to NULL. Operations related to importing and exporting data are disabled"
 
 ER_SEC_FILE_PRIV_DIRECTORY_INSECURE
-  eng "Insecure configuration for --secure-file-priv: %s is accessible through --secure-file-priv. Consider choosing a different directory."
+  eng "Insecure configuration for --%s: %s is accessible through --%s. Consider choosing a different directory."
 
 ER_SEC_FILE_PRIV_CANT_STAT
-  eng "Failed to get stat for directory pointed out by --secure-file-priv"
+  eng "Failed to get stat for directory pointed out by --%s"
 
 ER_SEC_FILE_PRIV_DIRECTORY_PERMISSIONS
-  eng "Insecure configuration for --secure-file-priv: Location is accessible to all OS users. Consider choosing a different directory."
+  eng "Insecure configuration for --%s: Location is accessible to all OS users. Consider choosing a different directory."
 
 ER_SEC_FILE_PRIV_ARGUMENT_TOO_LONG
-  eng "Value for --secure-file-priv is longer than maximum limit of %d"
+  eng "Value for --%s is longer than maximum limit of %d"
 
 ER_CANT_CREATE_NAMED_PIPES_THREAD
   eng "Can't create thread to handle named pipes (errno= %d)"
@@ -11677,6 +11677,9 @@ ER_KEYRING_COMPONENT_NO_CONFIG
 
 ER_KEYRING_COMPONENT_CONFIG_PARSE_FAILED
   eng "Keyring configuration JSON parse error: %s (%lu)"
+
+ER_SEC_LOG_PATH_NULL
+  eng "--%s is set to NULL. Dynamic log files can be saved anywhere, possibly overwriting other files."
 
 #
 # End of Percona Server 8.0 server error log messages

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1241,6 +1241,7 @@ bool relay_log_purge;
 bool relay_log_recovery;
 bool opt_allow_suspicious_udfs;
 const char *opt_secure_file_priv;
+const char *opt_secure_log_path;
 bool opt_log_slow_admin_statements = false;
 bool opt_log_slow_replica_statements = false;
 bool lower_case_file_system = false;
@@ -1478,6 +1479,7 @@ uint reg_ext_length;
 char logname_path[FN_REFLEN];
 char slow_logname_path[FN_REFLEN];
 char secure_file_real_path[FN_REFLEN];
+char secure_log_real_path[FN_REFLEN];
 Time_zone *default_tz;
 char *mysql_data_home = const_cast<char *>(".");
 const char *mysql_real_data_home_ptr = mysql_real_data_home;
@@ -11120,30 +11122,19 @@ static const char *get_relative_path(const char *path) {
   return path;
 }
 
-/**
-  Test a file path to determine if the path is compatible with the secure file
-  path restriction.
-
-  @param path null terminated character string
-
-  @retval true The path is secure
-  @retval false The path isn't secure
-*/
-
-bool is_secure_file_path(const char *path) {
+static bool is_secure_path(const char *path, const char *opt_base) {
   char buff1[FN_REFLEN], buff2[FN_REFLEN];
-  size_t opt_secure_file_priv_len;
+  size_t opt_base_len;
   /*
-    All paths are secure if opt_secure_file_priv is 0
+    All paths are secure if opt_base is 0
   */
-  if (!opt_secure_file_priv[0]) return true;
+  if (!opt_base[0]) return true;
 
-  opt_secure_file_priv_len = strlen(opt_secure_file_priv);
+  opt_base_len = strlen(opt_base);
 
   if (strlen(path) >= FN_REFLEN) return false;
 
-  if (!my_strcasecmp(system_charset_info, opt_secure_file_priv, "NULL"))
-    return false;
+  if (!my_strcasecmp(system_charset_info, opt_base, "NULL")) return false;
 
   if (my_realpath(buff1, path, 0)) {
     /*
@@ -11157,15 +11148,175 @@ bool is_secure_file_path(const char *path) {
   }
   convert_dirname(buff2, buff1, NullS);
   if (!lower_case_file_system) {
-    if (strncmp(opt_secure_file_priv, buff2, opt_secure_file_priv_len))
-      return false;
+    if (strncmp(opt_base, buff2, opt_base_len)) return false;
   } else {
     if (files_charset_info->coll->strnncoll(
             files_charset_info, (uchar *)buff2, strlen(buff2),
-            pointer_cast<const uchar *>(opt_secure_file_priv),
-            opt_secure_file_priv_len, true))
+            pointer_cast<const uchar *>(opt_base), opt_base_len, true))
       return false;
   }
+  return true;
+}
+
+/**
+  Test a file path to determine if the path is compatible with the secure file
+  path restriction.
+
+  @param path null terminated character string
+
+  @retval true The path is secure
+  @retval false The path isn't secure
+*/
+bool is_secure_file_path(const char *path) {
+  return is_secure_path(path, opt_secure_file_priv);
+}
+
+/**
+  Test a file path to determine if the path is compatible with the secure log
+  path restriction.
+
+  @param path null terminated character string
+
+  @retval true The path is secure
+  @retval false The path isn't secure
+*/
+bool is_secure_log_path(const char *path) {
+  return is_secure_path(path, opt_secure_log_path);
+}
+
+/**
+  check_secure_file_priv_path : Checks path specified through
+  --secure-file-priv and raises warning in following cases:
+  1. If path is empty string or NULL and mysqld is not running
+     with --initialize (bootstrap mode).
+  2. If path can access data directory
+  3. If path points to a directory which is accessible by
+     all OS users (non-Windows build only)
+
+  It throws error in following cases:
+
+  1. If path normalization fails
+  2. If it can not get stats of the directory
+
+  Assumptions :
+  1. Data directory path has been normalized
+  2. opt_secure_file_priv has been normalized unless it is set
+     to "NULL".
+
+  @returns Status of validation
+    @retval true : Validation is successful with/without warnings
+    @retval false : Validation failed. Error is raised.
+*/
+
+static bool check_secure_path(const char *opt_var, const char *variable_name,
+                              int warn_empty_err) {
+  char datadir_buffer[FN_REFLEN + 1] = {0};
+  char plugindir_buffer[FN_REFLEN + 1] = {0};
+  char whichdir[20] = {0};
+  size_t opt_plugindir_len = 0;
+  size_t opt_datadir_len = 0;
+  size_t opt_var_len = 0;
+  bool warn = false;
+  bool case_insensitive_fs;
+#ifndef _WIN32
+  MY_STAT dir_stat;
+#endif
+
+  if (!opt_var[0]) {
+    if (opt_initialize) {
+      /*
+        Do not impose --secure-file-priv restriction
+        in bootstrap mode
+      */
+      LogErr(INFORMATION_LEVEL, ER_SEC_FILE_PRIV_IGNORED, variable_name);
+    } else {
+      LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_EMPTY, variable_name);
+    }
+    return true;
+  }
+
+  /*
+    Setting --secure-file-priv to NULL would disable
+    reading/writing from/to file
+  */
+  if (!my_strcasecmp(system_charset_info, opt_var, "NULL")) {
+    LogErr(INFORMATION_LEVEL, warn_empty_err, variable_name);
+    return true;
+  }
+
+  /*
+    Check if --secure-file-priv can access data directory
+  */
+  opt_var_len = strlen(opt_var);
+
+  /*
+    Adds dir separator at the end.
+    This is required in subsequent comparison
+  */
+  convert_dirname(datadir_buffer, mysql_unpacked_real_data_home, NullS);
+  opt_datadir_len = strlen(datadir_buffer);
+
+  case_insensitive_fs = (test_if_case_insensitive(datadir_buffer) == 1);
+
+  if (!case_insensitive_fs) {
+    if (!strncmp(
+            datadir_buffer, opt_var,
+            opt_datadir_len < opt_var_len ? opt_datadir_len : opt_var_len)) {
+      warn = true;
+      strcpy(whichdir, "Data directory");
+    }
+  } else {
+    if (!files_charset_info->coll->strnncoll(
+            files_charset_info, (uchar *)datadir_buffer, opt_datadir_len,
+            pointer_cast<const uchar *>(opt_var), opt_var_len, true)) {
+      warn = true;
+      strcpy(whichdir, "Data directory");
+    }
+  }
+
+  /*
+    Don't bother comparing --secure-file-priv with --plugin-dir
+    if we already have a match against --datdir or
+    --plugin-dir is not pointing to a valid directory.
+  */
+  if (!warn && !my_realpath(plugindir_buffer, opt_plugin_dir, 0)) {
+    convert_dirname(plugindir_buffer, plugindir_buffer, NullS);
+    opt_plugindir_len = strlen(plugindir_buffer);
+
+    if (!case_insensitive_fs) {
+      if (!strncmp(plugindir_buffer, opt_var,
+                   opt_plugindir_len < opt_var_len ? opt_plugindir_len
+                                                   : opt_var_len)) {
+        warn = true;
+        strcpy(whichdir, "Plugin directory");
+      }
+    } else {
+      if (!files_charset_info->coll->strnncoll(
+              files_charset_info, (uchar *)plugindir_buffer, opt_plugindir_len,
+              pointer_cast<const uchar *>(opt_var), opt_var_len, true)) {
+        warn = true;
+        strcpy(whichdir, "Plugin directory");
+      }
+    }
+  }
+
+  if (warn)
+    LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_DIRECTORY_INSECURE, variable_name,
+           whichdir, variable_name);
+
+#ifndef _WIN32
+  /*
+     Check for --secure-file-priv directory's permission
+  */
+  if (!(my_stat(opt_var, &dir_stat, MYF(0)))) {
+    LogErr(ERROR_LEVEL, ER_SEC_FILE_PRIV_CANT_STAT, variable_name);
+    return false;
+  }
+
+  if (dir_stat.st_mode & S_IRWXO)
+    LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_DIRECTORY_PERMISSIONS,
+           variable_name);
+#endif
   return true;
 }
 
@@ -11194,117 +11345,15 @@ bool is_secure_file_path(const char *path) {
 */
 
 static bool check_secure_file_priv_path() {
-  char datadir_buffer[FN_REFLEN + 1] = {0};
-  char plugindir_buffer[FN_REFLEN + 1] = {0};
-  char whichdir[20] = {0};
-  size_t opt_plugindir_len = 0;
-  size_t opt_datadir_len = 0;
-  size_t opt_secure_file_priv_len = 0;
-  bool warn = false;
-  bool case_insensitive_fs;
-#ifndef _WIN32
-  MY_STAT dir_stat;
-#endif
-
-  if (!opt_secure_file_priv[0]) {
-    if (opt_initialize) {
-      /*
-        Do not impose --secure-file-priv restriction
-        in bootstrap mode
-      */
-      LogErr(INFORMATION_LEVEL, ER_SEC_FILE_PRIV_IGNORED);
-    } else {
-      LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_EMPTY);
-    }
-    return true;
-  }
-
-  /*
-    Setting --secure-file-priv to NULL would disable
-    reading/writing from/to file
-  */
-  if (!my_strcasecmp(system_charset_info, opt_secure_file_priv, "NULL")) {
-    LogErr(INFORMATION_LEVEL, ER_SEC_FILE_PRIV_NULL);
-    return true;
-  }
-
-  /*
-    Check if --secure-file-priv can access data directory
-  */
-  opt_secure_file_priv_len = strlen(opt_secure_file_priv);
-
-  /*
-    Adds dir separator at the end.
-    This is required in subsequent comparison
-  */
-  convert_dirname(datadir_buffer, mysql_unpacked_real_data_home, NullS);
-  opt_datadir_len = strlen(datadir_buffer);
-
-  case_insensitive_fs = (test_if_case_insensitive(datadir_buffer) == 1);
-
-  if (!case_insensitive_fs) {
-    if (!strncmp(datadir_buffer, opt_secure_file_priv,
-                 opt_datadir_len < opt_secure_file_priv_len
-                     ? opt_datadir_len
-                     : opt_secure_file_priv_len)) {
-      warn = true;
-      strcpy(whichdir, "Data directory");
-    }
-  } else {
-    if (!files_charset_info->coll->strnncoll(
-            files_charset_info, (uchar *)datadir_buffer, opt_datadir_len,
-            pointer_cast<const uchar *>(opt_secure_file_priv),
-            opt_secure_file_priv_len, true)) {
-      warn = true;
-      strcpy(whichdir, "Data directory");
-    }
-  }
-
-  /*
-    Don't bother comparing --secure-file-priv with --plugin-dir
-    if we already have a match against --datdir or
-    --plugin-dir is not pointing to a valid directory.
-  */
-  if (!warn && !my_realpath(plugindir_buffer, opt_plugin_dir, 0)) {
-    convert_dirname(plugindir_buffer, plugindir_buffer, NullS);
-    opt_plugindir_len = strlen(plugindir_buffer);
-
-    if (!case_insensitive_fs) {
-      if (!strncmp(plugindir_buffer, opt_secure_file_priv,
-                   opt_plugindir_len < opt_secure_file_priv_len
-                       ? opt_plugindir_len
-                       : opt_secure_file_priv_len)) {
-        warn = true;
-        strcpy(whichdir, "Plugin directory");
-      }
-    } else {
-      if (!files_charset_info->coll->strnncoll(
-              files_charset_info, (uchar *)plugindir_buffer, opt_plugindir_len,
-              pointer_cast<const uchar *>(opt_secure_file_priv),
-              opt_secure_file_priv_len, true)) {
-        warn = true;
-        strcpy(whichdir, "Plugin directory");
-      }
-    }
-  }
-
-  if (warn)
-    LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_DIRECTORY_INSECURE, whichdir);
-
-#ifndef _WIN32
-  /*
-     Check for --secure-file-priv directory's permission
-  */
-  if (!(my_stat(opt_secure_file_priv, &dir_stat, MYF(0)))) {
-    LogErr(ERROR_LEVEL, ER_SEC_FILE_PRIV_CANT_STAT);
-    return false;
-  }
-
-  if (dir_stat.st_mode & S_IRWXO)
-    LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_DIRECTORY_PERMISSIONS);
-#endif
-  return true;
+  return check_secure_path(opt_secure_file_priv, "secure-file-priv",
+                           ER_SEC_FILE_PRIV_NULL);
 }
+
+static bool check_secure_log_path() {
+  return check_secure_path(opt_secure_log_path, "secure-log-path",
+                           ER_SEC_LOG_PATH_NULL);
+}
+
 #ifdef WIN32
 // check_tmpdir_path_lengths returns true if all paths are valid,
 // false if any path is too long.
@@ -11324,9 +11373,53 @@ static bool check_tmpdir_path_lengths(const MY_TMPDIR &tmpdir_list) {
   return result;
 }
 #endif
+
+static int fix_secure_path(const char *&opt_path, char *realpath,
+                           const char *variable_name) {
+  bool opt_nonempty = false;
+  /*
+    Convert the secure-file-priv/secure-log-path option to system format,
+    allowing a quick strcmp to check if read or write is in an allowed dir
+  */
+  if (opt_initialize) opt_path = "";
+  opt_nonempty = opt_path[0] ? true : false;
+
+  if (opt_nonempty && strlen(opt_path) > FN_REFLEN) {
+    LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_ARGUMENT_TOO_LONG, variable_name,
+           FN_REFLEN - 1);
+    return 1;
+  }
+
+  char buff[FN_REFLEN] = {
+      0,
+  };
+  if (opt_nonempty && my_strcasecmp(system_charset_info, opt_path, "NULL")) {
+    int retval = my_realpath(buff, opt_path, MYF(MY_WME));
+    if (!retval) {
+      convert_dirname(realpath, buff, NullS);
+#ifdef WIN32
+      MY_DIR *dir = my_dir(realpath, MYF(MY_DONT_SORT + MY_WME));
+      if (!dir) {
+        retval = 1;
+      } else {
+        my_dirend(dir);
+      }
+#endif
+    }
+
+    if (retval) {
+      LogErr(ERROR_LEVEL, ER_SEC_FILE_PRIV_CANT_ACCESS_DIR, variable_name,
+             opt_path);
+      return 1;
+    }
+    opt_path = realpath;
+  }
+
+  return 0;
+}
+
 static int fix_paths(void) {
   char buff[FN_REFLEN];
-  bool secure_file_priv_nonempty = false;
   convert_dirname(mysql_home, mysql_home, NullS);
   /* Resolve symlinks to allow 'mysql_home' to be a relative symlink */
   my_realpath(mysql_home, mysql_home, MYF(0));
@@ -11381,43 +11474,16 @@ static int fix_paths(void) {
   if (!replica_load_tmpdir) replica_load_tmpdir = mysql_tmpdir;
 
   if (opt_help) return 0;
-  /*
-    Convert the secure-file-priv option to system format, allowing
-    a quick strcmp to check if read or write is in an allowed dir
-  */
-  if (opt_initialize) opt_secure_file_priv = "";
-  secure_file_priv_nonempty = opt_secure_file_priv[0] ? true : false;
 
-  if (secure_file_priv_nonempty && strlen(opt_secure_file_priv) > FN_REFLEN) {
-    LogErr(WARNING_LEVEL, ER_SEC_FILE_PRIV_ARGUMENT_TOO_LONG, FN_REFLEN - 1);
+  if (fix_secure_path(opt_secure_file_priv, secure_file_real_path,
+                      "secure-file-priv"))
     return 1;
-  }
-
-  memset(buff, 0, sizeof(buff));
-  if (secure_file_priv_nonempty &&
-      my_strcasecmp(system_charset_info, opt_secure_file_priv, "NULL")) {
-    int retval = my_realpath(buff, opt_secure_file_priv, MYF(MY_WME));
-    if (!retval) {
-      convert_dirname(secure_file_real_path, buff, NullS);
-#ifdef WIN32
-      MY_DIR *dir = my_dir(secure_file_real_path, MYF(MY_DONT_SORT + MY_WME));
-      if (!dir) {
-        retval = 1;
-      } else {
-        my_dirend(dir);
-      }
-#endif
-    }
-
-    if (retval) {
-      LogErr(ERROR_LEVEL, ER_SEC_FILE_PRIV_CANT_ACCESS_DIR,
-             opt_secure_file_priv);
-      return 1;
-    }
-    opt_secure_file_priv = secure_file_real_path;
-  }
-
   if (!check_secure_file_priv_path()) return 1;
+
+  if (fix_secure_path(opt_secure_log_path, secure_log_real_path,
+                      "secure-log-path"))
+    return 1;
+  if (!check_secure_log_path()) return 1;
 
   return 0;
 }

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -30,8 +30,8 @@
 #include <sys/types.h>
 #include <time.h>
 #include <atomic>
-#include <utility>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <mysql/components/minimal_chassis.h>
@@ -133,6 +133,7 @@ bool signal_restart_server();
 void kill_mysql(void);
 void refresh_status();
 bool is_secure_file_path(const char *path);
+bool is_secure_log_path(const char *path);
 ulong sql_rnd_with_mutex();
 
 struct System_status_var *get_thd_status_var(THD *thd, bool *aggregated);
@@ -226,6 +227,7 @@ extern mysql_rwlock_t LOCK_named_pipe_full_access_group;
 #endif
 extern bool opt_allow_suspicious_udfs;
 extern const char *opt_secure_file_priv;
+extern const char *opt_secure_log_path;
 extern bool opt_log_slow_replica_statements;
 extern bool sp_automatic_privileges, opt_noacl;
 extern bool opt_old_style_user_limits, trust_function_creators;


### PR DESCRIPTION
Previously dynamic logs files could be moved to anywhere on the
filesystem, potentially overwriting database files.

This commit adds the 'secure-log-path' system variable, similar to
'secure-file-priv', which restricts these files to a specific directory.