### PR TITLE
 [PS-9222][PoC] Include reordered fields when calculating mlog buffer size 

### DIFF
--- a/mysql-test/suite/innodb/include/instant_ddl_recovery.inc
+++ b/mysql-test/suite/innodb/include/instant_ddl_recovery.inc
@@ -61,3 +61,26 @@ SELECT * FROM t1;
 --echo # CLEANUP #
 --echo ###########
 DROP TABLE t1;
+
+#
+# Bug#35183686 ALTER_STORED_COLUMN_ORDER with algorithm=INSTANT makes wrong INSERT REDO log
+#
+--eval CREATE TABLE t1 (`c` text, `b` blob NOT NULL, `nc03242` longblob, `d` int DEFAULT NULL, UNIQUE KEY `b` (`b`(99))) ENGINE=InnoDB ROW_FORMAT=$row_format
+
+alter table t1
+  change c c text after d,
+  add column nc05984 bool,
+algorithm=instant;
+
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+
+INSERT INTO t1 SET b='ulccclraaacaucrouorouoooolrlo', d=6;
+
+--source include/kill_and_restart_mysqld.inc
+
+SELECT * FROM t1;
+
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/instant_alter_stored_column_order.result
+++ b/mysql-test/suite/innodb/r/instant_alter_stored_column_order.result
@@ -1,0 +1,14 @@
+# PS-9222 - Testing if ALGORITHM=instant crashes server
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, PRIMARY KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+ALTER TABLE t1 ADD COLUMN c4 VARCHAR(18) NOT NULL, algorithm=instant;
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+# Restart the server and reload the table to see if tables are corrupted.
+# Kill and restart
+# Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+c1	c2	c3	c4
+k1	2021-12-21 00:00:00.000	something	value
+k3	2021-12-21 00:00:00.000	something else	
+DROP TABLE t1;

--- a/mysql-test/suite/innodb/r/instant_ddl_recovery_debug.result
+++ b/mysql-test/suite/innodb/r/instant_ddl_recovery_debug.result
@@ -125,6 +125,21 @@ id	c1	c3
 # CLEANUP #
 ###########
 DROP TABLE t1;
+CREATE TABLE t1 (`c` text, `b` blob NOT NULL, `nc03242` longblob, `d` int DEFAULT NULL, UNIQUE KEY `b` (`b`(99))) ENGINE=InnoDB ROW_FORMAT=REDUNDANT;
+alter table t1
+change c c text after d,
+add column nc05984 bool,
+algorithm=instant;
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+INSERT INTO t1 SET b='ulccclraaacaucrouorouoooolrlo', d=6;
+# Kill and restart
+SELECT * FROM t1;
+b	nc03242	d	c	nc05984
+ulccclraaacaucrouorouoooolrlo	NULL	6	NULL	NULL
+DROP TABLE t1;
 ############################################
 # Test instant ADD/DROP COLUMN for DYNAMIC format
 ############################################
@@ -252,6 +267,21 @@ id	c1	c3
 # CLEANUP #
 ###########
 DROP TABLE t1;
+CREATE TABLE t1 (`c` text, `b` blob NOT NULL, `nc03242` longblob, `d` int DEFAULT NULL, UNIQUE KEY `b` (`b`(99))) ENGINE=InnoDB ROW_FORMAT=DYNAMIC;
+alter table t1
+change c c text after d,
+add column nc05984 bool,
+algorithm=instant;
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+INSERT INTO t1 SET b='ulccclraaacaucrouorouoooolrlo', d=6;
+# Kill and restart
+SELECT * FROM t1;
+b	nc03242	d	c	nc05984
+ulccclraaacaucrouorouoooolrlo	NULL	6	NULL	NULL
+DROP TABLE t1;
 ############################################
 # Test instant ADD/DROP COLUMN for COMPACT format
 ############################################
@@ -378,4 +408,19 @@ id	c1	c3
 ###########
 # CLEANUP #
 ###########
+DROP TABLE t1;
+CREATE TABLE t1 (`c` text, `b` blob NOT NULL, `nc03242` longblob, `d` int DEFAULT NULL, UNIQUE KEY `b` (`b`(99))) ENGINE=InnoDB ROW_FORMAT=COMPACT;
+alter table t1
+change c c text after d,
+add column nc05984 bool,
+algorithm=instant;
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+INSERT INTO t1 SET b='ulccclraaacaucrouorouoooolrlo', d=6;
+# Kill and restart
+SELECT * FROM t1;
+b	nc03242	d	c	nc05984
+ulccclraaacaucrouorouoooolrlo	NULL	6	NULL	NULL
 DROP TABLE t1;

--- a/mysql-test/suite/innodb/t/instant_alter_stored_column_order.test
+++ b/mysql-test/suite/innodb/t/instant_alter_stored_column_order.test
@@ -1,0 +1,31 @@
+--disable_query_log
+--disable_warnings
+DROP DATABASE IF EXISTS instant_alter_stored_column_order;
+CREATE DATABASE instant_alter_stored_column_order;
+USE instant_alter_stored_column_order;
+--enable_warnings
+--enable_query_log
+
+# PS-9222 Testing regression introduced by e6e13a8f, which causes engine crashed
+
+--echo # PS-9222 - Testing if ALGORITHM=instant crashes server
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, PRIMARY KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+
+ALTER TABLE t1 ADD COLUMN c4 VARCHAR(18) NOT NULL, algorithm=instant;
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+
+--echo # Restart the server and reload the table to see if tables are corrupted.
+--source include/kill_and_restart_mysqld.inc
+
+-- echo # Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+DROP TABLE t1;
+
+# cleanup
+--disable_query_log
+--disable_warnings
+DROP DATABASE instant_alter_stored_column_order;
+--enable_warnings
+--enable_query_log

--- a/storage/innobase/mtr/mtr0log.cc
+++ b/storage/innobase/mtr/mtr0log.cc
@@ -667,11 +667,12 @@ template <typename F>
 @param[in]  n             number of fields
 @param[in]  is_versioned  true if table has row versions
 @param[in,out]  f         vector of fields with versions
+@param[in]  changed_order array indicating fields changed position
 @param[in]  log_ptr       log buffer pointer
 @param[in]  func          callback to check size reopen log buffer */
 static bool log_index_fields(const dict_index_t *index, uint16_t n,
                              bool is_versioned, std::vector<dict_field_t *> &f,
-                             byte *&log_ptr, F &func) {
+                             bool *changed_order, byte *&log_ptr, F &func) {
   /* Write metadata for each field. Log the fields in their logical order. */
   for (size_t i = 0; i < n; i++) {
     dict_field_t *field = index->get_field(i);
@@ -696,7 +697,8 @@ static bool log_index_fields(const dict_index_t *index, uint16_t n,
     log_ptr += 2;
 
     if (is_versioned) {
-      if (col->is_instant_added() || col->is_instant_dropped()) {
+      if (col->is_instant_added() || col->is_instant_dropped() ||
+          changed_order[i]) {
         f.push_back(field);
       }
     }
@@ -738,7 +740,7 @@ static bool log_index_versioned_fields(const std::vector<dict_field_t *> &f,
            | 16th bit indicates add version info follows. */
     uint16_t phy_pos = field->get_phy_pos();
 
-    ut_ad(field->col->is_instant_added() || field->col->is_instant_dropped());
+    /* It also might be accompanying column order change (!added&&!dropped) */
 
     if (field->col->is_instant_added()) {
       /* Set 16th bit in phy_pos to indicate presence of version added */
@@ -843,20 +845,52 @@ bool mlog_open_and_write_index(mtr_t *mtr, const byte *rec,
     return true;
   };
 
+  /* Ordinal position of an existing field can't be changed with INSTANT
+  algorithm. But when it is combined with ADD/DROP COLUMN, ordinal position
+  of a filed can be changed. This bool array of size #fields in index,
+  represents if ordinal position of an existing filed is changed. */
+  bool *fields_with_changed_order = nullptr;
+  if (is_versioned) {
+    fields_with_changed_order = new bool[n];
+    memset(fields_with_changed_order, false, (sizeof(bool) * n));
+
+    uint16_t phy_pos = 0;
+    for (size_t i = 0; i < n; i++) {
+      dict_field_t *field = index->get_field(i);
+      const dict_col_t *col = field->col;
+
+      if (col->is_instant_added() || col->is_instant_dropped()) {
+        continue;
+      } else if (col->get_phy_pos() >= phy_pos) {
+        phy_pos = col->get_phy_pos();
+      } else {
+        fields_with_changed_order[i] = true;
+      }
+    }
+  }
+
   if (is_comp) {
     /* Write fields info. */
     if (!log_index_fields(index, n, is_versioned, instant_fields_to_log,
-                          log_ptr, f)) {
+                          fields_with_changed_order, log_ptr, f)) {
+      if (is_versioned) {
+        delete[] fields_with_changed_order;
+      }
       return false;
     }
   } else if (is_versioned) {
     for (size_t i = 0; i < n; i++) {
       dict_field_t *field = index->get_field(i);
       const dict_col_t *col = field->col;
-      if (col->is_instant_added() || col->is_instant_dropped()) {
+      if (col->is_instant_added() || col->is_instant_dropped() ||
+          fields_with_changed_order[i]) {
         instant_fields_to_log.push_back(field);
       }
     }
+  }
+
+  if (is_versioned) {
+    delete[] fields_with_changed_order;
   }
 
   if (!instant_fields_to_log.empty()) {
@@ -1093,7 +1127,6 @@ static void update_instant_info(instant_fields_list_t f, dict_index_t *index) {
   for (auto field : f) {
     bool is_added = field.v_added != UINT8_UNDEFINED;
     bool is_dropped = field.v_dropped != UINT8_UNDEFINED;
-    ut_ad(is_added || is_dropped);
 
     dict_col_t *col = index->fields[field.logical_pos].col;
 
@@ -1277,9 +1310,6 @@ static byte *mlog_parse_index_v1(byte *ptr, const byte *end_ptr,
         field->col->set_phy_pos(phy_pos);
         phy_pos_bitmap[phy_pos] = true;
       } else {
-        ut_ad(field->col->is_instant_added() ||
-              field->col->is_instant_dropped());
-
         if (field->col->is_instant_added() &&
             !field->col->is_instant_dropped()) {
           shift_count--;


### PR DESCRIPTION
**Note**: this change is intended to demonstrate the fix for a regression filed as PS-9222 found
in upstream MySQL 8.0.37 and should be reworked and merged accordingly only after it
has been imported. The current PR cherry-picks the commit causing the regression ([e6e13a8f](https://github.com/mysql/mysql-server/commit/e6e13a8f64ca1005f0d2d4da8463fdbef3767917)) from upstream as is, then apply the fix upon it.

The root cause is that the upstream commit adds fields to the log in additional conditions, but the mlog buffer size isn't calculated accordingly, then when the buffer is used up it triggers the assertion and crashes the server.

We've tested the fix with upstream MySQL 8.0.37 with the reproduce step in PS-9222, which is also added as an MTR test in this PR. And the MTR test in e6e13a8f also passes so no new regression is observed.