### PR TITLE
PS-8979: Merge MySQL 8.2.0 (unit tests fix)

### DIFF
--- a/router/tests/helpers/router_test_helpers.h
+++ b/router/tests/helpers/router_test_helpers.h
@@ -33,10 +33,10 @@
 
 #include "mysql/harness/stdx/attribute.h"
 
-#ifdef NDEBUG
-#define MYSQLD_BIN "mysqld"
-#else
+#ifdef HAVE_DEBUG_EXTNAME
 #define MYSQLD_BIN "mysqld-debug"
+#else
+#define MYSQLD_BIN "mysqld"
 #endif
 
 #define SKIP_GIT_TESTS(COND)                                       \

--- a/router/tests/integration/CMakeLists.txt
+++ b/router/tests/integration/CMakeLists.txt
@@ -20,6 +20,10 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+IF(DEBUG_EXTNAME)
+  ADD_COMPILE_DEFINITIONS(HAVE_DEBUG_EXTNAME)
+ENDIF()
+
 ADD_DEFINITIONS(-DSSL_TEST_DATA_DIR="${CMAKE_SOURCE_DIR}/mysql-test/std_data/")
 ADD_DEFINITIONS(-DCMAKE_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
 FOREACH(test_file

--- a/storage/ndb/src/common/portlib/NdbTCP.cpp
+++ b/storage/ndb/src/common/portlib/NdbTCP.cpp
@@ -412,9 +412,12 @@ can_resolve_hostname(const char* name)
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_protocol = IPPROTO_TCP;
 
-  struct addrinfo* ai_list;
+  struct addrinfo *ai_list = nullptr;
   int err = getaddrinfo(name, nullptr, &hints, &ai_list);
-  freeaddrinfo(ai_list);
+
+  if (ai_list != nullptr) {
+    freeaddrinfo(ai_list);
+  }
 
   if (err)
   {


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8979

The router integration tests were failing due to incorrectly set MYSQLD_BIN which was set to 'mysqld-debug' or 'mysqld' depending on NDEBUG option state.
The binary name actually depends on DEBUG_EXTNAME value. Changed MYSQLD_BIN to be set similarly.

Fixed freeaddrinfo() invocation on uninitialized pointer in NdbTCP test.