### PR TITLE
[WIP] PS FIPS support

### DIFF
--- a/include/mysql.h
+++ b/include/mysql.h
@@ -281,6 +281,11 @@ enum mysql_ssl_fips_mode {
   SSL_FIPS_MODE_STRICT
 };
 
+enum mysql_check_ssl_fips_enabled {
+  CHECK_SSL_FIPS_ENABLED_OFF = 0,
+  CHECK_SSL_FIPS_ENABLED_FORCE
+};
+
 typedef struct character_set {
   unsigned int number;   /* character set number              */
   unsigned int state;    /* character set state               */

--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/network/xcom_network_provider_ssl_native_lib.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/xcom/network/xcom_network_provider_ssl_native_lib.cc
@@ -325,20 +325,6 @@ static int configure_ssl_algorithms(SSL_CTX *ssl_ctx, const char *cipher,
   return 0;
 }
 
-/**
-  @retval true     for error
-  @retval false    for success
-*/
-static bool configure_ssl_fips_mode(const int fips_mode) {
-  bool rc = false;
-  char err_string[OPENSSL_ERROR_LENGTH] = {'\0'};
-  if (set_fips_mode(fips_mode, err_string)) {
-    G_ERROR("openssl fips mode set failed: %s", err_string);
-    rc = true;
-  }
-  return rc;
-}
-
 static int configure_ssl_ca(SSL_CTX *ssl_ctx, const char *ca_file,
                             const char *ca_path) {
   /* Load certs from the trusted ca. */
@@ -476,12 +462,6 @@ int Xcom_network_provider_ssl_library::xcom_init_ssl(
     const char *tls_ciphersuites) {
   int verify_server = SSL_VERIFY_NONE;
   int verify_client = SSL_VERIFY_NONE;
-
-  if (configure_ssl_fips_mode(
-          Network_provider_manager::getInstance().xcom_get_ssl_fips_mode())) {
-    G_ERROR("Error setting the ssl fips mode");
-    goto error;
-  }
 
   SSL_library_init();
   SSL_load_error_strings();

--- a/plugin/x/client/xconnection_impl.cc
+++ b/plugin/x/client/xconnection_impl.cc
@@ -629,12 +629,6 @@ XError Connection_impl::activate_tls() {
   if (!m_context->m_ssl_config.is_configured())
     return XError{CR_SSL_CONNECTION_ERROR, ER_TEXT_TLS_NOT_CONFIGURATED, true};
 
-  char err_string[OPENSSL_ERROR_LENGTH] = {'\0'};
-  if (set_fips_mode(
-          static_cast<uint32_t>(m_context->m_ssl_config.m_ssl_fips_mode),
-          err_string)) {
-    return XError{CR_SSL_CONNECTION_ERROR, err_string, true};
-  }
   auto ssl_ctx_flags = process_tls_version(
       details::null_when_empty(m_context->m_ssl_config.m_tls_version));
 

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -12394,6 +12394,15 @@ ER_CONN_CONTROL_DELAYED_CONN_STATS
 ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH
   eng "The --secure-file-path is configured, %s must be set accordingly."
 
+ER_SSL_FIPS_MODE_ENABLED
+  eng "We have detected a FIPS-approved version of OpenSSL library in your system. It has the default crypto provider set to use FIPS mode. Consequently Percona Server for MySQL will run in FIPS mode as well."
+
+ER_SSL_FIPS_MODE_DISABLED
+  eng "We have detected that version of OpenSSL library installed in your system is not FIPS-approved or it has no crypto provider set to use FIPS mode. Consequently Percona Server for MySQL will run in normal (non-FIPS) mode as well."
+
+ER_SSL_FIPS_MODE_FORCE_SET
+  eng "The --check-ssl-fips-enabled is set to FORCE but OpenSSL library in your system is not in FIPS mode."
+
 #
 # End of Percona Server 8.0 server error log messages
 #

--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -79,7 +79,6 @@
 #include "my_io.h"
 #include "my_loglevel.h"
 #include "my_macros.h"
-#include "my_openssl_fips.h"  // OPENSSL_ERROR_LENGTH, set_fips_mode
 #include "my_psi_config.h"
 #include "my_shm_defaults.h"
 #include "mysql.h"
@@ -8779,18 +8778,6 @@ int STDCALL mysql_options(MYSQL *mysql, enum mysql_option option,
       fprintf(stderr,
               "WARNING: MYSQL_OPT_SSL_FIPS_MODE is deprecated and will be "
               "removed in a future version.\n");
-      char ssl_err_string[OPENSSL_ERROR_LENGTH] = {'\0'};
-      ENSURE_EXTENSIONS_PRESENT(&mysql->options);
-      mysql->options.extension->ssl_fips_mode =
-          *static_cast<const ulong *>(arg);
-      if (set_fips_mode(mysql->options.extension->ssl_fips_mode,
-                        ssl_err_string)) {
-        DBUG_PRINT("error", ("fips mode set error %s:", ssl_err_string));
-        set_mysql_extended_error(
-            mysql, CR_SSL_FIPS_MODE_ERR, unknown_sqlstate,
-            "Set Fips mode ON/STRICT failed, detail: '%s'.", ssl_err_string);
-        return 1;
-      }
     } break;
     case MYSQL_OPT_SSL_MODE:
       ENSURE_EXTENSIONS_PRESENT(&mysql->options);

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -790,6 +790,7 @@ extern mysql_rwlock_t LOCK_system_variables_hash;
 extern mysql_rwlock_t LOCK_consistent_snapshot;
 
 extern ulong opt_ssl_fips_mode;
+extern ulong opt_check_ssl_fips_enabled;
 
 extern char *opt_disabled_storage_engines;
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -5212,6 +5212,15 @@ static Sys_var_enum Sys_ssl_fips_mode(
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr),
     DEPRECATED_VAR(""), sys_var::PARSE_EARLY);
 
+static const char *check_ssl_fips_enabled_names[] = {"OFF", "FORCE", nullptr};
+static Sys_var_enum Sys_check_ssl_fips_enabled(
+    "check_ssl_fips_enabled",
+    "Check if OpenSSL FIPS mode is enabled, permitted values are: OFF, FORCE",
+    READ_ONLY GLOBAL_VAR(opt_check_ssl_fips_enabled),
+    CMD_LINE(REQUIRED_ARG), check_ssl_fips_enabled_names,
+    DEFAULT(CHECK_SSL_FIPS_ENABLED_OFF), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+    ON_CHECK(nullptr), ON_UPDATE(nullptr), nullptr, sys_var::PARSE_EARLY);
+
 static Sys_var_bool Sys_auto_generate_certs(
     "auto_generate_certs",
     "Auto generate SSL certificates at server startup if --ssl is set to "


### PR DESCRIPTION
- Added checkup during server startup if system OpenSSL is configured to use FIPS. Corresponding message will be printed to server error log.
- Added --check-ssl-fips-enabled=OFF|FORCE system variable.
- In case --check-ssl-fips-enabled=FORCE and system OpenSSL is not configured to use FIPS server startup is cancelled.