### PR TITLE
PS-8580 postfix: Merge MySQL 5.7.41 (native partitioning inline fix)

### DIFF
--- a/sql/partitioning/partition_base.cc
+++ b/sql/partitioning/partition_base.cc
@@ -5064,7 +5064,7 @@ void Partition_base::cancel_pushed_idx_cond()
   Also sets stats.auto_increment_value.
 */
 
-inline int Partition_base::initialize_auto_increment(bool no_lock)
+int Partition_base::initialize_auto_increment(bool no_lock)
 {
   DBUG_ENTER("Partition_base::initialize_auto_increment");
 #ifndef NDEBUG

--- a/sql/partitioning/partition_handler.cc
+++ b/sql/partitioning/partition_handler.cc
@@ -852,7 +852,7 @@ void Partition_helper
 }
 
 
-inline void Partition_helper::set_auto_increment_if_higher()
+void Partition_helper::set_auto_increment_if_higher()
 {
   Field_num *field= static_cast<Field_num*>(m_table->found_next_number_field);
   ulonglong nr= (field->unsigned_flag || field->val_int() > 0)
@@ -1819,7 +1819,6 @@ err:
   @param[in]	rnd_init	True if called from rnd_init (else index_init).
 */
 
-inline
 void Partition_helper::set_partition_read_set()
 {
   /*

--- a/sql/partitioning/partition_handler.h
+++ b/sql/partitioning/partition_handler.h
@@ -135,13 +135,13 @@ public:
                                     const ulonglong max_reserved);
 
   /** lock mutex protecting auto increment value next_auto_inc_val. */
-  inline void lock_auto_inc()
+  void lock_auto_inc()
   {
     assert(auto_inc_mutex);
     mysql_mutex_lock(auto_inc_mutex);
   }
   /** unlock mutex protecting auto increment value next_auto_inc_val. */
-  inline void unlock_auto_inc()
+  void unlock_auto_inc()
   {
     assert(auto_inc_mutex);
     mysql_mutex_unlock(auto_inc_mutex);
@@ -453,7 +453,7 @@ public:
       @retval false success.
       @retval true  failure.
   */
-  inline bool init_partitioning(MEM_ROOT *mem_root)
+  bool init_partitioning(MEM_ROOT *mem_root)
   {
 #ifndef NDEBUG
     m_key_not_found_partitions.bitmap= NULL;
@@ -714,7 +714,7 @@ protected:
   /**
     Lock auto increment value if needed.
   */
-  inline void lock_auto_increment()
+  void lock_auto_increment()
   {
     /* lock already taken */
     if (m_auto_increment_safe_stmt_log_lock)
@@ -729,7 +729,7 @@ protected:
   /**
     unlock auto increment.
   */
-  inline void unlock_auto_increment()
+  void unlock_auto_increment()
   {
     /*
       If m_auto_increment_safe_stmt_log_lock is true, we have to keep the lock.
@@ -1046,7 +1046,7 @@ private:
   /**
     Update auto increment value if current row contains a higher value.
   */
-  inline void set_auto_increment_if_higher();
+  void set_auto_increment_if_higher();
   /**
     Common routine to set up index scans.
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8580

Fixed problem with invalid usage of the 'inline' keyword in the Native Partitioning code causing strange linker errors on Oracle Linux 9.