### PR TITLE
Bug#104121: Ensure that PREPAREd statements are shown correctly in PERFORMANCE_SCHEMA.THREADS table

### DIFF
--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -2750,6 +2750,13 @@ void THD::set_query(LEX_CSTRING query_arg) {
   mysql_mutex_lock(&LOCK_thd_query);
   m_query_string = query_arg;
   mysql_mutex_unlock(&LOCK_thd_query);
+
+  /* Set the query for display in the PERFORMANCE_SCHEMA.THREADS table.
+   * We must not call set_query_for_display(..), because this will additionally
+   * overwrite performance_schema.events_statements_history.SQL_TEXT and cause
+   * it to appear as NULL.
+   */
+  set_query_for_display_in_pfs_threads(query_arg.str, query_arg.length);
 }
 
 /**

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -4460,6 +4460,20 @@ class THD : public MDL_context_owner,
   const String normalized_query();
 
   /**
+    Set query to be displayed in performance schema (threads table only).
+  */
+  void set_query_for_display_in_pfs_threads(const char *query_arg
+                                            [[maybe_unused]],
+                                            size_t query_length_arg
+                                            [[maybe_unused]]) {
+#ifdef HAVE_PSI_THREAD_INTERFACE
+    // Set in pfs threads table
+    PSI_THREAD_CALL(set_thread_info)
+    (query_arg, static_cast<uint>(query_length_arg));
+#endif
+  }
+
+  /**
     Set query to be displayed in performance schema (threads table etc.). Also
     mark the query safe to display for information_schema.process_list.
   */
@@ -4468,11 +4482,7 @@ class THD : public MDL_context_owner,
     // Set in pfs events statements table
     MYSQL_SET_STATEMENT_TEXT(m_statement_psi, query_arg,
                              static_cast<uint>(query_length_arg));
-#ifdef HAVE_PSI_THREAD_INTERFACE
-    // Set in pfs threads table
-    PSI_THREAD_CALL(set_thread_info)
-    (query_arg, static_cast<uint>(query_length_arg));
-#endif
+    set_query_for_display_in_pfs_threads(query_arg, query_length_arg);
     set_safe_display(true);
   }
 


### PR DESCRIPTION
This reverts the deletion of several lines from `sql/sql_class.cc` in https://github.com/percona/percona-server/commit/afcaac4d6f8aecc70c418138f1d8dd4e4965e629#diff-65c68b03ca220f14939f817d3c9cfe7767580750f9ef47876b383780a0fd82c3L4357.

That deletion caused a regression: `PERFORMANCE_SCHEMA.THREADS` is no longer correctly updated while executing a `PREPARE`d statement.  Detailed example in https://bugs.mysql.com/bug.php?id=104121

The one-line patch proposed as a fix in https://bugs.mysql.com/bug.php?id=104121#c513825 has the unwanted side effect of overwriting `performance_schema.events_statements_history.SQL_TEXT` (causing it to appear as `NULL`).

We verified that this change *does not* undo the intended effect of the original commit. Passwords (still) do not leak into the `PERFORMANCE_SCHEMA.THREADS` table with this change:

    -- In one session (connected as `root`@`localhost`):
    mysql> CREATE USER alice IDENTIFIED BY 'thisisapassword';
    Query OK, 0 rows affected (0.01 sec)

    -- In another session (connected as `root`@`localhost`)
    mysql> select PROCESSLIST_INFO from performance_schema.threads;
    +-----------------------------------------------------------------+
    | PROCESSLIST_INFO                                                |
    +-----------------------------------------------------------------+
    ...
    | CREATE USER 'alice'@'%' IDENTIFIED BY <secret>                   |
    ...
    | select PROCESSLIST_INFO from performance_schema.threads         |
    +-----------------------------------------------------------------+
    53 rows in set (0.00 sec)