### PR TITLE
PS-1098: Fix audit_log_flush behavior when used with auto log rotation (5.7)

### DIFF
--- a/plugin/audit_log/file_logger.c
+++ b/plugin/audit_log/file_logger.c
@@ -218,38 +218,45 @@ static char *logname(LOGGER_HANDLE *log, char *buf, size_t buf_len,
 }
 
 
-static int do_rotate(LOGGER_HANDLE *log)
-{
-  char namebuf[FN_REFLEN];
-  int result;
-  unsigned int i;
-  char *buf_old, *buf_new, *tmp;
+static int do_rotate(LOGGER_HANDLE *log) {
+  char new_name_buf[FN_REFLEN] = {0};
+  char old_name_buf[FN_REFLEN] = {0};
+  char *new_name = NULL;
+  char *old_name = NULL;
+  unsigned int i = 0;
 
-  if (log->rotations == 0)
-    return 0;
+  if (log->rotations == 0) return 0;
 
-  memcpy(namebuf, log->path, log->path_len);
+  memcpy(new_name_buf, log->path, log->path_len);
+  memcpy(old_name_buf, log->path, log->path_len);
 
-  buf_new= logname(log, namebuf, sizeof(namebuf), log->rotations);
-  buf_old= log->path;
-  for (i=log->rotations-1; i>0; i--)
-  {
-    logname(log, buf_old, FN_REFLEN, i);
-    if (!access(buf_old, F_OK) &&
-        (result= my_rename(buf_old, buf_new, MYF(0))))
-      goto exit;
-    tmp= buf_old;
-    buf_old= buf_new;
-    buf_new= tmp;
+  for (i = log->rotations; i > 0; i--) {
+    new_name = logname(log, new_name_buf, sizeof(new_name_buf), i);
+
+    if (i > 1) {
+      old_name = logname(log, old_name_buf, sizeof(new_name_buf), i - 1);
+    }
+    else {
+      old_name = old_name_buf;
+      old_name_buf[log->path_len] = 0;
+    }
+
+    if (0 == access(old_name, F_OK) &&
+        0 != my_rename(old_name, new_name, MYF(0))) {
+      errno = my_errno();
+      return -1;
+    }
   }
-  if ((result= my_close(log->file, MYF(0))))
-    goto exit;
-  namebuf[log->path_len]= 0;
-  result= my_rename(namebuf, logname(log, log->path, FN_REFLEN, 1), MYF(0));
-  log->file= my_open(namebuf, LOG_FLAGS, MYF(0));
-exit:
-  errno= my_errno();
-  return log->file < 0 || result;
+
+  if (0 != my_close(log->file, MYF(0))) {
+    errno = my_errno();
+    return -1;
+  }
+
+  log->file = my_open(log->path, LOG_FLAGS, MYF(0));
+
+  errno = my_errno();
+  return log->file < 0 ? -1 : 0;
 }
 
 

--- a/plugin/audit_log/tests/mtr/audit_log_rotate_with_flush-master.opt
+++ b/plugin/audit_log/tests/mtr/audit_log_rotate_with_flush-master.opt
@@ -1,0 +1,5 @@
+--audit_log_file=test_audit.log
+--audit_log_format=JSON
+--audit_log_strategy=SEMISYNCHRONOUS
+--audit_log_rotate_on_size=4096
+--audit_log_rotations=1

--- a/plugin/audit_log/tests/mtr/audit_log_rotate_with_flush.result
+++ b/plugin/audit_log/tests/mtr/audit_log_rotate_with_flush.result
@@ -1,0 +1,5 @@
+#
+# PS-1098: 'SET GLOBAL audit_log_flush=1' reopens wrong file after auto rotation
+#
+SET GLOBAL audit_log_flush=1;
+success

--- a/plugin/audit_log/tests/mtr/audit_log_rotate_with_flush.test
+++ b/plugin/audit_log/tests/mtr/audit_log_rotate_with_flush.test
@@ -1,0 +1,25 @@
+--echo #
+--echo # PS-1098: 'SET GLOBAL audit_log_flush=1' reopens wrong file after auto rotation
+--echo #
+
+--disable_result_log
+--disable_query_log
+--source audit_log_events.inc
+--enable_query_log
+--enable_result_log
+
+SET GLOBAL audit_log_flush=1;
+
+let MYSQLD_DATADIR= `select @@datadir`;
+
+perl;
+  my $current_log_size = -s $ENV{'MYSQLD_DATADIR'} . "/test_audit.log";
+  my $rotated_log_size = -s $ENV{'MYSQLD_DATADIR'} . "/test_audit.log.1";
+
+  die "Current log file rewritten!" if ($current_log_size == 0);
+  die "Already rotated file reopened!" if ($rotated_log_size < 4096);
+EOF
+
+--remove_files_wildcard $MYSQLD_DATADIR test_audit.log*
+
+--echo success


### PR DESCRIPTION
https://jira.percona.com/browse/PS-1098

In case auto log rotation is enabled for audit log and 'SET GLOBAL audit_log_flush=1' is used right after log file is rotated it leads to just rotated file being reopend. Setting audit_log_flush=1 should do nothing except reopening current audit log file.

The reason of wrong behavior is that do_rotate() method uses data structures of logger handler to store temporary data while checking and renaming existing log files. Once it is done with this task logger handler may be not returned to its correct state in some scenarios.

Rewritten do_rotate() method not to use logger handler as temporary data storage.