### PR TITLE
PS-8964: Fixed hanging keyring_vault tests under ASan

### DIFF
--- a/plugin/keyring_vault/tests/mtr/mount_point_service.inc
+++ b/plugin/keyring_vault/tests/mtr/mount_point_service.inc
@@ -77,7 +77,7 @@ if ($vault_conf_ca)
     } else {
       $postdata= qq#{"type":"kv"}#;
     }
-    system(qq#curl --http1.1 --insecure -L -H "X-Vault-Token: $imported_vault_admin_token" $vault_ca_cert_opt --data '$postdata' --request POST $imported_vault_conf_address/v1/sys/mounts/$vault_mount#) == 0
+    system(qq#LD_PRELOAD= curl --http1.1 --insecure -L -H "X-Vault-Token: $imported_vault_admin_token" $vault_ca_cert_opt --data '$postdata' --request POST $imported_vault_conf_address/v1/sys/mounts/$vault_mount#) == 0
       or die "Cannot create mount point";
     # This sleep is needed to let Vault background process finish upgrading
     # kv to kv-v2 and therefore reduce the chances of
@@ -86,7 +86,7 @@ if ($vault_conf_ca)
   }
   elsif ($imported_mount_point_service_op eq 'DELETE')
   {
-    system(qq#curl --http1.1 --insecure -L -H "X-Vault-Token: $imported_vault_admin_token" $vault_ca_cert_opt -X DELETE $imported_vault_conf_address/v1/sys/mounts/$vault_mount#) == 0
+    system(qq#LD_PRELOAD= curl --http1.1 --insecure -L -H "X-Vault-Token: $imported_vault_admin_token" $vault_ca_cert_opt -X DELETE $imported_vault_conf_address/v1/sys/mounts/$vault_mount#) == 0
       or die "Cannot delete mount point";
   }
   else


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8964

For some reason 'curl' utility that is used to create mounts in Hashicorp Vault server hangs when run under Address Sanitizer (both from GCC and Clang).

Fixed by adding 'LD_PRELOAD= ' to the 'curl' utility invocations in the 'mount_point_service.inc'.