### PR TITLE
PS-8301 [8.0]: Disable Azure pipelines testing for certain branches

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,33 @@
+trigger:
+  branches:
+    include:
+    - '*'
+  paths:
+    exclude:
+    - doc
+    - build-ps
+    - man
+    - mysql-test
+    - packaging
+    - policy
+    - scripts
+    - support-files
+
+pr:
+  branches:
+    include:
+    - '*'
+  paths:
+    exclude:
+    - doc
+    - build-ps
+    - man
+    - mysql-test
+    - packaging
+    - policy
+    - scripts
+    - support-files
+
 jobs:
 - job: BiDiScan
   pool:


### PR DESCRIPTION
Disable Azure pipelines for branches that don't change source code and don't influence compilation.