### PR TITLE
PS-8699: ALTER INSTANCE RELOAD TLS hangs with many concurrent connect…

### DIFF
--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -2874,6 +2874,8 @@ skip_to_ssl:
       return packet_error;
     }
 
+    context.reset();
+
     DBUG_PRINT("info", ("Reading user information over SSL layer"));
     int rc = protocol->read_packet();
     pkt_len = protocol->get_packet_length();


### PR DESCRIPTION
…ion attempts

Issue: when a server has a huge new connection rate, ALTER INSTANCE RELOAD TLS will wait indefinitely until none of the new connections holds the lock for the main/admin SSL channel. This lock is held until the connection is properly initialized, which can take a significant amount of time because of network latencies/timeouts.

Reproduction: keep opening openssl connections to the MySQL server, e.g. one connection per second using the openssl command such as:

  openssl s_client -starttls mysql -connect localhost:<PORT>

In a mysql client, try to execute ALTER INSTANCE RELOAD TLS;

This attempt will block until there's at least one existing openssl process keeping a connection open.

Fix: release the channel lock immediately after the SSL connection is established. OpenSSL uses internal reference counting, and the SSL context can be safely freed after this point, it won't affect existing connections.

Testing: as the issue happens during the creation of a new connection, it can't be properly tested with MTR. Testing was done using two bash scripts, one executing the above openssl command in the background in an infinite loop, and the other executing ALTER INSTANCE RELOAD TLS in an infinite loop. (openssl s_client needs a fifo file to work properly when in the background)