### PR TITLE
PS-9218: Merge MySQL 8.4.0 (fix innodb.tablespace_encrypt_9)

### DIFF
--- a/mysql-test/suite/innodb/r/tablespace_encrypt_9.result
+++ b/mysql-test/suite/innodb/r/tablespace_encrypt_9.result
@@ -55,7 +55,7 @@ ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
 Pattern "CORRUPT LOG RECORD FOUND" found
 # Server shouldn't have restarted, so query should fail.
 SELECT * from test.t1 limit 10;
-ERROR HY000: Lost connection to MySQL server during query
+Got one of the listed errors
 #########################################################################
 # RESTART 2 : WITH KEYRING COMPONENT
 #########################################################################
@@ -106,7 +106,6 @@ ALTER TABLESPACE encrypt_ts ENCRYPTION='Y';
 # Connection con2:
 # Check that this connection id is same as of the one which was trying
 # to encrypt the tablespace before crash.
-Connectin ids are same.
 CREATE TABLESPACE temp_ts ADD DATAFILE 'temp_ts.ibd';
 # connection con3
 # Run a DDL with this connection con3

--- a/mysql-test/suite/innodb/t/tablespace_encrypt_9.test
+++ b/mysql-test/suite/innodb/t/tablespace_encrypt_9.test
@@ -91,7 +91,7 @@ let SEARCH_PATTERN=CORRUPT LOG RECORD FOUND;
 --source include/search_pattern.inc
 
 --echo # Server shouldn't have restarted, so query should fail.
---error CR_SERVER_LOST
+--error CR_SERVER_LOST,CR_CONNECTION_ERROR
 SELECT * from test.t1 limit 10;
 
 --echo #########################################################################
@@ -117,7 +117,7 @@ SELECT * FROM t1 LIMIT 10;
 --echo # Connection con1:
 connect (con1,localhost,root,,);
 connection con1;
-let $SAVED_CON_ID = `SELECT connection_id();`;
+#let $SAVED_CON_ID = `SELECT connection_id();`;
 --echo # Set Encryption process to crash at page 10
 SET SESSION debug= '+d,alter_encrypt_tablespace_page_10';
 --echo # Encrypt the tablespace. It will cause crash.
@@ -135,13 +135,13 @@ connect (con2,localhost,root,,);
 connection con2;
 --echo # Check that this connection id is same as of the one which was trying
 --echo # to encrypt the tablespace before crash.
-let $CUR_CON_ID = `SELECT connection_id();`;
-if ($CUR_CON_ID == $SAVED_CON_ID) {
-  --echo Connectin ids are same.
-}
-if ($CUR_CON_ID != $SAVED_CON_ID) {
-  --echo Connectin ids are not same.
-}
+#let $CUR_CON_ID = `SELECT connection_id();`;
+#if ($CUR_CON_ID == $SAVED_CON_ID) {
+#  --echo Connectin ids are same.
+#}
+#if ($CUR_CON_ID != $SAVED_CON_ID) {
+#  --echo Connectin ids are not same.
+#}
 
 # Run a DDL with this connection. At post DDL it will remove DDL Log records.
 CREATE TABLESPACE temp_ts ADD DATAFILE 'temp_ts.ibd';


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9218

- Added CR_CONNECTION_ERROR as expected code on server crash
- Removed connection_id() comparison before and after crash (for different connections)