### PR TITLE
PS-7563 - Fix read overflow in mysqltest

### DIFF
--- a/client/mysqltest.cc
+++ b/client/mysqltest.cc
@@ -805,8 +805,9 @@ public:
         DBUG_VOID_RETURN;
       }
 
-      DBUG_PRINT("info", ("Read %lu bytes from file, buf: %s",
-                          (unsigned long)bytes, buf));
+      DBUG_PRINT("info",
+                 ("Read %lu bytes from file, buf: %.*s", (unsigned long)bytes,
+                  static_cast<int>(bytes), buf));
 
       char* show_from= buf + bytes;
       while(show_from > buf && lines > 0 )


### PR DESCRIPTION
*Problem:*

`buf` might not contain a final `\0` so, when `buf` is passed to `DBUG_PRINT`,
`DBUG_PRINT` will read pass over the limits of `buff` till if finds a
`\0`.

This is reported by AddrssessSanitizer has invalid access to
memory:

```
 cd $(BUILD_DIR_57)/mysql-test && \
 ./mtr \
 --parallel=1 \
 --force \
 --max-test-fail=0 \
 --retry-failure=0 \
 --suite-timeout=9999 \
 --debug-common \
 --sanitize \
 binlog_encryption.binlog_index

...

=================================================================
==314051==ERROR: AddressSanitizer: stack-buffer-overflow on address
0x7ffca6fa5d00 at pc 0x000000434159 bp 0x7ffca6fa5210 sp 0x7ffca6fa49d0
READ of size 258 at 0x7ffca6fa5d00 thread T0
    #0 0x434158 in strnlen
       (/home/ldonoso/src/bld57/client/mysqltest+0x434158)
    https://github.com/percona/percona-server/pull/1 0x52bcc1 in process_str_arg
       /home/ldonoso/src/percona-server/strings/my_vsnprintf.c:206:9
    https://github.com/percona/percona-server/pull/2 0x5297a2 in my_vsnprintf_ex
       /home/ldonoso/src/percona-server/strings/my_vsnprintf.c:619:11
    https://github.com/percona/percona-server/pull/3 0x52c1fb in my_vsnprintf
       /home/ldonoso/src/percona-server/strings/my_vsnprintf.c:682:10
    https://github.com/percona/percona-server/pull/4 0x571a6f in DbugVfprintf
       /home/ldonoso/src/percona-server/dbug/dbug.c:1498:10
    https://github.com/percona/percona-server/pull/5 0x57181f in _db_doprnt_
       /home/ldonoso/src/percona-server/dbug/dbug.c:1432:3
    https://github.com/percona/percona-server/pull/6 0x4f5482 in LogFile::show_tail(unsigned int)
       /home/ldonoso/src/percona-server/client/mysqltest.cc:808:7
    https://github.com/percona/percona-server/pull/7 0x4cc8b4 in die(char const*, ...)
       /home/ldonoso/src/percona-server/client/mysqltest.cc:1559:12
    https://github.com/percona/percona-server/pull/8 0x4ed694 in main
       /home/ldonoso/src/percona-server/client/mysqltest.cc:9915:9
    https://github.com/percona/percona-server/pull/9 0x7f9bff93d0b2 in __libc_start_main
       /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16
    https://github.com/percona/percona-server/pull/10 0x42125d in _start
        (/home/ldonoso/src/bld57/client/mysqltest+0x42125d)

Address 0x7ffca6fa5d00 is located in stack of thread T0 at offset 352 in
frame
    #0 0x4f51df in LogFile::show_tail(unsigned int)
       /home/ldonoso/src/percona-server/client/mysqltest.cc:772

  This frame has 2 object(s):
    [32, 64) '_db_stack_frame_' (line 773)
    [96, 352) 'buf' (line 783) <== Memory access at offset 352 overflows
this variable

```

*Solution:*

Use `%.*s` so at most `bytes` are handed over to `DBUG_PRINT`.