### PR TITLE
PS-8635 fix: Remove Percona's implementation of build-id

### DIFF
--- a/include/my_stacktrace.h
+++ b/include/my_stacktrace.h
@@ -59,9 +59,6 @@ void my_write_core(int sig);
 #if HAVE_LIBCOREDUMPER
 void my_write_libcoredumper(int sig, char *path, time_t curr_time);
 #endif
-#ifdef __linux__
-void my_print_buildID();
-#endif
 
 /**
   Async-signal-safe utility functions used by signal handler routines.

--- a/mysql-test/t/coredump.test
+++ b/mysql-test/t/coredump.test
@@ -1,3 +1,5 @@
+# Valgrind reports false positives coming from coredumper internals
+--source include/not_valgrind.inc
 # ASAN disables core dumps
 --source include/not_asan.inc
 
@@ -96,13 +98,23 @@ remove_files_wildcard $MYSQLD_DATADIR mycore.*;
 --let $restart_parameters=restart:
 --source include/start_mysqld.inc
 
-# Check Build ID and server version has been written to error log
+--let $has_build_id = `SELECT COUNT(*) != 0 FROM performance_schema.global_variables WHERE variable_name = 'build_id'`
+
 --let $assert_text= Checking MySQL wrote Build ID
---let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
---let $assert_select= Build ID: ([a-f0-9]{40}|Not Available)
---let $assert_only_after=CURRENT_TEST: main.coredump
---let $assert_count=2
---source include/assert_grep.inc
+if ($has_build_id)
+{
+  # Check Build ID and server version has been written to error log
+  --let $assert_file= $MYSQLTEST_VARDIR/log/mysqld.1.err
+  --let $assert_select= ^BuildID\[sha1\]=[a-f0-9]{40}
+  --let $assert_only_after=CURRENT_TEST: main.coredump
+  --let $assert_count=2
+  --source include/assert_grep.inc
+}
+if (!$has_build_id)
+{
+  # emulate successful 'assert_grep.inc' output'
+  --echo include/assert_grep.inc [$assert_text]
+}
 
 # Check Build ID and server version has been written to error log
 --let $assert_text= Checking MySQL wrote Server Version

--- a/mysys/stacktrace.cc
+++ b/mysys/stacktrace.cc
@@ -56,19 +56,7 @@
 
 #if HAVE_LIBCOREDUMPER
 #include <coredumper/coredumper.h>
-#endif
-// my_print_buildID
-#ifdef __linux__
-#include <elf.h>
-#include <sys/stat.h>
 #include "my_io.h"
-#include "my_sys.h"
-#include "mysql/service_mysql_alloc.h"
-#if defined(__x86_64__)
-#define ElfW(type) Elf64_##type
-#else
-#define ElfW(type) Elf32_##type
-#endif
 #endif
 
 #include "my_thread.h"
@@ -265,68 +253,6 @@ static void my_demangle_symbols(char **addrs, int n) {
 }
 
 #endif /* HAVE_ABI_CXA_DEMANGLE */
-#ifdef __linux__
-void my_print_buildID() {
-  int readlink_bytes;
-  char proc_path[FN_REFLEN];
-  char mysqld_path[PATH_MAX + 1] = {0};
-  FILE *mysqld;
-  struct stat statbuf;
-  ElfW(Ehdr) *ehdr = 0;
-  ElfW(Phdr) *phdr = 0;
-  ElfW(Nhdr) *nhdr = 0;
-  unsigned char *build_id;
-  char buff[3];
-  uint i;
-  uint bytes_read;
-  snprintf(proc_path, sizeof(proc_path), "/proc/%d/exe", getpid());
-  readlink_bytes = readlink(proc_path, mysqld_path, sizeof(mysqld_path));
-  if (readlink_bytes < 1) {
-    my_safe_printf_stderr("Error reading process path\n");
-    return;
-  }
-  if (!(mysqld = fopen(mysqld_path, "r"))) {
-    my_safe_printf_stderr("Error opening mysql binary\n");
-    return;
-  }
-  if (fstat(fileno(mysqld), &statbuf) < 0) {
-    my_safe_printf_stderr("Error running fstat on mysql binary\n");
-    fclose(mysqld);
-    return;
-  }
-  ehdr = (ElfW(Ehdr) *)my_mmap(0, statbuf.st_size, PROT_READ | PROT_WRITE,
-                               MAP_PRIVATE, fileno(mysqld), 0);
-  phdr = (ElfW(Phdr) *)(ehdr->e_phoff + (size_t)ehdr);
-  while (phdr->p_type != PT_NOTE) {
-    ++phdr;
-  }
-  nhdr = (ElfW(Nhdr) *)(phdr->p_offset + (size_t)ehdr);
-  bytes_read = sizeof(ElfW(Nhdr));
-  while (nhdr->n_type != NT_GNU_BUILD_ID) {
-    nhdr = (ElfW(Nhdr) *)((size_t)nhdr + sizeof(ElfW(Nhdr)) + nhdr->n_namesz +
-                          nhdr->n_descsz);
-    bytes_read += nhdr->n_namesz + nhdr->n_descsz;
-    if (bytes_read > phdr->p_filesz) {
-      my_safe_printf_stderr("Build ID: Not Available \n");
-      fclose(mysqld);
-      return;
-    }
-  }
-  build_id =
-      (unsigned char *)my_malloc(PSI_NOT_INSTRUMENTED, nhdr->n_descsz, MYF(0));
-  memcpy(build_id, (void *)((size_t)nhdr + sizeof(ElfW(Nhdr)) + nhdr->n_namesz),
-         nhdr->n_descsz);
-  my_safe_printf_stderr("Build ID: ");
-  for (i = 0; i < nhdr->n_descsz; ++i) {
-    snprintf(buff, sizeof(buff), "%02hhx", build_id[i]);
-    my_safe_printf_stderr("%s", buff);
-  }
-  my_free(build_id);
-  fclose(mysqld);
-  my_safe_printf_stderr("\n");
-}
-#endif /* __linux__ */
-
 void my_print_stacktrace(const uchar *stack_bottom, ulong thread_stack) {
 #if defined(__FreeBSD__)
   static char procname_buffer[2048];

--- a/sql/signal_handler.cc
+++ b/sql/signal_handler.cc
@@ -142,10 +142,6 @@ void print_fatal_signal(int sig) {
   my_safe_printf_stderr("BuildID[sha1]=%s\n", server_build_id);
 #endif
 
-  my_safe_printf_stderr("\n");
-#ifdef __linux__
-  my_print_buildID();
-#endif
   my_safe_printf_stderr("Server Version: %s %s\n\n", server_version,
                         MYSQL_COMPILATION_COMMENT);
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8635

Problem
-------
Upon 'mysqld' crash the following two lines with identical hashes were written to the error log:
- "BuildID[sha1]=..."
- "Build ID: ..."

Fix
---
Reverted 'BuildID' part of the PS-7114
"Enhance crash artifacts for operator"
(https://jira.percona.com/browse/PS-7114)
(commit 8682e78)
because Oracle implemented the same functionality in MySQL Server 8.0.31 in WL #15161 "Add read-only build-id as system variable to mysqld" (commit mysql/mysql-server@321f106)..

"Server Version: ..." message and 'coredumper' output are not affected by this change and are still printed as before.

Fixed 'main.coredumper' MTR test case as it no longer prints "Build ID: ..." message. This test also marked as 'not_valgrind' becase Valgrind detects false positives coming from 'coredumper' internals.