### PR TITLE
Fixed PS-8136 - LOCK TABLES FOR BACKUP is not preventing ALTER INSTAN…

### DIFF
--- a/mysql-test/r/backup_locks.result
+++ b/mysql-test/r/backup_locks.result
@@ -909,6 +909,13 @@ CREATE TABLE t(a INT);
 LOCK TABLE t READ;
 LOCK BINLOG FOR BACKUP;
 DROP TABLE t;
+LOCK TABLES FOR BACKUP;
+SET SESSION lock_wait_timeout=1;
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+ERROR HY000: Lock wait timeout exceeded; try restarting transaction
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+ERROR HY000: Can't execute the query because you have a conflicting backup lock
+SET SESSION lock_wait_timeout=default;
 #-----------------------------------------------------------------------
 # Cleanup
 #-----------------------------------------------------------------------

--- a/mysql-test/t/backup_locks.test
+++ b/mysql-test/t/backup_locks.test
@@ -1155,6 +1155,28 @@ LOCK BINLOG FOR BACKUP;
 
 DROP TABLE t;
 
+#
+# LTFB + key rotation
+#
+
+--connect(con,localhost,root,,)
+LOCK TABLES FOR BACKUP;
+
+--connection default
+SET SESSION lock_wait_timeout=1;
+--error ER_LOCK_WAIT_TIMEOUT
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+--connection con
+--error ER_CANT_EXECUTE_WITH_BACKUP_LOCK
+ALTER INSTANCE ROTATE INNODB MASTER KEY;
+
+
+--disconnect con
+--connection default
+SET SESSION lock_wait_timeout=default;
+
+
 --echo #-----------------------------------------------------------------------
 --echo # Cleanup
 --echo #-----------------------------------------------------------------------

--- a/sql/sql_alter_instance.cc
+++ b/sql/sql_alter_instance.cc
@@ -90,6 +90,14 @@ Rotate_innodb_master_key::execute()
     return true;
   }
 
+  // Acquire Percona's LOCK TABLES FOR BACKUP lock
+  if (m_thd->backup_tables_lock.abort_if_acquired() ||
+      m_thd->backup_tables_lock.acquire_protection(
+          m_thd, MDL_TRANSACTION, m_thd->variables.lock_wait_timeout))
+  {
+    return true;
+  }
+
   if (hton->rotate_encryption_master_key())
   {
     /* SE should have raised error */


### PR DESCRIPTION
…CE ROTATE INNODB MASTER KEY

https://jira.percona.com/browse/PS-8136

Problem:
Lightweight MDL LTFB should block operations that will result on
inconsistent backups. Rotating master key after the backup has started
will make tables header to point to a key that is not present on backup
cache of keys as PXB reads them once at the beginning of the backup.
Rotating the master key should be blocked.

Fix:
Enhanced Rotate_innodb_master_key to wait for up to lock_wait_timeout
seconds in case other session has acquired LTFB and also fail in case
LTFB has been acquired by the current session.