### PR TITLE
Fix bug where LDAP user DN contains double quote

### DIFF
--- a/plugin/auth_ldap/src/connection.cc
+++ b/plugin/auth_ldap/src/connection.cc
@@ -308,7 +308,9 @@ groups_t Connection::search_groups(const std::string &user_name,
   std::stringstream log_stream;
   std::string filter = std::regex_replace(group_search_filter,
                                           std::regex("\\{UA\\}"), user_name);
-  filter = std::regex_replace(filter, std::regex("\\{UD\\}"), user_dn);
+  std::string escaped_user_dn =
+      std::regex_replace(user_dn, std::regex("\\\\\""), "\\\\\"");
+  filter = std::regex_replace(filter, std::regex("\\{UD\\}"), escaped_user_dn);
 
   LDAPMessage *l_result;
   char *attrs[] = {const_cast<char *>(group_search_attr.c_str()), nullptr};


### PR DESCRIPTION
The Jira issue is here:
https://jira.percona.com/browse/PS-8513

When using the authentication_ldap_simple plugin, the LDAP query is not properly escaped when the user DN contains a double quote `"` in their name.

During authentication, the function "[search_ldap_uid](https://github.com/percona/percona-server/blob/8.0/plugin/auth_ldap/src/auth_ldap_impl.cc#L338)" returns the users DN.

After authentication, in order to proxy the user to an LDAP group, the function "[search_groups](https://github.com/percona/percona-server/blob/8.0/plugin/auth_ldap/src/connection.cc#L300])" is called, which looks for the group, and uses the users DN to filter the users groups (Replacing "{UD}" in the variable "authentication_ldap_simple_group_search_filter" with the users DN).

If the users DN contains a double quote, then the library will attempt to pass the string returned from `search_ldap_uid` to the ldap function `ldap_search_ext_s`, which will return an error: `Bad search filter`


The reason for this, is that the DN returned by `search_ldap_uid` is not properly escaped.

The ldap library expects double quotes to be double escaped (`usern
\\"ame` instead of `usern\"ame`), while it only returns single-escaped DN.

This means that if `ldap_search_ext_s(filter_to_find_user_dn)` returns `"CN=tea\\\"m,CN=Users,DC=example,DC=local"`
Then:
```c
// This will work
ldap_search_ext_s("CN=tea\\\\\"m,CN=Users,DC=example,DC=local");

// This will not work
ldap_search_ext_s("CN=tea\\\"m,CN=Users,DC=example,DC=local");
```

As a fix, in this PR I am proposing to replace the string `\"` with `\\"` in the user DN when replacing the user_dn.