### PR TITLE
PS-8454: Fido authentication crashes after incorrect alter

### DIFF
--- a/sql/auth/sql_mfa.cc
+++ b/sql/auth/sql_mfa.cc
@@ -814,6 +814,11 @@ bool Multi_factor_auth_info::deserialize(uint nth_factor, Json_dom *mfa_dom) {
 bool Multi_factor_auth_info::init_registration(THD *thd, uint nth_factor) {
   /* check if we are registerting correct multi-factor authentication method */
   if (get_nth_factor() != nth_factor) return false;
+  /*
+    in case init registration is done, then server challenge will be
+    in auth string
+  */
+  if (get_auth_str_len()) return false;
   plugin_ref plugin = my_plugin_lock_by_name(nullptr, plugin_name(),
                                              MYSQL_AUTHENTICATION_PLUGIN);
   /* check if plugin is loaded */


### PR DESCRIPTION
Issue: Login with fido crashes the server after an incorrect ALTER adding a fido factor.

Fix: the generic MFA code calls the plugin twice after the alter, with incorrectly set up data structures.

This commit adds sanity checks to the fido authentication function which returns an error in this case.

It also restores an unneccessary change in the generic mfa code, added in the original fido PR.