### PR TITLE
PS-8723 merge: Merge MySQL 8.0.33 - Q2 2023 (ext::zlib fix)

### DIFF
--- a/components/encryption_udf/CMakeLists.txt
+++ b/components/encryption_udf/CMakeLists.txt
@@ -33,7 +33,7 @@ MYSQL_ADD_COMPONENT(encryption_udf
   encryption_udf_component.cc
   server_helpers.h
   server_helpers.cc
-  LINK_LIBRARIES OpenSSLPP::OpenSSLPP
+  LINK_LIBRARIES OpenSSLPP::OpenSSLPP ext::zlib
   MODULE_ONLY
 )
 

--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -368,6 +368,7 @@ ADD_DEPENDENCIES(sqlgunitlib GenError)
 SET_TARGET_PROPERTIES(sqlgunitlib
   PROPERTIES COMPILE_DEFINITIONS "${DISABLE_PSI_DEFINITIONS}"
 )
+TARGET_LINK_LIBRARIES(sqlgunitlib ext::zlib)
 
 MYSQL_ADD_EXECUTABLE(merge_small_tests-t ${ALL_SMALL_TESTS}
   ADD_TEST merge_small_tests
@@ -449,6 +450,7 @@ MYSQL_ADD_EXECUTABLE(rpl_commit_order_queue-t rpl_commit_order_queue-t.cc
 ADD_LIBRARY(rpl_event_ctx_lib STATIC
   ${CMAKE_SOURCE_DIR}/sql/rpl_event_ctx.cc
 )
+TARGET_LINK_LIBRARIES(rpl_event_ctx_lib ext::zlib)
 
 MYSQL_ADD_EXECUTABLE(rpl_event_ctx-t rpl_event_ctx-t.cc
   ENABLE_EXPORTS

--- a/unittest/gunit/keyring_vault/CMakeLists.txt
+++ b/unittest/gunit/keyring_vault/CMakeLists.txt
@@ -60,7 +60,7 @@ LIST(APPEND SRC_FILES
 
 ADD_LIBRARY(keyring_vault_test STATIC ${SRC_FILES})
 ADD_DEPENDENCIES(keyring_vault_test GenError)
-TARGET_LINK_LIBRARIES(keyring_vault_test extra::rapidjson)
+TARGET_LINK_LIBRARIES(keyring_vault_test extra::rapidjson ext::zlib)
 
 SET(ALL_KEYRING_VAULT_TESTS)
 FOREACH(test ${TESTS})


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8723

A number of source files either directly or indirectly (via, say, 'sql_class.h') include 'my_checksum.h' header file which in turn includes 'zlib.h' and has one of the inline functions referring to 'crc32_z()' function. The issue araises on old platforms (say, CentOS7) that have pretty old system 'zlib' library in which this function just does not exist. In other words, on such platforms, we should always include 'zlib.h' from the 'bundled' location.
However, because of the refactoring Oracle did in the CMake files in the fix for the Bug #35057542
"Create INTERFACE libraries for bundled/system zlib/zstd/lz4" (mysql/mysql-server@1f2b9d6), bundled 'zlib' include directory is no longer set globally in 'MY_INCLUDE_SYSTEM_DIRECTORIES'. Instead, individual targets are supposed to add 'ext::zlib' to the list of dependencies via 'TARGET_LINK_LIBRARIES()'.

This commit adds missing 'ext::zlib' dependencies to Percona-specific targets.