### PR TITLE
PS-8810: FEDERATED Update on Table can silently fail when Table contains DOUBLE Columns

### DIFF
--- a/mysql-test/suite/federated/r/federated_double_type.result
+++ b/mysql-test/suite/federated/r/federated_double_type.result
@@ -1,0 +1,38 @@
+CREATE DATABASE federated;
+CREATE DATABASE federated;
+CREATE TABLE t1 (id INT, i INT, d DOUBLE(8,6));
+Warnings:
+Warning	1681	Specifying number of digits for floating point data types is deprecated and will be removed in a future release.
+INSERT INTO t1 VALUES (0, 0, 8.730550);
+CREATE TABLE t2 (id INT, i INT, d DOUBLE);
+INSERT INTO t2 VALUES (0, 0, 8.730550);
+CREATE TABLE t3 (id INT, i INT, f FLOAT(8,6));
+Warnings:
+Warning	1681	Specifying number of digits for floating point data types is deprecated and will be removed in a future release.
+INSERT INTO t3 VALUES (0, 0, 8.730550);
+CREATE TABLE t1(id INT, i INT, d DOUBLE(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:SLAVE_PORT/test/t1';
+Warnings:
+Warning	1681	Specifying number of digits for floating point data types is deprecated and will be removed in a future release.
+CREATE TABLE t2(id INT, i INT, d DOUBLE) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:13002/test/t2';
+CREATE TABLE t3(id INT, i INT, f FLOAT(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:13002/test/t3';
+Warnings:
+Warning	1681	Specifying number of digits for floating point data types is deprecated and will be removed in a future release.
+include/assert.inc [Row should have been inserted]
+include/assert.inc [Row should have been inserted]
+include/assert.inc [Row should have been inserted]
+UPDATE t1 SET i = 1 WHERE id = 0;
+UPDATE t2 SET i = 1 WHERE id = 0;
+UPDATE t3 SET i = 1 WHERE id = 0;
+include/assert.inc [Row should have been updated]
+include/assert.inc [Row should have been updated]
+include/assert.inc [Row should have been updated]
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+DROP TABLE IF EXISTS federated.t1;
+DROP DATABASE federated;
+DROP TABLE IF EXISTS federated.t1;
+DROP DATABASE federated;

--- a/mysql-test/suite/federated/t/federated_double_type.test
+++ b/mysql-test/suite/federated/t/federated_double_type.test
@@ -1,0 +1,56 @@
+--source suite/federated/include/federated.inc
+
+--connection slave
+CREATE TABLE t1 (id INT, i INT, d DOUBLE(8,6));
+INSERT INTO t1 VALUES (0, 0, 8.730550);
+
+CREATE TABLE t2 (id INT, i INT, d DOUBLE);
+INSERT INTO t2 VALUES (0, 0, 8.730550);
+
+CREATE TABLE t3 (id INT, i INT, f FLOAT(8,6));
+INSERT INTO t3 VALUES (0, 0, 8.730550);
+
+--connection master
+--replace_result $SLAVE_MYPORT SLAVE_PORT
+--eval CREATE TABLE t1(id INT, i INT, d DOUBLE(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:$SLAVE_MYPORT/test/t1'
+--eval CREATE TABLE t2(id INT, i INT, d DOUBLE) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:$SLAVE_MYPORT/test/t2'
+--eval CREATE TABLE t3(id INT, i INT, f FLOAT(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:$SLAVE_MYPORT/test/t3'
+  
+--let $assert_text = Row should have been inserted
+--let $assert_cond = [SELECT COUNT(*) FROM t1 WHERE i=1] = 0
+--source include/assert.inc
+
+--let $assert_text = Row should have been inserted
+--let $assert_cond = [SELECT COUNT(*) FROM t2 WHERE i=1] = 0
+--source include/assert.inc
+
+--let $assert_text = Row should have been inserted
+--let $assert_cond = [SELECT COUNT(*) FROM t3 WHERE i=1] = 0
+--source include/assert.inc
+
+UPDATE t1 SET i = 1 WHERE id = 0;
+UPDATE t2 SET i = 1 WHERE id = 0;
+UPDATE t3 SET i = 1 WHERE id = 0;
+
+--let $assert_text = Row should have been updated
+--let $assert_cond = [SELECT COUNT(*) FROM t1 WHERE i=1] = 1
+--source include/assert.inc
+
+--let $assert_text = Row should have been updated
+--let $assert_cond = [SELECT COUNT(*) FROM t2 WHERE i=1] = 1
+--source include/assert.inc
+
+--let $assert_text = Row should have been updated
+--let $assert_cond = [SELECT COUNT(*) FROM t3 WHERE i=1] = 1
+--source include/assert.inc
+
+--connection slave
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+
+--connection master
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+--source suite/federated/include/federated_cleanup.inc

--- a/storage/federated/ha_federated.cc
+++ b/storage/federated/ha_federated.cc
@@ -1958,6 +1958,74 @@ int ha_federated::repair(THD *, HA_CHECK_OPT *check_opt) {
 }
 
 /*
+  We need to handle DOUBLE type in a special way.
+  This is because Federated SE does the update in the following way:
+  1. Query the remote server for the row(s) to be updated
+  2. Call update_row() for each row
+  3. Construct update query together with WHERE clause which contains all
+  columns (even if they were not specified in the original query)
+  4. Query the remote server
+
+  If the row contains DOUBLE(M,D) column, the value in WHERE clause is rounded
+  to D digits after the decimal point comparing to the underlying, actually
+  stored value. This is because of field definition. This rounded value goes to
+  the server side and appears there as Item_decimal. It is converted to double
+  in the following way:
+  1. convert decimal to string by decimal2string()
+  2. convert string to double by my_strtod()
+  Then analyze_field_constant() detects that the result would be rounded for
+  comparison with field having precision (M,D), so it is decided that row
+  matching is not safe and query execution does not continue.
+
+  This is desired behavior because if we have table:
+  CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT, i INT, d DOUBLE(8,6));
+  INSERT INTO f1(i, d) VALUES (0, 8.730550);
+  and we execute:
+  UPDATE t1 set i=1 where d=8.7305501;
+  we do not expect row to be updated.
+
+  Note that there is the same issue even if we use a single server.
+  If DOUBLE(M,D) column is specified in WHERE clause, the column is row is
+  not found. Like in the above example: UPDATE t1 set i=1 where d=8.730550;
+  Item_decimal = 8.730550 => string 8.730550 => double = 8.7305499999999991
+
+  Here we force server side to pass stored value through string to double
+  conversion which results in the same number as conversion of provided constant
+  to double (both go through the same conversion path). E.g.: Constant:
+  Item_decimal = 8.730550 => string 8.730550 => double = 8.7305499999999991
+  Stored value: Stored in DB as 8.7305500000000009 => apply (M,D) 8.730550 =>
+                string 8.730550 => double = 8.7305499999999991
+  */
+static bool handle_double_type_with_explicit_precision(Field *field,
+                                                       uchar *record,
+                                                       const uchar *old_data,
+                                                       String &where_string,
+                                                       String &field_value) {
+  if (field->type() != MYSQL_TYPE_DOUBLE) {
+    return true;
+  }
+  if (field->is_null_in_record(old_data)) {
+    return true;
+  }
+  const auto fn = down_cast<Field_num *>(field);
+  if (fn->dec == DECIMAL_NOT_SPECIFIED) {
+    return true;
+  }
+
+  where_string.append("CAST(");
+  size_t field_name_length = strlen(field->field_name);
+  append_ident(&where_string, field->field_name, field_name_length,
+               ident_quote_char);
+  where_string.append(" AS CHAR) = ");
+
+  field->val_str(&field_value,
+                 const_cast<uchar *>(old_data + field->offset(record)));
+  field_value.print(&where_string);
+
+  return false;
+}
+
+/*
   Yes, update_row() does what you expect, it updates a row. old_data will have
   the previous row record in it, while new_data will have the newest data in
   it.
@@ -2054,31 +2122,37 @@ int ha_federated::update_row(const uchar *old_data, uchar *) {
     }
 
     if (bitmap_is_set(table->read_set, (*field)->field_index())) {
-      size_t field_name_length = strlen((*field)->field_name);
-      append_ident(&where_string, (*field)->field_name, field_name_length,
-                   ident_quote_char);
-      if ((*field)->is_null_in_record(old_data))
-        where_string.append(STRING_WITH_LEN(" IS NULL "));
-      else {
-        bool needs_quote = (*field)->str_needs_quotes();
-        where_string.append(STRING_WITH_LEN(" = "));
-
-        const bool is_json = (*field)->type() == MYSQL_TYPE_JSON;
-        if (is_json) {
-          where_string.append("CAST(");
-        }
-
-        (*field)->val_str(
-            &field_value,
-            const_cast<uchar *>(old_data + (*field)->offset(record)));
-        if (needs_quote) where_string.append(value_quote_char);
-        field_value.print(&where_string);
-        if (needs_quote) where_string.append(value_quote_char);
-
-        if (is_json) {
-          where_string.append(" AS JSON)");
-        }
+      if (!handle_double_type_with_explicit_precision(
+              *field, record, old_data, where_string, field_value)) {
         field_value.length(0);
+      } else {
+        size_t field_name_length = strlen((*field)->field_name);
+        append_ident(&where_string, (*field)->field_name, field_name_length,
+                     ident_quote_char);
+        if ((*field)->is_null_in_record(old_data))
+          where_string.append(STRING_WITH_LEN(" IS NULL "));
+        else {
+          bool needs_quote = (*field)->str_needs_quotes();
+          where_string.append(STRING_WITH_LEN(" = "));
+
+          const bool is_json = (*field)->type() == MYSQL_TYPE_JSON;
+          if (is_json) {
+            where_string.append("CAST(");
+          }
+
+          (*field)->val_str(
+              &field_value,
+              const_cast<uchar *>(old_data + (*field)->offset(record)));
+
+          if (needs_quote) where_string.append(value_quote_char);
+          field_value.print(&where_string);
+          if (needs_quote) where_string.append(value_quote_char);
+
+          if (is_json) {
+            where_string.append(" AS JSON)");
+          }
+          field_value.length(0);
+        }
       }
       where_string.append(STRING_WITH_LEN(" AND "));
     }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8810

Problem:
If the table contains DOUBLE column with specified precision, update of the row, even if DOUBLE column is not specified in WHERE clause, reports that row has been updated, but the row is not updated.

Cause:
Federated SE constructs the query in a way that specifies all columns in WHERE clause even if the original query didn't contain all queries.

If the row contains DOUBLE(M,D) column, the value in WHERE clause is rounded to D digits after the decimal point compared to the underlying, actually stored value. This is because of the field definition. This rounded value goes to the server side and appears there as Item_decimal. It is converted to double in the following way:
  1. convert decimal to a string by decimal2string()
  2. convert string to double by my_strtod() Then analyze_field_constant() detects that the result would be rounded for comparison with the field having precision (M,D), so it is decided that row matching is not safe and query execution does not continue.

Solution:
Force server side to pass stored value through string to double conversion which results in the same number as the conversion of provided constant to double (both go through the same conversion path).