### PR TITLE
PS-8908: Mysqld crash when user forgets to set debug timeout

### DIFF
--- a/sql/debug_sync.cc
+++ b/sql/debug_sync.cc
@@ -1975,6 +1975,11 @@ bool debug_sync_set_action(THD *thd, const char *action_str, size_t len) {
   assert(thd);
   assert(action_str);
 
+  // A zero value keeps the facility disabled.
+  if (!opt_debug_sync_timeout) {
+    return false;
+  }
+
   value = strmake_root(thd->mem_root, action_str, len);
   rc = debug_sync_eval_action(thd, value);
   return rc;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8908

Problem:
If 'debug_sync_timeout' parameter is not specified in my.cnf or as a command line argument, the usage of debug sync factility leads to the assertion.

Cause:
The default value of 'debug_sync_timeout' is 0, which means the debug sync factility is disabled. In such a case 'debug_sync_control' member of the THD is not initialized during THD initialization (debug_sync_init_thread()).
The callstack debug_sync_set_action => debug_sync_eval_action => debug_sync_get_action uses 'debug_sync_control' member unconditionally causing the assertion.

Solution:
There was a missing check for 'debug_sync_timeout' in the above-mentioned callstack. Similar checks are present in debug_sync_update() or debug_sync_init() functions. Added missing check.