### PR TITLE
PS-8103: Do not unload dynamic libraries in an ASAN build

### DIFF
--- a/components/libminchassis/dynamic_loader_scheme_file.cc
+++ b/components/libminchassis/dynamic_loader_scheme_file.cc
@@ -29,6 +29,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 #include <mysql/components/services/mysql_rwlock.h>
 #include <mysqld_error.h>
 
+#include "my_config.h"
 #ifndef _WIN32
 #include <dlfcn.h>
 #endif
@@ -215,7 +216,12 @@ DEFINE_BOOL_METHOD(mysql_dynamic_loader_scheme_file_imp::unload,
     mysql_unload_plugin(it->first.c_str());
 
     /* Close library and delete entry from libraries list. */
+#if !defined(HAVE_VALGRIND) && !defined(HAVE_ASAN)
+    /*
+     * Avoid closing components under ASAN / Valgrind in order to get
+     * meaningfull leak report */
     dlclose(it->second);
+#endif
     object_files_list.erase(it);
     return false;
   } catch (...) {

--- a/sql/sql_plugin.cc
+++ b/sql/sql_plugin.cc
@@ -622,7 +622,12 @@ static inline void free_plugin_mem(st_plugin_dl *p) {
     PSI_SYSTEM_CALL(unload_plugin)
     (std::string(p->dl.str, p->dl.length).c_str());
 #endif
+#if !defined(HAVE_VALGRIND) && !defined(HAVE_ASAN)
+    /*
+     * Avoid closing components under ASAN / Valgrind in order to get
+     * meaningfull leak report */
     dlclose(p->handle);
+#endif
   }
   my_free(p->dl.str);
   if (p->version != MYSQL_PLUGIN_INTERFACE_VERSION) my_free(p->plugins);


### PR DESCRIPTION
Issue: address sanitizer and valgrind can't resolve stack traces inside
plugins and components. The reason behind this is that MySQL unloads
dynamic libraries loaded dynamically during shutdown, making the code
inaccessible to the sanitizers.

This also means that suppressions do not work inside components and
plugins, if the suppression involves a step in the stacktrace which is
inside the plugin/component.

Fix: add a conditional around dlunload to remove it from asan/valgrind
builds.