### PR TITLE
(5.7) PS-8879: OOM when alter column to compression

### DIFF
--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -2442,6 +2442,19 @@ row_insert_for_mysql(
 	const byte*		mysql_rec,
 	row_prebuilt_t*		prebuilt)
 {
+	struct CompressHeapCleaner {
+		CompressHeapCleaner(row_prebuilt_t* prebuilt)
+		: prebuilt_(prebuilt) { }
+
+		~CompressHeapCleaner() {
+			if (prebuilt_ && UNIV_LIKELY_NULL(prebuilt_->compress_heap)) {
+				mem_heap_empty(prebuilt_->compress_heap);
+			}
+		}
+
+		row_prebuilt_t *prebuilt_;
+	} compressCheapCleaner(prebuilt);
+
 	/* For intrinsic tables there a lot of restrictions that can be
 	relaxed including locking of table, transaction handling, etc.
 	Use direct cursor interface for inserting to intrinsic tables. */

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -3318,8 +3318,9 @@ row_sel_store_mysql_rec(
 		row_mysql_prebuilt_free_blob_heap(prebuilt);
 	}
 
-	if (UNIV_LIKELY_NULL(prebuilt->compress_heap))
-		row_mysql_prebuilt_free_compress_heap(prebuilt);
+	if (UNIV_LIKELY_NULL(prebuilt->compress_heap)) {
+		mem_heap_empty(prebuilt->compress_heap);
+	}
 
 	if (clust_templ_for_sec) {
 		/* Store all clustered index column of


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8879

Problem:
If the large table containing BLOB column is altered in the way that the COLUMN_FORMAT becomes COMPRESSED
(like ALTER TABLE t1 MODIFY a10 BLOB COLUMN_FORMAT COMPRESSED), we observe huge memory utilization during the ALTER. This can lead to OOM situation when mysqld gets killed by the system.

Cause:
Fix for PS-7657 (a943a8fe) removed emptying of compress_heap from before insertion of the row into InnoDB. This was because during the UPDATE, prior to storing the row, the compressed column is read from InnoDB and decompressed. Its decompressed version is kept on prebuilt->compress_heap. Then when we store the row, we need the compress_heap to be still valid to have access to the BLOB column value.
However, if we don't clean the compress_heap, it constantly grows in cases like ALTER ... COLUMN_FORMAT COMPRESSED, because during this process we copy all data from altered table to temp table in a loop.

Solution:
Rework the original fix in the way that compress_heap is emptied after the row is inserted.