### PR TITLE
PS-9067 Fix MTR test failures when run with --mem

### DIFF
--- a/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush.result
+++ b/mysql-test/suite/innodb/r/percona_changed_page_bmp_flush.result
@@ -1,5 +1,6 @@
 call mtr.add_suppression("Failed to set O_DIRECT on file");
 call mtr.add_suppression("O_DIRECT is known to result in");
+CALL mtr.add_suppression("\\[ERROR\\] InnoDB: Failed to create check sector file*");
 DROP TABLE IF EXISTS t1;
 RESET CHANGED_PAGE_BITMAPS;
 CREATE TABLE t1 (a INT, b BLOB) ENGINE=InnoDB;

--- a/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush.test
+++ b/mysql-test/suite/innodb/t/percona_changed_page_bmp_flush.test
@@ -6,6 +6,7 @@
 
 call mtr.add_suppression("Failed to set O_DIRECT on file");
 call mtr.add_suppression("O_DIRECT is known to result in");
+CALL mtr.add_suppression("\\[ERROR\\] InnoDB: Failed to create check sector file*");
 
 let $MYSQLD_DATADIR= `select @@datadir`;
 let $BITMAP_FILE= $MYSQLD_DATADIR/ib_modified_log_1_0.xdb;

--- a/mysql-test/t/bug84640.test
+++ b/mysql-test/t/bug84640.test
@@ -46,7 +46,8 @@ SET DEBUG_SYNC="now SIGNAL finish_open";
 
 --connection con1
 
---replace_result $custom_data_directory custom_data_directory
+# $tmpdir is different when the test is run with --mem
+--replace_regex /\/.*\/bug84640/custom_data_directory/
 --error 29
 reap;
 

--- a/mysql-test/t/percona_statement_set.test
+++ b/mysql-test/t/percona_statement_set.test
@@ -838,19 +838,19 @@ DROP PROCEDURE p5;
 #   lp:1626519 memory allocation for PLUGIN_VAR_MEMALLOC           #
 ####################################################################
 
-let $MYSQL_TMP_DIR= `select @@tmpdir`;
---replace_result $MYSQL_TMP_DIR TMPDIR
+# tmpdir is different when the test is run with --mem
+--replace_regex /\/.*\/tmp\/mysqld\..*/TMPDIR/
 --eval SET STATEMENT innodb_tmpdir=@@global.tmpdir FOR SELECT @@innodb_tmpdir
 SET SESSION innodb_tmpdir = @@global.tmpdir;
---replace_result $MYSQL_TMP_DIR TMPDIR
+--replace_regex /\/.*\/tmp\/mysqld\..*/TMPDIR/
 SELECT @@innodb_tmpdir;
---replace_result $MYSQL_TMP_DIR TMPDIR
+--replace_regex /\/.*\/tmp\/mysqld\..*/TMPDIR/
 SET STATEMENT sql_mode='' FOR SELECT @@innodb_tmpdir;
---replace_result $MYSQL_TMP_DIR TMPDIR
+--replace_regex /\/.*\/tmp\/mysqld\..*/TMPDIR/
 SELECT @@innodb_tmpdir;
 --replace_result $MYSQL_TEST_DIR TESTDIR
 --eval SET STATEMENT innodb_tmpdir='$MYSQL_TEST_DIR' FOR SELECT @@innodb_tmpdir
---replace_result $MYSQL_TMP_DIR TMPDIR
+--replace_regex /\/.*\/tmp\/mysqld\..*/TMPDIR/
 SELECT @@innodb_tmpdir;
 
 --echo #


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9067

When --mem is used to run MTR tests, thy are run in memory using tmpfs. This causes inconsistencies when recodring test results, since the file paths are not deterministic. So, replace_regex is used to mask the variable paths percona_statement_set.test and bug84640.test.
For percona_changed_page_bmp_flush.test, the generated warning is suppressed.