### PR TITLE
PS-8849 : Unexpected hitting Assertion failure: row0mysql.cc:218:len …

### DIFF
--- a/mysql-test/suite/innodb/r/multi_value_basic.result
+++ b/mysql-test/suite/innodb/r/multi_value_basic.result
@@ -1222,3 +1222,27 @@ INSERT INTO t1 VALUES (1);
 INSERT INTO t2 (data) VALUES ('{\"parentID\":1,\"idArray\":[1]}');
 DELETE FROM t1 WHERE id = 1;
 DROP TABLE t2,t1;
+#
+# PS-8849 'Unexpected hitting Assertion failure: row0mysql.cc:218:len < 256 * 256 thread'
+#
+CREATE TABLE t1 (id INT, a JSON DEFAULT NULL,
+KEY a ((CAST(a AS CHAR(255) ARRAY)))
+) PARTITION BY HASH(id) PARTITIONS 4;
+INSERT INTO t1 (id, a) VALUES (1, JSON_ARRAY('session', '1'));
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN;
+SELECT COUNT(*) FROM t1;
+COUNT(*)
+1
+connect  con1, localhost, root,,;
+UPDATE t1 SET a = JSON_ARRAY('session', '2') WHERE id = 1;
+connection default;
+SELECT a FROM t1 WHERE ('session' MEMBER OF (a));
+a
+["session", "1"]
+connection con1;
+COMMIT;
+# Clean-up.
+disconnect con1;
+connection default;
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/multi_value_basic.test
+++ b/mysql-test/suite/innodb/t/multi_value_basic.test
@@ -985,4 +985,33 @@ INSERT INTO t2 (data) VALUES ('{\"parentID\":1,\"idArray\":[1]}');
 DELETE FROM t1 WHERE id = 1;
 DROP TABLE t2,t1;
 
+--echo #
+--echo # PS-8849 'Unexpected hitting Assertion failure: row0mysql.cc:218:len < 256 * 256 thread'
+--echo #
+CREATE TABLE t1 (id INT, a JSON DEFAULT NULL,
+                 KEY a ((CAST(a AS CHAR(255) ARRAY)))
+) PARTITION BY HASH(id) PARTITIONS 4;
+INSERT INTO t1 (id, a) VALUES (1, JSON_ARRAY('session', '1'));
+
+SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+BEGIN;
+SELECT COUNT(*) FROM t1;
+
+--enable_connect_log
+--connect (con1, localhost, root,,)
+UPDATE t1 SET a = JSON_ARRAY('session', '2') WHERE id = 1;
+
+--connection default
+SELECT a FROM t1 WHERE ('session' MEMBER OF (a));
+
+--connection con1
+COMMIT;
+
+--echo # Clean-up.
+--disconnect con1
+
+--connection default
+--disable_connect_log
+DROP TABLE t1;
+
 --source include/wait_until_count_sessions.inc

--- a/storage/innobase/handler/ha_innopart.cc
+++ b/storage/innobase/handler/ha_innopart.cc
@@ -1516,8 +1516,11 @@ int ha_innopart::index_init(uint keynr, bool sorted) {
     m_prebuilt->m_no_prefetch = true;
   }
 
-  /* For scan across partitions, the keys needs to be materialized */
-  m_prebuilt->m_read_virtual_key = true;
+  /* For scan across partitions, the keys needs to be materialized.
+  Multi-value indexes do not support ordering and should not be materialized
+  though. */
+  if (!(table_share->key_info[keynr].flags & HA_MULTI_VALUED_KEY))
+    m_prebuilt->m_read_virtual_key = true;
 
   error = change_active_index(part_id, keynr);
   if (error != 0) {


### PR DESCRIPTION
…< 256 * 256 thread.

https://jira.percona.com/browse/PS-8849

Concurrent execution of repeatable-read transactions with queries to a partitioned InnoDB table which used multi-value keys and statements which updated or deleted rows in this table sometimes led to assertion failure.

This assertion failure occurred when transaction with such a query tried to reconstruct older version of row from undo log in order to adhere transaction isolation level rules. For partitioned tables such reconstruction also always involved restoring from undo log value of virtual column for multi-value key. The latter was enforced for all virtual keys by InnoDB partitioning handler code in order to be able to sort records coming from different partitions according to key value. However, for multi-value keys such reconstruction from undo is not done correctly, which resulted in assertion failure.

However, for multi-value keys such reconstruction forced by partitioning doesn't make sense as they can't be used for sorting. So this patch solves the problem by disabling such reconstruction in case of multi-value keys.