### PR TITLE
PS-8975 : Mysql freeze (threads waiting on __lll_lock_wait)

### DIFF
--- a/mysql-test/r/percona_userstat.result
+++ b/mysql-test/r/percona_userstat.result
@@ -141,4 +141,19 @@ COMMIT_TRANSACTIONS	ROLLBACK_TRANSACTIONS
 17	1
 SET autocommit=1;
 DROP TABLE t1;
+#
+# Bug PS-8975: Mysql freeze (threads waiting on __lll_lock_wait)
+#
+CREATE DATABASE mysqltest1;
+CREATE TABLE mysqltest1.t1 (i INT PRIMARY KEY AUTO_INCREMENT);
+INSERT INTO mysqltest1.t1 VALUES (), (), (), (), ();
+# Create user which has only table-level privilege on mysqltest1.t1.
+CREATE USER mysqltest_1@localhost;
+GRANT RELOAD ON *.* TO mysqltest_1@localhost;
+GRANT SELECT ON mysqltest1.t1 TO mysqltest_1@localhost;
+# Use mysqlslap to concurrently run queries to I_S.TABLE/INDEX_STATISTICS
+# and mysqltest1.t1 tables, as well as FLUSH PRIVILEGES statements
+# under mysqltest_1 user. This caused deadlock before the fix.
+DROP USER mysqltest_1@localhost;
+DROP DATABASE mysqltest1;
 SET GLOBAL userstat= @userstat_old;

--- a/mysql-test/t/percona_userstat.test
+++ b/mysql-test/t/percona_userstat.test
@@ -174,4 +174,22 @@ SELECT COMMIT_TRANSACTIONS, ROLLBACK_TRANSACTIONS FROM INFORMATION_SCHEMA.USER_S
 SET autocommit=1;
 DROP TABLE t1;
 
+
+--echo #
+--echo # Bug PS-8975: Mysql freeze (threads waiting on __lll_lock_wait)
+--echo #
+CREATE DATABASE mysqltest1;
+CREATE TABLE mysqltest1.t1 (i INT PRIMARY KEY AUTO_INCREMENT);
+INSERT INTO mysqltest1.t1 VALUES (), (), (), (), ();
+--echo # Create user which has only table-level privilege on mysqltest1.t1.
+CREATE USER mysqltest_1@localhost;
+GRANT RELOAD ON *.* TO mysqltest_1@localhost;
+GRANT SELECT ON mysqltest1.t1 TO mysqltest_1@localhost;
+--echo # Use mysqlslap to concurrently run queries to I_S.TABLE/INDEX_STATISTICS
+--echo # and mysqltest1.t1 tables, as well as FLUSH PRIVILEGES statements
+--echo # under mysqltest_1 user. This caused deadlock before the fix.
+--exec $MYSQL_SLAP --create-schema=test --user=mysqltest_1 --query="SELECT * FROM information_schema.table_statistics; SELECT * FROM information_schema.index_statistics; FLUSH PRIVILEGES; SELECT * FROM mysqltest1.t1" --iterations=1000 --concurrency=10 --silent 2>&1
+DROP USER mysqltest_1@localhost;
+DROP DATABASE mysqltest1;
+
 SET GLOBAL userstat= @userstat_old;

--- a/sql/handler.cc
+++ b/sql/handler.cc
@@ -5443,8 +5443,7 @@ void handler::update_global_table_stats() {
   if (it == global_table_stats->cend()) {
     global_table_stats->emplace(
         std::piecewise_construct, std::forward_as_tuple(key),
-        std::forward_as_tuple(static_cast<int>(ht->db_type), rows_read,
-                              rows_changed, rows_changed_x_indexes));
+        std::forward_as_tuple(rows_read, rows_changed, rows_changed_x_indexes));
   } else {
     TABLE_STATS *const table_stats = &it->second;
     table_stats->rows_read += rows_read;

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -2971,16 +2971,13 @@ struct handlerton {
 struct TABLE_STATS {
   ulonglong rows_read, rows_changed;
   ulonglong rows_changed_x_indexes;
-  /* Stores enum db_type, but forward declarations cannot be done */
-  const int engine_type;
 
-  TABLE_STATS(int engine_type_, ulonglong rows_read_, ulonglong rows_changed_,
+  TABLE_STATS(ulonglong rows_read_, ulonglong rows_changed_,
               ulonglong rows_changed_x_indexes_)
   noexcept
       : rows_read(rows_read_),
         rows_changed(rows_changed_),
-        rows_changed_x_indexes(rows_changed_x_indexes_),
-        engine_type(engine_type_) {}
+        rows_changed_x_indexes(rows_changed_x_indexes_) {}
 };
 
 constexpr const decltype(handlerton::flags) HTON_SUPPORTS_ENGINE_ATTRIBUTE{

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -3969,58 +3969,28 @@ static int fill_schema_table_stats(THD *thd, Table_ref *tables,
                                    Item *cond [[maybe_unused]]) {
   DBUG_ENTER("fill_schema_table_stats");
 
-  TABLE *const table = tables->table;
+  // Create copy of global table stats on current memory root,
+  // to be able safely check table privileges later, outside of
+  // LOCK_global_table_stats mutex scope.
+  using Table_stats_rec = std::tuple<const char *, const char *, TABLE_STATS>;
+  Mem_root_array<Table_stats_rec> table_stats_array(thd->mem_root);
 
   mysql_mutex_lock(&LOCK_global_table_stats);
   DEBUG_SYNC(thd, "fill_schema_table_stats");
-
+  table_stats_array.reserve(global_table_stats->size());
   for (const auto &it : *global_table_stats) {
-    restore_record(table, s->default_values);
-
     char *table_full_name = thd->mem_strdup(it.first.c_str());
     const char *const table_schema = strsep(&table_full_name, ".");
-    const TABLE_STATS *const table_stats = &it.second;
-
-    Table_ref tmp_table;
-    memset(reinterpret_cast<char *>(&tmp_table), 0, sizeof(tmp_table));
-    tmp_table.table_name = table_full_name;
-    tmp_table.db = table_schema;
-    tmp_table.grant.privilege = 0;
-    if (check_access(thd, SELECT_ACL, tmp_table.db, &tmp_table.grant.privilege,
-                     0, 0, is_infoschema_db(table_schema)) ||
-        check_grant(thd, SELECT_ACL, &tmp_table, 1, UINT_MAX, 1))
-      continue;
-
-    table->field[0]->store(table_schema, strlen(table_schema),
-                           system_charset_info);
-    table->field[1]->store(table_full_name, strlen(table_full_name),
-                           system_charset_info);
-    table->field[2]->store(table_stats->rows_read, true);
-    table->field[3]->store(table_stats->rows_changed, true);
-    table->field[4]->store(table_stats->rows_changed_x_indexes, true);
-
-    if (schema_table_store_record(thd, table)) {
-      mysql_mutex_unlock(&LOCK_global_table_stats);
-      DBUG_RETURN(1);
-    }
+    table_stats_array.emplace_back(table_schema, table_full_name, it.second);
   }
   mysql_mutex_unlock(&LOCK_global_table_stats);
-  DBUG_RETURN(0);
-}
 
-// Sends the global index stats back to the client.
-static int fill_schema_index_stats(THD *thd, Table_ref *tables,
-                                   Item *cond [[maybe_unused]]) {
   TABLE *const table = tables->table;
-  DBUG_ENTER("fill_schema_index_stats");
 
-  mysql_mutex_lock(&LOCK_global_index_stats);
-  for (const auto &it : *global_index_stats) {
-    restore_record(table, s->default_values);
-
-    char *index_full_name = thd->mem_strdup(it.first.c_str());
-    const char *const table_schema = strsep(&index_full_name, ".");
-    const char *const table_name = strsep(&index_full_name, ".");
+  for (const auto &rec : table_stats_array) {
+    const char *const table_schema = std::get<0>(rec);
+    const char *const table_name = std::get<1>(rec);
+    const TABLE_STATS *const table_stats = &std::get<2>(rec);
 
     Table_ref tmp_table;
     memset(reinterpret_cast<char *>(&tmp_table), 0, sizeof(tmp_table));
@@ -4032,19 +4002,73 @@ static int fill_schema_index_stats(THD *thd, Table_ref *tables,
         check_grant(thd, SELECT_ACL, &tmp_table, 1, UINT_MAX, 1))
       continue;
 
+    restore_record(table, s->default_values);
+
     table->field[0]->store(table_schema, strlen(table_schema),
                            system_charset_info);
     table->field[1]->store(table_name, strlen(table_name), system_charset_info);
-    table->field[2]->store(index_full_name, strlen(index_full_name),
-                           system_charset_info);
-    table->field[3]->store(it.second, true);  // rows_read
+    table->field[2]->store(table_stats->rows_read, true);
+    table->field[3]->store(table_stats->rows_changed, true);
+    table->field[4]->store(table_stats->rows_changed_x_indexes, true);
 
     if (schema_table_store_record(thd, table)) {
-      mysql_mutex_unlock(&LOCK_global_index_stats);
       DBUG_RETURN(1);
     }
   }
+  DBUG_RETURN(0);
+}
+
+// Sends the global index stats back to the client.
+static int fill_schema_index_stats(THD *thd, Table_ref *tables,
+                                   Item *cond [[maybe_unused]]) {
+  DBUG_ENTER("fill_schema_index_stats");
+
+  // Create copy of global index stats on current memory root,
+  // to be able safely check table privileges later, outside of
+  // LOCK_global_index_stats mutex scope.
+  using Index_stats_rec =
+      std::tuple<const char *, const char *, const char *, ulonglong>;
+  Mem_root_array<Index_stats_rec> index_stats_array(thd->mem_root);
+
+  mysql_mutex_lock(&LOCK_global_index_stats);
+  index_stats_array.reserve(global_index_stats->size());
+  for (const auto &it : *global_index_stats) {
+    char *index_full_name = thd->mem_strdup(it.first.c_str());
+    const char *const table_schema = strsep(&index_full_name, ".");
+    const char *const table_name = strsep(&index_full_name, ".");
+    index_stats_array.emplace_back(table_schema, table_name, index_full_name,
+                                   it.second);
+  }
   mysql_mutex_unlock(&LOCK_global_index_stats);
+
+  TABLE *const table = tables->table;
+
+  for (const auto &rec : index_stats_array) {
+    const char *const table_schema = std::get<0>(rec);
+    const char *const table_name = std::get<1>(rec);
+    const char *const index_name = std::get<2>(rec);
+
+    Table_ref tmp_table;
+    memset(reinterpret_cast<char *>(&tmp_table), 0, sizeof(tmp_table));
+    tmp_table.table_name = table_name;
+    tmp_table.db = table_schema;
+    tmp_table.grant.privilege = 0;
+    if (check_access(thd, SELECT_ACL, tmp_table.db, &tmp_table.grant.privilege,
+                     0, 0, is_infoschema_db(table_schema)) ||
+        check_grant(thd, SELECT_ACL, &tmp_table, 1, UINT_MAX, 1))
+      continue;
+
+    restore_record(table, s->default_values);
+    table->field[0]->store(table_schema, strlen(table_schema),
+                           system_charset_info);
+    table->field[1]->store(table_name, strlen(table_name), system_charset_info);
+    table->field[2]->store(index_name, strlen(index_name), system_charset_info);
+    table->field[3]->store(std::get<3>(rec), true);  // rows_read
+
+    if (schema_table_store_record(thd, table)) {
+      DBUG_RETURN(1);
+    }
+  }
   DBUG_RETURN(0);
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8975

When support for userstat was enabled, concurrent execution of queries to tables, including queries to I_S.TABLE/INDEX_STATISTICS and FLUSH PRIVILEGES command sometimes caused deadlocks between internal locks of Percona Server. As result statements in existing connections were stalled and it was impossible to create new connections to the server.

These deadlocks we caused by the fact that FLUSH PRIVILEGES and queries to I_S.TABLE/INDEX_STATISTICS were acquiring ACL_CACHE lock and LOCK_global_table/index_stats mutexes in different order.

This fix solves this problem by ensuring that we no longer try to acquire ACL_CACHE lock while holding LOCK_global_table/index_stats mutexes. To do this we have changed implementation of I_S.TABLE/ INDEX_STATISTICS to copy statistics records from global container to MEM_ROOT-allocated array under protection of LOCK_global_table/ index_stats mutexes first, and only the check if user has necessary privileges to see copied entries ((which can involve acquisition of ACL_CACHE lock) outside of mutex scope.

We also no longer store information about table engine type in global table statistics container, as this information is not used anywhere.