### PR TITLE
WIP: Avoid stalls during definition cache clean

### DIFF
--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -1343,9 +1343,13 @@ ulint dict_make_room_in_cache(
 
   i = len = UT_LIST_GET_LEN(dict_sys->table_LRU);
 
-  if (len < max_tables) {
+  if (len <= max_tables) {
     return (0);
   }
+
+  auto start = std::chrono::steady_clock::now();
+  std::cout << "!! making room in table cache: len=" << len
+            << " / max_tables=" << max_tables << std::endl;
 
   check_up_to = len - ((len * pct_check) / 100);
 
@@ -1380,6 +1384,10 @@ ulint dict_make_room_in_cache(
 
     table = prev_table;
   }
+
+  auto end = std::chrono::steady_clock::now();
+  std::cout << "!! done evicting table cache after " << (end - start).count()
+            << "ns: n_evicted=" << n_evicted << std::endl;
 
   return (n_evicted);
 }


### PR DESCRIPTION
LatchCounter uses a std::vector for storing registered counters, which
leads to n^2 behavior during dict_make_room_in_cache; this can hold the
dict_sys->mutex for multiple seconds at a time in the case where a very
large number of innodb tables (200,000+) have been opened since the last
cleaning round.

This commit changes LatchCounter to use std::unordered_set, creates a
separate member variable for the 'aggregate' counter, and adds a debug
output around dict_make_room_in_cache to monitor the timing.

---

#### Discussion

We encountered this performance issue on a production cluster of PXC 8.0.25-15.  At seemingly random intervals, one of the readers in the cluster would stop processing queries for multiple seconds, leading to a 'run' on the instance with CPU maxing out, connections piling up, and QPS not recovering on its own until the instance was depooled.

Each replica in this cluster serves a constant 2000-3000 QPS on average; this cluster has ~6,000,000 tables across ~90,000 schemata, and `opened_tables` increases by 700 per minute on average.  `table_definition_cache` is 10,000.

Investigating this issue proved tricky at first, but I did catch a useful `SHOW ENGINE INNODB STATUS` output which indicated contention on dict_sys->mutex, and that led me to [MySQL Bug #92133](https://bugs.mysql.com/bug.php?id=92133) and the [related blog post](https://www.percona.com/blog/2018/09/03/40-million-tables-in-mysql-8-0-with-zfs/).

After setting up a local PXC with a similar number of tables and writing a [load generator](https://github.com/robert-nix/mysql-loadgen) to make a SELECT with JOIN across 7 tables, I was able to reproduce the stalls.  After profiling during one of the stalls, I saw a single thread spinning [inside of a loop](https://gist.github.com/robert-nix/1875cb373ae4c0925d7ff77fe0819cb0#file-gistfile0-txt-L616-L695) within `dict_mem_table_free`; this corresponded to an inlined `dict_table_mutex_destroy` -> `TTASEventMutex<GenericPolicy<..>>::destroy` -> `LatchCounter::single_deregister` -> `(stl erase/remove_if)`.  It turned out there were around 250,000 entries in that LatchCounter's m_counters, which when combined with the fact that it is removing this counter for each mutex in the table LRU meant that mysqld is doing n^2 for a fairly large n while holding dict_sys->mutex.

This change to `unordered_set` is just a proof of concept; it is my understanding that insertion and deletion for `unordered_set` is slower than with just a flat vector for small N on modern processors, and I did see some performance loss (~10% QPS) during database warmup after this change (to be fair, this might be in the noise for my setup, so I'll do some more testing).  Additionally, while this change reduces the stall time significantly, it's still a noticeable stall:

a couple samples from before:
```
!! making room in table cache: len=206481 / max_tables=50000
!! done evicting table cache after 7744295345ns: n_evicted=92380
!! making room in table cache: len=157081 / max_tables=50000
!! done evicting table cache after 6878524069ns: n_evicted=107081
```
and after:
```
!! making room in table cache: len=156000 / max_tables=50000
!! done evicting table cache after 865225211ns: n_evicted=71165
!! making room in table cache: len=211093 / max_tables=50000
!! done evicting table cache after 2408978255ns: n_evicted=161093
!! making room in table cache: len=219300 / max_tables=50000
!! done evicting table cache after 1418924533ns: n_evicted=99906
!! making room in table cache: len=235317 / max_tables=50000
!! done evicting table cache after 2918130716ns: n_evicted=185317
```