### PR TITLE
PS-8722 merge: Merge MySQL 5.7.42 - Q2 2023 (after_do_update_pos_waiting fix)

### DIFF
--- a/sql/log_event.cc
+++ b/sql/log_event.cc
@@ -11977,8 +11977,7 @@ Rows_log_event::do_update_pos(Relay_log_info *rli)
   DBUG_EXECUTE_IF( "wait_after_do_update_pos",
    {
      const char act[] =
-         "now signal "
-         "signal.after_do_update_pos_waiting "
+         "now "
          "wait_for "
          "signal.after_do_update_pos_continue";
      assert(!debug_sync_set_action(current_thd, STRING_WITH_LEN(act)));


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8722

Fixed check-testcase phase of the
'rpl.rpl_stop_slave_with_non_transactional_update' MTR test case by removing emitting 'signal.after_do_update_pos_waiting' signal that was never consumed.