### PR TITLE
PS-8073: Replication crash when updating a table with a stored genera…

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_bug_ps_8073.result
+++ b/mysql-test/suite/rpl/r/rpl_bug_ps_8073.result
@@ -1,0 +1,90 @@
+include/master-slave.inc
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+[connection master]
+SET SESSION binlog_row_image= 'MINIMAL';
+CREATE TABLE t1 (
+a INT NOT NULL,
+g INT GENERATED ALWAYS AS (a) STORED,
+PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET a = 2 WHERE a = 1;
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	g
+2	2
+[connection master]
+DROP TABLE t1;
+CREATE TABLE t1 (
+a INT NOT NULL,
+b INT,
+g INT GENERATED ALWAYS AS (a) STORED,
+PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET b = 1 WHERE a = 1;
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	b	g
+1	1	1
+[connection master]
+DROP TABLE t1;
+CREATE TABLE t1 (
+a INT NOT NULL,
+g INT GENERATED ALWAYS AS (a+10) STORED,
+PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET a = 2 WHERE a = 1;
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	g
+2	12
+[connection master]
+DROP TABLE t1;
+CREATE TABLE t1 (
+a INT NOT NULL,
+b INT NOT NULL,
+g INT GENERATED ALWAYS AS (a+b) STORED,
+PRIMARY KEY (g)
+);
+INSERT INTO t1 (a, b) VALUES (1, 2);
+UPDATE t1 SET a = 3 WHERE a = 1;
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	b	g
+3	2	5
+[connection master]
+DROP TABLE t1;
+CREATE TABLE t1 (
+a INT NOT NULL,
+b INT,
+g INT GENERATED ALWAYS AS (a+10) STORED,
+PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET b = 2 WHERE a = 1;
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	b	g
+1	2	11
+[connection master]
+DROP TABLE t1;
+CREATE TABLE t1 (
+a INT NOT NULL,
+b INT NOT NULL,
+c INT,
+g INT GENERATED ALWAYS AS (a+b) STORED,
+PRIMARY KEY (g)
+);
+INSERT INTO t1 (a, b) VALUES (1, 2);
+UPDATE t1 SET c = 3 WHERE a = 1;
+include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+a	b	c	g
+1	2	3	3
+[connection master]
+DROP TABLE t1;
+include/rpl_end.inc

--- a/mysql-test/suite/rpl/t/rpl_bug_ps_8073.test
+++ b/mysql-test/suite/rpl/t/rpl_bug_ps_8073.test
@@ -1,0 +1,92 @@
+# PS-8073: Replication crash when updating a table with a stored generated field in the primary key
+# https://jira.percona.com/browse/PS-8073
+
+--source include/have_binlog_format_row.inc
+--source include/master-slave.inc
+
+SET SESSION binlog_row_image= 'MINIMAL';
+
+CREATE TABLE t1 (
+  a INT NOT NULL,
+  g INT GENERATED ALWAYS AS (a) STORED,
+  PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET a = 2 WHERE a = 1;
+
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+CREATE TABLE t1 (
+  a INT NOT NULL,
+  b INT,
+  g INT GENERATED ALWAYS AS (a) STORED,
+  PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET b = 1 WHERE a = 1;
+
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+CREATE TABLE t1 (
+  a INT NOT NULL,
+  g INT GENERATED ALWAYS AS (a+10) STORED,
+  PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET a = 2 WHERE a = 1;
+
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+CREATE TABLE t1 (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  g INT GENERATED ALWAYS AS (a+b) STORED,
+  PRIMARY KEY (g)
+);
+INSERT INTO t1 (a, b) VALUES (1, 2);
+UPDATE t1 SET a = 3 WHERE a = 1;
+
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+CREATE TABLE t1 (
+  a INT NOT NULL,
+  b INT,
+  g INT GENERATED ALWAYS AS (a+10) STORED,
+  PRIMARY KEY (g)
+);
+INSERT INTO t1 (a) VALUES (1);
+UPDATE t1 SET b = 2 WHERE a = 1;
+
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+CREATE TABLE t1 (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT,
+  g INT GENERATED ALWAYS AS (a+b) STORED,
+  PRIMARY KEY (g)
+);
+INSERT INTO t1 (a, b) VALUES (1, 2);
+UPDATE t1 SET c = 3 WHERE a = 1;
+
+--source include/sync_slave_sql_with_master.inc
+SELECT * FROM t1;
+
+--source include/rpl_connection_master.inc
+DROP TABLE t1;
+--source include/rpl_end.inc

--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -8000,6 +8000,7 @@ Rows_log_event::~Rows_log_event() {
 #ifdef MYSQL_SERVER
 int Rows_log_event::unpack_current_row(const Relay_log_info *const rli,
                                        MY_BITMAP const *cols,
+                                       MY_BITMAP const *local_cols,
                                        bool is_after_image, bool only_seek) {
   assert(m_table);
 
@@ -8047,6 +8048,11 @@ int Rows_log_event::unpack_current_row(const Relay_log_info *const rli,
               return true;
             if (!is_after_image &&  // Always exclude virtual generated columns
                 field->is_virtual_gcol())  // if not processing after-image
+              return true;
+            if (!bitmap_is_subset(  // Exclude generated columns which base
+                                    // columns are excluded from the binlog row
+                                    // image
+                    &field->gcol_info->base_columns_map, local_cols))
               return true;
             if (field->m_indexed)  // Never exclude generated columns that
                                    // have indexes
@@ -8767,7 +8773,7 @@ void Rows_log_event::do_post_row_operations(Relay_log_info const *rli,
       conditions. So this is probably a case of a corrupt event.
     */
     const uchar *previous_m_curr_row = m_curr_row;
-    error = unpack_current_row(rli, &m_cols, true /*is AI*/);
+    error = unpack_current_row(rli, &m_cols, &m_local_cols, true /*is AI*/);
 
     if (!error && previous_m_curr_row == m_curr_row) {
       error = 1;
@@ -9052,7 +9058,9 @@ int Rows_log_event::do_index_scan_and_update(Relay_log_info const *rli) {
   */
 
   prepare_record(m_table, &this->m_local_cols, false);
-  if ((error = unpack_current_row(rli, &m_cols, false /*is not AI*/))) goto end;
+  if ((error = unpack_current_row(rli, &m_cols, &m_local_cols,
+                                  false /*is not AI*/)))
+    goto end;
 
   /*
     Trying to do an index scan without a usable key
@@ -9275,7 +9283,7 @@ int Update_rows_log_event::skip_after_image_for_update_event(
       m_curr_row==curr_bi_start.
     */
     m_curr_row = m_curr_row_end;
-    return unpack_current_row(rli, &m_cols_ai, true /*is AI*/,
+    return unpack_current_row(rli, &m_cols_ai, &m_local_cols_ai, true /*is AI*/,
                               true /*only_seek*/);
   }
   return 0;
@@ -9292,7 +9300,8 @@ int Rows_log_event::do_hash_row(Relay_log_info const *rli) {
   /* Prepare the record, unpack and save positions. */
   entry->positions->bi_start = m_curr_row;  // save the bi start pos
   prepare_record(m_table, &this->m_local_cols, false);
-  if ((error = unpack_current_row(rli, &m_cols, false /*is not AI*/))) {
+  if ((error = unpack_current_row(rli, &m_cols, &m_local_cols,
+                                  false /*is not AI*/))) {
     hash_slave_rows_free_entry freer;
     freer(entry);
     goto end;
@@ -9330,8 +9339,8 @@ int Rows_log_event::do_hash_row(Relay_log_info const *rli) {
 
     /* We shouldn't need this, but lets not leave loose ends */
     prepare_record(m_table, &this->m_local_cols, false);
-    error =
-        unpack_current_row(rli, &m_cols_ai, true /*is AI*/, true /*only_seek*/);
+    error = unpack_current_row(rli, &m_cols_ai, &m_local_cols_ai,
+                               true /*is AI*/, true /*only_seek*/);
 
     /*
       This is the situation after unpacking the AI:
@@ -9412,7 +9421,8 @@ int Rows_log_event::do_scan_and_update(Relay_log_info const *rli) {
             m_curr_row_end = entry->positions->bi_ends;
 
             prepare_record(table, &this->m_local_cols, false);
-            if ((error = unpack_current_row(rli, &m_cols, false /*is not AI*/)))
+            if ((error = unpack_current_row(rli, &m_cols, &m_local_cols,
+                                            false /*is not AI*/)))
               goto close_table;
 
             if (record_compare(table, &this->m_local_cols))
@@ -9550,7 +9560,8 @@ int Rows_log_event::do_table_scan_and_update(Relay_log_info const *rli) {
 
   /** unpack the before image */
   prepare_record(table, &this->m_local_cols, false);
-  if (!(error = unpack_current_row(rli, &m_cols, false /*is not AI*/))) {
+  if (!(error = unpack_current_row(rli, &m_cols, &m_local_cols,
+                                   false /*is not AI*/))) {
     /** save a copy so that we can compare against it later */
     store_record(m_table, record[1]);
 
@@ -12139,7 +12150,8 @@ int Write_rows_log_event::write_row(const Relay_log_info *const rli,
                  table->file->ht->db_type != DB_TYPE_NDBCLUSTER);
 
   /* unpack row into table->record[0] */
-  if ((error = unpack_current_row(rli, &m_cols, true /*is AI*/))) return error;
+  if ((error = unpack_current_row(rli, &m_cols, &m_local_cols, true /*is AI*/)))
+    return error;
 
   /*
     When m_curr_row == m_curr_row_end, it means a row that contains nothing,
@@ -12300,7 +12312,7 @@ int Write_rows_log_event::write_row(const Relay_log_info *const rli,
     */
     if (!get_flags(COMPLETE_ROWS_F)) {
       restore_record(table, record[1]);
-      error = unpack_current_row(rli, &m_cols, true /*is AI*/);
+      error = unpack_current_row(rli, &m_cols, &m_local_cols, true /*is AI*/);
     }
 
 #ifndef NDEBUG
@@ -12466,7 +12478,7 @@ int Delete_rows_log_event::do_exec_row(const Relay_log_info *const rli) {
   int error;
   assert(m_table != nullptr);
   if (m_rows_lookup_algorithm == ROW_LOOKUP_NOT_NEEDED) {
-    error = unpack_current_row(rli, &m_cols, false, false);
+    error = unpack_current_row(rli, &m_cols, &m_local_cols, false, false);
     if (error) return error;
   }
   /* m_table->record[0] contains the BI */
@@ -12603,7 +12615,7 @@ int Update_rows_log_event::do_exec_row(const Relay_log_info *const rli) {
   int error = 0;
 
   if (m_rows_lookup_algorithm == ROW_LOOKUP_NOT_NEEDED) {
-    error = unpack_current_row(rli, &m_cols, false, false);
+    error = unpack_current_row(rli, &m_cols, &m_local_cols, false, false);
     if (error) return error;
   }
 
@@ -12622,7 +12634,8 @@ int Update_rows_log_event::do_exec_row(const Relay_log_info *const rli) {
 
   m_curr_row = m_curr_row_end;
   /* this also updates m_curr_row_end */
-  if ((error = unpack_current_row(rli, &m_cols_ai, true /*is AI*/)))
+  if ((error = unpack_current_row(rli, &m_cols_ai, &m_local_cols_ai,
+                                  true /*is AI*/)))
     return error;
 
   // Invoke check constraints on the unpacked row.

--- a/sql/log_event.h
+++ b/sql/log_event.h
@@ -2975,6 +2975,8 @@ class Rows_log_event : public virtual binary_log::Rows_event, public Log_event {
 
     @param cols The bitmap of columns included in the update.
 
+    @param local_cols The bitmap of local columns included in the update.
+
     @param is_after_image Should be true if this is an after-image,
     false if it is a before-image.
 
@@ -2990,7 +2992,8 @@ class Rows_log_event : public virtual binary_log::Rows_event, public Log_event {
     and maybe others).
   */
   int unpack_current_row(const Relay_log_info *const rli, MY_BITMAP const *cols,
-                         bool is_after_image, bool only_seek = false);
+                         MY_BITMAP const *local_cols, bool is_after_image,
+                         bool only_seek = false);
   /**
     Updates the generated columns of the `TABLE` object referenced by
     `m_table`, that have an active bit in the parameter bitset


### PR DESCRIPTION
…ted field in the primary key

https://jira.percona.com/browse/PS-8073

Problem:
When updating a table with a stored generated field in a primary key with binlog_row_image=minimal on a master, MySQL can't find the updated record on a replica.

Cause:
In f14a832e464b fix (a commit causing the bug) generated fields are updated in unpack_current_row. If a binlog row image doesn't contain base fields which a generated column depends on, generated fields will be updated incorrectly. Then they won't be found by Innodb.

Solution:
Exclude generated fields from update which base fields are excluded from the binlog row image.

This bug is reproduced in 5.7, but it requires additional commits from 8.0 to be fixed. I think, f14a832e464b can be required. Do we need to fix it in 5.7 anyway?