### PR TITLE
PS-7769 - Fix use-after-return error in audit_log_exclude_accounts_validate

### DIFF
--- a/plugin/audit_log/audit_log.c
+++ b/plugin/audit_log/audit_log.c
@@ -35,6 +35,7 @@
 #include "buffer.h"
 #include "audit_handler.h"
 #include "filter.h"
+#include "sql_const.h"
 
 #define PLUGIN_VERSION 0x0002
 
@@ -1593,24 +1594,31 @@ static MYSQL_THDVAR_STR(query_stack,
                         PLUGIN_VAR_NOSYSVAR | PLUGIN_VAR_NOCMDOPT,
                         "Query stack.", NULL, NULL, "");
 
+static const char *val_strmake(MYSQL_THD              thd,
+                               struct st_mysql_value *mysql_val)
+{
+  char        buf[STRING_BUFFER_USUAL_SIZE];
+  int         len= sizeof(buf);
+  const char *val= mysql_val->val_str(mysql_val, buf, &len);
+
+  if (val != NULL)
+    val= thd_strmake(thd, val, len);
+
+  return val;
+}
+
 static
 int
 audit_log_exclude_accounts_validate(
-          MYSQL_THD thd MY_ATTRIBUTE((unused)),
+          MYSQL_THD thd,
           struct st_mysql_sys_var *var MY_ATTRIBUTE((unused)),
           void *save,
           struct st_mysql_value *value)
 {
-  const char *new_val;
-  char buf[80];
-  int len= sizeof(buf);
-
   if (audit_log_include_accounts)
     return 1;
 
-  new_val = value->val_str(value, buf, &len);
-
-  *(const char **)(save) = new_val;
+  *(const char **)(save)= val_strmake(thd, value);
 
   return 0;
 }
@@ -1651,21 +1659,15 @@ static MYSQL_SYSVAR_STR(exclude_accounts, audit_log_exclude_accounts,
 static
 int
 audit_log_include_accounts_validate(
-          MYSQL_THD thd MY_ATTRIBUTE((unused)),
+          MYSQL_THD thd,
           struct st_mysql_sys_var *var MY_ATTRIBUTE((unused)),
           void *save,
           struct st_mysql_value *value)
 {
-  const char *new_val;
-  char buf[80];
-  int len= sizeof(buf);
-
   if (audit_log_exclude_accounts)
     return 1;
 
-  new_val = value->val_str(value, buf, &len);
-
-  *(const char **)(save) = new_val;
+  *(const char **)(save)= val_strmake(thd, value);
 
   return 0;
 }
@@ -1710,16 +1712,10 @@ audit_log_exclude_databases_validate(
           void *save,
           struct st_mysql_value *value)
 {
-  const char *new_val;
-  char buf[80];
-  int len= sizeof(buf);
-
   if (audit_log_include_databases)
     return 1;
 
-  new_val = value->val_str(value, buf, &len);
-
-  *(const char **)(save) = new_val;
+  *(const char **)(save)= val_strmake(thd, value);
 
   return 0;
 }
@@ -1760,21 +1756,15 @@ static MYSQL_SYSVAR_STR(exclude_databases, audit_log_exclude_databases,
 static
 int
 audit_log_include_databases_validate(
-          MYSQL_THD thd MY_ATTRIBUTE((unused)),
+          MYSQL_THD thd,
           struct st_mysql_sys_var *var MY_ATTRIBUTE((unused)),
           void *save,
           struct st_mysql_value *value)
 {
-  const char *new_val;
-  char buf[80];
-  int len= sizeof(buf);
-
   if (audit_log_exclude_databases)
     return 1;
 
-  new_val = value->val_str(value, buf, &len);
-
-  *(const char **)(save) = new_val;
+  *(const char **)(save)= val_strmake(thd, value);
 
   return 0;
 }
@@ -1814,21 +1804,15 @@ static MYSQL_SYSVAR_STR(include_databases, audit_log_include_databases,
 static
 int
 audit_log_exclude_commands_validate(
-          MYSQL_THD thd MY_ATTRIBUTE((unused)),
+          MYSQL_THD thd,
           struct st_mysql_sys_var *var MY_ATTRIBUTE((unused)),
           void *save,
           struct st_mysql_value *value)
 {
-  const char *new_val;
-  char buf[80];
-  int len= sizeof(buf);
-
   if (audit_log_include_commands)
     return 1;
 
-  new_val = value->val_str(value, buf, &len);
-
-  *(const char **)(save) = new_val;
+  *(const char **)(save)= val_strmake(thd, value);
 
   return 0;
 }
@@ -1869,21 +1853,15 @@ static MYSQL_SYSVAR_STR(exclude_commands, audit_log_exclude_commands,
 static
 int
 audit_log_include_commands_validate(
-          MYSQL_THD thd MY_ATTRIBUTE((unused)),
+          MYSQL_THD thd,
           struct st_mysql_sys_var *var MY_ATTRIBUTE((unused)),
           void *save,
           struct st_mysql_value *value)
 {
-  const char *new_val;
-  char buf[80];
-  int len= sizeof(buf);
-
   if (audit_log_exclude_commands)
     return 1;
 
-  new_val = value->val_str(value, buf, &len);
-
-  *(const char **)(save) = new_val;
+  *(const char **)(save)= val_strmake(thd, value);
 
   return 0;
 }


### PR DESCRIPTION
*Problem:*

`st_mysql_value::val_str` might return a pointer to `buf` which after
the function called is deleted. Therefore the value in `save`, after
reuturnin from the function, is invalid.

In this particular case, the error is not manifesting as `val_str`
returns memory allocated with `thd_strmake` and it does not use `buf`.

*Solution:*

Allocate memory with `thd_strmake` so the memory in `save` is not local.
