### PR TITLE
PS-8816 fix: main.execution_constants main.sp main.sp-error fail on binaries built with clang-16 / gcc-13

### DIFF
--- a/cmake/stack_direction.c
+++ b/cmake/stack_direction.c
@@ -30,7 +30,8 @@ int f(int *a) {
  Prevent compiler optimizations by calling function
  through pointer.
 */
-volatile int (*ptr_f)(int *) = f;
+typedef int (*test_function_ptr)(int *);
+volatile test_function_ptr ptr_f = f;
 int main() {
   int a;
   return ptr_f(&a);

--- a/configure.cmake
+++ b/configure.cmake
@@ -423,19 +423,42 @@ int main()
 IF(NOT STACK_DIRECTION)
   IF(CMAKE_CROSSCOMPILING)
    MESSAGE(FATAL_ERROR 
-   "STACK_DIRECTION is not defined.  Please specify -DSTACK_DIRECTION=1 "
-   "or -DSTACK_DIRECTION=-1 when calling cmake.")
+   "STACK_DIRECTION is not defined.  Please specify -DSTACK_DIRECTION=1, "
+   "-DSTACK_DIRECTION=-1 or -DSTACK_DIRECTION=0 (disables stack overrun "
+   "checking, should be used for ASan builds) when calling cmake.")
   ELSE()
-    TRY_RUN(STACKDIR_RUN_RESULT STACKDIR_COMPILE_RESULT    
-     ${CMAKE_BINARY_DIR} 
-     ${CMAKE_SOURCE_DIR}/cmake/stack_direction.c
-     )
-     # Test program returns 0 (down) or 1 (up).
-     # Convert to -1 or 1
-     IF(STACKDIR_RUN_RESULT EQUAL 0)
-       SET(STACK_DIRECTION -1 CACHE INTERNAL "Stack grows direction")
-     ELSE()
-       SET(STACK_DIRECTION 1 CACHE INTERNAL "Stack grows direction")
+    # Under Address Sanitizer when "detect_stack_use_after_return" runtime
+    # option is enabled (either via ASAN_OPTIONS environment variable or via
+    # "__asan_default_options()" function), there is no such concept as stack
+    # growth direction as stack frames are allocated with
+    # "__asan_stack_malloc()" special function that can return random
+    # addresses.
+    # Here, we just detect that the binaries are compiled under ASan
+    # and set "STACK_DIRECTION" to a special value "0" which will be
+    # processed by the #cmakedefine in the "config.h.cmake" into an
+    # /* #undef STACK_DIRECTION */
+    IF(WITH_ASAN)
+       SET(STACK_DIRECTION 0 CACHE INTERNAL "Stack growth direction")
+       MESSAGE(STATUS
+        "Stack growth direction under Address Sanitizer could be an "
+        "invalid concept. STACK_DIRECTION is set to a special value")
+    ELSE()
+      TRY_RUN(STACKDIR_RUN_RESULT STACKDIR_COMPILE_RESULT
+        ${CMAKE_BINARY_DIR}
+        ${CMAKE_SOURCE_DIR}/cmake/stack_direction.c
+       )
+       IF(NOT STACKDIR_COMPILE_RESULT)
+         MESSAGE(FATAL_ERROR
+          "Cannot compile stack_direction.c needed to detect stack growth "
+          "direction")
+       ENDIF()
+       # Test program returns 0 (down) or 1 (up).
+       # Convert to -1 or 1
+       IF(STACKDIR_RUN_RESULT EQUAL 0)
+         SET(STACK_DIRECTION -1 CACHE INTERNAL "Stack growth direction")
+       ELSE()
+         SET(STACK_DIRECTION 1 CACHE INTERNAL "Stack growth direction")
+       ENDIF()
      ENDIF()
      MESSAGE(STATUS "Checking stack direction : ${STACK_DIRECTION}")
    ENDIF()

--- a/mysql-test/t/alter_debug.test
+++ b/mysql-test/t/alter_debug.test
@@ -1,3 +1,6 @@
+# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with ASan
+# (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/have_debug.inc
 
 --echo #

--- a/mysql-test/t/execution_constants.test
+++ b/mysql-test/t/execution_constants.test
@@ -1,4 +1,6 @@
-# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with TSan
+# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with neither TSan
+# nor ASan (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/not_tsan.inc
 
 #

--- a/mysql-test/t/sp-error.test
+++ b/mysql-test/t/sp-error.test
@@ -2,7 +2,9 @@
 # Stored PROCEDURE error tests
 #
 
-# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with TSan
+# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with neither TSan
+# nor ASan (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/not_tsan.inc
 
 delimiter |;

--- a/mysql-test/t/sp.test
+++ b/mysql-test/t/sp.test
@@ -1,4 +1,6 @@
-# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with TSan
+# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with neither TSan
+# nor ASan (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/not_tsan.inc
 
 --source include/no_valgrind_without_big.inc

--- a/mysql-test/t/view_debug.test
+++ b/mysql-test/t/view_debug.test
@@ -1,3 +1,6 @@
+# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with ASan
+# (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/have_debug.inc
 
 --echo #


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8816

Stack overrun checks didn't work correctly for server built with
'clang-16' / 'gcc-13' causing failures of some MTR test cases
'main.sp', 'main.sp-error', 'main.execution_constants', etc.).

The problem occurred because the CMake check that defines stack
growth direction constant ('STACK_DIRECTION'), used in stack overrun
checking function 'check_stack_overrun()', didn't work correctly.
Helper program used by this CMake check ('cmake/stack_direction.c')
failed to compile due to 'incompatible-function-pointer-types' warning
being promoted to an error with newer compilers and this compilation
failure was ignored and wrongly interpreted as an indication of wrong
stack growth direction instead.

Fixed 'ptr_f' function pointer declaration in 'cmake/stack_direction.c'.
Instead of declaring a pointer to a function that returns 'volatile int'
we make the pointer to the function itself 'volatile'.

Also fixed the problem in 'configure.cmake' with
'TRY_RUN(... cmake/stack_direction.c ...)' ignoring compilation
result.

As under ASan (with 'detect_stack_use_after_return' enabled) stack
growth direction is just a wrong concept (in this case stack frames are
allocated on heap with pretty random addresses) 'check_stack_overrun()'
function modified so that under ASan it always returns 'false' (meaning
no stack overrun detected).

The following MTR test cases marked with 'not_asan.inc':
* main.alter_debug
* main.execution_constants
* main.sp-error
* main.sp
* main.view_debug