### PR TITLE
PS-9017: Check OpenSSL FIPS mode status during server startup (8.0.35)

### DIFF
--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -12433,6 +12433,9 @@ ER_CONN_CONTROL_DELAYED_CONN_STATS
 ER_LOG_NAME_NOT_MATCHING_SEC_LOG_PATH
   eng "The --secure-file-path is configured, %s must be set accordingly."
 
+ER_SSL_FIPS_MODE_ENABLED
+  eng "A FIPS-approved version of the OpenSSL cryptographic library has been detected in the operating system with a properly configured FIPS module available for loading. Percona Server for MySQL will load this module and run in FIPS mode."
+
 #
 # End of Percona Server 8.0 server error log messages
 #

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5694,6 +5694,10 @@ static int init_ssl() {
   if (opt_ssl_fips_mode != SSL_FIPS_MODE_OFF)
     LogErr(WARNING_LEVEL, ER_DEPRECATE_MSG_NO_REPLACEMENT, "--ssl-fips-mode");
 
+  if (get_fips_mode() == 1) {
+    LogErr(INFORMATION_LEVEL, ER_SSL_FIPS_MODE_ENABLED);
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-9017

Added checkup during server startup if system OpenSSL is configured to use FIPS. Corresponding message will be printed to server error log.