### PR TITLE
PS-8848: Make connection control plugin more verbose

### DIFF
--- a/plugin/connection_control/CMakeLists.txt
+++ b/plugin/connection_control/CMakeLists.txt
@@ -25,6 +25,7 @@ MYSQL_ADD_PLUGIN(connection_control
   connection_control.cc
   security_context_wrapper.cc
   connection_delay.cc
+  log_rate_limiter.cc
   MODULE_ONLY
   LINK_LIBRARIES extra::rapidjson
   )

--- a/plugin/connection_control/connection_control.cc
+++ b/plugin/connection_control/connection_control.cc
@@ -47,6 +47,13 @@ class Connection_control_error_handler : public Error_handler {
     LogPluginErrV(ERROR_LEVEL, errcode, vl);
     va_end(vl);
   }
+
+  void handle_info(longlong errcode, ...) override {
+    va_list vl;
+    va_start(vl, errcode);
+    LogPluginErrV(INFORMATION_LEVEL, errcode, vl);
+    va_end(vl);
+  }
 };
 }  // namespace connection_control
 

--- a/plugin/connection_control/connection_control_interfaces.h
+++ b/plugin/connection_control/connection_control_interfaces.h
@@ -39,6 +39,7 @@ class Connection_event_coordinator_services;
 class Error_handler {
  public:
   virtual void handle_error(longlong errcode, ...) = 0;
+  virtual void handle_info(longlong errcode, ...) = 0;
   virtual ~Error_handler() = default;
 };
 

--- a/plugin/connection_control/connection_delay.cc
+++ b/plugin/connection_control/connection_delay.cc
@@ -557,6 +557,10 @@ bool Connection_delay_action::notify_event(
       error_handler->handle_error(
           ER_CONN_CONTROL_STAT_CONN_DELAY_TRIGGERED_UPDATE_FAILED);
     }
+
+    m_log_rate_limiter.report_delayed_connection(
+        userhost, current_count == threshold, error_handler);
+
     /*
       Invoking sleep while holding read lock on Connection_delay_action
       would block access to cache data through IS table.

--- a/plugin/connection_control/connection_delay.h
+++ b/plugin/connection_control/connection_delay.h
@@ -33,6 +33,7 @@
 #include "plugin/connection_control/connection_control_interfaces.h" /* Observer interface */
 #include "plugin/connection_control/connection_control_memory.h" /* Connection_control_alloc */
 #include "plugin/connection_control/connection_delay_api.h" /* Constants */
+#include "plugin/connection_control/log_rate_limiter.h"
 #include "sql/table.h"                                      /* Table_ref */
 
 namespace connection_control {
@@ -236,6 +237,8 @@ class Connection_delay_action : public Connection_event_observer,
   Connection_delay_event m_userhost_hash;
   /** RW lock */
   mysql_rwlock_t *m_lock;
+  /** Log messages rate limit handling object **/
+  LogRateLimiter m_log_rate_limiter;
 };
 }  // namespace connection_control
 #endif /* !CONNECTION_DELAY_H */

--- a/plugin/connection_control/log_rate_limiter.cc
+++ b/plugin/connection_control/log_rate_limiter.cc
@@ -1,0 +1,87 @@
+/* Copyright (c) 2023 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include "log_rate_limiter.h"
+
+#include "mysqld_error.h"
+
+#include <chrono>
+
+namespace {
+
+constexpr uint64_t RATE_LIMIT_INTERVAL_SECONDS = 60;
+constexpr uint64_t RATE_LIMIT_MESSAGES_PER_INTERVAL = 2;
+
+}  // namespace
+
+namespace connection_control {
+
+LogRateLimiter::LogRateLimiter()
+    : m_sent_messages_per_interval_count{0},
+      m_delayed_connections_per_interval_count{0},
+      m_interval_start_timestamp{static_cast<uint64_t>(
+          std::chrono::duration_cast<std::chrono::seconds>(
+              std::chrono::system_clock::now().time_since_epoch())
+              .count())} {}
+
+void LogRateLimiter::report_delayed_connection(
+    const Sql_string &user_host, bool is_threshold_crossed,
+    Error_handler *error_handler) noexcept {
+  const uint64_t timestamp_now =
+      std::chrono::duration_cast<std::chrono::seconds>(
+          std::chrono::system_clock::now().time_since_epoch())
+          .count();
+
+  if (timestamp_now - m_interval_start_timestamp >
+      RATE_LIMIT_INTERVAL_SECONDS) {
+    if (m_delayed_connections_per_interval_count > 0 &&
+        m_delayed_connections_per_interval_count >
+            m_sent_messages_per_interval_count) {
+      error_handler->handle_info(
+          ER_CONN_CONTROL_DELAYED_CONN_STATS,
+          static_cast<unsigned long long>(
+              m_delayed_connections_per_interval_count),
+          static_cast<unsigned long long>(timestamp_now -
+                                          m_interval_start_timestamp));
+    }
+
+    m_interval_start_timestamp = timestamp_now;
+    m_sent_messages_per_interval_count = 0;
+    m_delayed_connections_per_interval_count = 0;
+  }
+
+  m_delayed_connections_per_interval_count++;
+
+  if (is_threshold_crossed &&
+      m_sent_messages_per_interval_count < RATE_LIMIT_MESSAGES_PER_INTERVAL) {
+    m_sent_messages_per_interval_count++;
+
+    if (m_sent_messages_per_interval_count >=
+        RATE_LIMIT_MESSAGES_PER_INTERVAL) {
+      const auto remaining_interval_seconds =
+          RATE_LIMIT_INTERVAL_SECONDS -
+          (timestamp_now - m_interval_start_timestamp);
+      error_handler->handle_info(
+          ER_CONN_CONTROL_FAILED_CONN_THRESHOLD_REACHED_WITH_WARN,
+          user_host.c_str(),
+          static_cast<unsigned long long>(remaining_interval_seconds));
+    } else {
+      error_handler->handle_info(ER_CONN_CONTROL_FAILED_CONN_THRESHOLD_REACHED,
+                                 user_host.c_str());
+    }
+  }
+}
+
+}  // namespace connection_control

--- a/plugin/connection_control/log_rate_limiter.h
+++ b/plugin/connection_control/log_rate_limiter.h
@@ -1,0 +1,41 @@
+/* Copyright (c) 2023 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef LOG_RATE_LIMITER_H
+#define LOG_RATE_LIMITER_H
+
+#include "connection_control_interfaces.h"
+
+#include <atomic>
+
+namespace connection_control {
+
+class LogRateLimiter {
+ public:
+  LogRateLimiter();
+
+  void report_delayed_connection(const Sql_string &user_host,
+                                 bool is_threshold_crossed,
+                                 Error_handler *error_handler) noexcept;
+
+ private:
+  uint m_sent_messages_per_interval_count;
+  uint64_t m_delayed_connections_per_interval_count;
+  uint64_t m_interval_start_timestamp;
+};
+
+}  // namespace connection_control
+
+#endif  // LOG_RATE_LIMITER_H

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -12382,6 +12382,15 @@ ER_GRP_RPL_FLOW_CONTROL_TIMEOUT
 ER_PERCONA_IGNORE_TMP_TABLE_SIZE
   eng "Tmp_table_size is set below 1MiB. The TEMPTABLE engine requires at least 1MiB table size, and will use that value instead. Please increase the limit to silence this warning."
 
+ER_CONN_CONTROL_FAILED_CONN_THRESHOLD_REACHED
+  eng "Failing connection attempts threshold reached for %s"
+
+ER_CONN_CONTROL_FAILED_CONN_THRESHOLD_REACHED_WITH_WARN
+  eng "Failing connection attempts threshold reached for %s, further messages will be suppressed for next %llu seconds"
+
+ER_CONN_CONTROL_DELAYED_CONN_STATS
+  eng "Delayed %llu connection attempts during last %llu seconds"
+
 #
 # End of Percona Server 8.0 server error log messages
 #


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8848

The Connection Control plugin is designed to introduce random delay for a user connection attempt in case number of failing attempts reaches some threshold. At the moment plugin adds this delay silently so you cannot notice the plugin is actually doing something by looking into server's logs.

Improved plugin to write an information message to server's error log in case number of failed connection attempts crosses the threshold. To control number of those messages printed to log in cases of a big number of failing connection attempts for different accounts, the limit of 10 messages per minute is hardcoded.
In case messages for some connection attempts were suppressed during the interval, there will be a message reporting overall number of delayed connection attempts during this period in the end of each interval.

(cherry picked from commit b00cf3af0fc2f617afb44e679f580ed478426940)