### PR TITLE
Fix crashing mysql due to inadequate cleanup of cached queries that use TempTable

### DIFF
--- a/mysql-test/r/temptable_repeat_cached_query.result
+++ b/mysql-test/r/temptable_repeat_cached_query.result
@@ -1,0 +1,24 @@
+CREATE TABLE `tb1` (
+`col1` varchar(8) NOT NULL
+);
+INSERT INTO `tb1`(col1) VALUES ('20211114');
+CREATE PROCEDURE `stored_proc1`()
+BEGIN
+WITH t_dataset_info as (
+SELECT col1 as yyyymmdd FROM tb1 WHERE col1 = (SELECT max(col1) FROM tb1 )
+)
+SELECT a.yyyymmdd as yyyymmdd
+FROM (
+SELECT a.yyyymmdd FROM t_dataset_info a
+WHERE a.yyyymmdd = (SELECT max(a.yyyymmdd) FROM t_dataset_info a WHERE a.yyyymmdd <= '20220131')
+) a;
+END|
+SET optimizer_switch="derived_merge=off";
+call stored_proc1();
+yyyymmdd
+20211114
+call stored_proc1();
+yyyymmdd
+20211114
+DROP PROCEDURE `stored_proc1`;
+DROP TABLE tb1;

--- a/mysql-test/t/temptable_repeat_cached_query.test
+++ b/mysql-test/t/temptable_repeat_cached_query.test
@@ -1,0 +1,32 @@
+########################################################################################
+# Check that repeat queries that are cached do not cause MySQL to crash due to
+# usable keys not being reset after completion of processing for each query for
+# the TempTable storage engine.
+########################################################################################
+
+CREATE TABLE `tb1` (
+  `col1` varchar(8) NOT NULL
+);
+
+INSERT INTO `tb1`(col1) VALUES ('20211114');
+
+--delimiter |
+CREATE PROCEDURE `stored_proc1`()
+BEGIN
+    WITH t_dataset_info as (
+        SELECT col1 as yyyymmdd FROM tb1 WHERE col1 = (SELECT max(col1) FROM tb1 )
+    )
+    SELECT a.yyyymmdd as yyyymmdd
+    FROM (
+          SELECT a.yyyymmdd FROM t_dataset_info a
+          WHERE a.yyyymmdd = (SELECT max(a.yyyymmdd) FROM t_dataset_info a WHERE a.yyyymmdd <= '20220131')
+          ) a;
+END|
+--delimiter ;
+
+SET optimizer_switch="derived_merge=off";
+call stored_proc1();
+call stored_proc1();
+
+DROP PROCEDURE `stored_proc1`;
+DROP TABLE tb1;


### PR DESCRIPTION
The TempTable storage engine can cause the MySQL engine to crash if the same query that created a temporary table is run more than once. The reason for this crash is that the TempTable handler is cleaned up after execution of the query, but the "keys in use" flag for the underlying temporary table remains "on" in the cached results. When the query is rerun, it uses the cached results from the previous run, and since the "keys in use" flag is set, logic in the execute stage of the query attempts to access a pointer to what it expects is an opened temporary table. But since the TempTable handler had been cleaned up after the first run, a new TempTable handler is instantiated for the new run, which does not yet have a pointer to an opened temporary table. When the query rerun attempts to access the opened temporary table via a null pointer the system crashes. The crashes only happen on the second rerun of the query. Subsequent reruns after the second one do not crash the engine.

This change fixes this issue by ensuring that the "keys in use" flag is reset (0) during the TempTable handler clean up, after the first run of a query. This is done because, if the underlying temporary table has been cleaned up, then by definition there should not be any "keys in use" on it.

Fixes bug https://bugs.mysql.com/bug.php?id=110152 reported to Oracle MySQL.

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.

Porintg notes: Percona only kept `main.temptable_repeat_cached_query`
    MTR test as the issue was solved in `mysql-8.0.35` at https://github.com/mysql/mysql-server/commit/a1d235e