### PR TITLE
PS-8143: Fix memory leak in File_query_log::set_rotated_name() (5.7)

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2282,6 +2282,9 @@ bool File_query_log::set_rotated_name(const bool need_lock)
     }
 
     if (need_lock) mysql_mutex_lock(&LOCK_global_system_variables);
+    if (opt_slow_logname != NULL) {
+      my_free(opt_slow_logname);
+    }
     opt_slow_logname = my_strdup(key_memory_LOG_name, log_file_name, MYF(MY_WME));
     if (need_lock) mysql_mutex_unlock(&LOCK_global_system_variables);
   }

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3377,7 +3377,10 @@ int init_common_variables()
   FIX_LOG_VAR(opt_general_logname,
               make_query_log_name(logname_path, QUERY_LOG_GENERAL));
   FIX_LOG_VAR(opt_slow_logname,
-              make_query_log_name(slow_logname_path, QUERY_LOG_SLOW));
+              my_strdup(
+                  key_memory_LOG_name,
+                  make_query_log_name(slow_logname_path, QUERY_LOG_SLOW),
+                  MYF(MY_WME)));
 
 #if defined(ENABLED_DEBUG_SYNC)
   /* Initialize the debug sync facility. See debug_sync.cc. */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5432,7 +5432,7 @@ static Sys_var_charptr Sys_slow_log_path(
        "slow_query_log_file", "Log slow queries to given log file. "
        "Defaults logging to hostname-slow.log. Must be enabled to activate "
        "other slow log options",
-       GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG),
+       PREALLOCATED GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG),
        IN_FS_CHARSET, DEFAULT(0), NO_MUTEX_GUARD, NOT_IN_BINLOG,
        ON_CHECK(check_log_path), ON_UPDATE(fix_slow_log_file));
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8143

The opt_slow_logname now uses allocated memory to keep file path.
Make sure previously allocated memory is freed when generating
rotated file name. Also add PREALLOCATED flag in variable declaration.