### PR TITLE
PS-8330 merge: Merge MySQL 8.0.30 - Q3 2022 (azure zlib fix)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -377,6 +377,7 @@ jobs:
           -DWITH_ICU=/usr/local/opt/icu4c
           -DWITH_SSL=/usr/local/opt/openssl@1.1
           -DWITH_FIDO=bundled
+          -DWITH_ZLIB=bundled
         "
       else
         CMAKE_OPT+="
@@ -388,13 +389,13 @@ jobs:
           -DWITH_SSL=system
           -DWITH_LIBEVENT=bundled
           -DWITH_PROTOBUF=bundled
+          -DWITH_ZLIB=bundled
         "
         if [[ "$(Inverted)" != "ON" ]]; then
           CMAKE_OPT+="
             -DWITH_READLINE=system
             -DWITH_ICU=system
             -DWITH_LZ4=bundled
-            -DWITH_ZLIB=system
             -DWITH_NUMA=ON
           "
         else
@@ -402,7 +403,6 @@ jobs:
             -DWITH_EDITLINE=bundled
             -DWITH_ICU=bundled
             -DWITH_LZ4=bundled
-            -DWITH_ZLIB=bundled
             -DWITH_NUMA=OFF
             -DWITH_ARCHIVE_STORAGE_ENGINE=OFF
             -DWITH_BLACKHOLE_STORAGE_ENGINE=OFF


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8330

In the fix for the bug #34015600 "Upgrade zlib to 1.2.12 [cmake changes]" (commit mysql/mysql-server@8b8d48c) Oracle increased the minimum required version of the 'zlib' library to '1.2.12'. Currently none of the supported Percona Server platforms has this version of the library (including linux / MacOS images used by Azure Pipelines).

'WITH_ZLIB' CMake configuration option is now unconditionally set to 'bundled' in the 'azure-pipelines.yml' build scripts.