### PR TITLE
PS-8042: Rename Audit_log_filter_buffer_bypassing_writes status var (8.0)

### DIFF
--- a/plugin/audit_log_filter/log_writer/file_writer_buffering.cc
+++ b/plugin/audit_log_filter/log_writer/file_writer_buffering.cc
@@ -190,7 +190,7 @@ void FileWriterBuffering::write(const char *record, size_t size) noexcept {
       FileWriterDecoratorBase::write(record, size);
       resume();
 
-      SysVars::inc_buffer_bypassing_writes();
+      SysVars::inc_direct_writes();
     } else {
       SysVars::inc_events_lost();
       SysVars::update_event_max_drop_size(size);

--- a/plugin/audit_log_filter/sys_vars.h
+++ b/plugin/audit_log_filter/sys_vars.h
@@ -311,7 +311,7 @@ class SysVars {
    * @brief Increment counter for the number of times data is written to log
    *        synchronously bypassing write buffer in asynchronous mode.
    */
-  static void inc_buffer_bypassing_writes() noexcept;
+  static void inc_direct_writes() noexcept;
 
   /**
    * @brief Update bookmark to latest event written to log.

--- a/plugin/audit_log_filter/tests/mtr/r/status_var_buffer_bypassing_writes.result
+++ b/plugin/audit_log_filter/tests/mtr/r/status_var_buffer_bypassing_writes.result
@@ -4,11 +4,11 @@ OK
 SELECT audit_log_filter_set_user('%', 'log_general');
 audit_log_filter_set_user('%', 'log_general')
 OK
-SHOW GLOBAL STATUS LIKE 'Audit_log_filter_buffer_bypassing_writes';
+SHOW GLOBAL STATUS LIKE 'Audit_log_filter_direct_writes';
 Variable_name	Value
-Audit_log_filter_buffer_bypassing_writes	0
-SHOW GLOBAL STATUS LIKE 'Audit_log_filter_buffer_bypassing_writes';
+Audit_log_filter_direct_writes	0
+SHOW GLOBAL STATUS LIKE 'Audit_log_filter_direct_writes';
 Variable_name	Value
-Audit_log_filter_buffer_bypassing_writes	3
+Audit_log_filter_direct_writes	3
 #
 # Cleanup

--- a/plugin/audit_log_filter/tests/mtr/r/status_var_list.result
+++ b/plugin/audit_log_filter/tests/mtr/r/status_var_list.result
@@ -1,7 +1,7 @@
 SHOW GLOBAL STATUS LIKE 'Audit_log_filter_%';
 Variable_name	Value
-Audit_log_filter_buffer_bypassing_writes	#
 Audit_log_filter_current_size	#
+Audit_log_filter_direct_writes	#
 Audit_log_filter_event_max_drop_size	#
 Audit_log_filter_events	#
 Audit_log_filter_events_filtered	#

--- a/plugin/audit_log_filter/tests/mtr/t/status_var_buffer_bypassing_writes.test
+++ b/plugin/audit_log_filter/tests/mtr/t/status_var_buffer_bypassing_writes.test
@@ -3,7 +3,7 @@
 SELECT audit_log_filter_set_filter('log_general', '{"filter": {"class": {"name": "general"}}}');
 SELECT audit_log_filter_set_user('%', 'log_general');
 
-SHOW GLOBAL STATUS LIKE 'Audit_log_filter_buffer_bypassing_writes';
+SHOW GLOBAL STATUS LIKE 'Audit_log_filter_direct_writes';
 
 --disable_query_log
 --disable_result_log
@@ -11,7 +11,7 @@ SELECT "4IHYyOZMEAUJcURiOO9nLoceKvbRi3HSZZObmonjTjv4IHYyOZMEAUJcURiOO9nLoceKvbRi
 --enable_result_log
 --enable_query_log
 
-SHOW GLOBAL STATUS LIKE 'Audit_log_filter_buffer_bypassing_writes';
+SHOW GLOBAL STATUS LIKE 'Audit_log_filter_direct_writes';
 
 --echo #
 --echo # Cleanup


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8042

Upstream added similar status var Audit_log_direct_writes. Renaming
Audit_log_filter_buffer_bypassing_writes to Audit_log_filter_direct_writes
to have similar names.