### PR TITLE
PS-9145: Fix openssl version detection in encryption_udf_digest_table.inc

### DIFF
--- a/mysql-test/include/have_openssl_binary_version.inc
+++ b/mysql-test/include/have_openssl_binary_version.inc
@@ -5,12 +5,8 @@
 # The condition has the same form as expressions evaluated by include/eval.inc
 # ==== Usage ====
 #
-# --let $openssl_binary_version = 1\\.1\\..*
-# --let $openssl_binary_version_do_not_skip = 1 (optional)
+# --let $openssl_binary_version = 1.1.*
 # --source include/have_openssl_binary_version.inc
-#
-# result (if $openssl_binary_version_do_not_skip was set to 1):
-# $openssl_binary_version_match = 0 | 1
 
 --disable_query_log
 --disable_result_log
@@ -49,24 +45,19 @@ EOF
 
 --source $OPENSSL_CONFIG_INC
 
+if ($STATUS_VAR)
+{
+ --error 0,1
+ --remove_file $OPENSSL_VERSION_INFO
+ --error 0,1
+ --remove_file $OPENSSL_CONFIG_INC
+ --skip Test requires openssl version to be $openssl_binary_version
+}
+
 --error 0,1
 --remove_file $OPENSSL_VERSION_INFO
 --error 0,1
 --remove_file $OPENSSL_CONFIG_INC
-
-if ($STATUS_VAR)
-{
-  if (!$openssl_binary_version_do_not_skip)
-  {
-    --skip Test requires openssl version to be $openssl_binary_version
-  }
-  --let $openssl_binary_version_match = 0
-}
-
-if (!$STATUS_VAR)
-{
-  --let $openssl_binary_version_match = 1
-}
 
 --enable_query_log
 --enable_result_log

--- a/mysql-test/include/percona_encryption_udf_digest_table.inc
+++ b/mysql-test/include/percona_encryption_udf_digest_table.inc
@@ -12,11 +12,9 @@ CREATE TEMPORARY TABLE digest_type(
 --enable_query_log
 --enable_result_log
 
---let $openssl_binary_version_do_not_skip = 1
+let $ssl_ver = query_get_value(show status like "Tls_library_version", Value, 1);
 
---let $openssl_binary_version = 1\\.0\\.2
---source include/have_openssl_binary_version.inc
-if ($openssl_binary_version_match)
+if (`select "$ssl_ver" like "OpenSSL 1.0.2%"`)
 {
   --disable_query_log
   --disable_result_log
@@ -40,9 +38,7 @@ if ($openssl_binary_version_match)
   --enable_result_log
 }
 
---let $openssl_binary_version = 1\\.1\\.0
---source include/have_openssl_binary_version.inc
-if ($openssl_binary_version_match)
+if (`select "$ssl_ver" like "OpenSSL 1.1.0%"`)
 {
   --disable_query_log
   --disable_result_log
@@ -68,9 +64,7 @@ if ($openssl_binary_version_match)
   --enable_result_log
 }
 
---let $openssl_binary_version = 1\\.1\\.1
---source include/have_openssl_binary_version.inc
-if ($openssl_binary_version_match)
+if (`select "$ssl_ver" like "OpenSSL 1.1.1%"`)
 {
   --disable_query_log
   --disable_result_log
@@ -105,9 +99,7 @@ if ($openssl_binary_version_match)
   --enable_result_log
 }
 
---let $openssl_binary_version = 3\\.0\\.\\d+
---source include/have_openssl_binary_version.inc
-if ($openssl_binary_version_match)
+if (`select "$ssl_ver" like "OpenSSL 3.%"`)
 {
   --disable_query_log
   --disable_result_log


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9145

There is an issue with running component_encryption_udf MTR tests on el7
platform with alternative system openssl11 lib. Test script is not able
to find correct openssl binary which is needed to identify openssl version.

To fix the issue encryption_udf_digest_table.inc modyfied to read
openssl version from Tls_library_version variable.
***
Revert changes in have_openssl_binary_version.inc
Remove unused openssl_binary_version_do_not_skip option.