### PR TITLE
PS-8167: Fix KMIP startup crash with invalid configuration

### DIFF
--- a/components/keyrings/keyring_kmip/keyring_kmip.cc
+++ b/components/keyrings/keyring_kmip/keyring_kmip.cc
@@ -163,7 +163,6 @@ static mysql_service_status_t keyring_kmip_init() {
 
   g_component_callbacks.reset(
       new keyring_common::service_implementation::Component_callbacks());
-  g_keyring_kmip_inited = true;
 
   return false;
 }


### PR DESCRIPTION
Issue: The KMIP component could crash when the server is started with
incorrect or non existing cconfig file together with some encryption
settings.

Fix: The KMIP code marked the plugin initialized even before
initialization fully completed. This change removes the unneccessary
early initialization setter, and leaves the correct later flag setting
as is.