### PR TITLE
PS-8731 Wrong path in the /etc/logrotate.d/mysql and /etc/my.cnf configuration files

### DIFF
--- a/build-ps/percona-server.spec
+++ b/build-ps/percona-server.spec
@@ -677,9 +677,9 @@ cd $MBD/release
 make DESTDIR=%{buildroot} install
 
 # Install logrotate and autostart
-#install -D -m 0644 packaging/rpm-common/mysql.logrotate %{buildroot}%{_sysconfdir}/logrotate.d/mysql
+install -D -m 0644 packaging/rpm-common/mysql.logrotate %{buildroot}%{_sysconfdir}/logrotate.d/mysql
 #investigate this logrotate
-install -D -m 0644 $MBD/release/support-files/mysql-log-rotate %{buildroot}%{_sysconfdir}/logrotate.d/mysql
+#install -D -m 0644 $MBD/release/support-files/mysql-log-rotate %{buildroot}%{_sysconfdir}/logrotate.d/mysql
 install -D -m 0644 $MBD/%{src_dir}/build-ps/rpm/mysqld.cnf %{buildroot}%{_sysconfdir}/my.cnf
 install -d %{buildroot}%{_sysconfdir}/my.cnf.d
 


### PR DESCRIPTION
Use the logrotate file from packaging/rpm-common directory similar to what upstream does - https://github.com/mysql/mysql-server/blob/8.0/packaging/rpm-oel/mysql.spec.in#L1091