### PR TITLE
PS-9165 postfix 8.0: Product Usage Tracking - phase 1 (MTR fixes)

### DIFF
--- a/mysql-test/suite/clone/t/plugin_mismatch.cnf
+++ b/mysql-test/suite/clone/t/plugin_mismatch.cnf
@@ -5,6 +5,7 @@ server_id=1
 
 [mysqld.2]
 server_id=2
+loose-percona-telemetry-disable=ON
 
 [ENV]
 SERVER_PORT_1 = @mysqld.1.port

--- a/mysql-test/suite/clone/t/plugin_mismatch.test
+++ b/mysql-test/suite/clone/t/plugin_mismatch.test
@@ -1,5 +1,10 @@
 --source include/have_example_plugin.inc
 
+# When the server is built with telemetry enabled ('-DWITH_PERCONA_TELEMETRY=ON'),
+# we deliberately enable telemetry component in the first instance and disable in the
+# second one in the .cnf file in order to check that mismatch in having this
+# component does not affect cloning plugin mismatch logic.
+
 --echo #
 --echo # PS-8188 : Make the clone_plugin to not force plugins to match on recipient/donor
 --echo #

--- a/mysql-test/suite/sys_vars/t/plugin_dir_basic-master.opt
+++ b/mysql-test/suite/sys_vars/t/plugin_dir_basic-master.opt
@@ -1,1 +1,2 @@
 --plugin-dir=$MYSQL_TMP_DIR
+--loose-percona-telemetry-disable=ON


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9165

'sys_vars.plugin_dir_basic' and  'clone.plugin_mismatch' MTR test cases modified so that they could be run on a server built both with and without telemetry component ('-DWITH_PERCONA_TELEMETRY=ON' CMake option).