### PR TITLE
PS-9040 Integrate clang-tidy checks for Percona server

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: Static analysis
+run-name: GitHub Actions for clang-tidy
+
+on: pull_request
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        run: |
+          git remote add upstream "https://github.com/${{ github.event.pull_request.base.repo.full_name }}"
+          git fetch --no-tags --no-recurse-submodules upstream "${{ github.event.pull_request.base.ref }}"
+          git submodule update --init --recursive
+
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang clang-tidy libldap2-dev curl libcurl4-openssl-dev bison libudev-dev libkrb5-dev
+
+      - name: Prepare compile_commands.json
+        run: |
+          cmake -B build -DCMAKE_INSTALL_PREFIX=../install -DWITH_DEBUG=1 -DDOWNLOAD_BOOST=1 -DWITH_BOOST=my_boost \
+          -DWITH_ZLIB=bundled -DWITH_SSL=system -DWITH_AUTHENTICATION_LDAP=0 -DWITH_LZ4=bundled \
+          -WITH_KEYRING_VAULT=ON -DWITH_ROCKSDB=0 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ \
+          -DWITH_PROTOBUF=bundled -DWITH_LIBEVENT=bundled -DWITH_EDITLINE=bundled -DWITH_ZSTD=bundled WITH_CURL=/usr/bin/curl \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DWITH_SYSTEM_LIBS=1 -DWITH_PROTOBUF=bundled -DWITH_FIDO=bundled ${{ github.workspace }}
+
+      - name: Create results directory
+        run: |
+          mkdir clang-tidy-result
+
+      - name: Analyze
+        # Don't disable push/merge option in the PR even if there are unfixed warnings.
+        continue-on-error: true
+        run: |
+          git diff --name-only --diff-filter=ACRM "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | \
+          grep -Ee "\.([ch](pp)|(cc|hh)|[i](c|h)|(cxx)|[chi])$" | xargs clang-tidy -p build --checks=-readability-* -export-fixes clang-tidy-result/fixes.yml
+
+      - name: Run clang-tidy-pr-comments action
+        uses: platisd/clang-tidy-pr-comments@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          clang_tidy_fixes: clang-tidy-result/fixes.yml
+          request_changes: true
+          suggestions_per_comment: 10


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9040

Creates a yaml file for clang-tidy workflow which is triggered on a pull request.

The workflow triggers a run of generating comiplation commands and uses the same to perform a clang-tidy check on the modified files and generates a report of the warnings in the changed code through a github action bot in the form of review comments on the pull request.