### PR TITLE
PS-9132 mysql.gtid_executed persistent GTID info lost when MySQL cras…

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -4981,7 +4981,7 @@ bool MYSQL_BIN_LOG::init_gtid_sets(Gtid_set *all_gtids, Gtid_set *lost_gtids,
             GLOBAL.GTID_PURGED should be empty in the case.
           */
           if (binlog_gtid_simple_recovery && is_server_starting &&
-              !is_relay_log)
+              !is_relay_log && reached_first_file)
           {
             assert(all_gtids->is_empty());
             assert(lost_gtids->is_empty());


### PR DESCRIPTION
…h in Gtid_state::save

mysql.gtid_executed is used to preserve the assigned GTIDs of all the transactions applied on a MySQL server. mysql> reset master;
Query OK, 0 rows affected (0.01 sec)

mysql> create database test;
Query OK, 1 row affected (0.00 sec)

mysql> show binary logs;
+------------------+-----------+
| Log_name | File_size |
+------------------+-----------+
| mysql-bin.000001 | 313 |
+------------------+-----------+
1 row in set (0.00 sec)

mysql> select * from mysql.gtid_executed;
Empty set (0.00 sec)

above is normal.
simulation environment MySQL is crashed because of OOM or killed, kill -9 （pid of MySQL）
gdb 'mysqld'
b Gtid_state::save
run --defaults-file=/etc/my.cnf
when gdb goto the breakpoint Gtid_state::save
Breakpoint 1, Gtid_state::save (this=0x3045710, gtid_set=0x7fffffffdfb0) at/percona-server-5.7.44-48/sql/rpl_gtid_state.cc:752 752 DBUG_ENTER("Gtid_state::save(Gtid_set *gtid_set)");

kill -9 （pid of MySQL）again

now start the MySQL
mysql> select * from mysql.gtid_executed;
Empty set (0.00 sec)

mysql> show binary logs;
+------------------+-----------+
| Log_name | File_size |
+------------------+-----------+
| mysql-bin.000001 | 313 |
| mysql-bin.000002 | 123 |
| mysql-bin.000003 | 398 |
+------------------+-----------+
3 rows in set (0.00 sec)

mysql> show binlog events in 'mysql-bin.000001';
+------------------+-----+----------------+-----------+-------------+-------------------------------------------------------------------+ | Log_name | Pos | Event_type | Server_id | End_log_pos | Info | +------------------+-----+----------------+-----------+-------------+-------------------------------------------------------------------+ | mysql-bin.000001 | 4 | Format_desc | 111 | 123 | Server ver: 5.7.44-48-debug-log, Binlog ver: 4 | | mysql-bin.000001 | 123 | Previous_gtids | 111 | 154 | | | mysql-bin.000001 | 154 | Gtid | 111 | 219 | SET @@SESSION.GTID_NEXT= '190ed983-db8b-11ee-b975-0242ab50d9bf:1' | | mysql-bin.000001 | 219 | Query | 111 | 313 | create database test | +------------------+-----+----------------+-----------+-------------+-------------------------------------------------------------------+ 4 rows in set (0.01 sec)

after MySQL restart the gitd in mysql-bin.000001mysql.gtid_executed is lost. the SQL "create database test" gitd in mysql-bin.000001mysql.gtid_executed is lost.

after apply this PR
mysql> select * from mysql.gtid_executed;
+--------------------------------------+----------------+--------------+ | source_uuid | interval_start | interval_end |
+--------------------------------------+----------------+--------------+ | 190ed983-db8b-11ee-b975-0242ab50d9bf | 1 | 1 |
+--------------------------------------+----------------+--------------+

mysql> select * from mysql.gtid_executed;
+--------------------------------------+----------------+--------------+ | source_uuid | interval_start | interval_end |
+--------------------------------------+----------------+--------------+ | 190ed983-db8b-11ee-b975-0242ab50d9bf | 1 | 1 |
+--------------------------------------+----------------+--------------+ 1 row in set (0.00 sec)

mysql> show binary logs;
+------------------+-----------+
| Log_name | File_size |
+------------------+-----------+
| mysql-bin.000001 | 313 |
| mysql-bin.000002 | 123 |
| mysql-bin.000003 | 438 |
+------------------+-----------+
mysql> show binlog events in 'mysql-bin.000001';
+------------------+-----+----------------+-----------+-------------+-------------------------------------------------------------------+ | Log_name | Pos | Event_type | Server_id | End_log_pos | Info | +------------------+-----+----------------+-----------+-------------+-------------------------------------------------------------------+ | mysql-bin.000001 | 4 | Format_desc | 111 | 123 | Server ver: 5.7.44-48-debug-log, Binlog ver: 4 | | mysql-bin.000001 | 123 | Previous_gtids | 111 | 154 | | | mysql-bin.000001 | 154 | Gtid | 111 | 219 | SET @@SESSION.GTID_NEXT= '190ed983-db8b-11ee-b975-0242ab50d9bf:1' | | mysql-bin.000001 | 219 | Query | 111 | 313 | create database test |

the gtid in mysql-bin.000001 is persistent in mysql.gtid_executed.