### PR TITLE
PS-8275: Implement auto_evict_timeout

### DIFF
--- a/mysql-test/suite/group_replication/r/gr_persist_only_variables.result
+++ b/mysql-test/suite/group_replication/r/gr_persist_only_variables.result
@@ -23,6 +23,7 @@ WHERE VARIABLE_NAME LIKE 'group_replication%'
 
 SET PERSIST_ONLY group_replication_advertise_recovery_endpoints = @@GLOBAL.group_replication_advertise_recovery_endpoints;
 SET PERSIST_ONLY group_replication_allow_local_lower_version_join = @@GLOBAL.group_replication_allow_local_lower_version_join;
+SET PERSIST_ONLY group_replication_auto_evict_timeout = @@GLOBAL.group_replication_auto_evict_timeout;
 SET PERSIST_ONLY group_replication_auto_increment_increment = @@GLOBAL.group_replication_auto_increment_increment;
 SET PERSIST_ONLY group_replication_autorejoin_tries = @@GLOBAL.group_replication_autorejoin_tries;
 SET PERSIST_ONLY group_replication_bootstrap_group = @@GLOBAL.group_replication_bootstrap_group;
@@ -82,7 +83,7 @@ SET PERSIST_ONLY group_replication_transaction_size_limit = @@GLOBAL.group_repli
 SET PERSIST_ONLY group_replication_unreachable_majority_timeout = @@GLOBAL.group_replication_unreachable_majority_timeout;
 SET PERSIST_ONLY group_replication_view_change_uuid = @@GLOBAL.group_replication_view_change_uuid;
 
-include/assert.inc ['Expect 60 persisted variables.']
+include/assert.inc ['Expect 61 persisted variables.']
 
 ############################################################
 # 2. Restart server, it must bootstrap the group and preserve
@@ -91,15 +92,16 @@ include/assert.inc ['Expect 60 persisted variables.']
 include/rpl_reconnect.inc
 include/gr_wait_for_member_state.inc
 
-include/assert.inc ['Expect 60 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 59 variables which last value was set through SET PERSIST.']
-include/assert.inc ['Expect 59 persisted variables with matching persisted and global values.']
+include/assert.inc ['Expect 61 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 60 variables which last value was set through SET PERSIST.']
+include/assert.inc ['Expect 60 persisted variables with matching persisted and global values.']
 
 ############################################################
 # 3. Test RESET PERSIST IF EXISTS.
 #    Verify that there are no persisted variables.
 RESET PERSIST IF EXISTS group_replication_advertise_recovery_endpoints;
 RESET PERSIST IF EXISTS group_replication_allow_local_lower_version_join;
+RESET PERSIST IF EXISTS group_replication_auto_evict_timeout;
 RESET PERSIST IF EXISTS group_replication_auto_increment_increment;
 RESET PERSIST IF EXISTS group_replication_autorejoin_tries;
 RESET PERSIST IF EXISTS group_replication_bootstrap_group;

--- a/mysql-test/suite/group_replication/r/gr_persist_variables.result
+++ b/mysql-test/suite/group_replication/r/gr_persist_variables.result
@@ -23,6 +23,7 @@ WHERE VARIABLE_NAME LIKE '%group_replication%'
 
 SET PERSIST group_replication_advertise_recovery_endpoints = @@GLOBAL.group_replication_advertise_recovery_endpoints;
 SET PERSIST group_replication_allow_local_lower_version_join = @@GLOBAL.group_replication_allow_local_lower_version_join;
+SET PERSIST group_replication_auto_evict_timeout = @@GLOBAL.group_replication_auto_evict_timeout;
 SET PERSIST group_replication_auto_increment_increment = @@GLOBAL.group_replication_auto_increment_increment;
 SET PERSIST group_replication_autorejoin_tries = @@GLOBAL.group_replication_autorejoin_tries;
 SET PERSIST group_replication_bootstrap_group = @@GLOBAL.group_replication_bootstrap_group;
@@ -84,7 +85,7 @@ SET PERSIST group_replication_transaction_size_limit = @@GLOBAL.group_replicatio
 SET PERSIST group_replication_unreachable_majority_timeout = @@GLOBAL.group_replication_unreachable_majority_timeout;
 SET PERSIST group_replication_view_change_uuid = @@GLOBAL.group_replication_view_change_uuid;
 
-include/assert.inc ['Expect 60 persisted variables.']
+include/assert.inc ['Expect 61 persisted variables.']
 
 ############################################################
 # 2. Restart server, it must bootstrap the group and preserve
@@ -93,15 +94,16 @@ include/assert.inc ['Expect 60 persisted variables.']
 include/rpl_reconnect.inc
 include/gr_wait_for_member_state.inc
 
-include/assert.inc ['Expect 60 persisted variables in persisted_variables table.']
-include/assert.inc ['Expect 59 variables which last value was set through SET PERSIST.']
-include/assert.inc ['Expect 59 variables which last value was set through SET PERSIST is equal to its global value.']
+include/assert.inc ['Expect 61 persisted variables in persisted_variables table.']
+include/assert.inc ['Expect 60 variables which last value was set through SET PERSIST.']
+include/assert.inc ['Expect 60 variables which last value was set through SET PERSIST is equal to its global value.']
 
 ############################################################
 # 3. Test RESET PERSIST.
 #    Verify that there are no persisted variables.
 RESET PERSIST group_replication_advertise_recovery_endpoints;
 RESET PERSIST group_replication_allow_local_lower_version_join;
+RESET PERSIST group_replication_auto_evict_timeout;
 RESET PERSIST group_replication_auto_increment_increment;
 RESET PERSIST group_replication_autorejoin_tries;
 RESET PERSIST group_replication_bootstrap_group;

--- a/mysql-test/suite/group_replication/r/gr_set_option_during_stop.result
+++ b/mysql-test/suite/group_replication/r/gr_set_option_during_stop.result
@@ -41,6 +41,7 @@ WHERE VARIABLE_NAME LIKE 'group_replication_%'
  AND VARIABLE_NAME != 'group_replication_start_on_boot'
  AND VARIABLE_NAME != 'group_replication_tls_source'
  AND VARIABLE_NAME != 'group_replication_transaction_size_limit'
+ AND VARIABLE_NAME != 'group_replication_auto_evict_timeout'
  ORDER BY VARIABLE_NAME;
 SET SESSION sql_log_bin = 1;
 SET @value= @@GLOBAL.group_replication_advertise_recovery_endpoints;
@@ -174,6 +175,8 @@ ORDER BY gb.VARIABLE_NAME;
 SET SESSION sql_log_bin = 1;
 SET @value= @@GLOBAL.group_replication_allow_local_lower_version_join;
 SET @@GLOBAL.group_replication_allow_local_lower_version_join= @value;
+SET @value= @@GLOBAL.group_replication_auto_evict_timeout;
+SET @@GLOBAL.group_replication_auto_evict_timeout= @value;
 SET @value= @@GLOBAL.group_replication_bootstrap_group;
 SET @@GLOBAL.group_replication_bootstrap_group= @value;
 SET @value= @@GLOBAL.group_replication_communication_stack;

--- a/mysql-test/suite/group_replication/r/gr_show_global_and_session_variables.result
+++ b/mysql-test/suite/group_replication/r/gr_show_global_and_session_variables.result
@@ -7,8 +7,8 @@ Note	####	Storing MySQL user name or password information in the master info rep
 include/start_and_bootstrap_group_replication.inc
 include/stop_group_replication.inc
 
-# Test#1: Basic check that there are 61 GR variables.
-include/assert.inc [There are 61 GR variables at present.]
+# Test#1: Basic check that there are 62 GR variables.
+include/assert.inc [There are 62 GR variables at present.]
 
 # Test#2: Verify group replication related variables at GLOBAL scope.
 SET @@SESSION.group_replication_allow_local_lower_version_join= 1;

--- a/mysql-test/suite/group_replication/r/gr_variables_default_values.result
+++ b/mysql-test/suite/group_replication/r/gr_variables_default_values.result
@@ -26,9 +26,9 @@ include/stop_group_replication.inc
 #
 # Test Unit#1
 # Set global/session group replication variables to default.
-# Curently there are 61 group replication variables.
+# Curently there are 62 group replication variables.
 #
-include/assert.inc [There are 61 GR variables at present.]
+include/assert.inc [There are 62 GR variables at present.]
 SET @@GLOBAL.group_replication_auto_increment_increment= default;
 ERROR 42000: Variable 'group_replication_auto_increment_increment' can't be set to the value of 'DEFAULT'
 SET @@GLOBAL.group_replication_compression_threshold= default;

--- a/mysql-test/suite/group_replication/r/gr_variables_privileges.result
+++ b/mysql-test/suite/group_replication/r/gr_variables_privileges.result
@@ -29,6 +29,8 @@ SET GLOBAL group_replication_advertise_recovery_endpoints = @@GLOBAL.group_repli
 ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
 SET GLOBAL group_replication_allow_local_lower_version_join = @@GLOBAL.group_replication_allow_local_lower_version_join;
 ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
+SET GLOBAL group_replication_auto_evict_timeout = @@GLOBAL.group_replication_auto_evict_timeout;
+ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
 SET GLOBAL group_replication_auto_increment_increment = @@GLOBAL.group_replication_auto_increment_increment;
 ERROR 42000: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation
 SET GLOBAL group_replication_autorejoin_tries = @@GLOBAL.group_replication_autorejoin_tries;
@@ -163,6 +165,7 @@ GRANT SYSTEM_VARIABLES_ADMIN, SESSION_VARIABLES_ADMIN ON *.* TO 'no_priv_user'@l
 
 SET GLOBAL group_replication_advertise_recovery_endpoints = @@GLOBAL.group_replication_advertise_recovery_endpoints;
 SET GLOBAL group_replication_allow_local_lower_version_join = @@GLOBAL.group_replication_allow_local_lower_version_join;
+SET GLOBAL group_replication_auto_evict_timeout = @@GLOBAL.group_replication_auto_evict_timeout;
 SET GLOBAL group_replication_auto_increment_increment = @@GLOBAL.group_replication_auto_increment_increment;
 SET GLOBAL group_replication_autorejoin_tries = @@GLOBAL.group_replication_autorejoin_tries;
 SET GLOBAL group_replication_bootstrap_group = @@GLOBAL.group_replication_bootstrap_group;

--- a/mysql-test/suite/group_replication/t/gr_set_option_during_stop.test
+++ b/mysql-test/suite/group_replication/t/gr_set_option_during_stop.test
@@ -74,6 +74,7 @@ INSERT INTO gr_options_that_cannot_be_change (name)
  AND VARIABLE_NAME != 'group_replication_start_on_boot'
  AND VARIABLE_NAME != 'group_replication_tls_source'
  AND VARIABLE_NAME != 'group_replication_transaction_size_limit'
+ AND VARIABLE_NAME != 'group_replication_auto_evict_timeout'
  ORDER BY VARIABLE_NAME;
 SET SESSION sql_log_bin = 1;
 --let $gr_options_that_cannot_be_change_count= `SELECT COUNT(*) FROM gr_options_that_cannot_be_change;`

--- a/mysql-test/suite/group_replication/t/gr_show_global_and_session_variables.test
+++ b/mysql-test/suite/group_replication/t/gr_show_global_and_session_variables.test
@@ -32,7 +32,7 @@
 
 --sleep 30
 
---let $gr_var_count= 61
+--let $gr_var_count= 62
 --echo
 --echo # Test#1: Basic check that there are $gr_var_count GR variables.
 

--- a/mysql-test/suite/group_replication/t/gr_variables_default_values.test
+++ b/mysql-test/suite/group_replication/t/gr_variables_default_values.test
@@ -91,7 +91,7 @@ SET @@GLOBAL.group_replication_communication_max_message_size= default;
 --let $saved_gr_paxos_single_leader = `SELECT @@GLOBAL.group_replication_paxos_single_leader;`
 
 # Total number of GR variables.
---let $total_gr_vars= 61
+--let $total_gr_vars= 62
 
 --echo #
 --echo # Test Unit#1

--- a/plugin/group_replication/include/pipeline_stats.h
+++ b/plugin/group_replication/include/pipeline_stats.h
@@ -668,6 +668,11 @@ class Flow_control_module {
   std::atomic<int64> m_quota_size;
 
   /*
+    Seconds spent in flow control
+  */
+  uint64 m_flow_control_time;
+
+  /*
     Counter incremented on every flow control step.
   */
   uint64 m_stamp;

--- a/plugin/group_replication/include/plugin.h
+++ b/plugin/group_replication/include/plugin.h
@@ -215,6 +215,7 @@ uint get_number_of_autorejoin_tries();
 ulonglong get_rejoin_timeout();
 void declare_plugin_cloning(bool is_running);
 bool get_allow_single_leader();
+uint get_auto_evict_timeout();
 /**
   Encapsulates the logic necessary to attempt a rejoin, i.e. gracefully leave
   the group, terminate GCS infrastructure, terminate auto-rejoin relevant plugin

--- a/plugin/group_replication/include/plugin_variables.h
+++ b/plugin/group_replication/include/plugin_variables.h
@@ -295,6 +295,8 @@ struct plugin_options_variables {
   ulong communication_stack_var;
 
   bool allow_single_leader_var{false};
+
+  uint auto_evict_timeout;
 };
 
 #endif /* PLUGIN_VARIABLES_INCLUDE */

--- a/plugin/group_replication/src/pipeline_stats.cc
+++ b/plugin/group_replication/src/pipeline_stats.cc
@@ -28,6 +28,7 @@
 #include "my_byteorder.h"
 #include "my_dbug.h"
 #include "my_systime.h"
+#include "plugin/group_replication/include/leave_group_on_failure.h"
 #include "plugin/group_replication/include/plugin.h"
 #include "plugin/group_replication/include/plugin_server_include.h"
 
@@ -741,6 +742,56 @@ Flow_control_module::~Flow_control_module() {
 void Flow_control_module::flow_control_step(
     Pipeline_stats_member_collector *member) {
   if (--seconds_to_skip > 0) return;
+
+  if (get_auto_evict_timeout() > 0) {
+    auto it = m_info.end();
+    if (group_member_mgr != nullptr) {
+      auto ml = group_member_mgr->get_all_members();
+      auto local_uuid = local_member_info->get_uuid();
+      auto it2 = std::find_if(
+          ml->begin(), ml->end(),
+          [local_uuid](auto const &v) { return v->get_uuid() == local_uuid; });
+      if (it2 != ml->end()) {
+        it = m_info.find((*it2)->get_gcs_member_id().get_member_id());
+      }
+      for (Group_member_info *member : *ml) {
+        delete member;
+      }
+      delete ml;
+
+      std::string current_primary_uuid;
+      if (group_member_mgr->get_primary_member_uuid(current_primary_uuid)) {
+        if (current_primary_uuid == local_uuid) {
+          it = m_info.end();  // The primary node should never self-leave
+                              // because of flow control
+        }
+      }
+    }
+
+    if (it != m_info.end() && it->second.is_flow_control_needed()) {
+      m_flow_control_time += get_flow_control_period_var();
+    } else {
+      m_flow_control_time = 0;
+    }
+    if (m_flow_control_time > get_auto_evict_timeout()) {
+      const char *exit_state_action_abort_log_message =
+          "Flow control timeout value reached, leaving Group Replication.";
+      leave_group_on_failure::mask leave_actions;
+      /*
+        Only follow exit_state_action if we were already inside a group. We may
+        happen to come across an applier error during the startup of GR (i.e.
+        during the execution of the START GROUP_REPLICATION command). We must
+        not follow exit_state_action on that situation.
+      */
+      leave_actions.set(leave_group_on_failure::HANDLE_EXIT_STATE_ACTION,
+                        gcs_module->belongs_to_group());
+      leave_group_on_failure::leave(
+          leave_actions, ER_GRP_RPL_FLOW_CONTROL_TIMEOUT, PSESSION_USE_THREAD,
+          nullptr, exit_state_action_abort_log_message);
+      m_flow_control_time = 0;
+      return;
+    }
+  }
 
   int32 holds = m_holds_in_period.exchange(0);
   Flow_control_mode fcm =

--- a/plugin/group_replication/src/plugin.cc
+++ b/plugin/group_replication/src/plugin.cc
@@ -342,6 +342,8 @@ bool get_allow_single_leader() {
     return ov.allow_single_leader_var;
 }
 
+uint get_auto_evict_timeout() { return ov.auto_evict_timeout; }
+
 /**
  * @brief Callback implementation of
  * handle_group_replication_incoming_connection. This is the entry point for
@@ -5112,6 +5114,19 @@ static MYSQL_SYSVAR_ENUM(
     &ov.communication_stack_values_typelib_t /* type lib */
 );
 
+static MYSQL_SYSVAR_UINT(auto_evict_timeout,    /* name */
+                         ov.auto_evict_timeout, /* var */
+                         PLUGIN_VAR_OPCMDARG |
+                             PLUGIN_VAR_PERSIST_AS_READ_ONLY, /* optional var */
+                         "Flow control auto eviction timeout",
+                         nullptr, /* check func */
+                         nullptr, /* update func */
+                         0U,      /* default */
+                         0U,      /* min */
+                         65535U,  /* max */
+                         0        /* block */
+);
+
 static SYS_VAR *group_replication_system_vars[] = {
     MYSQL_SYSVAR(group_name),
     MYSQL_SYSVAR(start_on_boot),
@@ -5173,6 +5188,7 @@ static SYS_VAR *group_replication_system_vars[] = {
     MYSQL_SYSVAR(view_change_uuid),
     MYSQL_SYSVAR(communication_stack),
     MYSQL_SYSVAR(paxos_single_leader),
+    MYSQL_SYSVAR(auto_evict_timeout),
     nullptr,
 };
 

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -12037,7 +12037,9 @@ ER_XB_MSG_DOWNGRADING_LOG_FILE
 ER_RPL_ENABLE_EVENT_ADD_WILD_PATTERN_FAILED
   eng "Could not add event rule '%s' to --replica-enable-event. %s"
 
-#
+ER_GRP_RPL_FLOW_CONTROL_TIMEOUT
+  eng "Flow control auto evict timeout reached. The server will now leave the group."
+
 # End of Percona Server 8.0 server error log messages
 #
 


### PR DESCRIPTION
This commit implement a new system variable,
group_replication_auto_evict_timeout, which automatically evicts members if they were in flow_control for more than the specified timeout.

By default this variable is 0, and doesn't change the existing behavior.

If it is set to a non zero value, any node that reaches the flow control threshold self evicts itself flom the cluster.

This change doesn't take into account the majority concept introduced in PS-8276: a single node is considered in flow control, and timeout calculation strarts, even if only a single node reaches the limit.