### PR TITLE
PS-8273 - RocksDB crash when inserting into table with unique key and TTL

### DIFF
--- a/mysql-test/suite/rocksdb/r/ttl_secondary_index_insert.result
+++ b/mysql-test/suite/rocksdb/r/ttl_secondary_index_insert.result
@@ -1,0 +1,18 @@
+CREATE TABLE t1 (
+`id` int NOT NULL AUTO_INCREMENT,
+`username` varchar(64) NOT NULL,
+`date` date NOT NULL,
+`hour` tinyint unsigned NOT NULL,
+`ipv4` varchar(15) NOT NULL,
+`ipv6` varchar(39) NOT NULL,
+`acctinputoctets` bigint DEFAULT NULL,
+`acctoutputoctets` bigint DEFAULT NULL,
+PRIMARY KEY (`id`),
+UNIQUE KEY `username_day_hour` (`username`,`date`,`hour`)
+) ENGINE=ROCKSDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1 COMMENT='ttl_duration=604800;';
+INSERT INTO t1 (`username`, `date`, `hour`, `ipv4`, `ipv6`, `acctinputoctets`, `acctoutputoctets`)
+VALUES ('100002992184', '2022-06-08', '10', '192.168.1.70', '', '1', '2');
+SELECT * from t1;
+id	username	date	hour	ipv4	ipv6	acctinputoctets	acctoutputoctets
+1	100002992184	2022-06-08	10	192.168.1.70		1	2
+drop table t1;

--- a/mysql-test/suite/rocksdb/t/ttl_secondary_index_insert.test
+++ b/mysql-test/suite/rocksdb/t/ttl_secondary_index_insert.test
@@ -1,0 +1,21 @@
+--source include/have_rocksdb.inc
+
+CREATE TABLE t1 (
+`id` int NOT NULL AUTO_INCREMENT,
+`username` varchar(64) NOT NULL,
+`date` date NOT NULL,
+`hour` tinyint unsigned NOT NULL,
+`ipv4` varchar(15) NOT NULL,
+`ipv6` varchar(39) NOT NULL,
+`acctinputoctets` bigint DEFAULT NULL,
+`acctoutputoctets` bigint DEFAULT NULL,
+PRIMARY KEY (`id`),
+UNIQUE KEY `username_day_hour` (`username`,`date`,`hour`)
+) ENGINE=ROCKSDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1 COMMENT='ttl_duration=604800;';
+
+INSERT INTO t1 (`username`, `date`, `hour`, `ipv4`, `ipv6`, `acctinputoctets`, `acctoutputoctets`)
+VALUES ('100002992184', '2022-06-08', '10', '192.168.1.70', '', '1', '2');
+
+SELECT * from t1;
+
+drop table t1;

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -10352,8 +10352,9 @@ int ha_rocksdb::check_and_lock_sk(
     guarantee SK uniqueness. We could optimize this by calling non-locking
     get instead.
   */
+  bool skip_ttl_check = !all_parts_used;
   rc = iter.get(&new_slice, all_parts_used ? &m_retrieved_record : nullptr,
-                m_lock_rows);
+                m_lock_rows, skip_ttl_check);
   if (rc && rc != HA_ERR_KEY_NOT_FOUND) {
     return rc;
   }


### PR DESCRIPTION
**Problem:**

This execution:

```
CREATE TABLE t1 (
`id` int NOT NULL AUTO_INCREMENT,
`username` varchar(64) NOT NULL,
`date` date NOT NULL,
`hour` tinyint unsigned NOT NULL,
`ipv4` varchar(15) NOT NULL,
`ipv6` varchar(39) NOT NULL,
`acctinputoctets` bigint DEFAULT NULL,
`acctoutputoctets` bigint DEFAULT NULL,
PRIMARY KEY (`id`),
UNIQUE KEY `username_day_hour` (`username`,`date`,`hour`)
) ENGINE=ROCKSDB AUTO_INCREMENT=1 DEFAULT CHARSET=latin1 COMMENT='ttl_duration=604800;';

INSERT INTO t1 (`username`, `date`, `hour`, `ipv4`, `ipv6`, `acctinputoctets`, `acctoutputoctets`)
VALUES ('100002992184', '2022-06-08', '10', '192.168.1.70', '', '1', '2');
```

causes the following crash:

```
13:12:26 UTC - mysqld got signal 11 ;
Most likely, you have hit a bug, but this error can also be caused by malfunctioning hardware.
Thread pointer: 0x7fb21ec0b7c0
Attempting backtrace. You can use the following information to find out
where mysqld died. If you see no messages after this, something went
terribly wrong...
stack_bottom = 7fb24fb67f08 thread_stack 0x46000
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(my_print_stacktrace(unsigned char const*, unsigned long)+0x42) [0x726eaa2]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(handle_fatal_signal+0x232) [0x5fa7132]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x14420) [0x7fb25ead0420]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(rocksdb::Slice::data() const+0xc) [0x7c4fa7c]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(myrocks::Rdb_string_reader::Rdb_string_reader(rocksdb::Slice const*)+0x21) [0x7c4f4f1]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(myrocks::rdb_should_hide_ttl_rec(myrocks::Rdb_key_def const&, rocksdb::Slice const&, myrocks::Rdb_transaction*)+0x101) [0x7c0d6f1]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(myrocks::Rdb_iterator_base::get(rocksdb::Slice const*, rocksdb::PinnableSlice*, myrocks::Rdb_lock_type, bool, bool)+0x32b) [0x83e4ffb]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(myrocks::ha_rocksdb::check_and_lock_sk(unsigned int, myrocks::ha_rocksdb::update_row_info const&, bool*, bool)+0x61a) [0x7c1ac7a]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(myrocks::ha_rocksdb::check_uniqueness_and_lock(myrocks::ha_rocksdb::update_row_info const&, bool, bool)+0x190) [0x7c1b140]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(myrocks::ha_rocksdb::update_write_row(unsigned char const*, unsigned char const*, bool)+0x271) [0x7c19941]
/home/ldonoso/src/fb-mysql-bld/runtime_output_directory/mysqld(myrocks::ha_rocksdb::write_row(unsigned char*)+0x2e5) [0x7c195d5]
```

The problem is caused when `all_parts_used` is `false` and so a null ptr
is passed to `iter.get`.

This causes the row not to be loaded and the crash when checking the TTL
of the row.

**Solution**:

In this scenario, we can skip the check of the ttl of the row.

It is not a problem if the record is stale since, next, `iter.seek` is
called and `iter.seek` checks the TTL.
