### PR TITLE
PS-8428 postfix: ALTER TABLE t ADD FULLTEXT crashes the server when --innodb_encrypt_online_alter_logs=ON

### DIFF
--- a/include/my_aes.h
+++ b/include/my_aes.h
@@ -138,39 +138,39 @@ longlong my_aes_get_size(uint32 source_length, enum my_aes_opmode opmode);
 bool my_aes_needs_iv(my_aes_opmode opmode);
 
 /**
-  Encrypt a buffer using AES 256-bit CBC with no padding
+  Encrypt a buffer using AES CBC with no padding
 
   @param [in] source         Pointer to data for encryption
   @param [in] source_length  Size of original data
   @param [out] dest          Buffer to place encrypted data (must be large
   enough)
-  @param [in] key            32-bytes key to be used for encryption
+  @param [in] key            Key to be used for encryption
+  @param [in] key_length     Size of the key
   @param [in] iv             16-bytes initialization vector.
   @return size of encrypted data, or MY_AES_BAD_DATA in case of an error
 */
 
-int my_legacy_aes_256_cbc_nopad_encrypt(const unsigned char *source,
-                                        uint32 source_length,
-                                        unsigned char *dest,
-                                        const unsigned char *key,
-                                        const unsigned char *iv);
+int my_legacy_aes_cbc_nopad_encrypt(const unsigned char *source,
+                                    uint32 source_length, unsigned char *dest,
+                                    const unsigned char *key, uint32 key_length,
+                                    const unsigned char *iv);
 
 /**
-  Decrypt a buffer encrypted with AES 256-bit CBC with no padding
+  Decrypt a buffer encrypted with AES CBC with no padding
 
   @param [in] source         Pointer to data for decryption
   @param [in] source_length  size of encrypted data
   @param [out] dest          buffer to place decrypted data (must be large
   enough)
-  @param [in] key            32-bytes key to be used for decryption
+  @param [in] key            Key to be used for decryption
+  @param [in] key_length     Size of the key
   @param [in] iv             16-bytes initialization vector
   @return size of original data, or MY_AES_BAD_DATA in case of an error
 */
 
-int my_legacy_aes_256_cbc_nopad_decrypt(const unsigned char *source,
-                                        uint32 source_length,
-                                        unsigned char *dest,
-                                        const unsigned char *key,
-                                        const unsigned char *iv);
+int my_legacy_aes_cbc_nopad_decrypt(const unsigned char *source,
+                                    uint32 source_length, unsigned char *dest,
+                                    const unsigned char *key, uint32 key_length,
+                                    const unsigned char *iv);
 
 #endif /* MY_AES_INCLUDED */

--- a/sql/event_crypt.cc
+++ b/sql/event_crypt.cc
@@ -14,10 +14,9 @@ bool decrypt_event(uint32 offs, const Binlog_crypt_data &crypto, uchar *buf,
   crypto.set_iv(iv, offs);
   memcpy(buf + EVENT_LEN_OFFSET, buf, 4);
 
-  assert(crypto.get_keys_length() == 32);
-  if (my_legacy_aes_256_cbc_nopad_decrypt(buf + 4, buf_len - 4, ebuf + 4,
-                                          crypto.get_key(), iv) !=
-      static_cast<int>(buf_len - 4)) {
+  if (my_legacy_aes_cbc_nopad_decrypt(
+          buf + 4, buf_len - 4, ebuf + 4, crypto.get_key(),
+          crypto.get_keys_length(), iv) != static_cast<int>(buf_len - 4)) {
     memcpy(buf, buf + EVENT_LEN_OFFSET, 4);
     return true;
   }

--- a/storage/innobase/row/row0log.cc
+++ b/storage/innobase/row/row0log.cc
@@ -314,8 +314,9 @@ bool log_tmp_block_encrypt(const byte *src_block, ulint size, byte *dst_block,
   }
 
   assert(crypt_info.encryption_klen == 32);
-  int res = my_legacy_aes_256_cbc_nopad_encrypt(src_block, size, dst_block,
-                                                crypt_info.encryption_key, iv);
+  int res = my_legacy_aes_cbc_nopad_encrypt(src_block, size, dst_block,
+                                            crypt_info.encryption_key,
+                                            crypt_info.encryption_klen, iv);
 
   if (res != static_cast<int>(size)) {
     ib::error() << "Unable to encrypt data block  src: "
@@ -344,8 +345,9 @@ bool log_tmp_block_decrypt(const byte *src_block, ulint size, byte *dst_block,
   }
 
   assert(crypt_info.encryption_klen == 32);
-  int res = my_legacy_aes_256_cbc_nopad_decrypt(src_block, size, dst_block,
-                                                crypt_info.encryption_key, iv);
+  int res = my_legacy_aes_cbc_nopad_decrypt(src_block, size, dst_block,
+                                            crypt_info.encryption_key,
+                                            crypt_info.encryption_klen, iv);
 
   if (res != static_cast<int>(size)) {
     ib::error() << "Unable to decrypt data block src: "


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8428

Original assumption that legacy Percona-specific encryption functions use only 256-bit primitives turned out to be wrong. Restored 'key_length' parameter in the
- 'my_legacy_aes_256_cbc_nopad_encrypt()'
- 'my_legacy_aes_256_cbc_nopad_decrypt()'
- 'my_legacy_aes_256_cbc_nopad_crypt()'
Functions themselves renamed to
- 'my_legacy_aes_cbc_nopad_encrypt()'
- 'my_legacy_aes_cbc_nopad_decrypt()'
- 'my_legacy_aes_cbc_nopad_crypt()'

'percona_rpl_encryption_master_binlog_ps_encrypted' and 'rpl.percona_rpl_encryption_slave_binlog_ps_encrypted' MTR test cases now pass as expected.