### PR TITLE
PS-8674 Compilation error on ARM AppleClang 14.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1830,7 +1830,13 @@ MYSQL_CHECK_LDAP()
 MYSQL_CHECK_LDAP_DLLS()
 
 # Percona LDAP Simple / LDAP SASL authentication plugins
-OPTION(WITH_PERCONA_AUTHENTICATION_LDAP "Build with Percona LDAP Simple / LDAP SASL authentication plugins" ON)
+# Problem with  MacOS system libraries and complains for compilation error ldap_set_urllist_proc
+IF(APPLE)
+  SET(WITH_PERCONA_AUTHENTICATION_LDAP_DEFAULT OFF)
+ELSE()
+  SET(WITH_PERCONA_AUTHENTICATION_LDAP_DEFAULT ON)
+ENDIF()
+OPTION(WITH_PERCONA_AUTHENTICATION_LDAP "Build with Percona LDAP Simple / LDAP SASL authentication plugins" ${WITH_PERCONA_AUTHENTICATION_LDAP_DEFAULT})
 
 # Add Windows specific jemalloc DLL
 IF(WIN32)


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8674

Disabled the PERCONA_AUTHENTICATION_LDAP on APPLE ARM because of compilation error

undefined symbols for architecture arm64:
  "_ldap_set_urllist_proc", referenced from:
ld: symbol(s) not found for architecture arm64

The problem with MacOS system libraries.