### PR TITLE
PS-8880: Server option replication_sender_observe_commit_only is not honored for XA ROLLBACK

### DIFF
--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -94,8 +94,8 @@ class Observe_transmission_guard {
 
     - The event is an `XID_EVENT`
     - The event is an `XA_PREPARE_LOG_EVENT`.
-    - The event is a `QUERY_EVENT` with query equal to "XA COMMIT" or "XA ABORT"
-      or "COMMIT".
+    - The event is a `QUERY_EVENT` with query equal to "XA COMMIT" or
+      "XA ROLLBACK" or "COMMIT".
     - The event is the first `QUERY_EVENT` after a `GTID_EVENT` and the query is
       not "BEGIN" --the statement is a DDL, for instance.
 
@@ -131,7 +131,7 @@ class Observe_transmission_guard {
             m_to_set = (strcmp("BEGIN", ev.query) != 0);
           else
             m_to_set = (strncmp("XA COMMIT", ev.query, 9) == 0) ||
-                       (strncmp("XA ABORT", ev.query, 8) == 0) ||
+                       (strncmp("XA ROLLBACK", ev.query, 11) == 0) ||
                        (strncmp("COMMIT", ev.query, 6) == 0);
           break;
         }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8880

Description
-----------
The server variable replication_sender_observe_commit_only is not honored for XA ROLLBACK command because of the typo error in https://github.com/mysql/mysql-server/blob/057f5c9509c6c9ea3ce3acdc619f3353c09e6ec6/sql/rpl_binlog_sender.cc#L134
```
=== TYPO BEGIN ===
            m_to_set = (strncmp("XA COMMIT", ev.query, 9) == 0) ||
                       (strncmp("XA ABORT", ev.query, 8) == 0) ||
                       (strncmp("COMMIT", ev.query, 6) == 0);
          break;
=== TYPO END ===
```
In the above code block, the command is compared against "XA ABORT", but it is not a valid query in MySQL.

Solution
--------
Changed XA ABORT to XA ROLLBACK in the above block.