### PR TITLE
PS-8503: Fix checkpoint age status vars update

### DIFF
--- a/mysql-test/suite/innodb/r/innodb_checkpoint_age.result
+++ b/mysql-test/suite/innodb/r/innodb_checkpoint_age.result
@@ -1,0 +1,2 @@
+include/assert.inc [Innodb_checkpoint_age not zero]
+include/assert.inc [Innodb_checkpoint_max_age not zero]

--- a/mysql-test/suite/innodb/t/innodb_checkpoint_age.test
+++ b/mysql-test/suite/innodb/t/innodb_checkpoint_age.test
@@ -1,0 +1,12 @@
+#
+# The purpose of this test is to make sure Innodb_checkpoint_age and Innodb_checkpoint_max_age
+# status variables are updated after server startup and have non-zero values.
+#
+
+--let $assert_text = Innodb_checkpoint_age not zero
+--let $assert_cond = VARIABLE_VALUE > 0 FROM performance_schema.global_status WHERE VARIABLE_NAME = "Innodb_checkpoint_age"
+--source include/assert.inc
+
+--let $assert_text = Innodb_checkpoint_max_age not zero
+--let $assert_cond = VARIABLE_VALUE > 0 FROM performance_schema.global_status WHERE VARIABLE_NAME = "Innodb_checkpoint_max_age"
+--source include/assert.inc

--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -1767,6 +1767,14 @@ void srv_export_innodb_status(void) {
     export_vars.innodb_buffer_pool_pages_old += buf_pool->LRU_old_len;
   }
 
+  export_vars.innodb_checkpoint_age =
+      (log_get_lsn(*log_sys) - log_sys->last_checkpoint_lsn);
+
+  log_limits_mutex_enter(*log_sys);
+  export_vars.innodb_checkpoint_max_age = log_free_check_capacity(*log_sys);
+  log_limits_mutex_exit(*log_sys);
+  ibuf_export_ibuf_status(&export_vars.innodb_ibuf_free_list,
+                          &export_vars.innodb_ibuf_segment_size);
   export_vars.innodb_lsn_current = log_get_lsn(*log_sys);
   export_vars.innodb_lsn_flushed = log_sys->flushed_to_disk_lsn;
   export_vars.innodb_lsn_last_checkpoint = log_sys->last_checkpoint_lsn;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8503

Restore code responsible for checkpoint age related status variables update.