### PR TITLE
PS-8879: OOM when alter column to compression

### DIFF
--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -23508,7 +23508,8 @@ innobase_get_field_from_update_vector(
 				or NULL.
 @param[in]	parent_update	update vector for the parent row
 @param[in]	foreign		foreign key information
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @return the field filled with computed value, or NULL if just want
 to store the value in passed in "my_rec" */
 dfield_t*

--- a/storage/innobase/include/row0merge.h
+++ b/storage/innobase/include/row0merge.h
@@ -301,7 +301,8 @@ this function and it will be passed to other functions for further accounting.
 @param[in]	add_v		new virtual columns added along with indexes
 @param[in]	eval_table	mysql table used to evaluate virtual column
 				value, see innobase_get_computed_value().
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @return DB_SUCCESS or error code */
 dberr_t
 row_merge_build_indexes(

--- a/storage/innobase/include/row0mysql.h
+++ b/storage/innobase/include/row0mysql.h
@@ -85,7 +85,7 @@ row_decompress_column(
 	ulint		dict_data_len,
 				/*!< in: optional dictionary data length */
 	row_prebuilt_t*	prebuilt);
-				/*!< in: use prebuilt->compress_heap only
+				/*!< in: use prebuilt->blob_heap only
 				here*/
 
 /** Compress blob/text/varchar column using zlib
@@ -155,7 +155,7 @@ row_mysql_store_blob_ref(
 				/*!< in: optional compression dictionary data
 				length */
 	row_prebuilt_t*	prebuilt);
-				/*<! in: use prebuilt->compress_heap only
+				/*<! in: use prebuilt->blob_heap only
 				here */
 /*******************************************************************//**
 Reads a reference to a BLOB in the MySQL format.
@@ -955,9 +955,9 @@ struct row_prebuilt_t {
 	ulint		n_fetch_cached;	/*!< number of not yet fetched rows
 					in fetch_cache */
 	mem_heap_t*	blob_heap;	/*!< in SELECTS BLOB fields are copied
-					to this heap */
-	mem_heap_t*	compress_heap;  /*!< memory heap used to compress
-					/decompress blob column*/
+					to this heap. It is also used to decompress compressed
+					column */
+	mem_heap_t*	compress_heap;  /*!< memory heap used to compress blob column*/
 	mem_heap_t*	old_vers_heap;	/*!< memory heap where a previous
 					version is built in consistent read */
 	bool		in_fts_query;	/*!< Whether we are in a FTS query */
@@ -1066,7 +1066,8 @@ innobase_get_field_from_update_vector(
 				or NULL.
 @param[in]	parent_update	update vector for the parent row
 @param[in]	foreign		foreign key information
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @return the field filled with computed value */
 dfield_t*
 innobase_get_computed_value(

--- a/storage/innobase/include/row0sel.h
+++ b/storage/innobase/include/row0sel.h
@@ -520,7 +520,8 @@ function is row_mysql_store_col_in_innobase_format() in row0mysql.cc.
 				or templ->icp_rec_field_no
 @param[in]	data		data to store
 @param[in]	len		length of the data
-@param[in]	prebuilt	use prebuilt->compress_heap only here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @param[in]	sec_field	secondary index field no if the secondary index
 				record but the prebuilt template is in
 				clustered index format and used only for end

--- a/storage/innobase/include/row0upd.h
+++ b/storage/innobase/include/row0upd.h
@@ -235,7 +235,8 @@ the equal ordering fields. NOTE: we compare the fields as binary strings!
 @param[in]	heap		memory heap from which allocated
 @param[in,out]	mysql_table	NULL, or mysql table object when
 				user thread invokes dml
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @param[out]	error		error number in case of failure
 @return own: update vector of differing fields, excluding roll ptr and
 trx id */

--- a/storage/innobase/row/row0merge.cc
+++ b/storage/innobase/row/row0merge.cc
@@ -498,7 +498,8 @@ row_merge_buf_redundant_convert(
 @param[in,out]	v_heap		heap memory to process data for virtual column
 @param[in,out]	my_table	mysql table object
 @param[in]	trx		transaction object
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @return number of rows added, 0 if out of space */
 static
 ulint
@@ -1707,7 +1708,8 @@ ALTER TABLE. stage->n_pk_recs_inc() will be called for each record read and
 stage->inc() will be called for each page read.
 @param[in]	eval_table	mysql table used to evaluate virtual column
 				value, see innobase_get_computed_value().
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @return DB_SUCCESS or error */
 static MY_ATTRIBUTE((warn_unused_result))
 dberr_t
@@ -4443,7 +4445,8 @@ this function and it will be passed to other functions for further accounting.
 @param[in]	add_v		new virtual columns added along with indexes
 @param[in]	eval_table	mysql table used to evaluate virtual column
 				value, see innobase_get_computed_value().
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @return DB_SUCCESS or error code */
 dberr_t
 row_merge_build_indexes(

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -589,7 +589,7 @@ row_decompress_column(
 	ulint		dict_data_len,
 				/*!< in: optional dictionary data length */
 	row_prebuilt_t*	prebuilt)
-				/*!< in: use prebuilt->compress_heap only
+				/*!< in: use prebuilt->blob_heap only
 				here*/
 {
 	ulint buf_len = 0;
@@ -834,7 +834,7 @@ row_mysql_store_blob_ref(
 				/*!< in: optional compression dictionary data
 				length */
 	row_prebuilt_t*	prebuilt)
-				/*<! in: use prebuilt->compress_heap only
+				/*<! in: use prebuilt->blob_heap only
 				here */
 {
 	/* MySQL might assume the field is set to zero except the length and

--- a/storage/innobase/row/row0purge.cc
+++ b/storage/innobase/row/row0purge.cc
@@ -1175,9 +1175,12 @@ row_purge_step(que_thr_t* thr)
 		row_purge_end(thr);
 	}
 
-	if (thr->prebuilt !=0 && thr->prebuilt->compress_heap != 0) {
-		mem_heap_empty(thr->prebuilt->compress_heap);
+	/* We use blob_heap to decompress compressed column. */
+	if (thr->prebuilt !=0 && thr->prebuilt->blob_heap != 0) {
+		mem_heap_empty(thr->prebuilt->blob_heap);
 	}
+	/* compress_heap was not used */
+	ut_ad(thr->prebuilt == 0 || thr->prebuilt->compress_heap == 0);
 
 	return(thr);
 }

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -2868,7 +2868,8 @@ function is row_mysql_store_col_in_innobase_format() in row0mysql.cc.
 				or templ->icp_rec_field_no
 @param[in]	data		data to store
 @param[in]	len		length of the data
-@param[in]	prebuilt	use prebuilt->compress_heap only here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @param[in]	sec_field	secondary index field no if the secondary index
 				record but the prebuilt template is in
 				clustered index format and used only for end

--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -885,7 +885,8 @@ the equal ordering fields. NOTE: we compare the fields as binary strings!
 @param[in]	heap		memory heap from which allocated
 @param[in]	mysql_table	NULL, or mysql table object when
 				user thread invokes dml
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @param[out]	error		error number in case of failure
 @return own: update vector of differing fields, excluding roll ptr and
 trx id,if error is not equal to DB_SUCCESS, return NULL */

--- a/storage/innobase/row/row0vers.cc
+++ b/storage/innobase/row/row0vers.cc
@@ -480,7 +480,8 @@ row_vers_non_vc_match(
 @param[in]	clust_index	clustered index
 @param[in]	index		the secondary index
 @param[in]	heap		heap used to build virtual dtuple
-@param[in]	prebuilt	compress_heap must be taken from here */
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression) */
 static
 void
 row_vers_build_clust_v_col(
@@ -816,7 +817,8 @@ func_exit:
 @param[in,out]	heap		heap memory
 @param[in,out]	v_heap		heap memory to keep virtual colum dtuple
 @param[in]	mtr		mtr holding the latch on rec
-@param[in]	prebuilt	compress_heap must be taken from here
+@param[in]	prebuilt	provides pointer to blob_heap (used for decompression)
+                        and compress_heap (used for compression)
 @return dtuple contains virtual column data */
 static
 const dtuple_t*

--- a/storage/innobase/trx/trx0purge.cc
+++ b/storage/innobase/trx/trx0purge.cc
@@ -292,10 +292,14 @@ trx_purge_sys_close(void)
 	for (que_thr_t* thr = UT_LIST_GET_FIRST(purge_sys->query->thrs);
 		thr != NULL;
 		thr = UT_LIST_GET_NEXT(thrs, thr)) {
+		/* We use blob_heap to decompress compressed column. */
 		if (thr->prebuilt != 0 &&
-			thr->prebuilt->compress_heap != 0) {
-			row_mysql_prebuilt_free_compress_heap(thr->prebuilt);
+			thr->prebuilt->blob_heap != 0) {
+			row_mysql_prebuilt_free_blob_heap(thr->prebuilt);
 		}
+
+		/* compress_heap was not used */
+		ut_ad(thr->prebuilt == 0 || thr->prebuilt->compress_heap == 0);
 	}
 
 	que_graph_free(purge_sys->query);


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8879

Post-push fix.

Fixed memory leak caused by not freeing heap used for decompression. blob_heap is now used for keeping decompressed columns, but purge was attempting to free compress_heap (which was used before the fix).

Adjusted functions' 'prebuilt' parameter description when applicable.