### PR TITLE
PS-8949 [8.0]: MyRocks configuration failure on a M1 Mac

### DIFF
--- a/cmake/compiler_features.cmake
+++ b/cmake/compiler_features.cmake
@@ -226,13 +226,60 @@ macro (ROCKSDB_SET_ARM64_DEFINTIONS)
   CHECK_VARIABLE_DEFINED(__ARM_FEATURE_CRYPTO HAVE_ARMV8_CRYPTO)
 
   IF (NOT HAVE_ARMV8_CRC OR NOT HAVE_ARMV8_CRYPTO)
-    IF (ALLOW_NO_ARMV8A_CRC_CRYPTO)
-      MESSAGE(WARNING "No ARMv8-A+crc+crypto support found and ALLOW_NO_ARMV8A_CRC_CRYPTO specified, building MyRocks but without ARMv8-A+crc+crypto/FastCRC32 support")
+    IF (ALLOW_NO_ARMV81A_CRYPTO)
+      MESSAGE(WARNING "No ARMv8.1-A+crypto support found and ALLOW_NO_ARMV81A_CRYPTO specified, building MyRocks but without ARMv8.1-A+crypto/FastCRC32 support")
     ELSE()
-      MESSAGE(FATAL_ERROR "No ARMv8-A+crc+crypto support found. Not building MyRocks. Set ALLOW_NO_ARMV8A_CRC_CRYPTO to build MyRocks with slow CRC32.")
+      MESSAGE(FATAL_ERROR "No ARMv8.1-A+crypto support found. Not building MyRocks. Set ALLOW_NO_ARMV81A_CRYPTO to build MyRocks with slow CRC32.")
     ENDIF()
   ENDIF()
 endmacro (ROCKSDB_SET_ARM64_DEFINTIONS)
+
+
+macro (ROCKSDB_SET_BUILD_ARCHITECTURE)
+  IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    IF (NOT ROCKSDB_BUILD_ARCH)
+      IF (ROCKSDB_DISABLE_MARCH_NATIVE)
+        # Intel Westmere is oldest CPU that supports SSE 4.2 and PCLMUL instruction sets
+        # the compiled binary will also work on "core2" and "nehalem" because "sse4.2" and "pclmul" are checked on runtime
+        SET(ROCKSDB_BUILD_ARCH "westmere")
+      ELSE()
+        SET(ROCKSDB_BUILD_ARCH "native")
+      ENDIF()
+      MESSAGE(STATUS "MyRocks x86_64 build architecture: -march=${ROCKSDB_BUILD_ARCH}")
+    ELSE()
+      MESSAGE(STATUS "MyRocks x86_64 build architecture: -march=${ROCKSDB_BUILD_ARCH}. If the enforced processor architecture is newer than the processor architecture of this build machine, the created binary may crash if executed on this machine.")
+    ENDIF()
+
+    # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_COMPILES called from ROCKSDB_SET_X86_DEFINTIONS()
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
+    ROCKSDB_SET_X86_DEFINTIONS()
+  ELSE() # aarch64
+    IF (NOT ROCKSDB_BUILD_ARCH)
+      IF (ROCKSDB_DISABLE_MARCH_NATIVE)
+        # minimal required platform is armv8.1-a (with "+lse" and "+crc"); support for "+crypto" is checked on runtime
+        SET(ROCKSDB_BUILD_ARCH "armv8.1-a+crypto")
+      ELSE()
+        IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+          IF (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 15) # clang-14 or older (doesn't support "-march=native")
+            SET(ROCKSDB_BUILD_ARCH "armv8.1-a+crypto")
+          ELSE()
+            # always compile binary with "+crypto" because support for "+crypto" is checked on runtime
+            SET(ROCKSDB_BUILD_ARCH "native+crypto")
+          ENDIF()
+        ELSE()
+          SET(ROCKSDB_BUILD_ARCH "native")
+        ENDIF()
+      ENDIF()
+      MESSAGE(STATUS "MyRocks arm64 build architecture: -march=${ROCKSDB_BUILD_ARCH}")
+    ELSE()
+      MESSAGE(STATUS "MyRocks arm64 build architecture: -march=${ROCKSDB_BUILD_ARCH}. If the enforced processor architecture is newer than the processor architecture of this build machine, the created binary may crash if executed on this machine.")
+    ENDIF()
+
+    # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_COMPILES called from ROCKSDB_SET_ARM64_DEFINTIONS()
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
+    ROCKSDB_SET_ARM64_DEFINTIONS()
+  ENDIF()
+endmacro (ROCKSDB_SET_BUILD_ARCHITECTURE)
 
 
 macro (ROCKSDB_SET_DEFINTIONS)

--- a/storage/rocksdb/CMakeLists.txt
+++ b/storage/rocksdb/CMakeLists.txt
@@ -103,7 +103,7 @@ ELSE()
   # get a list of rocksdb library source files
   # run with env -i to avoid passing variables
   EXECUTE_PROCESS(
-    COMMAND env -i ${CMAKE_CURRENT_SOURCE_DIR}/get_rocksdb_files.sh ${ROCKSDB_FOLLY}
+    COMMAND env -i CXX=${CMAKE_CXX_COMPILER} ${CMAKE_CURRENT_SOURCE_DIR}/get_rocksdb_files.sh ${ROCKSDB_FOLLY}
     OUTPUT_VARIABLE SCRIPT_OUTPUT
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
   )
@@ -202,43 +202,8 @@ ENDIF()
 
 
 INCLUDE(compiler_features)
-
-IF (CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  IF (NOT ROCKSDB_BUILD_ARCH)
-    IF (ROCKSDB_DISABLE_MARCH_NATIVE)
-      # Intel Westmere is oldest CPU that supports SSE 4.2 and PCLMUL instruction sets
-      # the compiled binary will also work on "core2" and "nehalem" because "sse4.2" and "pclmul" are checked on runtime
-      SET(ROCKSDB_BUILD_ARCH "westmere")
-    ELSE()
-      SET(ROCKSDB_BUILD_ARCH "native")
-    ENDIF()
-    MESSAGE(STATUS "MyRocks x86_64 build architecture: -march=${ROCKSDB_BUILD_ARCH}")
-  ELSE()
-    MESSAGE(STATUS "MyRocks x86_64 build architecture: -march=${ROCKSDB_BUILD_ARCH}. If the enforced processor architecture is newer than the processor architecture of this build machine, the created binary may crash if executed on this machine.")
-  ENDIF()
-
-  # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_COMPILES called from ROCKSDB_SET_X86_DEFINTIONS()
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
-  ROCKSDB_SET_X86_DEFINTIONS()
-ELSE() # aarch64
-  IF (NOT ROCKSDB_BUILD_ARCH)
-    IF (ROCKSDB_DISABLE_MARCH_NATIVE)
-      # the compiled binary will also work on "armv8-a" because "+crc" and "+crypto" are checked on runtime
-      SET(ROCKSDB_BUILD_ARCH "armv8-a+crc+crypto")
-    ELSE()
-      SET(ROCKSDB_BUILD_ARCH "native")
-    ENDIF()
-    MESSAGE(STATUS "MyRocks arm64 build architecture: -march=${ROCKSDB_BUILD_ARCH}")
-  ELSE()
-    MESSAGE(STATUS "MyRocks arm64 build architecture: -march=${ROCKSDB_BUILD_ARCH}. If the enforced processor architecture is newer than the processor architecture of this build machine, the created binary may crash if executed on this machine.")
-  ENDIF()
-
-  # CMAKE_CXX_FLAGS are used by CHECK_CXX_SOURCE_COMPILES called from ROCKSDB_SET_ARM64_DEFINTIONS()
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${ROCKSDB_BUILD_ARCH}")
-  ROCKSDB_SET_ARM64_DEFINTIONS()
-ENDIF()
-
-ROCKSDB_SET_DEFINTIONS()  # sets HAVE_URING, HAVE_MEMKIND, HAVE_ALIGNED_NEW
+ROCKSDB_SET_BUILD_ARCHITECTURE()  # sets "-march=" using ROCKSDB_BUILD_ARCH or ROCKSDB_DISABLE_MARCH_NATIVE
+ROCKSDB_SET_DEFINTIONS()          # sets HAVE_URING, HAVE_MEMKIND, HAVE_ALIGNED_NEW
 
 IF (HAVE_URING AND ROCKSDB_USE_IO_URING)
   SET(rocksdb_static_libs ${rocksdb_static_libs} ${URING_LIBRARY})


### PR DESCRIPTION
1. For "arm64" set:
a) `ROCKSDB_BUILD_ARCH=native+crypto` as default (support for "+crypto" is checked on runtime)
b) `ROCKSDB_BUILD_ARCH=armv8.1-a+crypto` when `ROCKSDB_DISABLE_MARCH_NATIVE==1` (for building packages)

2. Fix RocksDB issue:
```
-- Found Git: /usr/bin/git (found version "2.34.1")
/bin/sh: 1: g++: not found
```