### PR TITLE
PS-9071 merge: Merge MySQL 8.3.0 (c++20 macos boost::algorithm fix)

### DIFF
--- a/components/keyrings/keyring_kms/backend/kms.cc
+++ b/components/keyrings/keyring_kms/backend/kms.cc
@@ -53,7 +53,9 @@
 #endif
 
 #include <boost/algorithm/hex.hpp>
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
+#include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 const constexpr auto AWS_DATE_HEADER = "X-Amz-Date";
 const constexpr auto AWS_CONTENT_SHA256_HEADER = "X-Amz-Content-SHA256";


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9071

Fixed problem with including 'boost/algotithm/string.hpp' file that is an umbrella for all Boost string algorithms. As we still are using version 1.77.0 of the Boost libraries, this file probably has never been tested in c++20 mode and has compatibility issues on macos. Fixed by including required headers more granually.