### PR TITLE
PS-8907: Empty vio->signal_mask in the x plugin causes MySQL cannot h…

### DIFF
--- a/mysql-test/suite/x/r/kill_mysqld.result
+++ b/mysql-test/suite/x/r/kill_mysqld.result
@@ -1,0 +1,17 @@
+# restart:--log-error=MYSQLTEST_VARDIR/tmp/test_sig_handler.err --debug=d,simulate_sighup_print_status
+# Test SIGPIPE, SIGTSTP, SIGINT, which should be ignored
+SELECT 1;
+1
+1
+# Test SIGHUP, which should result in status dump in the error log
+SELECT 1;
+1
+1
+# Test SIGSTOP and SIGCONT which should be ignored
+SELECT 1;
+1
+1
+# Test SIGTERM, server should shutdown
+# restart
+include/assert_grep.inc [Status information found in error log]
+include/assert_grep.inc [Server is shutdown gracefully]

--- a/mysql-test/suite/x/t/kill_mysqld.test
+++ b/mysql-test/suite/x/t/kill_mysqld.test
@@ -1,0 +1,64 @@
+## This file provide test scenario for killing mysqld when there is an active mysqlx connection
+##
+
+--source include/have_debug.inc
+--source include/xplugin_preamble.inc
+--source include/xplugin_create_user.inc
+
+## Test Setup
+--write_file $MYSQL_TMP_DIR/sleep.xpl
+-->setsession
+-->sleep 100
+-->closesession
+EOF
+
+#
+# Test the effect of various signals on the server
+#
+--let $test_error_log= $MYSQLTEST_VARDIR/tmp/test_sig_handler.err
+--let $restart_parameters=restart:--log-error=$test_error_log --debug=d,simulate_sighup_print_status
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--source include/restart_mysqld.inc
+
+--exec_in_background $MYSQLXTEST -u x_root --password='' --file=$MYSQL_TMP_DIR/sleep.xpl 2>&1
+
+--let $mysqld_pid_file=`SELECT @@GLOBAL.pid_file`
+
+--echo # Test SIGPIPE, SIGTSTP, SIGINT, which should be ignored
+--exec kill -PIPE `cat $mysqld_pid_file`
+SELECT 1;
+
+--echo # Test SIGHUP, which should result in status dump in the error log
+--exec kill -HUP `cat $mysqld_pid_file`
+SELECT 1;
+
+
+--echo # Test SIGSTOP and SIGCONT which should be ignored
+--exec kill -STOP `cat $mysqld_pid_file`
+--exec kill -CONT `cat $mysqld_pid_file`
+SELECT 1;
+
+--echo # Test SIGTERM, server should shutdown
+--source include/expect_crash.inc
+--exec kill -TERM `cat $mysqld_pid_file`
+--source include/wait_until_disconnected.inc
+
+--let $restart_parameters=
+--source include/start_mysqld.inc
+
+# Test for SIGHUP output
+--let $assert_text = Status information found in error log
+--let $assert_file = $test_error_log
+--let $assert_count = 1
+--let $assert_select = Status information:
+--source include/assert_grep.inc
+
+# Test for SIGTERM output
+--let $assert_text = Server is shutdown gracefully
+--let $assert_file = $test_error_log
+--let $assert_count = 1
+--let $assert_select = mysqld.*: Shutdown complete
+--source include/assert_grep.inc
+
+--remove_file $test_error_log
+--source ../include/xplugin_cleanup.inc

--- a/plugin/x/src/ngs/socket_events.cc
+++ b/plugin/x/src/ngs/socket_events.cc
@@ -58,6 +58,8 @@
   } while (0)
 #endif
 
+extern sigset_t mysqld_signal_mask;
+
 namespace ngs {
 
 class Connection_acceptor_socket : public xpl::iface::Connection_acceptor {
@@ -92,6 +94,10 @@ class Connection_acceptor_socket : public xpl::iface::Connection_acceptor {
     vio = mysql_socket_vio_new(sock,
                                is_tcpip ? VIO_TYPE_TCPIP : VIO_TYPE_SOCKET, 0);
     if (!vio) throw std::bad_alloc();
+
+#ifdef USE_PPOLL_IN_VIO
+    vio->signal_mask = mysqld_signal_mask;
+#endif
 
     // enable TCP_NODELAY
     vio_fastsend(vio);


### PR DESCRIPTION
…andle signal

https://jira.percona.com/browse/PS-8907

Problem
-------
MySQL server abruptly terminates without performing a shutdown on SIGTERM when it has open connections from X plugin due to the unset signal_mask at the vio layer.

Solution
--------
Set the signal_mask at the time of creation of vio object so that signals are handled properly.


Testing Done
---
Jenkins : https://ps80.cd.percona.com/view/8.0%20parallel%20MTR/job/percona-server-8.0-pipeline-parallel-mtr/275/

Failing tests:
1. x.connection - Fixed.