### PR TITLE
PS-8106: MySQL crashes if you stop replication while it is replicating a CTAS.

### DIFF
--- a/mysql-test/suite/rpl/r/percona_bug_ps8106.result
+++ b/mysql-test/suite/rpl/r/percona_bug_ps8106.result
@@ -1,0 +1,40 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+SET @replica_parallel_workers_save = @@global.replica_parallel_workers;
+SET GLOBAL replica_parallel_workers = 0;
+include/start_slave.inc
+CREATE TABLE joinit (
+i int NOT NULL AUTO_INCREMENT,
+s varchar(64) DEFAULT NULL,
+t time NOT NULL,
+g int NOT NULL,
+PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+INSERT INTO joinit VALUES (NULL, uuid(), time(now()), (FLOOR( 1 + RAND() *60 )));
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+include/rpl_sync.inc
+CREATE TABLE joinit_copy AS SELECT * FROM joinit;
+DO SLEEP(1);
+STOP REPLICA;
+START REPLICA;
+SET GLOBAL replica_parallel_workers = @replica_parallel_workers_save;
+DROP TABLE joinit_copy;
+DROP TABLE joinit;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/percona_bug_ps8106.test
+++ b/mysql-test/suite/rpl/t/percona_bug_ps8106.test
@@ -1,0 +1,44 @@
+# PS-8106: MySQL crashes if you stop replication while it is replicating a CTAS.
+# https://jira.percona.com/browse/PS-8106
+
+--source include/have_debug_sync.inc
+--source include/have_binlog_format_row.inc
+
+--let $rpl_skip_start_slave= 1
+--source include/master-slave.inc
+
+--connection slave
+SET @replica_parallel_workers_save = @@global.replica_parallel_workers;
+SET GLOBAL replica_parallel_workers = 0;
+--source include/start_slave.inc
+
+--connection master
+CREATE TABLE joinit (
+ i int NOT NULL AUTO_INCREMENT,
+ s varchar(64) DEFAULT NULL,
+ t time NOT NULL,
+ g int NOT NULL,
+ PRIMARY KEY (i)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+INSERT INTO joinit VALUES (NULL, uuid(), time(now()), (FLOOR( 1 + RAND() *60 )));
+let $i= 0;
+while ($i < 15) {
+  INSERT INTO joinit SELECT NULL, uuid(), time(now()), (FLOOR( 1 + RAND( ) *60 )) FROM joinit;
+  inc $i;
+}
+
+--source include/rpl_sync.inc
+
+--connection master
+CREATE TABLE joinit_copy AS SELECT * FROM joinit;
+
+--connection slave
+DO SLEEP(1);
+STOP REPLICA;
+START REPLICA;
+SET GLOBAL replica_parallel_workers = @replica_parallel_workers_save;
+
+--connection master
+DROP TABLE joinit_copy;
+DROP TABLE joinit;
+--source include/rpl_end.inc


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8106

On rollback of `CREATE TABLE .. AS SELECT` statement DDL Log REMOVE CACHE is executed, but underlying procedure `dict_table_remove_from_cache_low` requires that table shouldn't have opened handles (`get_ref_count() == 0`). If tables were closed before rollback, this procedure can be executed freely.

This bug has nondeterministic character because statement can be commited already or not arrived yet to replica. Setting replica_parallel_workers != 0 makes rollback practically uncatchable, in most cases transaction will commit.

I runned all replication-related tests and did't found any degradation.

Also I tried to write test to this bug, but faced significant challenges: it seems that some special conditions are required to catch rollback, in my test I had commit in all tries. So to same some time I postponed writting of the test. Is it required? If yes, I'll try to finish and add it.