### PR TITLE
PS-9146: Exclude some tests from ASAN tests run

### DIFF
--- a/mysql-test/suite/binlog/t/binlog_mysqlbinlog_4g_start_position.test
+++ b/mysql-test/suite/binlog/t/binlog_mysqlbinlog_4g_start_position.test
@@ -33,7 +33,8 @@
 ###############################################################################
 
 # Bug #34847851	
---source include/not_windows.inc 
+--source include/not_windows.inc
+--source include/not_asan.inc
 --source include/big_test.inc
 --source include/have_binlog_format_row.inc
 

--- a/mysql-test/t/buffered_error_log.test
+++ b/mysql-test/t/buffered_error_log.test
@@ -1,5 +1,6 @@
 call mtr.add_suppression("Attempting backtrace. You can use the following information to");
 
+--source include/not_asan.inc
 --source include/have_debug.inc
 --source include/have_debug_sync.inc
 

--- a/mysql-test/t/percona_processlist_tid.test
+++ b/mysql-test/t/percona_processlist_tid.test
@@ -1,3 +1,4 @@
+--source include/not_asan.inc
 --source include/linux.inc
 
 --source include/count_sessions.inc


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9146

Exclude the following tests from ASAN tests run:
- binlog_mysqlbinlog_4g_start_position is a big tests and requires even more time with ASAN.
- buffered_error_log, processlist_tid - report internal lib issues.