### PR TITLE
PS-8580 postfix: Merge MySQL 5.7.41 (keyring_vault_timeout)

### DIFF
--- a/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.test
+++ b/plugin/keyring_vault/tests/mtr/keyring_vault_timeout.test
@@ -28,6 +28,7 @@ call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Error whil
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : connect\\(\\) timed out!'");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 28 with error message : Operation timed out after");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 7 with error message : couldn't connect to host'");
+call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'CURL returned this error code: 7 with error message : Failed to connect to");
 call mtr.add_suppression("\\[Warning\\] Plugin keyring_vault reported: 'vault_ca is not specified but vault_url is https://");
 call mtr.add_suppression("\\[ERROR\\] Plugin keyring_vault reported: 'Auto-detected mount point version is not the same as specified in 'secret_mount_point_version'\\.");
 --enable_query_log


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8580

Fixed stability issues with 'keyring_vault.keyring_vault_timeout' MTR test case caused by sporadic 'no route to host' instead of 'couldn't connect to host' errors reported from CURL.