### PR TITLE
PS-8886: The test federated.federated_double_type fails due to hardco…

### DIFF
--- a/mysql-test/suite/federated/r/federated_double_type.result
+++ b/mysql-test/suite/federated/r/federated_double_type.result
@@ -13,8 +13,8 @@ INSERT INTO t3 VALUES (0, 0, 8.730550);
 CREATE TABLE t1(id INT, i INT, d DOUBLE(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:SLAVE_PORT/test/t1';
 Warnings:
 Warning	1681	Specifying number of digits for floating point data types is deprecated and will be removed in a future release.
-CREATE TABLE t2(id INT, i INT, d DOUBLE) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:13002/test/t2';
-CREATE TABLE t3(id INT, i INT, f FLOAT(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:13002/test/t3';
+CREATE TABLE t2(id INT, i INT, d DOUBLE) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:SLAVE_PORT/test/t2';
+CREATE TABLE t3(id INT, i INT, f FLOAT(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:SLAVE_PORT/test/t3';
 Warnings:
 Warning	1681	Specifying number of digits for floating point data types is deprecated and will be removed in a future release.
 include/assert.inc [Row should have been inserted]

--- a/mysql-test/suite/federated/t/federated_double_type.test
+++ b/mysql-test/suite/federated/t/federated_double_type.test
@@ -13,7 +13,9 @@ INSERT INTO t3 VALUES (0, 0, 8.730550);
 --connection master
 --replace_result $SLAVE_MYPORT SLAVE_PORT
 --eval CREATE TABLE t1(id INT, i INT, d DOUBLE(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:$SLAVE_MYPORT/test/t1'
+--replace_result $SLAVE_MYPORT SLAVE_PORT
 --eval CREATE TABLE t2(id INT, i INT, d DOUBLE) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:$SLAVE_MYPORT/test/t2'
+--replace_result $SLAVE_MYPORT SLAVE_PORT
 --eval CREATE TABLE t3(id INT, i INT, f FLOAT(8,6)) ENGINE=FEDERATED CONNECTION='mysql://root@127.0.0.1:$SLAVE_MYPORT/test/t3'
   
 --let $assert_text = Row should have been inserted


### PR DESCRIPTION
…ded port in the result file

https://jira.percona.com/browse/PS-8886

The test case federated.federated_double_type failed when run with a different MTR build thread id because of the hardcoded port number in the result file.

This has been fixed by replacing the port number with a text with the use of MTR's replace_result command.