### PR TITLE
PS-8145: Fix MYSQL_LEX_CSTRING initialization in sql_audit::mysql_audit_notify() (8.0)

### DIFF
--- a/sql/sql_audit.cc
+++ b/sql/sql_audit.cc
@@ -484,9 +484,8 @@ int mysql_audit_notify(THD *thd, mysql_event_general_subclass_t subclass,
         cmd_class_lowercase= msg;
         std::transform(cmd_class_lowercase.begin(), cmd_class_lowercase.end(),
                        cmd_class_lowercase.begin(), ::tolower);
-        MYSQL_LEX_CSTRING command_class= {
-            STRING_WITH_LEN(cmd_class_lowercase.c_str())};
-        event.general_sql_command= command_class;
+        event.general_sql_command.str = cmd_class_lowercase.c_str();
+        event.general_sql_command.length = cmd_class_lowercase.length();
         break;
       }
     }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8145

The sizeof(const char *) was used as a string length during general_sql_command
initialization mysql_event_general_subclass_t audit event. As a result
there was wrong string length in some cases.
Changed it to use std::string::length() to properly initialize string
length.