### PR TITLE
PS-8704: Fix heap-buffer-overflow in mysql_query_attributes iterator

### DIFF
--- a/sql/server_component/mysql_query_attributes_imp.cc
+++ b/sql/server_component/mysql_query_attributes_imp.cc
@@ -98,12 +98,14 @@ class iterator {
   }
 
   bool next() {
-    while (ofs < thd->bind_parameter_values_count) {
+    assert(thd->bind_parameter_values_count > 0);
+
+    while (ofs < thd->bind_parameter_values_count - 1) {
       ofs++;
       current++;
       if (current->name_length > 0 && current->name) break;
     }
-    return ofs >= thd->bind_parameter_values_count;
+    return ofs >= thd->bind_parameter_values_count - 1;
   }
 
   const PS_PARAM *get_current() const { return current; }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8704

There was an attempt to access one past last element while going through query attributes list.