### PR TITLE
PS-8747: FEDERATED engine not handling wait_timeout

### DIFF
--- a/mysql-test/suite/federated/r/federated.result
+++ b/mysql-test/suite/federated/r/federated.result
@@ -2446,6 +2446,7 @@ DROP TABLE federated.t1;
 DROP TABLE federated.t1;
 #
 # Bug#105878: PS-7999: FEDERATED engine not reconnecting on wait_timeout exceeded
+# PS-8747: Got an error writing communication packets error during FEDERATED engine reconnection
 #
 SET @OLD_SLAVE_WAIT_TIMEOUT= @@GLOBAL.WAIT_TIMEOUT;
 SET @@GLOBAL.WAIT_TIMEOUT= 4;
@@ -2467,6 +2468,11 @@ sleep(5)
 SELECT * from test.t1;
 id
 1
+SET @debug_save= @@GLOBAL.DEBUG;
+DELETE FROM test.t1;
+SET @@GLOBAL.DEBUG='+d,PS-8747_wait_for_disconnect_after_check';
+INSERT INTO test.t1 SELECT tt.* FROM SEQUENCE_TABLE(20000) AS tt;
+SET GLOBAL DEBUG= @debug_save;
 DROP TABLE test.t1;
 DROP SERVER test;
 DROP TABLE test.t1;

--- a/mysql-test/suite/federated/t/federated.test
+++ b/mysql-test/suite/federated/t/federated.test
@@ -2152,6 +2152,7 @@ DROP TABLE federated.t1;
 
 --echo #
 --echo # Bug#105878: PS-7999: FEDERATED engine not reconnecting on wait_timeout exceeded
+--echo # PS-8747: Got an error writing communication packets error during FEDERATED engine reconnection
 --echo #
 connection slave;
 SET @OLD_SLAVE_WAIT_TIMEOUT= @@GLOBAL.WAIT_TIMEOUT;
@@ -2169,9 +2170,20 @@ eval CREATE SERVER test FOREIGN DATA WRAPPER test1 OPTIONS(
   database 'test');
 CREATE TABLE test.t1 (id int PRIMARY KEY) ENGINE=FEDERATED CONNECTION='test';
 
+# scenario 1: PS-7999
 SELECT * FROM test.t1;
 SELECT sleep(5);
 SELECT * from test.t1;
+
+# scenario 2: PS-8747
+SET @debug_save= @@GLOBAL.DEBUG;
+DELETE FROM test.t1;
+SET @@GLOBAL.DEBUG='+d,PS-8747_wait_for_disconnect_after_check';
+
+# Send data which will not fit into one communication packet, so client will try to send them
+# before flush and reconnection.
+INSERT INTO test.t1 SELECT tt.* FROM SEQUENCE_TABLE(20000) AS tt;
+SET GLOBAL DEBUG= @debug_save;
 
 DROP TABLE test.t1;
 DROP SERVER test;

--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -1374,6 +1374,24 @@ bool cli_advanced_command(MYSQL *mysql, enum enum_server_command command,
   if ((command != COM_QUIT) && mysql->reconnect && !vio_is_connected(net->vio))
     net->error = NET_ERROR_SOCKET_UNUSABLE;
 
+  /*
+    If the connection becomes dead after the above check,
+    and the packet we are sending is bigger than 16k (net_buffer_length default)
+    the client will try to send partial data. In such a case net_write_command()
+    will detect connection loss  when trying to send the packet over the network
+    and report the error via my_error() from net_write_raw_loop(). But we don't
+    want this error to be propagated back to the client session.
+    net_write_command() should fail silently and the below reconnection logic
+    should kick in.
+  */
+  DBUG_EXECUTE_IF(
+      "PS-8747_wait_for_disconnect_after_check",
+      DBUG_SET("-d,PS-8747_wait_for_disconnect_after_check");
+      net->error = 0;  // Even if above check detected we are already
+                       // disconnected pretend we know nothing about this.
+      sleep(10);       // MTR test will set interactive_timeout/wait_timeout = 4
+  );
+
   if (net_write_command(net, (uchar)command, header, header_length, arg,
                         arg_length)) {
     DBUG_PRINT("error",

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -2996,6 +2996,20 @@ int ha_federated::real_query(const char *query, size_t length) {
 
   if (!query || !length) goto end;
 
+  /* Here we operate on internal proxy -> server connection which uses
+     client code. But it is compiled in context of server code, so
+     all things like:
+     #ifdef MYSQL_SERVER
+         my_error(net->last_errno, MYF(0));
+     #endif
+     are compiled in.
+     proxy -> server connection has reconnection logic, and all internal errors
+     should be handled silently as long as the overal result of the operation
+     is success.
+     If this connection fails and cannot be recovered, the function will return
+     error, which will be handled by the server.
+  */
+
   rc = mysql_real_query(mysql, query, static_cast<ulong>(length));
 
   // Simulate as errors happened within the previous query
@@ -3031,6 +3045,7 @@ int ha_federated::real_query(const char *query, size_t length) {
     Diagnostics_area *da = current_thd->get_stmt_da();
     if (da->is_set()) {
       const uint err = da->mysql_errno();
+
       if ((err == ER_NET_PACKETS_OUT_OF_ORDER || err == ER_NET_ERROR_ON_WRITE ||
            err == ER_NET_WRITE_INTERRUPTED || err == ER_NET_READ_ERROR ||
            err == ER_NET_READ_INTERRUPTED) &&
@@ -3044,6 +3059,18 @@ int ha_federated::real_query(const char *query, size_t length) {
     }
   }
 end:
+  /* Reconnection can take place above or inside cli_advanced_command().
+   If it happens in cli_advanced_command(), diagnositcs are may contain
+   the information about the error which triggered the reconnection.
+   But as the reconnection was fine, the information about transient
+   problems should not be propagated to the client.
+   */
+  if (!rc) {
+    Diagnostics_area *da = current_thd->get_stmt_da();
+    da->reset_condition_info(current_thd);
+    da->reset_diagnostics_area();
+  }
+
   return rc;
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8747

Problem:
When Federated SE internal proxy-server connection timeout occurs 'Got an error writing communication packets' is reported back to the user while actual operation is done with success.

Cause:
Federated SE internally uses client connection to the server hosting actual table.
The reconnection logic was initially fixed by commit 9b9cfc9f4. The fix was then reverted in favor of upstream fix by commit 70ef8034a.

Before sending any data, cli_advanced_command() checks if connection is still alive and if it is not, it sets
net->error = NET_ERROR_SOCKET_UNUSABLE. This gives the information to net_write_packet() that it should not attempt to send any data, but return error immediately. However if connection is closed after check but before sending any data and the data to be sent exceeds 16384 (net_buffer_length default), net_write_packet() tries to send it, fails and fills diagnostics area of the current thread.
The failure is detected properly and reconnection takes place inside cli_advanced_command(), but diagnostics area is not cleared. Federated SE considers the operation as succeeded, but diagnostics area is propagated back to the user.

Solution:
If from point of view of Federated SE (ha_federated::real_query()) execution with possible reconnection on Federated SE level succeeded, clean diagnostics data of the user connection thread.