### PR TITLE
PS-8624: Expose number of TABLE objects with triggers in Table Cache

### DIFF
--- a/mysql-test/include/assert_trigger_cache_increment.inc
+++ b/mysql-test/include/assert_trigger_cache_increment.inc
@@ -3,13 +3,13 @@
 # Check that values of system status variables related to storing
 # triggers in Table Cache (Table_open_cache_misses,
 # Table_open_cache_trigger_hits, Table_open_cache_triggers_misses,
-# Table_open_cache_triggers_overflows) have got expected increments
-# since the last execution of this script, fail with debug info if
-# they have not.
+# Table_open_cache_triggers_overflows, Open_tables_with_triggers)
+# have got expected increments since the last execution of this script,
+# fail with debug info if they have not.
 #
 # ==== Usage ====
 #
-# --let $expected_inc = { "tc_misses_inc": VALUE1, "trg_hits_inc": VALUE2, "trg_misses_inc" : VALUE3, "trg_overflows_inc" : VALUE4 }
+# --let $expected_inc = { "tc_misses_inc": VALUE1, "trg_hits_inc": VALUE2, "trg_misses_inc" : VALUE3, "trg_overflows_inc" : VALUE4, "tc_trg_tables_inc" : VALUE5 }
 # --source include/assert_trigger_cache_increment.inc
 #
 # $expected_inc
@@ -23,7 +23,7 @@
 # # Run SELECT reading from table which was absent in Table Cache so far.
 # SELECT count(*) FROM t1;
 #
-# --let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+# --let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0, "tc_trg_tables_inc" : 0}
 # --source include/assert_trigger_cache_increment.inc
 #
 # Resulting output:
@@ -31,6 +31,7 @@
 # include/assert.inc [Expected table cache triggers hits increment : 0]
 # include/assert.inc [Expected table cache triggers misses increment : 0]
 # include/assert.inc [Expected table cache triggers overflows increment : 0]
+# include/assert.inc [Expected table cache open tables with triggers increment : 0]
 #
 
 # If missing, create helper scripts to iterate through bellow JSON array.
@@ -70,6 +71,12 @@ let $json_array = [
     "psname": "Table_open_cache_triggers_overflows",
     "varname": "trg_overflows_count",
     "atext": "Expected table cache triggers overflows increment"
+  },
+  {
+    "paramname" : "tc_trg_tables_inc",
+    "psname": "Open_tables_with_triggers",
+    "varname" : "tc_trg_tables_count",
+    "atext" : "Expected table cache open tables with triggers increment"
   }
 ];
 

--- a/mysql-test/r/table_open_cache_triggers_functionality.result
+++ b/mysql-test/r/table_open_cache_triggers_functionality.result
@@ -38,6 +38,7 @@ include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 SELECT count(*) FROM t1 AS a, t1 AS b;
 count(*)
 9
@@ -45,6 +46,7 @@ include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 SELECT count(*) FROM t4;
 count(*)
 1
@@ -52,15 +54,18 @@ include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Updating statement needs fully-loaded triggers, so there will be
 # a table cache hit, but also trigger miss and trigger will be
-# loaded.
+# loaded. Total number of table objects with fully-loaded triggers
+# in the cache should increase as result as well.
 INSERT INTO t1 VALUES (4);
 include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 1]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 1]
 
 # Repeating the statement will cause table cache and trigger hits.
 INSERT INTO t1 VALUES (5);
@@ -68,6 +73,7 @@ include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 1]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # When same statement needs 2 instances of the table, one for
 # updating and another for read-only purposes, then for updating
@@ -78,20 +84,24 @@ include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 1]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Statement needing 2 table objects with triggers will cause one
 # trigger hit and one trigger miss (causing trigger loading for
-# one of cached table objects).
+# one of cached table objects). Total number of table objects with
+# fully-loaded triggers in cache should increase further.
 LOCK TABLES t1 AS a WRITE, t1 AS b WRITE;
 include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 1]
 include/assert.inc [Expected table cache triggers misses increment : 1]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 1]
 UNLOCK TABLES;
 include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Running read-only statement on unrelated table should not disturb
 # trigger counters. Since only one table object for this table was
@@ -103,6 +113,7 @@ include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Statement which needs 3 table objects for updating will cause 2
 # trigger hits and 1 trigger (and TC) miss . As result we temporarily
@@ -112,6 +123,7 @@ include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 2]
 include/assert.inc [Expected table cache triggers misses increment : 1]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 1]
 
 # Once we are done with using all 3 table objects, one table
 # object with trigger gets evicted. 2 table objects with triggers
@@ -121,6 +133,7 @@ include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 1]
+include/assert.inc [Expected table cache open tables with triggers increment : -1]
 
 # Read-only statement will use table objects with triggers and
 # should not disturb trigger counters. Since we have not used
@@ -132,6 +145,7 @@ include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Statement that uses t1 for updating and table t2 in read-only
 # mode will reuse 1 table object with triggers (and also reuse object
@@ -141,25 +155,30 @@ include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 1]
 include/assert.inc [Expected table cache triggers misses increment : 0]
 include/assert.inc [Expected table cache triggers overflows increment : 0]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Statement that updates t2 will require loading of triggers (existing
 # table object will be used for this), this will cause table object
-# with triggers for table t1 eviction.
+# with triggers for table t1 eviction. So total number of table
+# objects with fully-loaded triggers should stay the same.
 INSERT INTO t2 VALUES (2);
 include/assert.inc [Expected table cache misses increment : 0]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 1]
 include/assert.inc [Expected table cache triggers overflows increment : 1]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Statement that updates t3 will require new table object and triggers
 # loaded for it. Since Table Cache already has 2 table objects with
 # triggers it will cause eviction of one of these objects. According
-# to LRU it should be object for t1.
+# to LRU it should be object for t1. Again total number of table
+# objects with fully-loaded triggers should stay the same.
 INSERT INTO t3 VALUES (2);
 include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 1]
 include/assert.inc [Expected table cache triggers overflows increment : 1]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 
 # Let us confirm that it is table object for t1 which is gone
 # missing, by showing that it and its triggers need to be loaded again.
@@ -168,6 +187,7 @@ include/assert.inc [Expected table cache misses increment : 1]
 include/assert.inc [Expected table cache triggers hits increment : 0]
 include/assert.inc [Expected table cache triggers misses increment : 1]
 include/assert.inc [Expected table cache triggers overflows increment : 1]
+include/assert.inc [Expected table cache open tables with triggers increment : 0]
 #
 # Clean up.
 #

--- a/mysql-test/t/table_open_cache_triggers_functionality.test
+++ b/mysql-test/t/table_open_cache_triggers_functionality.test
@@ -47,33 +47,34 @@ FLUSH STATUS;
 --echo # when only 1 is present in TC causes 1 hit and 1 miss.
 SELECT count(*) FROM t1;
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 SELECT count(*) FROM t1 AS a, t1 AS b;
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 SELECT count(*) FROM t4;
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
 --echo # Updating statement needs fully-loaded triggers, so there will be
 --echo # a table cache hit, but also trigger miss and trigger will be
---echo # loaded.
+--echo # loaded. Total number of table objects with fully-loaded triggers
+--echo # in the cache should increase as result as well.
 INSERT INTO t1 VALUES (4);
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 1 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
 --echo # Repeating the statement will cause table cache and trigger hits.
 INSERT INTO t1 VALUES (5);
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
@@ -83,21 +84,22 @@ INSERT INTO t1 VALUES (5);
 --echo # without triggers we also have for read-only part.
 INSERT INTO t1 SELECT * FROM t1;
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
 --echo # Statement needing 2 table objects with triggers will cause one
 --echo # trigger hit and one trigger miss (causing trigger loading for
---echo # one of cached table objects).
+--echo # one of cached table objects). Total number of table objects with
+--echo # fully-loaded triggers in cache should increase further.
 LOCK TABLES t1 AS a WRITE, t1 AS b WRITE;
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 1, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 1, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 1 }
 --source include/assert_trigger_cache_increment.inc
 
 UNLOCK TABLES;
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
@@ -106,7 +108,7 @@ UNLOCK TABLES;
 --echo # used before it will cause single TC miss as expected.
 SELECT count(*) FROM t4 AS a, t4 AS b;
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
@@ -115,7 +117,7 @@ SELECT count(*) FROM t4 AS a, t4 AS b;
 --echo # exceed the soft limit on open tables with triggers.
 LOCK TABLES t1 AS a WRITE, t1 AS b WRITE, t1 AS c WRITE;
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 2, "trg_misses_inc" : 1, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 2, "trg_misses_inc" : 1, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 1 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
@@ -124,7 +126,7 @@ LOCK TABLES t1 AS a WRITE, t1 AS b WRITE, t1 AS c WRITE;
 --echo # is left.
 UNLOCK TABLES;
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 1 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 1 , "tc_trg_tables_inc" : -1 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
@@ -133,7 +135,7 @@ UNLOCK TABLES;
 --echo # table t2 so far, there will be 1 TC miss.
 SELECT count(*) FROM t1, t2;
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
@@ -142,26 +144,29 @@ SELECT count(*) FROM t1, t2;
 --echo # without triggers for t2), and won't disturb cache otherwise.
 INSERT INTO t1 SELECT * FROM t2;
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 1, "trg_misses_inc" : 0, "trg_overflows_inc" : 0 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
 --echo # Statement that updates t2 will require loading of triggers (existing
 --echo # table object will be used for this), this will cause table object
---echo # with triggers for table t1 eviction.
+--echo # with triggers for table t1 eviction. So total number of table
+--echo # objects with fully-loaded triggers should stay the same.
+
 INSERT INTO t2 VALUES (2);
 
---let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 1 }
+--let $expected_inc = { "tc_misses_inc": 0, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 1 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
 --echo # Statement that updates t3 will require new table object and triggers
 --echo # loaded for it. Since Table Cache already has 2 table objects with
 --echo # triggers it will cause eviction of one of these objects. According
---echo # to LRU it should be object for t1.
+--echo # to LRU it should be object for t1. Again total number of table
+--echo # objects with fully-loaded triggers should stay the same.
 INSERT INTO t3 VALUES (2);
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 1 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 1 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo
@@ -169,7 +174,7 @@ INSERT INTO t3 VALUES (2);
 --echo # missing, by showing that it and its triggers need to be loaded again.
 INSERT INTO t1 VALUES (6);
 
---let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 1 }
+--let $expected_inc = { "tc_misses_inc": 1, "trg_hits_inc": 0, "trg_misses_inc" : 1, "trg_overflows_inc" : 1 , "tc_trg_tables_inc" : 0 }
 --source include/assert_trigger_cache_increment.inc
 
 --echo #

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -9903,6 +9903,13 @@ static int show_open_tables(THD *, SHOW_VAR *var, char *buff) {
   return 0;
 }
 
+static int show_open_tables_with_triggers(THD *, SHOW_VAR *var, char *buff) {
+  var->type = SHOW_LONG;
+  var->value = buff;
+  *((long *)buff) = (long)table_cache_manager.loaded_triggers_tables();
+  return 0;
+}
+
 static int show_prepared_stmt_count(THD *, SHOW_VAR *var, char *buff) {
   var->type = SHOW_LONG;
   var->value = buff;
@@ -10296,6 +10303,8 @@ SHOW_VAR status_vars[] = {
     {"Open_table_definitions", (char *)&show_table_definitions, SHOW_FUNC,
      SHOW_SCOPE_GLOBAL},
     {"Open_tables", (char *)&show_open_tables, SHOW_FUNC, SHOW_SCOPE_ALL},
+    {"Open_tables_with_triggers", (char *)&show_open_tables_with_triggers,
+     SHOW_FUNC, SHOW_SCOPE_ALL},
     {"Opened_files",
      const_cast<char *>(reinterpret_cast<const char *>(&my_file_total_opened)),
      SHOW_LONG_NOFLUSH, SHOW_SCOPE_GLOBAL},

--- a/sql/table_cache.cc
+++ b/sql/table_cache.cc
@@ -240,6 +240,20 @@ uint Table_cache_manager::cached_tables() {
 }
 
 /**
+  Get total number of used and unused TABLE objects with fully-loaded triggers
+  in all table caches.
+*/
+
+uint Table_cache_manager::loaded_triggers_tables() const {
+  uint result = 0;
+
+  for (uint i = 0; i < table_cache_instances; i++)
+    result += m_table_cache[i].loaded_triggers_tables();
+
+  return result;
+}
+
+/**
   Acquire locks on all instances of table cache and table definition
   cache (i.e. LOCK_open).
 */

--- a/sql/table_cache.h
+++ b/sql/table_cache.h
@@ -222,6 +222,8 @@ class Table_cache_manager {
 
   uint cached_tables();
 
+  uint loaded_triggers_tables() const;
+
   void lock_all_and_tdc();
   void unlock_all_and_tdc();
   void assert_owner(THD *thd);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8624

Follow-up to PS-7963: "Do not cache trigger definitions in the table cache for SELECT statements".

Improve observability of the Table Cache by adding "Open_tables_with_triggers" status variable which shows current number of TABLE instances with fully-loaded triggers in the Table Cache.

The new status variable in addition to existing "Table_open_cache_triggers_hits" and "Table_open_cache_triggers_misses" status variables should allow users better understand how well caching for TABLE objects with fully-loaded triggers is working and if value of option --table_open_cache_triggers, which limits number of such objects in the cache, needs to be adjusted.