### PR TITLE
PS-8873 percona-server-server-5.7 failing upgrade on debian 11

### DIFF
--- a/build-ps/debian/percona-server-server-5.7.postrm
+++ b/build-ps/debian/percona-server-server-5.7.postrm
@@ -28,7 +28,7 @@ place_upstart_job_back () {
 }
 
 get_pcount () {
-	PSCOUNT=$(ps -ef | grep "/usr/sbin/mysqld" | wc -l)
+	PSCOUNT=$(ps -o cmd --no-headers --ppid 1 | grep "mysqld" | wc -l)
 	echo "${PSCOUNT}"
 }
 
@@ -38,7 +38,7 @@ server_stop () {
 	while :; do
 		COUNT=$(( COUNT+1 ))
 		echo -n .
-		if [ "${PSCOUNT}" -eq 1 ];
+		if [ "${PSCOUNT}" -eq 0 ];
 		then
 			echo
 			break

--- a/build-ps/debian/percona-server-server-5.7.preinst
+++ b/build-ps/debian/percona-server-server-5.7.preinst
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 get_pcount () {
-	PSCOUNT=$(ps -C mysqld --no-headers | wc -l)
+	PSCOUNT=$(ps -o cmd --no-headers --ppid 1 | grep mysqld | wc -l)
 	echo "${PSCOUNT}"
 }
 


### PR DESCRIPTION
It's been tested on an environment with next installed instances:

- mysql 
- mysql docker
- demone mysqld-sleep

![Screenshot 2024-01-04 at 17 53 02](https://github.com/percona/percona-server/assets/25184101/ec076f5f-c8c8-4173-bef4-7075022b94ec)
