### PR TITLE
PS-9211: Fix doxygen for function templates

### DIFF
--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -3031,7 +3031,7 @@ String *Item_func_bit::val_str(String *str) {
 
 // Shift-functions, same as << and >> in C/C++
 
-/**
+/*
   Template function that evaluates the bitwise shift operation over integer
   arguments.
   @tparam to_left True if left-shift, false if right-shift
@@ -3057,7 +3057,7 @@ longlong Item_func_shift::eval_int_op() {
 template longlong Item_func_shift::eval_int_op<true>();
 template longlong Item_func_shift::eval_int_op<false>();
 
-/**
+/*
   Template function that evaluates the bitwise shift operation over binary
   string arguments.
   @tparam to_left True if left-shift, false if right-shift


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9211

Build with the clang-18 failed with the following error:

'@tparam' command used in a comment that is not attached to a template declaration

Made affected documentation a regular comment for now as attempts to fix
it for clang-18 brakes it for clang-16/17.