### PR TITLE
PS-8047 - Fix azure pipelines when using clang 7

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -335,13 +335,6 @@ jobs:
         '-DCMAKE_CXX_FLAGS_RELWITHDEBINFO=-O2 -g1 -DNDEBUG'
       )
 
-      if [[ "$CC" =~ clang-(6.0|7|8)$ ]]; then
-        COMPILE_OPT+=(
-          '-DCMAKE_C_FLAGS=-isystem /usr/include/c++/9 -isystem /usr/include'
-          '-DCMAKE_CXX_FLAGS=-isystem /usr/include/c++/9 -isystem /usr/include'
-        )
-      fi
-
       CMAKE_OPT="
         -DCMAKE_BUILD_TYPE=$(BuildType)
         -DBUILD_CONFIG=mysql_release


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8047

---

The included directories are no longer required and where causing
compilation errors.