### PR TITLE
PS-9057: Fix build with default value used for -DWITH_CURL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1001,14 +1001,10 @@ OPTION(WITH_AUTHENTICATION_CLIENT_PLUGINS
   "Build client-side authentication plugins, even if server-side are disabled"
   ${WITH_AUTHENTICATION_CLIENT_PLUGINS_DEFAULT})
 
-IF(WITH_INTERNAL)
-  IF(UNIX)
-    SET(WITH_CURL_DEFAULT "system")
-  ELSE()
-    SET(WITH_CURL_DEFAULT "bundled")
-  ENDIF()
+IF(UNIX)
+  SET(WITH_CURL_DEFAULT "system")
 ELSE()
-  SET(WITH_CURL_DEFAULT "none")
+  SET(WITH_CURL_DEFAULT "bundled")
 ENDIF()
 
 OPTION(WITH_LOCK_ORDER


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9057

Cmake fails in case -DWITH_CURL is not set directly. In this case it defaults to 'none' but curl is required to build component_keyring_vault.

Change WITH_CURL to be set to 'system' by default.