### PR TITLE
PS-8844: Fix access to buffered_error_log_filename after freed

### DIFF
--- a/mysys/buffered_error_log.cc
+++ b/mysys/buffered_error_log.cc
@@ -68,3 +68,8 @@ void Buffered_error_logger::write_to_disk_() {
   data->clear();
   data->reserve(curr_size);
 }
+
+void Buffered_error_logger::close() {
+  std::lock_guard<std::mutex> lk{data_mtx};
+  buffered_error_log_filename = nullptr;
+}

--- a/mysys/buffered_error_log.h
+++ b/mysys/buffered_error_log.h
@@ -33,6 +33,8 @@ class Buffered_error_logger {
 
   void write_to_disk();
 
+  void close();
+
   bool is_enabled();
 
  private:

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2752,6 +2752,9 @@ static void clean_up(bool print_message) {
     the component system unregister_ variable()  api's, hence we need
     to call the sys_var_end() after component_infrastructure_deinit()
   */
+  buffered_error_log.write_to_disk();
+  buffered_error_log
+      .close();  // buffered_error_log_filename will be freed by sys_var_end()
   sys_var_end();
   free_status_vars();
 


### PR DESCRIPTION
`~Buffered_error_logger()` was called after `buffered_error_log_filename` was freed within `sys_var_end()`.

Valgrind found the issue:
```
[ 62%] main.all_persisted_variables             w19 [ fail ]  Found warnings/errors in error log file!
==734180== Invalid read of size 1
==734180==    at 0x7AAF9CC: Buffered_error_logger::write_to_disk_() (buffered_error_log.cc:54)
==734180==    by 0x7AAF8A8: Buffered_error_logger::write_to_disk() (buffered_error_log.cc:44)
==734180==    by 0x7AAF6D9: Buffered_error_logger::~Buffered_error_logger() (buffered_error_log.cc:29)
==734180==    by 0xAF38494: __run_exit_handlers (exit.c:113)
==734180==    by 0xAF3860F: exit (exit.c:143)
==734180==    by 0x634DD9C: mysqld_exit(int) (mysqld.cc:2627)
==734180==    by 0x6360A45: mysqld_main(int, char**) (mysqld.cc:8771)
==734180==    by 0x5E8827C: main (main.cc:25)
```