### PR TITLE
PS-8205: Fix use of DICT_TF2_FLAG_IS_SET (8.0)

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -12154,11 +12154,16 @@ and set the encryption flag in table flags
 dberr_t create_table_info_t::enable_master_key_encryption(dict_table_t *table) {
   const char *encrypt = m_create_info->encrypt_type.str;
 
-  /* if table is part of tablespace - no need for retrieving
+  if (Encryption::is_none(encrypt)) return (DB_SUCCESS);
+
+  /* If table is part of tablespace - no need for retrieving
   master key as tablespace key was already decrypted
-  either by validate_first_page or during tablespace creation */
-  if (Encryption::is_none(encrypt) || !(m_flags2 & DICT_TF2_USE_FILE_PER_TABLE))
+  either by validate_first_page or during tablespace creation.
+  Just set the encryption flag and return. */
+  if (!(m_flags2 & DICT_TF2_USE_FILE_PER_TABLE)) {
+    DICT_TF2_FLAG_SET(table, DICT_TF2_ENCRYPTION_FILE_PER_TABLE);
     return (DB_SUCCESS);
+  }
 
   /* Set the encryption flag. */
   byte *master_key = nullptr;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4865,7 +4865,8 @@ template <typename Table>
     key_id = ha_alter_info->create_info->encryption_key_id;
 
     // re-encrypting, check that key used to encrypt table is present
-    if (DICT_TF2_FLAG_SET(ctx->old_table, DICT_TF2_ENCRYPTION_FILE_PER_TABLE)) {
+    if (DICT_TF2_FLAG_IS_SET(ctx->old_table,
+                             DICT_TF2_ENCRYPTION_FILE_PER_TABLE)) {
       if (Encryption::is_master_key_encryption(
               old_table->s->encrypt_type.str)) {
         // re-encrypting from master key encryption
@@ -4923,8 +4924,8 @@ template <typename Table>
     } else if (!(ctx->new_table->flags2 & DICT_TF2_USE_FILE_PER_TABLE) &&
                ha_alter_info->create_info->encrypt_type.length > 0 &&
                Encryption::is_master_key_encryption(encrypt) &&
-               !DICT_TF2_FLAG_SET(ctx->old_table,
-                                  DICT_TF2_ENCRYPTION_FILE_PER_TABLE)) {
+               !DICT_TF2_FLAG_IS_SET(ctx->old_table,
+                                     DICT_TF2_ENCRYPTION_FILE_PER_TABLE)) {
       dict_mem_table_free(ctx->new_table);
       my_error(ER_TABLESPACE_CANNOT_ENCRYPT, MYF(0));
       goto new_clustered_failed;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -4736,7 +4736,7 @@ prepare_inplace_alter_table_dict(
 		key_id= ha_alter_info->create_info->encryption_key_id;
 
 		// re-encrypting, check that key used to encrypt table is present
-		if (DICT_TF2_FLAG_SET(ctx->old_table, DICT_TF2_ENCRYPTION)) {
+		if (DICT_TF2_FLAG_IS_SET(ctx->old_table, DICT_TF2_ENCRYPTION)) {
 			if (Encryption::is_master_key_encryption(old_table->s->encrypt_type.str)) {
 				// re-encrypting from master key encryption
 				/* Check if keyring is ready. */
@@ -4800,7 +4800,7 @@ prepare_inplace_alter_table_dict(
 		} else if (!(ctx->new_table->flags2 & DICT_TF2_USE_FILE_PER_TABLE)
 		    && ha_alter_info->create_info->encrypt_type.length > 0
 		    && Encryption::is_master_key_encryption(encrypt)
-		    && !DICT_TF2_FLAG_SET(ctx->old_table,
+		    && !DICT_TF2_FLAG_IS_SET(ctx->old_table,
 					  DICT_TF2_ENCRYPTION)) {
 
 			dict_mem_table_free( ctx->new_table);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8205

Problem:
During the merge it was disccovered that DICT_TF2_FLAG_SET was used
instead of DICT_TF2_FLAG_IS_SET. After fixing, several encryption
related mtr tests started to fail:

component_keyring_file.dd_upgrade_encrypted
component_keyring_file.tablespace_encrypt_1
component_keyring_file.tablespace_encrypt_4
component_keyring_file.upgrade encryption.upgrade
innodb.percona_sys_tablespace_encrypt
innodb.tablespace_encrypt_1
innodb.tablespace_encrypt_4
main.percona_8_0_15_dd_upgrade_encrypted
main.percona_dd_upgrade_encrypted
main.dd_upgrade_encrypted

Cause:
The cause of MTR tests failures was that setting the flag was skipped
during table creation in
create_table_info_t::enable_master_key_encryption(). Then cached object
without flag set was used.
It was working fine after server reboot, because the flag is properly
set in dd_fill_dict_table() when the table is opened for the 1st time.

Solution:
Macro usage fixed.
create_table_info_t::enable_master_key_encryption() logic fixed.