### PR TITLE
PS-9117: Make innodb_interpreter_output sysvar readonly

### DIFF
--- a/mysql-test/suite/sys_vars/r/innodb_interpreter_basic.result
+++ b/mysql-test/suite/sys_vars/r/innodb_interpreter_basic.result
@@ -122,3 +122,9 @@ SET GLOBAL innodb_interpreter = null;
 ERROR 42000: Variable 'innodb_interpreter' can't be set to the value of 'NULL'
 SET GLOBAL innodb_interpreter = 0;
 ERROR 42000: Incorrect argument type to variable 'innodb_interpreter'
+#
+# PS-9117: Check server doesn't crash upon an attempt to set innodb_interpreter_output
+#
+SET SESSION innodb_interpreter = 'init';
+SET SESSION innodb_interpreter_output = '';
+ERROR HY000: Variable 'innodb_interpreter_output' is a read only variable

--- a/mysql-test/suite/sys_vars/t/innodb_interpreter_basic.test
+++ b/mysql-test/suite/sys_vars/t/innodb_interpreter_basic.test
@@ -98,3 +98,10 @@ SET SESSION innodb_interpreter = 0;
 SET GLOBAL innodb_interpreter = null;
 --error ER_WRONG_TYPE_FOR_VAR
 SET GLOBAL innodb_interpreter = 0;
+
+--echo #
+--echo # PS-9117: Check server doesn't crash upon an attempt to set innodb_interpreter_output
+--echo #
+SET SESSION innodb_interpreter = 'init';
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET SESSION innodb_interpreter_output = '';

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -24195,7 +24195,7 @@ static MYSQL_THDVAR_STR(interpreter, PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_NOPERSIST,
 output is stored in this innodb_interpreter_output variable. */
 static MYSQL_THDVAR_STR(interpreter_output,
                         PLUGIN_VAR_OPCMDARG | PLUGIN_VAR_MEMALLOC |
-                            PLUGIN_VAR_NOPERSIST,
+                            PLUGIN_VAR_NOPERSIST | PLUGIN_VAR_READONLY,
                         "Output from InnoDB testing module (ut0test).", nullptr,
                         nullptr, "The Default Value");
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9117

The innodb_interpreter_output sysvar used to show result of the latest cmd execution by innodb_interpreter and it points to internal interpreter state. Attempt to set this sysvar to any vaalue leads to server crash.
Make innodb_interpreter_output sysvar readonly. This prevents attempts of sysvar memory handling code to brake internal state of innodb interpreter.