### PR TITLE
PS-9071: Merge MySQL 8.3.0 (fix rpl_rocksdb_row_img_idx_* tests)

### DIFF
--- a/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_img_idx_full.cnf
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_img_idx_full.cnf
@@ -1,1 +1,4 @@
 !include suite/rpl/t/rpl_row_img.cnf
+
+[mysqld]
+binlog_transaction_dependency_tracking=COMMIT_ORDER

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_img_idx_min.cnf
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_img_idx_min.cnf
@@ -1,1 +1,4 @@
 !include suite/rpl/t/rpl_row_img.cnf
+
+[mysqld]
+binlog_transaction_dependency_tracking=COMMIT_ORDER

--- a/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_img_idx_noblob.cnf
+++ b/mysql-test/suite/rocksdb_rpl/t/rpl_rocksdb_row_img_idx_noblob.cnf
@@ -1,1 +1,4 @@
 !include suite/rpl/t/rpl_row_img.cnf
+
+[mysqld]
+binlog_transaction_dependency_tracking=COMMIT_ORDER


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9071

The rpl_rocksdb_row_img_idx_* MTR tests started failing after changing default value of binlog-transaction-dependency-tracking sysvar to WRITESET.

There is an issue with one specific configuration when table on main server uses InnoDB as storage engine and corresponding table on replica uses RocksDB and at the same time table on replica doesn't have directly defined key. With this configuration and WRITESET being used to track transactions dependencies replica fails to apply generated transactions in parallel. Test fails by timeout on replica while trying to lock transactions.

To fix tests issue changed binlog_transaction_dependency_tracking to COMMIT_ORDER for affected tests. The issue itself will be processed separately. Same issue is actual for PS versions < 8.3 as well, it is just not visible in MTR tests for older versions.