### PR TITLE
post-fix PS-8385 (Redo log consumer name)

### DIFF
--- a/storage/innobase/log/log0write.cc
+++ b/storage/innobase/log/log0write.cc
@@ -2088,14 +2088,12 @@ static void log_writer_wait_on_consumers(log_t &log, lsn_t next_write_lsn) {
       break;
     }
     const std::string name = consumer->get_name();
-    const Log_consumer::consumer_type consumer_type =
-        consumer->get_consumer_type();
 
     log_files_mutex_exit(*log_sys);
     /* This should not be a checkpointer nor archiver (CONSUMER_TYPE_SERVER), as
     we've used dedicated log_writer_wait_on_checkpoint() and
     log_writer_wait_on_archiver() to wait for them already */
-    ut_ad(consumer_type == Log_consumer::consumer_type::USER);
+    ut_ad(consumer->get_consumer_type() == Log_consumer::consumer_type::USER);
     log_writer_mutex_exit(log);
     if (attempt++ % ATTEMPTS_BETWEEN_WARNINGS == 0) {
       ib::log_warn(ER_IB_MSG_LOG_WRITER_WAIT_ON_CONSUMER, name.c_str(),


### PR DESCRIPTION
Problem:
consumer_type variable was been considered unused on non debug builds.

Fix:
Adjusted ut_ad to use consumer->get_consumer_type() directly instead of storing its value into a variable.