### PR TITLE
PS-8143: Fix memory leak in File_query_log::set_rotated_name() (8.0)

### DIFF
--- a/sql/log.cc
+++ b/sql/log.cc
@@ -2182,6 +2182,9 @@ bool File_query_log::set_rotated_name(const bool need_lock) {
     }
 
     if (need_lock) mysql_mutex_lock(&LOCK_global_system_variables);
+    if (opt_slow_logname != NULL) {
+      my_free(opt_slow_logname);
+    }
     opt_slow_logname =
         my_strdup(key_memory_LOG_name, log_file_name, MYF(MY_WME));
     if (need_lock) mysql_mutex_unlock(&LOCK_global_system_variables);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5359,7 +5359,9 @@ int init_common_variables() {
   FIX_LOG_VAR(opt_general_logname,
               make_query_log_name(logname_path, QUERY_LOG_GENERAL));
   FIX_LOG_VAR(opt_slow_logname,
-              make_query_log_name(slow_logname_path, QUERY_LOG_SLOW));
+              my_strdup(key_memory_LOG_name,
+                        make_query_log_name(slow_logname_path, QUERY_LOG_SLOW),
+                        MYF(MY_WME)));
 
 #if defined(ENABLED_DEBUG_SYNC)
   /* Initialize the debug sync facility. See debug_sync.cc. */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6070,9 +6070,9 @@ static Sys_var_charptr Sys_slow_log_path(
     "Log slow queries to given log file. "
     "Defaults logging to hostname-slow.log. Must be enabled to activate "
     "other slow log options",
-    GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET,
-    DEFAULT(nullptr), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_log_path),
-    ON_UPDATE(fix_slow_log_file));
+    PREALLOCATED GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG),
+    IN_FS_CHARSET, DEFAULT(nullptr), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+    ON_CHECK(check_log_path), ON_UPDATE(fix_slow_log_file));
 
 static Sys_var_have Sys_have_compress(
     "have_compress", "have_compress",


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8143

The opt_slow_logname now uses allocated memory to keep file path.
Make sure previously allocated memory is freed when generating
rotated file name. Also add PREALLOCATED flag in variable declaration.

(cherry picked from commit 4b5212cbf7e9a23166bfb7f3dd752c155915c868)