### PR TITLE
WDCZEN-19: Fix rocksdb.checkpointing MTR test case for ZenFS to ZenFS checkpointing.

### DIFF
--- a/mysql-test/suite/rocksdb/include/set_checkpoint.inc
+++ b/mysql-test/suite/rocksdb/include/set_checkpoint.inc
@@ -11,10 +11,15 @@ if ($succeeds)
   eval SET GLOBAL ROCKSDB_CREATE_CHECKPOINT = '$checkpoint';
 
   # Check checkpoint
-  --exec ls $checkpoint/CURRENT | sed s/.*CURRENT/CURRENT/g
+  --let $file_exists_file_name = $checkpoint/CURRENT
+  --let $file_exists_inverted = 0
+  --let $zenfs_data_dir_prefix =
+  --let $rocksdb_data_dir_prefix =
+  --source ./zenfs_file_exists.inc
 
   # Cleanup
-  --force-rmdir $checkpoint
+  --let $directory_to_force_delete = $checkpoint
+  --source ./zenfs_force_rmdir.inc
 }
 if (!$succeeds)
 {

--- a/mysql-test/suite/rocksdb/include/zenfs_file_exists.inc
+++ b/mysql-test/suite/rocksdb/include/zenfs_file_exists.inc
@@ -1,24 +1,31 @@
 # Expected arguments:
 # $file_exists_file_name - file name to check
 # $file_exists_inverted - if non-zero, $file_exists_file_name must not exist
+# $zenfs_data_dir_prefix - prefix of the ZenFS data directory where the file is (not) expected
+# $rocksdb_data_dir_prefix - prefix of the RocksDB data directory where the file is (not) expected
 #
 
 --source parse_rocksdb_fs_uri.inc
 if ($rocksdb_zenfs_disabled)
 {
 
-  --let $ROCKSDB_DATADIR = `SELECT CONCAT(@@datadir, '/', @@rocksdb_datadir)`
   if ($file_exists_inverted)
   {
     --error 1
   }
-  --file_exists $ROCKSDB_DATADIR/$file_exists_file_name
+
+  if(!$rocksdb_data_dir_prefix)
+  {
+    --file_exists $file_exists_file_name
+  }
+  if($rocksdb_data_dir_prefix)
+  {
+    --file_exists $rocksdb_data_dir_prefix/$file_exists_file_name
+  }
 }
 if (!$rocksdb_zenfs_disabled)
 {
   --file_exists $MYSQL_ZENFS
-
-  --let $zenfs_data_dir_prefix = ./.rocksdb
 
   --let $extracted_zenfs_file_name = `SELECT SUBSTRING_INDEX('$file_exists_file_name', '/', -1)`
   --let $extracted_zenfs_path = `SELECT LEFT('$file_exists_file_name', LENGTH('$file_exists_file_name') - LENGTH('$extracted_zenfs_file_name') - 1)`

--- a/mysql-test/suite/rocksdb/include/zenfs_force_rmdir.inc
+++ b/mysql-test/suite/rocksdb/include/zenfs_force_rmdir.inc
@@ -1,0 +1,25 @@
+# Expected arguments:
+# $directory_to_force_delete - Directory that should get force deleted
+#
+
+if ($directory_to_force_delete == '')
+{
+  --echo '$directory_to_force_delete' is empty
+  --die zenfs_force_rmdir.inc assertion failed
+}
+
+--source parse_rocksdb_fs_uri.inc
+
+--source include/stop_mysqld.inc
+if ($rocksdb_zenfs_disabled)
+{
+  --force-rmdir $directory_to_force_delete
+}
+if (!$rocksdb_zenfs_disabled)
+{
+  --let $zenfs_cmd = $MYSQL_ZENFS rmdir --zbd=$extracted_zenfs_device --path=$directory_to_force_delete --force > /dev/null
+
+  --exec $zenfs_cmd
+}
+
+--source include/start_mysqld.inc

--- a/mysql-test/suite/rocksdb/r/checkpoint.result
+++ b/mysql-test/suite/rocksdb/r/checkpoint.result
@@ -34,9 +34,11 @@ key (b) comment 'cfname=rev:cf2'
 ) ENGINE=ROCKSDB;
 DELETE FROM t5;
 SET GLOBAL ROCKSDB_CREATE_CHECKPOINT = '[CHECKPOINT]';
-CURRENT
+include/stop_mysqld.inc [server 1]
+# restart
 SET GLOBAL ROCKSDB_CREATE_CHECKPOINT = '[CHECKPOINT]';
-CURRENT
+include/stop_mysqld.inc [server 1]
+# restart
 truncate table t1;
 optimize table t1;
 truncate table t2;

--- a/mysql-test/suite/rocksdb/t/checkpoint.test
+++ b/mysql-test/suite/rocksdb/t/checkpoint.test
@@ -54,13 +54,23 @@ let $max = 1000;
 let $table = t5;
 --source suite/rocksdb/include/drop_table_repopulate_table.inc
 
+--source suite/rocksdb/include/parse_rocksdb_fs_uri.inc
+if ($rocksdb_zenfs_disabled)
+{
+  --let $TMP_CHECKPOINT_DIR = $MYSQL_TMP_DIR
+}
+if (!$rocksdb_zenfs_disabled)
+{
+  --let $TMP_CHECKPOINT_DIR = .
+}
+
 # Create checkpoint without trailing '/'
-let $checkpoint = $MYSQL_TMP_DIR/checkpoint;
+let $checkpoint = $TMP_CHECKPOINT_DIR/checkpoint;
 let $succeeds = 1;
 --source suite/rocksdb/include/set_checkpoint.inc
 
 # Create checkpoint with a trailing '/'
-let $checkpoint = $MYSQL_TMP_DIR/checkpoint/;
+let $checkpoint = $TMP_CHECKPOINT_DIR/checkpoint/;
 let $succeeds = 1;
 --source suite/rocksdb/include/set_checkpoint.inc
 
@@ -75,11 +85,23 @@ let $succeeds = 0;
 --source suite/rocksdb/include/set_checkpoint.inc
 
 # Set checkpoint as a directory that already exists, which fails
-let $checkpoint = $MYSQL_TMP_DIR/already-existing-directory;
---mkdir $checkpoint
+if ($rocksdb_zenfs_disabled)
+{
+  let $checkpoint = $TMP_CHECKPOINT_DIR/already-existing-directory;
+  --mkdir $checkpoint
+}
+if (!$rocksdb_zenfs_disabled)
+{
+  #'./.rocksdb' exists in the aux directory of zenfs at this point
+  let $checkpoint = $TMP_CHECKPOINT_DIR/.rocksdb;
+}
 let $succeeds = 0;
 --source suite/rocksdb/include/set_checkpoint.inc
---force-rmdir $checkpoint
+
+if ($rocksdb_zenfs_disabled)
+{
+  --force-rmdir $checkpoint
+}
 
 --disable_result_log
 truncate table t1;

--- a/mysql-test/suite/rocksdb/t/rocksdb_disable_file_deletions.test
+++ b/mysql-test/suite/rocksdb/t/rocksdb_disable_file_deletions.test
@@ -27,6 +27,8 @@ enable_query_log;
 # make sure the WAL has not been removed
 --let $file_exists_file_name = $wal
 --let $file_exists_inverted = 0
+--let $zenfs_data_dir_prefix = ./.rocksdb
+--let $rocksdb_data_dir_prefix = `SELECT CONCAT(@@datadir, '/', @@rocksdb_datadir)`
 --source ../include/zenfs_file_exists.inc
 
 connection con1;
@@ -48,6 +50,8 @@ enable_query_log;
 # make sure the WAL has disappeared
 --let $file_exists_file_name = $wal
 --let $file_exists_inverted = 1
+--let $zenfs_data_dir_prefix = ./.rocksdb
+--let $rocksdb_data_dir_prefix = `SELECT CONCAT(@@datadir, '/', @@rocksdb_datadir)`
 --source ../include/zenfs_file_exists.inc
 
 DROP TABLE t;


### PR DESCRIPTION

https://jira.percona.com/browse/WDCZEN-19

With https://github.com/westerndigitalcorporation/zenfs/pull/160 ZenFS to ZenFS
checkpointing in RocksDB was enabled by fixing ZenFS's renaming and providing a
`rmdir` utility command.

With this commit the MTR rocksdb.checkpointing test case is modified to use
ZenFS utility commands to find the `CURRENT` file and remove the
(tmp-)checkpoint directory.

The checkpointing directories in the ZenFS case have to be relative to its
auxiliary directory `./`.

Reported-by: Yura Sorokin <yura.sorokin@percona.com>
Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>