### PR TITLE
PS-8713: Add mysql_binlog_xxx() symbols to exported list

### DIFF
--- a/libmysql/CMakeLists.txt
+++ b/libmysql/CMakeLists.txt
@@ -145,6 +145,10 @@ SET(CLIENT_API_FUNCTIONS
   mysql_get_ssl_session_reused
   mysql_get_ssl_session_data
   mysql_free_ssl_session_data
+  # binlog API
+  mysql_binlog_close
+  mysql_binlog_fetch
+  mysql_binlog_open
   CACHE INTERNAL "Functions exported by client API"
 )
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8713

According to official C API Binary Log Interface documentation the following three functions must be available in libperconaserverclient.so
- mysql_binlog_open()
- mysql_binlog_fetch()
- mysql_binlog_close()