### PR TITLE
PS-4759: Percona Server Crashing when the stored procedure called the second time in the same session

### DIFF
--- a/mysql-test/r/parser_local_transformations.result
+++ b/mysql-test/r/parser_local_transformations.result
@@ -1,0 +1,23 @@
+CREATE TABLE a (a_id int);
+CREATE TABLE b (b_id int, a_id int);
+CREATE VIEW view1 AS
+SELECT a.a_id, MAX(b_id) as b_agg
+FROM (a LEFT JOIN b ON a.a_id = b.a_id)
+GROUP BY a.a_id;
+CREATE VIEW view2 AS
+SELECT b_agg
+FROM (view1 JOIN b ON view1.a_id = b.a_id);
+CREATE PROCEDURE p ()
+BEGIN
+IF (FALSE AND (SELECT COUNT(*) FROM view2) <= 0)
+THEN
+SELECT 'Dummy';
+END IF;
+END //
+CALL p();
+CALL p();
+DROP PROCEDURE p;
+DROP VIEW view1;
+DROP VIEW view2;
+DROP TABLE b;
+DROP TABLE a;

--- a/mysql-test/t/parser_local_transformations.test
+++ b/mysql-test/t/parser_local_transformations.test
@@ -1,0 +1,35 @@
+# PS-4759: Percona Server Crashing when the stored procedure
+# called the second time in the same session.
+#
+# This test is minimal variant of script attached in PS-4759.
+
+CREATE TABLE a (a_id int);
+CREATE TABLE b (b_id int, a_id int);
+
+CREATE VIEW view1 AS
+SELECT a.a_id, MAX(b_id) as b_agg
+FROM (a LEFT JOIN b ON a.a_id = b.a_id)
+GROUP BY a.a_id;
+
+CREATE VIEW view2 AS
+SELECT b_agg
+FROM (view1 JOIN b ON view1.a_id = b.a_id);
+
+DELIMITER //;
+CREATE PROCEDURE p ()
+BEGIN
+  IF (FALSE AND (SELECT COUNT(*) FROM view2) <= 0)
+  THEN
+    SELECT 'Dummy';
+  END IF;
+END //
+DELIMITER ;//
+
+CALL p();
+CALL p();
+
+DROP PROCEDURE p;
+DROP VIEW view1;
+DROP VIEW view2;
+DROP TABLE b;
+DROP TABLE a;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-4759

Bug was fixed already in commit https://github.com/percona/percona-server/commit/f3019ec2978ce9c00fedfbbe6d51120290be28da, just added testcase for it.

GCA merge from https://github.com/percona/percona-server/pull/4733