### PR TITLE
PS-8141: percona_encrypt_tmp_files_debug MTR test

### DIFF
--- a/mysql-test/t/percona_encrypt_tmp_files_debug.test
+++ b/mysql-test/t/percona_encrypt_tmp_files_debug.test
@@ -33,7 +33,13 @@ while($encryption_mode < 2)
 
   # Determining server temp dir where 'filesort()' temporary files will be
   # created.
-  --let $tmp_dir = `SELECT @@global.tmpdir`
+  # We use this to determine temp file used by filesort() later in this test.
+  # The problem with the value returned by SELECT @@global.tmpdir is that it
+  # return the tmp as seen from the server user perspective while proc/<pid>/fd/X
+  # links to something like /dev/shm/var_auto_ThIa/tmp/mysqld.1/MYabc
+  # (or /dev/shm/var_auto_ThIa/tmp/10/mysqld.1/MYabc if tests are executed in parallel)
+  # if the test executd with --mem option  
+  --let $tmp_dir = tmp\/*[0-9]*\/mysqld.1
 
   # Determining server PID file name.
   --let $pid_file = `SELECT @@global.pid_file`
@@ -88,6 +94,8 @@ while($encryption_mode < 2)
   # Looking for a file descriptor (symbolic link) from '/proc/$pid_no/fd'
   # which points to a file in $tmp_dir and starts with 'MY'. For instance,
   # lrwx------ 1 64  66 -> <build_dir>/mysql-test/var/tmp/mysqld.1/MYOi8yx9 (deleted)
+  # or in case if the test is run with --mem
+  # lrwx------ 1 64  45 -> /dev/shm/var_auto_ThIa/tmp/mysqld.1/MYSAK75H (deleted)
   # File descriptor number is extracted into $tmp_fd_no MTR variable.
   # In 'ls':
   # * "-o" means omit owner;
@@ -95,7 +103,7 @@ while($encryption_mode < 2)
   # * "--time-style='+'" means omit timestamp.
   --let $awk_filter = {print \$4}
   --let $fd_no_include_file = $MYSQL_TMP_DIR/fd_no_include_file.inc
-  --exec ls -og --time-style='+' /proc/$pid_no/fd | grep $tmp_dir/MY | awk '$awk_filter' > $fd_no_include_file
+  --exec ls -og --time-style='+' /proc/$pid_no/fd | grep -E $tmp_dir/MY | awk '$awk_filter' > $fd_no_include_file
   --replace_result $fd_no_include_file <fd_no_include_file>
   --eval LOAD DATA LOCAL INFILE '$fd_no_include_file' INTO TABLE id_table
   --remove_file $fd_no_include_file


### PR DESCRIPTION
fails if executed with --mem option

https://jira.percona.com/browse/PS-8141

Problem:
When percona_encrypt_tmp_files_debug MTR test is executed with --mem
option, it fails with the assertion

Cause:
The test uses proc filesystem to find the file used by filesort.
When the test is executed with --mem option, mysqld tmp directory
is located in /dev/shm and procfs links directly to it, not to
the location reported by SELECT @@global.tmpdir. This causes file not
being found and the test fails.

Solution:
Do not use the result of SELECT @@global.tmpdir in grep in the test.
Use tmp/*/mysqld.1 value instead which is constant anyway.