### PR TITLE
PS-8844: ASAN errors handling improvements

### DIFF
--- a/mysql-test/include/have_grep.inc
+++ b/mysql-test/include/have_grep.inc
@@ -4,7 +4,7 @@
 123
 456
 EOF
---error 0,1,2,42,127,512
+--error 0,1,2,127,512
 --exec grep -v -e "123" $MYSQL_TMP_DIR/grep_check
 let $status= $__error;
 

--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -3541,7 +3541,6 @@ sub environment_setup {
     if $opt_sanitize;
 
   $ENV{'ASAN_OPTIONS'} = "suppressions=${glob_mysql_test_dir}/asan.supp"
-    . ",detect_stack_use_after_return=false"
     if $opt_sanitize;
 
 # The Thread Sanitizer allocator should return NULL instead of crashing on out-of-memory.

--- a/mysql-test/t/alter_debug.test
+++ b/mysql-test/t/alter_debug.test
@@ -1,3 +1,6 @@
+# ER_STACK_OVERRUN_NEED_MORE does not currently work well with ASan
+# (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/have_debug.inc
 
 --echo #

--- a/mysql-test/t/client_command_line_aliases.test
+++ b/mysql-test/t/client_command_line_aliases.test
@@ -14,49 +14,49 @@
 
 --disable_abort_on_error
 --echo mysqlbinlog --read-from-remote-source: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQL_BINLOG --read-from-remote-source=BINLOG-DUMP-NON-GTIDS --port=$MASTER_MYPORT --user=root --host=127.0.0.1 $binlog_file 2>&1 | grep ^WARNING
 --echo mysqlbinlog --read-from-remote-master: expect warning
 --exec $MYSQL_BINLOG --read-from-remote-master=BINLOG-DUMP-NON-GTIDS --port=$MASTER_MYPORT --user=root --host=127.0.0.1 $binlog_file 2>&1 | grep ^WARNING
 
 --echo mysqldump --apply-replica-statements: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQL_DUMP --apply-replica-statements test 2>&1 | grep ^WARNING
 --echo mysqldump --apply-slave-statements: expect warning
 --exec $MYSQL_DUMP --apply-slave-statements test 2>&1 | grep ^WARNING
 
 --echo mysqldump --delete-source-logs: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQL_DUMP --delete-source-logs test 2>&1 | grep ^WARNING
 --echo mysqldump --delete-master-logs: expect warning
 --exec $MYSQL_DUMP --delete-master-logs test 2>&1 | grep ^WARNING
 
 --echo mysqldump --dump-replica: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQL_DUMP --dump-replica test 2>&1 | grep ^WARNING
 --echo mysqldump --dump-slave: expect warning
 --exec $MYSQL_DUMP --dump-slave test 2>&1 | grep ^WARNING
 
 --echo mysqldump --include-source-host-port: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQL_DUMP --include-source-host-port test 2>&1 | grep ^WARNING
 --echo mysqldump --include-master-host-port: expect warning
 --exec $MYSQL_DUMP --include-master-host-port test 2>&1 | grep ^WARNING
 
 --echo mysqldump --source-data: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQL_DUMP --source-data test 2>&1 | grep ^WARNING
 --echo mysqldump --master-data: expect warning
 --exec $MYSQL_DUMP --master-data test 2>&1 | grep ^WARNING
 
 --echo mysqladmin start-replica: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQLADMIN --no-defaults -uroot -S $MASTER_MYSOCK -P $MASTER_MYPORT start-replica 2>&1 | grep ^WARNING
 --echo mysqladmin start-slave: expect warning
 --exec $MYSQLADMIN --no-defaults -uroot -S $MASTER_MYSOCK -P $MASTER_MYPORT start-slave 2>&1 | grep ^WARNING
 
 --echo mysqladmin stop-replica: expect no warning
---error 1,42 # grep returns exit status 1
+--error 1 # grep returns exit status 1
 --exec $MYSQLADMIN --no-defaults -uroot -S $MASTER_MYSOCK -P $MASTER_MYPORT stop-replica 2>&1 | grep ^WARNING
 --echo mysqladmin stop-slave: expect warning
 --exec $MYSQLADMIN --no-defaults -uroot -S $MASTER_MYSOCK -P $MASTER_MYPORT stop-slave 2>&1 | grep ^WARNING

--- a/mysql-test/t/execution_constants.test
+++ b/mysql-test/t/execution_constants.test
@@ -1,4 +1,6 @@
-# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with TSan
+# ER_STACK_OVERRUN_NEED_MORE does not currently work well with neither TSan
+# nor ASan (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/not_tsan.inc
 
 #

--- a/mysql-test/t/sp-error.test
+++ b/mysql-test/t/sp-error.test
@@ -2,7 +2,9 @@
 # Stored PROCEDURE error tests
 #
 
-# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with TSan
+# ER_STACK_OVERRUN_NEED_MORE does not currently work well with neither TSan
+# nor ASan (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/not_tsan.inc
 
 delimiter |;

--- a/mysql-test/t/sp.test
+++ b/mysql-test/t/sp.test
@@ -1,4 +1,6 @@
-# ER_STACK_OVERRUN_NEED_MORE does not currenly work well with TSan
+# ER_STACK_OVERRUN_NEED_MORE does not currently work well with neither TSan
+# nor ASan (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/not_tsan.inc
 
 --source include/no_valgrind_without_big.inc

--- a/mysql-test/t/view_debug.test
+++ b/mysql-test/t/view_debug.test
@@ -1,3 +1,6 @@
+# ER_STACK_OVERRUN_NEED_MORE does not currently work well with ASan
+# (when ASAN_OPTIONS include 'detect_stack_use_after_return=true')
+--source include/not_asan.inc
 --source include/have_debug.inc
 
 --echo #

--- a/sql/check_stack.cc
+++ b/sql/check_stack.cc
@@ -111,14 +111,12 @@ bool check_stack_overrun(const THD *thd, long margin, unsigned char *buf) {
   assert(stack_direction == -1 || stack_direction == 1);
 
 #if defined(HAVE_ASAN)
-  // Stack grows upward, but our address computations do not work with
-  // the "fake stack" of ASAN. Just return OK.
+  // Address computations do not work with the "fake stack" of ASAN.
+  // Just return OK.
   // With ASAN_OPTIONS=detect_stack_use_after_return=true
   // any test which deliberately runs out of stack
   // (expects ER_STACK_OVERRUN_NEED_MORE) will most likely crash.
-  if (stack_direction == 1) {
-    return false;
-  }
+  return false;
 #endif
 
   long stack_used =


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8844
***
PS-8844: Merge MySQL 8.0.34 - Improve detect_stack_use_after_return ASAN option handling

In https://github.com/mysql/mysql-server/commit/75a1d41b2802 ASAN option
detect_stack_use_after_return was disabled for all tests by setting it
in mysql-test-run.pl as detect_stack_use_after_return=false. While this
fixes issues with tests which expect ER_STACK_OVERRUN_NEED_MORE error
to happen this also disabled AddressSanitizerUseAfterReturn check for
all other tests where it could be usefull.
    
To improve this:
- removed detect_stack_use_after_return=false from mysql-test-run.pl leaving it set to its default value;
- skipped MTR tests expecting ER_STACK_OVERRUN_NEED_MORE error when run with ASAN.
    
This is based on the following changes:
- https://github.com/percona/percona-server/pull/5072
- https://github.com/percona/percona-server/commit/cc359ef873de
***
PS-8844: Merge MySQL 8.0.34 - Remove error 42 suppression for mtr tests using 'grep'

In https://github.com/mysql/mysql-server/commit/75a1d41b2802 there was
added error 42 as expected to some tests using 'grep'.
    
This is already handled via ASAN suppressions. Corresponding rule was added
in https://github.com/percona/percona-server/commit/fe198afeda0b26ad885f20f37659b38a00a2e375.
    
Removed error 42 from expected in this change.