### PR TITLE
PS-7538: Crash with innodb_optimize_fulltext_only (8.0)

### DIFF
--- a/storage/innobase/fts/fts0opt.cc
+++ b/storage/innobase/fts/fts0opt.cc
@@ -549,6 +549,7 @@ static byte *fts_zip_read_word(
   void *null = nullptr;
   byte *ptr = word->f_str;
   int flush = Z_NO_FLUSH;
+  bool read_something = false;
 
   /* Either there was an error or we are at the Z_STREAM_END. */
   if (zip->status != Z_OK) {
@@ -599,6 +600,7 @@ static byte *fts_zip_read_word(
 
           word->f_len = len;
           len = 0;
+          read_something = true;
         }
         break;
 
@@ -627,7 +629,9 @@ static byte *fts_zip_read_word(
     ut_ad(word->f_len == strlen((char *)ptr));
   }
 
-  return (zip->status == Z_OK || zip->status == Z_STREAM_END ? ptr : nullptr);
+  return ((zip->status == Z_OK || zip->status == Z_STREAM_END) && read_something
+              ? ptr
+              : nullptr);
 }
 
 /** Callback function to fetch and compress the word in an FTS


### PR DESCRIPTION
Issue: innodb_optimize_fulltext_only=ON allows users to use OPTIMIZE TABLE to rebuild fulltext indices.

Internally the fulltext rebuild logic reads innodb_ft_num_word_optimize keys from the index, uses zlib to compress them, and then starts decompressing/iterating them.

There's an error in this decompressing logic: if zlib reports end of stream, the reader method assumes that we correctly read the last entry and returns it.

But it's also possible that we were already at the end of the stream, and we didn't read anything. The variable used for returning the next word is reused from the previous iteration in the optimize loop. If it contains a record that exists in the index, the logic ends up "optimizing" it again. If it contains a value that's not present in the index, it crashes.

Fix: only return success if there was actually something in the zip data.