### PR TITLE
PS-8725 : Assertion `m_opened_table != nullptr' failed in temptable::…

### DIFF
--- a/mysql-test/r/derived.result
+++ b/mysql-test/r/derived.result
@@ -4734,3 +4734,20 @@ Cat2	5
 Cat2	7
 NULL	NULL
 DROP TABLE t1;
+#
+# PS-8725 : Assertion `m_opened_table != nullptr' failed in temptable::Handler::opened_table_validate()
+# Bug#35105404: Server crashes with signal 11 and asserts in temptable code.
+#
+# Re-execution of statements involving MIN/MAX optimization and
+# derived/CTE table caused assertion failures.
+SET @optimizer_switch_saved= @@optimizer_switch;
+SET optimizer_switch="derived_merge=off";
+PREPARE stmt1 FROM "WITH cte AS (VALUES ROW(1), ROW(5), ROW(3)) SELECT column_0 FROM cte WHERE cte.column_0 = (SELECT max(column_0) FROM cte WHERE column_0 < 5)";
+EXECUTE stmt1;
+column_0
+3
+EXECUTE stmt1;
+column_0
+3
+DEALLOCATE PREPARE stmt1;
+SET optimizer_switch= @optimizer_switch_saved;

--- a/mysql-test/t/derived.test
+++ b/mysql-test/t/derived.test
@@ -3427,3 +3427,18 @@ FROM (SELECT a, b, count1, count2
       ORDER BY count1 desc, a, count2 desc, b) AS dt6;
 
 DROP TABLE t1;
+
+
+--echo #
+--echo # PS-8725 : Assertion `m_opened_table != nullptr' failed in temptable::Handler::opened_table_validate()
+--echo # Bug#35105404: Server crashes with signal 11 and asserts in temptable code.
+--echo #
+--echo # Re-execution of statements involving MIN/MAX optimization and
+--echo # derived/CTE table caused assertion failures.
+SET @optimizer_switch_saved= @@optimizer_switch;
+SET optimizer_switch="derived_merge=off";
+PREPARE stmt1 FROM "WITH cte AS (VALUES ROW(1), ROW(5), ROW(3)) SELECT column_0 FROM cte WHERE cte.column_0 = (SELECT max(column_0) FROM cte WHERE column_0 < 5)";
+EXECUTE stmt1;
+EXECUTE stmt1;
+DEALLOCATE PREPARE stmt1;
+SET optimizer_switch= @optimizer_switch_saved;


### PR DESCRIPTION
…Handler::opened_table_validate()

Test case only.

Original problem was fixed in MySQL Server 8.0.35 by the commit a1d235e83859ed39610b2d39eb1a7642964de72c (Bug#35105404 "Server crashes with signal 11 and asserts in temptable code."). However, this commit doesn't contain a public test case.

There was a GitHub contribution with a fix and test case by Nicholas Othieno, but we have chosen upstream's version of fix and a somewhat different test case.