### PR TITLE
PS-9071: Merge MySQL 8.3.0 (fix testSecureSocket test)

### DIFF
--- a/storage/ndb/src/common/util/testSecureSocket.cpp
+++ b/storage/ndb/src/common/util/testSecureSocket.cpp
@@ -747,6 +747,7 @@ int ReadLineTest::testRecv() {
                         nullptr);
     if (elapsed_time >= m_timeout) break;
     if (r == -1) continue;  // buffer full, no line found
+    if (r == 0) continue;   // timeout
     assert(r > 0);
     assert(m_recv_buffer[r] == '\0');
     assert(m_recv_buffer[r - 1] == '\n');


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9071

The NdbSocket::readln() may now return 0 in case of timeout after changes in https://github.com/mysql/mysql-server/commit/e4b3dde32d36bfdbccb008f909146d1957c5c9a4.