### PR TITLE
PS-8882 : Crash when performing CREATE TABLE AS SELECT during Alters/…

### DIFF
--- a/mysql-test/r/percona_bug_ps8882.result
+++ b/mysql-test/r/percona_bug_ps8882.result
@@ -1,0 +1,39 @@
+#
+# PS-8882: Crash when performing CREATE TABLE AS SELECT during Alters/Renames
+#
+CREATE TABLE t0 (id INT PRIMARY KEY, v1 VARCHAR(100), v2 VARCHAR(100), v3 VARCHAR(100));
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+# Create lots of tables in 'db1' and run RENAME TABLES statement
+# that atomically moves them to 'db2'. Then number of tables was
+# chosen in such way that capacity of Data Dictionary Cache of
+# dd::Table objects is exceeded in the process. Pause execution
+# of RENAME TABLE at the point where dd::Tables are still pinned
+# to cache.
+#
+# Maximum capacity of data-dictionary cache for dd::Table objects
+# is derived from --max_connections value.
+#
+# Create tables and construct RENAME TABLES along the way.
+#
+# Start RENAME TABLES and pause at the point where DD cache is
+# full and dd::Table objects are pinned to the cache.
+connect  con1, localhost, root,,;
+# Wait until RENAME TABLES is paused.
+SET debug_sync = 'now WAIT_FOR parked';
+#
+# Thanks to full DD cache dd::Table objects which are acquired by
+# the below statement are immediately destroyed once they are released.
+# So premature release of one of dd::Table objects in it caused
+# crashes before the fix.
+CREATE TABLE tt SELECT * FROM t0;
+# Resume RENAME TABLES execution.
+SET debug_sync = 'now SIGNAL go';
+disconnect con1;
+connection default;
+# Reap RENAME TABLES.
+# Clean-up.
+SET debug_sync = 'RESET';
+DROP TABLES t0, tt;
+DROP DATABASE db1;
+DROP DATABASE db2;

--- a/mysql-test/t/percona_bug_ps8882.test
+++ b/mysql-test/t/percona_bug_ps8882.test
@@ -1,0 +1,72 @@
+# We use DEBUG_SYNC facility.
+--source include/have_debug_sync.inc
+
+--echo #
+--echo # PS-8882: Crash when performing CREATE TABLE AS SELECT during Alters/Renames
+--echo #
+--enable_connect_log
+CREATE TABLE t0 (id INT PRIMARY KEY, v1 VARCHAR(100), v2 VARCHAR(100), v3 VARCHAR(100));
+CREATE DATABASE db1;
+CREATE DATABASE db2;
+
+--echo # Create lots of tables in 'db1' and run RENAME TABLES statement
+--echo # that atomically moves them to 'db2'. Then number of tables was
+--echo # chosen in such way that capacity of Data Dictionary Cache of
+--echo # dd::Table objects is exceeded in the process. Pause execution
+--echo # of RENAME TABLE at the point where dd::Tables are still pinned
+--echo # to cache.
+
+--disable_query_log
+--echo #
+--echo # Maximum capacity of data-dictionary cache for dd::Table objects
+--echo # is derived from --max_connections value.
+--let $max_tables = `SELECT @@max_connections + 10`
+
+--echo #
+--echo # Create tables and construct RENAME TABLES along the way.
+
+--let $i= 0
+--let $rename = RENAME TABLES
+while ($i < $max_tables)
+{
+  --eval CREATE TABLE db1.t$i (a INT PRIMARY KEY)
+  --let $rename = `SELECT CONCAT('$rename',' db1.t$i TO db2.t$i,')`
+  --inc $i
+}
+--eval CREATE TABLE db1.t$max_tables (a INT PRIMARY KEY)
+
+--echo #
+--echo # Start RENAME TABLES and pause at the point where DD cache is
+--echo # full and dd::Table objects are pinned to the cache.
+SET debug_sync = 'do_renames_before_return SIGNAL parked WAIT_FOR go';
+--send_eval $rename db1.t$max_tables TO db2.t$max_tables
+
+--enable_query_log
+connect (con1, localhost, root,,);
+
+--echo # Wait until RENAME TABLES is paused.
+SET debug_sync = 'now WAIT_FOR parked';
+
+--echo #
+--echo # Thanks to full DD cache dd::Table objects which are acquired by
+--echo # the below statement are immediately destroyed once they are released.
+--echo # So premature release of one of dd::Table objects in it caused
+--echo # crashes before the fix.
+CREATE TABLE tt SELECT * FROM t0;
+
+--echo # Resume RENAME TABLES execution.
+SET debug_sync = 'now SIGNAL go';
+
+disconnect con1;
+--source include/wait_until_disconnected.inc
+
+connection default;
+--echo # Reap RENAME TABLES.
+--reap
+
+--echo # Clean-up.
+SET debug_sync = 'RESET';
+DROP TABLES t0, tt;
+DROP DATABASE db1;
+DROP DATABASE db2;
+--disable_connect_log

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -10512,10 +10512,9 @@ Create_field *generate_create_field(THD *thd, Item *source_item,
     assert(table);
     const dd::Table *table_obj =
         table->s->tmp_table ? table->s->tmp_table_def : nullptr;
+    dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
 
     if (!table_obj && table->s->table_category != TABLE_UNKNOWN_CATEGORY) {
-      dd::cache::Dictionary_client::Auto_releaser releaser(thd->dd_client());
-
       if (thd->dd_client()->acquire(table->s->db.str, table->s->table_name.str,
                                     &table_obj)) {
         return nullptr; /* purecov: inspected */

--- a/sql/sql_rename.cc
+++ b/sql/sql_rename.cc
@@ -42,6 +42,7 @@
 #include "sql/dd/types/abstract_table.h"     // dd::Abstract_table
 #include "sql/dd/types/table.h"              // dd::Table
 #include "sql/dd_sql_view.h"                 // View_metadata_updater
+#include "sql/debug_sync.h"                  // DEBUG_SYNC
 #include "sql/derror.h"                      // ER_THD
 #include "sql/handler.h"
 #include "sql/log.h"          // query_logger
@@ -887,6 +888,8 @@ static bool do_rename(THD *thd, Table_ref *ren_table, const char *new_db,
   // Now, we know that rename succeeded, and can log the schema access
   thd->add_to_binlog_accessed_dbs(ren_table->db);
   thd->add_to_binlog_accessed_dbs(new_db);
+
+  DEBUG_SYNC(thd, "do_renames_before_return");
 
   return false;
 }


### PR DESCRIPTION
…Renames

https://jira.percona.com/browse/PS-8882

CREATE TABLE SELECT crashed if it was run when Data-dictionary Table object Cache was full. The latter situation can occur when one runs RENAME TABLES which renames number of tables larger than Data-dictionary Table object Cache capacity (which is equal to --max_connections).

The problem occured because in situation of full dd::Table object cache any release of dd::Table caused immediate deletion of this object. CREATE TABLE SELECT implementation acquired dd::Table object for source table at some point and then prematurely released it (due to wrong scope of helper dd::cache::Auto_releaser object). Later access to this already released and destroyed dd::Table object caused crash.

This patch solves the problem by using wider scope for Auto_releaser in CREATE TABLE SELECT implementation and thus ensuring that dd::Table object for source table is not released too early, before we stop using it.