### PR TITLE
Add grep and ps to lsan.supp

### DIFF
--- a/mysql-test/lsan.supp
+++ b/mysql-test/lsan.supp
@@ -33,3 +33,5 @@ leak:/usr/bin/sed
 leak:/usr/bin/python2.7
 leak:/usr/bin/python3.8
 leak:/usr/bin/python3.9
+leak:/usr/bin/grep
+leak:/usr/bin/ps


### PR DESCRIPTION
*Problem*:

Builds using `WITH_ASAN=ON` present the following issues in some platforms:

- `have_grep.inc` fails in platforms which do have `grep`.
- The following 2 tests hang forever: `main.mysqld_safe` and `main.percona_processlist_tid`

The error is caused because when `LD_PRELOAD` is set to include the ASAN library. This messes up with utilities as `grep` and `ps`. In some platforms, memory leaks are reported to be detected on those utilites, but in some other platforms an error not related with memory leaks is returned.

In the case of `grep` an error is returned when testing its presence in the platform, hence `have_grep.inc` interprets `grep` is not installed.

The circumstances under `LD_PRELOAD` is set by mtr are:

- gcc compiler is used.
- package tirpc installed.

The logic implementing this is located in <https://github.com/percona/percona-server/blob/0e89ba12cf9a1098e3e4c800449072727c1e6e37/mysql-test/lib/My/SafeProcess/CMakeLists.txt#L47-L76>

*Solution*:

Add the problematic programs to `lsan.supp`. Although, this solves just the problem of these programs failing because of memory leaks.
