### PR TITLE
PS-8169: LDAP SASL plugin

### DIFF
--- a/mysql-test/include/plugin.defs
+++ b/mysql-test/include/plugin.defs
@@ -181,6 +181,7 @@ ha_rocksdb         plugin_output_directory  no  ROCKSDB         rocksdb,rocksdb_
 auth_pam           plugin_output_directory  no  AUTH_PAM
 auth_pam_compat    plugin_output_directory  no  AUTH_PAM_COMPAT
 authentication_ldap_simple          plugin_output_directory  no  AUTH_LDAP             authentication_ldap_simple
+authentication_ldap_sasl          plugin_output_directory  no  AUTH_LDAP_SASL             authentication_ldap_sasl
 keyring_vault      plugin_output_directory  no  KEYRING_VAULT_PLUGIN keyring_vault
 test_udf_wrappers  plugin_output_directory  no  TEST_UDF_WRAPPERS_LIB
 binlog_utils_udf   plugin_output_directory  no  BINLOG_UTILS_UDF_LIB

--- a/plugin/auth_ldap/CMakeLists.txt
+++ b/plugin/auth_ldap/CMakeLists.txt
@@ -29,14 +29,26 @@ IF(WITH_LDAP)
     src/connection.cc
     src/pool.cc
   )
+SET(ALP_SOURCES_SASL
+    src/log_client.cc
+    src/plugin_common.cc
+    src/plugin_sasl.cc
+    src/auth_ldap_impl.cc
+    src/connection.cc
+    src/pool.cc
+  )
   ### Configuration ###
   ADD_DEFINITIONS(-DLOG_COMPONENT_TAG="auth_ldap")
 
   INCLUDE_DIRECTORIES(SYSTEM ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})
 
-  # libler?
   MYSQL_ADD_PLUGIN(authentication_ldap_simple ${ALP_SOURCES_SIMPLE}
     LINK_LIBRARIES ldap_r MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_simple")
+  TARGET_COMPILE_DEFINITIONS(authentication_ldap_simple PRIVATE -DPLUGIN_SIMPLE)
+
+  MYSQL_ADD_PLUGIN(authentication_ldap_sasl ${ALP_SOURCES_SASL}
+    LINK_LIBRARIES ldap_r MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_sasl")
+  TARGET_COMPILE_DEFINITIONS(authentication_ldap_sasl PRIVATE -DPLUGIN_SASL)
 
   IF(UNIX)
     IF(INSTALL_MYSQLTESTDIR)

--- a/plugin/auth_ldap/include/auth_ldap_impl.h
+++ b/plugin/auth_ldap/include/auth_ldap_impl.h
@@ -1,5 +1,6 @@
 #ifndef AUTH_LDAP_IMPL_MPALDAP_H
 /* Copyright (c) 2019 Francisco Miguel Biete Banon. All rights reserved.
+   Copyright (c) 2022, Percona Inc. All Rights Reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -34,6 +35,12 @@ struct t_group_mapping {
 
 class AuthLDAPImpl {
  public:
+  struct sasl_ctx {
+    std::function<std::string()> get_client_data;
+    std::function<void(std::string const &)> send_server_data;
+    std::string sasl_method;
+  };
+
   AuthLDAPImpl(const std::string &user_name, const std::string &auth_string,
                const std::string &user_search_attr,
                const std::string &group_search_filter,
@@ -54,8 +61,14 @@ class AuthLDAPImpl {
                               std::string *user_mysql,
                               std::string *roles_mysql);
 
+  bool bind_and_get_mysql_uid(sasl_ctx &ctx, const std::string &user_dn,
+                              std::string *user_mysql,
+                              std::string *roles_mysql);
+
  private:
   bool bind_internal(const std::string &user_dn, const std::string &password,
+                     Pool::pool_ptr_t *conn);
+  bool bind_internal(sasl_ctx &ctx, const std::string &user_dn,
                      Pool::pool_ptr_t *conn);
 
   std::string calc_ldap_uid();

--- a/plugin/auth_ldap/include/connection.h
+++ b/plugin/auth_ldap/include/connection.h
@@ -41,10 +41,17 @@ class Connection {
   Connection(const Connection &) = delete;  // non construction-copyable
   Connection &operator=(const Connection &) = delete;  // non copyable
 
+  enum class status { FAILURE, IN_PROGRESS, SUCCESS };
+
   void configure(const std::string &ldap_host, std::uint16_t ldap_port,
                  const std::string &fallback_host, std::uint16_t fallback_port,
                  bool use_ssl, bool use_tls);
-  bool connect(const std::string &bind_dn, const std::string &bind_pwd);
+  status connect(const std::string &bind_dn, const std::string &bind_auth,
+                 std::string &auth_resp,
+                 const std::string &sasl_mech = "" /* LDAP_SASL_SIMPLE */);
+  status connect_step(const std::string &bind_dn, const std::string &bind_auth,
+                      std::string &auth_resp, const std::string &sasl_mech);
+
   std::size_t get_idx_pool() const;
   bool is_snipped() const;
   bool is_zombie();

--- a/plugin/auth_ldap/include/plugin_common.h
+++ b/plugin/auth_ldap/include/plugin_common.h
@@ -1,5 +1,6 @@
 #ifndef PLUGIN_COMMON_MPALDAP_H
 /* Copyright (c) 2019 Francisco Miguel Biete Banon. All rights reserved.
+   Copyright (c) 2022, Percona Inc. All Rights Reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -34,7 +35,8 @@ int auth_ldap_common_authenticate_user(
     MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info, const char *password,
     mysql::plugin::auth_ldap::Pool *pool, const char *user_search_attr,
     const char *group_search_attr, const char *group_search_filter,
-    const char *bind_base_dn, const char *group_role_mapping);
+    const char *bind_base_dn, const char *group_role_mapping,
+    std::string const &sasl_method = "" /*LDAP_SASL_SIMPLE*/);
 
 int auth_ldap_common_generate_auth_string_hash(char *outbuf,
                                                unsigned int *buflen,

--- a/plugin/auth_ldap/include/plugin_sasl.h
+++ b/plugin/auth_ldap/include/plugin_sasl.h
@@ -1,0 +1,24 @@
+#ifndef PLUGIN_SIMPLE_MPALDAP_H
+/* Copyright (c) 2022, Percona Inc. All Rights Reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
+#define PLUGIN_SIMPLE_MPALDAP_H
+
+#include "plugin_common.h"
+
+#define MPALDAP_SIMPLE_PLUGIN_NAME "authentication_ldap_sasl"
+
+extern MYSQL_PLUGIN auth_ldap_sasl_plugin_info;
+
+#endif  // PLUGIN_SIMPLE_MPALDAP_H

--- a/plugin/auth_ldap/readme_sasl.txt
+++ b/plugin/auth_ldap/readme_sasl.txt
@@ -1,0 +1,62 @@
+The MySQL LDAP SASL authentication isn't that trivial.
+This readme tries to explain how it works at a high level.
+
+The LDAP library has two high level methods for SASL authentication:
+
+* ldap_sasl_interactive_bind(_s), and
+* ldap_sasl_bind(_s)
+
+Most examples on the internet use the ldap_sasl_interactive_s method, because
+that's the higher level "do all magic" method. It deals with the SASL library,
+executes all steps required for the specified SASL authentication method, and
+allows specifying the callback to provide the required inputs (e.g. usernames
+and passwords).
+
+It also makes the assumption that we only have one client and one (ldap) server
+machine, which isn't neccessarily true with MySQL: we can have a separate mysql
+client machine, a separate mysql server machine, and a separate ldap server.
+
+Because of this, MySQL has to use the more complex ldap_sasl_bind_s.
+
+ldap_sasl_bind_s only performs one (of the possibly many) authentication steps.
+It either retuns failure, success, or "in-progress" (more steps needed).
+
+ldap_sasl_bind_s doesn't deal with libsasl: all SASL calls have to be done by 
+the user code. The idea is that the SASL library responses are sent to the LDAP
+library using the cred parameter, and the LDAP library responses are given 
+using the last out parameter (servercredp). This out parameter has to be
+specified as the input parameter for the next SASL library call, which again
+sends another response...
+
+In our case, the SASL communication is already implemented: the client
+plugin calls the SASL library, and sends its responses to the server plugin.
+The server plugin has to send this data to the LDAP library, and forward the
+library's response to the client plugin. The client plugin performs the next
+SASL step using this response as the input, and sends the data for the next
+LDAP step...
+
+In theory, SASL supports many authentication methods. In practice the MySQL
+client side plugin only supports SCRAM-SHA-1 and GSSAPI (Kerberos). 
+Currently the PS server side plugin is only tested with SCRAM-SHA-1, and 
+because of this, it is hardcoded into the plugin. In the future we should
+try to test it with GSSAPI, and enable that as an option (system variable).
+
+
+Test setup
+====
+
+There is an MTR testcase in the tests directory. The testcase requires an
+LDAP server with SASL configured. There are no simple docker images or example
+servers with this setup, so it has to be created manually.
+
+The tests directory also contains two ldif files: one for the user, and one for
+enabling the SCRAM-SHA-1 authentication method.
+
+After adding these files with ldapmodify, a simple test can be executed with the
+following command:
+
+ldapsearch -LLL -H ldapi:/// -s "base" -b "" supportedSASLMechanisms -Y SCRAM-SHA-1 -U john3
+
+The password is "secret". If authentication succeeds, and it prints a list of the
+authentication methods supported by the server, the MTR testcase should work too.
+

--- a/plugin/auth_ldap/src/log_client.cc
+++ b/plugin/auth_ldap/src/log_client.cc
@@ -1,4 +1,5 @@
 /* Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+   Copyright (c) 2022, Percona Inc. All Rights Reserved.
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -22,7 +23,12 @@
 
 #include "plugin/auth_ldap/include/log_client.h"
 #include "include/mysql/services.h"
+#ifdef PLUGIN_SIMPLE
 #include "plugin/auth_ldap/include/plugin_simple.h"
+#endif
+#ifdef PLUGIN_SASL
+#include "plugin/auth_ldap/include/plugin_sasl.h"
+#endif
 
 namespace mysql {
 namespace plugin {
@@ -56,8 +62,15 @@ void Ldap_log_writer_error::write(ldap_log_type::ldap_type level,
       plevel = MY_ERROR_LEVEL;
       break;
   };
-  my_plugin_log_message(&auth_ldap_simple_plugin_info, plevel, "%s",
-                        data.c_str());
+  my_plugin_log_message(
+#ifdef PLUGIN_SIMPLE
+      &auth_ldap_simple_plugin_info
+#endif
+#ifdef PLUGIN_SASL
+          & auth_ldap_sasl_plugin_info
+#endif
+      ,
+      plevel, "%s", data.c_str());
 }
 
 /**

--- a/plugin/auth_ldap/src/plugin_sasl.cc
+++ b/plugin/auth_ldap/src/plugin_sasl.cc
@@ -1,0 +1,229 @@
+/* Copyright (c) 2022, Percona Inc. All Rights Reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software Foundation,
+   51 Franklin Street, Suite 500, Boston, MA 02110-1335 USA */
+
+#include "plugin/auth_ldap/include/plugin_sasl.h"
+#include "plugin/auth_ldap/include/auth_ldap_impl.h"
+#include "plugin/auth_ldap/include/connection.h"
+#include "plugin/auth_ldap/include/plugin_common.h"
+#include "plugin/auth_ldap/include/plugin_log.h"
+#include "plugin/auth_ldap/include/plugin_variables.h"
+#include "plugin/auth_ldap/include/pool.h"
+
+#include <ldap.h>
+#include <condition_variable>
+#include <mutex>
+
+mysql::plugin::auth_ldap::Ldap_logger *g_logger_server;
+
+MYSQL_PLUGIN auth_ldap_sasl_plugin_info;
+
+namespace {
+std::mutex active_m;
+std::condition_variable active_cv;
+int active_connections = 0;
+}  // namespace
+
+// Declaration to access the name of the SYS_VAR
+struct SYS_VAR {
+  MYSQL_PLUGIN_VAR_HEADER;
+};
+
+template <typename Copy_type>
+void update_sysvar(THD *, SYS_VAR *var, void *var_ptr, const void *value) {
+  // Update the value
+  *(Copy_type *)var_ptr = *(Copy_type *)const_cast<void *>(value);
+
+  if (strcmp(var->name, "authentication_ldap_sasl_log_status") == 0) {
+    g_logger_server->set_log_level(
+        static_cast<mysql::plugin::auth_ldap::ldap_log_level>(log_status));
+  } else if (strcmp(var->name, "authentication_ldap_group_role_maping") == 0) {
+    connPool->reset_group_role_mapping(str_or_empty(group_role_mapping));
+  } else {
+    connPool->reconfigure(
+        init_pool_size, max_pool_size, str_or_empty(server_host), server_port,
+        str_or_empty(fallback_server_host), fallback_server_port, ssl, tls,
+        str_or_empty(ca_path), str_or_empty(bind_root_dn),
+        str_or_empty(bind_root_pwd_real));
+    connPool->debug_info();
+  }
+}
+
+static void pwd_real_set(const char *value) {
+  char *v = nullptr;
+
+  if (value) {
+    v = my_strdup(PSI_NOT_INSTRUMENTED, value, MYF(0));
+  }
+
+  if (bind_root_pwd_real) {
+    my_free(bind_root_pwd_real);
+    bind_root_pwd_real = nullptr;
+  }
+
+  if (v && strlen(v)) {
+    bind_root_pwd_real = v;
+    bind_root_pwd = my_strdup(PSI_NOT_INSTRUMENTED, "********", MYF(0));
+  } else {
+    bind_root_pwd = my_strdup(PSI_NOT_INSTRUMENTED, "", MYF(0));
+  }
+}
+
+void update_pwd_sysvar(THD *, SYS_VAR *, void * /* unused */,
+                       const void *value) {
+  pwd_real_set(*static_cast<const char *const *>(value));
+
+  connPool->reconfigure(
+      init_pool_size, max_pool_size, str_or_empty(server_host), server_port,
+      str_or_empty(fallback_server_host), fallback_server_port, ssl, tls,
+      str_or_empty(ca_path), str_or_empty(bind_root_dn),
+      str_or_empty(bind_root_pwd_real));
+  connPool->debug_info();
+}
+
+static int auth_ldap_sasl_init(MYSQL_PLUGIN plugin_info) {
+  auth_ldap_sasl_plugin_info = plugin_info;
+
+  g_logger_server = new mysql::plugin::auth_ldap::Ldap_logger();
+  g_logger_server->set_log_level(
+      static_cast<mysql::plugin::auth_ldap::ldap_log_level>(log_status));
+  log_srv_dbg("Ldap_logger initialized");
+
+  auth_ldap_common_init();
+  log_srv_dbg("auth_ldap_sasl_init()");
+
+  pwd_real_set(bind_root_pwd);
+
+  log_srv_dbg("Creating LDAP connection pool");
+  connPool = new mysql::plugin::auth_ldap::Pool(
+      init_pool_size, max_pool_size, str_or_empty(server_host), server_port,
+      str_or_empty(fallback_server_host), fallback_server_port, ssl, tls,
+      str_or_empty(ca_path), str_or_empty(bind_root_dn),
+      str_or_empty(bind_root_pwd_real));
+  connPool->reset_group_role_mapping(str_or_empty(group_role_mapping));
+  connPool->debug_info();
+
+  log_srv_info("Plugin initialized");
+
+  {
+    std::unique_lock<std::mutex> l{active_m};
+    active_connections = 0;
+  }
+
+  return 0;
+}
+
+static int auth_ldap_sasl_deinit(MYSQL_PLUGIN plugin_info
+                                 __attribute__((unused))) {
+  log_srv_dbg("auth_ldap_sasl_deinit()");
+
+  {
+    std::unique_lock<std::mutex> l{active_m};
+    active_cv.wait(l, [&] { return active_connections <= 0; });
+    if (active_connections < 0) {
+      return 0;
+    }
+    active_connections--;
+  }
+
+  if (bind_root_pwd_real) {
+    my_free(bind_root_pwd_real);
+    bind_root_pwd_real = nullptr;
+  }
+
+  auth_ldap_common_deinit(connPool);
+
+  delete g_logger_server;
+  auth_ldap_sasl_plugin_info = nullptr;
+  return 0;
+}
+
+int mpaldap_sasl_authenticate(MYSQL_PLUGIN_VIO *vio,
+                              MYSQL_SERVER_AUTH_INFO *info) {
+  {
+    std::unique_lock<std::mutex> l{active_m};
+    if (active_connections < 0) {
+      // plugin was uninstalled
+      return CR_ERROR;
+    }
+    active_connections++;
+    active_cv.notify_one();
+  }
+
+  log_srv_dbg("mpaldap_sasl_authenticate()");
+
+  // TODO: this should be a system variable, supporting both SCRAM-SHA-1 and
+  // GSSAPI (kerberos). So far I've only tested this with SCRAM. If we test it
+  // with Kerberos and it works, we should make it a system variable.
+  const char *authentication_ldap_sasl_auth_method_name = "SCRAM-SHA-1";
+
+  if (vio->write_packet(
+          vio,
+          static_cast<const unsigned char *>(static_cast<const void *>(
+              authentication_ldap_sasl_auth_method_name)),
+          strlen(authentication_ldap_sasl_auth_method_name))) {
+    log_srv_error("Failed to write method name");
+    std::unique_lock<std::mutex> l{active_m};
+    active_connections--;
+    active_cv.notify_one();
+    return CR_ERROR;
+  }
+
+  info->password_used = PASSWORD_USED_YES;
+
+  auto ret = auth_ldap_common_authenticate_user(
+      vio, info, nullptr /* password */, connPool, user_search_attr,
+      group_search_attr, group_search_filter, bind_base_dn, group_role_mapping,
+      authentication_ldap_sasl_auth_method_name);
+
+  {
+    std::unique_lock<std::mutex> l{active_m};
+    active_connections--;
+    active_cv.notify_one();
+  }
+
+  return ret;
+}
+
+// Plugin declaration
+struct st_mysql_auth mpaldap_sasl_handler = {
+    MYSQL_AUTHENTICATION_INTERFACE_VERSION,  // int interface_version
+    "authentication_ldap_sasl_client",       // const char *client_auth_plugin
+    &mpaldap_sasl_authenticate,              // authentication function
+    &auth_ldap_common_generate_auth_string_hash,  // generate_authentication_string,
+    &auth_ldap_common_validate_auth_string_hash,  // validate_authentication_string,
+    &auth_ldap_common_set_salt,                   // set_salt,
+    0UL,  // const unsigned long authentication_flags
+    nullptr};
+
+mysql_declare_plugin(auth_ldap_sasl) {
+  MYSQL_AUTHENTICATION_PLUGIN,           /* plugin type */
+      &mpaldap_sasl_handler,             /* type-specific descriptor */
+      MPALDAP_SIMPLE_PLUGIN_NAME,        /* plugin name */
+      "Percona Inc",                     /* author */
+      "LDAP SASL authentication plugin", /* description */
+      PLUGIN_LICENSE_GPL,                /* license type */
+      &auth_ldap_sasl_init,              /* init function */
+      &auth_ldap_sasl_deinit,            /* deinit function */
+      nullptr,                           /* no check function */
+      0x0100,                            /* version = 1.0 */
+      nullptr,                           /* no status variables */
+      mpaldap_sysvars,                   /* system variables */
+      nullptr                            /* no reserved information */
+#if MYSQL_PLUGIN_INTERFACE_VERSION >= 0x103
+      ,
+      0 /* no flags */
+#endif
+}
+mysql_declare_plugin_end;

--- a/plugin/auth_ldap/tests/add3.ldif
+++ b/plugin/auth_ldap/tests/add3.ldif
@@ -1,0 +1,8 @@
+dn: uid=john3,ou=People,dc=example,dc=com
+objectClass: inetOrgPerson
+uid: john3
+sn: Doe
+givenName: John
+cn: John Doe
+displayName: John Doe
+userPassword: secret

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_sasl-master.opt
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_sasl-master.opt
@@ -1,0 +1,5 @@
+$AUTH_LDAP_SASL_OPT $AUTH_LDAP_SASL_LOAD
+--authentication_ldap_sasl_server_host='$MTR_LDAP_HOST'
+--authentication_ldap_sasl_server_port=$MTR_LDAP_PORT
+--authentication_ldap_sasl_fallback_server_host='$MTR_LDAP_FALLBACK_HOST'
+--authentication_ldap_sasl_fallback_server_port=$MTR_LDAP_FALLBACK_PORT

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_sasl.result
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_sasl.result
@@ -1,0 +1,25 @@
+CREATE ROLE 'test_role';
+CREATE ROLE 'test_role2';
+SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME LIKE 'authentication_ldap_sasl';
+PLUGIN_NAME	PLUGIN_STATUS
+authentication_ldap_sasl	ACTIVE
+SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_sasl';
+Variable_name	Value
+SET GLOBAL authentication_ldap_sasl_bind_base_dn = 'ou=People,dc=example,dc=com';
+SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_sasl';
+Variable_name	Value
+CREATE USER john3 IDENTIFIED WITH authentication_ldap_sasl BY 'cn=john3,ou=People,dc=example,dc=com';
+CREATE USER nonexistent IDENTIFIED WITH authentication_ldap_sasl BY 'uid=nonexistent';
+SHOW GRANTS FOR 'john3';
+Grants for john3@%
+GRANT USAGE ON *.* TO `john3`@`%`
+SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_sasl';
+Variable_name	Value
+ERROR HY000: Unknown MySQL error
+DROP USER john3;
+DROP USER nonexistent;
+DROP ROLE test_role;
+DROP ROLE test_role2;
+SET GLOBAL authentication_ldap_sasl_bind_base_dn = '';
+SET GLOBAL authentication_ldap_sasl_log_status = 1;
+SET GLOBAL authentication_ldap_sasl_group_role_mapping = '';

--- a/plugin/auth_ldap/tests/mtr/auth_ldap_sasl.test
+++ b/plugin/auth_ldap/tests/mtr/auth_ldap_sasl.test
@@ -1,0 +1,48 @@
+
+# This testcase requires an LDAP server setup with SASL, and the following user:
+# uid=john3,ou=People,dc=example,dc=com
+# Password: "secret" (stored in cleartext, otherwise sasl doesn't work)
+# SASL configured, SASL indetity "john3" should match the user!
+
+--source include/count_sessions.inc
+
+CREATE ROLE 'test_role';
+CREATE ROLE 'test_role2';
+
+SELECT PLUGIN_NAME, PLUGIN_STATUS FROM INFORMATION_SCHEMA.PLUGINS WHERE PLUGIN_NAME LIKE 'authentication_ldap_sasl';
+--replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT> $MTR_LDAP_FALLBACK_HOST <MTR_LDAP_FALLBACK_HOST> $MTR_LDAP_FALLBACK_PORT <MTR_LDAP_FALLBACK_PORT>
+SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_sasl';
+SET GLOBAL authentication_ldap_sasl_bind_base_dn = 'ou=People,dc=example,dc=com';
+
+# For debugging:
+# SET GLOBAL authentication_ldap_sasl_log_status = 6;
+
+--replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT> $MTR_LDAP_FALLBACK_HOST <MTR_LDAP_FALLBACK_HOST> $MTR_LDAP_FALLBACK_PORT <MTR_LDAP_FALLBACK_PORT>
+SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_sasl';
+CREATE USER john3 IDENTIFIED WITH authentication_ldap_sasl BY 'cn=john3,ou=People,dc=example,dc=com';
+CREATE USER nonexistent IDENTIFIED WITH authentication_ldap_sasl BY 'uid=nonexistent';
+
+--connect (con1,localhost,john3,secret,,,,)
+
+SHOW GRANTS FOR 'john3';
+
+--replace_result $MTR_LDAP_HOST <MTR_LDAP_HOST> $MTR_LDAP_PORT <MTR_LDAP_PORT> $MTR_LDAP_FALLBACK_HOST <MTR_LDAP_FALLBACK_HOST> $MTR_LDAP_FALLBACK_PORT <MTR_LDAP_FALLBACK_PORT>
+SHOW GLOBAL VARIABLES LIKE 'authentication_ldap_sasl';
+
+--disconnect con1
+--connection default
+
+--disable_query_log
+--error 2000
+--connect (con1,localhost,nonexistent,secret,,,,)
+--enable_query_log
+
+DROP USER john3;
+DROP USER nonexistent;
+DROP ROLE test_role;
+DROP ROLE test_role2;
+SET GLOBAL authentication_ldap_sasl_bind_base_dn = '';
+SET GLOBAL authentication_ldap_sasl_log_status = 1;
+SET GLOBAL authentication_ldap_sasl_group_role_mapping = '';
+
+--source include/wait_until_count_sessions.inc

--- a/plugin/auth_ldap/tests/scram.ldif
+++ b/plugin/auth_ldap/tests/scram.ldif
@@ -1,0 +1,4 @@
+dn: cn=config
+changetype: modify
+add: olcAuthzRegexp
+olcAuthzRegexp: {0}"uid=(.*),cn=scram-sha-1,cn=auth" "uid=$1,ou=People,dc=example,dc=com"


### PR DESCRIPTION
This commit adds the server side plugin for SASL LDAP authentication. The client side is already present in the sources.

A high level overview of the authentication process is also described in the readme file in the plugin directory.