### PR TITLE
Improve extraction of plugin sources.

### DIFF
--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -98,6 +98,8 @@ ELSE()
       MESSAGE(SEND_ERROR "Missing RocksDB plugin makefile in ${PLUGIN_ROOT}")
     ELSE()
       FILE(READ ${PLUGINMKFILE} PLUGINMK)
+      #Remove line continuation/breaking
+      STRING(REGEX REPLACE "[ \t\r]*\\\\\n[ \t\r]*" " "  PLUGINMK ${PLUGINMK})
       STRING(REGEX MATCH "SOURCES[ ]*=[ ]*([^\n]*)" FOO ${PLUGINMK})
       SET(MK_SOURCES ${CMAKE_MATCH_1})
       SEPARATE_ARGUMENTS(MK_SOURCES)


### PR DESCRIPTION
Removes line continuation when collecting plugin sources.

With this change source files can be found which are defined over multiple
lines like:
```
plugin_SOURCES = \
	file1.cc \
	file2.cc \
	file3.cc
```

Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>