### PR TITLE
PS-8973: Fix audit_log_filter.status_var_log_size test

### DIFF
--- a/plugin/audit_log_filter/tests/mtr/t/status_var_log_size.test
+++ b/plugin/audit_log_filter/tests/mtr/t/status_var_log_size.test
@@ -1,5 +1,7 @@
 --source audit_tables_init.inc
 
+--source clean_all_audit_logs.inc
+
 --let $audit_filter_log_path = `SELECT @@global.datadir`
 --let $audit_filter_log_name = `SELECT @@global.audit_log_filter_file`
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8973

Test fails to validate Audit_log_filter_current_size and Audit_log_filter_total_size counters when run with --repeat=2. Added audit log files cleanup to make sure previous tests run do not affect counters.

(cherry picked from commit 7c52a07f1fc84d6fdb3d6b3e2cb102b46d850df6)