### PR TITLE
PS-8330 merge: Merge MySQL 8.0.30 - Q3 2022 (macos ldap_simple / ldap_sals fix)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1830,6 +1830,9 @@ MYSQL_CHECK_SASL_DLLS()
 MYSQL_CHECK_LDAP()
 MYSQL_CHECK_LDAP_DLLS()
 
+# Percona LDAP Simple / LDAP SASL authentication plugins
+OPTION(WITH_PERCONA_AUTHENTICATION_LDAP "Build with Percona LDAP Simple / LDAP SASL authentication plugins" ON)
+
 # Add Windows specific jemalloc DLL
 IF(WIN32)
   MYSQL_CHECK_WIN_JEMALLOC()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -378,6 +378,7 @@ jobs:
           -DWITH_SSL=/usr/local/opt/openssl@1.1
           -DWITH_FIDO=bundled
           -DWITH_ZLIB=bundled
+          -DWITH_PERCONA_AUTHENTICATION_LDAP=OFF
         "
       else
         CMAKE_OPT+="

--- a/plugin/auth_ldap/CMakeLists.txt
+++ b/plugin/auth_ldap/CMakeLists.txt
@@ -13,7 +13,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-IF(WITH_LDAP)
+IF(WITH_PERCONA_AUTHENTICATION_LDAP)
   INCLUDE (CheckLibraryExists)
   CHECK_LIBRARY_EXISTS(ldap ldap_initialize "" HAVE_LDAP)
 
@@ -43,11 +43,11 @@ SET(ALP_SOURCES_SASL
   INCLUDE_DIRECTORIES(SYSTEM ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})
 
   MYSQL_ADD_PLUGIN(authentication_ldap_simple ${ALP_SOURCES_SIMPLE}
-    LINK_LIBRARIES ldap_r MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_simple")
+    LINK_LIBRARIES "${LDAP_LIBRARY}" "${LBER_LIBRARY}" MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_simple")
   TARGET_COMPILE_DEFINITIONS(authentication_ldap_simple PRIVATE -DPLUGIN_SIMPLE)
 
   MYSQL_ADD_PLUGIN(authentication_ldap_sasl ${ALP_SOURCES_SASL}
-    LINK_LIBRARIES ldap_r MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_sasl")
+    LINK_LIBRARIES "${LDAP_LIBRARY}" "${LBER_LIBRARY}" MODULE_ONLY MODULE_OUTPUT_NAME "authentication_ldap_sasl")
   TARGET_COMPILE_DEFINITIONS(authentication_ldap_sasl PRIVATE -DPLUGIN_SASL)
 
   IF(UNIX)
@@ -56,4 +56,4 @@ SET(ALP_SOURCES_SASL
     ENDIF(INSTALL_MYSQLTESTDIR)
   ENDIF(UNIX)
 
-ENDIF(WITH_LDAP)
+ENDIF(WITH_PERCONA_AUTHENTICATION_LDAP)


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8330

Intrroduced new 'WITH_PERCONA_AUTHENTICATION_LDAP' top-level CMake
option that controlls if Percona's 'authentication_ldap_simple' and
'authentication_ldap_sasl' are included in the build.

Fixed 'authentication_ldap_simple' / 'authentication_ldap_sasl' plugin
dependencies: instead ofthe hardcoded 'ldap_r' we now use
'${LDAP_LIBRARY} ${LBER_LIBRARY}' detected in the 'ldap.cmake'.

Azure Pipelines configuration file updated so that
'authentication_ldap_simple' / 'authentication_ldap_sasl' are not built
on MacOS.