### PR TITLE
PS-7871: Allow the MyRocks variables to be set dynamically through the SET_VAR syntax

### DIFF
--- a/mysql-test/include/percona_set_var_extension_test_hint.inc
+++ b/mysql-test/include/percona_set_var_extension_test_hint.inc
@@ -1,0 +1,36 @@
+--echo Creating auxiliary 'test_hint' SP which returns variable value before hint, with hint and after hint applying
+
+--disable_query_log
+DELIMITER \\;
+
+CREATE PROCEDURE test_hint (hint_str VARCHAR(255), var_str VARCHAR(64))
+BEGIN
+
+SET @orig_q= CONCAT("SELECT VARIABLE_VALUE INTO @before_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+
+SET @hint_q= CONCAT("SELECT /*+ ", hint_str,
+                    "*/ VARIABLE_VALUE" ,
+                    " INTO @hint_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+
+SET @after_q= CONCAT("SELECT VARIABLE_VALUE INTO @after_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
+
+PREPARE orig_stmt FROM @orig_q;
+PREPARE hint_stmt FROM @hint_q;
+PREPARE after_stmt FROM @after_q;
+
+EXECUTE orig_stmt;
+EXECUTE hint_stmt;
+EXECUTE after_stmt;
+
+SELECT  hint_str;
+SELECT @before_val, @hint_val, @after_val;
+
+DEALLOCATE PREPARE orig_stmt;
+DEALLOCATE PREPARE hint_stmt;
+DEALLOCATE PREPARE after_stmt;
+
+END\\
+
+DELIMITER ;\\
+
+--enable_query_log

--- a/mysql-test/r/percona_set_var_extension.result
+++ b/mysql-test/r/percona_set_var_extension.result
@@ -1,22 +1,4 @@
-CREATE PROCEDURE test_hint (hint_str VARCHAR(255), var_str VARCHAR(64))
-BEGIN
-SET @orig_q= CONCAT("SELECT VARIABLE_VALUE INTO @before_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
-SET @hint_q= CONCAT("SELECT /*+ ", hint_str,
-"*/ VARIABLE_VALUE" ,
-" INTO @hint_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
-SET @after_q= CONCAT("SELECT VARIABLE_VALUE INTO @after_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
-PREPARE orig_stmt FROM @orig_q;
-PREPARE hint_stmt FROM @hint_q;
-PREPARE after_stmt FROM @after_q;
-EXECUTE orig_stmt;
-EXECUTE hint_stmt;
-EXECUTE after_stmt;
-SELECT  hint_str;
-SELECT @before_val, @hint_val, @after_val;
-DEALLOCATE PREPARE orig_stmt;
-DEALLOCATE PREPARE hint_stmt;
-DEALLOCATE PREPARE after_stmt;
-END\\
+Creating auxiliary 'test_hint' SP which returns variable value before hint, with hint and after hint applying
 #####################################
 # Test SET_VAR hint myisam variables
 #####################################
@@ -121,13 +103,6 @@ DROP TABLE t1;
 ###########################################################
 # Test SET_VAR hint with stored procedure (CALL statement)
 ###########################################################
-CREATE PROCEDURE p1() BEGIN
-SELECT @@myisam_sort_buffer_size,
-@@myisam_repair_threads,
-@@sort_buffer_size,
-@@max_join_size,
-@@innodb_lock_wait_timeout;
-END|
 # check without hints
 CALL p1();
 @@myisam_sort_buffer_size	@@myisam_repair_threads	@@sort_buffer_size	@@max_join_size	@@innodb_lock_wait_timeout
@@ -150,14 +125,6 @@ DROP PROCEDURE p1;
 # The hint at statement should have higher preference to the
 # hint at CALL statement
 ###########################################################
-CREATE PROCEDURE p1() BEGIN
-CALL test_hint("SET_VAR(myisam_sort_buffer_size=600000)", "myisam_sort_buffer_size");
-CALL test_hint("SET_VAR(myisam_repair_threads=9)", "myisam_repair_threads");
-CALL test_hint("SET_VAR(sort_buffer_size=420000)", "sort_buffer_size");
-CALL test_hint("SET_VAR(max_join_size=200200200)", "max_join_size");
-CALL test_hint("SET_VAR(innodb_lock_wait_timeout=299)", "innodb_lock_wait_timeout");
-CALL /*+ SET_VAR(innodb_lock_wait_timeout=499)*/ test_hint("SET_VAR(innodb_lock_wait_timeout=299)", "innodb_lock_wait_timeout");
-END|
 
 # test without hints to CALL statement
 

--- a/mysql-test/suite/rocksdb/r/rocksdb_set_var_extension.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_set_var_extension.result
@@ -1,0 +1,458 @@
+Creating auxiliary 'test_hint' SP which returns variable value before hint, with hint and after hint applying
+#################################################
+# Test SET_VAR hint with RocksDB session variables
+#################################################
+SET rocksdb_blind_delete_primary_key=0;
+CALL test_hint("SET_VAR(rocksdb_blind_delete_primary_key=1)", "rocksdb_blind_delete_primary_key");
+hint_str
+SET_VAR(rocksdb_blind_delete_primary_key=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_blind_delete_primary_key=default;
+SET rocksdb_bulk_load_size=10;
+CALL test_hint("SET_VAR(rocksdb_bulk_load_size=2)", "rocksdb_bulk_load_size");
+hint_str
+SET_VAR(rocksdb_bulk_load_size=2)
+@before_val	@hint_val	@after_val
+10	2	10
+SET rocksdb_bulk_load_size=default;
+SET rocksdb_enable_iterate_bounds=0;
+CALL test_hint("SET_VAR(rocksdb_enable_iterate_bounds=1)", "rocksdb_enable_iterate_bounds");
+hint_str
+SET_VAR(rocksdb_enable_iterate_bounds=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_enable_iterate_bounds=default;
+SET rocksdb_lock_scanned_rows=0;
+CALL test_hint("SET_VAR(rocksdb_lock_scanned_rows=1)", "rocksdb_lock_scanned_rows");
+hint_str
+SET_VAR(rocksdb_lock_scanned_rows=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_lock_scanned_rows=default;
+CALL test_hint("SET_VAR(rocksdb_lock_wait_timeout=800)", "rocksdb_lock_wait_timeout");
+hint_str
+SET_VAR(rocksdb_lock_wait_timeout=800)
+@before_val	@hint_val	@after_val
+1	800	1
+SET rocksdb_lock_wait_timeout=200;
+CALL test_hint("SET_VAR(rocksdb_lock_wait_timeout=600)", "rocksdb_lock_wait_timeout");
+hint_str
+SET_VAR(rocksdb_lock_wait_timeout=600)
+@before_val	@hint_val	@after_val
+200	600	200
+SET rocksdb_lock_wait_timeout=default;
+SET rocksdb_master_skip_tx_api=0;
+CALL test_hint("SET_VAR(rocksdb_master_skip_tx_api=1)", "rocksdb_master_skip_tx_api");
+hint_str
+SET_VAR(rocksdb_master_skip_tx_api=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_master_skip_tx_api=default;
+SET rocksdb_perf_context_level=0;
+CALL test_hint("SET_VAR(rocksdb_perf_context_level=1)", "rocksdb_perf_context_level");
+hint_str
+SET_VAR(rocksdb_perf_context_level=1)
+@before_val	@hint_val	@after_val
+0	1	0
+SET rocksdb_perf_context_level=default;
+SET rocksdb_checksums_pct=0;
+CALL test_hint("SET_VAR(rocksdb_checksums_pct=1)", "rocksdb_checksums_pct");
+hint_str
+SET_VAR(rocksdb_checksums_pct=1)
+@before_val	@hint_val	@after_val
+0	1	0
+SET rocksdb_checksums_pct=default;
+SET rocksdb_store_row_debug_checksums=0;
+CALL test_hint("SET_VAR(rocksdb_store_row_debug_checksums=1)", "rocksdb_store_row_debug_checksums");
+hint_str
+SET_VAR(rocksdb_store_row_debug_checksums=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_store_row_debug_checksums=default;
+SET rocksdb_skip_fill_cache=0;
+CALL test_hint("SET_VAR(rocksdb_skip_fill_cache=1)", "rocksdb_skip_fill_cache");
+hint_str
+SET_VAR(rocksdb_skip_fill_cache=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_skip_fill_cache=default;
+SET rocksdb_trace_sst_api=0;
+CALL test_hint("SET_VAR(rocksdb_trace_sst_api=1)", "rocksdb_trace_sst_api");
+hint_str
+SET_VAR(rocksdb_trace_sst_api=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_trace_sst_api=default;
+SET rocksdb_verify_row_debug_checksums=0;
+CALL test_hint("SET_VAR(rocksdb_verify_row_debug_checksums=1)", "rocksdb_verify_row_debug_checksums");
+hint_str
+SET_VAR(rocksdb_verify_row_debug_checksums=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_verify_row_debug_checksums=default;
+SET rocksdb_write_batch_flush_threshold=0;
+CALL test_hint("SET_VAR(rocksdb_write_batch_flush_threshold=100)", "rocksdb_write_batch_flush_threshold");
+hint_str
+SET_VAR(rocksdb_write_batch_flush_threshold=100)
+@before_val	@hint_val	@after_val
+0	100	0
+SET rocksdb_write_batch_flush_threshold=0;
+SET rocksdb_write_batch_max_bytes=0;
+CALL test_hint("SET_VAR(rocksdb_write_batch_max_bytes=100)", "rocksdb_write_batch_max_bytes");
+hint_str
+SET_VAR(rocksdb_write_batch_max_bytes=100)
+@before_val	@hint_val	@after_val
+0	100	0
+SET rocksdb_write_batch_max_bytes=default;
+SET GLOBAL rocksdb_flush_log_at_trx_commit=0;
+SET rocksdb_write_disable_wal=0;
+CALL test_hint("SET_VAR(rocksdb_write_disable_wal=1)", "rocksdb_write_disable_wal");
+hint_str
+SET_VAR(rocksdb_write_disable_wal=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_write_disable_wal=default;
+SET rocksdb_write_ignore_missing_column_families=0;
+CALL test_hint("SET_VAR(rocksdb_write_ignore_missing_column_families=1)", "rocksdb_write_ignore_missing_column_families");
+hint_str
+SET_VAR(rocksdb_write_ignore_missing_column_families=1)
+@before_val	@hint_val	@after_val
+OFF	ON	OFF
+SET rocksdb_write_ignore_missing_column_families=default;
+###########################################################
+# Test SET_VAR hint with stored procedure (CALL statement)
+###########################################################
+# check without hints
+CALL p1();
+@@rocksdb_blind_delete_primary_key	@@rocksdb_bulk_load_size	@@rocksdb_force_index_records_in_range	@@rocksdb_enable_iterate_bounds	@@rocksdb_lock_scanned_rows	@@rocksdb_lock_wait_timeout	@@rocksdb_master_skip_tx_api	@@rocksdb_perf_context_level	@@rocksdb_checksums_pct	@@rocksdb_store_row_debug_checksums	@@rocksdb_records_in_range	@@rocksdb_skip_bloom_filter_on_read	@@rocksdb_skip_fill_cache	@@rocksdb_trace_sst_api	@@rocksdb_verify_row_debug_checksums	@@rocksdb_write_batch_flush_threshold	@@rocksdb_write_batch_max_bytes	@@rocksdb_write_disable_wal	@@rocksdb_write_ignore_missing_column_families
+0	1000	0	1	0	1	0	0	100	0	0	0	0	0	0	0	0	0	0
+# check with hints
+CALL /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) SET_VAR(rocksdb_bulk_load_size=1) SET_VAR(rocksdb_force_index_records_in_range=10) SET_VAR(rocksdb_enable_iterate_bounds=1) SET_VAR(rocksdb_lock_scanned_rows=1) SET_VAR(rocksdb_lock_wait_timeout=99) SET_VAR(rocksdb_master_skip_tx_api=1) SET_VAR(rocksdb_perf_context_level=1) SET_VAR(rocksdb_checksums_pct=1) SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_records_in_range=10) SET_VAR(rocksdb_skip_bloom_filter_on_read=1) SET_VAR(rocksdb_skip_fill_cache=1) SET_VAR(rocksdb_trace_sst_api=1) SET_VAR(rocksdb_verify_row_debug_checksums=1) SET_VAR(rocksdb_write_batch_flush_threshold=100) SET_VAR(rocksdb_write_batch_max_bytes=100) SET_VAR(rocksdb_write_disable_wal=1) SET_VAR(rocksdb_write_ignore_missing_column_families=1) */ p1();
+@@rocksdb_blind_delete_primary_key	@@rocksdb_bulk_load_size	@@rocksdb_force_index_records_in_range	@@rocksdb_enable_iterate_bounds	@@rocksdb_lock_scanned_rows	@@rocksdb_lock_wait_timeout	@@rocksdb_master_skip_tx_api	@@rocksdb_perf_context_level	@@rocksdb_checksums_pct	@@rocksdb_store_row_debug_checksums	@@rocksdb_records_in_range	@@rocksdb_skip_bloom_filter_on_read	@@rocksdb_skip_fill_cache	@@rocksdb_trace_sst_api	@@rocksdb_verify_row_debug_checksums	@@rocksdb_write_batch_flush_threshold	@@rocksdb_write_batch_max_bytes	@@rocksdb_write_disable_wal	@@rocksdb_write_ignore_missing_column_families
+1	1	10	1	1	99	1	1	1	1	10	1	1	1	1	100	100	1	1
+# some with invalid values
+CALL /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) SET_VAR(rocksdb_bulk_load_size=1) SET_VAR(rocksdb_force_index_records_in_range=10) SET_VAR(rocksdb_enable_iterate_bounds=1) SET_VAR(rocksdb_lock_scanned_rows=1) SET_VAR(rocksdb_lock_wait_timeout=abc) SET_VAR(rocksdb_master_skip_tx_api=1) SET_VAR(rocksdb_perf_context_level=1) SET_VAR(rocksdb_checksums_pct=1) SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_records_in_range=10) SET_VAR(rocksdb_skip_bloom_filter_on_read=1) SET_VAR(rocksdb_skip_fill_cache=1) SET_VAR(rocksdb_trace_sst_api=1) SET_VAR(rocksdb_verify_row_debug_checksums=1) SET_VAR(rocksdb_write_batch_flush_threshold=100) SET_VAR(rocksdb_write_batch_max_bytes=100) SET_VAR(rocksdb_write_disable_wal=1) SET_VAR(rocksdb_write_ignore_missing_column_families=1) */ p1();
+@@rocksdb_blind_delete_primary_key	@@rocksdb_bulk_load_size	@@rocksdb_force_index_records_in_range	@@rocksdb_enable_iterate_bounds	@@rocksdb_lock_scanned_rows	@@rocksdb_lock_wait_timeout	@@rocksdb_master_skip_tx_api	@@rocksdb_perf_context_level	@@rocksdb_checksums_pct	@@rocksdb_store_row_debug_checksums	@@rocksdb_records_in_range	@@rocksdb_skip_bloom_filter_on_read	@@rocksdb_skip_fill_cache	@@rocksdb_trace_sst_api	@@rocksdb_verify_row_debug_checksums	@@rocksdb_write_batch_flush_threshold	@@rocksdb_write_batch_max_bytes	@@rocksdb_write_disable_wal	@@rocksdb_write_ignore_missing_column_families
+1	1	10	1	1	1	1	1	1	1	10	1	1	1	1	100	100	1	1
+Warnings:
+Warning	1232	Incorrect argument type to variable 'rocksdb_lock_wait_timeout'
+DROP PROCEDURE p1;
+###########################################################
+# Test SET_VAR hint with stored procedure (CALL statement)
+# and with the same hint at statement in stored procedure
+# The hint at statement should have higher preference to the
+# hint at CALL statement
+###########################################################
+
+# test without hints to CALL statement
+
+CALL p1();
+hint_str
+SET_VAR(rocksdb_blind_delete_primary_key=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_bulk_load_size=2)
+@before_val	@hint_val	@after_val
+1000	2	1000
+hint_str
+SET_VAR(rocksdb_force_index_records_in_range=20)
+@before_val	@hint_val	@after_val
+0	20	0
+hint_str
+SET_VAR(rocksdb_enable_iterate_bounds=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_lock_scanned_rows=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_lock_wait_timeout=299)
+@before_val	@hint_val	@after_val
+1	299	1
+hint_str
+SET_VAR(rocksdb_master_skip_tx_api=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_perf_context_level=4)
+@before_val	@hint_val	@after_val
+0	4	0
+hint_str
+SET_VAR(rocksdb_checksums_pct=99)
+@before_val	@hint_val	@after_val
+100	99	100
+hint_str
+SET_VAR(rocksdb_store_row_debug_checksums=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_records_in_range=20)
+@before_val	@hint_val	@after_val
+0	20	0
+hint_str
+SET_VAR(rocksdb_skip_bloom_filter_on_read=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_skip_fill_cache=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_trace_sst_api=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_verify_row_debug_checksums=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_write_batch_flush_threshold=300)
+@before_val	@hint_val	@after_val
+0	300	0
+hint_str
+SET_VAR(rocksdb_write_batch_max_bytes=100)
+@before_val	@hint_val	@after_val
+0	100	0
+hint_str
+SET_VAR(rocksdb_write_disable_wal=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_write_ignore_missing_column_families=0)
+@before_val	@hint_val	@after_val
+OFF	OFF	OFF
+hint_str
+SET_VAR(rocksdb_lock_wait_timeout=299)
+@before_val	@hint_val	@after_val
+499	299	499
+
+# test with hints to CALL statement
+
+CALL /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) SET_VAR(rocksdb_bulk_load_size=1) SET_VAR(rocksdb_force_index_records_in_range=10) SET_VAR(rocksdb_enable_iterate_bounds=1) SET_VAR(rocksdb_lock_scanned_rows=1) SET_VAR(rocksdb_lock_wait_timeout=99) SET_VAR(rocksdb_master_skip_tx_api=1) SET_VAR(rocksdb_perf_context_level=2) SET_VAR(rocksdb_checksums_pct=1) SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_records_in_range=10) SET_VAR(rocksdb_skip_bloom_filter_on_read=1) SET_VAR(rocksdb_skip_fill_cache=1) SET_VAR(rocksdb_trace_sst_api=1) SET_VAR(rocksdb_verify_row_debug_checksums=1) SET_VAR(rocksdb_write_batch_flush_threshold=200) SET_VAR(rocksdb_write_batch_max_bytes=200) SET_VAR(rocksdb_write_disable_wal=1) SET_VAR(rocksdb_write_ignore_missing_column_families=1) */ p1();
+hint_str
+SET_VAR(rocksdb_blind_delete_primary_key=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_bulk_load_size=2)
+@before_val	@hint_val	@after_val
+1	2	1
+hint_str
+SET_VAR(rocksdb_force_index_records_in_range=20)
+@before_val	@hint_val	@after_val
+10	20	10
+hint_str
+SET_VAR(rocksdb_enable_iterate_bounds=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_lock_scanned_rows=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_lock_wait_timeout=299)
+@before_val	@hint_val	@after_val
+99	299	99
+hint_str
+SET_VAR(rocksdb_master_skip_tx_api=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_perf_context_level=4)
+@before_val	@hint_val	@after_val
+2	4	2
+hint_str
+SET_VAR(rocksdb_checksums_pct=99)
+@before_val	@hint_val	@after_val
+1	99	1
+hint_str
+SET_VAR(rocksdb_store_row_debug_checksums=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_records_in_range=20)
+@before_val	@hint_val	@after_val
+10	20	10
+hint_str
+SET_VAR(rocksdb_skip_bloom_filter_on_read=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_skip_fill_cache=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_trace_sst_api=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_verify_row_debug_checksums=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_write_batch_flush_threshold=300)
+@before_val	@hint_val	@after_val
+200	300	200
+hint_str
+SET_VAR(rocksdb_write_batch_max_bytes=100)
+@before_val	@hint_val	@after_val
+200	100	200
+hint_str
+SET_VAR(rocksdb_write_disable_wal=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_write_ignore_missing_column_families=0)
+@before_val	@hint_val	@after_val
+ON	OFF	ON
+hint_str
+SET_VAR(rocksdb_lock_wait_timeout=299)
+@before_val	@hint_val	@after_val
+499	299	499
+DROP PROCEDURE p1;
+#############################################
+# Test SET_VAR with rocksdb_blind_delete_primary_key
+#############################################
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0);
+SHOW STATUS LIKE 'rocksdb_rows_deleted_blind';
+Variable_name	Value
+rocksdb_rows_deleted_blind	0
+DELETE /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) */ FROM t1 WHERE a=1;
+SHOW STATUS LIKE 'rocksdb_rows_deleted_blind';
+Variable_name	Value
+rocksdb_rows_deleted_blind	1
+DROP TABLE t1;
+#############################################
+# Test SET_VAR with rocksdb_bulk_load_size
+#############################################
+# restart:--rocksdb_enable_bulk_load_api=0 --rocksdb_write_policy=write_prepared
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+CREATE TABLE t2 (a INT PRIMARY KEY) ENGINE=RocksDB;
+SET rocksdb_bulk_load=1;
+SET debug_sync="rocksdb.flush_batch SIGNAL flush_reached";
+INSERT /*+ SET_VAR(rocksdb_bulk_load_size=2) */ INTO t2(a) SELECT a FROM t1 WHERE a=0 OR a=1 OR a=2;
+SET debug_sync="now WAIT_FOR flush_reached";
+SET rocksdb_bulk_load=0;
+DROP TABLE t1, t2;
+# restart
+#############################################
+# Test SET_VAR with rocksdb_force_index_records_in_range
+#############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, INDEX bidx (b)) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0, 1), (1, 2), (2, 3), (3, 4);
+SELECT /*+ SET_VAR(rocksdb_force_index_records_in_range=0) */ COUNT(*) FROM t1 FORCE INDEX (bidx) WHERE b > 1 AND b < 3;
+COUNT(*)
+1
+SELECT /*+ SET_VAR(rocksdb_force_index_records_in_range=10000000) */ COUNT(*) FROM t1 FORCE INDEX (bidx) WHERE b > 1 AND b < 3;
+COUNT(*)
+1
+DROP TABLE t1;
+#############################################
+# Test SET_VAR with rocksdb_enable_iterate_bounds
+#############################################
+#############################################
+# Test SET_VAR with rocksdb_lock_scanned_rows
+#############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0, 0), (1, 0), (2, 0), (3, 0);
+SET @rocksdb_max_row_locks_saved=@@rocksdb_max_row_locks;
+SET GLOBAL rocksdb_max_row_locks=3;
+SELECT /*+ SET_VAR(rocksdb_lock_scanned_rows=1) */ * FROM t1 WHERE b=1 FOR UPDATE;
+ERROR HY000: Got error 10 'Operation aborted: Failed to acquire lock due to rocksdb_max_row_locks limit' from ROCKSDB
+DROP TABLE t1;
+SET GLOBAL rocksdb_max_row_locks=@rocksdb_max_row_locks_saved;
+#############################################
+# Test SET_VAR with rocksdb_master_skip_tx_api
+#############################################
+#############################################
+# Test SET_VAR with rocksdb_perf_context_level
+#############################################
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+SELECT /*+ SET_VAR(rocksdb_perf_context_level=4) */ COUNT(*) FROM t1;
+COUNT(*)
+4
+SELECT VALUE FROM INFORMATION_SCHEMA.ROCKSDB_PERF_CONTEXT WHERE STAT_TYPE='USER_KEY_COMPARISON_COUNT' INTO @count1;
+SELECT /*+ SET_VAR(rocksdb_perf_context_level=4) */ COUNT(*) FROM t1;
+COUNT(*)
+4
+SELECT VALUE FROM INFORMATION_SCHEMA.ROCKSDB_PERF_CONTEXT WHERE STAT_TYPE='USER_KEY_COMPARISON_COUNT' INTO @count2;
+include/assert.inc ["Counter not incremented"]
+DROP TABLE t1;
+#############################################
+# Test SET_VAR with rocksdb_checksums_pct, rocksdb_store_row_debug_checksums, rocksdb_verify_row_debug_checksums
+#############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0, 1), (1, 2), (2, 3), (3, 4);
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+SET debug_sync="rocksdb.encode_value_slice SIGNAL encode_value_slice_reached";
+INSERT /*+ SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_checksums_pct=100) */ INTO t2(a, b) SELECT a, b FROM t1 WHERE a=0;
+SET debug_sync="now WAIT_FOR encode_value_slice_reached";
+SET debug_sync="myrocks_verify_row_debug_checksum SIGNAL verify_checksum_reached";
+SELECT /*+ SET_VAR(rocksdb_verify_row_debug_checksums=1) */ * FROM t2;
+a	b
+0	1
+SET debug_sync="now WAIT_FOR verify_checksum_reached";
+TRUNCATE TABLE t2;
+SET debug_sync="rocksdb.encode_value_slice WAIT_FOR encode_value_slice_continue";
+INSERT /*+ SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_checksums_pct=0) */ INTO t2(a, b) SELECT a, b FROM t1 WHERE a=0;
+SET debug_sync=reset;
+DROP TABLE t1, t2;
+#############################################
+# Test SET_VAR with rocksdb_records_in_range
+#############################################
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+SELECT /*+ SET_VAR(rocksdb_records_in_range=0) */ COUNT(*) FROM t1 WHERE a > 1 AND a < 3;
+COUNT(*)
+1
+SELECT /*+ SET_VAR(rocksdb_records_in_range=10000000) */ COUNT(*) FROM t1 WHERE a > 1 AND a < 3;
+COUNT(*)
+1
+DROP TABLE t1;
+#############################################
+# Test SET_VAR with rocksdb_skip_bloom_filter_on_read
+#############################################
+#############################################
+# Test SET_VAR with rocksdb_skip_fill_cache
+#############################################
+#############################################
+# Test SET_VAR with rocksdb_trace_sst_api
+#############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+SET rocksdb_bulk_load=1;
+INSERT /*+ SET_VAR(rocksdb_trace_sst_api=1) */ INTO t1 VALUES (0, 0);
+SET rocksdb_bulk_load=0;
+include/assert_grep.inc [SST API tracing info not found.]
+DROP TABLE t1;
+#############################################
+# Test SET_VAR with rocksdb_lock_wait_timeout
+#############################################
+CREATE TABLE t1(a INT PRIMARY KEY)ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES(1),(2),(3);
+BEGIN;
+SELECT * FROM t1 WHERE a=1 FOR UPDATE;
+a
+1
+SET rocksdb_lock_wait_timeout=10000;
+SELECT @@rocksdb_lock_wait_timeout;
+@@rocksdb_lock_wait_timeout
+10000
+SELECT /*+ SET_VAR(rocksdb_lock_wait_timeout=1) */ * FROM t1 WHERE a=1 FOR UPDATE;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+COMMIT;
+SELECT /*+ SET_VAR(rocksdb_lock_wait_timeout="abc") */ * FROM t1 WHERE a=1 FOR UPDATE;
+a
+1
+Warnings:
+Warning	1232	Incorrect argument type to variable 'rocksdb_lock_wait_timeout'
+DROP TABLE t1;
+#############################################
+# Test SET_VAR with rocksdb_write_batch_flush_threshold, rocksdb_write_batch_max_bytes, write_disable_wal, write_ignore_missing_column_families
+#############################################
+DROP PROCEDURE test_hint;

--- a/mysql-test/suite/rocksdb/t/rocksdb_set_var_extension.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_set_var_extension.test
@@ -1,0 +1,368 @@
+--source include/have_debug_sync.inc
+--source include/have_rocksdb.inc
+
+# Install auxiliary 'test_hint' SP used in the test
+--source include/percona_set_var_extension_test_hint.inc
+
+--echo #################################################
+--echo # Test SET_VAR hint with RocksDB session variables
+--echo #################################################
+SET rocksdb_blind_delete_primary_key=0;
+CALL test_hint("SET_VAR(rocksdb_blind_delete_primary_key=1)", "rocksdb_blind_delete_primary_key");
+SET rocksdb_blind_delete_primary_key=default;
+
+SET rocksdb_bulk_load_size=10;
+CALL test_hint("SET_VAR(rocksdb_bulk_load_size=2)", "rocksdb_bulk_load_size");
+SET rocksdb_bulk_load_size=default;
+
+SET rocksdb_enable_iterate_bounds=0;
+CALL test_hint("SET_VAR(rocksdb_enable_iterate_bounds=1)", "rocksdb_enable_iterate_bounds");
+SET rocksdb_enable_iterate_bounds=default;
+
+SET rocksdb_lock_scanned_rows=0;
+CALL test_hint("SET_VAR(rocksdb_lock_scanned_rows=1)", "rocksdb_lock_scanned_rows");
+SET rocksdb_lock_scanned_rows=default;
+
+CALL test_hint("SET_VAR(rocksdb_lock_wait_timeout=800)", "rocksdb_lock_wait_timeout");
+SET rocksdb_lock_wait_timeout=200;
+CALL test_hint("SET_VAR(rocksdb_lock_wait_timeout=600)", "rocksdb_lock_wait_timeout");
+SET rocksdb_lock_wait_timeout=default;
+
+SET rocksdb_master_skip_tx_api=0;
+CALL test_hint("SET_VAR(rocksdb_master_skip_tx_api=1)", "rocksdb_master_skip_tx_api");
+SET rocksdb_master_skip_tx_api=default;
+
+SET rocksdb_perf_context_level=0;
+CALL test_hint("SET_VAR(rocksdb_perf_context_level=1)", "rocksdb_perf_context_level");
+SET rocksdb_perf_context_level=default;
+
+SET rocksdb_checksums_pct=0;
+CALL test_hint("SET_VAR(rocksdb_checksums_pct=1)", "rocksdb_checksums_pct");
+SET rocksdb_checksums_pct=default;
+
+SET rocksdb_store_row_debug_checksums=0;
+CALL test_hint("SET_VAR(rocksdb_store_row_debug_checksums=1)", "rocksdb_store_row_debug_checksums");
+SET rocksdb_store_row_debug_checksums=default;
+
+SET rocksdb_skip_fill_cache=0;
+CALL test_hint("SET_VAR(rocksdb_skip_fill_cache=1)", "rocksdb_skip_fill_cache");
+SET rocksdb_skip_fill_cache=default;
+
+SET rocksdb_trace_sst_api=0;
+CALL test_hint("SET_VAR(rocksdb_trace_sst_api=1)", "rocksdb_trace_sst_api");
+SET rocksdb_trace_sst_api=default;
+
+SET rocksdb_verify_row_debug_checksums=0;
+CALL test_hint("SET_VAR(rocksdb_verify_row_debug_checksums=1)", "rocksdb_verify_row_debug_checksums");
+SET rocksdb_verify_row_debug_checksums=default;
+
+SET rocksdb_write_batch_flush_threshold=0;
+CALL test_hint("SET_VAR(rocksdb_write_batch_flush_threshold=100)", "rocksdb_write_batch_flush_threshold");
+# We do not set it to 'default' because write_unprepared MTR combination uses 1 as the default value.
+# Other combinations use 0, so let's stick to 0.
+SET rocksdb_write_batch_flush_threshold=0;
+
+SET rocksdb_write_batch_max_bytes=0;
+CALL test_hint("SET_VAR(rocksdb_write_batch_max_bytes=100)", "rocksdb_write_batch_max_bytes");
+SET rocksdb_write_batch_max_bytes=default;
+
+# rocksdb_flush_log_at_trx_commit=1 (default) and rocksdb_flush_log_at_trx_commit=1 are not compatible
+# so change the 1st one for this test purpose
+SET GLOBAL rocksdb_flush_log_at_trx_commit=0;
+SET rocksdb_write_disable_wal=0;
+CALL test_hint("SET_VAR(rocksdb_write_disable_wal=1)", "rocksdb_write_disable_wal");
+SET rocksdb_write_disable_wal=default;
+
+SET rocksdb_write_ignore_missing_column_families=0;
+CALL test_hint("SET_VAR(rocksdb_write_ignore_missing_column_families=1)", "rocksdb_write_ignore_missing_column_families");
+SET rocksdb_write_ignore_missing_column_families=default;
+
+--echo ###########################################################
+--echo # Test SET_VAR hint with stored procedure (CALL statement)
+--echo ###########################################################
+--disable_query_log
+DELIMITER |;
+              CREATE PROCEDURE p1() BEGIN
+              SELECT @@rocksdb_blind_delete_primary_key,
+                     @@rocksdb_bulk_load_size,
+                     @@rocksdb_force_index_records_in_range,
+                     @@rocksdb_enable_iterate_bounds,
+                     @@rocksdb_lock_scanned_rows,
+                     @@rocksdb_lock_wait_timeout,
+                     @@rocksdb_master_skip_tx_api,
+                     @@rocksdb_perf_context_level,
+                     @@rocksdb_checksums_pct,
+                     @@rocksdb_store_row_debug_checksums,
+                     @@rocksdb_records_in_range,
+                     @@rocksdb_skip_bloom_filter_on_read,
+                     @@rocksdb_skip_fill_cache,
+                     @@rocksdb_trace_sst_api,
+                     @@rocksdb_verify_row_debug_checksums,
+                     @@rocksdb_write_batch_flush_threshold,
+                     @@rocksdb_write_batch_max_bytes,
+                     @@rocksdb_write_disable_wal,
+                     @@rocksdb_write_ignore_missing_column_families;
+              END|
+DELIMITER ;|
+--enable_query_log
+
+--echo # check without hints
+CALL p1();
+--echo # check with hints
+CALL /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) SET_VAR(rocksdb_bulk_load_size=1) SET_VAR(rocksdb_force_index_records_in_range=10) SET_VAR(rocksdb_enable_iterate_bounds=1) SET_VAR(rocksdb_lock_scanned_rows=1) SET_VAR(rocksdb_lock_wait_timeout=99) SET_VAR(rocksdb_master_skip_tx_api=1) SET_VAR(rocksdb_perf_context_level=1) SET_VAR(rocksdb_checksums_pct=1) SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_records_in_range=10) SET_VAR(rocksdb_skip_bloom_filter_on_read=1) SET_VAR(rocksdb_skip_fill_cache=1) SET_VAR(rocksdb_trace_sst_api=1) SET_VAR(rocksdb_verify_row_debug_checksums=1) SET_VAR(rocksdb_write_batch_flush_threshold=100) SET_VAR(rocksdb_write_batch_max_bytes=100) SET_VAR(rocksdb_write_disable_wal=1) SET_VAR(rocksdb_write_ignore_missing_column_families=1) */ p1();
+--echo # some with invalid values
+CALL /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) SET_VAR(rocksdb_bulk_load_size=1) SET_VAR(rocksdb_force_index_records_in_range=10) SET_VAR(rocksdb_enable_iterate_bounds=1) SET_VAR(rocksdb_lock_scanned_rows=1) SET_VAR(rocksdb_lock_wait_timeout=abc) SET_VAR(rocksdb_master_skip_tx_api=1) SET_VAR(rocksdb_perf_context_level=1) SET_VAR(rocksdb_checksums_pct=1) SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_records_in_range=10) SET_VAR(rocksdb_skip_bloom_filter_on_read=1) SET_VAR(rocksdb_skip_fill_cache=1) SET_VAR(rocksdb_trace_sst_api=1) SET_VAR(rocksdb_verify_row_debug_checksums=1) SET_VAR(rocksdb_write_batch_flush_threshold=100) SET_VAR(rocksdb_write_batch_max_bytes=100) SET_VAR(rocksdb_write_disable_wal=1) SET_VAR(rocksdb_write_ignore_missing_column_families=1) */ p1();
+DROP PROCEDURE p1;
+
+
+--echo ###########################################################
+--echo # Test SET_VAR hint with stored procedure (CALL statement)
+--echo # and with the same hint at statement in stored procedure
+--echo # The hint at statement should have higher preference to the
+--echo # hint at CALL statement
+--echo ###########################################################
+--disable_query_log
+DELIMITER |;
+              CREATE PROCEDURE p1() BEGIN
+                CALL test_hint("SET_VAR(rocksdb_blind_delete_primary_key=0)", "rocksdb_blind_delete_primary_key");
+                CALL test_hint("SET_VAR(rocksdb_bulk_load_size=2)", "rocksdb_bulk_load_size");
+                CALL test_hint("SET_VAR(rocksdb_force_index_records_in_range=20)", "rocksdb_force_index_records_in_range");
+                CALL test_hint("SET_VAR(rocksdb_enable_iterate_bounds=0)", "rocksdb_enable_iterate_bounds");
+                CALL test_hint("SET_VAR(rocksdb_lock_scanned_rows=0)", "rocksdb_lock_scanned_rows");
+                CALL test_hint("SET_VAR(rocksdb_lock_wait_timeout=299)", "rocksdb_lock_wait_timeout");
+                CALL test_hint("SET_VAR(rocksdb_master_skip_tx_api=0)", "rocksdb_master_skip_tx_api");
+                CALL test_hint("SET_VAR(rocksdb_perf_context_level=4)", "rocksdb_perf_context_level");
+                CALL test_hint("SET_VAR(rocksdb_checksums_pct=99)", "rocksdb_checksums_pct");
+                CALL test_hint("SET_VAR(rocksdb_store_row_debug_checksums=0)", "rocksdb_store_row_debug_checksums");
+                CALL test_hint("SET_VAR(rocksdb_records_in_range=20)", "rocksdb_records_in_range");
+                CALL test_hint("SET_VAR(rocksdb_skip_bloom_filter_on_read=0)", "rocksdb_skip_bloom_filter_on_read");
+                CALL test_hint("SET_VAR(rocksdb_skip_fill_cache=0)", "rocksdb_skip_fill_cache");
+                CALL test_hint("SET_VAR(rocksdb_trace_sst_api=0)", "rocksdb_trace_sst_api");
+                CALL test_hint("SET_VAR(rocksdb_verify_row_debug_checksums=0)", "rocksdb_verify_row_debug_checksums");
+                CALL test_hint("SET_VAR(rocksdb_write_batch_flush_threshold=300)", "rocksdb_write_batch_flush_threshold");
+                CALL test_hint("SET_VAR(rocksdb_write_batch_max_bytes=100)", "rocksdb_write_batch_max_bytes");
+                CALL test_hint("SET_VAR(rocksdb_write_disable_wal=0)", "rocksdb_write_disable_wal");
+                CALL test_hint("SET_VAR(rocksdb_write_ignore_missing_column_families=0)", "rocksdb_write_ignore_missing_column_families");
+                CALL /*+ SET_VAR(rocksdb_lock_wait_timeout=499)*/ test_hint("SET_VAR(rocksdb_lock_wait_timeout=299)", "rocksdb_lock_wait_timeout");
+              END|
+DELIMITER ;|
+--enable_query_log
+
+--echo
+--echo # test without hints to CALL statement
+--echo
+CALL p1();
+--echo
+--echo # test with hints to CALL statement
+--echo
+CALL /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) SET_VAR(rocksdb_bulk_load_size=1) SET_VAR(rocksdb_force_index_records_in_range=10) SET_VAR(rocksdb_enable_iterate_bounds=1) SET_VAR(rocksdb_lock_scanned_rows=1) SET_VAR(rocksdb_lock_wait_timeout=99) SET_VAR(rocksdb_master_skip_tx_api=1) SET_VAR(rocksdb_perf_context_level=2) SET_VAR(rocksdb_checksums_pct=1) SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_records_in_range=10) SET_VAR(rocksdb_skip_bloom_filter_on_read=1) SET_VAR(rocksdb_skip_fill_cache=1) SET_VAR(rocksdb_trace_sst_api=1) SET_VAR(rocksdb_verify_row_debug_checksums=1) SET_VAR(rocksdb_write_batch_flush_threshold=200) SET_VAR(rocksdb_write_batch_max_bytes=200) SET_VAR(rocksdb_write_disable_wal=1) SET_VAR(rocksdb_write_ignore_missing_column_families=1) */ p1();
+DROP PROCEDURE p1;
+
+
+# Test the behavior of particular variables (alphabetical order)
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_blind_delete_primary_key
+--echo #############################################
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0);
+SHOW STATUS LIKE 'rocksdb_rows_deleted_blind';
+DELETE /*+ SET_VAR(rocksdb_blind_delete_primary_key=1) */ FROM t1 WHERE a=1;
+SHOW STATUS LIKE 'rocksdb_rows_deleted_blind';
+DROP TABLE t1;
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_bulk_load_size
+--echo #############################################
+# commit_in_the_middle works for others than write_unprepared.
+# MTR suite combinations tests write_unprepared as well, so we need to skip it.
+# Also rocksdb_bulk_load_size will cause transactions flush only if rocksdb_enable_bulk_load_api is disabled 
+--let $restart_parameters=restart:--rocksdb_enable_bulk_load_api=0 --rocksdb_write_policy=write_prepared
+--source include/restart_mysqld.inc
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+CREATE TABLE t2 (a INT PRIMARY KEY) ENGINE=RocksDB;
+
+SET rocksdb_bulk_load=1;
+SET debug_sync="rocksdb.flush_batch SIGNAL flush_reached";
+INSERT /*+ SET_VAR(rocksdb_bulk_load_size=2) */ INTO t2(a) SELECT a FROM t1 WHERE a=0 OR a=1 OR a=2;
+SET debug_sync="now WAIT_FOR flush_reached";
+
+SET rocksdb_bulk_load=0;
+DROP TABLE t1, t2;
+--let $restart_parameters=
+--source include/restart_mysqld.inc
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_force_index_records_in_range
+--echo #############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT, INDEX bidx (b)) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0, 1), (1, 2), (2, 3), (3, 4);
+SELECT /*+ SET_VAR(rocksdb_force_index_records_in_range=0) */ COUNT(*) FROM t1 FORCE INDEX (bidx) WHERE b > 1 AND b < 3;
+--let $query_cost_1=query_get_value(SHOW STATUS LIKE 'Last_Query_Cost', Value, 1)
+SELECT /*+ SET_VAR(rocksdb_force_index_records_in_range=10000000) */ COUNT(*) FROM t1 FORCE INDEX (bidx) WHERE b > 1 AND b < 3;
+--let $query_cost_2=query_get_value(SHOW STATUS LIKE 'Last_Query_Cost', Value, 1)
+--assert($query_cost_1 != $query_cost_2)
+DROP TABLE t1;
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_enable_iterate_bounds
+--echo #############################################
+# no test
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_lock_scanned_rows
+--echo #############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0, 0), (1, 0), (2, 0), (3, 0);
+SET @rocksdb_max_row_locks_saved=@@rocksdb_max_row_locks;
+SET GLOBAL rocksdb_max_row_locks=3;
+--error ER_GET_ERRMSG
+SELECT /*+ SET_VAR(rocksdb_lock_scanned_rows=1) */ * FROM t1 WHERE b=1 FOR UPDATE;
+DROP TABLE t1;
+SET GLOBAL rocksdb_max_row_locks=@rocksdb_max_row_locks_saved;
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_master_skip_tx_api
+--echo #############################################
+# no test.
+# When this variable is set Rdb_writebatch_impl object is created insted of
+# Rdb_transaction_impl in ha_rocksdb.cc::get_or_create_tx()
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_perf_context_level
+--echo #############################################
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+SELECT /*+ SET_VAR(rocksdb_perf_context_level=4) */ COUNT(*) FROM t1;
+SELECT VALUE FROM INFORMATION_SCHEMA.ROCKSDB_PERF_CONTEXT WHERE STAT_TYPE='USER_KEY_COMPARISON_COUNT' INTO @count1;
+SELECT /*+ SET_VAR(rocksdb_perf_context_level=4) */ COUNT(*) FROM t1;
+SELECT VALUE FROM INFORMATION_SCHEMA.ROCKSDB_PERF_CONTEXT WHERE STAT_TYPE='USER_KEY_COMPARISON_COUNT' INTO @count2;
+--let $assert_text="Counter not incremented"
+--let $assert_cond=[SELECT @count1 < @count2]=1
+--source include/assert.inc
+DROP TABLE t1;
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_checksums_pct, rocksdb_store_row_debug_checksums, rocksdb_verify_row_debug_checksums
+--echo #############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0, 1), (1, 2), (2, 3), (3, 4);
+CREATE TABLE t2 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+
+# Defaults:
+# rocksdb_store_row_debug_checksums=0
+# rocksdb_checksums_pct=100
+#
+# Here we test that rocksdb_store_row_debug_checksums works.
+# We checksum 100% of the rows.
+SET debug_sync="rocksdb.encode_value_slice SIGNAL encode_value_slice_reached";
+INSERT /*+ SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_checksums_pct=100) */ INTO t2(a, b) SELECT a, b FROM t1 WHERE a=0;
+SET debug_sync="now WAIT_FOR encode_value_slice_reached";
+
+# Here we test myrocks_verify_row_debug_checksum.
+SET debug_sync="myrocks_verify_row_debug_checksum SIGNAL verify_checksum_reached";
+SELECT /*+ SET_VAR(rocksdb_verify_row_debug_checksums=1) */ * FROM t2;
+SET debug_sync="now WAIT_FOR verify_checksum_reached";
+
+TRUNCATE TABLE t2;
+
+# Here we test that rocksdb_checksums_pct works.
+# We checksum 0% of the rows.
+SET debug_sync="rocksdb.encode_value_slice WAIT_FOR encode_value_slice_continue";
+INSERT /*+ SET_VAR(rocksdb_store_row_debug_checksums=1) SET_VAR(rocksdb_checksums_pct=0) */ INTO t2(a, b) SELECT a, b FROM t1 WHERE a=0;
+
+# We didn't block on rocksdb.encode_value_slice sync point. Reset it to not block in the future.
+SET debug_sync=reset;
+
+DROP TABLE t1, t2;
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_records_in_range
+--echo #############################################
+# This test is similar to rocksdb_force_index_records_in_range
+CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=RocksDB;
+INSERT INTO t1 VALUES (0), (1), (2), (3);
+SELECT /*+ SET_VAR(rocksdb_records_in_range=0) */ COUNT(*) FROM t1 WHERE a > 1 AND a < 3;
+--let $query_cost_1=query_get_value(SHOW STATUS LIKE 'Last_Query_Cost', Value, 1)
+SELECT /*+ SET_VAR(rocksdb_records_in_range=10000000) */ COUNT(*) FROM t1 WHERE a > 1 AND a < 3;
+--let $query_cost_2=query_get_value(SHOW STATUS LIKE 'Last_Query_Cost', Value, 1)
+--assert($query_cost_1 != $query_cost_2)
+DROP TABLE t1;
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_skip_bloom_filter_on_read
+--echo #############################################
+# no test
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_skip_fill_cache
+--echo #############################################
+# no test
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_trace_sst_api
+--echo #############################################
+CREATE TABLE t1 (a INT PRIMARY KEY, b INT) ENGINE=RocksDB;
+SET rocksdb_bulk_load=1;
+INSERT /*+ SET_VAR(rocksdb_trace_sst_api=1) */ INTO t1 VALUES (0, 0);
+SET rocksdb_bulk_load=0;
+
+# Check that the error log contains the sst api tracing information
+--let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
+--let $assert_count=3
+--let $assert_select=SST Tracing:
+--let $assert_text=SST API tracing info not found.
+--source include/assert_grep.inc
+
+DROP TABLE t1;
+
+
+# The RocksDB test below is slightly different than InnoDB.
+# Since there are no gap locks lock wait does not work with non-existent rows.
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_lock_wait_timeout
+--echo #############################################
+
+CREATE TABLE t1(a INT PRIMARY KEY)ENGINE=ROCKSDB;
+INSERT INTO t1 VALUES(1),(2),(3);
+
+BEGIN;
+SELECT * FROM t1 WHERE a=1 FOR UPDATE;
+
+--source include/count_sessions.inc
+connect (con1,localhost,root,,);
+
+SET rocksdb_lock_wait_timeout=10000;
+SELECT @@rocksdb_lock_wait_timeout;
+--error ER_LOCK_WAIT_TIMEOUT
+SELECT /*+ SET_VAR(rocksdb_lock_wait_timeout=1) */ * FROM t1 WHERE a=1 FOR UPDATE;
+
+disconnect con1;
+
+connection default;
+--source include/wait_until_count_sessions.inc
+COMMIT;
+
+SELECT /*+ SET_VAR(rocksdb_lock_wait_timeout="abc") */ * FROM t1 WHERE a=1 FOR UPDATE;
+DROP TABLE t1;
+
+
+--echo #############################################
+--echo # Test SET_VAR with rocksdb_write_batch_flush_threshold, rocksdb_write_batch_max_bytes, write_disable_wal, write_ignore_missing_column_families
+--echo #############################################
+# no test
+
+
+#
+# cleanup
+#
+DROP PROCEDURE test_hint;

--- a/mysql-test/t/percona_set_var_extension.test
+++ b/mysql-test/t/percona_set_var_extension.test
@@ -1,37 +1,7 @@
 --source include/have_myisam.inc
-# Auxiliary SP which returns variable value before hint, with hint and after hint applying
 
-DELIMITER \\;
-
-CREATE PROCEDURE test_hint (hint_str VARCHAR(255), var_str VARCHAR(64))
-BEGIN
-
-SET @orig_q= CONCAT("SELECT VARIABLE_VALUE INTO @before_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
-
-SET @hint_q= CONCAT("SELECT /*+ ", hint_str,
-                    "*/ VARIABLE_VALUE" ,
-                    " INTO @hint_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
-
-SET @after_q= CONCAT("SELECT VARIABLE_VALUE INTO @after_val FROM performance_schema.session_variables where VARIABLE_NAME = '",  var_str, "'");
-
-PREPARE orig_stmt FROM @orig_q;
-PREPARE hint_stmt FROM @hint_q;
-PREPARE after_stmt FROM @after_q;
-
-EXECUTE orig_stmt;
-EXECUTE hint_stmt;
-EXECUTE after_stmt;
-
-SELECT  hint_str;
-SELECT @before_val, @hint_val, @after_val;
-
-DEALLOCATE PREPARE orig_stmt;
-DEALLOCATE PREPARE hint_stmt;
-DEALLOCATE PREPARE after_stmt;
-
-END\\
-
-DELIMITER ;\\
+# Install auxiliary 'test_hint' SP used in the test
+--source include/percona_set_var_extension_test_hint.inc
 
 --echo #####################################
 --echo # Test SET_VAR hint myisam variables
@@ -117,7 +87,7 @@ DROP TABLE t1;
 --echo ###########################################################
 --echo # Test SET_VAR hint with stored procedure (CALL statement)
 --echo ###########################################################
-
+--disable_query_log
 DELIMITER |;
               CREATE PROCEDURE p1() BEGIN
               SELECT @@myisam_sort_buffer_size,
@@ -127,6 +97,7 @@ DELIMITER |;
 		     @@innodb_lock_wait_timeout;
               END|
 DELIMITER ;|
+--enable_query_log
 
 --echo # check without hints
 CALL p1();
@@ -142,6 +113,7 @@ DROP PROCEDURE p1;
 --echo # The hint at statement should have higher preference to the
 --echo # hint at CALL statement
 --echo ###########################################################
+--disable_query_log
 DELIMITER |;
               CREATE PROCEDURE p1() BEGIN
 	      CALL test_hint("SET_VAR(myisam_sort_buffer_size=600000)", "myisam_sort_buffer_size");
@@ -152,6 +124,8 @@ DELIMITER |;
 	      CALL /*+ SET_VAR(innodb_lock_wait_timeout=499)*/ test_hint("SET_VAR(innodb_lock_wait_timeout=299)", "innodb_lock_wait_timeout");
               END|
 DELIMITER ;|
+--enable_query_log
+
 --echo
 --echo # test without hints to CALL statement
 --echo

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -1045,7 +1045,8 @@ static TYPELIB index_type_typelib = {array_elements(index_type_names) - 1,
                                      nullptr};
 
 // TODO: 0 means don't wait at all, and we don't support it yet?
-static MYSQL_THDVAR_ULONG(lock_wait_timeout, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_ULONG(lock_wait_timeout,
+                          PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                           "Number of seconds to wait for lock", nullptr,
                           nullptr, /*default*/ 1, /*min*/ 1,
                           /*max*/ RDB_MAX_LOCK_WAIT_SECONDS, 0);
@@ -1067,7 +1068,7 @@ static MYSQL_THDVAR_BOOL(
     nullptr, false);
 
 static MYSQL_THDVAR_BOOL(
-    trace_sst_api, PLUGIN_VAR_RQCMDARG,
+    trace_sst_api, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "Generate trace output in the log for each call to the SstFileWriter",
     nullptr, nullptr, false);
 
@@ -1123,13 +1124,13 @@ static MYSQL_THDVAR_BOOL(
 #if defined(ROCKSDB_INCLUDE_RFR) && ROCKSDB_INCLUDE_RFR
 
 static MYSQL_THDVAR_BOOL(
-    blind_delete_primary_key, PLUGIN_VAR_RQCMDARG,
+    blind_delete_primary_key, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "Deleting rows by primary key lookup, without reading rows (Blind Deletes)."
     " Blind delete is disabled if the table has secondary key",
     nullptr, nullptr, false);
 
 static MYSQL_THDVAR_BOOL(
-    enable_iterate_bounds, PLUGIN_VAR_OPCMDARG,
+    enable_iterate_bounds, PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "Enable rocksdb iterator upper/lower bounds in read options.", nullptr,
     nullptr, true);
 
@@ -1232,7 +1233,8 @@ static MYSQL_SYSVAR_BOOL(
     "Use write batches for replication thread instead of tx api", nullptr,
     nullptr, false);
 
-static MYSQL_THDVAR_BOOL(skip_bloom_filter_on_read, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_BOOL(skip_bloom_filter_on_read,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "Skip using bloom filter for reads", nullptr, nullptr,
                          false);
 
@@ -1245,22 +1247,24 @@ static MYSQL_SYSVAR_ULONG(max_row_locks, rocksdb_max_row_locks,
                           /*max*/ RDB_MAX_ROW_LOCKS, 0);
 
 static MYSQL_THDVAR_ULONGLONG(
-    write_batch_max_bytes, PLUGIN_VAR_RQCMDARG,
+    write_batch_max_bytes, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "Maximum size of write batch in bytes. 0 means no limit.", nullptr, nullptr,
     /* default */ 0, /* min */ 0, /* max */ SIZE_T_MAX, 1);
 
 static MYSQL_THDVAR_ULONGLONG(
-    write_batch_flush_threshold, PLUGIN_VAR_RQCMDARG,
+    write_batch_flush_threshold,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "Maximum size of write batch in bytes before flushing. Only valid if "
     "rocksdb_write_policy is WRITE_UNPREPARED. 0 means no limit.",
     nullptr, nullptr, /* default */ 0, /* min */ 0, /* max */ SIZE_T_MAX, 1);
 
 static MYSQL_THDVAR_BOOL(
-    lock_scanned_rows, PLUGIN_VAR_RQCMDARG,
+    lock_scanned_rows, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "Take and hold locks on rows that are scanned but not updated", nullptr,
     nullptr, false);
 
-static MYSQL_THDVAR_ULONG(bulk_load_size, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_ULONG(bulk_load_size,
+                          PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                           "Max #records in a batch for bulk-load mode", nullptr,
                           nullptr,
                           /*default*/ RDB_DEFAULT_BULK_LOAD_SIZE,
@@ -1415,7 +1419,7 @@ static MYSQL_SYSVAR_ENUM(
     rocksdb::InfoLogLevel::ERROR_LEVEL, &info_log_level_typelib);
 
 static MYSQL_THDVAR_INT(
-    perf_context_level, PLUGIN_VAR_RQCMDARG,
+    perf_context_level, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "Perf Context Level for rocksdb internal timer stat collection", nullptr,
     nullptr,
     /* default */ rocksdb::PerfLevel::kUninitialized,
@@ -1887,7 +1891,8 @@ static MYSQL_SYSVAR_UINT(flush_log_at_trx_commit,
                          /* min */ FLUSH_LOG_NEVER,
                          /* max */ FLUSH_LOG_BACKGROUND, 0);
 
-static MYSQL_THDVAR_BOOL(write_disable_wal, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_BOOL(write_disable_wal,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "WriteOptions::disableWAL for RocksDB",
                          rocksdb_check_write_disable_wal, nullptr,
                          rocksdb::WriteOptions().disableWAL);
@@ -1896,11 +1901,13 @@ static MYSQL_THDVAR_BOOL(write_disable_wal_save, PLUGIN_VAR_INVISIBLE,
                          rocksdb::WriteOptions().disableWAL);
 
 static MYSQL_THDVAR_BOOL(
-    write_ignore_missing_column_families, PLUGIN_VAR_RQCMDARG,
+    write_ignore_missing_column_families,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
     "WriteOptions::ignore_missing_column_families for RocksDB", nullptr,
     nullptr, rocksdb::WriteOptions().ignore_missing_column_families);
 
-static MYSQL_THDVAR_BOOL(skip_fill_cache, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_BOOL(skip_fill_cache,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "Skip filling block cache on read requests", nullptr,
                          nullptr, false);
 
@@ -1909,13 +1916,15 @@ static MYSQL_THDVAR_BOOL(
     "Allowing statement based binary logging which may break consistency",
     nullptr, nullptr, false);
 
-static MYSQL_THDVAR_UINT(records_in_range, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_UINT(records_in_range,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "Used to override the result of records_in_range(). "
                          "Set to a positive number to override",
                          nullptr, nullptr, 0,
                          /* min */ 0, /* max */ INT_MAX, 0);
 
-static MYSQL_THDVAR_UINT(force_index_records_in_range, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_UINT(force_index_records_in_range,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "Used to override the result of records_in_range() "
                          "when FORCE INDEX is used.",
                          nullptr, nullptr, 0,
@@ -2151,20 +2160,24 @@ static MYSQL_SYSVAR_BOOL(
     "Logging queries that got snapshot conflict errors into *.err log", nullptr,
     nullptr, rocksdb_print_snapshot_conflict_queries);
 
-static MYSQL_THDVAR_INT(checksums_pct, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_INT(checksums_pct,
+                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                         "How many percentages of rows to be checksummed",
                         nullptr, nullptr, RDB_MAX_CHECKSUMS_PCT,
                         /* min */ 0, /* max */ RDB_MAX_CHECKSUMS_PCT, 0);
 
-static MYSQL_THDVAR_BOOL(store_row_debug_checksums, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_BOOL(store_row_debug_checksums,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "Include checksums when writing index/table records",
                          nullptr, nullptr, false /* default value */);
 
-static MYSQL_THDVAR_BOOL(verify_row_debug_checksums, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_BOOL(verify_row_debug_checksums,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "Verify checksums when reading index/table records",
                          nullptr, nullptr, false /* default value */);
 
-static MYSQL_THDVAR_BOOL(master_skip_tx_api, PLUGIN_VAR_RQCMDARG,
+static MYSQL_THDVAR_BOOL(master_skip_tx_api,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_HINTUPDATEABLE,
                          "Skipping holding any lock on row access. "
                          "Not effective on slave.",
                          nullptr, nullptr, false);
@@ -3504,6 +3517,8 @@ class Rdb_transaction {
 
     /* Commit the current transaction */
     if (commit_no_binlog()) return true;
+
+    DEBUG_SYNC(m_thd, "rocksdb.flush_batch");
 
     /* Start another one */
     start_tx();

--- a/storage/rocksdb/rdb_converter.cc
+++ b/storage/rocksdb/rdb_converter.cc
@@ -25,6 +25,7 @@
 
 /* MySQL header files */
 #include "my_stacktrace.h"
+#include "sql/debug_sync.h"
 #include "sql/sql_array.h"
 
 /* MyRocks header files */
@@ -690,6 +691,7 @@ int Rdb_converter::verify_row_debug_checksum(
         my_core::my_checksum(0, rdb_slice_to_uchar_ptr(value),
                              value->size() - RDB_CHECKSUM_CHUNK_SIZE);
 
+    DEBUG_SYNC(const_cast<THD *>(m_thd), "myrocks_verify_row_debug_checksum");
     DBUG_EXECUTE_IF("myrocks_simulate_bad_pk_checksum1", stored_key_chksum++;);
 
     if (stored_key_chksum != computed_key_chksum) {
@@ -861,6 +863,8 @@ int Rdb_converter::encode_value_slice(
   }
 
   if (store_row_debug_checksums) {
+    DEBUG_SYNC(const_cast<THD *>(m_thd), "rocksdb.encode_value_slice");
+
     const ha_checksum key_crc32 = my_core::my_checksum(
         0, rdb_slice_to_uchar_ptr(&pk_packed_slice), pk_packed_slice.size());
     const ha_checksum val_crc32 =


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7871

This PR consists of several commits, one per variable + cleanup commits for easier review. Will be squashed after approval.

1. Merged contribution https://github.com/percona/percona-server/pull/4446
MTR test refactored to be independend of RocksDB (RDB specific part
moved to separate test, common part extracted to the include file)

2. Changed the following variables to hint-updatable, MTR tests introduced:
rocksdb_blind_delete_primary_key
rocksdb_bulk_load_size
rocksdb_lock_scanned_rows
rocksdb_enable_iterate_bounds
rocksdb_force_index_records_in_range
rocksdb_checksums_pct
rocksdb_perf_context_level
rocksdb_records_in_range
rocksdb_skip_bloom_filter_on_read
rocksdb_skip_fill_cache
rocksdb_store_row_debug_checksums
rocksdb_trace_sst_api
rocksdb_verify_row_debug_checksums
rocksdb_write_batch_flush_threshold
rocksdb_write_batch_max_bytes
rocksdb_write_disable_wal
rocksdb_write_ignore_missing_column_families