### PR TITLE
PS-8836 Follow-up for: MyRocks serialization violation? Read after wr…

### DIFF
--- a/mysql-test/suite/rocksdb/r/sk_rc_concurrent_point_update.result
+++ b/mysql-test/suite/rocksdb/r/sk_rc_concurrent_point_update.result
@@ -20,7 +20,7 @@ START TRANSACTION;
 Conn A: Started TRANSACTION A (SELECT .. FOR UPDATE )
 set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
 Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
-SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
+SELECT * from table1 FORCE INDEX(idx_val1) WHERE row_key = 1 AND val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
 Conn A: Sent SELECT
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 START TRANSACTION;
@@ -39,7 +39,7 @@ COMMIT;
 Conn B: COMMIT for update done
 set DEBUG_SYNC = "now SIGNAL update_done";
 Conn B: signalled Conn A with event `update_done`
-Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa';
+Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE row_key = 1 AND val1 = 14 AND val2 = 'Alfa';
 The SELECT output should be empty
 row_key	val1	val2
 ROLLBACK;
@@ -50,57 +50,4 @@ row_key	val1	val2
 2	14	Bravo
 3	14	Charlie
 4	14	Delta
-DROP TABLE table1;
-Conn A creating table
-CREATE TABLE table1 (
-
-val1 TINYINT NOT NULL,
-val2 VARCHAR(128) NOT NULL,
-
-KEY idx_val1 (val1)
-) ENGINE=RocksDB;
-INSERT INTO table1 (val1, val2) VALUES (14, 'Alfa'), (14, 'Bravo'), (14, 'Charlie'), (14, 'Delta');
-Conn A: `table1` created with 4 rows
-Conn A: Table before
-SELECT * FROM table1;
-val1	val2
-14	Alfa
-14	Bravo
-14	Charlie
-14	Delta
-SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
-START TRANSACTION;
-Conn A: Started TRANSACTION A (SELECT .. FOR UPDATE )
-set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
-Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
-SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
-Conn A: Sent SELECT
-SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
-START TRANSACTION;
-Conn B: Started TRANSACTION B (Concurrent update)
-Conn B: Waiting for Conn A to hit `waiting_for_update`
-set DEBUG_SYNC = "now WAIT_FOR waiting_for_update";
-Conn B: Conn A triggered `waiting_for_update`
-UPDATE table1 SET val1 = 15 WHERE val1 = 14 AND val2 = 'Alfa';
-SELECT * FROM table1;
-val1	val2
-15	Alfa
-14	Bravo
-14	Charlie
-14	Delta
-COMMIT;
-Conn B: COMMIT for update done
-set DEBUG_SYNC = "now SIGNAL update_done";
-Conn B: signalled Conn A with event `update_done`
-Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa';
-The SELECT output should be empty
-val1	val2
-ROLLBACK;
-Conn A: Table after
-SELECT * FROM table1;
-val1	val2
-15	Alfa
-14	Bravo
-14	Charlie
-14	Delta
 DROP TABLE table1;

--- a/mysql-test/suite/rocksdb/t/sk_rc_concurrent_point_update.test
+++ b/mysql-test/suite/rocksdb/t/sk_rc_concurrent_point_update.test
@@ -6,18 +6,12 @@
 --connect(con0, localhost, root,, test)
 --connection default
 
-let $i = 1;
-let $define_row_key = row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,;
-let $define_pk = PRIMARY KEY (row_key),;
-
-while ($i <= 2) {
-
 --echo Conn A creating table
-eval CREATE TABLE table1 (
-  $define_row_key
+CREATE TABLE table1 (
+  row_key BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   val1 TINYINT NOT NULL,
   val2 VARCHAR(128) NOT NULL,
-  $define_pk
+  PRIMARY KEY (row_key),
   KEY idx_val1 (val1)
 ) ENGINE=RocksDB;
 
@@ -40,7 +34,7 @@ START TRANSACTION;
 set DEBUG_SYNC = "rocksdb_concurrent_upd_or_delete_sk SIGNAL waiting_for_update WAIT_FOR update_done";
 --echo Conn A: activate DEBUG_SYNC point rocksdb_concurrent_upd_or_delete_sk
 
-send SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
+send SELECT * from table1 FORCE INDEX(idx_val1) WHERE row_key = 1 AND val1 = 14 AND val2 = 'Alfa' FOR UPDATE;
 --echo Conn A: Sent SELECT
 
 # Meanwhile, start another transaction from Conn B to update val1 in such a way that
@@ -67,7 +61,7 @@ set DEBUG_SYNC = "now SIGNAL update_done";
 # returned back by the lookup function (due to concurrent update invalidating
 # the search predicates
 
---echo Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE val1 = 14 AND val2 = 'Alfa';
+--echo Conn A: reaping SELECT * from table1 FORCE INDEX(idx_val1) WHERE row_key = 1 AND val1 = 14 AND val2 = 'Alfa';
 --echo The SELECT output should be empty
 --connection default
 reap;
@@ -76,15 +70,6 @@ ROLLBACK;
 SELECT * FROM table1;
 
 DROP TABLE table1;
-
-# next, run the above tests a second time without explicitly defining
-# the primary key. this tests scenarios around hidden PK.
-
-inc $i;
-let $define_row_key = ;
-let $define_pk = ;
-
-}
 
 --disconnect con0
 


### PR DESCRIPTION
…ite is failing (#5120)

https://jira.percona.com/browse/PS-8836

This is a cherry-pick of the
"Fix RC SK concurrency testcase for point updates" (commit facebook/mysql-5.6@3c1f09a)

Summary: Without row_key in the SELECT .. FOR UPDATE lookup, the sk_rc_concurrent_point_update.test behaved like an iterator-based scenario, which is covered by another test case. Also, the hidden primary key scenario also doesn't make sense for the point update case.

Differential Revision: D49566243

fbshipit-source-id: 86bec32da3823ee8625ca7e4bfc1ff8dab8b58fd

Authored-by: Saumitr Pathak <saumitr@meta.com>