### PR TITLE
PS-8328: MySQL 8 Crash when using group_concat with group by with rollup

### DIFF
--- a/mysql-test/r/olap.result
+++ b/mysql-test/r/olap.result
@@ -2283,3 +2283,35 @@ a	b
 3	NULL
 NULL	NULL
 DROP TABLE t;
+#
+# PS-8328: MySQL 8 Crash when using group_concat with group by with
+#          rollup.
+#
+CREATE TABLE t1 (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, string TEXT, i INT);
+INSERT INTO t1 (string, i) VALUES ('something', 10), ('something_else', 10), ('something_completely_else', 20);
+SELECT GROUP_CONCAT(string) FROM t1 GROUP BY string WITH ROLLUP;
+GROUP_CONCAT(string)
+something
+something_completely_else
+something_else
+something,something_completely_else,something_else
+SELECT string, GROUP_CONCAT(string) FROM t1 GROUP BY string WITH ROLLUP;
+string	GROUP_CONCAT(string)
+something	something
+something_completely_else	something_completely_else
+something_else	something_else
+NULL	something,something_completely_else,something_else
+SELECT i, GROUP_CONCAT(string) FROM t1 GROUP BY i WITH ROLLUP;
+i	GROUP_CONCAT(string)
+10	something,something_else
+20	something_completely_else
+NULL	something,something_else,something_completely_else
+SELECT i, string, GROUP_CONCAT(string) FROM t1 GROUP BY i, string WITH ROLLUP;
+i	string	GROUP_CONCAT(string)
+10	something	something
+10	something_else	something_else
+10	NULL	something,something_else
+20	something_completely_else	something_completely_else
+20	NULL	something_completely_else
+NULL	NULL	something,something_else,something_completely_else
+DROP TABLE t1;

--- a/mysql-test/t/olap.test
+++ b/mysql-test/t/olap.test
@@ -1254,3 +1254,16 @@ INSERT INTO t VALUES (NULL), (0), (1), (2), (3);
 --sorted_result
 SELECT DISTINCT x AS a, x AS b FROM t GROUP BY a, b WITH ROLLUP;
 DROP TABLE t;
+
+--echo #
+--echo # PS-8328: MySQL 8 Crash when using group_concat with group by with
+--echo #          rollup.
+--echo #
+
+CREATE TABLE t1 (id INT NOT NULL AUTO_INCREMENT PRIMARY KEY, string TEXT, i INT);
+INSERT INTO t1 (string, i) VALUES ('something', 10), ('something_else', 10), ('something_completely_else', 20);
+SELECT GROUP_CONCAT(string) FROM t1 GROUP BY string WITH ROLLUP;
+SELECT string, GROUP_CONCAT(string) FROM t1 GROUP BY string WITH ROLLUP;
+SELECT i, GROUP_CONCAT(string) FROM t1 GROUP BY i WITH ROLLUP;
+SELECT i, string, GROUP_CONCAT(string) FROM t1 GROUP BY i, string WITH ROLLUP;
+DROP TABLE t1;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8328

Starting from version 8.0.27 both PS and upstream crashed if query using both GROUP_CONCAT() aggregate and WITH ROLLUP clause was run.

This problem is a regression from the following upstream's commit:

https://github.com/mysql/mysql-server/commit/1407269ba68f5a4f07431f6b6010d8aaf1b81510

commit 1407269ba68f5a4f07431f6b6010d8aaf1b81510
Date:   Thu Apr 15 22:52:53 2021 +0200

Bug #32644631: PRELIMINARY FIXES FOR WL #14419 [wf framebuffer, noclose] Bug #32802301: REGRESSION: TYPE_CONVERSION_STATUS FIELD_VARSTRING::STORE: ...

It was caused by the fact that after the above commit we have started to replace references to grouped expression in rollup queries with Item_rollup_group_item even in cases when they are occurred inside of top-level aggregate function (which are wrapped in Item_rollup_sum_switcher themselves). This is not necessary (as grouped expression don't need to be replaced by NULL in this case) and has broken fragile assumptions in Item_rollup_sum_switcher and Item_func_group_concat interaction (this code assumes that both main and cloned versions of Item_func_group_concat referenced by Item_rollup_sum_switcher use temporary tables with the same structure, which was not true if expression for one of them was wrapped in Item_rollup_group_item item).

This patch makes these assumptions valid again by changing the code not to replace grouped expression in rollup queries with Item_rollup_group_item objects inside of top-level aggregates again.

Ideally, we should also refactor code in Item_func_group_concat and Item_rollup_sum_switcher to avoid such fragile assumptions, but such a change looks more appropriate for the upstream.