### PR TITLE
PS-8047 - Fix compilation of pfs_instr-t

### DIFF
--- a/libbinlogevents/src/gtids/gtidset.cpp
+++ b/libbinlogevents/src/gtids/gtidset.cpp
@@ -21,6 +21,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "libbinlogevents/include/gtids/gtidset.h"
+#include "my_compiler.h"
 #include <map>
 #include <string>
 
@@ -235,7 +236,10 @@ bool Gtid_set::is_empty() const { return m_gtid_set.empty(); }
 std::size_t Gtid_set::count() const {
   std::size_t count{0};
 
-  for ([[maybe_unused]] auto const &[uuid, intervals] : m_gtid_set) {
+MY_COMPILER_DIAGNOSTIC_PUSH()
+MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
+  for (auto const &[uuid, intervals] : m_gtid_set) {
+MY_COMPILER_DIAGNOSTIC_POP()
     for (auto &interval : intervals) {
       count += interval.count();
     }

--- a/libbinlogevents/src/gtids/gtidset.cpp
+++ b/libbinlogevents/src/gtids/gtidset.cpp
@@ -235,7 +235,7 @@ bool Gtid_set::is_empty() const { return m_gtid_set.empty(); }
 std::size_t Gtid_set::count() const {
   std::size_t count{0};
 
-  for (auto const &[uuid, intervals] : m_gtid_set) {
+  for ([[maybe_unused]] auto const &[uuid, intervals] : m_gtid_set) {
     for (auto &interval : intervals) {
       count += interval.count();
     }

--- a/libbinlogevents/src/gtids/gtidset.cpp
+++ b/libbinlogevents/src/gtids/gtidset.cpp
@@ -236,10 +236,10 @@ bool Gtid_set::is_empty() const { return m_gtid_set.empty(); }
 std::size_t Gtid_set::count() const {
   std::size_t count{0};
 
-MY_COMPILER_DIAGNOSTIC_PUSH()
-MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
   for (auto const &[uuid, intervals] : m_gtid_set) {
-MY_COMPILER_DIAGNOSTIC_POP()
+    MY_COMPILER_DIAGNOSTIC_POP()
     for (auto &interval : intervals) {
       count += interval.count();
     }

--- a/storage/perfschema/unittest/CMakeLists.txt
+++ b/storage/perfschema/unittest/CMakeLists.txt
@@ -30,7 +30,7 @@ ADD_DEPENDENCIES(pfs_server_stubs GenError)
 MACRO (PFS_ADD_TEST name)
   MYSQL_ADD_EXECUTABLE(${name}-t ${name}-t.cc ADD_TEST ${name})
   TARGET_LINK_LIBRARIES(${name}-t
-    mytap perfschema mysys pfs_server_stubs strings sql_main ${ICU_LIBRARIES})
+    mytap perfschema mysys pfs_server_stubs strings ${ICU_LIBRARIES})
 ENDMACRO()
 
 SET(tests


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8047

---

*Problem*:

gcc-7 compilation fails with the following error:

```
ld.lld: error: duplicate symbol: log_message(int, ...)
```
                                    ^
The function is defined in `pfs_server_stubs` and `sql_main`.

*Solution*:

Remove inclusion of `sql_main` which is not necessary.
