### PR TITLE
PS-7538: Crash with innodb_optimize_fulltext_only (5.7)

### DIFF
--- a/storage/innobase/fts/fts0opt.cc
+++ b/storage/innobase/fts/fts0opt.cc
@@ -584,6 +584,7 @@ fts_zip_read_word(
 	void*		null = NULL;
 	byte*		ptr = word->f_str;
 	int		flush = Z_NO_FLUSH;
+	bool		read_something = FALSE;
 
 	/* Either there was an error or we are at the Z_STREAM_END. */
 	if (zip->status != Z_OK) {
@@ -641,6 +642,7 @@ fts_zip_read_word(
 
 				word->f_len = len;
 				len = 0;
+				read_something = TRUE;
 			}
 			break;
 
@@ -669,7 +671,8 @@ fts_zip_read_word(
 		ut_ad(word->f_len == strlen((char*) ptr));
 	}
 
-	return(zip->status == Z_OK || zip->status == Z_STREAM_END ? ptr : NULL);
+	return((zip->status == Z_OK || zip->status == Z_STREAM_END) && read_something)
+		 ? ptr : NULL;
 }
 
 /**********************************************************************//**


### PR DESCRIPTION
Issue: innodb_optimize_fulltext_only=ON allows users to use OPTIMIZE TABLE to rebuild fulltext indices.

Internally the fulltext rebuild logic reads innodb_ft_num_word_optimize keys from the index, uses zlib to compress them, and then starts decompressing/iterating them.

There's an error in this decompressing logic: if zlib reports end of stream, the reader method assumes that we correctly read the last entry and returns it.

But it's also possible that we were already at the end of the stream, and we didn't read anything. The variable used for returning the next word is reused from the previous iteration in the optimize loop. If it contains a record that exists in the index, the logic ends up "optimizing" it again. If it contains a value that's not present in the index, it crashes.

Fix: only return success if there was actually something in the zip data.