### PR TITLE
PS-8277 fix: Assertion in vio_ssl_write() after executing asymmetric_verify() UDF

### DIFF
--- a/extra/opensslpp/src/opensslpp/core_error.cpp
+++ b/extra/opensslpp/src/opensslpp/core_error.cpp
@@ -39,6 +39,7 @@ static constexpr std::size_t error_message_buffer_size = 256;
 
     ERR_error_string_n(err, buffer.data(), buffer.size());
     message += buffer.data();
+    ERR_clear_error();
   }
 
   throw core_error{message};

--- a/include/mysqlpp/udf_wrappers.hpp
+++ b/include/mysqlpp/udf_wrappers.hpp
@@ -189,8 +189,8 @@ template <typename ImplType>
 class generic_udf<ImplType, INT_RESULT>
     : public generic_udf_base<ImplType, INT_RESULT> {
  public:
-  static double func(UDF_INIT *initid, UDF_ARGS *args, unsigned char *is_null,
-                     unsigned char *error) noexcept {
+  static long long func(UDF_INIT *initid, UDF_ARGS *args,
+                        unsigned char *is_null, unsigned char *error) noexcept {
     auto &extended_impl = *generic_udf_base<
         ImplType, INT_RESULT>::get_extended_impl_from_udf_initid(initid);
     udf_result_t<INT_RESULT> res;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8277

Fixed problem in the 'opensslpp::verify_with_rsa_public_key()' where after
unsuccessful signature verification OpenSSL error code queue may not be
properly cleared affecting invoking code that may rely on 'ERR_get_error()'.

Reworked 'opensslpp::core_error::raise_with_error_string()' function - now
we also make sure that OpenSSL error code queue is empty before throwing
the exception.

Fixed problem in UDF wrappers with incorrect helper function signature for the
'INT_RESULT' UDFs.