### PR TITLE
PS-8952 [8.0]: Add clang-17 to Azure Pipelines and fix clang-17 compilation issues

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,21 +90,45 @@ jobs:
           BuildType: Debug
 
       # clang-6 and newer compilers
-      clang-16 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+      clang-17 RelWithDebInfo [Ubuntu 22.04 Jammy]:
         imageName: 'ubuntu-22.04'
         UBUNTU_CODE_NAME: jammy
         Compiler: clang
-        CompilerVer: 16
+        CompilerVer: 17
         BuildType: RelWithDebInfo
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
-        clang-16 RelWithDebInfo INVERTED=ON [Ubuntu 22.04 Jammy]:
+        clang-17 RelWithDebInfo INVERTED=ON [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          UBUNTU_CODE_NAME: jammy
+          Compiler: clang
+          CompilerVer: 17
+          BuildType: RelWithDebInfo
+          INVERTED: ON
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-17 Debug [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          UBUNTU_CODE_NAME: jammy
+          Compiler: clang
+          CompilerVer: 17
+          BuildType: Debug
+
+      clang-17 Debug INVERTED=ON [Ubuntu 22.04 Jammy]:
+        imageName: 'ubuntu-22.04'
+        UBUNTU_CODE_NAME: jammy
+        Compiler: clang
+        CompilerVer: 17
+        BuildType: Debug
+        INVERTED: ON
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        clang-16 RelWithDebInfo [Ubuntu 22.04 Jammy]:
           imageName: 'ubuntu-22.04'
           UBUNTU_CODE_NAME: jammy
           Compiler: clang
           CompilerVer: 16
           BuildType: RelWithDebInfo
-          INVERTED: ON
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-16 Debug [Ubuntu 22.04 Jammy]:
@@ -113,14 +137,6 @@ jobs:
           Compiler: clang
           CompilerVer: 16
           BuildType: Debug
-
-      clang-16 Debug INVERTED=ON [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
-        UBUNTU_CODE_NAME: jammy
-        Compiler: clang
-        CompilerVer: 16
-        BuildType: Debug
-        INVERTED: ON
 
       ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
         clang-15 RelWithDebInfo [Ubuntu 22.04 Jammy]:

--- a/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_control_interface-t.cc
+++ b/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_control_interface-t.cc
@@ -1213,7 +1213,6 @@ TEST_F(XComControlTest, ViewChangedJoiningTest) {
 
   const Gcs_xcom_view_identifier &current_view_id =
       down_cast<const Gcs_xcom_view_identifier &>(current_view->get_view_id());
-  ASSERT_TRUE((&current_view_id) != nullptr);
   ASSERT_EQ(typeid(Gcs_xcom_view_identifier).name(),
             typeid(current_view_id).name());
 

--- a/unittest/gunit/strings_utf8-t.cc
+++ b/unittest/gunit/strings_utf8-t.cc
@@ -197,7 +197,7 @@ class StringLiteral {
   size_t size;
 };
 
-StringLiteral operator"" _sl(const char *ptr, size_t size) {
+StringLiteral operator""_sl(const char *ptr, size_t size) {
   return StringLiteral(ptr, size);
 }
 


### PR DESCRIPTION
1. Add clang-17 to Azure Pipelines
2. Fix the following clang-17 compilation issues:
    
A.
```
/home/yura/ws/percona-server-8.0/unittest/gunit/strings_utf8-t.cc:200:26: error: identifier '_sl' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
  200 | StringLiteral operator"" _sl(const char *ptr, size_t size) {
      |               ~~~~~~~~~~~^~~
      |               operator""_sl
1 error generated.
```
    
B.
```
/home/yura/ws/percona-server-8.0/unittest/gunit/libmysqlgcs/xcom/gcs_xcom_control_interface-t.cc:1216:17: error: reference cannot be bound to dereferenced null pointer in well-defined C++ code; comparison may be assumed to always evaluate to true [-Werror,-Wtautological-undefined-compare]
 1216 |   ASSERT_TRUE((&current_view_id) != nullptr);
      |                 ^~~~~~~~~~~~~~~     ~~~~~~~
/home/yura/ws/percona-server-8.0/extra/googletest/googletest-release-1.12.0/googletest/include/gtest/gtest.h:1794:50: note: expanded from macro 'ASSERT_TRUE'
 1794 | #define ASSERT_TRUE(condition) GTEST_ASSERT_TRUE(condition)
      |                                                  ^~~~~~~~~
/home/yura/ws/percona-server-8.0/extra/googletest/googletest-release-1.12.0/googletest/include/gtest/gtest.h:1777:23: note: expanded from macro 'GTEST_ASSERT_TRUE'
 1777 |   GTEST_TEST_BOOLEAN_(condition, #condition, false, true, GTEST_FATAL_FAILURE_)
      |                       ^~~~~~~~~
/home/yura/ws/percona-server-8.0/extra/googletest/googletest-release-1.12.0/googletest/include/gtest/internal/gtest-internal.h:1504:38: note: expanded from macro 'GTEST_TEST_BOOLEAN_'
 1504 |           ::testing::AssertionResult(expression))                     \
      |                                      ^~~~~~~~~~
1 error generated.
```
