### PR TITLE
Fixed PS-8174 - Assertion failure: buf0flu.cc:3567:UT_LIST_GET_LEN(bu…

### DIFF
--- a/storage/innobase/buf/buf0buf.cc
+++ b/storage/innobase/buf/buf0buf.cc
@@ -429,6 +429,24 @@ buf_pool_get_oldest_modification(void)
 	return(oldest_lsn);
 }
 
+ulint
+buf_get_flush_list_len(const buf_pool_t *buf_pool) {
+	ulint pages = 0;
+	if (buf_pool == NULL) {
+		for (ulint i = 0; i < srv_buf_pool_instances; i++) {
+			buf_pool_t *buf_pool_instance;
+
+			buf_pool_instance = buf_pool_from_array(i);
+
+			pages +=
+			    UT_LIST_GET_LEN(buf_pool_instance->flush_list);
+		}
+	} else {
+		pages = UT_LIST_GET_LEN(buf_pool->flush_list);
+	}
+	return (pages);
+}
+
 /********************************************************************//**
 Get total buffer pool statistics. */
 void

--- a/storage/innobase/buf/buf0flu.cc
+++ b/storage/innobase/buf/buf0flu.cc
@@ -3494,7 +3494,9 @@ DECLARE_THREAD(buf_flush_page_cleaner_coordinator)(
 
 		buf_flush_wait_batch_end(NULL, BUF_FLUSH_LIST);
 
-	} while (!success || n_flushed > 0);
+	} while (!success || n_flushed > 0 ||
+		 buf_get_n_pending_read_ios() > 0 ||
+		 buf_get_flush_list_len(NULL) > 0);
 
 	/* Some sanity checks */
 	ut_a(srv_get_active_thread_type() == SRV_NONE);

--- a/storage/innobase/include/buf0buf.h
+++ b/storage/innobase/include/buf0buf.h
@@ -1484,6 +1484,12 @@ buf_pool_watch_occurred(
 	const page_id_t&	page_id)
 MY_ATTRIBUTE((warn_unused_result));
 
+/** Get the current length of the flush list.
+@param[in] buf_pool buffer pool instance or nullptr to all instances
+@return number of pages in flush list */
+ulint
+buf_get_flush_list_len(const buf_pool_t *buf_pool);
+
 /********************************************************************//**
 Get total buffer pool statistics. */
 void


### PR DESCRIPTION
…f_pool->flush_list) == 0

https://jira.percona.com/browse/PS-8174

Problem:
There is a possibility that at shutdown by the time we do the last
sweep on flushing the buffer pool there are still pages in the flush
list. Those pages are still marked as io_fix->BUF_IO_READ thus they are
not eligible for flushing from flush_list.

Where is the workflow:

1. ibuf_merge_in_background requested those pages to be read in order to
merge the ibuf changes. This will mark the page as BUF_IO_READ and
increment buf_pool->n_pend_reads by 1.
2. When IO threads pick them up, it will start to merge the insert
bugger changes.
3. On the first change, it will add the page to flush_list.
4. If there are more changes to apply, it will and continue on applying
the changes until it is done.
5. Once the io thread finishes applying ibuf records to this page, it
will mark the page as BUF_IO_NONE
6. the io thread decreases buf_pool->n_pend_reads by 1.

The last sweep on flushing buffer pool considers the round of flushes
completed when n_flushed == 0 which is not correct, if it runs when we
are at step 4.

Also, there is a still another race condition that by the time we tried
to flush a page it was still marked as BUF_IO_READ (step 5), but when
the page cleaner code checks buf_get_n_pending_read_ios, the IO thread
has already decremented leaving one last page on flush_list.

Fix:

For the last round flushing pages at shutdown, only consider the flush
completed if there are no pending read io operations and flush_list size
is 0.