### PR TITLE
PS-8885: Improve handling of secure-log-path

### DIFF
--- a/mysql-test/r/secure_log_path.result
+++ b/mysql-test/r/secure_log_path.result
@@ -1,4 +1,57 @@
-SET @old_general_log_file = @@global.general_log_file;
-SET GLOBAL general_log_file="DATADIR/log_in_the_datadir";
-ERROR 42000: Variable 'general_log_file' can't be set to the value of 'DATADIR/log_in_the_datadir'
-SET GLOBAL general_log_file="TMPDIR/log_in_the_secure_tmpdir";
+# restart: --general-log=ON --general-log-file=general_log_in_datadir --slow-query-log=ON --slow-query-log-file=slow_log_in_datadir --buffered-error-log-size=1000 --buffered-error-log-filename=buffered_log_in_datadir
+# restart: --secure-log-path=TMPDIR --general-log=OFF --general-log-file=general_log_in_datadir --slow-query-log=OFF --slow-query-log-file=slow_log_in_datadir --buffered-error-log-size=0 --buffered-error-log-filename=buffered_log_in_datadir
+# restart: --secure-log-path=TMPDIR --general-log=ON --general-log-file=TMPDIR/general_log_in_tmpdir --slow-query-log=ON --slow-query-log-file=TMPDIR/slow_log_in_tmpdir --buffered-error-log-size=1000 --buffered-error-log-filename=TMPDIR/buffered_log_in_tmpdir
+SET GLOBAL general_log_file=DEFAULT;
+ERROR 42000: Variable 'general_log_file' can't be set to the value of 'DEFAULT'
+SET GLOBAL slow_query_log_file=DEFAULT;
+ERROR 42000: Variable 'slow_query_log_file' can't be set to the value of 'DEFAULT'
+SET GLOBAL buffered_error_log_filename=DEFAULT;
+SET GLOBAL general_log_file=general_log_in_datadir;
+ERROR 42000: Variable 'general_log_file' can't be set to the value of 'general_log_in_datadir'
+SET GLOBAL slow_query_log_file=slow_log_in_datadir;
+ERROR 42000: Variable 'slow_query_log_file' can't be set to the value of 'slow_log_in_datadir'
+SET GLOBAL buffered_error_log_filename=buffered_log_in_datadir;
+ERROR 42000: Variable 'buffered_error_log_filename' can't be set to the value of 'buffered_log_in_datadir'
+SET GLOBAL general_log_file="log_dir/general_log_in_datadir";
+ERROR 42000: Variable 'general_log_file' can't be set to the value of 'log_dir/general_log_in_datadir'
+SET GLOBAL slow_query_log_file="log_dir/slow_log_in_datadir";
+ERROR 42000: Variable 'slow_query_log_file' can't be set to the value of 'log_dir/slow_log_in_datadir'
+SET GLOBAL buffered_error_log_filename="log_dir/buffered_log_in_datadir";
+ERROR 42000: Variable 'buffered_error_log_filename' can't be set to the value of 'log_dir/buffered_log_in_datadir'
+SET GLOBAL general_log_file="DATADIR/general_log_in_datadir";
+ERROR 42000: Variable 'general_log_file' can't be set to the value of 'DATADIR/general_log_in_datadir'
+SET GLOBAL slow_query_log_file="DATADIR/slow_log_in_datadir";
+ERROR 42000: Variable 'slow_query_log_file' can't be set to the value of 'DATADIR/slow_log_in_datadir'
+SET GLOBAL buffered_error_log_filename="DATADIR/buffered_log_in_datadir";
+ERROR 42000: Variable 'buffered_error_log_filename' can't be set to the value of 'DATADIR/buffered_log_in_datadir'
+SET GLOBAL general_log_file="TMPDIR/renamed_general_log_in_datadir";
+SET GLOBAL slow_query_log_file="TMPDIR/renamed_slow_log_in_datadir";
+SET GLOBAL buffered_error_log_filename="TMPDIR/renamed_buffered_log_in_datadir";
+SET GLOBAL general_log=OFF;
+SET GLOBAL slow_query_log=OFF;
+SET GLOBAL buffered_error_log_size=0;
+SET GLOBAL general_log_file=DEFAULT;
+SET GLOBAL slow_query_log_file=DEFAULT;
+SET GLOBAL buffered_error_log_filename=DEFAULT;
+SET GLOBAL general_log_file=general_log_in_datadir;
+SET GLOBAL slow_query_log_file=slow_log_in_datadir;
+SET GLOBAL buffered_error_log_filename=buffered_log_in_datadir;
+SET GLOBAL general_log_file="DATADIR/general_log_in_datadir";
+SET GLOBAL slow_query_log_file="DATADIR/slow_log_in_datadir";
+SET GLOBAL buffered_error_log_filename="DATADIR/buffered_log_in_datadir";
+SET GLOBAL general_log_file="TMPDIR/renamed_general_log_in_datadir";
+SET GLOBAL slow_query_log_file="TMPDIR/renamed_slow_log_in_datadir";
+SET GLOBAL buffered_error_log_filename="TMPDIR/renamed_buffered_log_in_datadir";
+SET GLOBAL general_log_file=general_log_in_datadir;
+SET GLOBAL slow_query_log_file=slow_log_in_datadir;
+SET GLOBAL buffered_error_log_filename=buffered_log_in_datadir;
+SET GLOBAL general_log=ON;
+ERROR HY000: The --secure-file-path is configured, --general-log-file must be set accordingly.
+SET GLOBAL slow_query_log=ON;
+ERROR HY000: The --secure-file-path is configured, --slow-query-log-file must be set accordingly.
+SET GLOBAL buffered_error_log_size=1000;
+ERROR HY000: The --secure-file-path is configured, --buffered-error-log-filename must be set accordingly.
+Pattern "The --secure-file-path is configured, --general-log-file must be set accordingly" found
+Pattern "The --secure-file-path is configured, --slow-query-log-file must be set accordingly" found
+Pattern "The --secure-file-path is configured, --buffered-error-log-filename must be set accordingly" found
+# restart:

--- a/mysql-test/t/secure_log_path-master.opt
+++ b/mysql-test/t/secure_log_path-master.opt
@@ -1,1 +1,0 @@
---secure_log_path=$MYSQL_TMP_DIR

--- a/mysql-test/t/secure_log_path.test
+++ b/mysql-test/t/secure_log_path.test
@@ -1,19 +1,146 @@
-# Test that general_log_file can't be set outside of secure_log_path
-# if it is set. If it is empty, it should be allowed anywhere, which is
-# tested by other existing general_log_file tests.
+--let $datadir = `SELECT @@datadir`
+--let $tmpdir = `SELECT @@tmpdir`
 
-SET @old_general_log_file = @@global.general_log_file;
+# --secure-log-path not set, all logs may be located in data directory
+--let $restart_parameters = "restart: --general-log=ON --general-log-file=general_log_in_datadir --slow-query-log=ON --slow-query-log-file=slow_log_in_datadir --buffered-error-log-size=1000 --buffered-error-log-filename=buffered_log_in_datadir"
+--source include/restart_mysqld.inc
 
-let $datadir= `select @@datadir`;
+# --secure-log-path is set, insecure log names are allowed while corresponding logs are disabled
+--let $restart_parameters = "restart: --secure-log-path=$tmpdir --general-log=OFF --general-log-file=general_log_in_datadir --slow-query-log=OFF --slow-query-log-file=slow_log_in_datadir --buffered-error-log-size=0 --buffered-error-log-filename=buffered_log_in_datadir"
+--replace_result $tmpdir TMPDIR
+--source include/restart_mysqld.inc
+
+# --secure-log-path is set, logs configured to be within secure path
+--let $restart_parameters = "restart: --secure-log-path=$tmpdir --general-log=ON --general-log-file=$tmpdir/general_log_in_tmpdir --slow-query-log=ON --slow-query-log-file=$tmpdir/slow_log_in_tmpdir --buffered-error-log-size=1000 --buffered-error-log-filename=$tmpdir/buffered_log_in_tmpdir"
+--replace_result $tmpdir TMPDIR
+--source include/restart_mysqld.inc
+
+# Logs in data directory with default name are not allowed,
+# except for buffered_error_log_filename which is empty by default
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL general_log_file=DEFAULT;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL slow_query_log_file=DEFAULT;
+SET GLOBAL buffered_error_log_filename=DEFAULT;
+
+# Log name in data directory not allowed
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL general_log_file=general_log_in_datadir;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL slow_query_log_file=slow_log_in_datadir;
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL buffered_error_log_filename=buffered_log_in_datadir;
+
+# Log relative name in data directory not allowed
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL general_log_file="log_dir/general_log_in_datadir";
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL slow_query_log_file="log_dir/slow_log_in_datadir";
+--error ER_WRONG_VALUE_FOR_VAR
+SET GLOBAL buffered_error_log_filename="log_dir/buffered_log_in_datadir";
+
+# Log full name in data directory not allowed
 --replace_result $datadir DATADIR
 --error ER_WRONG_VALUE_FOR_VAR
---eval SET GLOBAL general_log_file="$datadir/log_in_the_datadir"
+--eval SET GLOBAL general_log_file="$datadir/general_log_in_datadir"
+--replace_result $datadir DATADIR
+--error ER_WRONG_VALUE_FOR_VAR
+--eval SET GLOBAL slow_query_log_file="$datadir/slow_log_in_datadir"
+--replace_result $datadir DATADIR
+--error ER_WRONG_VALUE_FOR_VAR
+--eval SET GLOBAL buffered_error_log_filename="$datadir/buffered_log_in_datadir"
 
---let $tmpdir= `SELECT @@tmpdir`
+# Setting names to valid values
 --replace_result $tmpdir TMPDIR
---eval SET GLOBAL general_log_file="$tmpdir/log_in_the_secure_tmpdir"
+--eval SET GLOBAL general_log_file="$tmpdir/renamed_general_log_in_datadir"
+--replace_result $tmpdir TMPDIR
+--eval SET GLOBAL slow_query_log_file="$tmpdir/renamed_slow_log_in_datadir"
+--replace_result $tmpdir TMPDIR
+--eval SET GLOBAL buffered_error_log_filename="$tmpdir/renamed_buffered_log_in_datadir"
 
---disable_query_log
-SET GLOBAL general_log_file = @old_general_log_file;
-call mtr.add_suppression("Insecure configuration for --secure-log-path");
---enable_query_log
+#
+# Restrictions implied by --secure-log-path do not take effect in case
+# general-log/slow-query-log/buffered-error-log-size disabled.
+SET GLOBAL general_log=OFF;
+SET GLOBAL slow_query_log=OFF;
+SET GLOBAL buffered_error_log_size=0;
+
+SET GLOBAL general_log_file=DEFAULT;
+SET GLOBAL slow_query_log_file=DEFAULT;
+SET GLOBAL buffered_error_log_filename=DEFAULT;
+
+SET GLOBAL general_log_file=general_log_in_datadir;
+SET GLOBAL slow_query_log_file=slow_log_in_datadir;
+SET GLOBAL buffered_error_log_filename=buffered_log_in_datadir;
+
+--replace_result $datadir DATADIR
+--eval SET GLOBAL general_log_file="$datadir/general_log_in_datadir"
+--replace_result $datadir DATADIR
+--eval SET GLOBAL slow_query_log_file="$datadir/slow_log_in_datadir"
+--replace_result $datadir DATADIR
+--eval SET GLOBAL buffered_error_log_filename="$datadir/buffered_log_in_datadir"
+
+--replace_result $tmpdir TMPDIR
+--eval SET GLOBAL general_log_file="$tmpdir/renamed_general_log_in_datadir"
+--replace_result $tmpdir TMPDIR
+--eval SET GLOBAL slow_query_log_file="$tmpdir/renamed_slow_log_in_datadir"
+--replace_result $tmpdir TMPDIR
+--eval SET GLOBAL buffered_error_log_filename="$tmpdir/renamed_buffered_log_in_datadir"
+
+#
+# Check general-log/slow-query-log/buffered-error-log-size cannot be enabled
+# while --secure-log-path is set and corresponding log names are configured
+# to be outside of secure location.
+SET GLOBAL general_log_file=general_log_in_datadir;
+SET GLOBAL slow_query_log_file=slow_log_in_datadir;
+SET GLOBAL buffered_error_log_filename=buffered_log_in_datadir;
+
+--error ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT
+SET GLOBAL general_log=ON;
+--error ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT
+SET GLOBAL slow_query_log=ON;
+--error ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT
+SET GLOBAL buffered_error_log_size=1000;
+
+#
+# Checking inconsistent log names when --secure-log-path is used during server start
+
+let restart_log= $MYSQLTEST_VARDIR/log/my_restart.err;
+let SEARCH_FILE= $restart_log;
+let $restart_file= $MYSQLTEST_VARDIR/tmp/mysqld.1.expect;
+
+--exec echo "wait" > $restart_file
+--shutdown_server
+--source include/wait_until_disconnected.inc
+
+# Unsecure location for general-log-file during server start
+--error 0,1
+--remove_file $restart_log
+--error 1
+--exec $MYSQLD_CMD --secure-log-path=$tmpdir --general-log=ON --general-log-file=general_log_in_datadir --slow-query-log=ON --slow-query-log-file=$tmpdir/slow_log_in_tmpdir --buffered-error-log-size=1000 --buffered-error-log-filename=$tmpdir/buffered_log_in_tmpdir --loose-console > $restart_log 2>&1
+
+let SEARCH_PATTERN= The --secure-file-path is configured, --general-log-file must be set accordingly;
+--source include/search_pattern.inc
+
+# Unsecure location for slow-query-log-file during server start
+--error 0,1
+--remove_file $restart_log
+--error 1
+--exec $MYSQLD_CMD --secure-log-path=$tmpdir --general-log=ON --general-log-file=$tmpdir/general_log_in_tmpdir --slow-query-log=ON --slow-query-log-file=slow_log_in_datadir --buffered-error-log-size=1000 --buffered-error-log-filename=$tmpdir/buffered_log_in_tmpdir --loose-console > $restart_log 2>&1
+
+let SEARCH_PATTERN= The --secure-file-path is configured, --slow-query-log-file must be set accordingly;
+--source include/search_pattern.inc
+
+# Unsecure location for buffered-error-log-filename during server start
+--error 0,1
+--remove_file $restart_log
+--error 1
+--exec $MYSQLD_CMD --secure-log-path=$tmpdir --general-log=ON --general-log-file=$tmpdir/general_log_in_tmpdir --slow-query-log=ON --slow-query-log-file=$tmpdir/slow_log_in_tmpdir --buffered-error-log-size=1000 --buffered-error-log-filename=buffered_log_in_datadir --loose-console > $restart_log 2>&1
+
+let SEARCH_PATTERN= The --secure-file-path is configured, --buffered-error-log-filename must be set accordingly;
+--source include/search_pattern.inc
+
+--remove_file $restart_log 10
+
+--let $restart_parameters = "restart:"
+--source include/start_mysqld.inc

--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -10071,6 +10071,8 @@ ER_TOO_BIG_ERROR_CODE
 ER_DYNAMIC_ROLE
   eng "The role %s is a dynamic role and can't be revoked or dropped. It should be managed by the external authentication plugin instead."
 
+ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT
+  eng "The --secure-file-path is configured, %s must be set accordingly."
 #
 # End of Percona Server 8.0 client messages
 #

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -12382,6 +12382,9 @@ ER_CONN_CONTROL_FAILED_CONN_THRESHOLD_REACHED_WITH_WARN
 ER_CONN_CONTROL_DELAYED_CONN_STATS
   eng "Delayed %llu connection attempts during last %llu seconds"
 
+ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH
+  eng "The --secure-file-path is configured, %s must be set accordingly."
+
 #
 # End of Percona Server 8.0 server error log messages
 #

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5458,6 +5458,26 @@ int init_common_variables() {
                         make_query_log_name(slow_logname_path, QUERY_LOG_SLOW),
                         MYF(MY_WME)));
 
+  if (opt_general_log && opt_general_logname != nullptr &&
+      !is_secure_log_path(opt_general_logname)) {
+    LogErr(ERROR_LEVEL, ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH,
+           "--general-log-file");
+    return 1;
+  }
+  if (opt_slow_log && opt_slow_logname != nullptr &&
+      !is_secure_log_path(opt_slow_logname)) {
+    LogErr(ERROR_LEVEL, ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH,
+           "--slow-query-log-file");
+    return 1;
+  }
+  if (buffered_error_log_size > 0 && buffered_error_log_filename != nullptr &&
+      strlen(buffered_error_log_filename) > 0 &&
+      !is_secure_log_path(buffered_error_log_filename)) {
+    LogErr(ERROR_LEVEL, ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH,
+           "--buffered-error-log-filename");
+    return 1;
+  }
+
 #if defined(ENABLED_DEBUG_SYNC)
   /* Initialize the debug sync facility. See debug_sync.cc. */
   if (debug_sync_init()) return 1; /* purecov: tested */
@@ -11729,9 +11749,9 @@ static const char *get_relative_path(const char *path) {
   return path;
 }
 
-static bool is_secure_path(const char *path, const char *opt_base) {
+static bool is_secure_path(const std::string &path, const char *opt_base) {
   char buff1[FN_REFLEN], buff2[FN_REFLEN];
-  size_t opt_base_len;
+  size_t opt_base_len = 0;
   /*
     All paths are secure if opt_base is 0
   */
@@ -11739,17 +11759,17 @@ static bool is_secure_path(const char *path, const char *opt_base) {
 
   opt_base_len = strlen(opt_base);
 
-  if (strlen(path) >= FN_REFLEN) return false;
+  if (path.length() >= FN_REFLEN) return false;
 
   if (!my_strcasecmp(system_charset_info, opt_base, "NULL")) return false;
 
-  if (my_realpath(buff1, path, 0)) {
+  if (my_realpath(buff1, path.c_str(), 0)) {
     /*
       The supplied file path might have been a file and not a directory.
     */
-    int length = (int)dirname_length(path);
+    int length = (int)dirname_length(path.c_str());
     if (length >= FN_REFLEN) return false;
-    memcpy(buff2, path, length);
+    memcpy(buff2, path.c_str(), length);
     buff2[length] = '\0';
     if (length == 0 || my_realpath(buff1, buff2, 0)) return false;
   }
@@ -11782,13 +11802,18 @@ bool is_secure_file_path(const char *path) {
   Test a file path to determine if the path is compatible with the secure log
   path restriction.
 
-  @param path null terminated character string
+  @param path Log path
 
   @retval true The path is secure
   @retval false The path isn't secure
 */
-bool is_secure_log_path(const char *path) {
-  return is_secure_path(path, opt_secure_log_path);
+bool is_secure_log_path(const std::string &path) {
+  if (strlen(opt_secure_log_path) == 0) {
+    // No secure path set
+    return true;
+  }
+
+  return !path.empty() && is_secure_path(path, opt_secure_log_path);
 }
 
 /**

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -134,7 +134,7 @@ void kill_mysql(void);
 void refresh_status();
 void reset_status_by_thd();
 bool is_secure_file_path(const char *path);
-bool is_secure_log_path(const char *path);
+bool is_secure_log_path(const std::string &path);
 ulong sql_rnd_with_mutex();
 
 struct System_status_var *get_thd_status_var(THD *thd, bool *aggregated);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -6185,7 +6185,8 @@ static Sys_var_charptr Sys_license("license",
                                    NO_CMD_LINE, IN_SYSTEM_CHARSET,
                                    DEFAULT(STRINGIFY_ARG(LICENSE)));
 
-static bool check_log_path(sys_var *self, THD *, set_var *var) {
+static bool check_log_path_base(sys_var *self, THD *thd [[maybe_unused]],
+                                set_var *var, std::string &log_path) {
   if (!var->value) return false;  // DEFAULT is ok
 
   if (!var->save_result.string_value.str) return true;
@@ -6205,7 +6206,9 @@ static bool check_log_path(sys_var *self, THD *, set_var *var) {
   char path[FN_REFLEN];
   size_t path_length = unpack_filename(path, var->save_result.string_value.str);
 
-  if (!path_length) return true;
+  if (path_length == 0) return true;
+
+  log_path.assign(path, path_length);
 
   if (!is_filename_allowed(var->save_result.string_value.str,
                            var->save_result.string_value.length, true)) {
@@ -6235,21 +6238,41 @@ static bool check_log_path(sys_var *self, THD *, set_var *var) {
 
   if (my_access(path, (F_OK | W_OK))) return true;  // directory is not writable
 
-  if (!is_secure_log_path((path))) return true;
-
   return false;
 }
 
-static bool check_log_path_allow_empty(sys_var *self, THD *thd, set_var *var) {
+static bool check_buffered_error_log_filename(sys_var *self, THD *thd,
+                                              set_var *var) {
+  // Empty value is allowed
   if (!var->value) return false;
 
   if (!var->save_result.string_value.str) return false;
 
   if (strlen(var->save_result.string_value.str) == 0) return false;
 
-  if (!check_log_path(self, thd, var)) return false;
+  std::string log_path;
+  if (check_log_path_base(self, thd, var, log_path)) {
+    return true;
+  }
 
-  return true;
+  if (buffered_error_log_size > 0 && !is_secure_log_path(log_path)) {
+    return true;
+  }
+
+  return false;
+}
+
+static bool check_general_log_file(sys_var *self, THD *thd, set_var *var) {
+  std::string log_path;
+  if (check_log_path_base(self, thd, var, log_path)) {
+    return true;
+  }
+
+  if (opt_general_log && !is_secure_log_path(log_path)) {
+    return true;
+  }
+
+  return false;
 }
 
 static bool fix_general_log_file(sys_var *, THD *, enum_var_type) {
@@ -6285,8 +6308,21 @@ static bool fix_general_log_file(sys_var *, THD *, enum_var_type) {
 static Sys_var_charptr Sys_general_log_path(
     "general_log_file", "Log connections and queries to given file",
     GLOBAL_VAR(opt_general_logname), CMD_LINE(REQUIRED_ARG), IN_FS_CHARSET,
-    DEFAULT(nullptr), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_log_path),
-    ON_UPDATE(fix_general_log_file));
+    DEFAULT(nullptr), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+    ON_CHECK(check_general_log_file), ON_UPDATE(fix_general_log_file));
+
+static bool check_slow_log_file(sys_var *self, THD *thd, set_var *var) {
+  std::string log_path;
+  if (check_log_path_base(self, thd, var, log_path)) {
+    return true;
+  }
+
+  if (opt_slow_log && !is_secure_log_path(log_path)) {
+    return true;
+  }
+
+  return false;
+}
 
 static bool fix_slow_log_file(sys_var *, THD *thd [[maybe_unused]],
                               enum_var_type) {
@@ -6331,7 +6367,7 @@ static Sys_var_charptr Sys_slow_log_path(
     "other slow log options",
     PREALLOCATED GLOBAL_VAR(opt_slow_logname), CMD_LINE(REQUIRED_ARG),
     IN_FS_CHARSET, DEFAULT(nullptr), NO_MUTEX_GUARD, NOT_IN_BINLOG,
-    ON_CHECK(check_log_path), ON_UPDATE(fix_slow_log_file));
+    ON_CHECK(check_slow_log_file), ON_UPDATE(fix_slow_log_file));
 
 static Sys_var_have Sys_have_compress(
     "have_compress", "have_compress",
@@ -6617,6 +6653,18 @@ static Sys_var_enum Sys_slow_query_log_rate_type(
     GLOBAL_VAR(opt_slow_query_log_rate_type), CMD_LINE(REQUIRED_ARG),
     slow_query_log_rate_name, DEFAULT(SLOG_RT_SESSION));
 
+static bool check_general_log(sys_var *self [[maybe_unused]],
+                              THD *thd [[maybe_unused]], set_var *var) {
+  if (var->save_result.ulonglong_value != 0 &&
+      !is_secure_log_path(opt_general_logname)) {
+    my_error(ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT, MYF(0),
+             "--general-log-file");
+    return true;
+  }
+
+  return false;
+}
+
 static bool fix_general_log_state(sys_var *, THD *thd, enum_var_type) {
   bool new_state = opt_general_log, res = false;
 
@@ -6643,7 +6691,7 @@ static Sys_var_bool Sys_general_log(
     "Defaults to logging to a file hostname.log, "
     "or if --log-output=TABLE is used, to a table mysql.general_log.",
     GLOBAL_VAR(opt_general_log), CMD_LINE(OPT_ARG), DEFAULT(false),
-    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr),
+    NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(check_general_log),
     ON_UPDATE(fix_general_log_state));
 
 static Sys_var_bool Sys_log_raw(
@@ -6652,6 +6700,18 @@ static Sys_var_bool Sys_log_raw(
     "debugging, not production as sensitive information may be logged.",
     GLOBAL_VAR(opt_general_log_raw), CMD_LINE(OPT_ARG), DEFAULT(false),
     NO_MUTEX_GUARD, NOT_IN_BINLOG);
+
+static bool check_slow_log(sys_var *self [[maybe_unused]],
+                           THD *thd [[maybe_unused]], set_var *var) {
+  if (var->save_result.ulonglong_value != 0 &&
+      !is_secure_log_path(opt_slow_logname)) {
+    my_error(ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT, MYF(0),
+             "--slow-query-log-file");
+    return true;
+  }
+
+  return false;
+}
 
 static bool fix_slow_log_state(sys_var *, THD *thd, enum_var_type) {
   bool new_state = opt_slow_log, res = false;
@@ -6679,7 +6739,7 @@ static Sys_var_bool Sys_slow_query_log(
     "hostname-slow.log or a table mysql.slow_log if --log-output=TABLE is "
     "used. Must be enabled to activate other slow log options",
     GLOBAL_VAR(opt_slow_log), CMD_LINE(OPT_ARG), DEFAULT(false), NO_MUTEX_GUARD,
-    NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(fix_slow_log_state));
+    NOT_IN_BINLOG, ON_CHECK(check_slow_log), ON_UPDATE(fix_slow_log_state));
 
 static bool check_slow_log_extra(sys_var *, THD *thd, set_var *) {
   // If FILE is not one of the log-targets, succeed but warn!
@@ -8270,7 +8330,20 @@ static Sys_var_enum Sys_terminology_use_previous(
 
 std::size_t buffered_error_log_size;
 
-static bool buffered_error_log_size_update(sys_var *, THD *, enum_var_type) {
+static bool check_buffered_error_log_size(sys_var *self [[maybe_unused]],
+                                          THD *thd [[maybe_unused]],
+                                          set_var *var) {
+  if (var->save_result.ulonglong_value > 0 &&
+      !is_secure_log_path(buffered_error_log_filename)) {
+    my_error(ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH_CLIENT, MYF(0),
+             "--buffered-error-log-filename");
+    return true;
+  }
+
+  return false;
+}
+
+static bool update_buffered_error_log_size(sys_var *, THD *, enum_var_type) {
   buffered_error_log.resize(buffered_error_log_size * 1024);
   return false;
 }
@@ -8279,14 +8352,14 @@ static Sys_var_charptr Sys_var_buffered_error_log_filename(
     "buffered_error_log_filename", "Filename of the buffered error log",
     GLOBAL_VAR(buffered_error_log_filename), CMD_LINE(REQUIRED_ARG),
     IN_FS_CHARSET, DEFAULT(""), NO_MUTEX_GUARD, NOT_IN_BINLOG,
-    ON_CHECK(check_log_path_allow_empty));
+    ON_CHECK(check_buffered_error_log_filename));
 
 static Sys_var_ulonglong Sys_var_buffered_error_log_size(
     "buffered_error_log_size", "Size of the buffered error log (kB)",
     GLOBAL_VAR(buffered_error_log_size), CMD_LINE(REQUIRED_ARG),
     VALID_RANGE(0, ULLONG_MAX), DEFAULT(0), BLOCK_SIZE(1), NO_MUTEX_GUARD,
-    NOT_IN_BINLOG, ON_CHECK(nullptr),
-    ON_UPDATE(buffered_error_log_size_update));
+    NOT_IN_BINLOG, ON_CHECK(check_buffered_error_log_size),
+    ON_UPDATE(update_buffered_error_log_size));
 
 #ifndef NDEBUG
 Debug_shutdown_actions Debug_shutdown_actions::instance;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8885

- Added validation of general-log-file, slow-query-log-file, and
  buffered-error-log-filename during server startup. Server startup is
  aborted in case file path doesn't match secure-log-path and
  corresponding log is enabled.
- Added validation for general-log, slow-query-log, and
  buffered-error-log-size. Logging cannot be enabled in case secure-log-path
  is set and corresponding log location is already set to insecure one.
- Default values for general-log-file and slow-query-log-file
  are not allowed in case secure-log-path is set.
- Log location restrictions introduced by secure-log-path do not take
  effect while corresponding logs are disabled.