### PR TITLE
PS-8560 [8.0]: Allow to build RocksDB for selected CPU architecture

### DIFF
--- a/cmake/compiler_features.cmake
+++ b/cmake/compiler_features.cmake
@@ -17,270 +17,333 @@
 # Functions to detect features supported by compiler
 
 include(CheckCXXSourceRuns)
-
-set(CMAKE_REQUIRED_FLAGS "-msse4.2 --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-#include <cstdint>
-#include <nmmintrin.h>
-int main() {
-  auto x = _mm_crc32_u32(0, 0);
-  return 0;
-}
-" HAVE_SSE42)
-
-
-set(CMAKE_REQUIRED_FLAGS "-mpclmul --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-#include <cstdint>
-#include <wmmintrin.h>
-int main() {
-  const auto a = _mm_set_epi64x(0, 0);
-  const auto b = _mm_set_epi64x(0, 0);
-  const auto c = _mm_clmulepi64_si128(a, b, 0x00);
-  auto d = _mm_cvtsi128_si64(c);
-  return 0;
-}
-" HAVE_PCLMUL)
-
-
-set(CMAKE_REQUIRED_FLAGS "-mavx2 --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-#include <cstdint>
-#include <immintrin.h>
-int main() {
-  const auto a = _mm256_setr_epi32(0, 1, 2, 3, 4, 7, 6, 5);
-  const auto b = _mm256_permutevar8x32_epi32(a, a);
-  return 0;
-}
-" HAVE_AVX2)
-
-
-set(CMAKE_REQUIRED_FLAGS "-mbmi --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-#include <cstdint>
-#include <immintrin.h>
-#include <cstdint>
-#include <immintrin.h>
-int main(int argc, char *argv[]) {
-  int a = (int)_tzcnt_u64((uint64_t)argc);
-  return 0;
-}
-" HAVE_BMI)
-
-
-set(CMAKE_REQUIRED_FLAGS "-mlzcnt --std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-#include <cstdint>
-#include <immintrin.h>
-int main(int argc, char *argv[]) {
-  int a = (int)_lzcnt_u64((uint64_t)argc);
-  return 0;
-}
-" HAVE_LZCNT)
-
-
-set(CMAKE_REQUIRED_FLAGS "-faligned-new -Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-struct alignas(1024) t {int a;};
-int main() { return 0; }
-" HAVE_ALIGNED_NEW)
-
-
-set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-#include <cstdint>
-int main() {
-  uint64_t a = 0xffffFFFFffffFFFF;
-  __uint128_t b = __uint128_t(a) * a;
-  a = static_cast<uint64_t>(b >> 64);
-  return 0;
-}
-" HAVE_UINT128_EXTENSION)
-
-
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_LINK_FLAGS} -Wno-error")
-FIND_LIBRARY(URING_LIBRARY NAMES uring)
-IF (URING_LIBRARY)
-	set(CMAKE_REQUIRED_LIBRARIES ${URING_LIBRARY})
-	CHECK_CXX_SOURCE_RUNS("
-	#include <liburing.h>
-	int main() {
-	  struct io_uring ring;
-	  io_uring_queue_init(1, &ring, 0);
-	  return 0;
-	}
-	" HAVE_URING)
-ENDIF()
-
-
-FIND_LIBRARY(MEMKIND_LIBRARY NAMES memkind)
-IF (MEMKIND_LIBRARY)
-	set(CMAKE_REQUIRED_LIBRARIES ${MEMKIND_LIBRARY})
-	CHECK_CXX_SOURCE_RUNS("
-	#include <memkind.h>
-	int main() {
-	  memkind_malloc(MEMKIND_DAX_KMEM, 1024);
-	  return 0;
-	}
-	" HAVE_MEMKIND)
-ENDIF()
-
-unset(CMAKE_REQUIRED_LIBRARIES)
-
-
-set(CMAKE_REQUIRED_FLAGS "-Wno-error")
-CHECK_CXX_SOURCE_RUNS("
-#if defined(_MSC_VER) && !defined(__thread)
-#define __thread __declspec(thread)
-#endif
-int main() {
-  static __thread int tls;
-  return 0;
-}
-" HAVE_THREAD_LOCAL)
-
-
-CHECK_CXX_SOURCE_RUNS("
-#include <fcntl.h>
-#include <linux/falloc.h>
-int main() {
-  int fd = open(\"/dev/null\", 0);
-  fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1024);
-  return 0;
-}
-" HAVE_FALLOCATE)
-
-
-CHECK_CXX_SOURCE_RUNS("
-#include <pthread.h>
-int main() {
-  int x = PTHREAD_MUTEX_ADAPTIVE_NP;
-  return 0;
-}
-" HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
-
-
-CHECK_CXX_SOURCE_RUNS("
-#include <pthread.h>
-#include <execinfo.h>
-int main() {
-  void* frames[1];
-  backtrace_symbols(frames, backtrace(frames, 1));
-  return 0;
-}
-" HAVE_BACKTRACE_SYMBOLS)
-
-
-CHECK_CXX_SOURCE_RUNS("
-#include <fcntl.h>
-int main() {
-  int fd = open(\"/dev/null\", 0);
-  sync_file_range(fd, 0, 1024, SYNC_FILE_RANGE_WRITE);
-  return 0;
-}
-" HAVE_SYNC_FILE_RANGE_WRITE)
-
-unset(CMAKE_REQUIRED_FLAGS)
-
-
 include(CheckCXXSymbolExists)
 
-if(CMAKE_SYSTEM_NAME MATCHES "^FreeBSD")
-  check_cxx_symbol_exists(malloc_usable_size malloc_np.h HAVE_MALLOC_USABLE_SIZE)
-else()
-  check_cxx_symbol_exists(malloc_usable_size malloc.h HAVE_MALLOC_USABLE_SIZE)
-endif()
 
-check_cxx_symbol_exists(sched_getcpu sched.h ROCKSDB_SCHED_GETCPU_PRESENT)
-check_cxx_symbol_exists(getauxval sys/auxv.h HAVE_AUXV_GETAUXVAL)
+function (CHECK_SSE42_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <nmmintrin.h>
+  int main() {
+    auto x = _mm_crc32_u32(0, 0);
+    return 0;
+  }
+  " HAVE_SSE42)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_SSE42})
+endfunction (CHECK_SSE42_SUPPORT)
+
+
+function (CHECK_PCLMUL_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <wmmintrin.h>
+  int main() {
+    const auto a = _mm_set_epi64x(0, 0);
+    const auto b = _mm_set_epi64x(0, 0);
+    const auto c = _mm_clmulepi64_si128(a, b, 0x00);
+    auto d = _mm_cvtsi128_si64(c);
+    return 0;
+  }
+  " HAVE_PCLMUL)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_PCLMUL})
+endfunction (CHECK_PCLMUL_SUPPORT)
+
+
+function (CHECK_AVX2_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <immintrin.h>
+  int main() {
+    const auto a = _mm256_setr_epi32(0, 1, 2, 3, 4, 7, 6, 5);
+    const auto b = _mm256_permutevar8x32_epi32(a, a);
+    return 0;
+  }
+  " HAVE_AVX2)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_AVX2})
+endfunction (CHECK_AVX2_SUPPORT)
+
+
+function (CHECK_BMI_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <immintrin.h>
+  int main(int argc, char *argv[]) {
+    int a = (int)_tzcnt_u64(argc);
+    return 0;
+  }
+  " HAVE_BMI)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_BMI})
+endfunction (CHECK_BMI_SUPPORT)
+
+
+function (CHECK_LZCNT_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <immintrin.h>
+  int main(int argc, char *argv[]) {
+    int a = (int)_lzcnt_u64(argc);
+    return 0;
+  }
+  " HAVE_LZCNT)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_LZCNT})
+endfunction (CHECK_LZCNT_SUPPORT)
+
+
+function (CHECK_ALIGNED_NEW_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-faligned-new -Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  struct alignas(1024) t {int a;};
+  int main() { return 0; }
+  " HAVE_ALIGNED_NEW)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_ALIGNED_NEW})
+endfunction (CHECK_ALIGNED_NEW_SUPPORT)
+
+
+function (CHECK_UINT128_EXTENSION_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "--std=c++11 -Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <cstdint>
+  int main() {
+    uint64_t a = 0xffffFFFFffffFFFF;
+    __uint128_t b = __uint128_t(a) * a;
+    a = static_cast<uint64_t>(b >> 64);
+    return 0;
+  }
+  " HAVE_UINT128_EXTENSION)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_UINT128_EXTENSION})
+endfunction (CHECK_UINT128_EXTENSION_SUPPORT)
+
+
+function (CHECK_URING_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_CXX_LINK_FLAGS} -Wno-error")
+  FIND_LIBRARY(URING_LIBRARY NAMES uring)
+  IF (URING_LIBRARY)
+    set(CMAKE_REQUIRED_LIBRARIES ${URING_LIBRARY})
+    CHECK_CXX_SOURCE_RUNS("
+    #include <liburing.h>
+    int main() {
+      struct io_uring ring;
+      io_uring_queue_init(1, &ring, 0);
+      return 0;
+    }
+    " HAVE_URING)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+  ENDIF()
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_URING})
+endfunction (CHECK_URING_SUPPORT)
+
+
+function (CHECK_MEMKIND_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  FIND_LIBRARY(MEMKIND_LIBRARY NAMES memkind)
+  IF (MEMKIND_LIBRARY)
+    set(CMAKE_REQUIRED_LIBRARIES ${MEMKIND_LIBRARY})
+    CHECK_CXX_SOURCE_RUNS("
+    #include <memkind.h>
+    int main() {
+      memkind_malloc(MEMKIND_DAX_KMEM, 1024);
+      return 0;
+    }
+    " HAVE_MEMKIND)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+  ENDIF()
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_MEMKIND})
+endfunction (CHECK_MEMKIND_SUPPORT)
+
+
+function (CHECK_THREAD_LOCAL_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #if defined(_MSC_VER) && !defined(__thread)
+  #define __thread __declspec(thread)
+  #endif
+  int main() {
+    static __thread int tls;
+    return 0;
+  }
+  " HAVE_THREAD_LOCAL)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_THREAD_LOCAL})
+endfunction (CHECK_THREAD_LOCAL_SUPPORT)
+
+
+function (CHECK_FALLOCATE_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <fcntl.h>
+  #include <linux/falloc.h>
+  int main() {
+    int fd = open(\"/dev/null\", 0);
+    fallocate(fd, FALLOC_FL_KEEP_SIZE, 0, 1024);
+    return 0;
+  }
+  " HAVE_FALLOCATE)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_FALLOCATE})
+endfunction (CHECK_FALLOCATE_SUPPORT)
+
+
+function (CHECK_PTHREAD_MUTEX_ADAPTIVE_NP_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <pthread.h>
+  int main() {
+    int x = PTHREAD_MUTEX_ADAPTIVE_NP;
+    return 0;
+  }
+  " HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_PTHREAD_MUTEX_ADAPTIVE_NP})
+endfunction (CHECK_PTHREAD_MUTEX_ADAPTIVE_NP_SUPPORT)
+
+
+function (CHECK_BACKTRACE_SYMBOLS_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <pthread.h>
+  #include <execinfo.h>
+  int main() {
+    void* frames[1];
+    backtrace_symbols(frames, backtrace(frames, 1));
+    return 0;
+  }
+  " HAVE_BACKTRACE_SYMBOLS)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_BACKTRACE_SYMBOLS})
+endfunction (CHECK_BACKTRACE_SYMBOLS_SUPPORT)
+
+
+function (CHECK_SYNC_FILE_RANGE_WRITE_SUPPORT PARAM_OUT)
+  set(CMAKE_REQUIRED_FLAGS "-Wno-error")
+  CHECK_CXX_SOURCE_RUNS("
+  #include <fcntl.h>
+  int main() {
+    int fd = open(\"/dev/null\", 0);
+    sync_file_range(fd, 0, 1024, SYNC_FILE_RANGE_WRITE);
+    return 0;
+  }
+  " HAVE_SYNC_FILE_RANGE_WRITE)
+  unset(CMAKE_REQUIRED_FLAGS)
+  set(${PARAM_OUT} ${HAVE_SYNC_FILE_RANGE_WRITE})
+endfunction (CHECK_SYNC_FILE_RANGE_WRITE_SUPPORT)
 
 
 MACRO(ROCKSDB_SET_DEFINTIONS)
-	if(HAVE_SSE42)
-	  add_definitions(-DHAVE_SSE42)
-	endif()
+  CHECK_SSE42_SUPPORT(HAVE_SSE42)
+  if (HAVE_SSE42)
+    add_definitions(-DHAVE_SSE42)
+  else()
+    IF (ALLOW_NO_SSE42)
+      MESSAGE(WARNING "No SSE42 support found and ALLOW_NO_SSE42 specified, building MyRocks but without SSE42/FastCRC32 support")
+    ELSE()
+      MESSAGE(FATAL_ERROR "No SSE42 support found. Not building MyRocks. Set ALLOW_NO_SSE42 to build MyRocks with slow CRC32.")
+    ENDIF()
+  endif()
 
-	IF (HAVE_PCLMUL)
-	  add_definitions(-DHAVE_PCLMUL)
-	ENDIF ()
+  CHECK_PCLMUL_SUPPORT(HAVE_PCLMUL)
+  IF (HAVE_PCLMUL)
+    add_definitions(-DHAVE_PCLMUL)
+  ENDIF ()
 
-	if(HAVE_AVX2 AND NOT ROCKSDB_DISABLE_AVX2)
-	  add_definitions(-DHAVE_AVX2)
-	endif()
+  CHECK_AVX2_SUPPORT(HAVE_AVX2)
+  if (HAVE_AVX2 AND NOT ROCKSDB_DISABLE_AVX2)
+    add_definitions(-DHAVE_AVX2)
+  endif()
 
-	if(HAVE_BMI)
-	  add_definitions(-DHAVE_BMI)
-	endif()
+  CHECK_BMI_SUPPORT(HAVE_BMI)
+  if (HAVE_BMI)
+    add_definitions(-DHAVE_BMI)
+  endif()
 
-	if(HAVE_LZCNT)
-	  add_definitions(-DHAVE_LZCNT)
-	endif()
+  CHECK_LZCNT_SUPPORT(HAVE_LZCNT)
+  if (HAVE_LZCNT)
+    add_definitions(-DHAVE_LZCNT)
+  endif()
 
-	if(HAVE_ALIGNED_NEW AND NOT ROCKSDB_DISABLE_ALIGNED_NEW)
-	  add_definitions(-DHAVE_ALIGNED_NEW)
-	endif()
+  CHECK_ALIGNED_NEW_SUPPORT(HAVE_ALIGNED_NEW)
+  if (HAVE_ALIGNED_NEW AND NOT ROCKSDB_DISABLE_ALIGNED_NEW)
+    add_definitions(-DHAVE_ALIGNED_NEW)
+  endif()
 
-	if(HAVE_UINT128_EXTENSION)
-	  add_definitions(-DHAVE_UINT128_EXTENSION)
-	endif()
+  CHECK_UINT128_EXTENSION_SUPPORT(HAVE_UINT128_EXTENSION)
+  if (HAVE_UINT128_EXTENSION)
+    add_definitions(-DHAVE_UINT128_EXTENSION)
+  endif()
 
-	if(HAVE_URING)
-	  if (ROCKSDB_USE_IO_URING)
-	     add_definitions(-DROCKSDB_IOURING_PRESENT)
-	   else()
-	     message(STATUS "uring library detected but not used as ROCKSDB_USE_IO_URING is not defined")
-	   endif()
-	endif()
+  CHECK_URING_SUPPORT(HAVE_URING)
+  if (HAVE_URING)
+    if (ROCKSDB_USE_IO_URING)
+       add_definitions(-DROCKSDB_IOURING_PRESENT)
+     else()
+       message(STATUS "uring library detected but not used as ROCKSDB_USE_IO_URING is not defined")
+     endif()
+  endif()
 
-	if(HAVE_MEMKIND)
-	  if (ROCKSDB_USE_MEMKIND)
-	     add_definitions(-DMEMKIND)
-	   else()
-	     message(STATUS "memkind library detected but not used as ROCKSDB_USE_MEMKIND is not defined")
-	   endif()
-	endif()
+  CHECK_MEMKIND_SUPPORT(HAVE_MEMKIND)
+  if (HAVE_MEMKIND)
+    if (ROCKSDB_USE_MEMKIND)
+       add_definitions(-DMEMKIND)
+     else()
+       message(STATUS "memkind library detected but not used as ROCKSDB_USE_MEMKIND is not defined")
+     endif()
+  endif()
 
-	if(HAVE_MALLOC_USABLE_SIZE)
-	  if (ROCKSDB_USE_MALLOC_USABLE_SIZE)
-	     add_definitions(-DROCKSDB_MALLOC_USABLE_SIZE)
-	   else()
-	     message(STATUS "malloc_usable_size() function detected but not used as ROCKSDB_USE_MALLOC_USABLE_SIZE is not defined")
-	   endif()
-	endif()
+  CHECK_THREAD_LOCAL_SUPPORT(HAVE_THREAD_LOCAL)
+  if (HAVE_THREAD_LOCAL)
+    add_definitions(-DROCKSDB_SUPPORT_THREAD_LOCAL)
+  else()
+    MESSAGE(FATAL_ERROR "No '__thread' support found. Not building MyRocks")
+  endif()
 
-	if(HAVE_THREAD_LOCAL)
-	  add_definitions(-DROCKSDB_SUPPORT_THREAD_LOCAL)
-	endif()
+  CHECK_FALLOCATE_SUPPORT(HAVE_FALLOCATE)
+  if (HAVE_FALLOCATE AND NOT ROCKSDB_DISABLE_FALLOCATE)
+    add_definitions(-DROCKSDB_FALLOCATE_PRESENT)
+  endif()
 
-	if(HAVE_FALLOCATE AND NOT ROCKSDB_DISABLE_FALLOCATE)
-	  add_definitions(-DROCKSDB_FALLOCATE_PRESENT)
-	endif()
+  CHECK_PTHREAD_MUTEX_ADAPTIVE_NP_SUPPORT(HAVE_PTHREAD_MUTEX_ADAPTIVE_NP)
+  if (HAVE_PTHREAD_MUTEX_ADAPTIVE_NP AND NOT ROCKSDB_DISABLE_PTHREAD_MUTEX_ADAPTIVE_NP)
+    add_definitions(-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX)
+  endif()
 
-	if(WITH_NUMA)
-	  add_definitions(-DNUMA)
-	endif()
+  CHECK_BACKTRACE_SYMBOLS_SUPPORT(HAVE_BACKTRACE_SYMBOLS)
+  if (HAVE_BACKTRACE_SYMBOLS AND NOT ROCKSDB_DISABLE_BACKTRACE)
+    add_definitions(-DROCKSDB_BACKTRACE)
+  endif()
 
-	if(WITH_JEMALLOC)
-	  add_definitions(-DROCKSDB_JEMALLOC)
-	endif()
+  CHECK_SYNC_FILE_RANGE_WRITE_SUPPORT(HAVE_SYNC_FILE_RANGE_WRITE)
+  if (HAVE_SYNC_FILE_RANGE_WRITE AND NOT ROCKSDB_DISABLE_SYNC_FILE_RANGE)
+    add_definitions(-DROCKSDB_RANGESYNC_PRESENT)
+  endif()
 
-	if(HAVE_SYNC_FILE_RANGE_WRITE AND NOT ROCKSDB_DISABLE_SYNC_FILE_RANGE)
-	  add_definitions(-DROCKSDB_RANGESYNC_PRESENT)
-	endif()
+  if (CMAKE_SYSTEM_NAME MATCHES "^FreeBSD")
+    check_cxx_symbol_exists(malloc_usable_size malloc_np.h HAVE_MALLOC_USABLE_SIZE)
+  else()
+    check_cxx_symbol_exists(malloc_usable_size malloc.h HAVE_MALLOC_USABLE_SIZE)
+  endif()
+  if (HAVE_MALLOC_USABLE_SIZE)
+    if (ROCKSDB_USE_MALLOC_USABLE_SIZE)
+       add_definitions(-DROCKSDB_MALLOC_USABLE_SIZE)
+     else()
+       message(STATUS "malloc_usable_size() function detected but not used as ROCKSDB_USE_MALLOC_USABLE_SIZE is not defined")
+     endif()
+  endif()
 
-	if(HAVE_PTHREAD_MUTEX_ADAPTIVE_NP AND NOT ROCKSDB_DISABLE_PTHREAD_MUTEX_ADAPTIVE_NP)
-	  add_definitions(-DROCKSDB_PTHREAD_ADAPTIVE_MUTEX)
-	endif()
+  check_cxx_symbol_exists(sched_getcpu sched.h ROCKSDB_SCHED_GETCPU_PRESENT)
+  if (ROCKSDB_SCHED_GETCPU_PRESENT AND NOT ROCKSDB_DISABLE_SCHED_GETCPU)
+    add_definitions(-DROCKSDB_SCHED_GETCPU_PRESENT -DHAVE_SCHED_GETCPU=1)
+  endif()
 
-	if(HAVE_BACKTRACE_SYMBOLS AND NOT ROCKSDB_DISABLE_BACKTRACE)
-	  add_definitions(-DROCKSDB_BACKTRACE)
-	endif()
-
-	if(ROCKSDB_SCHED_GETCPU_PRESENT AND NOT ROCKSDB_DISABLE_SCHED_GETCPU)
-	  add_definitions(-DROCKSDB_SCHED_GETCPU_PRESENT -DHAVE_SCHED_GETCPU=1)
-	endif()
-
-	if(HAVE_AUXV_GETAUXVAL AND NOT ROCKSDB_DISABLE_AUXV_GETAUXVAL)
-	  add_definitions(-DROCKSDB_AUXV_GETAUXVAL_PRESENT)
-	endif()
+  check_cxx_symbol_exists(getauxval sys/auxv.h HAVE_AUXV_GETAUXVAL)
+  if (HAVE_AUXV_GETAUXVAL AND NOT ROCKSDB_DISABLE_AUXV_GETAUXVAL)
+    add_definitions(-DROCKSDB_AUXV_GETAUXVAL_PRESENT)
+  endif()
 ENDMACRO()

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -188,37 +188,35 @@ IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
   IF (NOT ROCKSDB_BUILD_ARCH)
     IF (ROCKSDB_DISABLE_MARCH_NATIVE)
       # Intel Westmere is oldest CPU that supports SSE 4.2 and PCLMUL instruction sets
+      # the compiled binary will also work on "core2" and "nehalem" because "sse4.2" and "pclmul" are checked on runtime
       SET(ROCKSDB_BUILD_ARCH "westmere")
     ELSE()
       SET(ROCKSDB_BUILD_ARCH "native")
     ENDIF()
     MESSAGE(STATUS "MyRocks x86_64 build architecture: -march=${ROCKSDB_BUILD_ARCH}")
-    # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_RUNS called from ROCKSDB_SET_X86_DEFINTIONS()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
-    ROCKSDB_SET_X86_DEFINTIONS(0)  # check compiler + CPU support
   ELSE()
-    MESSAGE(STATUS "Force MyRocks build architecture: -march=${ROCKSDB_BUILD_ARCH}. Skipping CPU features checks therefore a created binary may crash on this machine.")
-    # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_RUNS called from ROCKSDB_SET_X86_DEFINTIONS()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
-    ROCKSDB_SET_X86_DEFINTIONS(1)  # only check compiler support
+    MESSAGE(STATUS "MyRocks x86_64 build architecture: -march=${ROCKSDB_BUILD_ARCH}. If the enforced processor architecture is newer than the processor architecture of this build machine, the created binary may crash if executed on this machine.")
   ENDIF()
+
+  # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_COMPILES called from ROCKSDB_SET_X86_DEFINTIONS()
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
+  ROCKSDB_SET_X86_DEFINTIONS()
 ELSE() # aarch64
   IF (NOT ROCKSDB_BUILD_ARCH)
     IF (ROCKSDB_DISABLE_MARCH_NATIVE)
+      # the compiled binary will also work on "armv8-a" because "+crc" and "+crypto" are checked on runtime
       SET(ROCKSDB_BUILD_ARCH "armv8-a+crc+crypto")
     ELSE()
       SET(ROCKSDB_BUILD_ARCH "native")
     ENDIF()
     MESSAGE(STATUS "MyRocks arm64 build architecture: -march=${ROCKSDB_BUILD_ARCH}")
-    # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_RUNS called from ROCKSDB_SET_ARM64_DEFINTIONS()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
-    ROCKSDB_SET_ARM64_DEFINTIONS(0)  # check compiler + CPU support
   ELSE()
-    MESSAGE(STATUS "Force MyRocks build architecture: -march=${ROCKSDB_BUILD_ARCH}. Skipping CPU features checks therefore a created binary may crash on this machine.")
-    # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_RUNS called from ROCKSDB_SET_ARM64_DEFINTIONS()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
-    ROCKSDB_SET_ARM64_DEFINTIONS(1)  # only check compiler support
+    MESSAGE(STATUS "MyRocks arm64 build architecture: -march=${ROCKSDB_BUILD_ARCH}. If the enforced processor architecture is newer than the processor architecture of this build machine, the created binary may crash if executed on this machine.")
   ENDIF()
+
+  # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_COMPILES called from ROCKSDB_SET_ARM64_DEFINTIONS()
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
+  ROCKSDB_SET_ARM64_DEFINTIONS()
 ENDIF()
 
 ROCKSDB_SET_DEFINTIONS()  # sets HAVE_URING, HAVE_MEMKIND, HAVE_ALIGNED_NEW

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -70,42 +70,46 @@ ELSE()
   )
 ENDIF()
 
+
 # This is a strong requirement coming from RocksDB. No conditional checks here.
-add_definitions(-DROCKSDB_PLATFORM_POSIX -DROCKSDB_LIB_IO_POSIX -DZLIB -DLZ4 -DZSTD)
+ADD_DEFINITIONS(-DROCKSDB_PLATFORM_POSIX -DROCKSDB_LIB_IO_POSIX -DZLIB -DLZ4 -DZSTD)
 
 IF (ROCKSDB_CUSTOM_NAMESPACE)
   ADD_DEFINITIONS(-DROCKSDB_NAMESPACE=${ROCKSDB_CUSTOM_NAMESPACE})
   ADD_DEFINITIONS(-DROCKSDB_CUSTOM_NAMESPACE=${ROCKSDB_CUSTOM_NAMESPACE})
 ENDIF()
 
-include(compiler_features)
-
-IF (NOT HAVE_THREAD_LOCAL)
-  MESSAGE(FATAL_ERROR "No '__thread' support found. Not building MyRocks")
+IF (WITH_NUMA)
+  ADD_DEFINITIONS(-DNUMA)
 ENDIF()
 
-IF (HAVE_SSE42)
-  MESSAGE(STATUS "MyRocks: SSE42 support found")
-  IF (CMAKE_COMPILER_IS_GNUCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9)
-    # Suppress the '#error "AES/PCLMUL instructions not enabled"' bug in gcc-4.8.x or lower at https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56298
-    add_compile_flags(${ROCKSDB_ROOT}/util/crc32c.cc COMPILE_FLAGS "-msse4.2 -mpclmul") # use Fast_CRC32
-  ELSE()
-    add_compile_flags(${ROCKSDB_ROOT}/util/crc32c.cc COMPILE_FLAGS "-msse4.2") # use Fast_CRC32
-  ENDIF()
-  IF (HAVE_PCLMUL)
-    add_compile_flags(${ROCKSDB_ROOT}/util/crc32c.cc COMPILE_FLAGS "-mpclmul") # use crc32c_3way instead of Fast_CRC32
-  ENDIF()
-ELSE()
-  IF (ALLOW_NO_SSE42)
-    MESSAGE(WARNING "No SSE42 support found and ALLOW_NO_SSE42 specified, building MyRocks but without SSE42/FastCRC32 support")
-  ELSE()
-    MESSAGE(FATAL_ERROR "No SSE42 support found. Not building MyRocks")
-  ENDIF()
+IF (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  ADD_DEFINITIONS(-DOS_LINUX)
 ENDIF()
 
-IF (HAVE_AVX2 AND NOT ROCKSDB_DISABLE_AVX2)
-  add_compile_flags(${ROCKSDB_ROOT}/table/block_based/filter_policy.cc COMPILE_FLAGS "-mavx2")
+IF (CMAKE_COMPILER_IS_GNUCXX)
+  ADD_COMPILE_OPTIONS(-fno-builtin-memcmp)
 ENDIF()
+
+
+INCLUDE(compiler_features)
+
+IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  IF (NOT ROCKSDB_BUILD_ARCH)
+    IF (ROCKSDB_DISABLE_MARCH_NATIVE)
+      # Intel Westmere is oldest CPU that supports SSE 4.2 and PCLMUL instruction sets
+      SET(ROCKSDB_BUILD_ARCH "westmere")
+    ELSE()
+      SET(ROCKSDB_BUILD_ARCH "native")
+    ENDIF()
+  ENDIF()
+
+  # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_RUNS called from ROCKSDB_SET_DEFINTIONS()
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
+  MESSAGE(STATUS "MyRocks build architecture: -march=${ROCKSDB_BUILD_ARCH}")
+ENDIF()
+
+ROCKSDB_SET_DEFINTIONS()  # sets HAVE_URING, HAVE_MEMKIND, HAVE_ALIGNED_NEW
 
 IF (HAVE_URING AND ROCKSDB_USE_IO_URING)
   SET(rocksdb_static_libs ${rocksdb_static_libs} ${URING_LIBRARY})
@@ -116,25 +120,12 @@ IF (HAVE_MEMKIND AND ROCKSDB_USE_MEMKIND)
 ENDIF()
 
 IF (HAVE_ALIGNED_NEW AND NOT ROCKSDB_DISABLE_ALIGNED_NEW)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
 ENDIF()
 
-IF (CMAKE_COMPILER_IS_GNUCXX)
-  add_compile_options(-fno-builtin-memcmp)
-ENDIF()
-
-IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64" AND NOT ROCKSDB_DISABLE_MARCH_NATIVE)
-  add_compile_options(-march=native)
-ENDIF()
-
-IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  add_definitions(-DOS_LINUX)
-ENDIF()
-
-ROCKSDB_SET_DEFINTIONS()
-get_directory_property(COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
-list(SORT COMPILE_DEFINITIONS)
-message(STATUS "MyRocks compile definitions: ${COMPILE_DEFINITIONS}")
+GET_DIRECTORY_PROPERTY(COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
+LIST(SORT COMPILE_DEFINITIONS)
+MESSAGE(STATUS "MyRocks compile definitions: ${COMPILE_DEFINITIONS}")
 
 
 # Suppress warnings for clang-13 or newer


### PR DESCRIPTION
1. Introduce `ROCKSDB_BUILD_ARCH` parameter to select MyRocks build architecture with `-march=${ROCKSDB_BUILD_ARCH}`.
2. Remove adding instruction set flags e.g. `-msse4.2` to individual files.