### PR TITLE
PXC-4165 FIXES UNSTABLE GROUP REPLICATION TESTS

### DIFF
--- a/mysql-test/include/gr_parallel_local_and_remote_transactions.inc
+++ b/mysql-test/include/gr_parallel_local_and_remote_transactions.inc
@@ -136,6 +136,7 @@ BEGIN;
 --echo # group_replication_before_message_broadcast debug sync point.
 --let $rpl_connection_name= $local_server_connection2
 --source include/rpl_connection.inc
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 --let $wait_condition=SELECT COUNT(*)=1 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'debug sync point: now'
 --source include/wait_condition.inc
 
@@ -157,9 +158,6 @@ COMMIT;
 --let $rpl_connection_name= $local_server_connection2
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
-
 
 --echo
 --echo ############################################################
@@ -187,6 +185,10 @@ if ($conflict_test)
 --let $rpl_connection_name= $local_server_connection1
 --source include/rpl_connection.inc
 SET @@GLOBAL.DEBUG=@debug_save;
+
+--let $rpl_connection_name= $local_server_connection2
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo ############################################################
 --echo # 8. Sync everything

--- a/mysql-test/suite/group_replication/r/gr_collations_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_collations_key_conflict.result
@@ -42,6 +42,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -57,8 +58,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -75,6 +74,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_disregard_nonunique_key.result
+++ b/mysql-test/suite/group_replication/r/gr_disregard_nonunique_key.result
@@ -35,6 +35,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -50,8 +51,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -67,6 +66,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_foreign_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_foreign_key_conflict.result
@@ -42,6 +42,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -57,8 +58,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -75,6 +74,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -125,6 +126,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -140,8 +142,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -157,6 +157,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_foreign_key_on_referenced_unique_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_foreign_key_on_referenced_unique_key_conflict.result
@@ -37,6 +37,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -52,8 +53,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -70,6 +69,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -122,6 +123,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -137,8 +139,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -154,6 +154,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_foreign_key_on_unique_key.result
+++ b/mysql-test/suite/group_replication/r/gr_foreign_key_on_unique_key.result
@@ -48,6 +48,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -63,8 +64,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -81,6 +80,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -136,6 +137,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -151,8 +153,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -168,6 +168,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_foreign_key_unique_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_foreign_key_unique_conflict.result
@@ -40,6 +40,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -55,8 +56,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -73,6 +72,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -121,6 +122,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -136,8 +138,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -153,6 +153,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_huge_write_set.result
+++ b/mysql-test/suite/group_replication/r/gr_huge_write_set.result
@@ -40,6 +40,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -55,8 +56,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -73,6 +72,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_json_array_unique_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_json_array_unique_key_conflict.result
@@ -41,6 +41,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -56,8 +57,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -74,6 +73,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -121,6 +122,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -136,8 +138,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -154,6 +154,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -201,6 +203,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -216,8 +219,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -233,6 +234,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -280,6 +283,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -295,8 +299,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -312,6 +314,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_multi_level_foreign_key.result
+++ b/mysql-test/suite/group_replication/r/gr_multi_level_foreign_key.result
@@ -41,6 +41,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -56,8 +57,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -74,6 +73,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -121,6 +122,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -136,8 +138,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -154,6 +154,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_multi_primary_foreign_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_multi_primary_foreign_key_conflict.result
@@ -40,7 +40,6 @@ UPDATE t1 SET a=2 WHERE a=1;
 # 5. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
@@ -58,6 +57,8 @@ ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 include/assert.inc [The value of Count_Transactions_Checked should be 7 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Checking the positive case in which there is no conflict.
@@ -94,7 +95,6 @@ include/sync_slave_sql_with_master.inc
 # 4. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ########################################################################
@@ -118,6 +118,8 @@ include/assert.inc [Table t2 will contain 2 rows after the above execution]
 include/assert.inc [Table t1 will contain 3 rows after the above execution]
 include/assert.inc [The value of Count_Transactions_Checked should be 12 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Clean up.

--- a/mysql-test/suite/group_replication/r/gr_multi_primary_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_multi_primary_key_conflict.result
@@ -37,7 +37,6 @@ UPDATE t1 SET a=4 AND b=5 WHERE b=2;
 # 5. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
@@ -55,6 +54,8 @@ ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 include/assert.inc [The value of Count_Transactions_Checked should be 4 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Checking the positive case in which there is no conflict.
@@ -86,7 +87,6 @@ include/sync_slave_sql_with_master.inc
 # 4. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ########################################################################
@@ -105,6 +105,8 @@ include/assert.inc [Table t1 will contain row after the above execution]
 include/assert.inc [Table t1 will contain 3 rows after the above execution]
 include/assert.inc [The value of Count_Transactions_Checked should be 6 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Clean up.

--- a/mysql-test/suite/group_replication/r/gr_multi_primary_unique_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_multi_primary_unique_key_conflict.result
@@ -37,7 +37,6 @@ UPDATE t1 SET b=6 WHERE c=4;
 # 5. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
@@ -55,6 +54,8 @@ ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 include/assert.inc [The value of Count_Transactions_Checked should be 4 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Checking the positive case in which there is no conflict.
@@ -86,7 +87,6 @@ include/sync_slave_sql_with_master.inc
 # 5. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ########################################################################
@@ -105,6 +105,8 @@ include/assert.inc [Table t1 will contain row after the above execution]
 include/assert.inc [Table t1 will contain 3 rows after the above execution]
 include/assert.inc [The value of Count_Transactions_Checked should be 6 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Clean up.

--- a/mysql-test/suite/group_replication/r/gr_multi_unique_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_multi_unique_key_conflict.result
@@ -36,7 +36,6 @@ INSERT INTO t1 VALUES(4, 2, 3);
 # 5. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
@@ -54,6 +53,8 @@ ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 include/assert.inc [The value of Count_Transactions_Checked should be 3 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Checking the positive case in which there is no conflict.
@@ -85,7 +86,6 @@ include/sync_slave_sql_with_master.inc
 # 4. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ########################################################################
@@ -104,6 +104,8 @@ include/assert.inc [Table t1 will contain row after the above execution]
 include/assert.inc [Table t1 will contain 3 rows after the above execution]
 include/assert.inc [The value of Count_Transactions_Checked should be 5 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Clean up.

--- a/mysql-test/suite/group_replication/r/gr_nullable_unique_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_nullable_unique_key_conflict.result
@@ -37,6 +37,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -52,8 +53,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -70,6 +69,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -118,6 +119,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -133,8 +135,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -150,6 +150,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -206,6 +208,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -221,8 +224,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -238,6 +239,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -299,6 +302,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -314,8 +318,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -331,6 +333,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -381,6 +385,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -396,8 +401,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -413,6 +416,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -477,6 +482,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -492,8 +498,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -509,6 +513,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_primary_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_primary_key_conflict.result
@@ -36,7 +36,6 @@ INSERT INTO t1 VALUES (1);
 # 5. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
@@ -54,6 +53,8 @@ ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 include/assert.inc [The value of Count_Transactions_Checked should be 3 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Checking the positive case in which there is no conflict.
@@ -85,7 +86,6 @@ include/sync_slave_sql_with_master.inc
 # 4. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ########################################################################
@@ -104,6 +104,8 @@ include/assert.inc [Table t1 will contain row after the above execution]
 include/assert.inc [Table t1 will contain 3 rows after the above execution]
 include/assert.inc [The value of Count_Transactions_Checked should be 5 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Clean up.

--- a/mysql-test/suite/group_replication/r/gr_primary_key_conflict_xa.result
+++ b/mysql-test/suite/group_replication/r/gr_primary_key_conflict_xa.result
@@ -37,7 +37,6 @@ INSERT INTO t1 VALUES (1);
 # 5. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
@@ -55,6 +54,8 @@ ERROR XAE04: XAER_NOTA: Unknown XID
 [connection server1]
 include/assert.inc [The value of Count_Transactions_Checked should be 3 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Checking the positive case in which there is no conflict.
@@ -87,7 +88,6 @@ include/sync_slave_sql_with_master.inc
 # 4. Signal the waiting thread on server_1 to resume.
 [connection server1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 ########################################################################
@@ -107,6 +107,8 @@ include/assert.inc [Table t1 will contain row after the above execution]
 include/assert.inc [Table t1 will contain 3 rows after the above execution]
 include/assert.inc [The value of Count_Transactions_Checked should be 6 after starting group replication]
 include/assert.inc [The value of Count_Conflicts_Detected should be 1 after starting group replication]
+[connection server1]
+SET DEBUG_SYNC='RESET';
 
 ############################################################
 # Clean up.

--- a/mysql-test/suite/group_replication/r/gr_primary_key_on_invisible_column_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_primary_key_on_invisible_column_conflict.result
@@ -42,6 +42,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -57,8 +58,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -75,6 +74,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -122,6 +123,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -137,8 +139,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -154,6 +154,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_primary_key_unique_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_primary_key_unique_conflict.result
@@ -38,6 +38,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -53,8 +54,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -71,6 +70,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -118,6 +119,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -133,8 +135,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -150,6 +150,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_primary_mode_group_operations_05.result
+++ b/mysql-test/suite/group_replication/r/gr_primary_mode_group_operations_05.result
@@ -53,6 +53,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -68,8 +69,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -86,6 +85,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_savepoint.result
+++ b/mysql-test/suite/group_replication/r/gr_savepoint.result
@@ -34,6 +34,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -49,8 +50,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -66,6 +65,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -114,6 +115,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -129,8 +131,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -146,6 +146,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -194,6 +196,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -209,8 +212,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -227,6 +228,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/r/gr_unique_key_conflict.result
+++ b/mysql-test/suite/group_replication/r/gr_unique_key_conflict.result
@@ -38,6 +38,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -53,8 +54,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -71,6 +70,8 @@ include/sync_slave_sql_with_master.inc
 ERROR 40000: Plugin instructed the server to rollback the current transaction.
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc
@@ -118,6 +119,7 @@ COMMIT;
 # 3. Wait until local transaction reaches the
 # group_replication_before_message_broadcast debug sync point.
 [connection server_1]
+SET DEBUG_SYNC="now WAIT_FOR signal.group_replication_before_message_broadcast_reached";
 
 ############################################################
 # 4. Execute a transaction on remote server, that will reach first
@@ -133,8 +135,6 @@ COMMIT;
 #    transaction.
 [connection server_1]
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
-SET @@GLOBAL.DEBUG= @debug_save;
 
 ############################################################
 # 6. Wait for remote transaction to be executed succesfully
@@ -150,6 +150,8 @@ include/sync_slave_sql_with_master.inc
 [connection server1]
 [connection server1]
 SET @@GLOBAL.DEBUG=@debug_save;
+[connection server_1]
+SET DEBUG_SYNC='RESET';
 ############################################################
 # 8. Sync everything
 include/rpl_sync.inc

--- a/mysql-test/suite/group_replication/t/gr_multi_primary_foreign_key_conflict.test
+++ b/mysql-test/suite/group_replication/t/gr_multi_primary_foreign_key_conflict.test
@@ -91,7 +91,6 @@ UPDATE t1 SET a=2 WHERE a=1;
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -126,6 +125,9 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
 
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################
@@ -173,7 +175,6 @@ UPDATE t1 SET a=9 WHERE a=7;
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -237,6 +238,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################

--- a/mysql-test/suite/group_replication/t/gr_multi_primary_key_conflict.test
+++ b/mysql-test/suite/group_replication/t/gr_multi_primary_key_conflict.test
@@ -89,7 +89,6 @@ UPDATE t1 SET a=4 AND b=5 WHERE b=2;
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -123,6 +122,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################
@@ -165,7 +168,6 @@ INSERT INTO t1 VALUE(12, 13);
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -209,6 +211,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################

--- a/mysql-test/suite/group_replication/t/gr_multi_primary_unique_key_conflict.test
+++ b/mysql-test/suite/group_replication/t/gr_multi_primary_unique_key_conflict.test
@@ -89,7 +89,6 @@ UPDATE t1 SET b=6 WHERE c=4;
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -123,6 +122,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################
@@ -165,7 +168,6 @@ INSERT INTO t1 VALUE(14, 15, 16, 17);
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -209,6 +211,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################

--- a/mysql-test/suite/group_replication/t/gr_multi_unique_key_conflict.test
+++ b/mysql-test/suite/group_replication/t/gr_multi_unique_key_conflict.test
@@ -86,7 +86,6 @@ INSERT INTO t1 VALUES(4, 2, 3);
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -120,6 +119,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################
@@ -162,7 +165,6 @@ INSERT INTO t1 VALUES(7, 6, 8);
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -206,6 +208,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################

--- a/mysql-test/suite/group_replication/t/gr_primary_key_conflict.test
+++ b/mysql-test/suite/group_replication/t/gr_primary_key_conflict.test
@@ -86,7 +86,7 @@ INSERT INTO t1 VALUES (1);
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
+
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -120,6 +120,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################
@@ -162,7 +166,6 @@ INSERT INTO t1 VALUES (3);
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -206,6 +209,10 @@ SET @@GLOBAL.DEBUG= @debug_save;
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################

--- a/mysql-test/suite/group_replication/t/gr_primary_key_conflict_xa.test
+++ b/mysql-test/suite/group_replication/t/gr_primary_key_conflict_xa.test
@@ -93,7 +93,6 @@ INSERT INTO t1 VALUES (1);
 --source include/wait_condition.inc
 
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -125,6 +124,10 @@ XA COMMIT 'trx';
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################
@@ -168,7 +171,6 @@ INSERT INTO t1 VALUES (3);
 --let $rpl_connection_name= server1
 --source include/rpl_connection.inc
 SET DEBUG_SYNC='now SIGNAL waiting';
-SET DEBUG_SYNC='RESET';
 SET @@GLOBAL.DEBUG= @debug_save;
 
 --echo
@@ -213,6 +215,10 @@ XA COMMIT 'trx2';
 --let $assert_text= The value of Count_Conflicts_Detected should be 1 after starting group replication
 --let $assert_cond= "$negatively_certified" = 1
 --source include/assert.inc
+
+--let $rpl_connection_name= server1
+--source include/rpl_connection.inc
+SET DEBUG_SYNC='RESET';
 
 --echo
 --echo ############################################################


### PR DESCRIPTION
https://jira.percona.com/browse/PXC-4165

Some group replication tests were failing because of debug wait sync time out warnings(Result content mismatch) and actual timeout where waiting thread didn't receive the signal to wake up and continue the test. It could be because of the immediate RESET being invoked right after the signal being emitted. So, the DEBUG_SYNC=RESET is moved to the cleanup stage of the test which fixed the issue.