### PR TITLE
PS-8502 [8.0]: Building issue with ccache on Azure - fix Boost version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ jobs:
 
   variables:
     UBUNTU_CODE_NAME: focal
-    BOOST_VERSION: boost_1_73_0
+    BOOST_VERSION: boost_1_77_0
     BOOST_DIR: $(Pipeline.Workspace)/boost
     USE_CCACHE: 1
     CCACHE_DIR: $(Pipeline.Workspace)/ccache
@@ -282,13 +282,13 @@ jobs:
         sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
         sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1
 
-        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES cmake cmake-curses-gui ccache bison libncurses5-dev libaio-dev libmecab-dev libnuma-dev liblzma-dev libssl-dev libreadline-dev libpam-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev libsasl2-modules-gssapi-mit || exit 1;
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES cmake cmake-curses-gui ccache bison libudev-dev libaio-dev libmecab-dev libnuma-dev liblzma-dev libssl-dev libreadline-dev libpam-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev libsasl2-modules-gssapi-mit || exit 1;
         if [[ "$(Inverted)" != "ON" ]]; then
-          sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install libevent-dev libeditline-dev liblz4-dev libre2-dev protobuf-compiler libprotobuf-dev libprotoc-dev libicu-dev || exit 1;
+          sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install libevent-dev libeditline-dev liblz4-dev protobuf-compiler libprotobuf-dev libprotoc-dev libicu-dev || exit 1;
         fi
       else
          brew update
-         brew install ccache protobuf lz4 re2 rapidjson openssl@1.1
+         brew install ccache protobuf lz4 rapidjson openssl@1.1
       fi
 
       UPDATE_TIME=$SECONDS

--- a/plugin/authentication_fido/src/plugin_fido.cc
+++ b/plugin/authentication_fido/src/plugin_fido.cc
@@ -150,7 +150,7 @@ void get_challange_length(unsigned int *outbuflen) {
   // 512 bytes should be enough to store that
   *outbuflen = 512;
 }
-};  // namespace authentication_fido_reg
+}  // namespace authentication_fido_reg
 
 BEGIN_SERVICE_IMPLEMENTATION(authentication_fido,
                              mysql_authentication_registration)


### PR DESCRIPTION
1. Update Boost version to match `SET(BOOST_PACKAGE_NAME "boost_1_77_0")` from `boost.cmake`.
2. Add `apt install libudev-dev` dependency from FIDO library
