### PR TITLE
Fix misleading error messages

### DIFF
--- a/mysql-test/t/percona_dd_upgrade_file_per_table_off.test
+++ b/mysql-test/t/percona_dd_upgrade_file_per_table_off.test
@@ -3,7 +3,8 @@
 --source include/have_util_unzip.inc
 
 --disable_query_log
-call mtr.add_suppression("Error in renaming mysql_index_stats.ibd");
+call mtr.add_suppression("Missing required files mysql/innodb_index_stats.ibd.");
+call mtr.add_suppression("Missing required files mysql/innodb_table_stats.ibd.");
 call mtr.add_suppression("Resizing redo log from");
 call mtr.add_suppression("Upgrading redo log");
 call mtr.add_suppression("Starting to delete and rewrite log files");

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -3042,7 +3042,10 @@ ER_RES_GRP_SOLARIS_PROCESSOR_AFFINITY_FAILED
   eng "%s failed: processor_affinity failed (error code %d - %-.192s)."
 
 ER_DD_UPGRADE_RENAME_IDX_STATS_FILE_FAILED
-  eng "Error in renaming mysql_index_stats.ibd."
+  eng "Missing required files mysql/innodb_index_stats.ibd."
+
+ER_DD_UPGRADE_RENAME_TBL_STATS_FILE_FAILED
+  eng "Missing required files mysql/innodb_table_stats.ibd."
 
 ER_DD_UPGRADE_DD_OPEN_FAILED
   eng "Error in opening data directory %s."

--- a/sql/dd/upgrade_57/upgrade.cc
+++ b/sql/dd/upgrade_57/upgrade.cc
@@ -175,7 +175,7 @@ static void rename_stats_tables() {
                        table_stats.c_str(), IBD_EXT.c_str(), 0, &not_used);
 
   if (mysql_file_rename(key_file_misc, from_path, to_path, MYF(0))) {
-    LogErr(WARNING_LEVEL, ER_DD_UPGRADE_RENAME_IDX_STATS_FILE_FAILED);
+    LogErr(WARNING_LEVEL, ER_DD_UPGRADE_RENAME_TBL_STATS_FILE_FAILED);
   }
 }
 


### PR DESCRIPTION
When the upgrade process fails due to missing either one of the files, innodb_index_stats.ibd and innodb_table_stats.ibd, the same misleading error was logged: "Error in renaming mysql_index_stats_ibd".

To correctly log the error, separate the messages for missing innodb\_{index,table}\_stats.ibd files to two variables, and use the corresponding variable during upgrade process.

All new code of the whole pull request, including one or several files that are either new files or modified ones, are contributed under the BSD-new license. I am contributing on behalf of my employer Amazon Web Services, Inc.