### PR TITLE
PS-8433: Reduce memory overhead from cached triggers by removing fixe…

### DIFF
--- a/sql/table_trigger_dispatcher.cc
+++ b/sql/table_trigger_dispatcher.cc
@@ -88,9 +88,8 @@ Table_trigger_dispatcher::Table_trigger_dispatcher(TABLE *subject_table)
       m_record1_field(nullptr),
       m_new_field(nullptr),
       m_old_field(nullptr),
-      m_has_unparseable_trigger(false) {
+      m_parse_error_message(nullptr) {
   memset(m_trigger_map, 0, sizeof(m_trigger_map));
-  m_parse_error_message[0] = 0;
 }
 
 Table_trigger_dispatcher::~Table_trigger_dispatcher() {
@@ -492,8 +491,8 @@ void Table_trigger_dispatcher::parse_triggers(THD *thd, List<Trigger> *triggers,
 
       /*
         In case we are upgrading, call set_parse_error_message() to set
-        m_has_unparseable_trigger in case of fatal errors too. As return type
-        of this function is void, we use m_has_unparseable_trigger to check
+        m_parse_error_message in case of fatal errors too. As return type
+        of this function is void, we use m_parse_error_message to check
         for any errors in Trigger upgrade upgrade.
       */
       if (is_upgrade && fatal_parse_error) {
@@ -692,4 +691,14 @@ bool Table_trigger_dispatcher::mark_fields(enum_trigger_event_type event) {
 
   m_subject_table->file->column_bitmaps_signal();
   return false;
+}
+
+void Table_trigger_dispatcher::set_parse_error_message(
+    const char *error_message) {
+  if (!m_parse_error_message) {
+    m_parse_error_message =
+        strdup_root(&m_subject_table->mem_root, error_message);
+    // Play safe even in case of OOM.
+    if (!m_parse_error_message) m_parse_error_message = ER_DEFAULT(ER_DA_OOM);
+  }
 }

--- a/sql/table_trigger_dispatcher.h
+++ b/sql/table_trigger_dispatcher.h
@@ -85,7 +85,7 @@ class Table_trigger_dispatcher : public Table_trigger_field_support {
     SQL-definition can not be parsed) for this table.
   */
   bool check_for_broken_triggers() {
-    if (m_has_unparseable_trigger) {
+    if (m_parse_error_message) {
       my_message(ER_PARSE_ERROR, m_parse_error_message, MYF(0));
       return true;
     }
@@ -175,19 +175,13 @@ class Table_trigger_dispatcher : public Table_trigger_field_support {
   /**
     Remember a parse error that occurred while parsing trigger definitions
     loaded from the Data Dictionary. This makes the Table_trigger_dispatcher
-    enter the error state flagged by m_has_unparseable_trigger == true. The
+    enter the error state flagged by m_parse_error_message != nullptr . The
     error message will be used whenever a statement invoking or manipulating
     triggers is issued against the Table_trigger_dispatcher's table.
 
     @param error_message The error message thrown by the parser.
   */
-  void set_parse_error_message(const char *error_message) {
-    if (!m_has_unparseable_trigger) {
-      m_has_unparseable_trigger = true;
-      snprintf(m_parse_error_message, sizeof(m_parse_error_message), "%s",
-               error_message);
-    }
-  }
+  void set_parse_error_message(const char *error_message);
 
  private:
   /************************************************************************
@@ -228,28 +222,21 @@ class Table_trigger_dispatcher : public Table_trigger_field_support {
   Field **m_old_field;
 
   /**
-    This flag indicates that one of the triggers was not parsed successfully,
-    and as a precaution the object has entered the state where all trigger
-    operations result in errors until all the table triggers are dropped. It is
+    Error which occurred while parsing one of the triggers for the table,
+    nullptr - if there was no error for any of its triggers.
+
+    Non-nullptr value indicates that as a precaution the object has entered
+    the state where all trigger operations result in errors (referencing
+    this error message saved) until all the table triggers are dropped. It is
     not safe to add triggers since it is unknown if the broken trigger has the
     same name or event type. Nor is it safe to invoke any trigger. The only
     safe operations are drop_trigger() and drop_all_triggers().
 
-    We can't use the value of m_parse_error_message as a flag to inform that
-    a trigger has a parse error since for multi-byte locale the first byte of
-    message can be 0 but the message still be meaningful. It means that just a
-    comparison against m_parse_error_message[0] can not be done safely.
-
     @see Table_trigger_dispatcher::set_parse_error()
   */
-  bool m_has_unparseable_trigger;
-
   /**
-    This error will be displayed when the user tries to manipulate or invoke
-    triggers on a table that has broken triggers. It is set once per statement
-    and thus will contain the first parse error encountered in the trigger file.
    */
-  char m_parse_error_message[MYSQL_ERRMSG_SIZE];
+  const char *m_parse_error_message;
 };
 
 ///////////////////////////////////////////////////////////////////////////

--- a/sql/trigger.cc
+++ b/sql/trigger.cc
@@ -347,9 +347,7 @@ Trigger::Trigger(
       m_action_order(action_order),
       m_trigger_name(trigger_name),
       m_sp(nullptr),
-      m_has_parse_error(false) {
-  m_parse_error_message[0] = 0;
-
+      m_parse_error_message(nullptr) {
   construct_definer_value(mem_root, &m_definer, definer_user, definer_host);
 }
 
@@ -369,7 +367,7 @@ Trigger::~Trigger() { sp_head::destroy(m_sp); }
 */
 
 bool Trigger::execute(THD *thd) {
-  if (m_has_parse_error) return true;
+  if (has_parse_error()) return true;
 
   bool err_status;
   Sub_statement_state statement_state;
@@ -669,4 +667,14 @@ void Trigger::print_upgrade_warning(THD *thd) {
       thd, Sql_condition::SL_WARNING, ER_WARN_TRIGGER_DOESNT_HAVE_CREATED,
       ER_THD(thd, ER_WARN_TRIGGER_DOESNT_HAVE_CREATED), get_db_name().str,
       get_subject_table_name().str, get_trigger_name().str);
+}
+
+/**
+  Mark trigger as having a parse error and remember the message for future use.
+*/
+
+void Trigger::set_parse_error_message(const char *error_message) {
+  m_parse_error_message = strdup_root(m_mem_root, error_message);
+  // Play safe even in case of OOM.
+  if (!m_parse_error_message) m_parse_error_message = ER_DEFAULT(ER_DA_OOM);
 }

--- a/sql/trigger.h
+++ b/sql/trigger.h
@@ -196,7 +196,7 @@ class Trigger {
 
   GRANT_INFO *get_subject_table_grant() { return &m_subject_table_grant; }
 
-  bool has_parse_error() const { return m_has_parse_error; }
+  bool has_parse_error() const { return m_parse_error_message; }
 
   const char *get_parse_error_message() const { return m_parse_error_message; }
 
@@ -242,11 +242,7 @@ class Trigger {
     m_definition_utf8 = trigger_def_utf8;
   }
 
-  void set_parse_error_message(const char *error_message) {
-    m_has_parse_error = true;
-    snprintf(m_parse_error_message, sizeof(m_parse_error_message), "%s",
-             error_message);
-  }
+  void set_parse_error_message(const char *error_message);
 
   /**
     Memory root to store all data of this Trigger object.
@@ -342,16 +338,15 @@ class Trigger {
   /// Pointer to the sp_head corresponding to the trigger.
   sp_head *m_sp;
 
-  /// This flags specifies whether the trigger has parse error or not.
-  bool m_has_parse_error;
-
   /**
+    Parse error for trigger, if it has one, nullptr - if not.
+
     This error will be displayed when the user tries to manipulate or invoke
     triggers on a table that has broken triggers. It will get set only once
     per statement and thus will contain the first parse error encountered in
     the trigger file.
   */
-  char m_parse_error_message[MYSQL_ERRMSG_SIZE];
+  const char *m_parse_error_message;
 };
 
 ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
…d size buffer for error.

https://jira.percona.com/browse/PS-8433

For tables with triggers, each TABLE instance in Table Cache has one Table_trigger_dispatcher sub-object and one or more Trigger sub-object associated with it.
Both these classes contain as members 512-byte buffer to store error message which occurred during trigger parsing. Since these buffers are not used in 99% of cases this looks like pure waste of memory.

This patch improves the situation by replacing these always-allocated fixed-size buffers with variable-size buffers which are allocated on TABLE's memory root on demand, only when the table has a trigger with a parse error.