### PR TITLE
PS-9031: Fix unstable percona_userstat_conn_handling test (8.0)

### DIFF
--- a/mysql-test/r/percona_userstat_conn_handling.result
+++ b/mysql-test/r/percona_userstat_conn_handling.result
@@ -1,5 +1,7 @@
 SET @userstat_old= @@userstat;
 SET GLOBAL userstat=ON;
+FLUSH USER_STATISTICS;
+FLUSH CLIENT_STATISTICS;
 CREATE USER mysqltest_1@localhost;
 GRANT USAGE ON *.* TO mysqltest_1@localhost;
 ALTER USER mysqltest_1@localhost WITH MAX_USER_CONNECTIONS 100;
@@ -54,4 +56,6 @@ ERROR 42000: Access denied for user 'mysqltest_1'@'localhost' to database 'foo'
 include/assert.inc [I_S.USER_STATISTICS ACCESS_DENIED: counts previous error]
 DROP USER mysqltest_1@localhost;
 DROP USER mysqltest_2@localhost;
+FLUSH USER_STATISTICS;
+FLUSH CLIENT_STATISTICS;
 SET GLOBAL userstat= @userstat_old;

--- a/mysql-test/t/percona_userstat_conn_handling.test
+++ b/mysql-test/t/percona_userstat_conn_handling.test
@@ -1,6 +1,9 @@
 SET @userstat_old= @@userstat;
 SET GLOBAL userstat=ON;
 
+FLUSH USER_STATISTICS;
+FLUSH CLIENT_STATISTICS;
+
 # concurrent connections count tracked only if resource limits enabled globally
 # or just for specific users
 CREATE USER mysqltest_1@localhost;
@@ -198,5 +201,8 @@ let $count_sessions= 1;
 
 DROP USER mysqltest_1@localhost;
 DROP USER mysqltest_2@localhost;
+
+FLUSH USER_STATISTICS;
+FLUSH CLIENT_STATISTICS;
 
 SET GLOBAL userstat= @userstat_old;


### PR DESCRIPTION
https://jira.percona.com/browse/PS-9031

The percona_userstat_conn_handling test relies on I_S.USER_STATISTICS and I_S.CLIENT_STATISTICS content. Currently USER_STATISTICS and CLIENT_STATISTICS are not flushed before test execution. As a result other tests affct percona_userstat_conn_handling test behavior.

Added FLUSH for both USER_STATISTICS and CLIENT_STATISTICS to fix the test.