### PR TITLE
PS-9165 Percona telemetry MTR test post-push fix

### DIFF
--- a/mysql-test/r/percona_utility_user.result
+++ b/mysql-test/r/percona_utility_user.result
@@ -162,7 +162,7 @@ COUNT(DISTINCT PROCESSLIST_ID)
 SELECT COUNT(*) FROM performance_schema.threads where type='FOREGROUND';
 COUNT(*)
 3
-ERROR HY000: You are not owner of thread 10
+ERROR HY000: You are not owner of thread X
 REVOKE PROXY ON 'frank'@'%' FROM 'root'@'localhost';
 CREATE ROLE r1;
 GRANT r1 TO frank@'%';

--- a/mysql-test/t/percona_utility_user.test
+++ b/mysql-test/t/percona_utility_user.test
@@ -245,6 +245,7 @@ SELECT COUNT(*) FROM performance_schema.threads where type='FOREGROUND';
 connection default;
 
 --disable_query_log
+--replace_regex /thread [0-9]+/thread X/
 --error ER_KILL_DENIED_ERROR
 --eval KILL $conn_id
 --enable_query_log


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9165

The thread number in the test percona_utility_user is masked since it is different when telemetry is enabled from when it is disabled.