### PR TITLE
Fix deprecated usage of unencrypted `git` protocol

### DIFF
--- a/build-ps/percona-server-8.0_builder.sh
+++ b/build-ps/percona-server-8.0_builder.sh
@@ -171,12 +171,12 @@ get_sources(){
             echo "InnoDB version differs from defined in version file"
             exit 1
         fi
-        FT_TAG=$(git ls-remote --tags git://github.com/percona/PerconaFT.git | grep -c ${PERCONAFT_BRANCH})
+        FT_TAG=$(git ls-remote --tags https://github.com/percona/PerconaFT.git | grep -c ${PERCONAFT_BRANCH})
         if [ ${FT_TAG} = 0 ]; then
             echo "There is no TAG for PerconaFT. Please set it and re-run build!"
             exit 1
         fi
-        TOKUBACKUP_TAG=$(git ls-remote --tags git://github.com/percona/Percona-TokuBackup.git | grep -c ${TOKUBACKUP_BRANCH})
+        TOKUBACKUP_TAG=$(git ls-remote --tags https://github.com/percona/Percona-TokuBackup.git | grep -c ${TOKUBACKUP_BRANCH})
         if [ ${TOKUBACKUP_TAG} = 0 ]; then
             echo "There is no TAG for Percona-TokuBackup. Please set it and re-run build!"
             exit 1
@@ -976,7 +976,7 @@ BRANCH="release-8.0.27-18"
 RPM_RELEASE=1
 DEB_RELEASE=1
 MECAB_INSTALL_DIR="${WORKDIR}/mecab-install"
-REPO="git://github.com/percona/percona-server.git"
+REPO="https://github.com/percona/percona-server.git"
 PRODUCT=Percona-Server-8.0
 MYSQL_VERSION_MAJOR=8
 MYSQL_VERSION_MINOR=0


### PR DESCRIPTION
GitHub no longer supports the unencrypted `git` protocol. Use https
instead:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>