### PR TITLE
PS-9048: Exclude % symbol from ngram generated index tokens

### DIFF
--- a/mysql-test/suite/innodb_fts/include/percona_ps9048.inc
+++ b/mysql-test/suite/innodb_fts/include/percona_ps9048.inc
@@ -1,0 +1,12 @@
+SET @old_innodb_optimize_fulltext_only = @@innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+
+--eval CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) $PARSER) ENGINE=InnoDB $CHARSET
+
+INSERT INTO t1 VALUES ('vdf%vdfd%ghdi%opu');
+
+--exec $MYSQL_SLAP --host=127.0.0.1 --user=root --port=$MASTER_MYPORT --create-schema=test --delimiter=";" --number-of-queries=1000 --concurrency=5 --query="OPTIMIZE TABLE t1; UPDATE t1 SET c = CONCAT('foo', RAND()) LIMIT 200;" > $MYSQL_TMP_DIR/mysql_slap_output.txt
+
+DROP TABLE t1;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;
+--remove_file $MYSQL_TMP_DIR/mysql_slap_output.txt

--- a/mysql-test/suite/innodb_fts/r/percona_mecab_ps9048.result
+++ b/mysql-test/suite/innodb_fts/r/percona_mecab_ps9048.result
@@ -1,0 +1,11 @@
+INSTALL PLUGIN mecab SONAME 'libpluginmecab.so';
+SHOW STATUS LIKE 'mecab_charset';
+Variable_name	Value
+mecab_charset	ujis
+SET @old_innodb_optimize_fulltext_only = @@innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) WITH PARSER MECAB) ENGINE=InnoDB DEFAULT CHARSET=ujis;
+INSERT INTO t1 VALUES ('vdf%vdfd%ghdi%opu');
+DROP TABLE t1;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;
+UNINSTALL PLUGIN mecab;

--- a/mysql-test/suite/innodb_fts/r/percona_ngram_ps9048.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ngram_ps9048.result
@@ -1,0 +1,6 @@
+SET @old_innodb_optimize_fulltext_only = @@innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) WITH PARSER NGRAM) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+INSERT INTO t1 VALUES ('vdf%vdfd%ghdi%opu');
+DROP TABLE t1;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;

--- a/mysql-test/suite/innodb_fts/t/percona_mecab_ps9048-master.opt
+++ b/mysql-test/suite/innodb_fts/t/percona_mecab_ps9048-master.opt
@@ -1,0 +1,1 @@
+$MECAB_OPT

--- a/mysql-test/suite/innodb_fts/t/percona_mecab_ps9048.test
+++ b/mysql-test/suite/innodb_fts/t/percona_mecab_ps9048.test
@@ -1,0 +1,23 @@
+--source include/have_mecab.inc
+
+eval INSTALL PLUGIN mecab SONAME '$MECAB';
+
+let $test_charset=ujis;
+let $mecab_charset=`SELECT variable_value FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='mecab_charset'`;
+
+if ($mecab_charset == '') {
+  -- skip Test fail to load mecab parser.
+}
+
+if ($mecab_charset != $test_charset) {
+  UNINSTALL PLUGIN mecab;
+  -- skip Test mecab charset mismatch.
+}
+
+SHOW STATUS LIKE 'mecab_charset';
+
+--let $PARSER=WITH PARSER MECAB
+--let $CHARSET=DEFAULT CHARSET=ujis
+--source suite/innodb_fts/include/percona_ps9048.inc
+
+UNINSTALL PLUGIN mecab;

--- a/mysql-test/suite/innodb_fts/t/percona_ngram_ps9048.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ngram_ps9048.test
@@ -1,0 +1,5 @@
+--source include/have_ngram.inc
+
+--let $PARSER=WITH PARSER NGRAM
+--let $CHARSET=DEFAULT CHARSET=utf8mb4
+--source suite/innodb_fts/include/percona_ps9048.inc

--- a/plugin/fulltext/ngram_parser/plugin_ngram.cc
+++ b/plugin/fulltext/ngram_parser/plugin_ngram.cc
@@ -68,10 +68,10 @@ ngram_parse(
 		if (next + char_len > end || char_len == 0) {
 			break;
 		} else {
-			/* Skip SPACE and control characters */
+			/* Skip SPACE, %, and control characters */
 			int ctype = 0;
 			cs->cset->ctype(cs, &ctype, (uchar*) next, (uchar*) end);
-			if (char_len == 1 && (*next == ' ' || ctype & _MY_CTR)) {
+			if (char_len == 1 && (*next == ' ' || *next == '%' || ctype & _MY_CTR)) {
 				start = next + 1;
 				next = start;
 				n_chars = 0;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9048

There is an assertion failure during optimize table execution in case string in indexed column contains % and ngram parser is used. The % is treated in specal way and not expected in index tokens. Improved ngram parser not to include % into parsed tokens.