### PR TITLE
PS-8978: Merge MySQL 8.0.35 - Fix linking issue using `WITH_VALGRIND=ON`

### DIFF
--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -337,7 +337,7 @@ ENDIF()
 
 # Avoid 'requires dynamic R_X86_64_PC32 reloc' linker error for dd_sdi-t.cc
 # when built with ASAN
-IF(WITH_ASAN)
+IF(WITH_ASAN OR WITH_VALGRIND)
   ADD_CXX_COMPILE_FLAGS_TO_FILES(-fPIC FILES dd_sdi-t.cc)
 ENDIF()
 


### PR DESCRIPTION
Fix the following issue when `lld` is not detected or `-DUSE_LD_LLD=OFF` is used:
```
/usr/bin/ld: CMakeFiles/merge_large_tests-t.dir/dd_sdi-t.cc.o: warning: relocation against `_ZThn56_N2dd10Index_impl15se_private_dataEv' in read-only section `.text._ZN12sdi_unittestL11mock_dd_objEPN2dd5IndexEPNS0_6ColumnE'
/usr/bin/ld: CMakeFiles/merge_large_tests-t.dir/dd_sdi-t.cc.o: relocation R_X86_64_PC32 against symbol `_ZThn56_N2dd11Column_impl15se_private_dataEv' can not be used when making a PIE object; recompile with -fPIE
```