### PR TITLE
PS-8042: Fixes for audit_log_filter

### DIFF
--- a/plugin/audit_log_filter/audit_keyring.cc
+++ b/plugin/audit_log_filter/audit_keyring.cc
@@ -72,7 +72,7 @@ bool get_keyring_options_key_list_sorted(OptionsIdList &list) {
   list.clear();
 
   my_service<SERVICE_TYPE(keyring_keys_metadata_iterator)> iterator_srv(
-      "keyring_keys_metadata_iterator", SysVars::get_comp_regystry_srv());
+      "keyring_keys_metadata_iterator", SysVars::get_comp_registry_srv());
 
   if (!iterator_srv.is_valid()) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -165,7 +165,7 @@ bool get_active_keyring_options_key(std::string &options_id) {
 bool get_keyring_options(const std::string &options_id,
                          std::string &options_json_str) {
   my_service<SERVICE_TYPE(keyring_reader_with_status)> reader_srv(
-      "keyring_reader_with_status", SysVars::get_comp_regystry_srv());
+      "keyring_reader_with_status", SysVars::get_comp_registry_srv());
 
   if (!reader_srv.is_valid()) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -234,7 +234,7 @@ bool get_keyring_options(const std::string &options_id,
 
 bool generate_keyring_options_id(std::string &options_id) {
   my_service<SERVICE_TYPE(keyring_reader_with_status)> reader_srv(
-      "keyring_reader_with_status", SysVars::get_comp_regystry_srv());
+      "keyring_reader_with_status", SysVars::get_comp_registry_srv());
 
   if (!reader_srv.is_valid()) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -285,7 +285,7 @@ bool generate_keyring_options_id(std::string &options_id) {
 bool set_keyring_options(const std::string &options_id,
                          const std::string &options_json_str) {
   my_service<SERVICE_TYPE(keyring_writer)> writer_srv(
-      "keyring_writer", SysVars::get_comp_regystry_srv());
+      "keyring_writer", SysVars::get_comp_registry_srv());
 
   if (!writer_srv.is_valid()) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -330,7 +330,7 @@ bool generate_keyring_options(std::string &options_id) {
 
 bool check_keyring_initialized() noexcept {
   my_service<SERVICE_TYPE(keyring_component_status)> component_status(
-      "keyring_component_status", SysVars::get_comp_regystry_srv());
+      "keyring_component_status", SysVars::get_comp_registry_srv());
 
   if (!component_status.is_valid()) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -417,7 +417,7 @@ void prune_encryption_options(
   }
 
   my_service<SERVICE_TYPE(keyring_writer)> writer_srv(
-      "keyring_writer", SysVars::get_comp_regystry_srv());
+      "keyring_writer", SysVars::get_comp_registry_srv());
 
   if (!writer_srv.is_valid()) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,

--- a/plugin/audit_log_filter/audit_log_filter.cc
+++ b/plugin/audit_log_filter/audit_log_filter.cc
@@ -96,7 +96,7 @@ bool init_logging_service(SERVICE_TYPE(registry) * *reg_srv,
 
 bool init_abort_exempt_privilege() {
   my_service<SERVICE_TYPE(dynamic_privilege_register)> reg_priv_srv(
-      "dynamic_privilege_register", SysVars::get_comp_regystry_srv());
+      "dynamic_privilege_register", SysVars::get_comp_registry_srv());
 
   if (reg_priv_srv.is_valid() && !reg_priv_srv->register_privilege(
                                      STRING_WITH_LEN("AUDIT_ABORT_EXEMPT"))) {
@@ -108,7 +108,7 @@ bool init_abort_exempt_privilege() {
 
 void deinit_abort_exempt_privilege() {
   my_service<SERVICE_TYPE(dynamic_privilege_register)> reg_priv_srv(
-      "dynamic_privilege_register", SysVars::get_comp_regystry_srv());
+      "dynamic_privilege_register", SysVars::get_comp_registry_srv());
 
   if (reg_priv_srv.is_valid()) {
     reg_priv_srv->unregister_privilege(STRING_WITH_LEN("AUDIT_ABORT_EXEMPT"));
@@ -187,7 +187,7 @@ static std::array udfs_list{
  *         code otherwise
  */
 int audit_log_filter_init(MYSQL_PLUGIN plugin_info [[maybe_unused]]) {
-  const auto *comp_registry_srv = SysVars::get_comp_regystry_srv();
+  const auto *comp_registry_srv = SysVars::get_comp_registry_srv();
 
   auto comp_scope_guard = create_scope_guard([&] {
     if (comp_registry_srv != nullptr) {
@@ -325,7 +325,7 @@ int audit_log_filter_deinit(void *arg [[maybe_unused]]) {
   LogPluginErr(INFORMATION_LEVEL, ER_LOG_PRINTF_MSG,
                "Uninstalled Audit Event Filter");
 
-  const auto *reg_srv = SysVars::get_comp_regystry_srv();
+  const auto *reg_srv = SysVars::get_comp_registry_srv();
   deinit_logging_service(&reg_srv, &log_bi, &log_bs);
   mysql_plugin_registry_release(reg_srv);
 
@@ -361,7 +361,7 @@ AuditLogFilter::AuditLogFilter(
       m_is_active{true} {}
 
 bool AuditLogFilter::init() noexcept {
-  auto *reg_srv = SysVars::get_comp_regystry_srv();
+  auto *reg_srv = SysVars::get_comp_registry_srv();
 
   if (reg_srv->acquire(
           "mysql_thd_security_context",
@@ -391,7 +391,7 @@ void AuditLogFilter::deinit() noexcept {
   m_audit_udf->deinit();
   m_log_writer->close();
 
-  const auto *reg_srv = SysVars::get_comp_regystry_srv();
+  const auto *reg_srv = SysVars::get_comp_registry_srv();
   reg_srv->release(reinterpret_cast<my_h_service>(
       const_cast<SERVICE_TYPE_NO_CONST(mysql_thd_security_context) *>(
           m_security_context_srv)));
@@ -481,7 +481,7 @@ int AuditLogFilter::notify_event(MYSQL_THD thd, mysql_event_class_t event_class,
 
 void AuditLogFilter::send_audit_start_event() noexcept {
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
-      "mysql_current_thread_reader", SysVars::get_comp_regystry_srv());
+      "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
 
   MYSQL_THD thd;
 
@@ -502,7 +502,7 @@ void AuditLogFilter::send_audit_start_event() noexcept {
 
 void AuditLogFilter::send_audit_stop_event() noexcept {
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
-      "mysql_current_thread_reader", SysVars::get_comp_regystry_srv());
+      "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
 
   MYSQL_THD thd;
 
@@ -567,7 +567,7 @@ void AuditLogFilter::on_audit_log_rotated() noexcept {
 void AuditLogFilter::get_connection_attrs(MYSQL_THD thd,
                                           AuditRecordVariant &audit_record) {
   my_service<SERVICE_TYPE(mysql_connection_attributes_iterator)> attrs_service(
-      "mysql_connection_attributes_iterator", SysVars::get_comp_regystry_srv());
+      "mysql_connection_attributes_iterator", SysVars::get_comp_registry_srv());
 
   if (!attrs_service.is_valid()) {
     return;

--- a/plugin/audit_log_filter/audit_log_reader.cc
+++ b/plugin/audit_log_filter/audit_log_reader.cc
@@ -70,7 +70,7 @@ bool AuditLogReader::init() noexcept {
   m_reload_requested = false;
 
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
-      "mysql_current_thread_reader", SysVars::get_comp_regystry_srv());
+      "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
 
   MYSQL_THD thd;
 

--- a/plugin/audit_log_filter/audit_table/audit_log_filter.cc
+++ b/plugin/audit_log_filter/audit_table/audit_log_filter.cc
@@ -73,15 +73,15 @@ TableResult AuditLogFilter::index_scan_locate_record_by_rule_name(
     TableAccessContext *ta_context, TA_key *key,
     const std::string &rule_name) noexcept {
   my_service<SERVICE_TYPE(table_access_index_v1)> index_srv(
-      "table_access_index_v1", SysVars::get_comp_regystry_srv());
+      "table_access_index_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv(
-      "mysql_charset", SysVars::get_comp_regystry_srv());
+      "mysql_charset", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_factory)> string_srv(
-      "mysql_string_factory", SysVars::get_comp_regystry_srv());
+      "mysql_string_factory", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_charset_converter)> string_convert_srv(
-      "mysql_string_charset_converter", SysVars::get_comp_regystry_srv());
+      "mysql_string_charset_converter", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_varchar_access_v1)> varchar_srv(
-      "field_varchar_access_v1", SysVars::get_comp_regystry_srv());
+      "field_varchar_access_v1", SysVars::get_comp_registry_srv());
 
   if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
                       kKeyFilterNameName, kKeyFilterNameNameLength,
@@ -109,7 +109,7 @@ void AuditLogFilter::index_scan_end(TableAccessContext *ta_context,
                                     TA_key key) noexcept {
   if (key != nullptr) {
     my_service<SERVICE_TYPE(table_access_index_v1)> index_srv(
-        "table_access_index_v1", SysVars::get_comp_regystry_srv());
+        "table_access_index_v1", SysVars::get_comp_registry_srv());
     index_srv->end(ta_context->ta_session, ta_context->ta_table, key);
   }
 }
@@ -120,9 +120,9 @@ TableResult AuditLogFilter::get_next_pk_value(TableAccessContext *ta_context,
   next_pk = 1;
 
   my_service<SERVICE_TYPE(table_access_index_v1)> index_srv(
-      "table_access_index_v1", SysVars::get_comp_regystry_srv());
+      "table_access_index_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_integer_access_v1)> integer_srv(
-      "field_integer_access_v1", SysVars::get_comp_regystry_srv());
+      "field_integer_access_v1", SysVars::get_comp_registry_srv());
 
   if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
                       kKeyFilterPrimaryName, kKeyFilterPrimaryNameLength,
@@ -173,19 +173,19 @@ TableResult AuditLogFilter::load_filters(
   }
 
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv(
-      "mysql_charset", SysVars::get_comp_regystry_srv());
+      "mysql_charset", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_factory)> string_srv(
-      "mysql_string_factory", SysVars::get_comp_regystry_srv());
+      "mysql_string_factory", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_charset_converter)> string_convert_srv(
-      "mysql_string_charset_converter", SysVars::get_comp_regystry_srv());
+      "mysql_string_charset_converter", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_varchar_access_v1)> varchar_srv(
-      "field_varchar_access_v1", SysVars::get_comp_regystry_srv());
+      "field_varchar_access_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_integer_access_v1)> integer_srv(
-      "field_integer_access_v1", SysVars::get_comp_regystry_srv());
+      "field_integer_access_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_scan_v1)> scan_srv(
-      "table_access_scan_v1", SysVars::get_comp_regystry_srv());
+      "table_access_scan_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_any_access_v1)> any_srv(
-      "field_any_access_v1", SysVars::get_comp_regystry_srv());
+      "field_any_access_v1", SysVars::get_comp_registry_srv());
 
   if (scan_srv->init(ta_context->ta_session, ta_context->ta_table)) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -296,19 +296,19 @@ TableResult AuditLogFilter::insert_filter(
   }
 
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv(
-      "mysql_charset", SysVars::get_comp_regystry_srv());
+      "mysql_charset", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_factory)> string_srv(
-      "mysql_string_factory", SysVars::get_comp_regystry_srv());
+      "mysql_string_factory", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_charset_converter)> string_convert_srv(
-      "mysql_string_charset_converter", SysVars::get_comp_regystry_srv());
+      "mysql_string_charset_converter", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_varchar_access_v1)> varchar_srv(
-      "field_varchar_access_v1", SysVars::get_comp_regystry_srv());
+      "field_varchar_access_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_integer_access_v1)> integer_srv(
-      "field_integer_access_v1", SysVars::get_comp_regystry_srv());
+      "field_integer_access_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_update_v1)> table_update_srv(
-      "table_access_update_v1", SysVars::get_comp_regystry_srv());
+      "table_access_update_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_v1)> table_access_srv(
-      "table_access_v1", SysVars::get_comp_regystry_srv());
+      "table_access_v1", SysVars::get_comp_registry_srv());
 
   CHARSET_INFO_h utf8 = charset_srv->get_utf8mb4();
   HStringContainer filter_name_value{string_srv};
@@ -371,9 +371,9 @@ TableResult AuditLogFilter::delete_filter(
   }
 
   my_service<SERVICE_TYPE(table_access_update_v1)> table_update_srv(
-      "table_access_update_v1", SysVars::get_comp_regystry_srv());
+      "table_access_update_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_v1)> table_access_srv(
-      "table_access_v1", SysVars::get_comp_regystry_srv());
+      "table_access_v1", SysVars::get_comp_registry_srv());
 
   auto rc = table_update_srv->delete_row(ta_context->ta_session,
                                          ta_context->ta_table);

--- a/plugin/audit_log_filter/audit_table/audit_log_user.cc
+++ b/plugin/audit_log_filter/audit_table/audit_log_user.cc
@@ -71,15 +71,15 @@ TableResult AuditLogUser::index_scan_locate_record_by_rule_name(
     TableAccessContext *ta_context, TA_key *key,
     const std::string &rule_name) noexcept {
   my_service<SERVICE_TYPE(table_access_index_v1)> index_srv(
-      "table_access_index_v1", SysVars::get_comp_regystry_srv());
+      "table_access_index_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv(
-      "mysql_charset", SysVars::get_comp_regystry_srv());
+      "mysql_charset", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_factory)> string_srv(
-      "mysql_string_factory", SysVars::get_comp_regystry_srv());
+      "mysql_string_factory", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_charset_converter)> string_convert_srv(
-      "mysql_string_charset_converter", SysVars::get_comp_regystry_srv());
+      "mysql_string_charset_converter", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_varchar_access_v1)> varchar_srv(
-      "field_varchar_access_v1", SysVars::get_comp_regystry_srv());
+      "field_varchar_access_v1", SysVars::get_comp_registry_srv());
 
   if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
                       kKeyFilterNameName, kKeyFilterNameNameLength,
@@ -108,15 +108,15 @@ TableResult AuditLogUser::index_scan_locate_record_by_user_name_host(
     TableAccessContext *ta_context, TA_key *key, const std::string &user_name,
     const std::string &user_host) noexcept {
   my_service<SERVICE_TYPE(table_access_index_v1)> index_srv(
-      "table_access_index_v1", SysVars::get_comp_regystry_srv());
+      "table_access_index_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv(
-      "mysql_charset", SysVars::get_comp_regystry_srv());
+      "mysql_charset", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_factory)> string_srv(
-      "mysql_string_factory", SysVars::get_comp_regystry_srv());
+      "mysql_string_factory", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_charset_converter)> string_convert_srv(
-      "mysql_string_charset_converter", SysVars::get_comp_regystry_srv());
+      "mysql_string_charset_converter", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_varchar_access_v1)> varchar_srv(
-      "field_varchar_access_v1", SysVars::get_comp_regystry_srv());
+      "field_varchar_access_v1", SysVars::get_comp_registry_srv());
 
   if (index_srv->init(ta_context->ta_session, ta_context->ta_table,
                       kKeyPrimaryName, kKeyPrimaryLength, key_primary_cols,
@@ -152,7 +152,7 @@ void AuditLogUser::index_scan_end(TableAccessContext *ta_context,
                                   TA_key key) noexcept {
   if (key != nullptr) {
     my_service<SERVICE_TYPE(table_access_index_v1)> index_srv(
-        "table_access_index_v1", SysVars::get_comp_regystry_srv());
+        "table_access_index_v1", SysVars::get_comp_registry_srv());
     index_srv->end(ta_context->ta_session, ta_context->ta_table, key);
   }
 }
@@ -170,15 +170,15 @@ TableResult AuditLogUser::load_users(AuditUsersContainer &container) noexcept {
   }
 
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv(
-      "mysql_charset", SysVars::get_comp_regystry_srv());
+      "mysql_charset", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_factory)> string_srv(
-      "mysql_string_factory", SysVars::get_comp_regystry_srv());
+      "mysql_string_factory", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_charset_converter)> string_convert_srv(
-      "mysql_string_charset_converter", SysVars::get_comp_regystry_srv());
+      "mysql_string_charset_converter", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_varchar_access_v1)> varchar_srv(
-      "field_varchar_access_v1", SysVars::get_comp_regystry_srv());
+      "field_varchar_access_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_scan_v1)> scan_srv(
-      "table_access_scan_v1", SysVars::get_comp_regystry_srv());
+      "table_access_scan_v1", SysVars::get_comp_registry_srv());
 
   if (scan_srv->init(ta_context->ta_session, ta_context->ta_table)) {
     LogPluginErrMsg(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
@@ -268,11 +268,11 @@ TableResult AuditLogUser::delete_user_by_filter(
   }
 
   my_service<SERVICE_TYPE(table_access_index_v1)> index_srv(
-      "table_access_index_v1", SysVars::get_comp_regystry_srv());
+      "table_access_index_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_update_v1)> table_update_srv(
-      "table_access_update_v1", SysVars::get_comp_regystry_srv());
+      "table_access_update_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_v1)> table_access_srv(
-      "table_access_v1", SysVars::get_comp_regystry_srv());
+      "table_access_v1", SysVars::get_comp_registry_srv());
 
   int rc = 0;
   while (rc == 0) {
@@ -324,9 +324,9 @@ TableResult AuditLogUser::delete_user_by_name_host(
   }
 
   my_service<SERVICE_TYPE(table_access_update_v1)> table_update_srv(
-      "table_access_update_v1", SysVars::get_comp_regystry_srv());
+      "table_access_update_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_v1)> table_access_srv(
-      "table_access_v1", SysVars::get_comp_regystry_srv());
+      "table_access_v1", SysVars::get_comp_registry_srv());
 
   if (scan_result == TableResult::Found &&
       table_update_srv->delete_row(ta_context->ta_session,
@@ -373,17 +373,17 @@ TableResult AuditLogUser::set_update_filter(
   }
 
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv(
-      "mysql_charset", SysVars::get_comp_regystry_srv());
+      "mysql_charset", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_factory)> string_srv(
-      "mysql_string_factory", SysVars::get_comp_regystry_srv());
+      "mysql_string_factory", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(mysql_string_charset_converter)> string_convert_srv(
-      "mysql_string_charset_converter", SysVars::get_comp_regystry_srv());
+      "mysql_string_charset_converter", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(field_varchar_access_v1)> varchar_srv(
-      "field_varchar_access_v1", SysVars::get_comp_regystry_srv());
+      "field_varchar_access_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_update_v1)> table_update_srv(
-      "table_access_update_v1", SysVars::get_comp_regystry_srv());
+      "table_access_update_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_v1)> table_access_srv(
-      "table_access_v1", SysVars::get_comp_regystry_srv());
+      "table_access_v1", SysVars::get_comp_registry_srv());
 
   CHARSET_INFO_h utf8 = charset_srv->get_utf8mb4();
   HStringContainer filter_name_value{string_srv};

--- a/plugin/audit_log_filter/audit_table/base.cc
+++ b/plugin/audit_log_filter/audit_table/base.cc
@@ -33,7 +33,7 @@ TableAccessContext::~TableAccessContext() {
 
   if (ta_session != nullptr) {
     my_service<SERVICE_TYPE(table_access_factory_v1)> ta_factory_srv(
-        "table_access_factory_v1", SysVars::get_comp_regystry_srv());
+        "table_access_factory_v1", SysVars::get_comp_registry_srv());
     ta_factory_srv->destroy(ta_session);
     ta_session = nullptr;
   }
@@ -51,11 +51,11 @@ std::unique_ptr<TableAccessContext> AuditTableBase::open_table() noexcept {
   }
 
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
-      "mysql_current_thread_reader", SysVars::get_comp_regystry_srv());
+      "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_factory_v1)> ta_factory_srv(
-      "table_access_factory_v1", SysVars::get_comp_regystry_srv());
+      "table_access_factory_v1", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(table_access_v1)> table_access_srv(
-      "table_access_v1", SysVars::get_comp_regystry_srv());
+      "table_access_v1", SysVars::get_comp_registry_srv());
 
   thd_reader_srv->get(&ta_context->thd);
 

--- a/plugin/audit_log_filter/audit_udf.cc
+++ b/plugin/audit_log_filter/audit_udf.cc
@@ -136,7 +136,7 @@ std::unique_ptr<UserNameInfo> check_parse_user_name_host(
 }
 
 bool has_audit_admin_privilege(char *message) {
-  const auto *reg_srv = SysVars::get_comp_regystry_srv();
+  const auto *reg_srv = SysVars::get_comp_registry_srv();
 
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
       "mysql_current_thread_reader", reg_srv);
@@ -192,7 +192,7 @@ AuditUdf::~AuditUdf() { deinit(); }
 
 bool AuditUdf::init(UdfFuncInfo *begin, UdfFuncInfo *end) {
   my_service<SERVICE_TYPE(udf_registration)> udf_registration_srv(
-      "udf_registration", SysVars::get_comp_regystry_srv());
+      "udf_registration", SysVars::get_comp_registry_srv());
 
   for (UdfFuncInfo *it = begin; it != end; ++it) {
     if (udf_registration_srv->udf_register(it->udf_name, STRING_RESULT,
@@ -213,7 +213,7 @@ void AuditUdf::deinit() noexcept {
   if (!m_active_udf_names.empty()) {
     int was_present = 0;
     my_service<SERVICE_TYPE(udf_registration)> udf_registration_srv(
-        "udf_registration", SysVars::get_comp_regystry_srv());
+        "udf_registration", SysVars::get_comp_registry_srv());
 
     for (const auto &name : m_active_udf_names) {
       udf_registration_srv->udf_unregister(name.c_str(), &was_present);
@@ -786,7 +786,7 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
   *error = 0;
 
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
-      "mysql_current_thread_reader", SysVars::get_comp_regystry_srv());
+      "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
 
   MYSQL_THD thd;
 
@@ -964,7 +964,7 @@ char *AuditUdf::audit_log_read_udf(AuditUdf *udf [[maybe_unused]],
 
 void AuditUdf::audit_log_read_udf_deinit(UDF_INIT *initid [[maybe_unused]]) {
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
-      "mysql_current_thread_reader", SysVars::get_comp_regystry_srv());
+      "mysql_current_thread_reader", SysVars::get_comp_registry_srv());
 
   MYSQL_THD thd;
 
@@ -1262,7 +1262,7 @@ void AuditUdf::audit_log_encryption_password_set_udf_deinit(UDF_INIT *) {}
 bool AuditUdf::set_return_value_charset(
     UDF_INIT *initid, const std::string &charset_name) noexcept {
   my_service<SERVICE_TYPE(mysql_udf_metadata)> udf_metadata_srv(
-      "mysql_udf_metadata", SysVars::get_comp_regystry_srv());
+      "mysql_udf_metadata", SysVars::get_comp_registry_srv());
   char *charset = const_cast<char *>(charset_name.c_str());
   return !udf_metadata_srv->result_set(initid, "charset",
                                        static_cast<void *>(charset));
@@ -1271,7 +1271,7 @@ bool AuditUdf::set_return_value_charset(
 bool AuditUdf::set_args_charset(UDF_ARGS *udf_args,
                                 const std::string &charset_name) noexcept {
   my_service<SERVICE_TYPE(mysql_udf_metadata)> udf_metadata_srv(
-      "mysql_udf_metadata", SysVars::get_comp_regystry_srv());
+      "mysql_udf_metadata", SysVars::get_comp_registry_srv());
   char *charset = const_cast<char *>(charset_name.c_str());
   for (uint index = 0; index < udf_args->arg_count; ++index) {
     if (udf_args->arg_type[index] == STRING_RESULT &&

--- a/plugin/audit_log_filter/event_field_action/print_query_attrs.cc
+++ b/plugin/audit_log_filter/event_field_action/print_query_attrs.cc
@@ -43,7 +43,7 @@ bool EventFieldActionPrintQueryAttrs::apply(const AuditRecordFieldsList &fields
                                             AuditRecordVariant &audit_record,
                                             AuditRule *audit_rule
                                             [[maybe_unused]]) const noexcept {
-  auto *comp_reg_srv = SysVars::get_comp_regystry_srv();
+  auto *comp_reg_srv = SysVars::get_comp_registry_srv();
 
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
       "mysql_current_thread_reader", comp_reg_srv);

--- a/plugin/audit_log_filter/event_field_action/print_service_comp.cc
+++ b/plugin/audit_log_filter/event_field_action/print_service_comp.cc
@@ -52,7 +52,7 @@ bool EventFieldActionPrintServiceComp::apply(const AuditRecordFieldsList &fields
                                              AuditRecordVariant &audit_record,
                                              AuditRule *audit_rule
                                              [[maybe_unused]]) const noexcept {
-  auto *comp_reg_srv = SysVars::get_comp_regystry_srv();
+  auto *comp_reg_srv = SysVars::get_comp_registry_srv();
 
   my_service<SERVICE_TYPE(mysql_current_thread_reader)> thd_reader_srv(
       "mysql_current_thread_reader", comp_reg_srv);

--- a/plugin/audit_log_filter/event_filter_function/query_digest.cc
+++ b/plugin/audit_log_filter/event_filter_function/query_digest.cc
@@ -45,7 +45,7 @@ bool EventFilterFunctionQueryDigest::validate_args(
 }
 
 std::string EventFilterFunctionQueryDigest::get_query_digest() const noexcept {
-  auto *comp_registry_srv = SysVars::get_comp_regystry_srv();
+  auto *comp_registry_srv = SysVars::get_comp_registry_srv();
 
   my_service<SERVICE_TYPE(mysql_charset)> charset_srv("mysql_charset",
                                                       comp_registry_srv);

--- a/plugin/audit_log_filter/sys_vars.cc
+++ b/plugin/audit_log_filter/sys_vars.cc
@@ -69,6 +69,7 @@ std::atomic<uint64_t> record_id{0};
 LogBookmark log_bookmark;
 std::string encryption_options_id;
 bool log_encryption_enabled{false};
+comp_registry_srv_container_t comp_registry_srv;
 
 /*
  * Status variables
@@ -904,9 +905,19 @@ std::string SysVars::get_encryption_options_id() noexcept {
   return encryption_options_id;
 }
 
-decltype(get_component_registry_service().get())
-SysVars::get_comp_registry_srv() noexcept {
-  static auto comp_registry_srv = get_component_registry_service();
+comp_registry_srv_t *SysVars::acquire_comp_registry_srv() noexcept {
+  assert(comp_registry_srv == nullptr);
+  comp_registry_srv = get_component_registry_service();
+  return comp_registry_srv.get();
+}
+
+void SysVars::release_comp_registry_srv() noexcept {
+  assert(comp_registry_srv != nullptr);
+  comp_registry_srv.reset();
+}
+
+comp_registry_srv_t *SysVars::get_comp_registry_srv() noexcept {
+  assert(comp_registry_srv != nullptr);
   return comp_registry_srv.get();
 }
 

--- a/plugin/audit_log_filter/sys_vars.cc
+++ b/plugin/audit_log_filter/sys_vars.cc
@@ -41,9 +41,9 @@ const size_t kMaxDbNameLength = 64;
 
 bool has_system_variables_privilege(MYSQL_THD thd) {
   my_service<SERVICE_TYPE(mysql_thd_security_context)> security_context_service(
-      "mysql_thd_security_context", SysVars::get_comp_regystry_srv());
+      "mysql_thd_security_context", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(global_grants_check)> grants_check_service(
-      "global_grants_check", SysVars::get_comp_regystry_srv());
+      "global_grants_check", SysVars::get_comp_registry_srv());
 
   bool has_audit_admin_grant = false;
   bool has_system_variables_admin_grant = false;
@@ -499,9 +499,9 @@ MYSQL_SYSVAR_ENUM(encryption, log_encryption_type,
 int password_history_keep_days_check_func(MYSQL_THD thd, SYS_VAR *var,
                                           void *save, st_mysql_value *value) {
   my_service<SERVICE_TYPE(mysql_thd_security_context)> security_context_service(
-      "mysql_thd_security_context", SysVars::get_comp_regystry_srv());
+      "mysql_thd_security_context", SysVars::get_comp_registry_srv());
   my_service<SERVICE_TYPE(global_grants_check)> grants_check_service(
-      "global_grants_check", SysVars::get_comp_regystry_srv());
+      "global_grants_check", SysVars::get_comp_registry_srv());
 
   bool has_audit_admin_grant = false;
 
@@ -677,7 +677,7 @@ bool SysVars::validate() noexcept {
   }
 
   my_service<SERVICE_TYPE(system_variable_source)> sysvar_source_service(
-      "system_variable_source", SysVars::get_comp_regystry_srv());
+      "system_variable_source", SysVars::get_comp_registry_srv());
 
   enum_variable_source log_max_size_source;
 
@@ -905,7 +905,7 @@ std::string SysVars::get_encryption_options_id() noexcept {
 }
 
 decltype(get_component_registry_service().get())
-SysVars::get_comp_regystry_srv() noexcept {
+SysVars::get_comp_registry_srv() noexcept {
   static auto comp_registry_srv = get_component_registry_service();
   return comp_registry_srv.get();
 }

--- a/plugin/audit_log_filter/sys_vars.h
+++ b/plugin/audit_log_filter/sys_vars.h
@@ -397,12 +397,23 @@ class SysVars {
   static std::string get_encryption_options_id() noexcept;
 
   /**
+   * @brief Acquire component registry service.
+   *
+   * @return component registry service instance
+   */
+  static comp_registry_srv_t *acquire_comp_registry_srv() noexcept;
+
+  /**
+   * @brief Release component registry service.
+   */
+  static void release_comp_registry_srv() noexcept;
+
+  /**
    * @brief Get component registry service instance.
    *
    * @return component registry service instance
    */
-  static decltype(get_component_registry_service().get())
-  get_comp_registry_srv() noexcept;
+  static comp_registry_srv_t *get_comp_registry_srv() noexcept;
 };
 
 }  // namespace audit_log_filter

--- a/plugin/audit_log_filter/sys_vars.h
+++ b/plugin/audit_log_filter/sys_vars.h
@@ -402,7 +402,7 @@ class SysVars {
    * @return component registry service instance
    */
   static decltype(get_component_registry_service().get())
-  get_comp_regystry_srv() noexcept;
+  get_comp_registry_srv() noexcept;
 };
 
 }  // namespace audit_log_filter

--- a/plugin/audit_log_filter/tests/mtr/t/audit_api_message_emit.test
+++ b/plugin/audit_log_filter/tests/mtr/t/audit_api_message_emit.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 SET GLOBAL DEBUG='+d,audit_log_filter_add_record_debug_info';
 

--- a/plugin/audit_log_filter/tests/mtr/t/encryption_password_history.test
+++ b/plugin/audit_log_filter/tests/mtr/t/encryption_password_history.test
@@ -1,3 +1,4 @@
+--source include/have_debug.inc
 --source include/have_component_keyring_file.inc
 --source suite/component_keyring_file/inc/setup_component.inc
 

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_by_class.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_by_class.test
@@ -1,6 +1,5 @@
 
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_by_field.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_by_field.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_by_subclass.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_by_subclass.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_inclusive_exclusive.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_filter_inclusive_exclusive.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_function_query_digest.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_function_query_digest.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_function_string_find.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_function_string_find.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_replace_field.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_replace_field.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/filter_definition_replace_filter.test
+++ b/plugin/audit_log_filter/tests/mtr/t/filter_definition_replace_filter.test
@@ -1,5 +1,4 @@
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`

--- a/plugin/audit_log_filter/tests/mtr/t/percona_bug_ps8719.test
+++ b/plugin/audit_log_filter/tests/mtr/t/percona_bug_ps8719.test
@@ -1,6 +1,5 @@
 # PS-8719: Audit log plugin stalls on flush
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 SELECT audit_log_filter_set_filter('log_all', '{"filter": {"log": true}}');
 SELECT audit_log_filter_set_user('%', 'log_all');

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_encryption_password_operations.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_encryption_password_operations.test
@@ -1,3 +1,4 @@
+--source include/have_debug.inc
 --source include/have_component_keyring_file.inc
 --source suite/component_keyring_file/inc/setup_component.inc
 

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_flush.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_flush.test
@@ -1,6 +1,5 @@
 
 --source include/have_debug.inc
---source include/have_debug_sync.inc
 
 SET GLOBAL DEBUG='+d,audit_log_filter_add_record_debug_info';
 SET GLOBAL DEBUG='+d,audit_log_filter_rotate_after_audit_rules_flush';

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_remove_filter.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_remove_filter.test
@@ -1,3 +1,5 @@
+--source include/have_debug.inc
+
 --echo #
 --echo # Check wrong argument number
 --error 1123

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_remove_user.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_remove_user.test
@@ -1,3 +1,5 @@
+--source include/have_debug.inc
+
 --echo #
 --echo # Check wrong argument number
 --error 1123

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_set_filter.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_set_filter.test
@@ -1,3 +1,5 @@
+--source include/have_debug.inc
+
 --echo #
 --echo # Check wrong argument number
 --error 1123

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_set_user.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_filter_set_user.test
@@ -1,3 +1,5 @@
+--source include/have_debug.inc
+
 --echo #
 --echo # Check wrong argument number
 --error 1123

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_read_bookmark.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_read_bookmark.test
@@ -1,3 +1,4 @@
+--source include/have_debug.inc
 
 --echo #
 --echo # Check wrong argument number

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_read_multiple_files.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_read_multiple_files.test
@@ -1,1 +1,2 @@
+--source include/have_debug.inc
 --source udf_audit_log_read_multiple_files_base.inc

--- a/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_read_multiple_files_encrypted.test
+++ b/plugin/audit_log_filter/tests/mtr/t/udf_audit_log_read_multiple_files_encrypted.test
@@ -1,3 +1,4 @@
+--source include/have_debug.inc
 --source include/have_component_keyring_file.inc
 --source suite/component_keyring_file/inc/setup_component.inc
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8042

- Fix logging component init/deinit
- Skip some MTRs requering debug facilities when running for release build
- Remove unnecessary have_debug_sync.inc usages
- Fix typo in method name
- Fix registry srv reloading during plugin re-installation