### PR TITLE
PS-9071: Merge MySQL 8.3.0 (fix test_router_stacktrace tests)

### DIFF
--- a/mysys/stacktrace.cc
+++ b/mysys/stacktrace.cc
@@ -238,7 +238,7 @@ void my_print_stacktrace(const uchar *stack_bottom, ulong thread_stack) {
     my_safe_printf_stderr("\n");
   };
   cookie_t cookie{.index = 0};
-  stacktrace::full(1, print_callback, error_callback, &cookie);
+  stacktrace::full(0, print_callback, error_callback, &cookie);
 }
 #elif defined(HAVE_BACKTRACE)
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9071

Most of test_router_stacktrace tests expect to see my_print_stacktrace() method in stacktrace to find out if stacktrace was provided. Recent upstream changes in mysys/stacktrace.cc removed my_print_stacktrace() from the stacktrace.

Updated stacktrace::full() invocation in my_print_stacktrace() not to skip itself while printing stacktrace.