### PR TITLE
Fixed PS-8018 (Parallel replication with blackhole table on replica throws error 1863)

### DIFF
--- a/mysql-test/suite/rpl/r/bug93917.result
+++ b/mysql-test/suite/rpl/r/bug93917.result
@@ -7,6 +7,7 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
 [connection slave]
 [connection master]
 ********************************************************************************

--- a/mysql-test/suite/rpl/r/rpl_blackhole.result
+++ b/mysql-test/suite/rpl/r/rpl_blackhole.result
@@ -4,6 +4,7 @@ Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
 call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
 CREATE TABLE t1 (a INT, b INT, c INT);
 CREATE TABLE t2 (a INT, b INT, c INT);
 include/sync_slave_sql_with_master.inc

--- a/mysql-test/suite/rpl/r/rpl_blackhole_partitioned.result
+++ b/mysql-test/suite/rpl/r/rpl_blackhole_partitioned.result
@@ -1,0 +1,25 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
+[connection master]
+CREATE TABLE t1(id INT)
+Engine=InnoDB PARTITION BY RANGE (id)
+(PARTITION p1 VALUES LESS THAN (10),
+PARTITION p2 VALUES LESS THAN MAXVALUE);
+include/sync_slave_sql_with_master.inc
+ALTER TABLE t1 ENGINE=BLACKHOLE;
+Warnings:
+Warning	1287	The partition engine, used by table 'test.t1', is deprecated and will be removed in a future release. Please use native partitioning instead.
+[connection master]
+INSERT INTO t1 (id) VALUES (1), (5), (9), (13), (17);
+DELETE FROM t1 WHERE id > 4 AND id < 15;
+UPDATE t1 SET id = 18 WHERE id = 17;
+include/sync_slave_sql_with_master.inc
+include/check_slave_is_running.inc
+[connection master]
+DROP TABLE t1;
+include/sync_slave_sql_with_master.inc
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/bug93917.test
+++ b/mysql-test/suite/rpl/t/bug93917.test
@@ -9,6 +9,8 @@
 
 --source include/master-slave.inc
 
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
+
 --let $safe_load_data_dir = `SELECT @@global.secure_file_priv`
 --let $server_1_binlog_record_file = $safe_load_data_dir/bug93917_server_1.txt
 --let $server_2_binlog_record_file = $safe_load_data_dir/bug93917_server_2.txt

--- a/mysql-test/suite/rpl/t/rpl_blackhole.test
+++ b/mysql-test/suite/rpl/t/rpl_blackhole.test
@@ -20,6 +20,7 @@ source include/have_blackhole.inc;
 source include/master-slave.inc;
 
 call mtr.add_suppression("Unsafe statement written to the binary log using statement format since BINLOG_FORMAT = STATEMENT");
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
 
 # We start with no primary key
 CREATE TABLE t1 (a INT, b INT, c INT);

--- a/mysql-test/suite/rpl/t/rpl_blackhole_partitioned.test
+++ b/mysql-test/suite/rpl/t/rpl_blackhole_partitioned.test
@@ -1,0 +1,46 @@
+--source include/have_blackhole.inc
+--source include/have_innodb.inc
+--source include/have_partition.inc
+--source include/master-slave.inc
+
+# This testcase checks that the bug which caused replication into a partitioned
+# BLACKHOLE table to stop if any other than the first partition was involved,
+# is no longer a bug.
+
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
+
+--source include/rpl_connection_master.inc
+# Source table needs to have at least two partitions and no indexes.
+CREATE TABLE t1(id INT)
+    Engine=InnoDB PARTITION BY RANGE (id)
+    (PARTITION p1 VALUES LESS THAN (10),
+     PARTITION p2 VALUES LESS THAN MAXVALUE);
+
+--source include/sync_slave_sql_with_master.inc
+
+# Replicating into a BLACKHOLE table.
+ALTER TABLE t1 ENGINE=BLACKHOLE;
+
+--source include/rpl_connection_master.inc
+# All partitions need to have some data in them.
+INSERT INTO t1 (id) VALUES (1), (5), (9), (13), (17);
+
+# Delete operation needs to do something in the second partition. Without
+# indexes this command will use table scans to find all affected rows.
+DELETE FROM t1 WHERE id > 4 AND id < 15;
+
+# Now try to touch the second partition with an UPDATE.
+UPDATE t1 SET id = 18 WHERE id = 17;
+
+--source include/sync_slave_sql_with_master.inc
+
+# Replica should successfully process DELETEs and UPDATEs from a source
+# instance.
+--source include/check_slave_is_running.inc
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+
+--source include/sync_slave_sql_with_master.inc
+
+--source include/rpl_end.inc

--- a/mysql-test/suite/tokudb.rpl/r-native-partitioning/rpl_tokudb_rfr_partition_table.result
+++ b/mysql-test/suite/tokudb.rpl/r-native-partitioning/rpl_tokudb_rfr_partition_table.result
@@ -3,7 +3,7 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-call mtr.add_suppression(".*read free replication is disabled for TokuDB/RocksDB table.*continue with rows lookup");
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
 CREATE TABLE t1 (id int(11) NOT NULL, pid int(11), PRIMARY KEY (id)) ENGINE=TokuDB
 PARTITION BY RANGE (id)
 (PARTITION p_1 VALUES LESS THAN (10) ENGINE = TokuDB,

--- a/mysql-test/suite/tokudb.rpl/r/rpl_rfr_disable_on_expl_pk_absence.result
+++ b/mysql-test/suite/tokudb.rpl/r/rpl_rfr_disable_on_expl_pk_absence.result
@@ -3,7 +3,7 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-call mtr.add_suppression("read free replication is disabled for TokuDB/RocksDB table");
+call mtr.add_suppression("read free replication is disabled for table");
 CREATE TABLE t (a int(11), b char(20)) ENGINE = TokuDB;
 INSERT INTO t (a, b) VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
 SELECT * FROM t;

--- a/mysql-test/suite/tokudb.rpl/r/rpl_tokudb_rfr_partition_table.result
+++ b/mysql-test/suite/tokudb.rpl/r/rpl_tokudb_rfr_partition_table.result
@@ -3,7 +3,7 @@ Warnings:
 Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
 Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
 [connection master]
-call mtr.add_suppression(".*read free replication is disabled for TokuDB/RocksDB table.*continue with rows lookup");
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
 CREATE TABLE t1 (id int(11) NOT NULL, pid int(11), PRIMARY KEY (id)) ENGINE=TokuDB
 PARTITION BY RANGE (id)
 (PARTITION p_1 VALUES LESS THAN (10) ENGINE = TokuDB,

--- a/mysql-test/suite/tokudb.rpl/t/rpl_rfr_disable_on_expl_pk_absence.test
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_rfr_disable_on_expl_pk_absence.test
@@ -20,7 +20,7 @@
 --source include/have_binlog_format_row.inc
 --source include/master-slave.inc
 
-call mtr.add_suppression("read free replication is disabled for TokuDB/RocksDB table");
+call mtr.add_suppression("read free replication is disabled for table");
 
 --connection master
 CREATE TABLE t (a int(11), b char(20)) ENGINE = TokuDB;

--- a/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_rfr_partition_table.test
+++ b/mysql-test/suite/tokudb.rpl/t/rpl_tokudb_rfr_partition_table.test
@@ -6,7 +6,7 @@
 --source include/have_binlog_format_row.inc
 --source include/master-slave.inc
 
-call mtr.add_suppression(".*read free replication is disabled for TokuDB/RocksDB table.*continue with rows lookup");
+call mtr.add_suppression(".*read free replication is disabled for table.*continue with rows lookup");
 
 connection master;
 

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -10096,7 +10096,7 @@ Rows_log_event::decide_row_lookup_algorithm_and_key()
         if (!table->s->rfr_lookup_warning)
         {
           sql_print_warning("Slave: read free replication is disabled "
-                            "for TokuDB/RocksDB table `%s.%s` "
+                            "for table `%s.%s` "
                             "as it does not have implicit primary key, "
                             "continue with rows lookup",
                             print_slave_db_safe(table->s->db.str),

--- a/storage/blackhole/ha_blackhole.h
+++ b/storage/blackhole/ha_blackhole.h
@@ -109,4 +109,5 @@ private:
   virtual int write_row(uchar *buf);
   virtual int update_row(const uchar *old_data, uchar *new_data);
   virtual int delete_row(const uchar *buf);
+  virtual bool rpl_lookup_rows() { return false; }
 };


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8018

Problem:

Applying DELETE commands on a replica causes an error that stops
the replication process if the involved table uses BLACKHOLE engine and
is subject to table scans for finding a particular row. In other words,
has no usable indexes.

When applying DELETEs, Partition_helper::ph_delete_row() checks that
the partition ID that was determined by partition info, is exactly the
partition ID from Partition_helper::m_last_part. Latter is set in
Partition_helper::ph_rnd_next() to an ID of the first partition that
reports having the requested row. Since BLACKHOLE engine stores nothing,
it searches nothing. On replicas it happily reports that it has any
requested row. Thus making Partition_helper::ph_rnd_next() believe that
partition 0 is the one that has the row. Partition_helper::m_last_part is
therefore always set to 0 when BLACKHOLE engine is in use. That's fine for
rows in the first partition, but causes HA_ERR_ROW_IN_WRONG_PARTITION for
other partitions.

Fix:

BLACKHOLE engine has no need to track specific rows, so the solution is
to disable the check in Partition_helper::ph_delete_row() by making
ha_blackhole::rpl_lookup_rows() always return false.

handler::rpl_lookup_rows() was introduced as a part of optimizations for
TokuDB and RocksDB, and with that introduced a warning that explicitly
mentions "TokuDB/RocksDB" in its text. Receiving such warning when
BLACKHOLE engine is used would be confusing. So the text of the message is
changed to be engine-agnostic.