### PR TITLE
PS-7949 - Stop buf_lru_manager_thread during calls to buf_pool_invalidate instance

### DIFF
--- a/mysql-test/suite/group_replication/t/gr_acf_receiver_network_partition.test
+++ b/mysql-test/suite/group_replication/t/gr_acf_receiver_network_partition.test
@@ -177,7 +177,7 @@ SET SESSION sql_log_bin= 1;
 --let $group_replication_member_id= $server2_uuid
 --source include/gr_wait_for_member_state.inc
 
---let $wait_condition= SELECT COUNT(*)=1 FROM performance_schema.error_log WHERE error_code='MY-013788' AND PRIO='Warning' AND data LIKE "This server is not able to reach a majority of members in the group. This server will skip the replication failover channels handling until this server is back to the group majority."
+--let $wait_condition= SELECT COUNT(*)=1 FROM performance_schema.error_log WHERE error_code='MY-013790' AND PRIO='Warning' AND data LIKE "This server is not able to reach a majority of members in the group. This server will skip the replication failover channels handling until this server is back to the group majority."
 --source include/wait_condition.inc
 
 
@@ -230,7 +230,7 @@ SET SESSION sql_log_bin= 1;
 --let $wait_condition=SELECT COUNT(*)=2 FROM performance_schema.replication_group_members where MEMBER_STATE="ONLINE"
 --source include/wait_condition.inc
 
---let $wait_condition= SELECT COUNT(*)=1 FROM performance_schema.error_log WHERE error_code='MY-013789' AND PRIO='Warning' AND data LIKE "This server is back to the group majority. Replication failover channels handling is resumed."
+--let $wait_condition= SELECT COUNT(*)=1 FROM performance_schema.error_log WHERE error_code='MY-013791' AND PRIO='Warning' AND data LIKE "This server is back to the group majority. Replication failover channels handling is resumed."
 --source include/wait_condition.inc
 
 

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3695,6 +3695,9 @@ static void buf_lru_manager_thread(size_t buf_pool_instance) {
          srv_shutdown_state.load() == SRV_SHUTDOWN_CLEANUP) {
     ut_d(buf_flush_page_cleaner_disabled_loop());
 
+    // There must be no ongoing operation during buf_pool_invalidate_instance
+    os_event_wait(buf_pool->no_invalidate);
+
     buf_lru_manager_sleep_if_needed(next_loop_time);
 
     buf_lru_manager_adapt_sleep_time(buf_pool, lru_n_flushed, lru_sleep_time);

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -2297,6 +2297,10 @@ struct buf_pool_t {
   running. Protected by flush_state_mutex. */
   os_event_t no_flush[BUF_FLUSH_N_TYPES];
 
+  /** This is event is set when there is no ongoing invalidation of the
+   * buff_pool_t. */
+  os_event_t no_invalidate;
+
   /** A red-black tree is used exclusively during recovery to speed up
   insertions in the flush_list. This tree contains blocks in order of
   oldest_modification LSN and is kept in sync with the flush_list.  Each


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7949

---

*Problem*:

For buffer pool invalidation to proceed we must ensure there is no
write activity happening.

PS does not implement this guarantee as PS implements a multi-threaded
LRU Manager unlike MySQL that uses a single thread. Hence, flush
operations in the initial state might be possible.

This error manifests when running the test `clone.remote_ddl_basic`.
Although, it is not deterministic as it involves a particular
interleaving of execution of several threads.

*Solution*:

Stop `buf_lru_manager_thread` when `buf_pool_invalidate_instance`
by checking that the event `buf_pool_t->no_invalidate` is set.