### PR TITLE
fix: mysql-helpers backport for debian/ubuntu packaging

### DIFF
--- a/build-ps/debian/extra/mysql-helpers
+++ b/build-ps/debian/extra/mysql-helpers
@@ -1,4 +1,4 @@
-# Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2017, 2021, Oracle and/or its affiliates.
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,
@@ -106,9 +106,14 @@ verify_ready() {
 			fi
 		fi
 
-		if [ ! -d ${MYSQLFILES} -a ! -L ${MYSQLFILES} ]; then
-			if [ "$(dirname "${MYSQLFILES}")" = "/var/lib" -o ${MYSQLFILES} = NULL ]; then
-				install -d -m0770 -omysql -gmysql ${MYSQLFILES}
+		# Ensures that the mysql_upgrade_info file is owned by the database
+		if [ -O "${MYSQLDATA}/mysql_upgrade_info" ]; then
+			chown --reference="${MYSQLDATA}" "${MYSQLDATA}/mysql_upgrade_info"
+		fi
+
+		if [ "${MYSQLFILES}" != "NULL" -a ! -d "${MYSQLFILES}" -a ! -L "${MYSQLFILES}" ]; then
+			if [ "$(dirname ${MYSQLFILES})" = "/var/lib" ]; then
+				install -d -m0770 -omysql -gmysql "${MYSQLFILES}"
 			else
 				echo "Error: Secure-file-priv dir ${MYSQLFILES} does not exist. For security reasons the service will not automatically create directories outside /var/lib."
 				ERROR_FLAG=1
@@ -139,7 +144,7 @@ verify_ready() {
 		fi
 
 		if [ ! -d ${MYSQLRUN} -a ! -L ${MYSQLRUN} ]; then
-			install -d -m0755 -omysql -gmysql ${MYSQLRUN}
+		            install -d -m0755 -omysql -gmysql ${MYSQLRUN}
 		fi
 }
 
@@ -155,6 +160,7 @@ verify_database() {
 		SQL=$(mktemp -u ${MYSQLFILES}/XXXXXXXXXX)
 		install /dev/null -m0600 -omysql -gmysql "${SQL}"
 		cat << EOF > ${SQL}
+SET @@SESSION.SQL_LOG_BIN=0;
 USE mysql;
 INSTALL PLUGIN auth_socket SONAME 'auth_socket.so';
 ALTER USER 'root'@'localhost' IDENTIFIED WITH 'auth_socket';


### PR DESCRIPTION
This is the fix for https://bugs.mysql.com/bug.php?id=100384 still present in last version 8.

The file is duplicate in the source:

```
build-ps/debian/extra/mysql-helpers
packaging/deb-in/extra/mysql-helpers
```

the one in `packaging/` was already ok.

Regards