### PR TITLE
PS-8042: Fix audit_log_filter.log_format_encrypted test

### DIFF
--- a/plugin/audit_log_filter/tests/mtr/t/decrypt_rotated_log.inc
+++ b/plugin/audit_log_filter/tests/mtr/t/decrypt_rotated_log.inc
@@ -24,6 +24,19 @@
 --let encryption_iterations = $encryption_iterations
 
 perl;
+  my $help_text = qx(openssl enc -help 2>&1);
+  my $openssl_iter_support = 1;
+
+  if ($help_text !~ m/\-iter/) {
+    $openssl_iter_support = 0;
+  }
+
+  open(OUTPUT, ">$ENV{MYSQLTEST_VARDIR}/tmp/audit_decrypt_openssl_status.inc") or die "Cannot open tmp file";
+  print OUTPUT "let \$openssl_iter_support = $openssl_iter_support;\n";
+  close(OUTPUT);
+
+  if (!$openssl_iter_support) { exit; }
+
   my $dir_name = $ENV{'audit_filter_log_path'} or die "Empty audit_filter_log_path";
   my $password = $ENV{'encryption_password'} or die "Empty encryption_password";
   my $iterations = $ENV{'encryption_iterations'} or die "Empty encryption_iterations";
@@ -40,3 +53,10 @@ perl;
 
   closedir $dh;
 EOF
+
+--source  $MYSQLTEST_VARDIR/tmp/audit_decrypt_openssl_status.inc
+--remove_file $MYSQLTEST_VARDIR/tmp/audit_decrypt_openssl_status.inc
+
+if (!$openssl_iter_support) {
+  --skip 'openssl enc -iter' not supported
+}


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8042

The audit_log_filter.log_format_encrypted test internally uses '-iter' option to pass iterations number to 'openssl enc -d'. This is needed for openssl to be able to properly calculate IV and key from a password. Test uses this util to decrypt log files to be able to check their content.

Some older openssl versions like 1.0.2 do not support this '-iter' parameter. They just use iterations count hardcoded to 1. In this case 'openssl enc' cannot be used for this purpose.

At the same time openssl API is fine to be used by the plugin to encrypt/decrypt log files.

To suppress test failure in such cases improved decrypt_rotated_log.inc to skip test in case available 'openssl enc' version does not support '-iter' parameter.