### PR TITLE
PS-8811: Linking issues with protobuf with macOS 12 on Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -370,7 +370,8 @@ jobs:
         fi
       else
          brew update
-         brew install ccache protobuf lz4 rapidjson openssl@1.1
+         brew install ccache protobuf@21 lz4 rapidjson openssl@1.1
+         brew link protobuf@21
       fi
 
       UPDATE_TIME=$SECONDS


### PR DESCRIPTION
Fix by using `brew install protobuf@21` which is compatible with MySQL 8.0.33.