### PR TITLE
PS-8844 [8.0]: Set "-fvisibility-inlines-hidden" for all components

### DIFF
--- a/cmake/component.cmake
+++ b/cmake/component.cmake
@@ -112,7 +112,29 @@ MACRO(MYSQL_ADD_COMPONENT component_arg)
         SET(COMPONENT_COMPILE_VISIBILITY
           "-fvisibility=hidden" CACHE INTERNAL
           "Use -fvisibility=hidden for components" FORCE)
-        TARGET_COMPILE_OPTIONS(${target} PRIVATE "-fvisibility=hidden")
+
+        # By default gcc / clang toolchain, when creating a shared library,
+        # marks all symbols as 'exported' - __attribute__((visibility("default"))).
+        # This includes not only the symbols declared explicitly in the library
+        # source code but also those linked from the dependent static libraries
+        # as well as symbols instantiated from the standard library templated code.
+        # This is not a desired behavior for UDF shared objects, MySQL plugins /
+        # components that rely on dynamic symbol lookups ('dlsym()' calls).
+        # The exported symbols namespace may be extremely polluted in this case,
+        # which may lead to slower symbols lookups as well as raising security
+        # concerns of being able to load symbols not intended originally to be
+        # loadable.
+        # The solution is to switch to __attribute__((visibility("hidden"))) by
+        # default and mark 'exported' only those sybbols that are marked with
+        # __attribute__((visibility("default"))) explicitly.
+        # Here, for gcc for instance, CXX_VISIBILITY_PRESET CMake target property
+        # will be translated into '-fvisibility=hidden' compiler option.
+        # VISIBILITY_INLINES_HIDDEN as an addition to the previous one will also
+        # add '-fvisibility-inlines-hidden' (helps a lot with STL code).
+        SET_TARGET_PROPERTIES(${target} PROPERTIES
+          CXX_VISIBILITY_PRESET hidden
+          VISIBILITY_INLINES_HIDDEN YES
+        )
       ENDIF()
     ENDIF()
 

--- a/components/encryption_udf/CMakeLists.txt
+++ b/components/encryption_udf/CMakeLists.txt
@@ -32,27 +32,4 @@ MYSQL_ADD_COMPONENT(encryption_udf
   MODULE_ONLY
 )
 
-# By default gcc / clang toolchain, when creating a shared library,
-# marks all symbols as 'exported' - __attribute__((visibility("default"))).
-# This includes not only the symbols declared explicitly in the library
-# source code but also those linked from the dependent static libraries
-# as well as symbols instantiated from the standard library templated code.
-# This is not a desired behavior for UDF shared objects, MySQL plugins /
-# components that rely on dynamic symbol lookups ('dlsym()' calls).
-# The exported symbols namespace may be extremely polluted in this case,
-# which may lead to slower symbols lookups as well as raising security
-# concerns of being able to load symbols not intended originally to be
-# loadable.
-# The solution is to switch to __attribute__((visibility("hidden"))) by
-# default and mark 'exported' only those sybbols that are marked with
-# __attribute__((visibility("default"))) explicitly.
-# Here, for gcc for instance, CXX_VISIBILITY_PRESET CMake target property
-# will be translated into '-fvisibility=hidden' compiler option.
-# VISIBILITY_INLINES_HIDDEN as an addition to the previous one will also
-# add '-fvisibility-inlines-hidden' (helps a lot with STL code).
-set_target_properties(component_encryption_udf PROPERTIES
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN YES
-)
-
 target_include_directories(component_encryption_udf SYSTEM PRIVATE ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})

--- a/components/masking_functions/CMakeLists.txt
+++ b/components/masking_functions/CMakeLists.txt
@@ -58,11 +58,6 @@ MYSQL_ADD_COMPONENT(masking_functions
   MODULE_ONLY
 )
 
-set_target_properties(component_masking_functions PROPERTIES
-  CXX_VISIBILITY_PRESET hidden
-  VISIBILITY_INLINES_HIDDEN YES
-)
-
 target_compile_definitions(component_masking_functions PRIVATE LOG_COMPONENT_TAG="component_masking_functions")
 target_include_directories(component_masking_functions PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(component_masking_functions SYSTEM PRIVATE ${BOOST_PATCHES_DIR} ${BOOST_INCLUDE_DIR})


### PR DESCRIPTION
By default gcc / clang toolchain, when creating a shared library, marks all symbols as 'exported' - `__attribute__((visibility("default")))`. This includes not only the symbols declared explicitly in the library source code but also those linked from the dependent static libraries as well as symbols instantiated from the standard library templated code. This is not a desired behavior for UDF shared objects, MySQL plugins / components that rely on dynamic symbol lookups ('dlsym()' calls). The exported symbols namespace may be extremely polluted in this case, which may lead to slower symbols lookups as well as raising security concerns of being able to load symbols not intended originally to be loadable.
The solution is to switch to `__attribute__((visibility("hidden")))` by default and mark 'exported' only those symbols that are marked with `__attribute__((visibility("default")))` explicitly.

Here, for gcc for instance, `CXX_VISIBILITY_PRESET` CMake target property will be translated into `-fvisibility=hidden` compiler option. `VISIBILITY_INLINES_HIDDEN` as an addition to the previous one will also add `-fvisibility-inlines-hidden` (helps a lot with STL code).
```
        SET_TARGET_PROPERTIES(${target} PROPERTIES
          CXX_VISIBILITY_PRESET hidden
          VISIBILITY_INLINES_HIDDEN YES
        )
```