### PR TITLE
PS-8330 merge: Merge MySQL 8.0.30 - Q3 2022 (gcc-7 structured bindings)

### DIFF
--- a/sql/histograms/equi_height.cc
+++ b/sql/histograms/equi_height.cc
@@ -131,7 +131,10 @@ static bool FitsIntoBuckets(const Value_map<T> &value_map,
   size_t used_buckets = 1;
   ha_rows current_bucket_values = 0;
 
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
   for (const auto &[value, count] : value_map) {
+    MY_COMPILER_DIAGNOSTIC_POP()
     assert(count > 0);
     /*
       If the current bucket is not empty and adding the values causes it to
@@ -192,7 +195,10 @@ template <class T>
 static ha_rows FindBucketMaxValues(const Value_map<T> &value_map,
                                    size_t max_buckets) {
   ha_rows total_values = 0;
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
   for (const auto &[value, count] : value_map) total_values += count;
+  MY_COMPILER_DIAGNOSTIC_POP()
   if (max_buckets == 1) return total_values;
 
   // Conservative upper bound to avoid dealing with rounding and odd max_buckets
@@ -388,7 +394,10 @@ bool Equi_height<T>::build_histogram(const Value_map<T> &value_map,
 
   // Get total count of non-null values.
   ha_rows num_non_null_values = 0;
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
   for (const auto &[value, count] : value_map) num_non_null_values += count;
+  MY_COMPILER_DIAGNOSTIC_POP()
 
   // No non-null values, nothing to do.
   if (num_non_null_values == 0) {

--- a/sql/xa/transaction_cache.cc
+++ b/sql/xa/transaction_cache.cc
@@ -171,7 +171,10 @@ xa::Transaction_cache::list xa::Transaction_cache::get_cached_transactions() {
   auto &instance = xa::Transaction_cache::instance();
   list to_return;
   MUTEX_LOCK(mutex_guard, &instance.m_LOCK_transaction_cache);
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
   for (auto [_, trx] : instance.m_transaction_cache) to_return.push_back(trx);
+  MY_COMPILER_DIAGNOSTIC_POP()
   return to_return;
 }
 

--- a/unittest/gunit/histograms-t.cc
+++ b/unittest/gunit/histograms-t.cc
@@ -1476,7 +1476,10 @@ void VerifyEquiHeightSelectivities(const Value_map<T> &value_map,
       static_cast<double>(histogram->get_num_buckets_specified());
 
   ha_rows non_null_values = 0;
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
   for (const auto &[value, count] : value_map) non_null_values += count;
+  MY_COMPILER_DIAGNOSTIC_POP()
   ha_rows total_values = non_null_values + value_map.get_num_null_values();
 
   ha_rows cumulative_values = 0;

--- a/unittest/gunit/optimizer_test.h
+++ b/unittest/gunit/optimizer_test.h
@@ -53,9 +53,12 @@ static void SetJoinConditions(const mem_root_deque<TABLE_LIST *> &join_list);
 
 static void DestroyFakeTables(
     const std::unordered_map<string, Fake_TABLE *> &fake_tables) {
+  MY_COMPILER_DIAGNOSTIC_PUSH()
+  MY_COMPILER_GCC_DIAGNOSTIC_IGNORE("-Wunused-variable")
   for (const auto &[name, table] : fake_tables) {
     destroy(table);
   }
+  MY_COMPILER_DIAGNOSTIC_POP()
 }
 
 namespace optimizer_test {


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8330

Suppressed "unused variables" warnings inside structured bindings
when using 'gcc-7'.