### PR TITLE
Improve ZenFS build

### DIFF
--- a/build-ps/percona-server-8.0_builder.sh
+++ b/build-ps/percona-server-8.0_builder.sh
@@ -24,6 +24,8 @@ Usage: $0 [OPTIONS]
         --perconaft_branch  Branch for PerconaFT
         --tokubackup_repo   TokuBackup repo
         --tokubackup_branch Btanch for TokuBackup
+        --zenfs_repo        ZenFS repo
+        --zenfs_branch      Branch for ZenFS
         --rpm_release       RPM version( default = 1)
         --deb_release       DEB version( default = 1)
         --debug             Build debug tarball
@@ -63,8 +65,10 @@ parse_arguments() {
             --install_deps=*) INSTALL="$val" ;;
             --perconaft_branch=*) PERCONAFT_BRANCH="$val" ;;
             --tokubackup_branch=*)      TOKUBACKUP_BRANCH="$val" ;;
+            --zenfs_branch=*)      ZENFS_BRANCH="$val" ;;
             --perconaft_repo=*) PERCONAFT_REPO="$val" ;;
             --tokubackup_repo=*) TOKUBACKUP_REPO="$val" ;;
+            --zenfs_repo=*) ZENFS_REPO="$val" ;;
             --rpm_release=*) RPM_RELEASE="$val" ;;
             --deb_release=*) DEB_RELEASE="$val" ;;
             --debug=*) DEBUG="$val" ;;
@@ -192,6 +196,8 @@ get_sources(){
     echo "PERCONAFT_BRANCH=${PERCONAFT_BRANCH}" >> ../percona-server-8.0.properties
     echo "TOKUBACKUP_REPO=${TOKUBACKUP_REPO}" >> ../percona-server-8.0.properties
     echo "TOKUBACKUP_BRANCH=${TOKUBACKUP_BRANCH}" >> ../percona-server-8.0.properties
+    echo "ZENFS_REPO=${ZENFS_REPO}" >> ../percona-server-8.0.properties
+    echo "ZENFS_BRANCH=${ZENFS_BRANCH}" >> ../percona-server-8.0.properties
     export TOKUDB_VERSION=${MYSQL_VERSION_MAJOR}.${MYSQL_VERSION_MINOR}.${MYSQL_VERSION_PATCH}${MYSQL_VERSION_EXTRA}
     echo "TOKUDB_VERSION=${MYSQL_VERSION_MAJOR}.${MYSQL_VERSION_MINOR}.${MYSQL_VERSION_PATCH}${MYSQL_VERSION_EXTRA}" >> ../percona-server-8.0.properties
     BOOST_PACKAGE_NAME=$(cat cmake/boost.cmake|grep "SET(BOOST_PACKAGE_NAME"|awk -F '"' '{print $2}')
@@ -254,6 +260,17 @@ get_sources(){
 
     fi
     #
+
+    if [ ! ${ZENFS_REPO} = 0 ]; then
+        rm -rf ${WORKDIR}/percona-server/storage/rocksdb/rocksdb_plugins/zenfs
+        git clone ${ZENFS_REPO} ${WORKDIR}/percona-server/storage/rocksdb/rocksdb_plugins/zenfs
+    fi
+    if [ ! ${ZENFS_BRANCH} = 0 ]; then
+        cd ${WORKDIR}/percona-server/storage/rocksdb/rocksdb_plugins/zenfs
+        git checkout ${ZENFS_BRANCH}
+        cd -
+    fi
+
     git submodule update
     cd storage/rocksdb/rocksdb_plugins/zenfs
     ZEN_VER=$(git describe --abbrev=7 --dirty)


### PR DESCRIPTION
Introduce a `zenfs_branch` and a `zenfs_repo` flag for easy test and preview
builds during ZenFS development.

Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>