### PR TITLE
PS-9125: Fix gtid_next formatting in Gtid_specification::automatic_to_string()

### DIFF
--- a/sql/rpl_gtid_specification.cc
+++ b/sql/rpl_gtid_specification.cc
@@ -140,6 +140,7 @@ std::size_t Gtid_specification::automatic_to_string(char *buf) const {
     pos += sep_len;
     pos += automatic_tag.to_string(buf + pos);
   }
+  buf[pos] = '\0';
   return pos;
 }
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9125

There was a missing '\0' in the end of buffer containing formatted gtid_next in Gtid_specification::automatic_to_string() which lead to garbage symbols in the end of read @@session.gtid_next sysvar.