### PR TITLE
PS-9040 Integrate clang-tidy checks for Percona server

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,57 @@
+# Copyright (c) 2024 Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+Checks:
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  clang-analyzer-*,
+  -clang-diagnostic-unused-function,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-type-vararg,
+  google-*,
+  -google-readability-todo,
+  -google-readability-braces-around-statements,
+  -google-runtime-int,
+  misc-*,
+  -misc-const-correctness,
+  modernize-use-nullptr,
+  llvm-*,
+  -llvm-header-guard,
+  -llvm-include-order,
+  performance-*,
+  readability-*,
+  -readability-braces-around-statements,
+  -readability-named-parameter
+  -readability-redundant-member-init
+
+CheckOptions:
+  - key:        readability-magic-numbers.IgnoredIntegerValues
+    value:      "1;2;3;4;8;9;10;15;32;127;128;240;255"
+  # Allow things like CHARSET_INFO cs;
+  - key:             readability-identifier-length.MinimumParameterNameLength
+    value:           2
+  - key:             readability-identifier-length.MinimumVariableNameLength
+    value:           2
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 50
+
+FormatStyle: "file"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,80 @@
+# Workflow with limited permissions that performs the checks and provides analysis results through an artifact
+name: Static_analysis
+run-name: GitHub actions for clang-tidy checks
+
+on:
+  pull_request:
+    branches:
+      - 5.7
+      - 8.0
+      - trunk
+      - release-*
+
+env:
+  UBUNTU_CODE_NAME: "jammy"
+  COMPILER_VERSION: "17"
+  BOOST_VERSION: "1_59_0"
+  BOOST_DIR: "/home/runner/my_boost"
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - name: Fetch base branch
+        run: |
+          git remote add target "https://github.com/${{ github.event.pull_request.base.repo.full_name }}"
+          git fetch --no-tags --no-recurse-submodules target "${{ github.event.pull_request.base.ref }}"
+
+      - name: Install dependencies and clang-tidy
+        run: |
+          curl -sSL "http://apt.llvm.org/llvm-snapshot.gpg.key" | sudo -E apt-key add -
+          echo "deb http://apt.llvm.org/${UBUNTU_CODE_NAME}/ llvm-toolchain-${UBUNTU_CODE_NAME}-${COMPILER_VERSION} main" | sudo tee -a /etc/apt/sources.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y --allow-unauthenticated --no-install-recommends clang-${COMPILER_VERSION} clang-tidy-${COMPILER_VERSION} libldap2-dev curl libcurl4-openssl-dev bison libudev-dev libkrb5-dev libreadline-dev zlib1g-dev liblz4-dev \
+          libedit-dev libevent-dev protobuf-compiler libprotobuf-dev libprotoc-dev libfido2-dev libldap2-dev libsasl2-dev libsasl2-modules
+
+      - name: Cache boost
+        id: cache-boost
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.BOOST_DIR }}
+          key: ${{ runner.os }}-boost-${{ env.BOOST_VERSION }}
+
+      - name: Download boost
+        if: steps.cache-boost.outputs.cache-hit != 'true'
+        run: |
+          wget --progress=dot:giga -P ${BOOST_DIR} --no-check-certificate "https://sourceforge.net/projects/boost/files/boost/${BOOST_VERSION//_/.}/boost_${BOOST_VERSION}.tar.gz"
+          tar -xzf "${BOOST_DIR}/boost_${BOOST_VERSION}.tar.gz" -C "${BOOST_DIR}"
+
+      - name: Prepare compile_commands.json
+        run: |
+          cmake -B ../debug-build -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_BUILD_TYPE=Debug -DWITH_BOOST=${BOOST_DIR} -DWITH_SSL=system \
+          -DWITH_AUTHENTICATION_LDAP=ON -DWITH_KEYRING_VAULT=ON -DWITH_ROCKSDB=ON -DCMAKE_C_COMPILER=clang-${COMPILER_VERSION} -DCMAKE_CXX_COMPILER=clang++-${COMPILER_VERSION} \
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DWITH_SYSTEM_LIBS=ON ${{ github.workspace }}
+
+      - name: Create results directory
+        run: |
+          mkdir clang-tidy-result
+
+      - name: Analyze
+        # Don't disable push/merge option in the PR even if there are unfixed warnings.
+        continue-on-error: true
+        run: |
+          git diff -U0 "$(git merge-base HEAD "target/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff-${COMPILER_VERSION}.py -p1 -path ../debug-build -export-fixes clang-tidy-result/fixes.yml
+
+      - name: Save PR metadata
+        run: |
+          echo "${{ github.event.number }}" > clang-tidy-result/pr-id.txt
+          echo "${{ github.event.pull_request.head.repo.full_name }}" > clang-tidy-result/pr-head-repo.txt
+          echo "${{ github.event.pull_request.head.sha }}" > clang-tidy-result/pr-head-sha.txt
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: clang-tidy-result
+          path: clang-tidy-result/

--- a/.github/workflows/post-pr-comments.yml
+++ b/.github/workflows/post-pr-comments.yml
@@ -1,0 +1,92 @@
+# Secure workflow with access to repository secrets and GitHub token for posting analysis results
+name: Post the static analysis results
+
+on:
+  workflow_run:
+    workflows: [ Static_analysis ]
+    types:
+      - completed
+
+jobs:
+  clang-tidy-results:
+    # Trigger the job only if the Static_analysis workflow completed successfully
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Download analysis results
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+          });
+          const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          const fs = require("fs");
+          fs.writeFileSync("${{ github.workspace }}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Extract analysis results
+      run: |
+        mkdir clang-tidy-result
+        unzip -j clang-tidy-result.zip -d clang-tidy-result
+    - name: Set environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const assert = require("node:assert").strict;
+          const fs = require("fs");
+          function exportVar(varName, fileName, regEx) {
+              const val = fs.readFileSync("${{ github.workspace }}/clang-tidy-result/" + fileName, {
+                  encoding: "ascii"
+              }).trimEnd();
+              assert.ok(regEx.test(val), "Invalid value format for " + varName);
+              core.exportVariable(varName, val);
+          }
+          exportVar("PR_ID", "pr-id.txt", /^[0-9]+$/);
+          exportVar("PR_HEAD_REPO", "pr-head-repo.txt", /^[-./0-9A-Z_a-z]+$/);
+          exportVar("PR_HEAD_SHA", "pr-head-sha.txt", /^[0-9A-Fa-f]+$/);
+    - uses: actions/checkout@v4
+      with:
+        repository: ${{ env.PR_HEAD_REPO }}
+        ref: ${{ env.PR_HEAD_SHA }}
+        persist-credentials: false
+    - name: Redownload analysis results
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+          });
+          const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "clang-tidy-result"
+          })[0];
+          const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: "zip",
+          });
+          const fs = require("fs");
+          fs.writeFileSync("${{ github.workspace }}/clang-tidy-result.zip", Buffer.from(download.data));
+    - name: Extract analysis results
+      run: |
+        mkdir clang-tidy-result
+        unzip -j clang-tidy-result.zip -d clang-tidy-result
+    - name: Run clang-tidy-pr-comments action
+      uses: platisd/clang-tidy-pr-comments@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        clang_tidy_fixes: clang-tidy-result/fixes.yml
+        pull_request_id: ${{ env.PR_ID }}

--- a/mysys/.clang-tidy
+++ b/mysys/.clang-tidy
@@ -1,0 +1,29 @@
+# Copyright (c) 2024 Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+---
+# This is legacy code, so disable some warnings.
+Checks:
+  -bugprone-assignment-in-if-condition,
+  -bugprone-narrowing-conversions,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -google-readability-casting,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion
+
+
+InheritParentConfig: true

--- a/sql/.clang-tidy
+++ b/sql/.clang-tidy
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+# Disable some warnings for server code
+Checks:
+  -cppcoreguidelines-owning-memory
+
+InheritParentConfig: true

--- a/strings/.clang-tidy
+++ b/strings/.clang-tidy
@@ -1,0 +1,55 @@
+# Copyright (c) 2024 Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+---
+# This is legacy code, so disable some warnings.
+Checks:
+  -bugprone-assignment-in-if-condition,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-avoid-goto,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-interfaces-global-init,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-no-malloc,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-special-member-functions,
+  -misc-definitions-in-headers,
+  -misc-non-private-member-variables-in-classes,
+  -readability-function-cognitive-complexity,
+  -readability-implicit-bool-conversion,
+  -readability-magic-numbers,
+  -readability-named-parameter,
+  -readability-non-const-parameter,
+  -readability-redundant-declaration
+
+InheritParentConfig: true
+
+
+CheckOptions:
+  - key:        readability-magic-numbers.IgnoredIntegerValues
+    value:      "1;2;3;4;9;32;1114111"
+  # Allow things like CHARSET_INFO cs;
+  - key:        readability-identifier-length.MinimumParameterNameLength
+    value:      1
+  - key:        readability-identifier-length.MinimumVariableNameLength
+    value:      2

--- a/unittest/gunit/.clang-tidy
+++ b/unittest/gunit/.clang-tidy
@@ -1,0 +1,26 @@
+# Copyright (c) 2024 Percona LLC and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License, version 2.0,
+# as published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License, version 2.0, for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+---
+Checks:
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -readability-magic-numbers
+
+InheritParentConfig: true
+
+CheckOptions:
+  - key: readability-function-cognitive-complexity.Threshold
+    value: 100


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9040

Add top-level .clang-tidy file, and extra files in strings/, mysys/, sql/ and unittest/gunit/.
(Back ported from 8.0).