### PR TITLE
PS-8836 fix: MyRocks serialization violation? Read after write is failing

### DIFF
--- a/mysql-test/suite/rocksdb/include/rocksdb_concurrent_delete_sk.inc
+++ b/mysql-test/suite/rocksdb/include/rocksdb_concurrent_delete_sk.inc
@@ -17,7 +17,7 @@ INSERT INTO t1 VALUES(1,1), (2,2), (3,3), (4,4), (5,5);
 --echo --SK first row delete
 connection con;
 eval SET SESSION TRANSACTION ISOLATION LEVEL $isolation_level;
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 send_eval SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 
 # While that connection is waiting, delete the first row (the one con
@@ -34,7 +34,7 @@ reap;
 
 # Deleting a middle row
 --echo --SK middle row delete
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 send_eval SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 
 connection default;
@@ -55,7 +55,7 @@ if ($isolation_level == "READ COMMITTED")
 
 # Deleting the end row
 --echo --SK end row delete
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 send_eval SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 
 connection default;

--- a/mysql-test/suite/rocksdb/r/rocksdb_concurrent_delete.result
+++ b/mysql-test/suite/rocksdb/r/rocksdb_concurrent_delete.result
@@ -36,7 +36,7 @@ CREATE TABLE t1 (pk INT PRIMARY KEY, a INT, index a(a)) ENGINE=RocksDB;
 INSERT INTO t1 VALUES(1,1), (2,2), (3,3), (4,4), (5,5);
 --SK first row delete
 SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 SET debug_sync='now WAIT_FOR parked';
 DELETE FROM t1 WHERE pk = 1;
@@ -47,14 +47,14 @@ a
 4
 5
 --SK middle row delete
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 SET debug_sync='now WAIT_FOR parked';
 DELETE FROM t1 WHERE pk = 3;
 SET debug_sync='now SIGNAL go';
 ERROR 40001: Deadlock found when trying to get lock; try restarting transaction
 --SK end row delete
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 SET debug_sync='now WAIT_FOR parked';
 DELETE FROM t1 WHERE pk = 5;
@@ -289,7 +289,7 @@ CREATE TABLE t1 (pk INT PRIMARY KEY, a INT, index a(a)) ENGINE=RocksDB;
 INSERT INTO t1 VALUES(1,1), (2,2), (3,3), (4,4), (5,5);
 --SK first row delete
 SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 SET debug_sync='now WAIT_FOR parked';
 DELETE FROM t1 WHERE pk = 1;
@@ -300,7 +300,7 @@ a
 4
 5
 --SK middle row delete
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 SET debug_sync='now WAIT_FOR parked';
 DELETE FROM t1 WHERE pk = 3;
@@ -310,7 +310,7 @@ a
 4
 5
 --SK end row delete
-SET debug_sync='rocksdb_concurrent_delete_sk SIGNAL parked WAIT_FOR go';
+SET debug_sync='rocksdb_concurrent_upd_or_delete_sk SIGNAL parked WAIT_FOR go';
 SELECT a FROM t1 FORCE INDEX(a) FOR UPDATE;
 SET debug_sync='now WAIT_FOR parked';
 DELETE FROM t1 WHERE pk = 5;

--- a/mysql-test/suite/rocksdb/r/sk_rc_concurrent_point_update.result
+++ b/mysql-test/suite/rocksdb/r/sk_rc_concurrent_point_update.result
@@ -1,0 +1,106 @@
+Conn A creating table
+CREATE TABLE table1 (
+row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+val1 TINYINT NOT NULL,
+val2 VARCHAR(128) NOT NULL,
+PRIMARY KEY (row_key),
+KEY idx_val1 (val1)
+) ENGINE=RocksDB;
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+Conn A: `table1` created with 4 rows
+Conn A: Table before
+SELECT * FROM table1;
+row_key	val1	val2
+1	14	Alfa
+2	14	Bravo
+3	14	Charlie
+4	14	Delta
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn A: Started TRANSACTION A (SELECT .. FOR UPDATE )
+set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
+Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
+SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
+Conn A: Sent SELECT
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn B: Started TRANSACTION B (Concurrent update)
+Conn B: Waiting for Conn A to hit `waiting_for_update`
+set DEBUG_SYNC = "now WAIT_FOR waiting_for_update";
+Conn B: Conn A triggered `waiting_for_update`
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND val2 = 'Alfa';
+SELECT * FROM table1;
+row_key	val1	val2
+1	15	Alfa
+2	14	Bravo
+3	14	Charlie
+4	14	Delta
+COMMIT;
+Conn B: COMMIT for update done
+set DEBUG_SYNC = "now SIGNAL update_done";
+Conn B: signalled Conn A with event `update_done`
+Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa';
+The SELECT output should be empty
+row_key	val1	val2
+ROLLBACK;
+Conn A: Table after
+SELECT * FROM table1;
+row_key	val1	val2
+1	15	Alfa
+2	14	Bravo
+3	14	Charlie
+4	14	Delta
+DROP TABLE table1;
+Conn A creating table
+CREATE TABLE table1 (
+
+val1 TINYINT NOT NULL,
+val2 VARCHAR(128) NOT NULL,
+
+KEY idx_val1 (val1)
+) ENGINE=RocksDB;
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+Conn A: `table1` created with 4 rows
+Conn A: Table before
+SELECT * FROM table1;
+val1	val2
+14	Alfa
+14	Bravo
+14	Charlie
+14	Delta
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn A: Started TRANSACTION A (SELECT .. FOR UPDATE )
+set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
+Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
+SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
+Conn A: Sent SELECT
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn B: Started TRANSACTION B (Concurrent update)
+Conn B: Waiting for Conn A to hit `waiting_for_update`
+set DEBUG_SYNC = "now WAIT_FOR waiting_for_update";
+Conn B: Conn A triggered `waiting_for_update`
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND val2 = 'Alfa';
+SELECT * FROM table1;
+val1	val2
+15	Alfa
+14	Bravo
+14	Charlie
+14	Delta
+COMMIT;
+Conn B: COMMIT for update done
+set DEBUG_SYNC = "now SIGNAL update_done";
+Conn B: signalled Conn A with event `update_done`
+Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa';
+The SELECT output should be empty
+val1	val2
+ROLLBACK;
+Conn A: Table after
+SELECT * FROM table1;
+val1	val2
+15	Alfa
+14	Bravo
+14	Charlie
+14	Delta
+DROP TABLE table1;

--- a/mysql-test/suite/rocksdb/r/sk_rc_concurrent_update.result
+++ b/mysql-test/suite/rocksdb/r/sk_rc_concurrent_update.result
@@ -1,0 +1,88 @@
+Conn A creating table
+CREATE TABLE table1 (
+row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+val1 TINYINT NOT NULL,
+val2 VARCHAR(128) NOT NULL,
+PRIMARY KEY (row_key),
+KEY idx_val1 (val1)
+) ENGINE=RocksDB;
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+Conn A: `table1` created with 4 rows
+Conn A: Table before
+SELECT * FROM table1;
+row_key	val1	val2
+1	14	Alfa
+2	14	Bravo
+3	14	Charlie
+4	14	Delta
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn A: Started TRANSACTION A (Update )
+set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
+Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND  val2 = 'Bravo';
+Conn A: Sent UPDATE
+Conn B: Start transaction B
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn B: Started TRANSACTION B (Update)
+Conn B: Waiting for Conn A to hit `waiting_for_update`
+set DEBUG_SYNC = "now WAIT_FOR waiting_for_update";
+Conn B: Conn A triggered `waiting_for_update`
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND val2 = 'Alfa';
+COMMIT;
+Conn B: COMMIT for update done
+set DEBUG_SYNC = "now SIGNAL update_done";
+Conn B: signalled Conn A with event `update_done`
+Conn A: Table after
+SELECT * FROM table1;
+row_key	val1	val2
+1	15	Alfa
+2	15	Bravo
+3	14	Charlie
+4	14	Delta
+DROP TABLE table1;
+Conn A creating table
+CREATE TABLE table1 (
+
+val1 TINYINT NOT NULL,
+val2 VARCHAR(128) NOT NULL,
+
+KEY idx_val1 (val1)
+) ENGINE=RocksDB;
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+Conn A: `table1` created with 4 rows
+Conn A: Table before
+SELECT * FROM table1;
+val1	val2
+14	Alfa
+14	Bravo
+14	Charlie
+14	Delta
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn A: Started TRANSACTION A (Update )
+set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
+Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND  val2 = 'Bravo';
+Conn A: Sent UPDATE
+Conn B: Start transaction B
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn B: Started TRANSACTION B (Update)
+Conn B: Waiting for Conn A to hit `waiting_for_update`
+set DEBUG_SYNC = "now WAIT_FOR waiting_for_update";
+Conn B: Conn A triggered `waiting_for_update`
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND val2 = 'Alfa';
+COMMIT;
+Conn B: COMMIT for update done
+set DEBUG_SYNC = "now SIGNAL update_done";
+Conn B: signalled Conn A with event `update_done`
+Conn A: Table after
+SELECT * FROM table1;
+val1	val2
+15	Alfa
+15	Bravo
+14	Charlie
+14	Delta
+DROP TABLE table1;

--- a/mysql-test/suite/rocksdb/r/sk_rc_read_set.result
+++ b/mysql-test/suite/rocksdb/r/sk_rc_read_set.result
@@ -1,0 +1,86 @@
+Creating TABLE `table1`
+CREATE TABLE table1 (
+row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+val1 TINYINT NOT NULL,
+val2 VARCHAR(128) NOT NULL,
+PRIMARY KEY (row_key),
+KEY idx_val1 (val1, val2(1))
+) ENGINE=RocksDB;
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+`table1` created with 4 rows
+Table before
+SELECT * FROM table1;
+row_key	val1	val2
+1	14	Alfa
+2	14	Bravo
+3	14	Charlie
+4	14	Delta
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn A: Started RC TRANSACTION
+Conn A: SELECT with val1 referenced - NO LOCKS
+SELECT val1 from table1 WHERE val1 = 14;
+val1
+14
+14
+14
+14
+Conn A: SELECT .. FOR SHARE with val1 referenced - READ LOCK
+SELECT val1 from table1 WHERE val1 = 14 FOR SHARE;
+val1
+14
+14
+14
+14
+Conn A: SELECT .. FOR UPDATE with val1 referenced - WRITE LOCK
+SELECT val1 from table1 WHERE val1 = 14 FOR UPDATE;
+val1
+14
+14
+14
+14
+ROLLBACK;
+DROP TABLE table1;
+Creating TABLE `table1`
+CREATE TABLE table1 (
+
+val1 TINYINT NOT NULL,
+val2 VARCHAR(128) NOT NULL,
+
+KEY idx_val1 (val1, val2(1))
+) ENGINE=RocksDB;
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+`table1` created with 4 rows
+Table before
+SELECT * FROM table1;
+val1	val2
+14	Alfa
+14	Bravo
+14	Charlie
+14	Delta
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+Conn A: Started RC TRANSACTION
+Conn A: SELECT with val1 referenced - NO LOCKS
+SELECT val1 from table1 WHERE val1 = 14;
+val1
+14
+14
+14
+14
+Conn A: SELECT .. FOR SHARE with val1 referenced - READ LOCK
+SELECT val1 from table1 WHERE val1 = 14 FOR SHARE;
+val1
+14
+14
+14
+14
+Conn A: SELECT .. FOR UPDATE with val1 referenced - WRITE LOCK
+SELECT val1 from table1 WHERE val1 = 14 FOR UPDATE;
+val1
+14
+14
+14
+14
+ROLLBACK;
+DROP TABLE table1;

--- a/mysql-test/suite/rocksdb/t/sk_rc_concurrent_point_update.test
+++ b/mysql-test/suite/rocksdb/t/sk_rc_concurrent_point_update.test
@@ -1,0 +1,91 @@
+--source include/have_rocksdb.inc
+--source include/have_debug_sync.inc
+
+--source include/count_sessions.inc
+
+--connect(con0, localhost, root,, test)
+--connection default
+
+let $i = 1;
+let $define_row_key = row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,;
+let $define_pk = PRIMARY KEY (row_key),;
+
+while ($i <= 2) {
+
+--echo Conn A creating table
+eval CREATE TABLE table1 (
+  $define_row_key
+  val1 TINYINT NOT NULL,
+  val2 VARCHAR(128) NOT NULL,
+  $define_pk
+  KEY idx_val1 (val1)
+) ENGINE=RocksDB;
+
+# Conn A: first, create a table with a few rows, keeping the val1 column all the same
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+--echo Conn A: `table1` created with 4 rows
+
+--echo Conn A: Table before
+SELECT * FROM table1;
+
+# next, start a transaction from Conn A to do a locking read for the rows based on a SK condition
+# to be specific, select rows matching val1 = 14
+# the update command should be `sent` after activating a DEBUG_SYNC point, so that the
+# update gets frozen
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+--echo Conn A: Started TRANSACTION A (SELECT .. FOR UPDATE )
+
+set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
+--echo Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
+
+send SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
+--echo Conn A: Sent SELECT
+
+# Meanwhile, start another transaction from Conn B to update val1 in such a way that
+# the parallel transaction from Conn A hits the conflict
+--connection con0
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+--echo Conn B: Started TRANSACTION B (Concurrent update)
+
+--echo Conn B: Waiting for Conn A to hit `waiting_for_update`
+set DEBUG_SYNC = "now WAIT_FOR waiting_for_update";
+--echo Conn B: Conn A triggered `waiting_for_update`
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND val2 = 'Alfa';
+SELECT * FROM table1;
+COMMIT;
+--echo Conn B: COMMIT for update done
+
+# Unfreeze the Conn A update so that it can hit the conflict, and error out
+set DEBUG_SYNC = "now SIGNAL update_done";
+--echo Conn B: signalled Conn A with event `update_done`
+
+# The followed reaped output should be empty due to KEY_NOT_FOUND being
+# returned back by the lookup function (due to concurrent update invalidating
+# the search predicates
+
+--echo Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa';
+--echo The SELECT output should be empty
+--connection default
+reap;
+ROLLBACK;
+--echo Conn A: Table after
+SELECT * FROM table1;
+
+DROP TABLE table1;
+
+# next, run the above tests a second time without explicitly defining
+# the primary key. this tests scenarios around hidden PK.
+
+inc $i;
+let $define_row_key = ;
+let $define_pk = ;
+
+}
+
+--disconnect con0
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/rocksdb/t/sk_rc_concurrent_update.test
+++ b/mysql-test/suite/rocksdb/t/sk_rc_concurrent_update.test
@@ -1,0 +1,84 @@
+--source include/have_rocksdb.inc
+--source include/have_debug_sync.inc
+
+--source include/count_sessions.inc
+
+--connect(con0, localhost, root,, test)
+--connection default
+
+let $i = 1;
+let $define_row_key = row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,;
+let $define_pk = PRIMARY KEY (row_key),;
+
+while ($i <= 2) {
+
+--echo Conn A creating table
+eval CREATE TABLE table1 (
+  $define_row_key
+  val1 TINYINT NOT NULL,
+  val2 VARCHAR(128) NOT NULL,
+  $define_pk
+  KEY idx_val1 (val1)
+) ENGINE=RocksDB;
+
+# Conn A: first, create a table with a few rows, keeping the val1 column all the same
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+--echo Conn A: `table1` created with 4 rows
+
+--echo Conn A: Table before
+SELECT * FROM table1;
+
+# next, start a transaction from Conn A to update the rows based on a SK condition
+# to be specific, update val1 to 15 if it's 14
+# the update command should be `sent` after activating a DEBUG_SYNC point, so that the
+# update gets frozen.
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+--echo Conn A: Started TRANSACTION A (Update )
+
+set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
+--echo Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
+
+send UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND  val2 = 'Bravo';
+--echo Conn A: Sent UPDATE
+
+# Meanwhile, start another transaction from Conn B to update val1 in such a way that
+# the parallel transaction from Conn A hits the conflict
+--connection con0
+
+--echo Conn B: Start transaction B
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+--echo Conn B: Started TRANSACTION B (Update)
+
+--echo Conn B: Waiting for Conn A to hit `waiting_for_update`
+set DEBUG_SYNC = "now WAIT_FOR waiting_for_update";
+--echo Conn B: Conn A triggered `waiting_for_update`
+UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND val2 = 'Alfa';
+COMMIT;
+--echo Conn B: COMMIT for update done
+
+# Unfreeze the Conn A update so that it can hit the conflict, and error out
+set DEBUG_SYNC = "now SIGNAL update_done";
+--echo Conn B: signalled Conn A with event `update_done`
+
+--connection default
+reap;
+--echo Conn A: Table after
+SELECT * FROM table1;
+
+DROP TABLE table1;
+
+# next, run the above tests a second time without explicitly defining
+# the primary key. this tests scenarios around hidden PK.
+
+inc $i;
+let $define_row_key = ;
+let $define_pk = ;
+
+}
+
+--disconnect con0
+
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/rocksdb/t/sk_rc_read_set.test
+++ b/mysql-test/suite/rocksdb/t/sk_rc_read_set.test
@@ -1,0 +1,63 @@
+--source include/have_rocksdb.inc
+
+let $i = 1;
+let $define_row_key = row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,;
+let $define_pk = PRIMARY KEY (row_key),;
+
+while ($i <= 2) {
+
+--echo Creating TABLE `table1`
+eval CREATE TABLE table1 (
+  $define_row_key
+  val1 TINYINT NOT NULL,
+  val2 VARCHAR(128) NOT NULL,
+  $define_pk
+  KEY idx_val1 (val1, val2(1))
+) ENGINE=RocksDB;
+
+# first, create a table with a few rows, keeping the val1 column all the same
+INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
+--echo `table1` created with 4 rows
+
+--echo Table before
+SELECT * FROM table1;
+
+# next, start an RC transaction and send SELECT queries that result in:
+# RDB_LOCK_NONE, RDB_LOCK_READ and RDB_LOCK_WRITE getting set for the query
+# All three below should result in the same output.
+
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+START TRANSACTION;
+--echo Conn A: Started RC TRANSACTION
+
+--echo Conn A: SELECT with val1 referenced - NO LOCKS
+SELECT val1 from table1 WHERE val1 = 14;
+
+--echo Conn A: SELECT .. FOR SHARE with val1 referenced - READ LOCK
+SELECT val1 from table1 WHERE val1 = 14 FOR SHARE;
+
+--echo Conn A: SELECT .. FOR UPDATE with val1 referenced - WRITE LOCK
+SELECT val1 from table1 WHERE val1 = 14 FOR UPDATE;
+
+# Further explanation:
+# The fix for correctly returning KEY_NOT_FOUND for stale secondary keys
+# (that had been concurrently updated by another transaction) involves
+# comparing secondary key with a fresh copy of the SK built from newly
+# read record. The newly read record does rely on the read_set bitmap.
+# Depending on the query, all fields may not get copied into the record
+# from which the 'fresh' copy of SK gets built. This can cause simple
+# comparisons to fail for the SELECT .. FOR SHARE case without the fix.
+# The fix makes sure that the entire record is read by ignoring the
+# read_set bitmap.
+
+ROLLBACK;
+DROP TABLE table1;
+
+# next, run the above tests a second time without explicitly defining
+# the primary key. this tests scenarios around hidden PK.
+
+inc $i;
+let $define_row_key = ;
+let $define_pk = ;
+
+}

--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -7385,6 +7385,7 @@ ha_rocksdb::ha_rocksdb(my_core::handlerton *const hton,
       m_sk_packed_tuple(nullptr),
       m_end_key_packed_tuple(nullptr),
       m_sk_packed_tuple_old(nullptr),
+      m_sk_packed_tuple_updated(nullptr),
       m_pack_buffer(nullptr),
       m_lock_rows(RDB_LOCK_NONE),
       m_keyread_only(false),
@@ -7657,6 +7658,8 @@ int ha_rocksdb::alloc_key_buffers(const TABLE *const table_arg,
             my_malloc(rdb_handler_memory_key, max_packed_sk_len, MYF(0)))) ||
       !(m_sk_packed_tuple_old = static_cast<uchar *>(
             my_malloc(rdb_handler_memory_key, max_packed_sk_len, MYF(0)))) ||
+      !(m_sk_packed_tuple_updated = reinterpret_cast<uchar *>(
+            my_malloc(rdb_handler_memory_key, max_packed_sk_len, MYF(0)))) ||
       !(m_end_key_packed_tuple = static_cast<uchar *>(
             my_malloc(rdb_handler_memory_key, max_packed_sk_len, MYF(0)))) ||
       !(m_pack_buffer = static_cast<uchar *>(
@@ -7665,6 +7668,8 @@ int ha_rocksdb::alloc_key_buffers(const TABLE *const table_arg,
   if (!(m_sk_packed_tuple = static_cast<uchar *>(
             my_malloc(PSI_NOT_INSTRUMENTED, max_packed_sk_len, MYF(0)))) ||
       !(m_sk_packed_tuple_old = static_cast<uchar *>(
+            my_malloc(PSI_NOT_INSTRUMENTED, max_packed_sk_len, MYF(0)))) ||
+      !(m_sk_packed_tuple_updated = reinterpret_cast<uchar *>(
             my_malloc(PSI_NOT_INSTRUMENTED, max_packed_sk_len, MYF(0)))) ||
       !(m_end_key_packed_tuple = static_cast<uchar *>(
             my_malloc(PSI_NOT_INSTRUMENTED, max_packed_sk_len, MYF(0)))) ||
@@ -7694,6 +7699,9 @@ void ha_rocksdb::free_key_buffers() {
 
   my_free(m_sk_packed_tuple_old);
   m_sk_packed_tuple_old = nullptr;
+
+  my_free(m_sk_packed_tuple_updated);
+  m_sk_packed_tuple_updated = nullptr;
 
   my_free(m_end_key_packed_tuple);
   m_end_key_packed_tuple = nullptr;
@@ -9153,21 +9161,23 @@ ulong ha_rocksdb::index_flags(uint inx, uint part, bool all_parts) const {
   pair for.
 */
 int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf,
+                                     const rocksdb::Slice *key,
                                      const rocksdb::Slice *value,
                                      bool *skip_row) {
+  DBUG_TRACE;
   assert(buf != nullptr);
   assert(table != nullptr);
 
   int rc = 0;
+  const Rdb_key_def &kd = *m_key_descr_arr[keyno];
 
 #ifndef NDEBUG
   bool save_keyread_only = m_keyread_only;
   DBUG_EXECUTE_IF("dbug.rocksdb.HA_EXTRA_KEYREAD", { m_keyread_only = true; });
 #endif
   bool covered_lookup =
-      (m_keyread_only && m_key_descr_arr[keyno]->can_cover_lookup()) ||
-      m_key_descr_arr[keyno]->covers_lookup(value,
-                                            m_converter->get_lookup_bitmap());
+      (m_keyread_only && kd.can_cover_lookup()) ||
+      kd.covers_lookup(value, m_converter->get_lookup_bitmap());
 #ifndef NDEBUG
   m_keyread_only = save_keyread_only;
 #endif
@@ -9175,11 +9185,66 @@ int ha_rocksdb::secondary_index_read(const int keyno, uchar *const buf,
   if (covered_lookup && m_lock_rows == RDB_LOCK_NONE) {
     inc_covered_sk_lookup();
   } else {
-    DEBUG_SYNC(ha_thd(), "rocksdb_concurrent_delete_sk");
+    DEBUG_SYNC(ha_thd(), "rocksdb_concurrent_upd_or_delete_sk");
     rc = get_row_by_rowid(buf, m_last_rowkey.ptr(), m_last_rowkey.length(),
                           skip_row);
+
+    if (skip_row && *skip_row) goto done;
+
+    if (m_lock_rows != RDB_LOCK_NONE &&
+        (my_core::thd_tx_isolation(ha_thd()) == ISO_READ_COMMITTED)) {
+      /*
+        At this point, buf contains `row`, read via the primary key
+        generated from the secondary key (saved onto
+        m_last_rowkey in the calling function)
+
+        Next step, we recreate secondary key from the newly read `row`, and
+        compare with secondary key send by caller as `key`
+      */
+
+      longlong hidden_pk_id = 0;
+      if (has_hidden_pk(table) &&
+          (rc = read_hidden_pk_id_from_rowkey(&hidden_pk_id))) {
+        goto done;
+      }
+
+      const uint new_packed_size =
+          kd.pack_record(table, m_pack_buffer, buf, m_sk_packed_tuple_updated,
+                         nullptr, 0, hidden_pk_id, 0, nullptr, 0);
+      const rocksdb::Slice updated_key(
+          reinterpret_cast<char *>(m_sk_packed_tuple_updated), new_packed_size);
+
+      if (updated_key.compare(*key)) {
+        /*
+           This catches the situation where the secondary key in an ongoing
+           locking read differs from the secondary key the row read via the
+           primary key.
+
+           This would happen if there's a parallel connection that has updated
+           this same row after the secondary key is read, but before the primary
+           key is fetched.
+
+           If we return this row in spite of the changed key, then we get
+           incorrect behaviour depending on the scenario. For point queries, we
+           will return rows that don't match the query. For range scans, the
+           other sql iterator code will exit (EOF) prematurely due to the
+           secondar key value not falling within the scan range, signifying that
+           the range scan is over, even though there are in fact matching keys
+           left.
+
+           By returning HA_ERR_KEY_NOT_FOUND here, range queries can skip over
+           the problematic row, continue and cover all remaining matching rows.
+           This works in conjunction with should_skip_invalidated_record().
+           Point queries will just return empty result set.
+
+        */
+
+        rc = HA_ERR_KEY_NOT_FOUND;
+      }
+    }
   }
 
+done:
   return rc;
 }
 
@@ -9801,7 +9866,8 @@ int ha_rocksdb::get_row_by_sk(uchar *buf, const Rdb_key_def &kd,
 
   m_last_rowkey.copy((const char *)m_pk_packed_tuple, size, &my_charset_bin);
 
-  rc = secondary_index_read(active_index, buf, &m_retrieved_record, nullptr);
+  rc = secondary_index_read(active_index, buf, key, &m_retrieved_record,
+                            nullptr);
   if (!rc) {
     table->set_found_row();
   }
@@ -9967,7 +10033,8 @@ int ha_rocksdb::index_next_with_direction_intern(uchar *const buf,
                          &my_charset_bin);
 
       bool skip_row = false;
-      rc = secondary_index_read(active_index, buf, &value, &skip_row);
+      rc = secondary_index_read(active_index, buf, &key, &value, &skip_row);
+
       if (!rc && skip_row) {
         // SKIP LOCKED
         continue;
@@ -11359,7 +11426,7 @@ int ha_rocksdb::rnd_end() {
 void ha_rocksdb::build_decoder() {
   m_converter->setup_field_decoders(table->read_set, active_index,
                                     m_keyread_only,
-                                    m_lock_rows == RDB_LOCK_WRITE);
+                                    m_lock_rows != RDB_LOCK_NONE);
 }
 
 void ha_rocksdb::check_build_decoder() {

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -220,6 +220,14 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   Rdb_string_writer m_sk_tails_old;
 
   /*
+     Temporary buffer being used to store updated values of SK tuple
+     to compare with possibly stale SK due to a concurrent update
+     (like in the case of a snapshot conflict)
+     currently being used in the iterator and point query paths
+  */
+  uchar *m_sk_packed_tuple_updated;
+
+  /*
     Temporary space for packing VARCHARs (we provide it to
     pack_record()/pack_index_tuple() calls).
   */
@@ -322,6 +330,7 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
                       const Rdb_tbl_def *const old_tbl_def_arg = nullptr) const
       MY_ATTRIBUTE((__warn_unused_result__));
   int secondary_index_read(const int keyno, uchar *const buf,
+                           const rocksdb::Slice *key,
                            const rocksdb::Slice *value, bool *skip_row)
       MY_ATTRIBUTE((__warn_unused_result__));
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8836

This is a cherry-pick of the
"Fix for snapshot conflict on SK due to concurrent update" (commit facebook/mysql-5.6@98da68c)

Summary: The issue that was being hit has two different connections to the MySQL server trying to update two different rows via a secondary index scan with RC isolation level set. During the SK index scan, either one of the iterators may end up returning the value updated by the other connection. This leads to the iterator range condition failing, and the iterator returns an early EOF back, and the update fails to apply on the remaining rows that were actually valid candidates for update based on the WHERE conditions.

Differential Revision: D48740767

fbshipit-source-id: f9b58edc249b6deace936dbafc70f79456eb49ca