### PR TITLE
PS-7923 Assign a thread ID to InnoDB's encryption resume thread

### DIFF
--- a/mysql-test/r/bug_ps7923.result
+++ b/mysql-test/r/bug_ps7923.result
@@ -1,0 +1,10 @@
+CREATE PROCEDURE my_infinite_alter_ts()
+BEGIN
+WHILE TRUE DO
+ALTER TABLESPACE mysql ENCRYPTION='Y';
+ALTER TABLESPACE mysql ENCRYPTION='N';
+END WHILE;
+END//
+CALL my_infinite_alter_ts();
+# Kill and restart:<hidden args>
+DROP PROCEDURE my_infinite_alter_ts;

--- a/mysql-test/suite/innodb/r/tablespace_encrypt_9.result
+++ b/mysql-test/suite/innodb/r/tablespace_encrypt_9.result
@@ -103,7 +103,7 @@ CREATE TABLESPACE temp_ts ADD DATAFILE 'temp_ts.ibd';
 # connection con3
 SELECT connection_id();
 connection_id()
-10
+11
 # Run a DDL with this connection con3
 ALTER TABLESPACE temp_ts ENCRYPTION='Y';
 set global innodb_buf_flush_list_now = 1;

--- a/mysql-test/t/bug_ps7923-master.opt
+++ b/mysql-test/t/bug_ps7923-master.opt
@@ -1,0 +1,4 @@
+$KEYRING_PLUGIN_LOAD_EARLY
+--loose-keyring_file_data=$MYSQL_TMP_DIR/keyring
+$KEYRING_PLUGIN_OPT
+--gtid-mode=ON --enforce-gtid-consistency=ON

--- a/mysql-test/t/bug_ps7923.test
+++ b/mysql-test/t/bug_ps7923.test
@@ -1,0 +1,30 @@
+--connect (con1,localhost,root,,)
+
+--connection default
+
+DELIMITER //;
+
+CREATE PROCEDURE my_infinite_alter_ts()
+BEGIN
+  WHILE TRUE DO
+    ALTER TABLESPACE mysql ENCRYPTION='Y';
+    ALTER TABLESPACE mysql ENCRYPTION='N';
+  END WHILE;
+END//
+
+DELIMITER ;//
+
+--connection con1
+--send CALL my_infinite_alter_ts()
+
+--sleep 5
+
+--connection default
+
+--let $do_not_echo_parameters = 1
+--let $restart_parameters = restart: --gtid-mode=ON --enforce-gtid-consistency=ON $KEYRING_PLUGIN_LOAD_EARLY --loose-keyring_file_data=$MYSQL_TMP_DIR/keyring $KEYRING_PLUGIN_OPT
+--source include/kill_and_restart_mysqld.inc
+
+--disconnect con1
+
+DROP PROCEDURE my_infinite_alter_ts;

--- a/sql/rpl_gtid_owned.cc
+++ b/sql/rpl_gtid_owned.cc
@@ -72,6 +72,7 @@ enum_return_status Owned_gtids::add_gtid_owner(const Gtid &gtid,
   assert(gtid.sidno <= get_max_sidno());
   assert(gtid.gno > 0);
   assert(gtid.gno < GNO_END);
+  assert(owner != 0);
   Node *n =
       (Node *)my_malloc(key_memory_Sid_map_Node, sizeof(Node), MYF(MY_WME));
   if (n == nullptr) RETURN_REPORTED_ERROR;
@@ -89,6 +90,7 @@ void Owned_gtids::remove_gtid(const Gtid &gtid, const my_thread_id owner) {
   DBUG_TRACE;
   // printf("Owned_gtids::remove(sidno=%d gno=%lld)\n", sidno, gno);
   // assert(contains_gtid(sidno, gno)); // allow group not owned
+  assert(owner != 0);
   malloc_unordered_multimap<rpl_gno, unique_ptr_my_free<Node>> *hash =
       get_hash(gtid.sidno);
   auto it_range = hash->equal_range(gtid.gno);

--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -4955,6 +4955,8 @@ static void resume_alter_encrypt_tablespace(THD *thd) {
 void fsp_init_resume_alter_encrypt_tablespace() {
   THD *thd = create_internal_thd();
 
+  thd->set_new_thread_id();
+
   resume_alter_encrypt_tablespace(thd);
 
   destroy_internal_thd(thd);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7923

Problem:
InnoDB creates a thread to resume encryption but does not assign it an ID. By default threads have ID of 0, which is a magic value that changes what Owned_gtids::is_owned_by() actually checks for.

Fix:
Assign an ID to an encryption thread. Add assertions to Owned_gtids::add_gtid_owner() and Owned_gtids::remove_gtid() to catch similar errors earlier where it's easier to reason about.

Re-recorded 'innodb.tablespace_encrypt_9' MTR test case as new named thread shifted connection IDs.