### PR TITLE
PS-9048 fix 8.0: Fixed problem with percent character in n-grams

### DIFF
--- a/mysql-test/suite/innodb_fts/include/percona_ft_special_chars.inc
+++ b/mysql-test/suite/innodb_fts/include/percona_ft_special_chars.inc
@@ -1,0 +1,331 @@
+--let $fts_parser_clause =
+if ($fts_parser != '')
+{
+  --let $fts_parser_clause = WITH PARSER $fts_parser
+}
+
+--echo *** saving global system variables
+SET @old_innodb_optimize_fulltext_only = @@global.innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+
+SET @old_innodb_ft_aux_table = @@global.innodb_ft_aux_table;
+
+--echo
+--echo *** creating a simple table with a full text index
+SET innodb_ft_enable_stopword = OFF;
+eval CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) $fts_parser_clause) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SET GLOBAL innodb_ft_aux_table = 'test/t1';
+
+--echo
+--echo ***************************************
+--echo *** Part I: original crash scenario ***
+--echo ***************************************
+
+--echo
+--echo *** inserting a record containing the '%' character
+SET @special_string = 'vdf%vdfd%ghdi%opu';
+--let $special_string = `SELECT @special_string`
+# for both default and mecab parser
+if ($fts_parser != ngram)
+{
+  # there are 4 words separated by the '%' character
+  --let $expected_number_of_records = 4
+}
+if ($fts_parser == ngram)
+{
+  --let $expected_number_of_records = `SELECT LENGTH(@special_string) - 1`
+}
+INSERT INTO t1 VALUES (@special_string);
+
+--let $assert_text = number of records in the index cache after inserting '$special_string' is expected to be $expected_number_of_records
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE] = $expected_number_of_records
+--source include/assert.inc
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+
+--let $assert_text = number of records in the index table after inserting '$special_string' is expected to be zero
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE] = 0
+--source include/assert.inc
+
+OPTIMIZE TABLE t1;
+
+--echo
+--echo *** updating the table with another record also containing the '%' character
+SET @special_string = 'sd%he%ff';
+--let $special_string = `SELECT @special_string`
+--let $old_expected_number_of_records = $expected_number_of_records
+# for both default and mecab parser
+if ($fts_parser != ngram)
+{
+  --let $expected_number_of_records = 3
+}
+if ($fts_parser == ngram)
+{
+  --let $expected_number_of_records = `SELECT LENGTH(@special_string) - 1`
+}
+UPDATE t1 SET c = @special_string;
+
+--let $assert_text = number of records in the index cache after updating to '$special_string' is expected to be $expected_number_of_records
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE] = $expected_number_of_records
+--source include/assert.inc
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+
+--let $assert_text = number of records in the index table after updating to '$special_string' is expected to be $old_expected_number_of_records
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE] = $old_expected_number_of_records
+--source include/assert.inc
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+
+OPTIMIZE TABLE t1;
+
+--let $assert_text = number of records in the index cache after updating to '$special_string' and optimizing is expected to be zero
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE] = 0
+--source include/assert.inc
+
+--let $assert_text = number of records in the index table after updating to '$special_string' and optimizing is expected to be $expected_number_of_records
+--let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE] = $expected_number_of_records
+--source include/assert.inc
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+
+--echo
+--echo *** deleting the record
+DELETE FROM t1;
+OPTIMIZE TABLE t1;
+
+--echo
+--echo **************************************************
+--echo *** Part II: indexing other special characters ***
+--echo **************************************************
+
+--echo
+--echo *** creating a list of all printable characters (ASCII 33..126)
+--echo *** (whitespace and control characters are excluded)
+
+delimiter |;
+CREATE FUNCTION generate_special_characters(range_from TINYINT UNSIGNED, range_to TINYINT UNSIGNED) RETURNS VARCHAR(256) DETERMINISTIC
+BEGIN
+  DECLARE i TINYINT UNSIGNED DEFAULT range_from;
+  DECLARE res VARCHAR(256) DEFAULT '';
+  WHILE i <= range_to DO
+    SET res = CONCAT(res, CHAR(i USING ascii));
+    SET i = i + 1;
+  END WHILE;
+  RETURN res;
+END|
+delimiter ;|
+
+SET @special_characters = generate_special_characters(33, 126);
+SELECT @special_characters;
+
+DROP FUNCTION generate_special_characters;
+
+--echo
+--echo *** for each character from the set we create a string containing this character
+--echo *** and perform SELECTs with various MATCH() ... AGAINST() clauses (both in
+--echo *** NATURAL LANGUAGE and BOOLEAN modes)
+
+--echo
+--echo *** please note that it is totally OK that some of these checks do not return
+--echo *** the result we call "expected" - a number of characters have special meaning
+--echo *** (especially in BOOLEAN mode) - our goal here is to test for crashes
+
+--echo
+--echo *** also we expect the number of mismatches to be much lower when
+--echo *** 'ft_query_extra_word_chars' is set to 'ON'
+--echo
+
+--disable_query_log
+--disable_result_log
+
+--let $number_of_characters = `SELECT LENGTH(@special_characters)`
+--let $charaacted_idx = 0
+while ($charaacted_idx < $number_of_characters)
+{
+  eval SET @special_char = SUBSTRING(@special_characters, $charaacted_idx + 1, 1);
+  --let $special_char = `SELECT @special_char`
+  SET @special_string = CONCAT('abc', @special_char, 'def');
+  # for both default and mecab parser
+  if ($fts_parser == '')
+  {
+    SET @alnum_plus_character = @special_char REGEXP '^[a-zA-Z0-9_]';
+    --let $expected_number_of_records = `SELECT IF(@alnum_plus_character, 1, 2)`
+  }
+  if ($fts_parser == ngram)
+  {
+    --let $expected_number_of_records = `SELECT LENGTH(@special_string) - 1`
+  }
+  if ($fts_parser == mecab)
+  {
+    SET @alnum_plus_character = @special_char REGEXP '^[a-zA-Z]';
+    --let $expected_number_of_records = `SELECT IF(@alnum_plus_character, 1, 2)`
+  }
+  INSERT INTO t1 VALUES(@special_string);
+
+  --let $assert_text = number of records for the special string containing '$special_char' is expected to be $expected_number_of_records
+  --let $assert_cond = [SELECT COUNT(*) FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE] = $expected_number_of_records
+  --source include/assert.inc
+
+  if ($fts_parser != ngram)
+  {
+    SET @expected_matches = JSON_ARRAY(
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'abc', 'result', IF(@alnum_plus_character, 0, 1)),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'def', 'result', IF(@alnum_plus_character, 0, 1)),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('abc', @special_char, 'def'), 'result', IF(@alnum_plus_character, 1, 0)),
+
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'a', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'b', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'c', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', @special_char, 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'd', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'e', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'f', 'result', 0),
+
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'ab', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'bc', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('c', @special_char), 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT(@special_char, 'd'), 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'de', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'ef', 'result', 0),
+
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'zbc', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'dez', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('bc', @special_char, 'de'), 'result', 0),
+
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('abc', @special_char), 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT(@special_char, 'def'), 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('zabc', @special_char, 'def'), 'result', 0),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'abc', 'result', IF(@alnum_plus_character, 0, 1)),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'def', 'result', IF(@alnum_plus_character, 0, 1)),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('abc', @special_char, 'def'), 'result', IF(@alnum_plus_character, 1, 0)),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'a', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'b', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'c', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', @special_char, 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'd', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'e', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'f', 'result', 0),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'ab', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'bc', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('c', @special_char), 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT(@special_char, 'd'), 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'de', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'ef', 'result', 0),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'zbc', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'dez', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('bc', @special_char, 'de'), 'result', 0),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('abc', @special_char), 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT(@special_char, 'def'), 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('zabc', @special_char, 'def'), 'result', 0)
+    );
+  }
+
+  if ($fts_parser == ngram)
+  {
+    SET @expected_matches = JSON_ARRAY(
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'a', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'b', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'c', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', @special_char, 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'd', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'e', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'f', 'result', 0),
+
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'ab', 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'bc', 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('c', @special_char), 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT(@special_char, 'd'), 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'de', 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'ef', 'result', 1),
+
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'ac', 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('z', @special_char), 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT(@special_char, 'z'), 'result', 0),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'df', 'result', 0),
+
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'abc', 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('bc', @special_char), 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT('c', @special_char, 'd'), 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', CONCAT(@special_char, 'de'), 'result', 1),
+      JSON_OBJECT('mode', 'NATURAL LANGUAGE', 'pattern', 'def', 'result', 1),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'a', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'b', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'c', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', @special_char, 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'd', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'e', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'f', 'result', 0),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'ab', 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'bc', 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('c', @special_char), 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT(@special_char, 'd'), 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'de', 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'ef', 'result', 1),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'ac', 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('z', @special_char), 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT(@special_char, 'z'), 'result', 0),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'df', 'result', 0),
+
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'abc', 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('bc', @special_char), 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT('c', @special_char, 'd'), 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', CONCAT(@special_char, 'de'), 'result', 1),
+      JSON_OBJECT('mode', 'BOOLEAN', 'pattern', 'def', 'result', 1)
+    );
+  }
+
+  --let $number_of_queries = `SELECT JSON_LENGTH(@expected_matches)`
+  --let $query_idx = 0
+  while ($query_idx < $number_of_queries)
+  {
+    eval SET @extraction_common_path = CONCAT(CHAR(36 USING utf8mb4), '[$query_idx]');
+    eval SET @extraction_mode_path = CONCAT(@extraction_common_path, '.mode');
+    eval SET @extraction_pattern_path = CONCAT(@extraction_common_path, '.pattern');
+    eval SET @extraction_result_path = CONCAT(@extraction_common_path, '.result');
+
+    --let $mode = `SELECT JSON_UNQUOTE(JSON_EXTRACT(@expected_matches, @extraction_mode_path))`
+    SET @pattern = JSON_UNQUOTE(JSON_EXTRACT(@expected_matches, @extraction_pattern_path));
+    --let $pattern = `SELECT @pattern`
+    --let $expected_result = `SELECT JSON_EXTRACT(@expected_matches, @extraction_result_path)`
+
+    --error 0, ER_PARSE_ERROR
+    eval SELECT COUNT(*) INTO @query_result FROM t1 WHERE MATCH(c) AGAINST (@pattern IN $mode MODE);
+    if ($mysql_errno)
+    {
+      --echo *** mode: "$mode", pattern: "$pattern", expected result: $expected_result, FTS syntax error
+    }
+    if (!$mysql_errno)
+    {
+      --let $result = `SELECT @query_result`
+      if ($result != $expected_result)
+      {
+        --echo *** mode: "$mode", pattern: "$pattern", expected result: $expected_result, result: $result
+      }
+    }
+
+
+    --inc $query_idx
+  }
+
+  DELETE FROM t1;
+  OPTIMIZE TABLE t1;
+
+  --inc $charaacted_idx
+}
+
+--enable_result_log
+--enable_query_log
+
+--echo
+--echo *** dropping the table
+DROP TABLE t1;
+
+--echo
+--echo *** restoring global system variables
+SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;

--- a/mysql-test/suite/innodb_fts/include/percona_install_mecab_plugin.inc
+++ b/mysql-test/suite/innodb_fts/include/percona_install_mecab_plugin.inc
@@ -1,0 +1,50 @@
+eval INSTALL PLUGIN mecab SONAME '$MECAB';
+
+--let $ipadic_charset = utf-8
+--let $mysql_charset = utf8
+--let $mecab_charset = `SELECT variable_value FROM performance_schema.global_status WHERE VARIABLE_NAME = 'mecab_charset'`
+
+if ($mecab_charset == '')
+{
+  # restart with package dictionary
+  --let $MYSQL_DATADIR = `SELECT @@datadir`
+  --let $MYSQL_BASEDIR = `SELECT @@basedir`
+
+  --let $mecabrc = $MYSQL_DATADIR/mecabrc
+  --let $dicdir = $MYSQL_BASEDIR/lib/mecab/dic/ipadic_$ipadic_charset
+
+  --exec echo "dicdir=$dicdir" > $mecabrc
+
+  --let $restart_parameters = "restart: --loose-mecab-rc-file=$mecabrc $MECAB_OPT --innodb-ft-min-token_size=2"
+  --let $do_not_echo_parameters = 1
+  --source include/restart_mysqld.inc
+
+  eval INSTALL PLUGIN mecab SONAME '$MECAB';
+
+  --let $mecab_charset = `SELECT variable_value FROM performance_schema.global_status WHERE VARIABLE_NAME = 'mecab_charset'`
+}
+
+if ($mecab_charset != $mysql_charset)
+{
+  --let $skip_message_idx = 0
+  if ($mecab_charset != '')
+  {
+    UNINSTALL PLUGIN mecab;
+    --let $skip_message_idx = 1
+  }
+  if ($mecabrc != '')
+  {
+    --remove_file $mecabrc
+    --let $mecabrc =
+  }
+  if ($skip_message_idx == 0)
+  {
+    --skip Test fail to load mecab parser, please set correct 'loose_mecab_rc_file'.
+  }
+  if ($skip_message_idx == 1)
+  {
+    --skip Test mecab charset mismatch
+  }
+}
+
+SHOW STATUS LIKE 'mecab_charset';

--- a/mysql-test/suite/innodb_fts/include/percona_uninstall_mecab_plugin.inc
+++ b/mysql-test/suite/innodb_fts/include/percona_uninstall_mecab_plugin.inc
@@ -1,0 +1,6 @@
+UNINSTALL PLUGIN mecab;
+if ($mecabrc != '')
+{
+  --remove_file $mecabrc
+  --let $mecabrc =
+}

--- a/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_default_ewc_off.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_default_ewc_off.result
@@ -1,0 +1,464 @@
+SET ft_query_extra_word_chars = OFF;
+*** saving global system variables
+SET @old_innodb_optimize_fulltext_only = @@global.innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+SET @old_innodb_ft_aux_table = @@global.innodb_ft_aux_table;
+
+*** creating a simple table with a full text index
+SET innodb_ft_enable_stopword = OFF;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SET GLOBAL innodb_ft_aux_table = 'test/t1';
+
+***************************************
+*** Part I: original crash scenario ***
+***************************************
+
+*** inserting a record containing the '%' character
+SET @special_string = 'vdf%vdfd%ghdi%opu';
+INSERT INTO t1 VALUES (@special_string);
+include/assert.inc [number of records in the index cache after inserting 'vdf%vdfd%ghdi%opu' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+include/assert.inc [number of records in the index table after inserting 'vdf%vdfd%ghdi%opu' is expected to be zero]
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+*** updating the table with another record also containing the '%' character
+SET @special_string = 'sd%he%ff';
+UPDATE t1 SET c = @special_string;
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ff
+he
+sd
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' and optimizing is expected to be zero]
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' and optimizing is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ff
+he
+sd
+
+*** deleting the record
+DELETE FROM t1;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+**************************************************
+*** Part II: indexing other special characters ***
+**************************************************
+
+*** creating a list of all printable characters (ASCII 33..126)
+*** (whitespace and control characters are excluded)
+CREATE FUNCTION generate_special_characters(range_from TINYINT UNSIGNED, range_to TINYINT UNSIGNED) RETURNS VARCHAR(256) DETERMINISTIC
+BEGIN
+DECLARE i TINYINT UNSIGNED DEFAULT range_from;
+DECLARE res VARCHAR(256) DEFAULT '';
+WHILE i <= range_to DO
+SET res = CONCAT(res, CHAR(i USING ascii));
+SET i = i + 1;
+END WHILE;
+RETURN res;
+END|
+SET @special_characters = generate_special_characters(33, 126);
+SELECT @special_characters;
+@special_characters
+!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+DROP FUNCTION generate_special_characters;
+
+*** for each character from the set we create a string containing this character
+*** and perform SELECTs with various MATCH() ... AGAINST() clauses (both in
+*** NATURAL LANGUAGE and BOOLEAN modes)
+
+*** please note that it is totally OK that some of these checks do not return
+*** the result we call "expected" - a number of characters have special meaning
+*** (especially in BOOLEAN mode) - our goal here is to test for crashes
+
+*** also we expect the number of mismatches to be much lower when
+*** 'ft_query_extra_word_chars' is set to 'ON'
+
+include/assert.inc [number of records for the special string containing '!' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc!def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc!", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "!def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc!", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc!def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '"' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc"", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ""def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ""def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc"def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '#' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc#def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc#", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "#def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc#", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc#def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '$' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc$def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc$", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "$def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc$", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc$def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '%' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc%", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc%def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '&' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc&def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc&", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "&def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc&", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc&def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ''' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc'def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc'", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "'def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc'", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc'def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '(' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc(def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc(", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "(def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc(def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc(def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "(", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c(", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "(d", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "bc(de", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc(", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "(def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "zabc(def", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing ')' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc)def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc)", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ")def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc)def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc)def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ")", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c)", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ")d", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "bc)de", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc)", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ")def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "zabc)def", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing '*' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc*def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "*", expected result: 0, FTS syntax error
+*** mode: "NATURAL LANGUAGE", pattern: "abc*", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "*def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "*", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc*", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc*def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '+' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc+def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc+", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "+def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "+", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c+", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc+", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc+def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ',' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc,def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc,", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ",def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc,def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc,def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc,", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ",def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc,def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '-' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc-def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc-", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "-def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc-def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "-", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c-", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc-", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing '.' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc.def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc.", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ".def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc.def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc.def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc.", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ".def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc.def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '/' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc/def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc/", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "/def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc/", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc/def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '0' is expected to be 1]
+include/assert.inc [number of records for the special string containing '1' is expected to be 1]
+include/assert.inc [number of records for the special string containing '2' is expected to be 1]
+include/assert.inc [number of records for the special string containing '3' is expected to be 1]
+include/assert.inc [number of records for the special string containing '4' is expected to be 1]
+include/assert.inc [number of records for the special string containing '5' is expected to be 1]
+include/assert.inc [number of records for the special string containing '6' is expected to be 1]
+include/assert.inc [number of records for the special string containing '7' is expected to be 1]
+include/assert.inc [number of records for the special string containing '8' is expected to be 1]
+include/assert.inc [number of records for the special string containing '9' is expected to be 1]
+include/assert.inc [number of records for the special string containing ':' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc:def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc:", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ":def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc:def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc:def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc:", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ":def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc:def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ';' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc;def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc;", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ";def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc;def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc;def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc;", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ";def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc;def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '<' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc<def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc<", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "<def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "<", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c<", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc<", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc<def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '=' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc=def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc=", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "=def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc=", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc=def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '>' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc>def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc>", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ">def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc>def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc>def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ">", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c>", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc>", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ">def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc>def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '?' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc?def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc?", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "?def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc?", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc?def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '@' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc@def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc@", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "@def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc@def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc@def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "@", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c@", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "@d", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "bc@de", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc@", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "@def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "zabc@def", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing 'A' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'B' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'C' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'D' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'E' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'F' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'G' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'H' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'I' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'J' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'K' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'L' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'M' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'N' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'O' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'P' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'R' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'S' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'T' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'U' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'V' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'W' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'X' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '[' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc[def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc[", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "[def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc[", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc[def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '\' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc\def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc\", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "\def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc\", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc\def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ']' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc]def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc]", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "]def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc]", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc]def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '^' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc^def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc^", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "^def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc^", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc^def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '_' is expected to be 1]
+include/assert.inc [number of records for the special string containing '`' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc`def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc`", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "`def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc`", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc`def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing 'a' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'b' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'c' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'd' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'e' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'f' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'g' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'h' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'i' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'j' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'k' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'l' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'm' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'n' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'o' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'p' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'r' is expected to be 1]
+include/assert.inc [number of records for the special string containing 's' is expected to be 1]
+include/assert.inc [number of records for the special string containing 't' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'u' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'v' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'w' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'x' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '{' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc{def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc{", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "{def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc{", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc{def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '|' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc|def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc|", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "|def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc|", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc|def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '}' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc}def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc}", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "}def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc}", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc}def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '~' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc~def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc~", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "~def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc~def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc~def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "~", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c~", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc~", expected result: 0, FTS syntax error
+
+*** dropping the table
+DROP TABLE t1;
+
+*** restoring global system variables
+SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;

--- a/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_default_ewc_on.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_default_ewc_on.result
@@ -1,0 +1,268 @@
+SET ft_query_extra_word_chars = ON;
+*** saving global system variables
+SET @old_innodb_optimize_fulltext_only = @@global.innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+SET @old_innodb_ft_aux_table = @@global.innodb_ft_aux_table;
+
+*** creating a simple table with a full text index
+SET innodb_ft_enable_stopword = OFF;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SET GLOBAL innodb_ft_aux_table = 'test/t1';
+
+***************************************
+*** Part I: original crash scenario ***
+***************************************
+
+*** inserting a record containing the '%' character
+SET @special_string = 'vdf%vdfd%ghdi%opu';
+INSERT INTO t1 VALUES (@special_string);
+include/assert.inc [number of records in the index cache after inserting 'vdf%vdfd%ghdi%opu' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+include/assert.inc [number of records in the index table after inserting 'vdf%vdfd%ghdi%opu' is expected to be zero]
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+*** updating the table with another record also containing the '%' character
+SET @special_string = 'sd%he%ff';
+UPDATE t1 SET c = @special_string;
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ff
+he
+sd
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' and optimizing is expected to be zero]
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' and optimizing is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ff
+he
+sd
+
+*** deleting the record
+DELETE FROM t1;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+**************************************************
+*** Part II: indexing other special characters ***
+**************************************************
+
+*** creating a list of all printable characters (ASCII 33..126)
+*** (whitespace and control characters are excluded)
+CREATE FUNCTION generate_special_characters(range_from TINYINT UNSIGNED, range_to TINYINT UNSIGNED) RETURNS VARCHAR(256) DETERMINISTIC
+BEGIN
+DECLARE i TINYINT UNSIGNED DEFAULT range_from;
+DECLARE res VARCHAR(256) DEFAULT '';
+WHILE i <= range_to DO
+SET res = CONCAT(res, CHAR(i USING ascii));
+SET i = i + 1;
+END WHILE;
+RETURN res;
+END|
+SET @special_characters = generate_special_characters(33, 126);
+SELECT @special_characters;
+@special_characters
+!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+DROP FUNCTION generate_special_characters;
+
+*** for each character from the set we create a string containing this character
+*** and perform SELECTs with various MATCH() ... AGAINST() clauses (both in
+*** NATURAL LANGUAGE and BOOLEAN modes)
+
+*** please note that it is totally OK that some of these checks do not return
+*** the result we call "expected" - a number of characters have special meaning
+*** (especially in BOOLEAN mode) - our goal here is to test for crashes
+
+*** also we expect the number of mismatches to be much lower when
+*** 'ft_query_extra_word_chars' is set to 'ON'
+
+include/assert.inc [number of records for the special string containing '!' is expected to be 2]
+include/assert.inc [number of records for the special string containing '"' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc"", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ""def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ""def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc"def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '#' is expected to be 2]
+include/assert.inc [number of records for the special string containing '$' is expected to be 2]
+include/assert.inc [number of records for the special string containing '%' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc%", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc%def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '&' is expected to be 2]
+include/assert.inc [number of records for the special string containing ''' is expected to be 2]
+include/assert.inc [number of records for the special string containing '(' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "abc(def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "(", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c(", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "(d", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "bc(de", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc(", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "(def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "zabc(def", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing ')' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "abc)def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ")", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c)", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ")d", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "bc)de", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc)", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ")def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "zabc)def", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing '*' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "*", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "*", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc*", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc*def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '+' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "abc+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "+", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c+", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc+", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc+def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ',' is expected to be 2]
+include/assert.inc [number of records for the special string containing '-' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "-", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c-", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc-", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing '.' is expected to be 2]
+include/assert.inc [number of records for the special string containing '/' is expected to be 2]
+include/assert.inc [number of records for the special string containing '0' is expected to be 1]
+include/assert.inc [number of records for the special string containing '1' is expected to be 1]
+include/assert.inc [number of records for the special string containing '2' is expected to be 1]
+include/assert.inc [number of records for the special string containing '3' is expected to be 1]
+include/assert.inc [number of records for the special string containing '4' is expected to be 1]
+include/assert.inc [number of records for the special string containing '5' is expected to be 1]
+include/assert.inc [number of records for the special string containing '6' is expected to be 1]
+include/assert.inc [number of records for the special string containing '7' is expected to be 1]
+include/assert.inc [number of records for the special string containing '8' is expected to be 1]
+include/assert.inc [number of records for the special string containing '9' is expected to be 1]
+include/assert.inc [number of records for the special string containing ':' is expected to be 2]
+include/assert.inc [number of records for the special string containing ';' is expected to be 2]
+include/assert.inc [number of records for the special string containing '<' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "abc<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "<", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c<", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc<", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc<def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '=' is expected to be 2]
+include/assert.inc [number of records for the special string containing '>' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "abc>def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ">", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c>", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc>", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: ">def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc>def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '?' is expected to be 2]
+include/assert.inc [number of records for the special string containing '@' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "abc@def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "@", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c@", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "@d", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "bc@de", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc@", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "@def", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "zabc@def", expected result: 0, FTS syntax error
+include/assert.inc [number of records for the special string containing 'A' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'B' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'C' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'D' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'E' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'F' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'G' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'H' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'I' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'J' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'K' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'L' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'M' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'N' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'O' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'P' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'R' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'S' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'T' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'U' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'V' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'W' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'X' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '[' is expected to be 2]
+include/assert.inc [number of records for the special string containing '\' is expected to be 2]
+include/assert.inc [number of records for the special string containing ']' is expected to be 2]
+include/assert.inc [number of records for the special string containing '^' is expected to be 2]
+include/assert.inc [number of records for the special string containing '_' is expected to be 1]
+include/assert.inc [number of records for the special string containing '`' is expected to be 2]
+include/assert.inc [number of records for the special string containing 'a' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'b' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'c' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'd' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'e' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'f' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'g' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'h' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'i' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'j' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'k' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'l' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'm' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'n' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'o' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'p' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'r' is expected to be 1]
+include/assert.inc [number of records for the special string containing 's' is expected to be 1]
+include/assert.inc [number of records for the special string containing 't' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'u' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'v' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'w' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'x' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '{' is expected to be 2]
+include/assert.inc [number of records for the special string containing '|' is expected to be 2]
+include/assert.inc [number of records for the special string containing '}' is expected to be 2]
+include/assert.inc [number of records for the special string containing '~' is expected to be 2]
+*** mode: "BOOLEAN", pattern: "abc~def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "~", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "c~", expected result: 0, FTS syntax error
+*** mode: "BOOLEAN", pattern: "abc~", expected result: 0, FTS syntax error
+
+*** dropping the table
+DROP TABLE t1;
+
+*** restoring global system variables
+SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;

--- a/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_mecab_ewc_off.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_mecab_ewc_off.result
@@ -1,0 +1,517 @@
+INSTALL PLUGIN mecab SONAME 'libpluginmecab.so';
+SHOW STATUS LIKE 'mecab_charset';
+Variable_name	Value
+mecab_charset	utf8
+SET ft_query_extra_word_chars = OFF;
+*** saving global system variables
+SET @old_innodb_optimize_fulltext_only = @@global.innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+SET @old_innodb_ft_aux_table = @@global.innodb_ft_aux_table;
+
+*** creating a simple table with a full text index
+SET innodb_ft_enable_stopword = OFF;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) WITH PARSER mecab) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SET GLOBAL innodb_ft_aux_table = 'test/t1';
+
+***************************************
+*** Part I: original crash scenario ***
+***************************************
+
+*** inserting a record containing the '%' character
+SET @special_string = 'vdf%vdfd%ghdi%opu';
+INSERT INTO t1 VALUES (@special_string);
+include/assert.inc [number of records in the index cache after inserting 'vdf%vdfd%ghdi%opu' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+include/assert.inc [number of records in the index table after inserting 'vdf%vdfd%ghdi%opu' is expected to be zero]
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+*** updating the table with another record also containing the '%' character
+SET @special_string = 'sd%he%ff';
+UPDATE t1 SET c = @special_string;
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ff
+he
+sd
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' and optimizing is expected to be zero]
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' and optimizing is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ff
+he
+sd
+
+*** deleting the record
+DELETE FROM t1;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+**************************************************
+*** Part II: indexing other special characters ***
+**************************************************
+
+*** creating a list of all printable characters (ASCII 33..126)
+*** (whitespace and control characters are excluded)
+CREATE FUNCTION generate_special_characters(range_from TINYINT UNSIGNED, range_to TINYINT UNSIGNED) RETURNS VARCHAR(256) DETERMINISTIC
+BEGIN
+DECLARE i TINYINT UNSIGNED DEFAULT range_from;
+DECLARE res VARCHAR(256) DEFAULT '';
+WHILE i <= range_to DO
+SET res = CONCAT(res, CHAR(i USING ascii));
+SET i = i + 1;
+END WHILE;
+RETURN res;
+END|
+SET @special_characters = generate_special_characters(33, 126);
+SELECT @special_characters;
+@special_characters
+!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+DROP FUNCTION generate_special_characters;
+
+*** for each character from the set we create a string containing this character
+*** and perform SELECTs with various MATCH() ... AGAINST() clauses (both in
+*** NATURAL LANGUAGE and BOOLEAN modes)
+
+*** please note that it is totally OK that some of these checks do not return
+*** the result we call "expected" - a number of characters have special meaning
+*** (especially in BOOLEAN mode) - our goal here is to test for crashes
+
+*** also we expect the number of mismatches to be much lower when
+*** 'ft_query_extra_word_chars' is set to 'ON'
+
+include/assert.inc [number of records for the special string containing '!' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc!def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc!", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "!def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc!", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc!def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '"' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc"", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ""def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ""def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc"def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '#' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc#def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc#", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "#def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc#", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc#def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '$' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc$def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc$", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "$def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc$", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc$def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '%' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc%", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc%def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '&' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc&def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc&", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "&def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc&", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc&def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ''' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc'def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc'", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "'def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc'", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc'def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '(' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc(def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc(", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "(def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc(def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ')' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc)def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc)", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ")def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc)def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '*' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc*def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc*", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "*def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc*", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc*def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '+' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc+def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc+", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "+def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc+", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc+def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ',' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc,def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc,", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ",def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc,def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc,def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc,", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ",def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc,def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '-' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc-def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc-", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "-def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc-def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc-def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc-", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc-def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '.' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc.def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc.", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ".def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc.def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc.def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc.", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ".def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc.def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '/' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc/def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc/", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "/def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc/", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc/def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '0' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc0def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc0", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "0def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc0def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc0def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc0", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "0def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '1' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc1def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc1", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "1def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc1def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc1def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc1", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "1def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '2' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc2def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc2", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "2def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc2def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc2def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc2", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "2def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '3' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc3def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc3", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "3def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc3def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc3def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc3", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "3def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '4' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc4def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc4", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "4def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc4def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc4def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc4", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "4def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '5' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc5def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc5", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "5def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc5def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc5def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc5", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "5def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '6' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc6def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc6", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "6def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc6def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc6def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc6", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "6def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '7' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc7def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc7", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "7def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc7def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc7def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc7", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "7def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '8' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc8def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc8", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "8def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc8def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc8def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc8", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "8def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '9' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc9def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc9", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "9def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc9def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc9def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc9", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "9def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ':' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc:def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc:", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ":def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc:def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc:def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc:", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ":def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc:def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ';' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc;def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc;", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ";def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc;def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc;def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc;", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ";def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc;def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '<' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc<def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc<", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "<def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc<", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc<def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '=' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc=def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc=", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "=def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc=", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc=def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '>' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc>def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc>", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ">def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc>def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc>def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc>", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ">def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc>def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '?' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc?def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc?", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "?def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc?", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc?def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '@' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc@def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc@", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "@def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc@def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc@def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc@", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "@def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc@def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing 'A' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'B' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'C' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'D' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'E' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'F' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'G' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'H' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'I' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'J' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'K' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'L' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'M' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'N' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'O' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'P' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'R' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'S' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'T' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'U' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'V' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'W' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'X' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '[' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc[def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc[", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "[def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc[", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc[def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '\' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc\def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc\", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "\def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc\", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc\def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ']' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc]def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc]", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "]def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc]", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc]def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '^' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc^def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc^", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "^def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc^", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc^def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '_' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc_def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc_", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "_def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc_def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc_def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc_", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "_def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '`' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc`def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc`", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "`def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc`", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc`def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing 'a' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'b' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'c' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'd' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'e' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'f' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'g' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'h' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'i' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'j' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'k' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'l' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'm' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'n' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'o' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'p' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'r' is expected to be 1]
+include/assert.inc [number of records for the special string containing 's' is expected to be 1]
+include/assert.inc [number of records for the special string containing 't' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'u' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'v' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'w' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'x' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '{' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc{def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc{", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "{def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc{", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc{def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '|' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc|def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc|", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "|def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc|", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc|def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '}' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc}def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc}", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "}def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc}", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc}def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '~' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc~def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc~", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "~def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc~def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc~def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc~", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc~def", expected result: 0, result: 1
+
+*** dropping the table
+DROP TABLE t1;
+
+*** restoring global system variables
+SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;
+UNINSTALL PLUGIN mecab;

--- a/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_mecab_ewc_on.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_mecab_ewc_on.result
@@ -1,0 +1,493 @@
+INSTALL PLUGIN mecab SONAME 'libpluginmecab.so';
+SHOW STATUS LIKE 'mecab_charset';
+Variable_name	Value
+mecab_charset	utf8
+SET ft_query_extra_word_chars = ON;
+*** saving global system variables
+SET @old_innodb_optimize_fulltext_only = @@global.innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+SET @old_innodb_ft_aux_table = @@global.innodb_ft_aux_table;
+
+*** creating a simple table with a full text index
+SET innodb_ft_enable_stopword = OFF;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) WITH PARSER mecab) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SET GLOBAL innodb_ft_aux_table = 'test/t1';
+
+***************************************
+*** Part I: original crash scenario ***
+***************************************
+
+*** inserting a record containing the '%' character
+SET @special_string = 'vdf%vdfd%ghdi%opu';
+INSERT INTO t1 VALUES (@special_string);
+include/assert.inc [number of records in the index cache after inserting 'vdf%vdfd%ghdi%opu' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+include/assert.inc [number of records in the index table after inserting 'vdf%vdfd%ghdi%opu' is expected to be zero]
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+*** updating the table with another record also containing the '%' character
+SET @special_string = 'sd%he%ff';
+UPDATE t1 SET c = @special_string;
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+ff
+he
+sd
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' is expected to be 4]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ghdi
+opu
+vdf
+vdfd
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' and optimizing is expected to be zero]
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' and optimizing is expected to be 3]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+ff
+he
+sd
+
+*** deleting the record
+DELETE FROM t1;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+**************************************************
+*** Part II: indexing other special characters ***
+**************************************************
+
+*** creating a list of all printable characters (ASCII 33..126)
+*** (whitespace and control characters are excluded)
+CREATE FUNCTION generate_special_characters(range_from TINYINT UNSIGNED, range_to TINYINT UNSIGNED) RETURNS VARCHAR(256) DETERMINISTIC
+BEGIN
+DECLARE i TINYINT UNSIGNED DEFAULT range_from;
+DECLARE res VARCHAR(256) DEFAULT '';
+WHILE i <= range_to DO
+SET res = CONCAT(res, CHAR(i USING ascii));
+SET i = i + 1;
+END WHILE;
+RETURN res;
+END|
+SET @special_characters = generate_special_characters(33, 126);
+SELECT @special_characters;
+@special_characters
+!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+DROP FUNCTION generate_special_characters;
+
+*** for each character from the set we create a string containing this character
+*** and perform SELECTs with various MATCH() ... AGAINST() clauses (both in
+*** NATURAL LANGUAGE and BOOLEAN modes)
+
+*** please note that it is totally OK that some of these checks do not return
+*** the result we call "expected" - a number of characters have special meaning
+*** (especially in BOOLEAN mode) - our goal here is to test for crashes
+
+*** also we expect the number of mismatches to be much lower when
+*** 'ft_query_extra_word_chars' is set to 'ON'
+
+include/assert.inc [number of records for the special string containing '!' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc!def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc!", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "!def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc!def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc!", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "!def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '"' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc"", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ""def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc"", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ""def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "zabc"def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '#' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc#def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc#", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "#def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc#def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc#", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "#def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '$' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc$def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc$", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "$def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc$def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc$", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "$def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '%' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc%", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "%def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc%", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "%def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '&' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc&def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc&", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "&def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc&def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc&", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "&def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ''' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc'def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc'", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "'def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc'def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc'", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "'def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '(' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc(def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc(", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "(def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc(def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc(def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc(", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ')' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc)def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc)", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ")def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc)def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc)def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc)", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '*' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc*def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc*", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "*def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc*def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc*", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "*def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '+' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc+def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc+", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "+def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc+def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc+", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "+def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ',' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc,def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc,", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ",def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc,def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc,def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc,", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ",def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '-' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc-def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc-", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "-def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc-def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc-def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc-", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '.' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc.def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc.", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ".def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc.def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc.def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc.", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ".def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '/' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc/def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc/", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "/def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc/def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc/", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "/def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '0' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc0def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc0", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "0def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc0def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc0def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc0", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "0def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '1' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc1def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc1", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "1def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc1def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc1def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc1", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "1def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '2' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc2def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc2", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "2def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc2def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc2def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc2", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "2def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '3' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc3def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc3", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "3def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc3def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc3def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc3", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "3def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '4' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc4def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc4", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "4def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc4def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc4def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc4", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "4def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '5' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc5def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc5", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "5def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc5def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc5def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc5", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "5def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '6' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc6def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc6", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "6def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc6def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc6def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc6", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "6def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '7' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc7def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc7", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "7def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc7def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc7def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc7", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "7def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '8' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc8def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc8", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "8def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc8def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc8def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc8", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "8def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '9' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc9def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc9", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "9def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc9def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc9def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc9", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "9def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ':' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc:def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc:", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ":def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc:def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc:def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc:", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ":def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ';' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc;def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc;", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ";def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc;def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc;def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc;", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ";def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '<' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc<def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc<", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "<def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc<def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc<", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "<def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '=' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc=def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc=", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "=def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc=def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc=", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "=def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '>' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc>def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc>", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: ">def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc>def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc>def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc>", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: ">def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '?' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc?def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc?", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "?def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc?def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc?", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "?def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '@' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc@def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc@", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "@def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc@def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc@def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc@", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "@def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing 'A' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'B' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'C' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'D' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'E' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'F' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'G' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'H' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'I' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'J' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'K' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'L' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'M' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'N' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'O' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'P' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'R' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'S' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'T' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'U' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'V' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'W' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'X' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'Z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '[' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc[def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc[", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "[def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc[def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc[", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "[def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '\' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc\def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc\", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "\def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc\def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc\", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "\def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing ']' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc]def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc]", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "]def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc]def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc]", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "]def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '^' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc^def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc^", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "^def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc^def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc^", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "^def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '_' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc_def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc_", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "_def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc_def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc_def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc_", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "_def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '`' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc`def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc`", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "`def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc`def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc`", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "`def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing 'a' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'b' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'c' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'd' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'e' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'f' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'g' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'h' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'i' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'j' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'k' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'l' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'm' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'n' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'o' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'p' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'q' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'r' is expected to be 1]
+include/assert.inc [number of records for the special string containing 's' is expected to be 1]
+include/assert.inc [number of records for the special string containing 't' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'u' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'v' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'w' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'x' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'y' is expected to be 1]
+include/assert.inc [number of records for the special string containing 'z' is expected to be 1]
+include/assert.inc [number of records for the special string containing '{' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc{def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc{", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "{def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc{def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc{", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "{def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '|' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc|def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc|", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "|def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc|def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc|", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "|def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '}' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc}def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc}", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "}def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc}def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc}", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "}def", expected result: 0, result: 1
+include/assert.inc [number of records for the special string containing '~' is expected to be 2]
+*** mode: "NATURAL LANGUAGE", pattern: "abc~def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "abc~", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "~def", expected result: 0, result: 1
+*** mode: "NATURAL LANGUAGE", pattern: "zabc~def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc~def", expected result: 0, result: 1
+*** mode: "BOOLEAN", pattern: "abc~", expected result: 0, result: 1
+
+*** dropping the table
+DROP TABLE t1;
+
+*** restoring global system variables
+SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;
+UNINSTALL PLUGIN mecab;

--- a/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_ngram_ewc_off.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_ngram_ewc_off.result
@@ -1,0 +1,329 @@
+SET ft_query_extra_word_chars = OFF;
+*** saving global system variables
+SET @old_innodb_optimize_fulltext_only = @@global.innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+SET @old_innodb_ft_aux_table = @@global.innodb_ft_aux_table;
+
+*** creating a simple table with a full text index
+SET innodb_ft_enable_stopword = OFF;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) WITH PARSER ngram) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SET GLOBAL innodb_ft_aux_table = 'test/t1';
+
+***************************************
+*** Part I: original crash scenario ***
+***************************************
+
+*** inserting a record containing the '%' character
+SET @special_string = 'vdf%vdfd%ghdi%opu';
+INSERT INTO t1 VALUES (@special_string);
+include/assert.inc [number of records in the index cache after inserting 'vdf%vdfd%ghdi%opu' is expected to be 16]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+%g
+%o
+%v
+d%
+df
+df
+di
+f%
+fd
+gh
+hd
+i%
+op
+pu
+vd
+vd
+include/assert.inc [number of records in the index table after inserting 'vdf%vdfd%ghdi%opu' is expected to be zero]
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+*** updating the table with another record also containing the '%' character
+SET @special_string = 'sd%he%ff';
+UPDATE t1 SET c = @special_string;
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' is expected to be 7]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+%f
+%h
+d%
+e%
+ff
+he
+sd
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' is expected to be 16]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+%g
+%o
+%v
+d%
+df
+df
+di
+f%
+fd
+gh
+hd
+i%
+op
+pu
+vd
+vd
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' and optimizing is expected to be zero]
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' and optimizing is expected to be 7]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+%f
+%h
+d%
+e%
+ff
+he
+sd
+
+*** deleting the record
+DELETE FROM t1;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+**************************************************
+*** Part II: indexing other special characters ***
+**************************************************
+
+*** creating a list of all printable characters (ASCII 33..126)
+*** (whitespace and control characters are excluded)
+CREATE FUNCTION generate_special_characters(range_from TINYINT UNSIGNED, range_to TINYINT UNSIGNED) RETURNS VARCHAR(256) DETERMINISTIC
+BEGIN
+DECLARE i TINYINT UNSIGNED DEFAULT range_from;
+DECLARE res VARCHAR(256) DEFAULT '';
+WHILE i <= range_to DO
+SET res = CONCAT(res, CHAR(i USING ascii));
+SET i = i + 1;
+END WHILE;
+RETURN res;
+END|
+SET @special_characters = generate_special_characters(33, 126);
+SELECT @special_characters;
+@special_characters
+!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+DROP FUNCTION generate_special_characters;
+
+*** for each character from the set we create a string containing this character
+*** and perform SELECTs with various MATCH() ... AGAINST() clauses (both in
+*** NATURAL LANGUAGE and BOOLEAN modes)
+
+*** please note that it is totally OK that some of these checks do not return
+*** the result we call "expected" - a number of characters have special meaning
+*** (especially in BOOLEAN mode) - our goal here is to test for crashes
+
+*** also we expect the number of mismatches to be much lower when
+*** 'ft_query_extra_word_chars' is set to 'ON'
+
+include/assert.inc [number of records for the special string containing '!' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c!", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "!d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c!d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '"' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c"", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ""d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c"d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '#' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c#", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "#d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c#d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '$' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c$", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "$d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c$d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '%' is expected to be 6]
+*** mode: "NATURAL LANGUAGE", pattern: "c%", expected result: 1, result: 0
+*** mode: "NATURAL LANGUAGE", pattern: "%d", expected result: 1, result: 0
+*** mode: "NATURAL LANGUAGE", pattern: "c%d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c%", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "%d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c%d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '&' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c&", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "&d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c&d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing ''' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c'", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "'d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c'd", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '(' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c(", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "(d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "bc(", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c(d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "(de", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing ')' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c)", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ")d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "bc)", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c)d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ")de", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '*' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "*d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '+' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c+", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "+d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c+d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing ',' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c,", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ",d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c,d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '-' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c-", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "-d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c-d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "-de", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '.' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c.", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ".d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c.d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '/' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c/", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "/d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c/d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '0' is expected to be 6]
+include/assert.inc [number of records for the special string containing '1' is expected to be 6]
+include/assert.inc [number of records for the special string containing '2' is expected to be 6]
+include/assert.inc [number of records for the special string containing '3' is expected to be 6]
+include/assert.inc [number of records for the special string containing '4' is expected to be 6]
+include/assert.inc [number of records for the special string containing '5' is expected to be 6]
+include/assert.inc [number of records for the special string containing '6' is expected to be 6]
+include/assert.inc [number of records for the special string containing '7' is expected to be 6]
+include/assert.inc [number of records for the special string containing '8' is expected to be 6]
+include/assert.inc [number of records for the special string containing '9' is expected to be 6]
+include/assert.inc [number of records for the special string containing ':' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c:", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ":d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c:d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing ';' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c;", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ";d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c;d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '<' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c<", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "<d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c<d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '=' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c=", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "=d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c=d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '>' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c>", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ">d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c>d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '?' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c?", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "?d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c?d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '@' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c@", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "@d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c@d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing 'A' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'B' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'C' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'D' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'E' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'F' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'G' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'H' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'I' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'J' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'K' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'L' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'M' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'N' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'O' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'P' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'Q' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'R' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'S' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'T' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'U' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'V' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'W' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'X' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'Y' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'Z' is expected to be 6]
+include/assert.inc [number of records for the special string containing '[' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c[", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "[d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c[d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '\' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c\", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "\d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c\d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing ']' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c]", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "]d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c]d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '^' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c^", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "^d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c^d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '_' is expected to be 6]
+include/assert.inc [number of records for the special string containing '`' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c`", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "`d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c`d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing 'a' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'b' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'c' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'd' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'e' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'f' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'g' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'h' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'i' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'j' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'k' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'l' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'm' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'n' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'o' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'p' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'q' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'r' is expected to be 6]
+include/assert.inc [number of records for the special string containing 's' is expected to be 6]
+include/assert.inc [number of records for the special string containing 't' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'u' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'v' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'w' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'x' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'y' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'z' is expected to be 6]
+include/assert.inc [number of records for the special string containing '{' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c{", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "{d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c{d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '|' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c|", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "|d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c|d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '}' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c}", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "}d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c}d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '~' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c~", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "~d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c~d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "~de", expected result: 1, result: 0
+
+*** dropping the table
+DROP TABLE t1;
+
+*** restoring global system variables
+SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;

--- a/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_ngram_ewc_on.result
+++ b/mysql-test/suite/innodb_fts/r/percona_ft_special_chars_ngram_ewc_on.result
@@ -1,0 +1,249 @@
+SET ft_query_extra_word_chars = ON;
+*** saving global system variables
+SET @old_innodb_optimize_fulltext_only = @@global.innodb_optimize_fulltext_only;
+SET GLOBAL innodb_optimize_fulltext_only = ON;
+SET @old_innodb_ft_aux_table = @@global.innodb_ft_aux_table;
+
+*** creating a simple table with a full text index
+SET innodb_ft_enable_stopword = OFF;
+CREATE TABLE t1 (c TINYTEXT, FULLTEXT KEY (c) WITH PARSER ngram) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+SET GLOBAL innodb_ft_aux_table = 'test/t1';
+
+***************************************
+*** Part I: original crash scenario ***
+***************************************
+
+*** inserting a record containing the '%' character
+SET @special_string = 'vdf%vdfd%ghdi%opu';
+INSERT INTO t1 VALUES (@special_string);
+include/assert.inc [number of records in the index cache after inserting 'vdf%vdfd%ghdi%opu' is expected to be 16]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+%g
+%o
+%v
+d%
+df
+df
+di
+f%
+fd
+gh
+hd
+i%
+op
+pu
+vd
+vd
+include/assert.inc [number of records in the index table after inserting 'vdf%vdfd%ghdi%opu' is expected to be zero]
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+*** updating the table with another record also containing the '%' character
+SET @special_string = 'sd%he%ff';
+UPDATE t1 SET c = @special_string;
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' is expected to be 7]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_CACHE ORDER BY WORD;
+WORD
+%f
+%h
+d%
+e%
+ff
+he
+sd
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' is expected to be 16]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+%g
+%o
+%v
+d%
+df
+df
+di
+f%
+fd
+gh
+hd
+i%
+op
+pu
+vd
+vd
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+include/assert.inc [number of records in the index cache after updating to 'sd%he%ff' and optimizing is expected to be zero]
+include/assert.inc [number of records in the index table after updating to 'sd%he%ff' and optimizing is expected to be 7]
+SELECT WORD FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE ORDER BY WORD;
+WORD
+%f
+%h
+d%
+e%
+ff
+he
+sd
+
+*** deleting the record
+DELETE FROM t1;
+OPTIMIZE TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	optimize	status	OK
+
+**************************************************
+*** Part II: indexing other special characters ***
+**************************************************
+
+*** creating a list of all printable characters (ASCII 33..126)
+*** (whitespace and control characters are excluded)
+CREATE FUNCTION generate_special_characters(range_from TINYINT UNSIGNED, range_to TINYINT UNSIGNED) RETURNS VARCHAR(256) DETERMINISTIC
+BEGIN
+DECLARE i TINYINT UNSIGNED DEFAULT range_from;
+DECLARE res VARCHAR(256) DEFAULT '';
+WHILE i <= range_to DO
+SET res = CONCAT(res, CHAR(i USING ascii));
+SET i = i + 1;
+END WHILE;
+RETURN res;
+END|
+SET @special_characters = generate_special_characters(33, 126);
+SELECT @special_characters;
+@special_characters
+!"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
+DROP FUNCTION generate_special_characters;
+
+*** for each character from the set we create a string containing this character
+*** and perform SELECTs with various MATCH() ... AGAINST() clauses (both in
+*** NATURAL LANGUAGE and BOOLEAN modes)
+
+*** please note that it is totally OK that some of these checks do not return
+*** the result we call "expected" - a number of characters have special meaning
+*** (especially in BOOLEAN mode) - our goal here is to test for crashes
+
+*** also we expect the number of mismatches to be much lower when
+*** 'ft_query_extra_word_chars' is set to 'ON'
+
+include/assert.inc [number of records for the special string containing '!' is expected to be 6]
+include/assert.inc [number of records for the special string containing '"' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "c"", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ""d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c"d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '#' is expected to be 6]
+include/assert.inc [number of records for the special string containing '$' is expected to be 6]
+include/assert.inc [number of records for the special string containing '%' is expected to be 6]
+*** mode: "NATURAL LANGUAGE", pattern: "c%", expected result: 1, result: 0
+*** mode: "NATURAL LANGUAGE", pattern: "%d", expected result: 1, result: 0
+*** mode: "NATURAL LANGUAGE", pattern: "c%d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c%", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "%d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "c%d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '&' is expected to be 6]
+include/assert.inc [number of records for the special string containing ''' is expected to be 6]
+include/assert.inc [number of records for the special string containing '(' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "(d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "(de", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing ')' is expected to be 6]
+*** mode: "BOOLEAN", pattern: ")d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: ")de", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '*' is expected to be 6]
+include/assert.inc [number of records for the special string containing '+' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "+d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing ',' is expected to be 6]
+include/assert.inc [number of records for the special string containing '-' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "-d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "-de", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '.' is expected to be 6]
+include/assert.inc [number of records for the special string containing '/' is expected to be 6]
+include/assert.inc [number of records for the special string containing '0' is expected to be 6]
+include/assert.inc [number of records for the special string containing '1' is expected to be 6]
+include/assert.inc [number of records for the special string containing '2' is expected to be 6]
+include/assert.inc [number of records for the special string containing '3' is expected to be 6]
+include/assert.inc [number of records for the special string containing '4' is expected to be 6]
+include/assert.inc [number of records for the special string containing '5' is expected to be 6]
+include/assert.inc [number of records for the special string containing '6' is expected to be 6]
+include/assert.inc [number of records for the special string containing '7' is expected to be 6]
+include/assert.inc [number of records for the special string containing '8' is expected to be 6]
+include/assert.inc [number of records for the special string containing '9' is expected to be 6]
+include/assert.inc [number of records for the special string containing ':' is expected to be 6]
+include/assert.inc [number of records for the special string containing ';' is expected to be 6]
+include/assert.inc [number of records for the special string containing '<' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "<d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '=' is expected to be 6]
+include/assert.inc [number of records for the special string containing '>' is expected to be 6]
+*** mode: "BOOLEAN", pattern: ">d", expected result: 1, result: 0
+include/assert.inc [number of records for the special string containing '?' is expected to be 6]
+include/assert.inc [number of records for the special string containing '@' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'A' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'B' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'C' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'D' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'E' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'F' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'G' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'H' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'I' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'J' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'K' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'L' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'M' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'N' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'O' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'P' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'Q' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'R' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'S' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'T' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'U' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'V' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'W' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'X' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'Y' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'Z' is expected to be 6]
+include/assert.inc [number of records for the special string containing '[' is expected to be 6]
+include/assert.inc [number of records for the special string containing '\' is expected to be 6]
+include/assert.inc [number of records for the special string containing ']' is expected to be 6]
+include/assert.inc [number of records for the special string containing '^' is expected to be 6]
+include/assert.inc [number of records for the special string containing '_' is expected to be 6]
+include/assert.inc [number of records for the special string containing '`' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'a' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'b' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'c' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'd' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'e' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'f' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'g' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'h' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'i' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'j' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'k' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'l' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'm' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'n' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'o' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'p' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'q' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'r' is expected to be 6]
+include/assert.inc [number of records for the special string containing 's' is expected to be 6]
+include/assert.inc [number of records for the special string containing 't' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'u' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'v' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'w' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'x' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'y' is expected to be 6]
+include/assert.inc [number of records for the special string containing 'z' is expected to be 6]
+include/assert.inc [number of records for the special string containing '{' is expected to be 6]
+include/assert.inc [number of records for the special string containing '|' is expected to be 6]
+include/assert.inc [number of records for the special string containing '}' is expected to be 6]
+include/assert.inc [number of records for the special string containing '~' is expected to be 6]
+*** mode: "BOOLEAN", pattern: "~d", expected result: 1, result: 0
+*** mode: "BOOLEAN", pattern: "~de", expected result: 1, result: 0
+
+*** dropping the table
+DROP TABLE t1;
+
+*** restoring global system variables
+SET GLOBAL innodb_ft_aux_table = @old_innodb_ft_aux_table;
+SET GLOBAL innodb_optimize_fulltext_only = @old_innodb_optimize_fulltext_only;

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_off-master.opt
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_off-master.opt
@@ -1,0 +1,1 @@
+--innodb-ft-min-token-size=2

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_off.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_off.test
@@ -1,0 +1,8 @@
+#
+# PS-9048: Debug assertion with OPTIMIZE table and fulltext indexes in InnoDB
+# https://perconadev.atlassian.net/browse/PS-9048
+#
+SET ft_query_extra_word_chars = OFF;
+
+--let $fts_parser =
+--source suite/innodb_fts/include/percona_ft_special_chars.inc

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_on-master.opt
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_on-master.opt
@@ -1,0 +1,1 @@
+--innodb-ft-min-token-size=2

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_on.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_default_ewc_on.test
@@ -1,0 +1,8 @@
+#
+# PS-9048: Debug assertion with OPTIMIZE table and fulltext indexes in InnoDB
+# https://perconadev.atlassian.net/browse/PS-9048
+#
+SET ft_query_extra_word_chars = ON;
+
+--let $fts_parser =
+--source suite/innodb_fts/include/percona_ft_special_chars.inc

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_off-master.opt
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_off-master.opt
@@ -1,0 +1,2 @@
+$MECAB_OPT
+--innodb-ft-min-token-size=2

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_off.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_off.test
@@ -1,0 +1,14 @@
+#
+# PS-9048: Debug assertion with OPTIMIZE table and fulltext indexes in InnoDB
+# https://perconadev.atlassian.net/browse/PS-9048
+#
+--source include/have_mecab.inc
+
+--source suite/innodb_fts/include/percona_install_mecab_plugin.inc
+
+SET ft_query_extra_word_chars = OFF;
+
+--let $fts_parser = mecab
+--source suite/innodb_fts/include/percona_ft_special_chars.inc
+
+--source suite/innodb_fts/include/percona_uninstall_mecab_plugin.inc

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_on-master.opt
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_on-master.opt
@@ -1,0 +1,2 @@
+$MECAB_OPT
+--innodb-ft-min-token-size=2

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_on.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_mecab_ewc_on.test
@@ -1,0 +1,14 @@
+#
+# PS-9048: Debug assertion with OPTIMIZE table and fulltext indexes in InnoDB
+# https://perconadev.atlassian.net/browse/PS-9048
+#
+--source include/have_mecab.inc
+
+--source suite/innodb_fts/include/percona_install_mecab_plugin.inc
+
+SET ft_query_extra_word_chars = ON;
+
+--let $fts_parser = mecab
+--source suite/innodb_fts/include/percona_ft_special_chars.inc
+
+--source suite/innodb_fts/include/percona_uninstall_mecab_plugin.inc

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_ngram_ewc_off.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_ngram_ewc_off.test
@@ -1,0 +1,10 @@
+#
+# PS-9048: Debug assertion with OPTIMIZE table and fulltext indexes in InnoDB
+# https://perconadev.atlassian.net/browse/PS-9048
+#
+--source include/have_ngram.inc
+
+SET ft_query_extra_word_chars = OFF;
+
+--let $fts_parser = ngram
+--source suite/innodb_fts/include/percona_ft_special_chars.inc

--- a/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_ngram_ewc_on.test
+++ b/mysql-test/suite/innodb_fts/t/percona_ft_special_chars_ngram_ewc_on.test
@@ -1,0 +1,10 @@
+#
+# PS-9048: Debug assertion with OPTIMIZE table and fulltext indexes in InnoDB
+# https://perconadev.atlassian.net/browse/PS-9048
+#
+--source include/have_ngram.inc
+
+SET ft_query_extra_word_chars = ON;
+
+--let $fts_parser = ngram
+--source suite/innodb_fts/include/percona_ft_special_chars.inc

--- a/mysql-test/suite/innodb_fts/t/percona_mecab_null_character.test
+++ b/mysql-test/suite/innodb_fts/t/percona_mecab_null_character.test
@@ -1,44 +1,8 @@
 --source include/have_mecab.inc
 
-eval INSTALL PLUGIN mecab SONAME '$MECAB';
-
-let $ipadic_charset=utf-8;
-let $mysql_charset=utf8;
-let $mecab_charset=`SELECT variable_value FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='mecab_charset'`;
-
-if ($mecab_charset == '') {
-  # Restart with package dictionary.
-  let $MYSQL_DATADIR=`select @@datadir`;
-  let $MYSQL_BASEDIR=`select @@basedir`;
-
-  let $mecabrc = $MYSQL_DATADIR/mecabrc;
-  let $dicdir  = $MYSQL_BASEDIR/lib/mecab/dic/ipadic_$ipadic_charset;
-
-  -- exec echo "dicdir=$dicdir" > $mecabrc
-
-  -- source include/shutdown_mysqld.inc
-  -- exec echo "restart: --loose_mecab_rc_file=$mecabrc $MECAB_OPT --innodb_ft_min_token_size=2" >$MYSQLTEST_VARDIR/tmp/mysqld.1.expect
-  -- enable_reconnect
-  -- source include/wait_until_connected_again.inc
-  -- disable_reconnect
-
-  eval INSTALL PLUGIN mecab SONAME '$MECAB';
-
-  let $mecab_charset=`SELECT variable_value FROM INFORMATION_SCHEMA.GLOBAL_STATUS WHERE VARIABLE_NAME='mecab_charset'`;
-}
-
-if ($mecab_charset == '') {
-  -- skip Test fail to load mecab parser, please set correct 'loose_mecab_rc_file'.
-}
-
-if ($mecab_charset != $mysql_charset) {
-  UNINSTALL PLUGIN mecab;
-  -- skip Test mecab charset mismatch.
-}
-
-SHOW STATUS LIKE 'mecab_charset';
+--source suite/innodb_fts/include/percona_install_mecab_plugin.inc
 
 --let $PARSER=WITH PARSER MECAB
 --source suite/innodb_fts/include/percona_null_character.inc
 
-UNINSTALL PLUGIN mecab;
+--source suite/innodb_fts/include/percona_uninstall_mecab_plugin.inc

--- a/storage/innobase/fts/fts0opt.cc
+++ b/storage/innobase/fts/fts0opt.cc
@@ -490,7 +490,8 @@ fts_index_fetch_nodes(
 	fts_table_t*	fts_table,	/*!< in: table of the FTS INDEX */
 	const fts_string_t*
 			word,		/*!< in: the word to fetch */
-	fts_fetch_t*	fetch)		/*!< in: fetch callback.*/
+	fts_fetch_t*	fetch,		/*!< in: fetch callback.*/
+	bool		exact_match)	/*!< in: exact match.*/
 {
 	pars_info_t*	info;
 	dberr_t		error;
@@ -525,23 +526,26 @@ fts_index_fetch_nodes(
 		*graph = fts_parse_sql(
 			fts_table,
 			info,
-			"DECLARE FUNCTION my_func;\n"
-			"DECLARE CURSOR c IS"
-			" SELECT word, doc_count, first_doc_id, last_doc_id,"
-			" ilist\n"
-			" FROM $table_name\n"
-			" WHERE word LIKE :word\n"
-			" ORDER BY first_doc_id;\n"
-			"BEGIN\n"
-			"\n"
-			"OPEN c;\n"
-			"WHILE 1 = 1 LOOP\n"
-			"  FETCH c INTO my_func();\n"
-			"  IF c % NOTFOUND THEN\n"
-			"    EXIT;\n"
-			"  END IF;\n"
-			"END LOOP;\n"
-			"CLOSE c;");
+			mem_heap_printf(
+				info->heap,
+				"DECLARE FUNCTION my_func;\n"
+				"DECLARE CURSOR c IS"
+				" SELECT word, doc_count, first_doc_id,"
+				" last_doc_id, ilist\n"
+				" FROM $table_name\n"
+				" WHERE word %s :word\n"
+				" ORDER BY first_doc_id;\n"
+				"BEGIN\n"
+				"\n"
+				"OPEN c;\n"
+				"WHILE 1 = 1 LOOP\n"
+				"  FETCH c INTO my_func();\n"
+				"  IF c %% NOTFOUND THEN\n"
+				"    EXIT;\n"
+				"  END IF;\n"
+				"END LOOP;\n"
+				"CLOSE c;",
+				(exact_match ? "=" : "LIKE")));
 	}
 
 	for (;;) {
@@ -1822,7 +1826,7 @@ fts_optimize_words(
 		fetch.total_memory = 0;
 		error = fts_index_fetch_nodes(
 			trx, &graph, &optim->fts_index_table, word,
-			&fetch);
+			&fetch, true);
 		ut_ad(fetch.total_memory < fts_result_cache_limit);
 
 		if (error == DB_SUCCESS) {

--- a/storage/innobase/fts/fts0que.cc
+++ b/storage/innobase/fts/fts0que.cc
@@ -1209,7 +1209,8 @@ fts_query_difference(
 		fetch.read_record = fts_query_index_fetch_nodes;
 
 		error = fts_index_fetch_nodes(
-			trx, &graph, &query->fts_index_table, token, &fetch);
+			trx, &graph, &query->fts_index_table, token, &fetch,
+			 false);
 
 		/* DB_FTS_EXCEED_RESULT_CACHE_LIMIT passed by 'query->error' */
 		ut_ad(!(query->error != DB_SUCCESS && error != DB_SUCCESS));
@@ -1334,7 +1335,8 @@ fts_query_intersect(
 		fetch.read_record = fts_query_index_fetch_nodes;
 
 		error = fts_index_fetch_nodes(
-			trx, &graph, &query->fts_index_table, token, &fetch);
+			trx, &graph, &query->fts_index_table, token, &fetch,
+			false);
 
 		/* DB_FTS_EXCEED_RESULT_CACHE_LIMIT passed by 'query->error' */
 		ut_ad(!(query->error != DB_SUCCESS && error != DB_SUCCESS));
@@ -1456,7 +1458,7 @@ fts_query_union(
 
 	/* Read the nodes from disk. */
 	error = fts_index_fetch_nodes(
-		trx, &graph, &query->fts_index_table, token, &fetch);
+		trx, &graph, &query->fts_index_table, token, &fetch, false);
 
 	/* DB_FTS_EXCEED_RESULT_CACHE_LIMIT passed by 'query->error' */
 	ut_ad(!(query->error != DB_SUCCESS && error != DB_SUCCESS));
@@ -2850,7 +2852,7 @@ fts_query_phrase_search(
 
 			error = fts_index_fetch_nodes(
 				trx, &graph, &query->fts_index_table,
-				token, &fetch);
+				token, &fetch, false);
 
 			/* DB_FTS_EXCEED_RESULT_CACHE_LIMIT passed by 'query->error' */
 			ut_ad(!(query->error != DB_SUCCESS && error != DB_SUCCESS));

--- a/storage/innobase/include/fts0priv.h
+++ b/storage/innobase/include/fts0priv.h
@@ -310,7 +310,8 @@ fts_index_fetch_nodes(
 	fts_table_t*	fts_table,	/*!< in: FTS aux table */
 	const fts_string_t*
 			word,		/*!< in: the word to fetch */
-	fts_fetch_t*	fetch);		/*!< in: fetch callback.*/
+	fts_fetch_t*	fetch,		/*!< in: fetch callback.*/
+	bool		exact_match);	/*!< in: exact match.*/
 
 /******************************************************************//**
 Create a fts_optimizer_word_t instance.


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9048

Fixed problem with 'fts_index_fetch_nodes()' function not being able to properly handle situations when 'word' parameter contained special characters used by 'LIKE' clauses ('%' and '_'). Introduced additional boolean parameter 'exact_match' that instructs this function to use either 'WHERE word = :word' or 'WHERE word LIKE :word' clauses when selecting records from internal FTS tables. We call 'fts_index_fetch_nodes()' with 'exact_match' set to 'true' only from 'fts_optimize_words()' (when we perform 'OPTIMIZE TABLE' under 'innodb_optimize_fulltext_only' enabled). In every other place
* fts_query_difference()
* fts_query_intersect()
* fts_query_union()
* fts_query_phrase_search() where we indeed need pattern matching we call this function with 'exact_match' set to 'false' (instructing the function to use the 'LIKE' clause).

Added two new MTR test cases:
* 'innodb_fts.percona_ft_ngram_special_chars_ewc_on'
* 'innodb_fts.percona_ft_ngram_special_chars_ewc_off' which reproduce original crash scenario under both 'ft_query_extra_word_chars' set to 'ON' and 'OFF'. These tests cases also check ngram parsing / querying strings containing various special characters. Please note that they have "result mismatch" status strings recorded in the '.result' files for certain combinations of special characters and this is expected behavior.