### PR TITLE
PS-8042: Improve audit_log_filter.log_prune_seconds test

### DIFF
--- a/plugin/audit_log_filter/log_writer/file_handle.cc
+++ b/plugin/audit_log_filter/log_writer/file_handle.cc
@@ -242,7 +242,15 @@ PruneFilesList FileHandle::get_prune_files(
     const std::string &file_name) noexcept {
   PruneFilesList prune_files;
   const auto base_file_name = FileName::from_path(file_name).get_base_name();
-  const auto time_now = std::time(nullptr);
+  auto time_now = std::time(nullptr);
+
+  DBUG_EXECUTE_IF("audit_log_filter_debug_timestamp", {
+    // This will return the time of the newest rotated log + 1 minute so
+    // file age will be calculated properly for files which are subject
+    // for age based pruning.
+    time_now = std::chrono::system_clock::to_time_t(
+        SysVars::get_debug_time_point_for_rotation());
+  });
 
   for (const auto &entry :
        std::filesystem::directory_iterator{working_dir_name}) {

--- a/plugin/audit_log_filter/tests/mtr/r/log_prune_seconds.result
+++ b/plugin/audit_log_filter/tests/mtr/r/log_prune_seconds.result
@@ -1,3 +1,4 @@
+SET GLOBAL DEBUG='+d,audit_log_filter_debug_timestamp';
 SET @old_prune_seconds = @@global.audit_log_filter_prune_seconds;
 SET @old_max_size = @@global.audit_log_filter_max_size;
 SET GLOBAL audit_log_filter_prune_seconds = 0;
@@ -11,17 +12,18 @@ OK
 SELECT audit_log_filter_remove_user('%');
 audit_log_filter_remove_user('%')
 OK
-Logs age exceeds expected prune_seconds 2
-SET GLOBAL audit_log_filter_prune_seconds = 2;
-Logs age doesn't exceed expected prune_seconds 2
+Logs age exceeds expected prune_seconds 180
+SET GLOBAL audit_log_filter_prune_seconds = 180;
+Logs age doesn't exceed expected prune_seconds 180
 SELECT audit_log_filter_set_user('%', 'log_all');
 audit_log_filter_set_user('%', 'log_all')
 OK
 SELECT audit_log_filter_remove_user('%');
 audit_log_filter_remove_user('%')
 OK
-Logs age doesn't exceed expected prune_seconds 2
+Logs age doesn't exceed expected prune_seconds 180
 #
 # Cleanup
 SET GLOBAL audit_log_filter_prune_seconds = @old_prune_seconds;
 SET GLOBAL audit_log_filter_max_size = @old_max_size;
+SET GLOBAL DEBUG='-d,audit_log_filter_debug_timestamp';

--- a/plugin/audit_log_filter/tests/mtr/t/log_prune_seconds.test
+++ b/plugin/audit_log_filter/tests/mtr/t/log_prune_seconds.test
@@ -1,4 +1,7 @@
+--source include/have_debug.inc
 --source audit_tables_init.inc
+
+SET GLOBAL DEBUG='+d,audit_log_filter_debug_timestamp';
 
 SET @old_prune_seconds = @@global.audit_log_filter_prune_seconds;
 SET @old_max_size = @@global.audit_log_filter_max_size;
@@ -12,34 +15,24 @@ SELECT audit_log_filter_set_user('%', 'log_all');
 # prune_seconds is not set, no logs prune happens
 --source generate_audit_events.inc
 --source generate_audit_events.inc
---source generate_audit_events.inc
---source generate_audit_events.inc
---source generate_audit_events.inc
---source generate_audit_events.inc
---source generate_audit_events.inc
---source generate_audit_events.inc
 
 # stop updating log before size check
 SELECT audit_log_filter_remove_user('%');
 
 --let $log_path = `SELECT @@global.datadir`
 --let $log_name = `SELECT @@global.audit_log_filter_file`
---let $prune_seconds = 2
+--let $prune_seconds = 180
 
 --source check_logs_age.inc
 
 # logs get pruned after prune_seconds update
-SET GLOBAL audit_log_filter_prune_seconds = 2;
+SET GLOBAL audit_log_filter_prune_seconds = 180;
 
 --source check_logs_age.inc
 
 # oldest log rotation time should not exceed prune_seconds while writing
 # audit events
 SELECT audit_log_filter_set_user('%', 'log_all');
---source generate_audit_events.inc
---source generate_audit_events.inc
---source generate_audit_events.inc
---source generate_audit_events.inc
 --source generate_audit_events.inc
 --source generate_audit_events.inc
 
@@ -54,3 +47,5 @@ SELECT audit_log_filter_remove_user('%');
 
 SET GLOBAL audit_log_filter_prune_seconds = @old_prune_seconds;
 SET GLOBAL audit_log_filter_max_size = @old_max_size;
+
+SET GLOBAL DEBUG='-d,audit_log_filter_debug_timestamp';


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8042

The audit_log_filter.log_prune_seconds MTR tests expects the plugin to generate a set of rotated log files. Log rotation timestamp at the moment is taken from current system time. When test is run on fast hardware, log rotation happens too soon and with the same timestamp for different logs. As a result, rotated logs get rewritten and expected files set is not generated.

To fix that, modified the test to use DEBUG='+d,audit_log_filter_debug_timestamp'. This ensures each next rotated log file has unique timestamp in its name.