### PR TITLE
PS-8877 : Selecting from performance_schema.innodb_redo_log_files cra…

### DIFF
--- a/mysql-test/suite/innodb/r/percona_bug_ps8877.result
+++ b/mysql-test/suite/innodb/r/percona_bug_ps8877.result
@@ -1,0 +1,8 @@
+#
+# PS-8877 : Selecting from performance_schema.innodb_redo_log_files crashes MySQL
+#
+CREATE DATABASE mysqlslap;
+# Use 'mysqlslap' to run "SELECT * FROM P_S.innodb_redo_log_files" query
+# concurrently in 10 connections. This caused assertion failure before
+# the fix.
+DROP DATABASE mysqlslap;

--- a/mysql-test/suite/innodb/t/percona_bug_ps8877.test
+++ b/mysql-test/suite/innodb/t/percona_bug_ps8877.test
@@ -1,0 +1,9 @@
+--echo #
+--echo # PS-8877 : Selecting from performance_schema.innodb_redo_log_files crashes MySQL
+--echo #
+CREATE DATABASE mysqlslap;
+--echo # Use 'mysqlslap' to run "SELECT * FROM P_S.innodb_redo_log_files" query
+--echo # concurrently in 10 connections. This caused assertion failure before
+--echo # the fix.
+--exec $MYSQL_SLAP --query="SELECT * FROM performance_schema.innodb_redo_log_files" --iterations=1000 --concurrency=10 --silent 2>&1
+DROP DATABASE mysqlslap;

--- a/storage/innobase/log/log0pfs.cc
+++ b/storage/innobase/log/log0pfs.cc
@@ -79,95 +79,98 @@ class Log_files_pfs_table {
   };
 
  public:
-  static Log_files_pfs_table s_instance;
+  /** Share for PFS table with metadata of redo log files. */
+  struct Share : public PFS_engine_table_share_proxy {
+    /** Name of the PFS mysql table (belongs to performance_schema) */
+    static constexpr const char *TABLE_NAME = "innodb_redo_log_files";
 
-  /** Name of the PFS mysql table (belongs to performance_schema) */
-  static constexpr const char *TABLE_NAME = "innodb_redo_log_files";
+    Share() : PFS_engine_table_share_proxy() {
+      m_table_name = TABLE_NAME;
+      m_table_name_length = strlen(TABLE_NAME);
+      m_table_definition =
+          "`FILE_ID` BIGINT NOT NULL"
+          " COMMENT 'Id of the file.',\n"
 
-  Log_files_pfs_table() {
-    m_pfs_table.m_table_name = TABLE_NAME;
-    m_pfs_table.m_table_name_length = strlen(TABLE_NAME);
-    m_pfs_table.m_table_definition =
-        "`FILE_ID` BIGINT NOT NULL"
-        " COMMENT 'Id of the file.',\n"
+          "`FILE_NAME` VARCHAR(2000) NOT NULL"
+          " COMMENT 'Path to the file.',\n"
 
-        "`FILE_NAME` VARCHAR(2000) NOT NULL"
-        " COMMENT 'Path to the file.',\n"
+          "`START_LSN` BIGINT NOT NULL"
+          " COMMENT 'LSN of the first block in the file.',\n"
 
-        "`START_LSN` BIGINT NOT NULL"
-        " COMMENT 'LSN of the first block in the file.',\n"
+          "`END_LSN` BIGINT NOT NULL"
+          " COMMENT 'LSN after the last block in the file.',\n"
 
-        "`END_LSN` BIGINT NOT NULL"
-        " COMMENT 'LSN after the last block in the file.',\n"
+          "`SIZE_IN_BYTES` BIGINT NOT NULL"
+          " COMMENT 'Size of the file (in bytes).',\n"
 
-        "`SIZE_IN_BYTES` BIGINT NOT NULL"
-        " COMMENT 'Size of the file (in bytes).',\n"
+          "`IS_FULL` TINYINT NOT NULL"
+          " COMMENT '1 iff file has no free space inside.',\n"
 
-        "`IS_FULL` TINYINT NOT NULL"
-        " COMMENT '1 iff file has no free space inside.',\n"
+          "`CONSUMER_LEVEL` INT NOT NULL"
+          " COMMENT 'All redo log consumers registered on smaller levels"
+          " than this value, have already consumed this file.'\n";
 
-        "`CONSUMER_LEVEL` INT NOT NULL"
-        " COMMENT 'All redo log consumers registered on smaller levels"
-        " than this value, have already consumed this file.'\n";
+      m_ref_length = sizeof(m_position);
+      m_acl = READONLY;
+      delete_all_rows = nullptr;
+      get_row_count = [] {
+        log_t &log = *log_sys;
+        IB_mutex_guard latch{&(log.m_files_mutex), UT_LOCATION_HERE};
+        return 1ULL * log_files_number_of_existing_files(log.m_files);
+      };
 
-    m_pfs_table.m_ref_length = sizeof(m_position);
-    m_pfs_table.m_acl = READONLY;
-    m_pfs_table.delete_all_rows = nullptr;
-    m_pfs_table.get_row_count = [] {
-      log_t &log = *log_sys;
-      IB_mutex_guard latch{&(log.m_files_mutex), UT_LOCATION_HERE};
-      return 1ULL * log_files_number_of_existing_files(log.m_files);
-    };
+      auto &proxy_table = m_proxy_engine_table;
 
-    auto &proxy_table = m_pfs_table.m_proxy_engine_table;
+      proxy_table.open_table = [](PSI_pos **pos) {
+        uint32_t **pos_ptr = reinterpret_cast<uint32_t **>(pos);
+        Log_files_pfs_table *table = new Log_files_pfs_table();
+        *pos_ptr = &(table->m_position);
+        return reinterpret_cast<PSI_table_handle *>(table);
+      };
 
-    proxy_table.open_table = [](PSI_pos **pos) {
-      uint32_t **pos_ptr = reinterpret_cast<uint32_t **>(pos);
-      *pos_ptr = &s_instance.m_position;
-      return reinterpret_cast<PSI_table_handle *>(&s_instance);
-    };
+      proxy_table.close_table = [](PSI_table_handle *handle) {
+        auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
+        table->close();
+        delete table;
+      };
 
-    proxy_table.close_table = [](PSI_table_handle *handle) {
-      auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
-      table->close();
-    };
+      proxy_table.rnd_init = [](PSI_table_handle *handle, bool) {
+        auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
+        return table->rnd_init();
+      };
 
-    proxy_table.rnd_init = [](PSI_table_handle *handle, bool) {
-      auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
-      return table->rnd_init();
-    };
+      proxy_table.rnd_next = [](PSI_table_handle *handle) {
+        auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
+        return table->rnd_next();
+      };
 
-    proxy_table.rnd_next = [](PSI_table_handle *handle) {
-      auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
-      return table->rnd_next();
-    };
+      proxy_table.rnd_pos = [](PSI_table_handle *handle) {
+        auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
+        return table->rnd_pos();
+      };
 
-    proxy_table.rnd_pos = [](PSI_table_handle *handle) {
-      auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
-      return table->rnd_pos();
-    };
+      proxy_table.read_column_value = [](PSI_table_handle *handle,
+                                         PSI_field *field, uint32_t index) {
+        auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
+        return table->read_column_value(field, index);
+      };
 
-    proxy_table.read_column_value = [](PSI_table_handle *handle,
-                                       PSI_field *field, uint32_t index) {
-      auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
-      return table->read_column_value(field, index);
-    };
+      proxy_table.reset_position = [](PSI_table_handle *handle) {
+        auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
+        table->reset_pos();
+      };
 
-    proxy_table.reset_position = [](PSI_table_handle *handle) {
-      auto table = reinterpret_cast<Log_files_pfs_table *>(handle);
-      table->reset_pos();
-    };
+      proxy_table.index_init = nullptr;
+      proxy_table.index_read = nullptr;
+      proxy_table.index_next = nullptr;
 
-    proxy_table.index_init = nullptr;
-    proxy_table.index_read = nullptr;
-    proxy_table.index_next = nullptr;
-
-    proxy_table.write_column_value = nullptr;
-    proxy_table.write_row_values = nullptr;
-    proxy_table.update_column_value = nullptr;
-    proxy_table.update_row_values = nullptr;
-    proxy_table.delete_row_values = nullptr;
-  }
+      proxy_table.write_column_value = nullptr;
+      proxy_table.write_row_values = nullptr;
+      proxy_table.update_column_value = nullptr;
+      proxy_table.update_row_values = nullptr;
+      proxy_table.delete_row_values = nullptr;
+    }
+  };
 
   int read_column_value(PSI_field *field, uint32_t index) {
     const auto row_index = m_position;
@@ -275,16 +278,17 @@ class Log_files_pfs_table {
 
   void close() { m_position = 0; }
 
-  PFS_engine_table_share_proxy *get_proxy_share() { return &m_pfs_table; }
+  static PFS_engine_table_share_proxy *get_proxy_share() { return &s_share; }
 
  private:
   uint32_t m_rows_n{};
   uint32_t m_position{};
-  PFS_engine_table_share_proxy m_pfs_table{};
   std::unique_ptr<Row[]> m_rows_array;
+
+  static Share s_share;
 };
 
-Log_files_pfs_table Log_files_pfs_table::s_instance{};
+Log_files_pfs_table::Share Log_files_pfs_table::s_share{};
 
 template <typename T>
 static bool acquire_service(SERVICE_TYPE(registry) * reg_srv, T *service,
@@ -321,7 +325,7 @@ bool log_pfs_create_tables() {
   ut_a(pfs_table != nullptr);
 
   PFS_engine_table_share_proxy *pfs_proxy_tables[1];
-  pfs_proxy_tables[0] = Log_files_pfs_table::s_instance.get_proxy_share();
+  pfs_proxy_tables[0] = Log_files_pfs_table::get_proxy_share();
 
   Auto_THD auto_thd;
   auto thd = auto_thd.thd;
@@ -341,7 +345,7 @@ bool log_pfs_create_tables() {
     dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
 
     if (drop_native_table_for_pfs(PERFORMANCE_SCHEMA_DB_NAME.str,
-                                  Log_files_pfs_table::TABLE_NAME)) {
+                                  Log_files_pfs_table::Share::TABLE_NAME)) {
       end_transaction(thd, true);
       pfs_sdi_enable();
       return false;
@@ -375,7 +379,7 @@ void log_pfs_delete_tables() {
     return;
   }
   PFS_engine_table_share_proxy *pfs_proxy_tables[1];
-  pfs_proxy_tables[0] = Log_files_pfs_table::s_instance.get_proxy_share();
+  pfs_proxy_tables[0] = Log_files_pfs_table::get_proxy_share();
   pfs_table->delete_tables(pfs_proxy_tables, 1);
   pfs_tables_created = false;
 }


### PR DESCRIPTION
…shes MySQL

https://jira.percona.com/browse/PS-8877

Concurrent queries on performance_schema.innodb_redo_log_files sometimes caused assertion failure.

Failure occurred due to trivial race condition when two threads tried to execute Log_files_pfs_table::rnd_next() method concurrently for the same object. This happened because Log_files_pfs_table was made a singleton object, while in theory in PFS plugin API objects which represent table handle/PSI_table_handle are supposed to be per usage in statement and per connection, to be able to store state of a cursor for particular table usage in the query in particular connection.

This patch solves this problem by making Log_files_pfs_table non-singleton object which is allocated on table open and deleted on table close. It also introduces auxiliary singleton Log_files_pfs_table::Share class to which shared information from Log_files_pfs_table has been moved.