### PR TITLE
PS-8854 [8.1]: Convert percona-udf to a component with function auto-registration

### DIFF
--- a/build-ps/debian/percona-server-server.install
+++ b/build-ps/debian/percona-server-server.install
@@ -126,12 +126,6 @@ usr/lib/mysql/plugin/auth_pam.so
 usr/lib/mysql/plugin/debug/auth_pam.so
 usr/lib/mysql/plugin/auth_pam_compat.so
 usr/lib/mysql/plugin/debug/auth_pam_compat.so
-usr/lib/mysql/plugin/libfnv1a_udf.so
-usr/lib/mysql/plugin/debug/libfnv1a_udf.so
-usr/lib/mysql/plugin/libfnv_udf.so
-usr/lib/mysql/plugin/debug/libfnv_udf.so
-usr/lib/mysql/plugin/libmurmur_udf.so
-usr/lib/mysql/plugin/debug/libmurmur_udf.so
 usr/lib/mysql/plugin/dialog.so
 usr/lib/mysql/plugin/debug/dialog.so
 usr/lib/mysql/plugin/connection_control.so
@@ -173,6 +167,8 @@ usr/lib/mysql/plugin/audit_log_filter.so
 usr/lib/mysql/plugin/debug/audit_log_filter.so
 usr/lib/mysql/plugin/component_masking_functions.so
 usr/lib/mysql/plugin/debug/component_masking_functions.so
+usr/lib/mysql/plugin/component_percona_udf.so
+usr/lib/mysql/plugin/debug/component_percona_udf.so
 
 
 # support files

--- a/build-ps/debian/percona-server-server.postinst
+++ b/build-ps/debian/percona-server-server.postinst
@@ -194,10 +194,8 @@ take_upstart_job_backup
 #Some postinstall info about UDF
 #
 echo -e "\n\n * Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit."
-echo -e " * Run the following commands to create these functions:\n"
-echo -e "\tmysql -e \"CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'\""
-echo -e "\tmysql -e \"CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'\""
-echo -e "\tmysql -e \"CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'\""
+echo -e " * Run the following command to install these functions (fnv_64, fnv1a_64, murmur_hash):\n"
+echo -e "\tmysql -e \"INSTALL COMPONENT 'file://component_percona_udf'\""
 echo -e "\n * See http://www.percona.com/doc/percona-server/8.0/management/udf_percona_toolkit.html for more details\n\n"
 #
 

--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -758,10 +758,8 @@ if [ -d /etc/percona-server.conf.d ]; then
 fi
 
 echo "Percona Server is distributed with several useful UDF (User Defined Function) from Percona Toolkit."
-echo "Run the following commands to create these functions:"
-echo "mysql -e \"CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so'\""
-echo "mysql -e \"CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so'\""
-echo "mysql -e \"CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so'\""
+echo "Run the following command to install these functions (fnv_64, fnv1a_64, murmur_hash):"
+echo "mysql -e \"INSTALL COMPONENT 'file://component_percona_udf'\""
 echo "See http://www.percona.com/doc/percona-server/8.0/management/udf_percona_toolkit.html for more details"
 
 %preun -n percona-server-server
@@ -1092,12 +1090,6 @@ fi
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/auth_pam.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/auth_pam_compat.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/auth_pam_compat.so
-%attr(755, root, root) %{_libdir}/mysql/plugin/libfnv1a_udf.*
-%attr(755, root, root) %{_libdir}/mysql/plugin/debug/libfnv1a_udf.*
-%attr(755, root, root) %{_libdir}/mysql/plugin/libfnv_udf.*
-%attr(755, root, root) %{_libdir}/mysql/plugin/debug/libfnv_udf.*
-%attr(755, root, root) %{_libdir}/mysql/plugin/libmurmur_udf.*
-%attr(755, root, root) %{_libdir}/mysql/plugin/debug/libmurmur_udf.*
 %attr(755, root, root) %{_libdir}/mysql/plugin/dialog.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/dialog.so
 #%attr(755, root, root) %{_libdir}/mysql/plugin/query_response_time.so
@@ -1119,6 +1111,8 @@ fi
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/component_keyring_kms.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/component_masking_functions.so
 %attr(755, root, root) %{_libdir}/mysql/plugin/debug/component_masking_functions.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/component_percona_udf.so
+%attr(755, root, root) %{_libdir}/mysql/plugin/debug/component_percona_udf.so
 #
 #%attr(644, root, root) %{_datadir}/percona-server/fill_help_tables.sql
 #%attr(644, root, root) %{_datadir}/percona-server/mysql_sys_schema.sql

--- a/components/percona_udf/CMakeLists.txt
+++ b/components/percona_udf/CMakeLists.txt
@@ -1,0 +1,27 @@
+# Copyright (c) 2023 Percona LLC and/or its affiliates. All rights reserved.
+
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; version 2 of
+# the License.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+MYSQL_ADD_COMPONENT(percona_udf
+  percona_udf.cc
+  fnv1a_udf.cc
+  fnv_udf.cc
+  murmur_udf.cc
+  MODULE_ONLY)
+
+TARGET_INCLUDE_DIRECTORIES(component_percona_udf SYSTEM PRIVATE
+  ${BOOST_PATCHES_DIR}
+  ${BOOST_INCLUDE_DIR}
+)

--- a/components/percona_udf/fnv1a_udf.cc
+++ b/components/percona_udf/fnv1a_udf.cc
@@ -113,6 +113,7 @@
 #include <string.h>
 #include "my_sys.h"
 #include "mysql.h"
+#include "percona_udf.h"
 
 /* On the first call, use this as the initial_value. */
 #define FNV1A_64_INIT 0xcbf29ce484222325ULL
@@ -121,18 +122,9 @@
 /* Magic number for the hashing. */
 #define FNV_64_PRIME 0x100000001b3ULL
 
-/* Prototypes */
-
-extern "C" {
-ulonglong hash64a(const void *buf, size_t len, ulonglong hval);
-bool fnv1a_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
-ulonglong fnv1a_64(UDF_INIT *initid, UDF_ARGS *args, char *is_null,
-                   char *error);
-}
-
 /* Implementations */
 
-ulonglong hash64a(const void *buf, size_t len, ulonglong hval) {
+static ulonglong hash64a(const void *buf, size_t len, ulonglong hval) {
   const unsigned char *bp = (const unsigned char *)buf;
   const unsigned char *be = bp + len;
 
@@ -147,7 +139,8 @@ ulonglong hash64a(const void *buf, size_t len, ulonglong hval) {
   return hval;
 }
 
-bool fnv1a_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+bool VISIBILITY_DEFAULT fnv1a_64_init(UDF_INIT *initid, UDF_ARGS *args,
+                                      char *message) {
   if (args->arg_count == 0) {
     strcpy(message, "FNV1A_64 requires at least one argument");
     return true;
@@ -156,9 +149,10 @@ bool fnv1a_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   return false;
 }
 
-ulonglong fnv1a_64(UDF_INIT *initid [[maybe_unused]], UDF_ARGS *args,
-                   char *is_null [[maybe_unused]],
-                   char *error [[maybe_unused]]) {
+ulonglong VISIBILITY_DEFAULT fnv1a_64(UDF_INIT *initid [[maybe_unused]],
+                                      UDF_ARGS *args,
+                                      char *is_null [[maybe_unused]],
+                                      char *error [[maybe_unused]]) {
   uint null_default = HASH_NULL_DEFAULT;
   ulonglong result = FNV1A_64_INIT;
   uint i;

--- a/components/percona_udf/fnv_udf.cc
+++ b/components/percona_udf/fnv_udf.cc
@@ -117,6 +117,7 @@
 #include <my_sys.h>
 #include <mysql.h>
 #include <string.h>
+#include "percona_udf.h"
 
 /* On the first call, use this as the initial_value. */
 #define HASH_64_INIT 0x84222325cbf29ce4ULL
@@ -125,17 +126,9 @@
 /* Magic number for the hashing. */
 #define FNV_64_PRIME 0x100000001b3ULL
 
-/* Prototypes */
-
-extern "C" {
-ulonglong hash64(const void *buf, size_t len, ulonglong hval);
-bool fnv_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
-ulonglong fnv_64(UDF_INIT *initid, UDF_ARGS *args, char *is_null, char *error);
-}
-
 /* Implementations */
 
-ulonglong hash64(const void *buf, size_t len, ulonglong hval) {
+static ulonglong hash64(const void *buf, size_t len, ulonglong hval) {
   const unsigned char *bp = (const unsigned char *)buf;
   const unsigned char *be = bp + len;
 
@@ -150,7 +143,8 @@ ulonglong hash64(const void *buf, size_t len, ulonglong hval) {
   return hval;
 }
 
-bool fnv_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+bool VISIBILITY_DEFAULT fnv_64_init(UDF_INIT *initid, UDF_ARGS *args,
+                                    char *message) {
   if (args->arg_count == 0) {
     strcpy(message, "FNV_64 requires at least one argument");
     return true;
@@ -159,9 +153,10 @@ bool fnv_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   return false;
 }
 
-ulonglong fnv_64(UDF_INIT *initid [[maybe_unused]], UDF_ARGS *args,
-                 char *is_null [[maybe_unused]],
-                 char *error [[maybe_unused]]) {
+ulonglong VISIBILITY_DEFAULT fnv_64(UDF_INIT *initid [[maybe_unused]],
+                                    UDF_ARGS *args,
+                                    char *is_null [[maybe_unused]],
+                                    char *error [[maybe_unused]]) {
   uint null_default = HASH_NULL_DEFAULT;
   ulonglong result = HASH_64_INIT;
   uint i;

--- a/components/percona_udf/murmur_udf.cc
+++ b/components/percona_udf/murmur_udf.cc
@@ -47,20 +47,12 @@
 #include <string.h>
 #include "my_sys.h"
 #include "mysql.h"
+#include "percona_udf.h"
 
 /* On the first call, use this as the initial_value. */
 #define HASH_64_INIT 0x84222325cbf29ce4ULL
 /* Default for NULLs, just so the result is never NULL. */
 #define HASH_NULL_DEFAULT 0x0a0b0c0d
-
-/* Prototypes */
-
-extern "C" {
-ulonglong MurmurHash2(const void *key, int len, unsigned int seed);
-bool murmur_hash_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
-ulonglong murmur_hash(UDF_INIT *initid, UDF_ARGS *args, char *is_null,
-                      char *error);
-}
 
 /* Implementations */
 
@@ -69,7 +61,7 @@ ulonglong murmur_hash(UDF_INIT *initid, UDF_ARGS *args, char *is_null,
  * This is the 64 bit version of MurmurHash2 for 32-bit platforms.
  */
 
-ulonglong MurmurHash2(const void *key, int len, unsigned int seed) {
+static ulonglong MurmurHash2(const void *key, int len, unsigned int seed) {
   const unsigned int m = 0x5bd1e995;
   const int r = 24;
 
@@ -131,7 +123,8 @@ ulonglong MurmurHash2(const void *key, int len, unsigned int seed) {
   return h;
 }
 
-bool murmur_hash_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
+bool VISIBILITY_DEFAULT murmur_hash_init(UDF_INIT *initid, UDF_ARGS *args,
+                                         char *message) {
   if (args->arg_count == 0) {
     strcpy(message, "MURMUR_HASH requires at least one argument");
     return true;
@@ -140,9 +133,10 @@ bool murmur_hash_init(UDF_INIT *initid, UDF_ARGS *args, char *message) {
   return false;
 }
 
-ulonglong murmur_hash(UDF_INIT *initid [[maybe_unused]], UDF_ARGS *args,
-                      char *is_null [[maybe_unused]],
-                      char *error [[maybe_unused]]) {
+ulonglong VISIBILITY_DEFAULT murmur_hash(UDF_INIT *initid [[maybe_unused]],
+                                         UDF_ARGS *args,
+                                         char *is_null [[maybe_unused]],
+                                         char *error [[maybe_unused]]) {
   uint null_default = HASH_NULL_DEFAULT;
   ulonglong result = HASH_64_INIT;
   uint i;

--- a/components/percona_udf/percona_udf.cc
+++ b/components/percona_udf/percona_udf.cc
@@ -1,0 +1,81 @@
+/* Copyright (c) 2023 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#include <array>
+#include <bitset>
+
+#include <boost/preprocessor/stringize.hpp>
+
+#include <mysql/components/component_implementation.h>
+#include <mysqlpp/udf_registration.hpp>
+
+#include "percona_udf.h"
+
+// defined as a macro because needed both raw and stringized
+#define CURRENT_COMPONENT_NAME percona_udf
+#define CURRENT_COMPONENT_NAME_STR BOOST_PP_STRINGIZE(CURRENT_COMPONENT_NAME)
+
+REQUIRES_SERVICE_PLACEHOLDER(udf_registration);
+
+#define DECLARE_UDF_INFO_NO_DEINIT(NAME, TYPE) \
+  mysqlpp::udf_info { #NAME, TYPE, (Udf_func_any)&NAME, &NAME##_init, nullptr }
+
+static const std::array known_udfs{
+    DECLARE_UDF_INFO_NO_DEINIT(fnv_64, INT_RESULT),
+    DECLARE_UDF_INFO_NO_DEINIT(fnv1a_64, INT_RESULT),
+    DECLARE_UDF_INFO_NO_DEINIT(murmur_hash, INT_RESULT)};
+
+#undef DECLARE_UDF_INFO_NO_DEINIT
+#undef DECLARE_UDF_INFO
+
+using udf_bitset_type =
+    std::bitset<std::tuple_size<decltype(known_udfs)>::value>;
+static udf_bitset_type registered_udfs;
+
+static mysql_service_status_t component_init() {
+  mysqlpp::register_udfs(mysql_service_udf_registration, known_udfs,
+                         registered_udfs);
+  return registered_udfs.all() ? 0 : 1;
+}
+
+static mysql_service_status_t component_deinit() {
+  mysqlpp::unregister_udfs(mysql_service_udf_registration, known_udfs,
+                           registered_udfs);
+
+  return registered_udfs.none() ? 0 : 1;
+}
+
+// clang-format off
+BEGIN_COMPONENT_PROVIDES(CURRENT_COMPONENT_NAME)
+END_COMPONENT_PROVIDES();
+
+BEGIN_COMPONENT_REQUIRES(CURRENT_COMPONENT_NAME)
+  REQUIRES_SERVICE(udf_registration),
+END_COMPONENT_REQUIRES();
+
+BEGIN_COMPONENT_METADATA(CURRENT_COMPONENT_NAME)
+  METADATA("mysql.author", "Percona Corporation"),
+  METADATA("mysql.license", "GPL"),
+END_COMPONENT_METADATA();
+
+DECLARE_COMPONENT(CURRENT_COMPONENT_NAME, CURRENT_COMPONENT_NAME_STR)
+  component_init,
+  component_deinit,
+END_DECLARE_COMPONENT();
+// clang-format on
+
+DECLARE_LIBRARY_COMPONENTS &COMPONENT_REF(CURRENT_COMPONENT_NAME)
+    END_DECLARE_LIBRARY_COMPONENTS

--- a/components/percona_udf/percona_udf.h
+++ b/components/percona_udf/percona_udf.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2023 Percona LLC and/or its affiliates. All rights reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+#ifndef PERCONA_UDF_H
+#define PERCONA_UDF_H
+
+#include "my_inttypes.h"  // ulonglong
+
+#define VISIBILITY_DEFAULT __attribute__((visibility("default")))
+
+/* Prototypes */
+
+extern "C" {
+bool fnv_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+void fnv_64_deinit(UDF_INIT *initid);
+ulonglong fnv_64(UDF_INIT *initid, UDF_ARGS *args, char *is_null, char *error);
+
+bool fnv1a_64_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+void fnv1a_64_deinit(UDF_INIT *initid);
+ulonglong fnv1a_64(UDF_INIT *initid, UDF_ARGS *args, char *is_null,
+                   char *error);
+
+bool murmur_hash_init(UDF_INIT *initid, UDF_ARGS *args, char *message);
+void murmur_hash_deinit(UDF_INIT *initid);
+ulonglong murmur_hash(UDF_INIT *initid, UDF_ARGS *args, char *is_null,
+                      char *error);
+}
+
+#endif /* PERCONA_UDF_H */

--- a/mysql-test/include/plugin.defs
+++ b/mysql-test/include/plugin.defs
@@ -205,3 +205,4 @@ binlog_utils_udf   plugin_output_directory  no  BINLOG_UTILS_UDF_LIB
 procfs             plugin_output_directory  no  PROCFS_PLUGIN procfs
 component_encryption_udf            plugin_output_directory  no  ENCRYPTION_UDF_COMPONENT
 component_masking_functions         plugin_output_directory  no  MASKING_FUNCTIONS_COMPONENT
+component_percona_udf               plugin_output_directory  no  PERCONA_UDF_COMPONENT

--- a/mysql-test/suite/percona/r/component_percona_udf.result
+++ b/mysql-test/suite/percona/r/component_percona_udf.result
@@ -1,11 +1,27 @@
-*** checking if UDF works without creating the function
+*** UDF should fail without functions or component
 SELECT MURMUR_HASH('hello', 'world');
 ERROR 42000: FUNCTION test.MURMUR_HASH does not exist
 
-*** creating UDF functions
-CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so';
-CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so';
-CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so';
+*** checking backward compatibility: create UDF functions
+CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'component_percona_udf.so';
+CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'component_percona_udf.so';
+CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'component_percona_udf.so';
+
+*** checking backward compatibility: check UDF functions
+include/assert.inc [checking hash value for FNV1A_64()]
+include/assert.inc [checking hash value for FNV_64()]
+include/assert.inc [checking hash value for MURMUR_HASH()]
+
+*** checking backward compatibility: drop UDF functions
+DROP FUNCTION fnv1a_64;
+DROP FUNCTION fnv_64;
+DROP FUNCTION murmur_hash;
+*** UDF should fail without functions or component
+SELECT MURMUR_HASH('hello', 'world');
+ERROR 42000: FUNCTION test.MURMUR_HASH does not exist
+
+*** installing percona_udf component
+INSTALL COMPONENT 'file://component_percona_udf';
 
 *** checking UDF functions
 include/assert.inc [checking hash value for FNV1A_64()]
@@ -31,7 +47,5 @@ include/assert.inc [checking hash value for BIT_XOR(MURMUR_HASH())]
 include/assert.inc [checking hash value for FNV1A_64(col1, col2, col3)]
 
 *** cleaning up
-DROP FUNCTION fnv1a_64;
-DROP FUNCTION fnv_64;
-DROP FUNCTION murmur_hash;
 DROP TABLE t1;
+UNINSTALL COMPONENT 'file://component_percona_udf';

--- a/mysql-test/suite/percona/t/component_percona_udf.test
+++ b/mysql-test/suite/percona/t/component_percona_udf.test
@@ -1,12 +1,41 @@
---echo *** checking if UDF works without creating the function
+--echo *** UDF should fail without functions or component
 --error ER_SP_DOES_NOT_EXIST
 SELECT MURMUR_HASH('hello', 'world');
 
 --echo
---echo *** creating UDF functions
-CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'libfnv1a_udf.so';
-CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'libfnv_udf.so';
-CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'libmurmur_udf.so';
+--echo *** checking backward compatibility: create UDF functions
+CREATE FUNCTION fnv1a_64 RETURNS INTEGER SONAME 'component_percona_udf.so';
+CREATE FUNCTION fnv_64 RETURNS INTEGER SONAME 'component_percona_udf.so';
+CREATE FUNCTION murmur_hash RETURNS INTEGER SONAME 'component_percona_udf.so';
+
+--echo
+--echo *** checking backward compatibility: check UDF functions
+
+--let $assert_text = checking hash value for FNV1A_64()
+--let $assert_cond = `SELECT FNV1A_64('hello', 'world') = 1214055856804091265`
+--source include/assert.inc
+
+--let $assert_text = checking hash value for FNV_64()
+--let $assert_cond = `SELECT FNV_64('hello', 'world') = 2924375256774005480`
+--source include/assert.inc
+
+--let $assert_text = checking hash value for MURMUR_HASH()
+--let $assert_cond = `SELECT MURMUR_HASH('hello', 'world') = -7857203399167365490`
+--source include/assert.inc
+
+--echo
+--echo *** checking backward compatibility: drop UDF functions
+DROP FUNCTION fnv1a_64;
+DROP FUNCTION fnv_64;
+DROP FUNCTION murmur_hash;
+
+--echo *** UDF should fail without functions or component
+--error ER_SP_DOES_NOT_EXIST
+SELECT MURMUR_HASH('hello', 'world');
+
+--echo
+--echo *** installing percona_udf component
+INSTALL COMPONENT 'file://component_percona_udf';
 
 --echo
 --echo *** checking UDF functions
@@ -58,8 +87,5 @@ INSERT INTO t1(col1, col2, col3) VALUES (3, "short", "words");
 
 --echo
 --echo *** cleaning up
-DROP FUNCTION fnv1a_64;
-DROP FUNCTION fnv_64;
-DROP FUNCTION murmur_hash;
-
 DROP TABLE t1;
+UNINSTALL COMPONENT 'file://component_percona_udf';

--- a/plugin/percona-udf/CMakeLists.txt
+++ b/plugin/percona-udf/CMakeLists.txt
@@ -1,3 +1,0 @@
-MYSQL_ADD_PLUGIN(libfnv1a_udf fnv1a_udf.cc MODULE_ONLY)
-MYSQL_ADD_PLUGIN(libfnv_udf fnv_udf.cc MODULE_ONLY)
-MYSQL_ADD_PLUGIN(libmurmur_udf murmur_udf.cc MODULE_ONLY)


### PR DESCRIPTION
1. Rename `main.percona_udf` to `percona.component_percona_udf`.

2. Move and convert `plugin/percona-udf/*` to `components/percona_udf/*`.

3. Update `build-ps` scripts and `plugin.defs`.