### PR TITLE
PS-8844: Fix the failing clone.plugin_mismatch

### DIFF
--- a/mysql-test/suite/clone/r/plugin_mismatch.result
+++ b/mysql-test/suite/clone/r/plugin_mismatch.result
@@ -5,9 +5,10 @@
 # not installed on recipient
 INSTALL PLUGIN example SONAME 'ha_example.so';
 INSTALL PLUGIN audit_log SONAME 'audit_log.so';;
-# create a copy of plugin_dir for recipient without the example and validate_password plugin
-# Now the recipient server do not have these plugins and we do a clone now from donor which
-# these
+
+# create a different plugin_dir for recipient without the example and
+# audit_log plugin. Now the recipient server do not have these plugins
+# and we do a clone now from donor which has these plugins installed.
 # restart: --plugin_dir=RECIPIENT_NEW_PLUGIN_DIR
 #connection donor
 CREATE TABLE t1(col1 INT PRIMARY KEY, col2 char(64), FULLTEXT KEY fts_index(col2));

--- a/mysql-test/suite/clone/t/plugin_mismatch.test
+++ b/mysql-test/suite/clone/t/plugin_mismatch.test
@@ -18,15 +18,17 @@
 --connect (conn_recipient, 127.0.0.1, root,,test,$recipient_port)
 --connection conn_recipient
 
---echo # create a copy of plugin_dir for recipient without the example and validate_password plugin
---echo # Now the recipient server do not have these plugins and we do a clone now from donor which
---echo # these
+--echo
+--echo # create a different plugin_dir for recipient without the example and
+--echo # audit_log plugin. Now the recipient server do not have these plugins
+--echo # and we do a clone now from donor which has these plugins installed.
+
 --mkdir $MYSQL_TMP_DIR/plugin_dir
 --let $plugin_dir=`SELECT @@plugin_dir`
---force-cpdir $plugin_dir $MYSQL_TMP_DIR/plugin_dir
---let $RECIPIENT_NEW_PLUGIN_DIR=$MYSQL_TMP_DIR/plugin_dir/plugin_output_directory
---remove_file $RECIPIENT_NEW_PLUGIN_DIR/ha_example.so
---remove_file $RECIPIENT_NEW_PLUGIN_DIR/audit_log.so
+--let $RECIPIENT_NEW_PLUGIN_DIR=$MYSQL_TMP_DIR/plugin_dir
+
+# Copy only mysql_clone plugin that is required for the test.
+--copy_file $plugin_dir/mysql_clone.so $RECIPIENT_NEW_PLUGIN_DIR/mysql_clone.so
 
 --replace_result $RECIPIENT_NEW_PLUGIN_DIR RECIPIENT_NEW_PLUGIN_DIR
 --let $restart_parameters="restart: --plugin_dir=$RECIPIENT_NEW_PLUGIN_DIR"


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8844

The test clone.plugin_mismatch fails when run from installed directories due to the different path of the plugin directory used by the test.

Failure:
        CURRENT_TEST: clone.plugin_mismatch
        mysqltest: At line 28: Command "remove_file" failed with error 1. my_errno=2.

The test involves simulating the secnario of missing plugins on recipient server. To do the same, the test earlier used to copy all plugins to recipient server's plugin_dir and delete some plugins to test the clone plugin's behavior when recipeint had some plugins missing.

During the test investigation, it was found that it is just sufficient to have only the clone plugin copied to the recipient server so that it simulates the missing plugins.

This patch makes the the test independent of plugin paths so it works on both build and installed directories.