### PR TITLE
PS-8115 - Fix `CREATE EVENT DEFINER`

### DIFF
--- a/mysql-test/r/events_bugs.result
+++ b/mysql-test/r/events_bugs.result
@@ -402,6 +402,24 @@ ERROR 42000: Access denied; you need (at least one of) the SUPER privilege(s) fo
 DROP EVENT e1;
 ERROR HY000: Unknown event 'e1'
 DROP USER mysqltest_u1@localhost;
+CREATE USER 'mysqltest_u1@corp'@'localhost';
+GRANT EVENT ON events_test.* TO 'mysqltest_u1@corp'@'localhost';
+CREATE DEFINER='mysqltest_u1@corp'@'localhost' EVENT e1 ON SCHEDULE EVERY 1 DAY STARTS '2006-01-01 00:00:00' DO SELECT 1;
+SHOW CREATE EVENT e1;
+Event	sql_mode	time_zone	Create Event	character_set_client	collation_connection	Database Collation
+e1	ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	SYSTEM	CREATE DEFINER=`mysqltest_u1@corp`@`localhost` EVENT `e1` ON SCHEDULE EVERY 1 DAY STARTS '2006-01-01 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO SELECT 1	latin1	latin1_swedish_ci	latin1_swedish_ci
+DROP EVENT e1;
+DROP USER 'mysqltest_u1@corp'@'localhost';
+CREATE USER 'mysqltest_u1@corp@comp'@'localhost';
+GRANT EVENT ON events_test.* TO 'mysqltest_u1@corp@comp'@'localhost';
+CREATE DEFINER='mysqltest_u1@corp@comp'@'localhost' EVENT e1 ON SCHEDULE EVERY 1 DAY STARTS '2006-01-01 00:00:00' DO SELECT 1;
+SHOW CREATE EVENT e1;
+Event	sql_mode	time_zone	Create Event	character_set_client	collation_connection	Database Collation
+e1	ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION	SYSTEM	CREATE DEFINER=`mysqltest_u1@corp@comp`@`localhost` EVENT `e1` ON SCHEDULE EVERY 1 DAY STARTS '2006-01-01 00:00:00' ON COMPLETION NOT PRESERVE ENABLE DO SELECT 1	latin1	latin1_swedish_ci	latin1_swedish_ci
+DROP EVENT e1;
+DROP USER 'mysqltest_u1@corp@comp'@'localhost';
+CREATE USER 'mysqltest_u1'@'localhost@corp';
+ERROR HY000: Malformed hostname (illegal symbol: '@')
 SET GLOBAL EVENT_SCHEDULER= OFF;
 SET @save_time_zone= @@TIME_ZONE;
 SET TIME_ZONE= '+00:00';

--- a/mysql-test/t/events_bugs.test
+++ b/mysql-test/t/events_bugs.test
@@ -685,6 +685,37 @@ connection default;
 
 DROP USER mysqltest_u1@localhost;
 
+#
+# PS#8115: Check a user containing an '@' is processed correctly
+#
+
+--let $user= 'mysqltest_u1@corp'@'localhost'
+--let $event= e1
+--eval CREATE USER $user
+--eval GRANT EVENT ON events_test.* TO $user
+
+--eval CREATE DEFINER=$user EVENT $event ON SCHEDULE EVERY 1 DAY STARTS '2006-01-01 00:00:00' DO SELECT 1
+--eval SHOW CREATE EVENT $event
+
+--eval DROP EVENT $event
+--eval DROP USER $user
+
+# user with several '@' is processed correctly
+--let $user= 'mysqltest_u1@corp@comp'@'localhost'
+--let $event= e1
+--eval CREATE USER $user
+--eval GRANT EVENT ON events_test.* TO $user
+
+--eval CREATE DEFINER=$user EVENT $event ON SCHEDULE EVERY 1 DAY STARTS '2006-01-01 00:00:00' DO SELECT 1
+--eval SHOW CREATE EVENT $event
+
+--eval DROP EVENT $event
+--eval DROP USER $user
+
+# '@' is not allowed in the hostname
+--let $user= 'mysqltest_u1'@'localhost@corp'
+--error ER_UNKNOWN_ERROR
+--eval CREATE USER $user
 
 #
 # BUG#16420: Events: timestamps become UTC


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8115
https://ps57.cd.percona.com/job/percona-server-5.7-pipeline/26486/

*Problem*:

When the user contains the character `@` this is associated to the
hostname.

*Solution*:

Do as 8.0 and consider that the hostname is the part from the last '@'
till the end of the value of `DEFINER`.

'@' is an illegal character in the hostname.
