### PR TITLE
PS-9096 Backport bug fixes from MySQL 8.0

### DIFF
--- a/include/my_md5.h
+++ b/include/my_md5.h
@@ -33,7 +33,7 @@
 extern "C" {
 #endif
 
-void compute_md5_hash(char *digest, const char *buf, int len);
+void compute_md5_hash(char *digest, const char *buf, size_t len);
 
 /*
   Convert an array of bytes to a hexadecimal representation.

--- a/mysys_ssl/my_md5.cc
+++ b/mysys_ssl/my_md5.cc
@@ -39,7 +39,7 @@
 #if defined(HAVE_OPENSSL)
 #include <openssl/md5.h>
 
-static void my_md5_hash(unsigned char* digest, unsigned const char *buf, int len)
+static void my_md5_hash(unsigned char* digest, unsigned const char *buf, size_t len)
 {
   MD5_CTX ctx;
   MD5_Init (&ctx);
@@ -58,7 +58,7 @@ static void my_md5_hash(unsigned char* digest, unsigned const char *buf, int len
 
     @return              void
 */
-void compute_md5_hash(char *digest, const char *buf, int len)
+void compute_md5_hash(char *digest, const char *buf, size_t len)
 {
 #if defined(HAVE_OPENSSL)
   my_md5_hash((unsigned char*)digest, (unsigned const char*)buf, len);

--- a/sql/json_dom.h
+++ b/sql/json_dom.h
@@ -34,6 +34,7 @@
 #include "sql_error.h"          // Sql_condition
 #include "prealloced_array.h"   // Prealloced_array
 
+#include <functional>
 #include <map>
 #include <string>
 

--- a/storage/innobase/sync/sync0debug.cc
+++ b/storage/innobase/sync/sync0debug.cc
@@ -43,11 +43,12 @@ Created 2012-08-21 Sunny Bains
 #include "ut0new.h"
 #include "srv0start.h"
 
+#include <algorithm>
+#include <functional>
+#include <iostream>
 #include <map>
 #include <vector>
 #include <string>
-#include <algorithm>
-#include <iostream>
 
 #ifdef UNIV_DEBUG
 

--- a/storage/myisam/sort.cc
+++ b/storage/myisam/sort.cc
@@ -28,6 +28,7 @@
 */
 
 #include <algorithm>
+#include <functional>
 
 #include "fulltext.h"
 #if defined(_WIN32)


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9096

- Fixes the type of the length parameter in MD5 encryption methods.
- Fixes a compilation failure in VS2022.