### PR TITLE
PS-8854 fix: Fixed the list of default MTR test suites

### DIFF
--- a/mysql-test/mysql-test-run.pl
+++ b/mysql-test/mysql-test-run.pl
@@ -302,7 +302,6 @@ our @DEFAULT_SUITES = qw(
   percona_innodb
   percona-pam-for-mysql
   component_masking_functions
-  data_masking
   procfs
   rocksdb
   rocksdb_rpl


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8854

Removed 'data_masking' from the list of the default MTR test suites.