### PR TITLE
PS-8844: Fix the failing main.mysqldump_gtid_purged

### DIFF
--- a/mysql-test/include/start_proc_in_background.inc
+++ b/mysql-test/include/start_proc_in_background.inc
@@ -46,11 +46,11 @@ if (!$command)
 
 if ($output_file)
 {
-  if ($redirect_stderr == 1)
+  if ($redirect_stderr)
   {
     --let $line = $line 2> $output_file
   }
-  if ($redirect_stderr == 0)
+  if (!$redirect_stderr)
   {
     --let $line = $line > $output_file
   }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8844

This patch fixes the test failure of main.mysqldump_gtid_purged that failed due to the uninitialized variable $redirect_stderr in the start_proc_in_background.inc.