### PR TITLE
PS-8626: Inserting JSON data through LOAD DATA INFILE doesn't show fa…

### DIFF
--- a/mysql-test/r/percona_heap_json.result
+++ b/mysql-test/r/percona_heap_json.result
@@ -5,7 +5,7 @@
 CREATE TABLE t0(utf0k json) ENGINE=MEMORY;
 INSERT INTO t0 values('0');
 INSERT INTO t0 VALUES('DBMS stands for DataBase ...');
-ERROR 22032: Invalid JSON text: "Invalid value." at position 0 in value for column 't0.utf0k'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 0 in value for column 't0.utf0k' at row 1.
 SELECT * FROM t0;
 utf0k
 0

--- a/mysql-test/suite/gcol/r/gcol_bugfixes.result
+++ b/mysql-test/suite/gcol/r/gcol_bugfixes.result
@@ -1473,7 +1473,7 @@ ALTER TABLE t
 ADD COLUMN g1 JSON GENERATED ALWAYS AS (x),
 ADD COLUMN g2 JSON GENERATED ALWAYS AS (JSON_ARRAY(x));
 SELECT * FROM t;
-ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't.g1'.
+ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't.g1' at row 1.
 DROP TABLE t;
 #
 # Bug#32234773: UPDATE_GENERATED_READ_FIELDS:

--- a/mysql-test/suite/json/r/json_ddl_innodb.result
+++ b/mysql-test/suite/json/r/json_ddl_innodb.result
@@ -53,7 +53,7 @@ DROP PROCEDURE p;
 CREATE TABLE t1(txt TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin);
 INSERT INTO t1 VALUES ('not JSON');
 ALTER TABLE t1 MODIFY COLUMN txt JSON;
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.txt'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.txt' at row 1.
 SELECT * FROM t1;
 txt
 not JSON
@@ -68,7 +68,7 @@ INSERT INTO t3 VALUES (JSON_OBJECT('a', 'b'));
 CREATE TABLE t4 AS SELECT UPPER(j) AS jj FROM t3;
 INSERT INTO t4 VALUES ('not JSON');
 ALTER TABLE t4 MODIFY COLUMN jj JSON;
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.jj'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.jj' at row 2.
 SELECT * FROM t4 order by jj;
 jj
 not JSON

--- a/mysql-test/suite/json/r/json_functions_innodb.result
+++ b/mysql-test/suite/json/r/json_functions_innodb.result
@@ -5331,7 +5331,7 @@ CREATE FUNCTION func_that_fails() RETURNS JSON
 LANGUAGE SQL DETERMINISTIC NO SQL
 RETURN '[not valid json]';
 SELECT JSON_EXTRACT(func_that_fails(), '$');
-ERROR 22032: Invalid JSON text: "Invalid value." at position 2 in value for column '.func_that_fails()'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 2 in value for column '.func_that_fails()' at row 1.
 DROP FUNCTION func_that_fails;
 create function get_types( input_value json )
 returns json
@@ -8724,7 +8724,7 @@ SET NAMES latin1;
 CREATE TABLE t (j JSON);
 INSERT INTO t VALUES ('{}');
 UPDATE t SET j='1', j='1111-11-11', j=('1' NOT BETWEEN j AND '1');
-ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't.j'.
+ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't.j' at row 1.
 SELECT * FROM t;
 j
 {}
@@ -9208,7 +9208,7 @@ CREATE TABLE t1(j JSON);
 CREATE TABLE t2(vc VARCHAR(10));
 CREATE FUNCTION f1(i INT) RETURNS INT RETURN i;
 INSERT INTO t1 SELECT f1(3);
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t2 SELECT f1(3);
 CREATE FUNCTION f2(vc VARCHAR(10)) RETURNS VARCHAR(10) RETURN vc;
 INSERT INTO t1 SELECT f2('[1,2,3]');

--- a/mysql-test/suite/json/r/json_gcol_innodb.result
+++ b/mysql-test/suite/json/r/json_gcol_innodb.result
@@ -31,9 +31,9 @@ ERROR 22018: Invalid JSON value for CAST to INTEGER from column json_extract at 
 INSERT INTO t(j) VALUES ('"abc"');
 ERROR 22018: Invalid JSON value for CAST to INTEGER from column json_extract at row 1
 INSERT INTO t(j) VALUES ('');
-ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't.j'.
+ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't.j' at row 1.
 INSERT INTO t(j) VALUES ('[');
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j' at row 1.
 SELECT * FROM t ORDER BY id;
 id	j	gc
 0	"5"	5
@@ -48,16 +48,16 @@ id	j	gc
 2	[123]	123
 3	[123]	123
 UPDATE t SET j = '[';
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j' at row 1.
 DROP TABLE t;
 CREATE TABLE t(id INT, j JSON,
 gc JSON GENERATED ALWAYS AS (JSON_ARRAY(j)));
 INSERT INTO t(id, j)
 VALUES (1, '1'), (2, '[true, false]'), (3, '{"a":1,"b":2}');
 INSERT INTO t(j) VALUES ('');
-ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't.j'.
+ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't.j' at row 1.
 INSERT INTO t(j) VALUES ('[');
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j' at row 1.
 SELECT * FROM t ORDER BY id;
 id	j	gc
 1	1	[1]
@@ -70,7 +70,7 @@ id	j	gc
 2	"abc"	["abc"]
 3	"abc"	["abc"]
 UPDATE t SET j = '[';
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't.j' at row 1.
 DROP TABLE t;
 CREATE TABLE t(ts TIMESTAMP, j JSON AS (CAST(ts AS JSON)));
 INSERT INTO t(ts) VALUES ('2000-01-01 00:00:00');

--- a/mysql-test/suite/json/r/json_innodb.result
+++ b/mysql-test/suite/json/r/json_innodb.result
@@ -309,3 +309,37 @@ SELECT j, JSON_TYPE(j->'$[0]') FROM t;
 j	JSON_TYPE(j->'$[0]')
 ["base64:type15:YWFh"]	BLOB
 DROP TABLE t;
+#
+# PS-8626 "Inserting JSON data through LOAD DATA INFILE doesn't show failed record"
+#
+# Test for INSERT.
+CREATE TABLE t1 (t TEXT, j JSON);
+INSERT INTO t1 (j) VALUES
+('{"name": "b", "pets": \{"dog": 3, "chicken": 1} , "surname": "test"}'),
+('{"name": "a", "pets": \{"dog": 3, "chicken": 3} , "surname": "testfailed"'),
+('{"name": "q", "pets": \{"dog": 3, "chicken": 2} , "surname": "test"}');
+ERROR 22032: Invalid JSON text: "Missing a comma or '}' after an object member." at position 72 in value for column 't1.j' at row 2.
+#
+# Test for UPDATE.
+INSERT INTO t1 (t) VALUES
+('{"name": "b", "pets": \{"dog": 3, "chicken": 1} , "surname": "test"}'),
+('{"name": "a", "pets": \{"dog": 3, "chicken": 3} , "surname": "testfailed"'),
+('{"name": "q", "pets": \{"dog": 3, "chicken": 2} , "surname": "test"}');
+UPDATE t1 SET j = t WHERE t LIKE '%testfailed%';
+ERROR 22032: Invalid JSON text: "Missing a comma or '}' after an object member." at position 72 in value for column 't1.j' at row 2.
+#
+# Test for ALTER TABLE.
+ALTER TABLE t1 ADD COLUMN gj JSON GENERATED ALWAYS AS (t) STORED;
+ERROR 22032: Invalid JSON text: "Missing a comma or '}' after an object member." at position 72 in value for column '#sql-temporary.gj' at row 2.
+#
+# Test for SELECT.
+ALTER TABLE t1 ADD COLUMN gj JSON GENERATED ALWAYS AS (t) VIRTUAL;
+SELECT * FROM t1;
+ERROR 22032: Invalid JSON text: "Missing a comma or '}' after an object member." at position 72 in value for column 't1.gj' at row 2.
+#
+# Test for LOAD DATA (for which problem was reported originally).
+SELECT t INTO OUTFILE 'MYSQLTEST_VARDIR/tmp/t1' FROM t1;
+TRUNCATE TABLE t1;
+LOAD DATA INFILE 'MYSQLTEST_VARDIR/tmp/t1' INTO TABLE t1 (j);
+ERROR 22032: Invalid JSON text: "Missing a comma or '}' after an object member." at position 72 in value for column 't1.j' at row 2.
+DROP TABLE t1;

--- a/mysql-test/suite/json/r/json_insert_innodb.result
+++ b/mysql-test/suite/json/r/json_insert_innodb.result
@@ -86,32 +86,32 @@ i	LENGTH(j)	j
 CREATE TABLE auxtbl(ts TIMESTAMP);
 INSERT INTO auxtbl VALUES ('2015-02-24 18:52:00');
 INSERT INTO t1(j) VALUES ('');
-ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES ('[');
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (x'cafebabe');
 ERROR 22032: Cannot create a JSON value from a string with CHARACTER SET 'binary'.
 INSERT INTO t1(j) VALUES (ST_GeomFromText('POINT(1 1)'));
 ERROR 22032: Cannot create a JSON value from a string with CHARACTER SET 'binary'.
 INSERT INTO t1(j) VALUES (-1);
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (CAST(1 AS UNSIGNED));
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (3.14);
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (3.14E30);
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (PI());
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) select ts from auxtbl;
-ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't1.j' at row 1.
 DROP TABLE auxtbl;
 INSERT INTO t1(j) VALUES (CAST('15:52:00' as TIME));
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (CAST('2015-02-24' as DATE));
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (TIMESTAMP '2015-02-24 15:52:00');
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 # ----------------------------------------------------------------------
 # INSERT using prepared statement (PS)
 # ----------------------------------------------------------------------
@@ -141,20 +141,20 @@ prepare ps1 from 'insert into pt1 values (cast(? as json))';
 execute ps1 using @g;
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @a;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @b;
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @c;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @d;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @e;
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @f;
-ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @g;
 select json_type(j), j from pt1 order by j;

--- a/mysql-test/suite/json/r/json_prep_stmts.result
+++ b/mysql-test/suite/json/r/json_prep_stmts.result
@@ -25,19 +25,19 @@ scalar JSON value, without cast the parameter is rejected as invald JSON.
 execute ps_insert_cast using @int;
 prepare ps_insert from 'insert into t1 values (?)';
 execute ps_insert using @int;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 Decimal parameter: With CAST, the decimal value is converted to a
 scalar JSON value, without cast the parameter is rejected as invald JSON.
 execute ps_insert_cast using @dec;
 prepare ps_insert from 'insert into t1 values (?)';
 execute ps_insert using @dec;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 Float parameter: With CAST, the float value is converted to a
 scalar JSON value, without cast the parameter is rejected as invald JSON.
 execute ps_insert_cast using @flt;
 prepare ps_insert from 'insert into t1 values (?)';
 execute ps_insert using @flt;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 String parameter containing an integer: Both statements accept the
 parameter as a scalar JSON value.
 execute ps_insert_cast using @intstr;
@@ -59,7 +59,7 @@ execute ps_insert_cast using @strstr;
 ERROR 22032: Invalid JSON text in argument 1 to function cast_as_json: "Invalid value." at position 0.
 prepare ps_insert from 'insert into t1 values (?)';
 execute ps_insert using @strstr;
-ERROR 22032: Invalid JSON text: "Invalid value." at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 0 in value for column 't1.j' at row 1.
 String parameter containing a quoted string: Both statements accept
 the parameter as a scalar JSON value.
 execute ps_insert_cast using @quotstr;
@@ -71,7 +71,7 @@ execute ps_insert_cast using @ts;
 ERROR 22032: Invalid JSON text in argument 1 to function cast_as_json: "The document root must not be followed by other values." at position 4.
 prepare ps_insert from 'insert into t1 values (?)';
 execute ps_insert using @ts;
-ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't1.j' at row 1.
 Parameter that is a NULL value: accepted with both statements:
 execute ps_insert_cast using @null;
 prepare ps_insert from 'insert into t1 values (?)';

--- a/mysql-test/suite/json/t/json_innodb.test
+++ b/mysql-test/suite/json/t/json_innodb.test
@@ -291,3 +291,42 @@ INSERT INTO t VALUES (JSON_ARRAY('aaa'));
 UPDATE t SET j = JSON_REPLACE(j, '$[0]', REPEAT(CHAR(97), 3));
 SELECT j, JSON_TYPE(j->'$[0]') FROM t;
 DROP TABLE t;
+
+--echo #
+--echo # PS-8626 "Inserting JSON data through LOAD DATA INFILE doesn't show failed record"
+--echo #
+--echo # Test for INSERT.
+CREATE TABLE t1 (t TEXT, j JSON);
+--error ER_INVALID_JSON_TEXT
+INSERT INTO t1 (j) VALUES
+  ('{"name": "b", "pets": \{"dog": 3, "chicken": 1} , "surname": "test"}'),
+  ('{"name": "a", "pets": \{"dog": 3, "chicken": 3} , "surname": "testfailed"'),
+  ('{"name": "q", "pets": \{"dog": 3, "chicken": 2} , "surname": "test"}');
+--echo #
+--echo # Test for UPDATE.
+INSERT INTO t1 (t) VALUES
+  ('{"name": "b", "pets": \{"dog": 3, "chicken": 1} , "surname": "test"}'),
+  ('{"name": "a", "pets": \{"dog": 3, "chicken": 3} , "surname": "testfailed"'),
+  ('{"name": "q", "pets": \{"dog": 3, "chicken": 2} , "surname": "test"}');
+--error ER_INVALID_JSON_TEXT
+UPDATE t1 SET j = t WHERE t LIKE '%testfailed%';
+--echo #
+--echo # Test for ALTER TABLE.
+--replace_regex /#sql-[0-9a-f_]*/#sql-temporary/
+--error ER_INVALID_JSON_TEXT
+ALTER TABLE t1 ADD COLUMN gj JSON GENERATED ALWAYS AS (t) STORED;
+--echo #
+--echo # Test for SELECT.
+ALTER TABLE t1 ADD COLUMN gj JSON GENERATED ALWAYS AS (t) VIRTUAL;
+--error ER_INVALID_JSON_TEXT
+SELECT * FROM t1;
+--echo #
+--echo # Test for LOAD DATA (for which problem was reported originally).
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--eval SELECT t INTO OUTFILE '$MYSQLTEST_VARDIR/tmp/t1' FROM t1
+TRUNCATE TABLE t1;
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--error ER_INVALID_JSON_TEXT
+--eval LOAD DATA INFILE '$MYSQLTEST_VARDIR/tmp/t1' INTO TABLE t1 (j)
+--remove_file $MYSQLTEST_VARDIR/tmp/t1
+DROP TABLE t1;

--- a/mysql-test/suite/rocksdb/r/type_json.result
+++ b/mysql-test/suite/rocksdb/r/type_json.result
@@ -54,7 +54,7 @@ DROP PROCEDURE p;
 CREATE TABLE t1(txt TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin);
 INSERT INTO t1 VALUES ('not JSON');
 ALTER TABLE t1 MODIFY COLUMN txt JSON;
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.txt'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.txt' at row 1.
 SELECT * FROM t1;
 txt
 not JSON
@@ -69,7 +69,7 @@ INSERT INTO t3 VALUES (JSON_OBJECT('a', 'b'));
 CREATE TABLE t4 AS SELECT UPPER(j) AS jj FROM t3;
 INSERT INTO t4 VALUES ('not JSON');
 ALTER TABLE t4 MODIFY COLUMN jj JSON;
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.jj'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column '#sql-temporary.jj' at row 2.
 SELECT * FROM t4 order by jj;
 jj
 not JSON
@@ -246,32 +246,32 @@ i	LENGTH(j)	j
 CREATE TABLE auxtbl(ts TIMESTAMP);
 INSERT INTO auxtbl VALUES ('2015-02-24 18:52:00');
 INSERT INTO t1(j) VALUES ('');
-ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "The document is empty." at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES ('[');
-ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "Invalid value." at position 1 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (x'cafebabe');
 ERROR 22032: Cannot create a JSON value from a string with CHARACTER SET 'binary'.
 INSERT INTO t1(j) VALUES (ST_GeomFromText('POINT(1 1)'));
 ERROR 22032: Cannot create a JSON value from a string with CHARACTER SET 'binary'.
 INSERT INTO t1(j) VALUES (-1);
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (CAST(1 AS UNSIGNED));
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (3.14);
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (3.14E30);
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (PI());
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) select ts from auxtbl;
-ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 't1.j' at row 1.
 DROP TABLE auxtbl;
 INSERT INTO t1(j) VALUES (CAST('15:52:00' as TIME));
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (CAST('2015-02-24' as DATE));
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 INSERT INTO t1(j) VALUES (TIMESTAMP '2015-02-24 15:52:00');
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 't1.j' at row 1.
 # ----------------------------------------------------------------------
 # INSERT using prepared statement (PS)
 # ----------------------------------------------------------------------
@@ -301,20 +301,20 @@ prepare ps1 from 'insert into pt1 values (cast(? as json))';
 execute ps1 using @g;
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @a;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @b;
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @c;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @d;
-ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @e;
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @f;
-ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 'pt2.j'.
+ERROR 22032: Invalid JSON text: "The document root must not be followed by other values." at position 4 in value for column 'pt2.j' at row 1.
 prepare ps2 from 'insert into pt2 values (?)';
 execute ps2 using @g;
 select json_type(j), j from pt1 order by j;

--- a/mysql-test/suite/x/r/admin_modify_collection_options.result
+++ b/mysql-test/suite/x/r/admin_modify_collection_options.result
@@ -192,7 +192,7 @@ Got expected error:
 Mysqlx.Error {
   severity: ERROR
   code: 3140
-  msg: "Invalid JSON text: \"The document is empty.\" at position 0 in value for column \'test_coll._json_schema\'."
+  msg: "Invalid JSON text: \"The document is empty.\" at position 0 in value for column \'test_coll._json_schema\' at row 1."
   sql_state: "22032"
 }
 

--- a/mysql-test/suite/x/r/crud_insert_generated_ids.result
+++ b/mysql-test/suite/x/r/crud_insert_generated_ids.result
@@ -151,7 +151,7 @@ Insert: bad doc (literal) no insert
 command ok
 
 0 rows affected
-Got expected error: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'coll.doc'. (code 3140)
+Got expected error: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'coll.doc' at row 1. (code 3140)
 doc
 0 rows affected
 
@@ -161,7 +161,7 @@ Insert: 2 doc (literal) one bad, no insert
 command ok
 
 0 rows affected
-Got expected error: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'coll.doc'. (code 3140)
+Got expected error: Invalid JSON text: "not a JSON text, may need CAST" at position 0 in value for column 'coll.doc' at row 1. (code 3140)
 doc
 0 rows affected
 
@@ -344,7 +344,7 @@ command ok
 Mysqlx.Error {
   severity: ERROR
   code: 3140
-  msg: "Invalid JSON text: \"not a JSON text, may need CAST\" at position 0 in value for column \'coll.doc\'."
+  msg: "Invalid JSON text: \"not a JSON text, may need CAST\" at position 0 in value for column \'coll.doc\' at row 1."
   sql_state: "22032"
 }
 

--- a/mysql-test/suite/x/r/insert_crud_o.result
+++ b/mysql-test/suite/x/r/insert_crud_o.result
@@ -1460,7 +1460,7 @@ send Mysqlx.Crud.Insert {
   }
 }
 
-Got expected error: Invalid JSON text: "Missing a comma or '}' after an object member." at position 98 in value for column 'main_collection.doc'. (code 3140)
+Got expected error: Invalid JSON text: "Missing a comma or '}' after an object member." at position 98 in value for column 'main_collection.doc' at row 1. (code 3140)
 ================================================================================
 CLEAN UP
 ================================================================================

--- a/mysql-test/suite/x/r/insert_table_bad_column_type.result
+++ b/mysql-test/suite/x/r/insert_table_bad_column_type.result
@@ -106,7 +106,7 @@ send Mysqlx.Crud.Insert {
 Mysqlx.Error {
   severity: ERROR
   code: 3140
-  msg: "Invalid JSON text: \"Missing a name for object member.\" at position 1 in value for column \'mytable.j\'."
+  msg: "Invalid JSON text: \"Missing a name for object member.\" at position 1 in value for column \'mytable.j\' at row 1."
   sql_state: "22032"
 }
 

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -7588,7 +7588,7 @@ ER_SLAVE_CHANNEL_OPERATION_NOT_ALLOWED
    eng "%-.192s cannot be performed on channel '%-.192s'."
 
 ER_INVALID_JSON_TEXT 22032
-  eng "Invalid JSON text: \"%s\" at position %u in value for column '%-.200s'."
+  eng "Invalid JSON text: \"%s\" at position %u in value for column '%-.200s' at row %ld."
 
 # The last parameter is now always empty but kept for backward compatibility
 ER_INVALID_JSON_TEXT_IN_PARAM 22032

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -7686,7 +7686,8 @@ type_conversion_status Field_json::store(const char *from, size_t length,
         s_err.append('.');
         s_err.append(err_field_name);
         my_error(ER_INVALID_JSON_TEXT, MYF(0), parse_err, err_offset,
-                 s_err.c_ptr_safe());
+                 s_err.c_ptr_safe(),
+                 current_thd->get_stmt_da()->current_row_for_condition());
       },
       JsonDocumentDefaultDepthHandler));
 
@@ -7710,7 +7711,7 @@ type_conversion_status Field_json::unsupported_conversion() {
   s.append('.');
   s.append(field_name);
   my_error(ER_INVALID_JSON_TEXT, MYF(0), "not a JSON text, may need CAST", 0,
-           s.c_ptr_safe());
+           s.c_ptr_safe(), 1);
   return TYPE_ERR_BAD_VALUE;
 }
 


### PR DESCRIPTION
…iled record.

When LOAD DATA or multi-row INSERT statement tried to store bad data in a JSON column an error message was emitted, which didn't reference number of row which caused the problem. Such behavior was not consistent with how similar problems were reported for columns of other types. It didn't allow user to understand which record among inserted was problematic.

This patch solves the problem by changing message for ER_INVALID_JSON_TEXT error, which is emitted in such cases, to mention number of row being inserted. It is easy to do so, as the information about row being processed is already available at the point where error is emitted from Diagnostics_area::current_row_for_condition() member function.

It makes behavior for JSON type consistent with how warnings and errors are reported for other types.