### PR TITLE
WDCZEN-42 fix: rocksdb.bulk_load_xxx sporadically fail

### DIFF
--- a/mysql-test/suite/rocksdb/r/bulk_load_errors.result
+++ b/mysql-test/suite/rocksdb/r/bulk_load_errors.result
@@ -93,3 +93,4 @@ ERROR HY000: Rows inserted during bulk load must not overlap existing rows
 SET rocksdb_bulk_load=0;
 DROP TABLE t1;
 DROP TABLE t2;
+# restart

--- a/mysql-test/suite/rocksdb/t/bulk_load_errors.test
+++ b/mysql-test/suite/rocksdb/t/bulk_load_errors.test
@@ -155,3 +155,19 @@ DROP TABLE t1;
 DROP TABLE t2;
 
 --source include/wait_until_count_sessions.inc
+
+--source include/parse_rocksdb_fs_uri.inc
+if (!$rocksdb_zenfs_disabled)
+{
+  --file_exists $MYSQL_ZENFS
+  --let $rocksdb_base_dir = `SELECT @@rocksdb_datadir`
+  --let $expected_bulk_load_tmp_sst = test.t1_PRIMARY_2_0.bulk_load.tmp.sst
+  --source include/shutdown_mysqld.inc
+  --exec $MYSQL_ZENFS delete --zbd=$extracted_zenfs_device --path=$rocksdb_base_dir/$expected_bulk_load_tmp_sst > /dev/null 2>&1
+  --source include/start_mysqld.inc
+}
+if ($rocksdb_zenfs_disabled)
+{
+  # fake "# restart" message written to the test log to get identical results in ZenFS / non-ZenFS modes
+  --echo # restart
+}


### PR DESCRIPTION
https://jira.percona.com/browse/WDCZEN-42

Fixed problem in the 'rocksdb.bulk_load_errors' MTR test case when in
ZenFS mode it does not remove all temporary '*.bulk_load.tmp.sst' files
that may affect other 'rocksdb.bulk_load_xxx' tests.