### PR TITLE
PS-8257 Failed upgrade attempt to 8.0.29 corrupts the data dictionary

### DIFF
--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11572,6 +11572,9 @@ ER_IB_WARN_MANY_NON_LRU_FILES_OPENED
 ER_IB_MSG_TRYING_TO_OPEN_FILE_FOR_LONG_TIME
   eng "Trying to open a file for %lld seconds. Configuration only allows for %zu open files. Consider setting innobase_open_files higher."
 
+ER_IB_MSG_DOWNGRADING_LOG_FILE
+  eng "Upgrade fail, cleaning up redo logs, so server can start with previous version"
+
 ER_GLOBAL_CONN_LIMIT
   eng "Connection closed. Global connection memory limit %llu bytes exceeded. Consumed %llu bytes."
 

--- a/sql/dd/impl/upgrade/server.cc
+++ b/sql/dd/impl/upgrade/server.cc
@@ -591,6 +591,7 @@ static bool check_tables(THD *thd, std::unique_ptr<Schema> &schema,
         }
       }
     }
+    DBUG_EXECUTE_IF("upgrade_failed_during_init", (*error_count)++;);
     return error_count->has_too_many_errors();
   };
 

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1212,6 +1212,7 @@ bool opt_no_monitor = false;
 bool opt_no_dd_upgrade = false;
 long opt_upgrade_mode = UPGRADE_AUTO;
 bool opt_initialize = false;
+bool dd_init_failed_during_upgrade = false;
 bool opt_skip_replica_start = false;  ///< If set, slave is not autostarted
 bool opt_enable_named_pipe = false;
 bool opt_local_infile, opt_replica_compressed_protocol;
@@ -6586,6 +6587,10 @@ static int init_server_components() {
     if (!is_help_or_validate_option() &&
         dd::init(dd::enum_dd_init_type::DD_RESTART_OR_UPGRADE)) {
       LogErr(ERROR_LEVEL, ER_DD_INIT_FAILED);
+
+      if (!dd::upgrade::no_server_upgrade_required()) {
+        dd_init_failed_during_upgrade = true;
+      }
 
       /* If clone recovery fails, we rollback the files to previous
       dataset and attempt to restart server. */

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -186,6 +186,7 @@ extern MYSQL_PLUGIN_IMPORT std::atomic<int32>
 extern bool opt_no_dd_upgrade;
 extern long opt_upgrade_mode;
 extern bool opt_initialize;
+extern bool dd_init_failed_during_upgrade;
 extern bool opt_safe_user_create;
 extern bool opt_local_infile, opt_myisam_use_mmap;
 extern bool opt_replica_compressed_protocol;

--- a/storage/innobase/include/log0log.h
+++ b/storage/innobase/include/log0log.h
@@ -962,10 +962,9 @@ void log_files_header_fill(byte *buf, lsn_t start_lsn, const char *creator,
 void log_files_header_flush(log_t &log, uint32_t nth_file, lsn_t start_lsn);
 
 /** Changes format of redo files to previous format version.
-
-@note Note this will work between the two formats 5_7_9 & current because
-the only change is the version number */
-void log_files_downgrade(log_t &log);
+@param[in]      log             redo log
+@param[in]      log_format      previous format version */
+void log_files_downgrade(log_t &log, uint32_t log_format);
 
 /** Writes the next checkpoint info to header of the first log file.
 Note that two pages of the header are used alternately for consecutive

--- a/storage/innobase/log/log0chkp.cc
+++ b/storage/innobase/log/log0chkp.cc
@@ -448,7 +448,7 @@ void meb_log_print_file_hdr(byte *block) {
 
 #ifndef UNIV_HOTBACKUP
 
-void log_files_downgrade(log_t &log) {
+void log_files_downgrade(log_t &log, uint32_t log_format) {
   ut_ad(srv_shutdown_state.load() >= SRV_SHUTDOWN_LAST_PHASE);
   ut_a(!log_checkpointer_is_active());
 
@@ -462,7 +462,7 @@ void log_files_downgrade(log_t &log) {
       static_cast<page_no_t>(dest_offset / univ_page_size.physical());
 
   /* Write old version */
-  mach_write_to_4(buf + LOG_HEADER_FORMAT, LOG_HEADER_FORMAT_5_7_9);
+  mach_write_to_4(buf + LOG_HEADER_FORMAT, log_format);
 
   log_block_set_checksum(buf, log_block_calc_checksum_crc32(buf));
 
@@ -661,7 +661,6 @@ void log_create_first_checkpoint(log_t &log, lsn_t lsn) {
   page_no_t block_page_no;
   uint64_t block_offset;
 
-  ut_a(srv_is_being_started);
   ut_a(!srv_read_only_mode);
   ut_a(!recv_recovery_is_on());
   ut_a(buf_are_flush_lists_empty_validate());


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8257

Problem:
Failed upgrade attempt to 8.0.29 corrupts the data dictionary

Analysis:
8.0.29 has changed the redo log format and shuffle the redo type code,
so lower version can't parse redo log file in case of failed upgrade

Fix:
Recreate the empty redo log file during failed upgrade
so lower version does not need to parse redo file