### PR TITLE
PS-8330 merge: Merge MySQL 8.0.30 - Q3 2022 (azure macos-12)

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,14 +36,14 @@ jobs:
 
   strategy:
     matrix:
-      macOS 10.15 Release:
-        imageName: 'macOS-10.15'
+      macOS 12 Release:
+        imageName: 'macOS-12'
         Compiler: clang
         BuildType: RelWithDebInfo
 
       ${{ if ne(variables['Build.Reason'], 'IndividualCI') }}:
-        macOS 10.15 Debug:
-          imageName: 'macOS-10.15'
+        macOS 12 Debug:
+          imageName: 'macOS-12'
           Compiler: clang
           BuildType: Debug
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8330

Azure Pipelines are now using 'macOS-12' image instead of deprecated 'macOS-10.15'.