### PR TITLE
PS-7980: Basic implementation of LDAP authorization

### DIFF
--- a/include/mysql/plugin_auth.h
+++ b/include/mysql/plugin_auth.h
@@ -144,6 +144,10 @@ struct MYSQL_SERVER_AUTH_INFO {
     method
   */
   auth_factor_desc *multi_factor_auth_info;
+
+  /** Comma separated list of possible roles the user can have, if they do
+     exists on the server */
+  char external_roles[512];
 };
 
 /**

--- a/include/mysql/plugin_auth.h.pp
+++ b/include/mysql/plugin_auth.h.pp
@@ -190,6 +190,7 @@ struct MYSQL_SERVER_AUTH_INFO {
   unsigned long additional_auth_string_length;
   unsigned int current_auth_factor;
   auth_factor_desc *multi_factor_auth_info;
+  char external_roles[512];
 };
 typedef int (*authenticate_user_t)(MYSQL_PLUGIN_VIO *vio,
                                    MYSQL_SERVER_AUTH_INFO *info);

--- a/plugin/auth_ldap/include/auth_ldap_impl.h
+++ b/plugin/auth_ldap/include/auth_ldap_impl.h
@@ -38,23 +38,36 @@ class AuthLDAPImpl {
                const std::string &user_search_attr,
                const std::string &group_search_filter,
                const std::string &group_search_attr,
-               const std::string &bind_base_dn, Pool *pool);
+               const std::string &bind_base_dn, const std::string &mapping,
+               Pool *pool);
   ~AuthLDAPImpl();
 
   bool bind(const std::string &user_dn, const std::string &password);
   bool get_ldap_uid(std::string *user_dn);
 
-  bool get_mysql_uid(std::string *user_mysql, const std::string &user_dn);
+  bool get_mysql_uid(std::string *user_mysql, std::string *roles_mysql,
+                     const std::string &user_dn,
+                     Pool::pool_ptr_t *use_conn = nullptr);
+
+  bool bind_and_get_mysql_uid(const std::string &user_dn,
+                              const std::string &password,
+                              std::string *user_mysql,
+                              std::string *roles_mysql);
 
  private:
+  bool bind_internal(const std::string &user_dn, const std::string &password,
+                     Pool::pool_ptr_t *conn);
+
   std::string calc_ldap_uid();
 
   void calc_mappings(const std::string &group_str);
   std::string calc_mysql_user(const groups_t &groups);
+  std::string calc_mysql_roles(const groups_t &groups);
 
   bool matched_map(const t_group_mapping &map, const groups_t &groups);
 
-  groups_t search_ldap_groups(const std::string &user_dn);
+  groups_t search_ldap_groups(const std::string &user_dn,
+                              Pool::pool_ptr_t *use_conn);
 
   std::string search_ldap_uid();
 
@@ -69,6 +82,7 @@ class AuthLDAPImpl {
   std::string user_name_;
   std::string user_auth_string_;
   std::vector<t_group_mapping> mappings_;
+  std::map<std::string, std::string> group_role_mapping_;
 };
 }  // namespace auth_ldap
 }  // namespace plugin

--- a/plugin/auth_ldap/include/plugin_common.h
+++ b/plugin/auth_ldap/include/plugin_common.h
@@ -34,7 +34,7 @@ int auth_ldap_common_authenticate_user(
     MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info, const char *password,
     mysql::plugin::auth_ldap::Pool *pool, const char *user_search_attr,
     const char *group_search_attr, const char *group_search_filter,
-    const char *bind_base_dn);
+    const char *bind_base_dn, const char *group_role_mapping);
 
 int auth_ldap_common_generate_auth_string_hash(char *outbuf,
                                                unsigned int *buflen,

--- a/plugin/auth_ldap/include/plugin_variables.h
+++ b/plugin/auth_ldap/include/plugin_variables.h
@@ -42,6 +42,7 @@ static unsigned int server_port;
 static bool ssl;
 static bool tls;
 static char *user_search_attr;
+static char *group_role_mapping;
 
 static mysql::plugin::auth_ldap::Pool *connPool;
 
@@ -147,6 +148,13 @@ static MYSQL_SYSVAR_STR(user_search_attr, user_search_attr,
                         &update_sysvar<char *> /* update */,
                         "uid" /* default */);
 
+static MYSQL_SYSVAR_STR(
+    group_role_mapping, group_role_mapping,
+    PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC,
+    "Maps LDAP groups to MySQL groups. Uses comma separated list, where "
+    "entries could be <name>, or <ldap_name>=<mysql_name>",
+    nullptr /* check */, &update_sysvar<char *> /* update */, "" /* default */);
+
 static SYS_VAR *mpaldap_sysvars[] = {MYSQL_SYSVAR(auth_method_name),
                                      MYSQL_SYSVAR(bind_base_dn),
                                      MYSQL_SYSVAR(bind_root_dn),
@@ -162,6 +170,7 @@ static SYS_VAR *mpaldap_sysvars[] = {MYSQL_SYSVAR(auth_method_name),
                                      MYSQL_SYSVAR(ssl),
                                      MYSQL_SYSVAR(tls),
                                      MYSQL_SYSVAR(user_search_attr),
+                                     MYSQL_SYSVAR(group_role_mapping),
                                      nullptr};
 
 #endif  // PLUGIN_VARIABLES_MPALDAP_H

--- a/plugin/auth_ldap/include/pool.h
+++ b/plugin/auth_ldap/include/pool.h
@@ -16,6 +16,7 @@
 #define MPAL_POOL_H
 
 #include <boost/dynamic_bitset.hpp>
+#include <map>
 #include <mutex>
 #include <vector>
 
@@ -40,6 +41,7 @@ class Pool {
   pool_ptr_t borrow_connection(bool default_connect = true);
   void debug_info();
   void return_connection(pool_ptr_t conn);
+  void reset_group_role_mapping(const std::string &mapping);
   void reconfigure(std::size_t new_pool_initial_size,
                    std::size_t new_pool_max_size, const std::string &ldap_host,
                    std::uint16_t ldap_port, bool use_ssl, bool use_tls,
@@ -63,6 +65,7 @@ class Pool {
   std::string ca_path_;
   std::string bind_dn_;
   std::string bind_pwd_;
+  std::map<std::string, std::string> group_role_mapping_;
   using bs_used_t = boost::dynamic_bitset<>;
   bs_used_t bs_used_;
   using connection_vec_t = std::vector<pool_ptr_t>;

--- a/plugin/auth_ldap/src/auth_ldap_impl.cc
+++ b/plugin/auth_ldap/src/auth_ldap_impl.cc
@@ -25,18 +25,37 @@ namespace mysql {
 namespace plugin {
 namespace auth_ldap {
 
+static std::map<std::string, std::string> calc_group_mappings(
+    std::string const &mapping) {
+  std::map<std::string, std::string> group_mapping;
+  std::vector<std::string> roles;
+  boost::algorithm::split(roles, mapping, boost::is_any_of(","));
+  for (auto const &role : roles) {
+    std::vector<std::string> r;
+    boost::algorithm::split(r, role, boost::is_any_of("="));
+    if (r.size() == 1) {
+      group_mapping[role] = role;
+    } else {
+      group_mapping[r[0]] = r[1];
+    }
+  }
+  return group_mapping;
+}
+
 AuthLDAPImpl::AuthLDAPImpl(const std::string &user_name,
                            const std::string &auth_string,
                            const std::string &user_search_attr,
                            const std::string &group_search_filter,
                            const std::string &group_search_attr,
-                           const std::string &bind_base_dn, Pool *pool)
+                           const std::string &bind_base_dn,
+                           const std::string &mapping, Pool *pool)
     : pool_(pool),
       user_search_attr_(user_search_attr),
       group_search_attr_(group_search_attr),
       group_search_filter_(group_search_filter),
       bind_base_dn_(bind_base_dn),
-      user_name_(user_name) {
+      user_name_(user_name),
+      group_role_mapping_(calc_group_mappings(mapping)) {
   std::vector<std::string> parts;
   boost::algorithm::split(parts, auth_string, boost::is_any_of("#"));
   user_auth_string_ = boost::algorithm::trim_copy(parts[0]);
@@ -48,8 +67,9 @@ AuthLDAPImpl::AuthLDAPImpl(const std::string &user_name,
 
 AuthLDAPImpl::~AuthLDAPImpl() {}
 
-bool AuthLDAPImpl::bind(const std::string &user_dn,
-                        const std::string &password) {
+bool AuthLDAPImpl::bind_internal(const std::string &user_dn,
+                                 const std::string &password,
+                                 Pool::pool_ptr_t *conn_out) {
   log_srv_dbg("AuthLDAPImpl::bind()");
   bool success = false;
   std::ostringstream log_stream;
@@ -65,9 +85,36 @@ bool AuthLDAPImpl::bind(const std::string &user_dn,
   }
   log_srv_dbg(log_stream.str());
 
-  pool_->return_connection(conn);
+  if (conn_out == nullptr || !success) {
+    pool_->return_connection(conn);
+  } else {
+    *conn_out = conn;
+  }
 
   return success;
+}
+
+bool AuthLDAPImpl::bind(const std::string &user_dn,
+                        const std::string &password) {
+  return bind_internal(user_dn, password, nullptr);
+}
+
+bool AuthLDAPImpl::bind_and_get_mysql_uid(const std::string &user_dn,
+                                          const std::string &password,
+                                          std::string *user_mysql,
+                                          std::string *roles_mysql) {
+  // If we have a separate bind_root_dn configured, we'll use that
+  // Otherwise we'll try to query roles with the actual user, it should work in
+  // most cases
+  Pool::pool_ptr_t conn;
+  if (!bind_internal(user_dn, password, &conn)) {
+    return false;
+  }
+
+  bool ret = get_mysql_uid(user_mysql, roles_mysql, user_dn, &conn);
+  pool_->return_connection(conn);
+
+  return ret;
 }
 
 bool AuthLDAPImpl::get_ldap_uid(std::string *user_dn) {
@@ -91,15 +138,21 @@ bool AuthLDAPImpl::get_ldap_uid(std::string *user_dn) {
 }
 
 bool AuthLDAPImpl::get_mysql_uid(std::string *user_mysql,
-                                 const std::string &user_dn) {
+                                 std::string *roles_mysql,
+                                 const std::string &user_dn,
+                                 Pool::pool_ptr_t *use_conn) {
   log_srv_dbg("AuthLDAPImpl::get_mysql_uid()");
   if (user_dn.empty()) return false;
 
-  auto ldap_groups = search_ldap_groups(user_dn);
-  if (ldap_groups.size() == 0) return false;
+  auto ldap_groups = search_ldap_groups(user_dn, use_conn);
 
-  *user_mysql = calc_mysql_user(ldap_groups);
-  if (user_mysql->empty()) return false;
+  if (user_mysql != nullptr) {
+    if (ldap_groups.size() == 0) return false;
+    *user_mysql = calc_mysql_user(ldap_groups);
+    if (user_mysql->empty()) return false;
+  }
+
+  *roles_mysql = calc_mysql_roles(ldap_groups);
 
   return true;
 }
@@ -147,6 +200,19 @@ void AuthLDAPImpl::calc_mappings(const std::string &group_str) {
   }
 }
 
+std::string AuthLDAPImpl::calc_mysql_roles(const groups_t &groups) {
+  log_srv_dbg("AuthLDAPImpl::calc_mysql_roles()");
+  std::string roles;
+  for (const auto &group : groups) {
+    auto it = group_role_mapping_.find(group);
+    if (it != group_role_mapping_.end()) {
+      if (!roles.empty()) roles += ",";
+      roles += it->second;
+    }
+  }
+  return roles;
+}
+
 std::string AuthLDAPImpl::calc_mysql_user(const groups_t &groups) {
   log_srv_dbg("AuthLDAPImpl::calc_mysql_user()");
   for (const t_group_mapping &map : mappings_) {
@@ -184,17 +250,21 @@ bool AuthLDAPImpl::matched_map(const t_group_mapping &map,
   return matched;
 }
 
-groups_t AuthLDAPImpl::search_ldap_groups(const std::string &user_dn) {
+groups_t AuthLDAPImpl::search_ldap_groups(const std::string &user_dn,
+                                          Pool::pool_ptr_t *use_conn) {
   log_srv_dbg("AuthLDAPImpl::search_ldap_groups");
   groups_t list;
 
-  std::shared_ptr<Connection> conn = pool_->borrow_connection();
+  std::shared_ptr<Connection> conn =
+      use_conn != nullptr ? *use_conn : pool_->borrow_connection(true);
   if (conn == nullptr) return list;
 
   list = conn->search_groups(user_name_, user_dn, group_search_attr_,
                              group_search_filter_, bind_base_dn_);
 
-  pool_->return_connection(conn);
+  if (use_conn == nullptr) {
+    pool_->return_connection(conn);
+  }
 
   return list;
 }

--- a/plugin/auth_ldap/src/connection.cc
+++ b/plugin/auth_ldap/src/connection.cc
@@ -46,7 +46,7 @@ bool Connection::connect(const std::string &bind_dn,
                          const std::string &bind_pwd) {
   std::lock_guard<std::mutex> lock(conn_mutex_);
 
-  if(bind_pwd.empty()) {
+  if (bind_pwd.empty()) {
     return false;
   }
 

--- a/plugin/auth_ldap/src/plugin_common.cc
+++ b/plugin/auth_ldap/src/plugin_common.cc
@@ -36,7 +36,8 @@ int auth_ldap_common_authenticate_user(
     MYSQL_PLUGIN_VIO *vio [[maybe_unused]], MYSQL_SERVER_AUTH_INFO *info,
     const char *password, mysql::plugin::auth_ldap::Pool *pool,
     const char *user_search_attr, const char *group_search_attr,
-    const char *group_search_filter, const char *bind_base_dn) {
+    const char *group_search_filter, const char *bind_base_dn,
+    const char *group_role_mapping) {
   std::stringstream log_stream;
 
   log_srv_dbg("auth_ldap_common_authenticate_user()");
@@ -45,7 +46,8 @@ int auth_ldap_common_authenticate_user(
       std::make_unique<mysql::plugin::auth_ldap::AuthLDAPImpl>(
           str_or_empty(info->user_name), str_or_empty(info->auth_string),
           str_or_empty(user_search_attr), str_or_empty(group_search_filter),
-          str_or_empty(group_search_attr), str_or_empty(bind_base_dn), pool);
+          str_or_empty(group_search_attr), str_or_empty(bind_base_dn),
+          str_or_empty(group_role_mapping), pool);
 
   // Fin LDAP user dn
   std::string user_dn;
@@ -56,26 +58,25 @@ int auth_ldap_common_authenticate_user(
     return CR_AUTH_USER_CREDENTIALS;
   }
 
+  bool use_authenticated_as = strlen(info->authenticated_as) == 0;
+
+  // Proxy authentication
+  std::string user_mysql;
+  std::string roles_mysql;
+
   // Authenticate on ldap
-  if (!impl->bind(user_dn, str_or_empty(password))) {
+  if (!impl->bind_and_get_mysql_uid(
+          user_dn, str_or_empty(password),
+          use_authenticated_as ? &user_mysql : nullptr, &roles_mysql)) {
     log_stream << "LDAP user authentication failed for ["
                << str_or_empty(info->user_name) << "] as [" << user_dn << "]";
     log_srv_warn(log_stream.str());
     return CR_AUTH_USER_CREDENTIALS;
   }
 
-  if (strlen(info->authenticated_as) == 0) {
-    // Proxy authentication
-    std::string user_mysql;
-    if (impl->get_mysql_uid(&user_mysql, user_dn)) {
-      strcpy(info->authenticated_as, user_mysql.c_str());
-    } else {
-      log_stream << "MySQL user proxy not found for ["
-                 << str_or_empty(info->user_name) << "]";
-      log_srv_warn(log_stream.str());
-      return CR_AUTH_USER_CREDENTIALS;
-    }
-  }
+  if (use_authenticated_as)
+    strncpy(info->authenticated_as, user_mysql.c_str(), MYSQL_USERNAME_LENGTH);
+  strncpy(info->external_roles, roles_mysql.c_str(), 511);
 
   log_stream << "SUCCESS: auth_ldap_common_authenticate_user("
              << str_or_empty(info->user_name) << ") as ["

--- a/plugin/auth_ldap/src/pool.cc
+++ b/plugin/auth_ldap/src/pool.cc
@@ -5,6 +5,7 @@
 #include <thread>
 #include "my_sys.h"
 
+#include <boost/algorithm/string.hpp>
 #include "plugin/auth_ldap/include/plugin_log.h"
 
 namespace mysql {
@@ -110,6 +111,21 @@ void Pool::return_connection(pool_ptr_t conn) {
     if (bs_used_.count() >= std::ceil(pool_max_size_ * 0.9)) {
       std::thread t(&Pool::zombie_control, this);
       t.detach();
+    }
+  }
+}
+
+void Pool::reset_group_role_mapping(std::string const &mapping) {
+  std::vector<std::string> roles;
+  boost::algorithm::split(roles, mapping, boost::is_any_of(","));
+  group_role_mapping_.clear();
+  for (auto const &role : roles) {
+    std::vector<std::string> r;
+    boost::algorithm::split(r, role, boost::is_any_of("="));
+    if (r.size() == 1) {
+      group_role_mapping_[role] = role;
+    } else {
+      group_role_mapping_[r[0]] = r[1];
     }
   }
 }

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple-master.opt
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple-master.opt
@@ -1,3 +1,4 @@
 $AUTH_LDAP_OPT $AUTH_LDAP_LOAD
 --authentication_ldap_simple_server_host='$MTR_LDAP_HOST'
 --authentication_ldap_simple_server_port=$MTR_LDAP_PORT
+

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple.result
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple.result
@@ -1,3 +1,5 @@
+CREATE ROLE 'test_role';
+CREATE ROLE 'test_role2';
 SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME LIKE 'authentication_ldap_simple%';
 PLUGIN_NAME	PLUGIN_STATUS
 authentication_ldap_simple	ACTIVE
@@ -8,6 +10,7 @@ authentication_ldap_simple_bind_base_dn
 authentication_ldap_simple_bind_root_dn	
 authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
+authentication_ldap_simple_group_role_mapping	
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
 authentication_ldap_simple_init_pool_size	10
@@ -19,6 +22,7 @@ authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	uid
 SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
+SET GLOBAL authentication_ldap_simple_group_role_mapping = 'admin_staff=test_role';
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
@@ -26,6 +30,7 @@ authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
 authentication_ldap_simple_bind_root_dn	
 authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
+authentication_ldap_simple_group_role_mapping	admin_staff=test_role
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
 authentication_ldap_simple_init_pool_size	10
@@ -36,8 +41,33 @@ authentication_ldap_simple_server_port	<MTR_LDAP_PORT>
 authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	uid
-CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=John A. Zoidberg,ou=people,dc=planetexpress,dc=com';
+CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com';
 CREATE USER nonexistent IDENTIFIED WITH authentication_ldap_simple BY 'uid=nonexistent';
+SHOW GRANTS FOR 'zoidberg';
+Grants for zoidberg@%
+GRANT USAGE ON *.* TO `zoidberg`@`%`
+"should show test_role"
+SHOW GRANTS FOR 'zoidberg';
+Grants for zoidberg@%
+GRANT USAGE ON *.* TO `zoidberg`@`%`
+GRANT `test_role`@`%` TO `zoidberg`@`%`
+"should show test_role,test_role2"
+GRANT 'test_role2' TO zoidberg;
+SHOW GRANTS FOR 'zoidberg';
+Grants for zoidberg@%
+GRANT USAGE ON *.* TO `zoidberg`@`%`
+GRANT `test_role`@`%`,`test_role2`@`%` TO `zoidberg`@`%`
+FLUSH PRIVILEGES;
+"should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
+Grants for zoidberg@%
+GRANT USAGE ON *.* TO `zoidberg`@`%`
+GRANT `test_role`@`%`,`test_role2`@`%` TO `zoidberg`@`%`
+"should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
+Grants for zoidberg@%
+GRANT USAGE ON *.* TO `zoidberg`@`%`
+GRANT `test_role`@`%`,`test_role2`@`%` TO `zoidberg`@`%`
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 Variable_name	Value
 authentication_ldap_simple_auth_method_name	SIMPLE
@@ -45,6 +75,7 @@ authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
 authentication_ldap_simple_bind_root_dn	
 authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
+authentication_ldap_simple_group_role_mapping	admin_staff=test_role
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
 authentication_ldap_simple_init_pool_size	10
@@ -56,7 +87,22 @@ authentication_ldap_simple_ssl	OFF
 authentication_ldap_simple_tls	OFF
 authentication_ldap_simple_user_search_attr	uid
 ERROR 28000: Access denied for user 'nonexistent'@'localhost' (using password: YES)
+"should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
+Grants for zoidberg@%
+GRANT USAGE ON *.* TO `zoidberg`@`%`
+GRANT `test_role`@`%`,`test_role2`@`%` TO `zoidberg`@`%`
+REVOKE test_role FROM zoidberg;
+ERROR HY000: The role test_role is a dynamic role and can't be revoked or dropped. It should be managed by the external authentication plugin instead.
+"should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
+Grants for zoidberg@%
+GRANT USAGE ON *.* TO `zoidberg`@`%`
+GRANT `test_role`@`%`,`test_role2`@`%` TO `zoidberg`@`%`
 DROP USER zoidberg;
 DROP USER nonexistent;
+DROP ROLE test_role;
+DROP ROLE test_role2;
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
 SET GLOBAL authentication_ldap_simple_log_status = 1;
+SET GLOBAL authentication_ldap_simple_group_role_mapping = '';

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple.test
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple.test
@@ -5,20 +5,46 @@
 
 --source include/count_sessions.inc
 
+CREATE ROLE 'test_role';
+CREATE ROLE 'test_role2';
+
 SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME LIKE 'authentication_ldap_simple%';
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
+SET GLOBAL authentication_ldap_simple_group_role_mapping = 'admin_staff=test_role';
 
 # For debugging:
 # SET GLOBAL authentication_ldap_simple_log_status = 6;
 
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
-CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=John A. Zoidberg,ou=people,dc=planetexpress,dc=com';
+CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com';
 CREATE USER nonexistent IDENTIFIED WITH authentication_ldap_simple BY 'uid=nonexistent';
 
---connect (con1,localhost,zoidberg,zoidberg,,,,CLEARTEXT)
+# Note: role not shown at this point, as the user never logged on
+SHOW GRANTS FOR 'zoidberg';
+
+--connect (con1,localhost,zoidberg,hermes,,,,CLEARTEXT)
+
+# Note: role shown as it was added to the auth cache
+--echo "should show test_role"
+SHOW GRANTS FOR 'zoidberg';
+
+--connection default
+--echo "should show test_role,test_role2"
+GRANT 'test_role2' TO zoidberg;
+
+SHOW GRANTS FOR 'zoidberg';
+
+FLUSH PRIVILEGES;
+
+--echo "should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
+
+--connection con1
+--echo "should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
 
 --replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
@@ -31,9 +57,23 @@ SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 --connect (con1,localhost,nonexistent,zoidberg,,,,CLEARTEXT)
 --enable_query_log
 
+# Note: role remains in the in memory auth cache... should we allow that?
+--echo "should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
+
+--error ER_DYNAMIC_ROLE
+REVOKE test_role FROM zoidberg;
+
+# Note: revoke role fails, role should be removed from LDAP
+--echo "should show test_role,test_role2"
+SHOW GRANTS FOR 'zoidberg';
+
 DROP USER zoidberg;
 DROP USER nonexistent;
+DROP ROLE test_role;
+DROP ROLE test_role2;
 SET GLOBAL authentication_ldap_simple_bind_base_dn = '';
 SET GLOBAL authentication_ldap_simple_log_status = 1;
+SET GLOBAL authentication_ldap_simple_group_role_mapping = '';
 
 --source include/wait_until_count_sessions.inc

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -9924,6 +9924,9 @@ ER_TOO_MANY_ERROR_CODES
 ER_TOO_BIG_ERROR_CODE
   eng "Provided error code is bigger than maximum allowed %lu"
 
+ER_DYNAMIC_ROLE
+  eng "The role %s is a dynamic role and can't be revoked or dropped. It should be managed by the external authentication plugin instead."
+
 #
 # End of Percona Server 8.0 client messages
 #

--- a/sql/auth/role_tables.cc
+++ b/sql/auth/role_tables.cc
@@ -21,6 +21,7 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include "sql/auth/role_tables.h"
+#include "sql/auth/sql_authentication.h"
 
 #include <string.h>
 #include <memory>
@@ -329,6 +330,26 @@ bool populate_roles_caches(THD *thd, TABLE_LIST *tablelst) {
     }
     rebuild_vertex_index(thd);
     opt_mandatory_roles_cache = false;
+  }
+
+  // Re-grant external roles provided by authentication plugins
+  for (const auto &p : g_external_roles) {
+    const char *host = p.first.second.c_str();
+    const char *username = p.first.first.c_str();
+    ACL_USER *acl_user = find_acl_user(host, username, true);
+    if (acl_user == nullptr) {
+      continue;
+    }
+
+    for (const auto &r : p.second) {
+      const char *host2 = r.second.c_str();
+      const char *name = r.first.c_str();
+      ACL_USER *acl_role = find_acl_user(host2, name, false);
+      if (acl_role == nullptr) {
+        continue;
+      }
+      grant_role(acl_role, acl_user, false);
+    }
   }
 
   return false;

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -37,6 +37,7 @@
 #include <utility>
 #include <vector> /* std::vector */
 
+#include "boost/algorithm/string.hpp"
 #include "crypt_genhash_impl.h"  // generate_user_salt
 #include "include/compression.h"
 #include "m_string.h"
@@ -1080,6 +1081,7 @@ plugin_ref Cached_authentication_plugins::get_cached_plugin_ref(
   return cached_plugin;
 }
 
+external_roles_t g_external_roles;
 Cached_authentication_plugins *g_cached_authentication_plugins = nullptr;
 
 bool disconnect_on_expired_password = true;
@@ -4014,6 +4016,28 @@ int acl_authenticate(THD *thd, enum_server_command command) {
       assert(mpvio.restrictions);
       sctx->set_master_access(acl_user->access, *(mpvio.restrictions));
       assign_priv_user_host(sctx, const_cast<ACL_USER *>(acl_user));
+
+      if (acl_user->user != nullptr) {
+        // Adding external roles
+        Acl_cache_lock_guard acl_cache_lock2(thd,
+                                             Acl_cache_lock_mode::WRITE_MODE);
+        acl_cache_lock2.lock();
+        const name_and_host_t u(std::string(acl_user->user),
+                                std::string(acl_user->host.get_host()));
+        if (g_external_roles.find(u) != g_external_roles.end())
+          g_external_roles[u].clear();
+        std::vector<std::string> roles;
+        boost::algorithm::split(roles, mpvio.auth_info.external_roles,
+                                boost::is_any_of(","));
+        for (const auto &role : roles) {
+          ACL_USER *acl_role = find_acl_user("", role.c_str(), false);
+          if (acl_role != nullptr && acl_role->user != nullptr) {
+            grant_role(acl_role, acl_user, false);
+            const name_and_host_t r(std::string(acl_role->user), "");
+            g_external_roles[u].push_back(r);
+          }
+        }
+      }
       /* Assign default role */
       {
         List_of_auth_id_refs default_roles;

--- a/sql/auth/sql_authentication.h
+++ b/sql/auth/sql_authentication.h
@@ -240,6 +240,10 @@ class Cached_authentication_plugins {
   bool m_valid;
 };
 
+using name_and_host_t = std::pair<std::string, std::string>;
+using external_roles_t =
+    std::map<name_and_host_t, std::vector<name_and_host_t>>;
+extern external_roles_t g_external_roles;
 extern Cached_authentication_plugins *g_cached_authentication_plugins;
 
 ACL_USER *decoy_user(const LEX_CSTRING &username, const LEX_CSTRING &hostname,

--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -90,6 +90,7 @@
 #include "sql/auth/role_tables.h"
 #include "sql/auth/roles.h"
 #include "sql/auth/sql_auth_cache.h"
+#include "sql/auth/sql_authentication.h"
 #include "sql/auth/sql_security_ctx.h"
 #include "sql/auth/sql_user_table.h"
 #include "sql/current_thd.h"
@@ -3181,6 +3182,33 @@ bool mysql_revoke_role(THD *thd, const List<LEX_USER> *users,
         }
       }
     }
+
+    while ((lex_user = users_it++)) {
+      for (const auto &p : g_external_roles) {
+        const char *host = p.first.second.c_str();
+        const char *username = p.first.first.c_str();
+        if (strcmp(username, lex_user->user.str) ||
+            strcmp(host, lex_user->host.str)) {
+          continue;
+        }
+
+        roles_it.rewind();
+        while (LEX_USER *role = roles_it++) {
+          for (const auto &r : p.second) {
+            const char *name = r.first.c_str();
+            Role_id id(role->user.str, "");
+            Role_id id2(name, "");
+            if (id == id2) {
+              my_error(ER_DYNAMIC_ROLE, MYF(0), role->user.str);
+              commit_and_close_mysql_tables(thd);
+              return true;
+            }
+          }
+        }
+      }
+    }
+
+    users_it.rewind();
     while ((lex_user = users_it++) && !errors) {
       roles_it.rewind();
       if (lex_user->user.str == nullptr) {


### PR DESCRIPTION
This patch adds the ability to provide roles from an external source to
MySQL users with authentication plugins, and adds a simple LDAP
implementation.

How it works:

We extend the authentication info structure used by authentication
plugins by one more type, which should contain role names.

During authorization, the server will automatically add these to the in
memory cache, but not to the persisted mysql database. This means that
the roles will shouw up on queries working on the cache, such as SHOW
GRANTS, but will be invisible on queries working on the persisted
database.

Another limitation is that in the current implementation, external roles
are only populated when a user logs on. Users who didn't log on since
the server was started will only show persisted roles.

If needed, both of these could be changed in the future - for example by
adding another column to the role mappings (showing that it's an
externally managed role) they could be persisted.

We could also extend the plugin API to provide additional methods for
checking external changes automatically - for example by using a
background thread.

As permissions are only important when a user actually logs in, these
were omitted from this first version.

Interaction with related SQL commands:

* FLUSH PRIVILEGES reloads the in memory cache from the persisted
  database. With this patch we also track external roles separately, and
  automatically re-add them at the same place. This way once an external
  node gets added, it will always stay visible.
* External roles are rechecked for every login. If the list changes in
  the external database,those changes will be reflected in the new
  session
* For now we allow REVOKEing external roles - but they will be readded
  automatically during the next login. Maybe it would be a better
  solution to disable REVOKE for these with an error message explaining
  that they should be removed in the external application.