### PR TITLE
PS-9011 fix 8.0: Backport Bug#35625510 crash upgrade to 8.0.32/8.0.34 if tables in mysqldb has instant column

### DIFF
--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -3134,11 +3134,13 @@ static dict_index_t *dict_index_build_internal_clust(
 
   ut::free(indexed);
 
-  if (!table->is_system_table) {
-    if (table->has_row_versions()) {
-      new_index->create_fields_array();
-    }
-    new_index->create_nullables(table->current_row_version);
+  new_index->create_nullables(table->current_row_version);
+
+  if (table->has_row_versions()) {
+    new_index->create_fields_array();
+  } else {
+    /* Table with no row version are considered of version 0 */
+    ut_a(new_index->get_nullable_in_version(0) == new_index->n_nullable);
   }
 
   ut_ad(UT_LIST_GET_LEN(table->indexes) == 0);


### PR DESCRIPTION
Cherry picked fix for the bug Bug #112946 / #35625510
"INSTANT algo <= 8028 on table in mysql schema leads to corruption post upgrade"
(https://bugs.mysql.com/bug.php?id=112946)
(commit mysql/mysql-server@68da9a2)
from 8.2.0 to 8.0.35.