### PR TITLE
PS-8422: Merge MySQL 8.0.31 (fix have_fips.inc)

### DIFF
--- a/mysys/my_openssl_fips.cc
+++ b/mysys/my_openssl_fips.cc
@@ -125,8 +125,12 @@ bool set_fips_mode(const int fips_mode, char err_string[OPENSSL_ERROR_LENGTH]) {
   @retval non-zero: FIPS is supported.
 */
 int test_ssl_fips_mode(char err_string[OPENSSL_ERROR_LENGTH]) {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+  int ret = EVP_default_properties_is_fips_enabled(nullptr);
+#else  /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
   unsigned test_fips_mode = get_fips_mode() == 0 ? 1 : 0;
   int ret = set_fips_mode_inner(test_fips_mode);
+#endif /* OPENSSL_VERSION_NUMBER >= 0x30000000L */
   unsigned long err = (ret == 0) ? ERR_get_error() : 0;
 
   if (err != 0) {


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8422

The have_fips.inc is used to check if FIPS is supported with current openssl build. Internally it toggle's FIPS mode to see whether it is available.

This approach doesn't work for OSes which come with bundled openssl-3. To fix that test_ssl_fips_mode() method updated to use EVP_default_properties_is_fips_enabled() instead of toggleing current FIPS state.