### PR TITLE
PS-8116 IMPORT TABLESPACE with different data directory fails

### DIFF
--- a/mysql-test/suite/innodb/r/bug76142.result
+++ b/mysql-test/suite/innodb/r/bug76142.result
@@ -1,7 +1,6 @@
 #
 # Bug 76142: InnoDB tablespace import fails when importing table w/ different data directory
 #
-CALL mtr.add_suppression("InnoDB: The table .* doesn't have a corresponding tablespace, it was discarded");
 CREATE TABLE t1 (a INT PRIMARY KEY) ENGINE=InnoDB;
 INSERT INTO t1 VALUES (1);
 CREATE TABLE t2 (a INT PRIMARY KEY) ENGINE=InnoDB DATA DIRECTORY='MYSQL_TMP_DIR';
@@ -11,21 +10,17 @@ UNLOCK TABLES;
 ALTER TABLE t2 DISCARD TABLESPACE;
 FLUSH TABLE t1 FOR EXPORT;
 UNLOCK TABLES;
-ALTER TABLE t1 DISCARD TABLESPACE;
-ALTER TABLE t2 IMPORT TABLESPACE;
-ERROR HY000: Schema mismatch (Table location flags do not match. The source table does not use a DATA DIRECTORY but the destination table does.)
-ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Schema mismatch (Table location flags do not match. The source table uses a DATA DIRECTORY but the destination table does not.)
-ALTER TABLE t1 IMPORT TABLESPACE;
-INSERT INTO t1 VALUES (4);
 ALTER TABLE t2 IMPORT TABLESPACE;
 INSERT INTO t2 VALUES (2);
+ALTER TABLE t1 DISCARD TABLESPACE;
+ALTER TABLE t1 IMPORT TABLESPACE;
+INSERT INTO t1 VALUES (4);
 SELECT * FROM t1;
 a
-1
+3
 4
 SELECT * FROM t2;
 a
+1
 2
-3
 DROP TABLE t1, t2;

--- a/mysql-test/suite/innodb/r/import_tablespace_schema_missmatch.result
+++ b/mysql-test/suite/innodb/r/import_tablespace_schema_missmatch.result
@@ -11,7 +11,8 @@ DROP TABLE t1;
 CREATE TABLE t1 (id int unsigned NOT NULL PRIMARY KEY);
 ALTER TABLE t1 DISCARD TABLESPACE;
 ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Schema mismatch (Table location flags do not match. The source table uses a DATA DIRECTORY but the destination table does not.)
+Warnings:
+Warning	1810	InnoDB: IO Read error: (2, No such file or directory) Error opening './test/t1.cfg', will attempt to import without schema verification
 DROP TABLE t1;
 #
 # Test-case-2
@@ -21,9 +22,15 @@ FLUSH TABLES t1 FOR EXPORT;
 UNLOCK TABLES;
 DROP TABLE t1;
 CREATE TABLE t1 (id int unsigned NOT NULL PRIMARY KEY) DATA DIRECTORY='MYSQL_TMP_DIR/alt_dir';
+SELECT * from t1;
+id
 ALTER TABLE t1 DISCARD TABLESPACE;
 ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Schema mismatch (Table location flags do not match. The source table does not use a DATA DIRECTORY but the destination table does.)
+SELECT * FROM t1;
+id
+1
+2
+3
 DROP TABLE t1;
 #
 # Bug #30190199 ERROR WHEN IMPORTING TABLESPACE WITH DIFFERENT DATA
@@ -38,7 +45,6 @@ DROP TABLE t1;
 CREATE TABLE t1 (id int unsigned NOT NULL PRIMARY KEY);
 ALTER TABLE t1 DISCARD TABLESPACE;
 ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Schema mismatch (Table location flags do not match. The source table uses a DATA DIRECTORY but the destination table does not.)
 DROP TABLE t1;
 #
 # Test-case-4
@@ -50,7 +56,6 @@ DROP TABLE t1;
 CREATE TABLE t1 (id int unsigned NOT NULL PRIMARY KEY) DATA DIRECTORY='MYSQL_TMP_DIR/alt_dir';
 ALTER TABLE t1 DISCARD TABLESPACE;
 ALTER TABLE t1 IMPORT TABLESPACE;
-ERROR HY000: Schema mismatch (Table location flags do not match. The source table does not use a DATA DIRECTORY but the destination table does.)
 DROP TABLE t1;
 #
 # Cleanup

--- a/mysql-test/suite/innodb/t/bug76142.test
+++ b/mysql-test/suite/innodb/t/bug76142.test
@@ -4,8 +4,6 @@
 --echo # Bug 76142: InnoDB tablespace import fails when importing table w/ different data directory
 --echo #
 
-CALL mtr.add_suppression("InnoDB: The table .* doesn't have a corresponding tablespace, it was discarded");
-
 --let $MYSQLD_DATADIR = `SELECT @@datadir`
 --let $DB = `SELECT DATABASE()`
 
@@ -28,29 +26,15 @@ FLUSH TABLE t1 FOR EXPORT;
 --copy_file $MYSQLD_DATADIR/$DB/t1.ibd $MYSQL_TMP_DIR/$DB/t2.ibd
 UNLOCK TABLES;
 
-ALTER TABLE t1 DISCARD TABLESPACE;
-
---error ER_TABLE_SCHEMA_MISMATCH
 ALTER TABLE t2 IMPORT TABLESPACE;
+INSERT INTO t2 VALUES (2);
 
---copy_file $MYSQLD_DATADIR/$DB/temp.cfg $MYSQLD_DATADIR/$DB/t1.cfg
---copy_file $MYSQLD_DATADIR/$DB/temp.ibd $MYSQLD_DATADIR/$DB/t1.ibd
-
---error ER_TABLE_SCHEMA_MISMATCH
-ALTER TABLE t1 IMPORT TABLESPACE;
-
-
---move_file $MYSQL_TMP_DIR/$DB/t2.cfg $MYSQLD_DATADIR/$DB/t1.cfg
---move_file $MYSQL_TMP_DIR/$DB/t2.ibd $MYSQLD_DATADIR/$DB/t1.ibd
-
---move_file $MYSQLD_DATADIR/$DB/temp.cfg $MYSQL_TMP_DIR/$DB/t2.cfg
---move_file $MYSQLD_DATADIR/$DB/temp.ibd $MYSQL_TMP_DIR/$DB/t2.ibd
+ALTER TABLE t1 DISCARD TABLESPACE;
+--move_file $MYSQLD_DATADIR/$DB/temp.cfg $MYSQLD_DATADIR/$DB/t1.cfg
+--move_file $MYSQLD_DATADIR/$DB/temp.ibd $MYSQLD_DATADIR/$DB/t1.ibd
 
 ALTER TABLE t1 IMPORT TABLESPACE;
 INSERT INTO t1 VALUES (4);
-
-ALTER TABLE t2 IMPORT TABLESPACE;
-INSERT INTO t2 VALUES (2);
 
 SELECT * FROM t1;
 SELECT * FROM t2;

--- a/mysql-test/suite/innodb/t/import_tablespace_schema_missmatch.test
+++ b/mysql-test/suite/innodb/t/import_tablespace_schema_missmatch.test
@@ -23,11 +23,9 @@ CREATE TABLE t1 (id int unsigned NOT NULL PRIMARY KEY);
 ALTER TABLE t1 DISCARD TABLESPACE;
 
 --move_file $MYSQL_TMP_DIR/t1.ibd $MYSQLD_DATADIR/$DB/t1.ibd
---error ER_TABLE_SCHEMA_MISMATCH
 
 ALTER TABLE t1 IMPORT TABLESPACE;
 DROP TABLE t1;
---remove_file $MYSQLD_DATADIR/$DB/t1.ibd
 
 --echo #
 --echo # Test-case-2
@@ -44,14 +42,16 @@ UNLOCK TABLES;
 DROP TABLE t1;
 --replace_result $MYSQL_TMP_DIR MYSQL_TMP_DIR
 eval CREATE TABLE t1 (id int unsigned NOT NULL PRIMARY KEY) $data_directory;
+SELECT * from t1;
 ALTER TABLE t1 DISCARD TABLESPACE;
 
 --move_file $MYSQL_TMP_DIR/t1.ibd $MYSQL_TMP_DIR/alt_dir/$DB/t1.ibd
 
---error ER_TABLE_SCHEMA_MISMATCH
+--disable_warnings
 ALTER TABLE t1 IMPORT TABLESPACE;
+--enable_warnings
+SELECT * FROM t1;
 DROP TABLE t1;
---remove_file $MYSQL_TMP_DIR/alt_dir/$DB/t1.ibd
 
 
 --echo #
@@ -78,11 +78,8 @@ ALTER TABLE t1 DISCARD TABLESPACE;
 --move_file $MYSQL_TMP_DIR/t1.cfg $MYSQLD_DATADIR/$DB/t1.cfg
 --move_file $MYSQL_TMP_DIR/t1.ibd $MYSQLD_DATADIR/$DB/t1.ibd
 
---error ER_TABLE_SCHEMA_MISMATCH
 ALTER TABLE t1 IMPORT TABLESPACE;
 DROP TABLE t1;
---remove_file $MYSQLD_DATADIR/$DB/t1.ibd
---remove_file $MYSQLD_DATADIR/$DB/t1.cfg
 
 --echo #
 --echo # Test-case-4
@@ -105,11 +102,8 @@ ALTER TABLE t1 DISCARD TABLESPACE;
 --move_file $MYSQL_TMP_DIR/t1.ibd $MYSQL_TMP_DIR/alt_dir/$DB/t1.ibd
 --move_file $MYSQL_TMP_DIR/t1.cfg $MYSQL_TMP_DIR/alt_dir/$DB/t1.cfg
 
---error ER_TABLE_SCHEMA_MISMATCH
 ALTER TABLE t1 IMPORT TABLESPACE;
 DROP TABLE t1;
---remove_file $MYSQL_TMP_DIR/alt_dir/$DB/t1.ibd
---remove_file $MYSQL_TMP_DIR/alt_dir/$DB/t1.cfg
 
 --echo #
 --echo # Cleanup

--- a/storage/innobase/fil/fil0fil.cc
+++ b/storage/innobase/fil/fil0fil.cc
@@ -795,8 +795,13 @@ retry:
 				<< ib::hex(space->flags) << ")!";
 		}
 
-		unsigned relevant_space_flags = space->flags;
-		unsigned relevant_flags = flags;
+
+		/* Validate the flags but do not compare the data directory
+		flag, in case this tablespace was relocated. */
+		unsigned relevant_space_flags
+			= space->flags & ~FSP_FLAGS_MASK_DATA_DIR;
+		unsigned relevant_flags
+			= flags & ~FSP_FLAGS_MASK_DATA_DIR;
 
                 // in case of Keyring encryption it can so happen that there will be a crash after all pages of tablespace is rotated
                 // and DD is updated, but page0 of the tablespace has not been yet update. We handle this here.

--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -1321,28 +1321,20 @@ row_import::match_schema(
 	THD*		thd) UNIV_NOTHROW
 {
 	/* Do some simple checks. */
+	const unsigned relevant_flags = m_flags & ~DICT_TF_MASK_DATA_DIR;
+	const unsigned relevant_table_flags =
+	    m_table->flags & ~DICT_TF_MASK_DATA_DIR;
 
-	if (m_flags != m_table->flags) {
-		if (dict_tf_to_row_format_string(m_flags) !=
-				dict_tf_to_row_format_string(m_table->flags)) {
+	if (relevant_flags != relevant_table_flags) {
+		if (dict_tf_to_row_format_string(relevant_flags) !=
+			dict_tf_to_row_format_string(relevant_table_flags)) {
 			ib_errf(thd, IB_LOG_LEVEL_ERROR, ER_TABLE_SCHEMA_MISMATCH,
 				 "Table flags don't match, server table has %s"
 				 " and the meta-data file has %s",
-				(const char*)dict_tf_to_row_format_string(m_table->flags),
-				(const char*)dict_tf_to_row_format_string(m_flags));
-		} else if (DICT_TF_HAS_DATA_DIR(m_flags) !=
-				DICT_TF_HAS_DATA_DIR(m_table->flags)) {
-			/* If the meta-data flag is set for data_dir,
-			but table flag is not set for data_dir or vice versa
-			then return error. */
-			ib_errf(thd, IB_LOG_LEVEL_ERROR, ER_TABLE_SCHEMA_MISMATCH,
-				"Table location flags do not match. "
-				"The source table %s a DATA DIRECTORY "
-				"but the destination table %s.",
-				(DICT_TF_HAS_DATA_DIR(m_flags) ? "uses"
-				: "does not use"),
-				(DICT_TF_HAS_DATA_DIR(m_table->flags) ? "does"
-				: "does not"));
+				(const char*)dict_tf_to_row_format_string(
+					         relevant_table_flags),
+				(const char*)dict_tf_to_row_format_string(
+					         relevant_flags));
 		} else {
 			ib_errf(thd, IB_LOG_LEVEL_ERROR, ER_TABLE_SCHEMA_MISMATCH,
 				"Table flags don't match");
@@ -3673,7 +3665,6 @@ row_import_for_mysql(
 	rw_lock_s_lock_func(dict_operation_lock, 0, __FILE__, __LINE__);
 
 	row_import	cfg;
-	ulint		space_flags = 0;
 
 	/* Read CFP file */
 	if (dict_table_is_encrypted(table)) {
@@ -3765,25 +3756,6 @@ row_import_for_mysql(
 			}
 		}
 
-		space_flags = fetchIndexRootPages.get_space_flags();
-
-		/* If the fsp flag is set for data_dir, but table flag is not
-		set for data_dir or vice versa then return error. */
-		if (err == DB_SUCCESS
-			&& FSP_FLAGS_HAS_DATA_DIR(space_flags) !=
-			DICT_TF_HAS_DATA_DIR(table->flags)) {
-			ib_errf(trx->mysql_thd, IB_LOG_LEVEL_ERROR,
-				ER_TABLE_SCHEMA_MISMATCH,
-				"Table location flags do not match. "
-				"The source table %s a DATA DIRECTORY "
-				"but the destination table %s.",
-				(FSP_FLAGS_HAS_DATA_DIR(space_flags) ? "uses"
-				: "does not use"),
-				(DICT_TF_HAS_DATA_DIR(table->flags) ? "does"
-				: "does not"));
-			err = DB_ERROR;
-			return(row_import_error(prebuilt, trx, err));
-		}
 
 	} else {
 		rw_lock_s_unlock_gen(dict_operation_lock, 0);


### PR DESCRIPTION
 PS-8116 IMPORT TABLESPACE with different data directory fails
    https://jira.percona.com/browse/PS-8116

    Problem:
    Reimplement Import tablespace with different data directory.
    https://jira.percona.com/browse/PS-1697

    Feature was removed in 8.0.20 and 5.7.30 due to upstream marking
    mismatch in data directory as an error.
    https://github.com/mysql/mysql-server/commit/9909cd94f896

    Introduce the support again in 5.7 and 8.0