### PR TITLE
PS-9069 Merge MySQL 8.0.36 - Fix rocksdb.add_index_inplace_sstfilewriter

### DIFF
--- a/mysql-test/suite/rocksdb/t/add_index_inplace_sstfilewriter.test
+++ b/mysql-test/suite/rocksdb/t/add_index_inplace_sstfilewriter.test
@@ -49,6 +49,8 @@ eval LOAD DATA INFILE '$file' INTO TABLE t1;
 --enable_query_log
 set rocksdb_bulk_load=0;
 
+--remove_file $file
+
 # Make sure all the data is there.
 select count(pk) from t1;
 select count(a) from t1;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9069

The test add_index_inplace_sstfilewriter fails with the following error when run with --repeat=N --parallel=M where N > M even though the primary key columns are indeed sorted.

CURRENT_TEST: rocksdb.add_index_inplace_sstfilewriter
mysqltest: At line 48: Query 'LOAD DATA INFILE '$file' INTO TABLE t1' failed.
ERROR 8000 (HY000): Rows must be inserted in primary key order during bulk load operation

This happens because once the test_loadfile.txt file is generated, it is not cleared/deleted. So, the subsequent runs of the testcase use the same existing file to fill in the data and 1500000 rows are duplicated and gets appended to the contents of the file. So, when the testcase is executed for the subsequent runs, the rows of the duplicated data will cause the contents of the file to NOT be sorted.

The issue is fixed by deleting the test_loadfile.txt file once the data is loaded into the database tables.