### PR TITLE
PS-8747: FEDERATED engine not handling wait_timeout

### DIFF
--- a/mysql-test/suite/federated/r/federated.result
+++ b/mysql-test/suite/federated/r/federated.result
@@ -2446,7 +2446,6 @@ DROP TABLE federated.t1;
 DROP TABLE federated.t1;
 #
 # Bug#105878: PS-7999: FEDERATED engine not reconnecting on wait_timeout exceeded
-# PS-8747: Got an error writing communication packets error during FEDERATED engine reconnection
 #
 SET @OLD_SLAVE_WAIT_TIMEOUT= @@GLOBAL.WAIT_TIMEOUT;
 SET @@GLOBAL.WAIT_TIMEOUT= 4;
@@ -2468,11 +2467,6 @@ sleep(5)
 SELECT * from test.t1;
 id
 1
-SET @debug_save= @@GLOBAL.DEBUG;
-DELETE FROM test.t1;
-SET @@GLOBAL.DEBUG='+d,PS-8747_wait_for_disconnect_after_check';
-INSERT INTO test.t1 SELECT tt.* FROM SEQUENCE_TABLE(20000) AS tt;
-SET GLOBAL DEBUG= @debug_save;
 DROP TABLE test.t1;
 DROP SERVER test;
 DROP TABLE test.t1;

--- a/mysql-test/suite/federated/r/federated_debug.result
+++ b/mysql-test/suite/federated/r/federated_debug.result
@@ -27,6 +27,29 @@ a
 # Drop tables on master and slave
 DROP TABLE t1;
 DROP TABLE t1;
+#
+# PS-8747: Got an error writing communication packets error during FEDERATED engine reconnection
+#
+SET @OLD_SLAVE_WAIT_TIMEOUT= @@GLOBAL.WAIT_TIMEOUT;
+SET @@GLOBAL.WAIT_TIMEOUT= 4;
+CREATE TABLE test.t1 (id int PRIMARY KEY);
+CREATE SERVER test FOREIGN DATA WRAPPER test1 OPTIONS(
+user 'root',
+password '',
+host '127.0.0.1',
+port SLAVE_PORT,
+database 'test');
+CREATE TABLE test.t1 (id int PRIMARY KEY) ENGINE=FEDERATED CONNECTION='test';
+SELECT * FROM test.t1;
+id
+SET @debug_save= @@GLOBAL.DEBUG;
+SET @@GLOBAL.DEBUG='+d,PS-8747_wait_for_disconnect_after_check';
+INSERT INTO test.t1 SELECT tt.* FROM SEQUENCE_TABLE(20000) AS tt;
+SET GLOBAL DEBUG= @debug_save;
+DROP TABLE test.t1;
+DROP SERVER test;
+DROP TABLE test.t1;
+SET @@GLOBAL.WAIT_TIMEOUT= @OLD_SLAVE_WAIT_TIMEOUT;
 # Federated cleanup
 DROP TABLE IF EXISTS federated.t1;
 DROP DATABASE federated;

--- a/mysql-test/suite/federated/t/federated.test
+++ b/mysql-test/suite/federated/t/federated.test
@@ -2152,7 +2152,6 @@ DROP TABLE federated.t1;
 
 --echo #
 --echo # Bug#105878: PS-7999: FEDERATED engine not reconnecting on wait_timeout exceeded
---echo # PS-8747: Got an error writing communication packets error during FEDERATED engine reconnection
 --echo #
 connection slave;
 SET @OLD_SLAVE_WAIT_TIMEOUT= @@GLOBAL.WAIT_TIMEOUT;
@@ -2170,20 +2169,9 @@ eval CREATE SERVER test FOREIGN DATA WRAPPER test1 OPTIONS(
   database 'test');
 CREATE TABLE test.t1 (id int PRIMARY KEY) ENGINE=FEDERATED CONNECTION='test';
 
-# scenario 1: PS-7999
 SELECT * FROM test.t1;
 SELECT sleep(5);
 SELECT * from test.t1;
-
-# scenario 2: PS-8747
-SET @debug_save= @@GLOBAL.DEBUG;
-DELETE FROM test.t1;
-SET @@GLOBAL.DEBUG='+d,PS-8747_wait_for_disconnect_after_check';
-
-# Send data which will not fit into one communication packet, so client will try to send them
-# before flush and reconnection.
-INSERT INTO test.t1 SELECT tt.* FROM SEQUENCE_TABLE(20000) AS tt;
-SET GLOBAL DEBUG= @debug_save;
 
 DROP TABLE test.t1;
 DROP SERVER test;

--- a/mysql-test/suite/federated/t/federated_debug.test
+++ b/mysql-test/suite/federated/t/federated_debug.test
@@ -34,6 +34,41 @@ DROP TABLE t1;
 connection slave;
 DROP TABLE t1;
 
+--echo #
+--echo # PS-8747: Got an error writing communication packets error during FEDERATED engine reconnection
+--echo #
+connection slave;
+SET @OLD_SLAVE_WAIT_TIMEOUT= @@GLOBAL.WAIT_TIMEOUT;
+SET @@GLOBAL.WAIT_TIMEOUT= 4;
+CREATE TABLE test.t1 (id int PRIMARY KEY);
+
+connection master;
+--replace_result $SLAVE_MYPORT SLAVE_PORT
+eval CREATE SERVER test FOREIGN DATA WRAPPER test1 OPTIONS(
+  user 'root',
+  password '',
+  host '127.0.0.1',
+  port $SLAVE_MYPORT,
+  database 'test');
+CREATE TABLE test.t1 (id int PRIMARY KEY) ENGINE=FEDERATED CONNECTION='test';
+
+# The following SELECT will setup internal client-server connection inside Federated SE
+SELECT * FROM test.t1;
+
+SET @debug_save= @@GLOBAL.DEBUG;
+SET @@GLOBAL.DEBUG='+d,PS-8747_wait_for_disconnect_after_check';
+
+# Send data which will not fit into one communication packet, so client will try to send them
+# before flush and reconnection.
+INSERT INTO test.t1 SELECT tt.* FROM SEQUENCE_TABLE(20000) AS tt;
+SET GLOBAL DEBUG= @debug_save;
+
+DROP TABLE test.t1;
+DROP SERVER test;
+connection slave;
+DROP TABLE test.t1;
+SET @@GLOBAL.WAIT_TIMEOUT= @OLD_SLAVE_WAIT_TIMEOUT;
+
 connection default;
 --echo # Federated cleanup
 source suite/federated/include/federated_cleanup.inc;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8747

Post push fix.
Scenario which needs debug facility moved to federated_debug.test