### PR TITLE
PS-8844: Fix compiler version checks in Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -481,14 +481,15 @@ jobs:
         -DWITH_PAM=ON
       "
 
-      if [[ ( "$(Compiler)" == "gcc" ) && ( $(bc <<< "$(CompilerVer) < 8.1") -eq 1 ) ]]; then
+      function get_ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+      if [[ ( "$(Compiler)" == "gcc" ) && ( 10#$(get_ver $REAL_COMPILER_VER) -lt 10#$(get_ver 8.1.0) ) ]]; then
         CMAKE_OPT+="
           -DWITH_ROUTER=OFF
           -DWITH_PERCONA_AUDIT_LOG_FILTER=OFF
         "
       fi
 
-      if [[ ( "$(Compiler)" == "clang" ) && ( $(bc <<< "$(CompilerVer) < 7") -eq 1 ) ]]; then
+      if [[ ( "$(Compiler)" == "clang" ) && ( 10#$(get_ver $REAL_COMPILER_VER) -lt 10#$(get_ver 7.0.0) ) ]]; then
         CMAKE_OPT+="
           -DWITH_PERCONA_AUDIT_LOG_FILTER=OFF
         "


### PR DESCRIPTION
1. Use `$REAL_COMPILER_VER` instead of `$(CompilerVer)`.
2. The method using `bc <<< "$(CompilerVer)` works only with 2 digits (e.g. `7.4`). It doesn't work with 3+ digits (e.g. `7.4.1`).