### PR TITLE
PS-8422 [8.0]: fix innodb_fts.percona_mecab_null_character

### DIFF
--- a/mysql-test/suite/innodb_fts/r/percona_mecab_null_character.result
+++ b/mysql-test/suite/innodb_fts/r/percona_mecab_null_character.result
@@ -1,7 +1,7 @@
 INSTALL PLUGIN mecab SONAME 'libpluginmecab.so';
 SHOW STATUS LIKE 'mecab_charset';
 Variable_name	Value
-mecab_charset	utf8
+mecab_charset	utf8mb4
 #
 # PS-3851: Crash when SELECT using a fulltext search index with special character
 #

--- a/mysql-test/suite/innodb_fts/t/percona_mecab_null_character.test
+++ b/mysql-test/suite/innodb_fts/t/percona_mecab_null_character.test
@@ -3,7 +3,7 @@
 eval INSTALL PLUGIN mecab SONAME '$MECAB';
 
 let $ipadic_charset=utf-8;
-let $mysql_charset=utf8;
+let $mysql_charset=utf8mb4;
 let $mecab_charset=`SELECT variable_value FROM performance_schema.global_status WHERE VARIABLE_NAME='mecab_charset'`;
 
 if ($mecab_charset == '') {
@@ -33,7 +33,7 @@ if ($mecab_charset == '') {
 
 if ($mecab_charset != $mysql_charset) {
   UNINSTALL PLUGIN mecab;
-  -- skip Test mecab charset mismatch.
+  -- skip Test mecab charset mismatch (mecab_charset=$mecab_charset, mysql_charset=$mysql_charset).
 }
 
 SHOW STATUS LIKE 'mecab_charset';


### PR DESCRIPTION
After changes by upstream in https://github.com/mysql/mysql-server/commit/f4445048160 we have to change `mysql_charset` to `utf8mb4` for `innodb_fts.percona_mecab_null_character`.