### PR TITLE
Documentation: Updating apt repo Percona repositories (8.0)

### DIFF
--- a/doc/source/installation/apt_repo.rst
+++ b/doc/source/installation/apt_repo.rst
@@ -62,7 +62,7 @@ Installing |Percona Server| from Percona ``apt`` repository
 
 #. Once you install this package the Percona repositories should be added. You
    can check the repository setup in the
-   :file:`/etc/apt/sources.list.d/percona-release.list` file.
+   :file:`/etc/apt/sources.list.d/percona-original-release.list` file.
 
 #. Enable the repository:
 


### PR DESCRIPTION
In the step 4, it should be  `/etc/apt/sources.list.d/percona-original-release.list` , this is the one available in sources.list.d. The other is not find /etc/apt/sources.list.d/percona-release.list
![Screen Shot 2022-09-05 at 09 13 36](https://user-images.githubusercontent.com/58795858/188491036-507e1556-e907-4fe0-a32b-b98eb8fd8fad.png)
