### PR TITLE
PS-8155: Implement multiple LDAP server support

### DIFF
--- a/plugin/auth_ldap/include/connection.h
+++ b/plugin/auth_ldap/include/connection.h
@@ -34,17 +34,16 @@ class Connection {
   static const unsigned ZombieAfterSeconds = 120;
 
   Connection(std::size_t idx, const std::string &ldap_host,
-             std::uint16_t ldap_port, bool use_ssl, bool use_tls,
-             const std::string &ca_path);
+             std::uint16_t ldap_port, const std::string &fallback_host,
+             std::uint16_t fallback_port, bool use_ssl, bool use_tls);
   ~Connection();
 
- public:
   Connection(const Connection &) = delete;  // non construction-copyable
   Connection &operator=(const Connection &) = delete;  // non copyable
 
- public:
   void configure(const std::string &ldap_host, std::uint16_t ldap_port,
-                 bool use_ssl, bool use_tls, const std::string &ca_path);
+                 const std::string &fallback_host, std::uint16_t fallback_port,
+                 bool use_ssl, bool use_tls);
   bool connect(const std::string &bind_dn, const std::string &bind_pwd);
   std::size_t get_idx_pool() const;
   bool is_snipped() const;
@@ -61,22 +60,24 @@ class Connection {
                          const std::string &group_search_filter,
                          const std::string &base_dn);
 
- private:
-  std::string get_ldap_uri();
-  void log_error(const std::string &str, int ldap_err);
-  void log_warning(const std::string &str, int ldap_err);
+  static void initialize_global_ldap_parameters(bool enable_debug,
+                                                std::string const &ca_path);
 
  private:
+  std::string get_ldap_uri();
+  static void log_error(const std::string &str, int ldap_err);
+  static void log_warning(const std::string &str, int ldap_err);
+
   bool available_;
   std::size_t index_;
   std::atomic<bool> snipped_;
   std::string ldap_host_;
   std::uint16_t ldap_port_;
+  std::string ldap_fallback_host_;
+  std::uint16_t ldap_fallback_port_;
   bool use_ssl_;
   bool use_tls_;
-  std::string ca_path_;
 
- private:
   std::time_t borrowed_ts_;
   std::mutex conn_mutex_;
   LDAP *ldap_;

--- a/plugin/auth_ldap/include/log_client.h
+++ b/plugin/auth_ldap/include/log_client.h
@@ -33,6 +33,7 @@ namespace plugin {
 namespace auth_ldap {
 struct ldap_log_type {
   enum ldap_type {
+    LDAP_LOG_LDAP_DBG,
     LDAP_LOG_DBG,
     LDAP_LOG_INFO,
     LDAP_LOG_WARNING,
@@ -45,7 +46,8 @@ enum ldap_log_level {
   LDAP_LOG_LEVEL_ERROR,
   LDAP_LOG_LEVEL_ERROR_WARNING,
   LDAP_LOG_LEVEL_ERROR_WARNING_INFO,
-  LDAP_LOG_LEVEL_ALL
+  LDAP_LOG_LEVEL_MYSQL_DBG,
+  LDAP_LOG_LEVEL_LDAP_DBG
 };
 
 class Ldap_log_writer_error {
@@ -72,8 +74,13 @@ template <ldap_log_type::ldap_type type>
 void Ldap_logger::log(const std::string &msg) {
   std::ostringstream log_stream;
   switch (type) {
+    case ldap_log_type::LDAP_LOG_LDAP_DBG:
+      if (LDAP_LOG_LEVEL_LDAP_DBG > m_log_level) {
+        return;
+      }
+      break;
     case ldap_log_type::LDAP_LOG_DBG:
-      if (LDAP_LOG_LEVEL_ALL > m_log_level) {
+      if (LDAP_LOG_LEVEL_MYSQL_DBG > m_log_level) {
         return;
       }
       break;

--- a/plugin/auth_ldap/include/plugin_log.h
+++ b/plugin/auth_ldap/include/plugin_log.h
@@ -19,6 +19,9 @@
 
 extern mysql::plugin::auth_ldap::Ldap_logger *g_logger_server;
 
+#define log_ldap_dbg \
+  g_logger_server    \
+      ->log<mysql::plugin::auth_ldap::ldap_log_type::LDAP_LOG_LDAP_DBG>
 #define log_srv_dbg \
   g_logger_server->log<mysql::plugin::auth_ldap::ldap_log_type::LDAP_LOG_DBG>
 #define log_srv_info \

--- a/plugin/auth_ldap/include/plugin_variables.h
+++ b/plugin/auth_ldap/include/plugin_variables.h
@@ -39,6 +39,8 @@ static int log_status;
 static unsigned int max_pool_size;
 static char *server_host;
 static unsigned int server_port;
+static char *fallback_server_host;
+static unsigned int fallback_server_port;
 static bool ssl;
 static bool tls;
 static char *user_search_attr;
@@ -113,7 +115,7 @@ static MYSQL_SYSVAR_UINT(max_pool_size, max_pool_size, PLUGIN_VAR_RQCMDARG,
 static MYSQL_SYSVAR_INT(log_status, log_status, PLUGIN_VAR_RQCMDARG,
                         "The logging level", nullptr /* check */,
                         &update_sysvar<unsigned int> /* update */,
-                        1 /* default */, 1 /*minimum */, 5 /* maximum */,
+                        1 /* default */, 1 /*minimum */, 6 /* maximum */,
                         0 /* blocksize */);
 static MYSQL_SYSVAR_STR(server_host, server_host,
                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
@@ -126,7 +128,20 @@ static MYSQL_SYSVAR_UINT(server_port, server_port,
                          "The LDAP server TCP/IP port number",
                          nullptr /* check */,
                          &update_sysvar<unsigned int> /* update */,
-                         389 /* default */, 1 /*minimum */, 32376 /* maximum */,
+                         389 /* default */, 1 /*minimum */, 65535 /* maximum */,
+                         0 /* blocksize */);
+static MYSQL_SYSVAR_STR(fallback_server_host, fallback_server_host,
+                        PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_MEMALLOC |
+                            PLUGIN_VAR_READONLY,
+                        "The fallback LDAP server host", nullptr /* check */,
+                        &update_sysvar<char *> /* update */,
+                        nullptr /* default */);
+static MYSQL_SYSVAR_UINT(fallback_server_port, fallback_server_port,
+                         PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
+                         "The fallback LDAP server TCP/IP port number",
+                         nullptr /* check */,
+                         &update_sysvar<unsigned int> /* update */,
+                         0 /* default */, 0 /*minimum */, 65535 /* maximum */,
                          0 /* blocksize */);
 static MYSQL_SYSVAR_BOOL(
     ssl, ssl, PLUGIN_VAR_RQCMDARG | PLUGIN_VAR_READONLY,
@@ -167,6 +182,8 @@ static SYS_VAR *mpaldap_sysvars[] = {MYSQL_SYSVAR(auth_method_name),
                                      MYSQL_SYSVAR(max_pool_size),
                                      MYSQL_SYSVAR(server_host),
                                      MYSQL_SYSVAR(server_port),
+                                     MYSQL_SYSVAR(fallback_server_host),
+                                     MYSQL_SYSVAR(fallback_server_port),
                                      MYSQL_SYSVAR(ssl),
                                      MYSQL_SYSVAR(tls),
                                      MYSQL_SYSVAR(user_search_attr),

--- a/plugin/auth_ldap/include/pool.h
+++ b/plugin/auth_ldap/include/pool.h
@@ -28,9 +28,10 @@ namespace auth_ldap {
 class Pool {
  public:
   Pool(std::size_t pool_initial_size, std::size_t pool_max_size,
-       const std::string &ldap_host, std::uint16_t ldap_port, bool use_ssl,
-       bool use_tls, const std::string &ca_path, const std::string &bind_dn,
-       const std::string &bind_pwd);
+       const std::string &ldap_host, std::uint16_t ldap_port,
+       const std::string &fallback_host, std::uint16_t fallback_port,
+       bool use_ssl, bool use_tls, const std::string &ca_path,
+       const std::string &bind_dn, const std::string &bind_pwd);
   ~Pool();
 
  public:
@@ -44,7 +45,8 @@ class Pool {
   void reset_group_role_mapping(const std::string &mapping);
   void reconfigure(std::size_t new_pool_initial_size,
                    std::size_t new_pool_max_size, const std::string &ldap_host,
-                   std::uint16_t ldap_port, bool use_ssl, bool use_tls,
+                   std::uint16_t ldap_port, const std::string &fallback_host,
+                   std::uint16_t fallback_port, bool use_ssl, bool use_tls,
                    const std::string &ca_path, const std::string &bind_dn,
                    const std::string &bind_pwd);
   void zombie_control();
@@ -60,6 +62,8 @@ class Pool {
   std::size_t pool_max_size_;
   std::string ldap_host_;
   std::uint16_t ldap_port_;
+  std::string ldap_fallback_host_;
+  std::uint16_t ldap_fallback_port_;
   bool use_ssl_;
   bool use_tls_;
   std::string ca_path_;

--- a/plugin/auth_ldap/src/connection.cc
+++ b/plugin/auth_ldap/src/connection.cc
@@ -6,20 +6,87 @@
 
 #include "plugin/auth_ldap/include/plugin_log.h"
 
+namespace {
+// example of this callback is in the OpenLDAP's
+// servers/slapd/back-meta/bind.c (meta_back_default_urllist)
+int cb_urllist_proc(LDAP * /* ld */, LDAPURLDesc **urllist, LDAPURLDesc **url,
+                    void * /* params */) {
+  if (urllist == url) return LDAP_SUCCESS;
+
+  LDAPURLDesc **urltail;
+  for (urltail = &(*url)->lud_next; *urltail; urltail = &(*urltail)->lud_next)
+    /* count */;
+
+  // all failed hosts go to the end of list
+  *urltail = *urllist;
+  // succeeded host becomes first
+  *urllist = *url;
+  // mark end of list
+  *url = nullptr;
+
+  return LDAP_SUCCESS;
+}
+
+void cb_log(LDAP_CONST char *data) { log_ldap_dbg(data); }
+
+}  // namespace
+
 namespace mysql {
 namespace plugin {
 namespace auth_ldap {
+
+void Connection::initialize_global_ldap_parameters(bool enable_debug,
+                                                   std::string const &ca_path) {
+  int version = LDAP_VERSION3;
+  int err = ldap_set_option(nullptr, LDAP_OPT_PROTOCOL_VERSION, &version);
+  if (err != LDAP_OPT_SUCCESS) {
+    log_error("ldap_set_option(LDAP_OPT_PROTOCOL_VERSION)", err);
+  }
+
+  if (ca_path.size() == 0) {
+    int reqCert = LDAP_OPT_X_TLS_NEVER;
+    err = ldap_set_option(nullptr, LDAP_OPT_X_TLS_REQUIRE_CERT, &reqCert);
+    if (err != LDAP_OPT_SUCCESS) {
+      log_error("ldap_set_option(LDAP_OPT_X_TLS_REQUIRE_CERT)", err);
+    }
+  } else {
+    char *cca_path = const_cast<char *>(ca_path.c_str());
+    err = ldap_set_option(nullptr, LDAP_OPT_X_TLS_CACERTFILE,
+                          static_cast<void *>(cca_path));
+    if (err != LDAP_OPT_SUCCESS) {
+      log_error("ldap_set_option(LDAP_OPT_X_TLS_CACERTFILE)", err);
+    }
+  }
+
+  err = ldap_set_option(nullptr, LDAP_OPT_X_TLS_NEWCTX, LDAP_OPT_ON);
+  if (err != LDAP_OPT_SUCCESS) {
+    log_error("ldap_set_option(LDAP_OPT_X_TLS_NEWCTX)", err);
+  }
+
+  if (enable_debug) {
+    static const unsigned short debug_any = 0xffff;
+    err = ldap_set_option(nullptr, LDAP_OPT_DEBUG_LEVEL, &debug_any);
+    if (err != LDAP_OPT_SUCCESS) {
+      log_error("ldap_set_option(LDAP_OPT_DEBUG_LEVEL)", err);
+    }
+    ber_set_option(nullptr, LBER_OPT_LOG_PRINT_FN,
+                   reinterpret_cast<const void *>(cb_log));
+  }
+}
+
 Connection::Connection(std::size_t idx, const std::string &ldap_host,
-                       std::uint16_t ldap_port, bool use_ssl, bool use_tls,
-                       const std::string &ca_path)
+                       std::uint16_t ldap_port,
+                       const std::string &fallback_host,
+                       std::uint16_t fallback_port, bool use_ssl, bool use_tls)
     : available_(true),
       index_(idx),
       snipped_(false),
       ldap_host_(ldap_host),
       ldap_port_(ldap_port),
+      ldap_fallback_host_(fallback_host),
+      ldap_fallback_port_(fallback_port),
       use_ssl_(use_ssl),
       use_tls_(use_tls),
-      ca_path_(ca_path),
       ldap_(nullptr) {}
 
 Connection::~Connection() {
@@ -30,21 +97,27 @@ Connection::~Connection() {
 }
 
 void Connection::configure(const std::string &ldap_host,
-                           std::uint16_t ldap_port, bool use_ssl, bool use_tls,
-                           const std::string &ca_path) {
+                           std::uint16_t ldap_port,
+                           const std::string &fallback_host,
+                           std::uint16_t fallback_port, bool use_ssl,
+                           bool use_tls) {
   // ldap function use c_strs from these variables
   // changing them during a connect call could lead to a crash
   std::lock_guard<std::mutex> lock(conn_mutex_);
   ldap_host_ = ldap_host;
   ldap_port_ = ldap_port;
+  ldap_fallback_host_ = fallback_host;
+  ldap_fallback_port_ = fallback_port;
   use_ssl_ = use_ssl;
   use_tls_ = use_tls;
-  ca_path_ = ca_path;
 }
 
 bool Connection::connect(const std::string &bind_dn,
                          const std::string &bind_pwd) {
   std::lock_guard<std::mutex> lock(conn_mutex_);
+
+  int version = LDAP_VERSION3;
+  ldap_set_option(nullptr, LDAP_OPT_PROTOCOL_VERSION, &version);
 
   if (bind_pwd.empty()) {
     return false;
@@ -57,37 +130,7 @@ bool Connection::connect(const std::string &bind_dn,
       ldap_unbind_ext_s(ldap_, nullptr, nullptr);
     }
 
-    int version = LDAP_VERSION3;
-    int err = ldap_set_option(nullptr, LDAP_OPT_PROTOCOL_VERSION, &version);
-    if (err != LDAP_OPT_SUCCESS) {
-      log_error("ldap_set_option(LDAP_OPT_PROTOCOL_VERSION)", err);
-      return false;
-    }
-
-    if (ca_path_.size() == 0) {
-      int reqCert = LDAP_OPT_X_TLS_NEVER;
-      err = ldap_set_option(nullptr, LDAP_OPT_X_TLS_REQUIRE_CERT, &reqCert);
-      if (err != LDAP_OPT_SUCCESS) {
-        log_error("ldap_set_option(LDAP_OPT_X_TLS_REQUIRE_CERT)", err);
-        return false;
-      }
-    } else {
-      char *cca_path = const_cast<char *>(ca_path_.c_str());
-      err = ldap_set_option(nullptr, LDAP_OPT_X_TLS_CACERTFILE,
-                            static_cast<void *>(cca_path));
-      if (err != LDAP_OPT_SUCCESS) {
-        log_error("ldap_set_option(LDAP_OPT_X_TLS_CACERTFILE)", err);
-        return false;
-      }
-    }
-
-    err = ldap_set_option(nullptr, LDAP_OPT_X_TLS_NEWCTX, LDAP_OPT_ON);
-    if (err != LDAP_OPT_SUCCESS) {
-      log_error("ldap_set_option(LDAP_OPT_X_TLS_NEWCTX)", err);
-      return false;
-    }
-
-    err = ldap_initialize(&(ldap_), get_ldap_uri().c_str());
+    int err = ldap_initialize(&(ldap_), get_ldap_uri().c_str());
     if (err != LDAP_SUCCESS) {
       log_error("ldap_initialize", err);
       return false;
@@ -111,6 +154,11 @@ bool Connection::connect(const std::string &bind_dn,
         log_error("ldap_start_tls_s", err);
         return false;
       }
+    }
+
+    err = ldap_set_urllist_proc(ldap_, cb_urllist_proc, nullptr);
+    if (err != LDAP_OPT_SUCCESS) {
+      log_warning("ldap_set_urllist_proc failed", err);
     }
 
     struct berval *serverCreds;
@@ -284,6 +332,21 @@ std::string Connection::get_ldap_uri() {
   std::ostringstream str_stream;
   str_stream << (use_ssl_ ? "ldaps://" : "ldap://") << ldap_host_ << ":"
              << ldap_port_;
+  if (!ldap_fallback_host_.empty()) {
+    // We allow 2 formats for fallback:
+    // * only fallback_host is specified (port is 0): in this case, we add it to
+    // the connection string as is
+    // * port is also specified: in this case we add the protocal prefix and
+    // port to it
+    str_stream << ",";
+    if (ldap_fallback_port_ != 0) {
+      str_stream << (use_ssl_ ? "ldaps://" : "ldap://");
+    }
+    str_stream << ldap_fallback_host_;
+    if (ldap_fallback_port_ != 0) {
+      str_stream << ":" << ldap_fallback_port_;
+    }
+  }
   return str_stream.str();
 }
 

--- a/plugin/auth_ldap/src/log_client.cc
+++ b/plugin/auth_ldap/src/log_client.cc
@@ -29,7 +29,6 @@ namespace plugin {
 namespace auth_ldap {
 Ldap_logger::Ldap_logger() {
   m_log_level = LDAP_LOG_LEVEL_NONE;
-  m_log_writer = NULL;
   m_log_writer = new Ldap_log_writer_error();
 }
 
@@ -45,6 +44,7 @@ void Ldap_log_writer_error::write(ldap_log_type::ldap_type level,
                                   const std::string &data) {
   plugin_log_level plevel = MY_INFORMATION_LEVEL;
   switch (level) {
+    case ldap_log_type::LDAP_LOG_LDAP_DBG:
     case ldap_log_type::LDAP_LOG_DBG:
     case ldap_log_type::LDAP_LOG_INFO:
       plevel = MY_INFORMATION_LEVEL;

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple-master.opt
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple-master.opt
@@ -1,4 +1,5 @@
 $AUTH_LDAP_OPT $AUTH_LDAP_LOAD
 --authentication_ldap_simple_server_host='$MTR_LDAP_HOST'
 --authentication_ldap_simple_server_port=$MTR_LDAP_PORT
-
+--authentication_ldap_simple_fallback_server_host='$MTR_LDAP_FALLBACK_HOST'
+--authentication_ldap_simple_fallback_server_port=$MTR_LDAP_FALLBACK_PORT

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple.result
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple.result
@@ -10,6 +10,8 @@ authentication_ldap_simple_bind_base_dn
 authentication_ldap_simple_bind_root_dn	
 authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
+authentication_ldap_simple_fallback_server_host	<MTR_LDAP_FALLBACK_HOST>
+authentication_ldap_simple_fallback_server_port	<MTR_LDAP_FALLBACK_PORT>
 authentication_ldap_simple_group_role_mapping	
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
@@ -30,6 +32,8 @@ authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
 authentication_ldap_simple_bind_root_dn	
 authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
+authentication_ldap_simple_fallback_server_host	<MTR_LDAP_FALLBACK_HOST>
+authentication_ldap_simple_fallback_server_port	<MTR_LDAP_FALLBACK_PORT>
 authentication_ldap_simple_group_role_mapping	admin_staff=test_role
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))
@@ -75,6 +79,8 @@ authentication_ldap_simple_bind_base_dn	ou=people,dc=planetexpress,dc=com
 authentication_ldap_simple_bind_root_dn	
 authentication_ldap_simple_bind_root_pwd	
 authentication_ldap_simple_ca_path	
+authentication_ldap_simple_fallback_server_host	<MTR_LDAP_FALLBACK_HOST>
+authentication_ldap_simple_fallback_server_port	<MTR_LDAP_FALLBACK_PORT>
 authentication_ldap_simple_group_role_mapping	admin_staff=test_role
 authentication_ldap_simple_group_search_attr	cn
 authentication_ldap_simple_group_search_filter	(|(&(objectClass=posixGroup)(memberUid={UA}))(&(objectClass=group)(member={UD})))

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_simple.test
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_simple.test
@@ -9,7 +9,7 @@ CREATE ROLE 'test_role';
 CREATE ROLE 'test_role2';
 
 SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME LIKE 'authentication_ldap_simple%';
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
+--replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT> $MTR_LDAP_FALLBACK_HOST <MTR_LDAP_FALLBACK_HOST> $MTR_LDAP_FALLBACK_PORT <MTR_LDAP_FALLBACK_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 SET GLOBAL authentication_ldap_simple_bind_base_dn = 'ou=people,dc=planetexpress,dc=com';
 SET GLOBAL authentication_ldap_simple_group_role_mapping = 'admin_staff=test_role';
@@ -17,7 +17,7 @@ SET GLOBAL authentication_ldap_simple_group_role_mapping = 'admin_staff=test_rol
 # For debugging:
 # SET GLOBAL authentication_ldap_simple_log_status = 6;
 
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
+--replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT> $MTR_LDAP_FALLBACK_HOST <MTR_LDAP_FALLBACK_HOST> $MTR_LDAP_FALLBACK_PORT <MTR_LDAP_FALLBACK_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 CREATE USER zoidberg IDENTIFIED WITH authentication_ldap_simple BY 'cn=Hermes Conrad,ou=people,dc=planetexpress,dc=com';
 CREATE USER nonexistent IDENTIFIED WITH authentication_ldap_simple BY 'uid=nonexistent';
@@ -46,7 +46,7 @@ SHOW GRANTS FOR 'zoidberg';
 --echo "should show test_role,test_role2"
 SHOW GRANTS FOR 'zoidberg';
 
---replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT>
+--replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT> $MTR_LDAP_FALLBACK_HOST <MTR_LDAP_FALLBACK_HOST> $MTR_LDAP_FALLBACK_PORT <MTR_LDAP_FALLBACK_PORT>
 SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_simple%';
 
 --disconnect con1


### PR DESCRIPTION
This change adds support to a fallback LDAP server, which is used when
the primary server can't be reached.

To configure a fallback server, the LDAP authentication plugin adds two
new parameters, authentication_ldap_simple_fallback_server_host and
authentication_ldap_simple_fallback_server_port. These valueas are used
if the host parameter is non empty.

The change also improves the logging capabilities of the authentication
plugin by forwarding the LDAP library debug messages to the MySQL error
log. This feature requires setting authentication_ldap_simple_log_status
to its new maximum value, 6.