### PR TITLE
PS-9165 postfix 8.0: Product Usage Tracking - phase 1 (MTR fixes)

### DIFF
--- a/mysql-test/include/have_percona_telemetry.inc
+++ b/mysql-test/include/have_percona_telemetry.inc
@@ -1,0 +1,3 @@
+if (`SELECT COUNT(*) = 0 FROM mysql.component WHERE component_urn='file://component_percona_telemetry'`) {
+  --skip Test not supported when Percona Telemetry is not built-in
+}

--- a/mysql-test/include/not_have_percona_telemetry.inc
+++ b/mysql-test/include/not_have_percona_telemetry.inc
@@ -1,0 +1,3 @@
+if (`SELECT COUNT(*) = 1 FROM mysql.component WHERE component_urn='file://component_percona_telemetry'`) {
+  --skip Test not supported when Percona Telemetry is built-in
+}

--- a/mysql-test/suite/test_service_sql_api/r/test_session_info_percona_telemetry.result
+++ b/mysql-test/suite/test_service_sql_api/r/test_session_info_percona_telemetry.result
@@ -1,0 +1,724 @@
+CREATE TABLE t1(id INT NOT NULL);
+##########################################
+# Shutdown
+##########################################
+##########################################
+# Restart
+##########################################
+##########################################
+# Run plugin
+##########################################
+INSTALL PLUGIN test_session_info SONAME 'TEST_SESSION_INFO';
+##########################################
+# Stop plugin
+##########################################
+UNINSTALL PLUGIN test_session_info;
+##########################################
+# Plugin log
+##########################################
+============================================================================================
+Test in a server thread
+Opening Session 1
+Opening Session 2
+============================================================================================
+Session 1 : srv_session_info_get_thd and srv_session_info_get_session_id
+============================================================================================
+Thread handler id IS equal to session id returned by srv_session_info_get_session_id(Session_1)
+
+============================================================================================
+Session 2 : srv_session_info_get_thd and srv_session_info_get_session_id
+============================================================================================
+Thread handler id IS equal to session id returned by srv_session_info_get_session_id(Session_2)
+
+SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  10
+name  type  processlist_id  processlist_user  processlist_host  processlist_db  processlist_command  processlist_state  processlist_info  role  instrumented  history  connection_type  
+thread/sql/one_connection  FOREGROUND  10  root  localhost  test  Query  executing  SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  10  [NULL]  YES  YES  Plugin  
+
+num_cols      : 13
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  11
+name  type  processlist_id  processlist_user  processlist_host  processlist_db  processlist_command  processlist_state  processlist_info  role  instrumented  history  connection_type  
+thread/sql/one_connection  FOREGROUND  11  root  localhost  test  Query  executing  SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  11  [NULL]  YES  YES  Plugin  
+
+num_cols      : 13
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 1 : srv_session_info_get_current_db
+============================================================================================
+/*Session_1*/ SHOW TABLES LIKE '%slave%'
+error     : 1046
+error msg : No database selected
+
+current_db before init_db : (null)
+current_db after init_db  : mysql
+
+/*Session_1*/ SHOW TABLES LIKE '%slave%'
+Tables_in_mysql (%slave%)  
+slave_master_info  
+slave_relay_log_info  
+slave_worker_info  
+
+num_cols      : 1
+nb rows       : 3
+affected rows : 0
+server status : 2
+warn count    : 0
+
+/*Session_1*/ USE information_schema
+affected rows : 0
+server status : 2
+warn count    : 0
+
+current_db after 'USE db_name' command : information_schema
+
+current_db before init_db : information_schema
+current_db after init_db  : test
+
+/*Session_1*/ SHOW TABLES
+Tables_in_test  
+t1  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 2 : srv_session_info_get_current_db
+============================================================================================
+/*Session_2*/ SHOW TABLES LIKE '%slave%'
+error     : 1046
+error msg : No database selected
+
+current_db before init_db : (null)
+current_db after init_db  : mysql
+
+Session 2's view
+/*Session_2*/ SHOW TABLES LIKE '%slave%'
+Tables_in_mysql (%slave%)  
+slave_master_info  
+slave_relay_log_info  
+slave_worker_info  
+
+num_cols      : 1
+nb rows       : 3
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Session 2's view
+/*Session_2*/ USE information_schema
+affected rows : 0
+server status : 2
+warn count    : 0
+
+current_db after 'USE db_name' command : information_schema
+
+current_db before init_db : information_schema
+current_db after init_db  : test
+
+Session 2's view
+/*Session_2*/ SHOW TABLES
+Tables_in_test  
+t1  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 1 : srv_session_info_set/get_client_port
+============================================================================================
+Port before srv_session_info_set_client_port : 0
+Port after srv_session_info_set_client_port  : 100
+
+Session 1's view
+/*Session_1*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+Session 2's view
+/*Session_2*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+============================================================================================
+Session 2 : srv_session_info_set/get_client_port
+============================================================================================
+Port before srv_session_info_set_client_port : 0
+Port after srv_session_info_set_client_port  : 200
+
+Session 1's view
+/*Session_1*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost:200  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+Session 2's view
+/*Session_2*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost:200  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+============================================================================================
+Session 1 : srv_session_info_set_connection_type
+============================================================================================
+Session 1's view
+SELECT CONNECTION_TYPE, CONNECTION_TYPE IS NULL FROM performance_schema.threads WHERE PROCESSLIST_ID =  10 /*session_1_id*/
+CONNECTION_TYPE  CONNECTION_TYPE IS NULL  
+Plugin  0  
+
+num_cols      : 2
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting NO_VIO_TYPE on session_1
+Session 1's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  10 /*session_1_id*/
+CONNECTION_TYPE  
+Plugin  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting VIO_TYPE_TCPIP on session_1
+Session 1's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  10 /*session_1_id*/
+CONNECTION_TYPE  
+TCP/IP  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting VIO_TYPE_NAMEDPIPE on session_1
+Session 1's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  10 /*session_1_id*/
+CONNECTION_TYPE  
+Named Pipe  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 2 : srv_session_info_set_connection_type
+============================================================================================
+Session 2's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  11 /*session_2_id*/
+CONNECTION_TYPE  
+Plugin  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting VIO_TYPE_SSL on session_2
+Setting VIO_TYPE_TCPIP on session_1
+Session 2's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  11 /*session_2_id*/
+CONNECTION_TYPE  
+SSL/TLS  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Session 2's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  11  /*session_2_id*/
+CONNECTION_TYPE  
+Shared Memory  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+BEFORE kill of Session 1
+============================================================================================
+SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+ID  USER  HOST  DB  COMMAND  INFO  
+10  root  localhost:100  test  Query  PLUGIN: SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id  
+11  root  localhost:200  test  Sleep  PLUGIN  
+
+num_cols      : 6
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+============================================================================================
+srv_session_info_killed(Session_1) : 0
+srv_session_info_killed(Session_2) : 0
+============================================================================================
+Killing Session 1
+KILL CONNECTION 10 /*session_1_id*/
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+AFTER kill of Session 1
+============================================================================================
+SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+
+============================================================================================
+srv_session_info_killed(Session 1) : 1
+srv_session_info_killed(Session 2) : 0
+============================================================================================
+Closing Session 1
+Closing Session 1 failed as expected. It was already closed by EXEC_TEST_CMD
+============================================================================================
+Get/Set session info with closed session(Session 1)
+============================================================================================
+srv_session_info_get_thd             : 0
+srv_session_info_get_session_id      : 0
+srv_session_info_set_client_port     : 1
+srv_session_info_get_client_port     : 0
+srv_session_info_get_current_db      : (null)
+srv_session_info_set_connection_type : 1
+
+============================================================================================
+SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+
+============================================================================================
+Perform KILL QUERY and suicide (KILL CONNECTION) on Session 2
+============================================================================================
+KILL QUERY 11 /*session_2_id*/
+srv_session_info_killed(Session 2) : 0
+KILL CONNECTION 11  /*session_2_id*/
+srv_session_info_killed(Session 2) : 1
+============================================================================================
+Get/Set session info with killed session(Session 2)
+============================================================================================
+srv_session_info_get_thd             : 1
+srv_session_info_get_session_id      : 11
+srv_session_info_set_client_port     : 0
+srv_session_info_get_client_port     : 11111
+srv_session_info_get_current_db      : test
+srv_session_info_set_connection_type : 0
+
+============================================================================================
+Session 2 got killed but not closed, thus it will appear in the processlist as Killed
+============================================================================================
+/*Session 3*/SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+ID  USER  HOST  DB  COMMAND  INFO  
+11  root  localhost:11111  test  Killed  PLUGIN  
+12  root  localhost  [NULL]  Query  PLUGIN: /*Session 3*/SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id  
+
+num_cols      : 6
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+Closing Session 2
+Closing Session 3
+Follows threaded run
+============================================================================================
+init thread
+Opening Session 1
+Opening Session 2
+============================================================================================
+Session 1 : srv_session_info_get_thd and srv_session_info_get_session_id
+============================================================================================
+Thread handler id IS equal to session id returned by srv_session_info_get_session_id(Session_1)
+
+============================================================================================
+Session 2 : srv_session_info_get_thd and srv_session_info_get_session_id
+============================================================================================
+Thread handler id IS equal to session id returned by srv_session_info_get_session_id(Session_2)
+
+SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  13
+name  type  processlist_id  processlist_user  processlist_host  processlist_db  processlist_command  processlist_state  processlist_info  role  instrumented  history  connection_type  
+thread/test_service_sql/session_info  FOREGROUND  13  root  localhost  [NULL]  Query  executing  SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  13  [NULL]  YES  YES  Plugin  
+
+num_cols      : 13
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  14
+name  type  processlist_id  processlist_user  processlist_host  processlist_db  processlist_command  processlist_state  processlist_info  role  instrumented  history  connection_type  
+thread/test_service_sql/session_info  FOREGROUND  14  root  localhost  [NULL]  Query  executing  SELECT name,type,processlist_id,processlist_user,processlist_host,processlist_db,processlist_command,processlist_state,processlist_info,`role`,instrumented,history,connection_type FROM performance_schema.threads WHERE processlist_id =  14  [NULL]  YES  YES  Plugin  
+
+num_cols      : 13
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 1 : srv_session_info_get_current_db
+============================================================================================
+/*Session_1*/ SHOW TABLES LIKE '%slave%'
+error     : 1046
+error msg : No database selected
+
+current_db before init_db : (null)
+current_db after init_db  : mysql
+
+/*Session_1*/ SHOW TABLES LIKE '%slave%'
+Tables_in_mysql (%slave%)  
+slave_master_info  
+slave_relay_log_info  
+slave_worker_info  
+
+num_cols      : 1
+nb rows       : 3
+affected rows : 0
+server status : 2
+warn count    : 0
+
+/*Session_1*/ USE information_schema
+affected rows : 0
+server status : 2
+warn count    : 0
+
+current_db after 'USE db_name' command : information_schema
+
+current_db before init_db : information_schema
+current_db after init_db  : test
+
+/*Session_1*/ SHOW TABLES
+Tables_in_test  
+t1  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 2 : srv_session_info_get_current_db
+============================================================================================
+/*Session_2*/ SHOW TABLES LIKE '%slave%'
+error     : 1046
+error msg : No database selected
+
+current_db before init_db : (null)
+current_db after init_db  : mysql
+
+Session 2's view
+/*Session_2*/ SHOW TABLES LIKE '%slave%'
+Tables_in_mysql (%slave%)  
+slave_master_info  
+slave_relay_log_info  
+slave_worker_info  
+
+num_cols      : 1
+nb rows       : 3
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Session 2's view
+/*Session_2*/ USE information_schema
+affected rows : 0
+server status : 2
+warn count    : 0
+
+current_db after 'USE db_name' command : information_schema
+
+current_db before init_db : information_schema
+current_db after init_db  : test
+
+Session 2's view
+/*Session_2*/ SHOW TABLES
+Tables_in_test  
+t1  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 1 : srv_session_info_set/get_client_port
+============================================================================================
+Port before srv_session_info_set_client_port : 0
+Port after srv_session_info_set_client_port  : 100
+
+Session 1's view
+/*Session_1*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+Session 2's view
+/*Session_2*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+============================================================================================
+Session 2 : srv_session_info_set/get_client_port
+============================================================================================
+Port before srv_session_info_set_client_port : 0
+Port after srv_session_info_set_client_port  : 200
+
+Session 1's view
+/*Session_1*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost:200  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+Session 2's view
+/*Session_2*/ SELECT host FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+host  
+localhost:100  
+localhost:200  
+
+num_cols      : 1
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+============================================================================================
+Session 1 : srv_session_info_set_connection_type
+============================================================================================
+Session 1's view
+SELECT CONNECTION_TYPE, CONNECTION_TYPE IS NULL FROM performance_schema.threads WHERE PROCESSLIST_ID =  13 /*session_1_id*/
+CONNECTION_TYPE  CONNECTION_TYPE IS NULL  
+Plugin  0  
+
+num_cols      : 2
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting NO_VIO_TYPE on session_1
+Session 1's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  13 /*session_1_id*/
+CONNECTION_TYPE  
+Plugin  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting VIO_TYPE_TCPIP on session_1
+Session 1's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  13 /*session_1_id*/
+CONNECTION_TYPE  
+TCP/IP  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting VIO_TYPE_NAMEDPIPE on session_1
+Session 1's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  13 /*session_1_id*/
+CONNECTION_TYPE  
+Named Pipe  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+Session 2 : srv_session_info_set_connection_type
+============================================================================================
+Session 2's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  14 /*session_2_id*/
+CONNECTION_TYPE  
+Plugin  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Setting VIO_TYPE_SSL on session_2
+Setting VIO_TYPE_TCPIP on session_1
+Session 2's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  14 /*session_2_id*/
+CONNECTION_TYPE  
+SSL/TLS  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+Session 2's view
+SELECT CONNECTION_TYPE FROM performance_schema.threads WHERE PROCESSLIST_ID =  14  /*session_2_id*/
+CONNECTION_TYPE  
+Shared Memory  
+
+num_cols      : 1
+nb rows       : 1
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+BEFORE kill of Session 1
+============================================================================================
+SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+ID  USER  HOST  DB  COMMAND  INFO  
+13  root  localhost:100  test  Query  PLUGIN: SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id  
+14  root  localhost:200  test  Sleep  PLUGIN  
+
+num_cols      : 6
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+============================================================================================
+srv_session_info_killed(Session_1) : 0
+srv_session_info_killed(Session_2) : 0
+============================================================================================
+Killing Session 1
+KILL CONNECTION 13 /*session_1_id*/
+affected rows : 0
+server status : 2
+warn count    : 0
+
+============================================================================================
+AFTER kill of Session 1
+============================================================================================
+SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+
+============================================================================================
+srv_session_info_killed(Session 1) : 1
+srv_session_info_killed(Session 2) : 0
+============================================================================================
+Closing Session 1
+Closing Session 1 failed as expected. It was already closed by EXEC_TEST_CMD
+============================================================================================
+Get/Set session info with closed session(Session 1)
+============================================================================================
+srv_session_info_get_thd             : 0
+srv_session_info_get_session_id      : 0
+srv_session_info_set_client_port     : 1
+srv_session_info_get_client_port     : 0
+srv_session_info_get_current_db      : (null)
+srv_session_info_set_connection_type : 1
+
+============================================================================================
+SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+
+============================================================================================
+Perform KILL QUERY and suicide (KILL CONNECTION) on Session 2
+============================================================================================
+KILL QUERY 14 /*session_2_id*/
+srv_session_info_killed(Session 2) : 0
+KILL CONNECTION 14  /*session_2_id*/
+srv_session_info_killed(Session 2) : 1
+============================================================================================
+Get/Set session info with killed session(Session 2)
+============================================================================================
+srv_session_info_get_thd             : 1
+srv_session_info_get_session_id      : 14
+srv_session_info_set_client_port     : 0
+srv_session_info_get_client_port     : 11111
+srv_session_info_get_current_db      : test
+srv_session_info_set_connection_type : 0
+
+============================================================================================
+Session 2 got killed but not closed, thus it will appear in the processlist as Killed
+============================================================================================
+/*Session 3*/SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id
+ID  USER  HOST  DB  COMMAND  INFO  
+14  root  localhost:11111  test  Killed  PLUGIN  
+15  root  localhost  [NULL]  Query  PLUGIN: /*Session 3*/SELECT ID, USER, HOST, DB, COMMAND, INFO FROM INFORMATION_SCHEMA.PROCESSLIST WHERE info LIKE 'PLUGIN%' ORDER BY id  
+
+num_cols      : 6
+nb rows       : 2
+affected rows : 0
+server status : 34
+warn count    : 1
+
+Closing Session 2
+Closing Session 3
+deinit thread
+##########################################
+# Cleanup
+##########################################
+DROP TABLE t1;

--- a/mysql-test/suite/test_service_sql_api/t/test_session_info_percona_telemetry-master.opt
+++ b/mysql-test/suite/test_service_sql_api/t/test_session_info_percona_telemetry-master.opt
@@ -1,0 +1,2 @@
+$TEST_SESSION_INFO_OPT
+--mysqlx=off

--- a/mysql-test/suite/test_service_sql_api/t/test_session_info_percona_telemetry-master.opt
+++ b/mysql-test/suite/test_service_sql_api/t/test_session_info_percona_telemetry-master.opt
@@ -1,2 +1,2 @@
 $TEST_SESSION_INFO_OPT
---mysqlx=off
+--loose-mysqlx=off

--- a/mysql-test/suite/test_service_sql_api/t/test_session_info_percona_telemetry.test
+++ b/mysql-test/suite/test_service_sql_api/t/test_session_info_percona_telemetry.test
@@ -1,6 +1,6 @@
 # This test relies on real session IDs. They are different if Percona Telemetry
-# is built in, so it is better to disable this test than mask IDs in result
---source include/not_have_percona_telemetry.inc
+# is built in. This is the version for binary with Percona Telemetry built-in.
+--source include/have_percona_telemetry.inc
 
 CREATE TABLE t1(id INT NOT NULL);
 

--- a/mysql-test/suite/x/r/regression.result
+++ b/mysql-test/suite/x/r/regression.result
@@ -4,7 +4,7 @@ call mtr.add_suppression("Plugin mysqlx reported: .Setup of socket: '' failed, t
 Bug #21472634
 RUN show processlist;
 Id	User	Host	db	Command		State	Info			
-5	event_scheduler	localhost	null	Daemon	Waiting on empty queue	null
+$PROC_ES_ID	event_scheduler	localhost	null	Daemon	Waiting on empty queue	null
 $PROC_1_ID	root	localhost	test	Sleep		null
 $PROC_2_ID	x_root	localhost	null	Query	init	PLUGIN: show processlist
 0 rows affected
@@ -12,7 +12,7 @@ Warnings generated:
 WARNING | 1287 | 'INFORMATION_SCHEMA.PROCESSLIST' is deprecated and will be removed in a future release. Please use performance_schema.processlist instead
 RUN SELECT id,user,command,state FROM information_schema.processlist ORDER BY id
 id	user	command	state
-5	event_scheduler	Daemon	Waiting on empty queue
+$PROC_ES_ID	event_scheduler	Daemon	Waiting on empty queue
 $PROC_1_ID	root	Sleep	
 $PROC_2_ID	x_root	Query	executing
 0 rows affected

--- a/mysql-test/suite/x/t/prep_stmt_sundries.test
+++ b/mysql-test/suite/x/t/prep_stmt_sundries.test
@@ -479,12 +479,22 @@ source ../include/wait_for_status_variables.inc;
 --let $assert_cond= [SHOW GLOBAL STATUS LIKE "Prepared_stmt_count", Value, 1] = 0
 --source include/assert.inc
 
+# When Percona Telemetry is built-in it installs the component, which changes conters values
+--let $Com_stmt_prepare_expected = 11
+--let $Com_stmt_execute_expected = 6
+--let $Com_stmt_close_expected = 7
+if (`SELECT COUNT(*) = 1 FROM mysql.component WHERE component_urn='file://component_percona_telemetry'`) {
+--let $Com_stmt_prepare_expected = 13
+--let $Com_stmt_execute_expected = 8
+--let $Com_stmt_close_expected = 9
+}
+
 --let $assert_text= Global system status Com_stmt_prepare must be set to zero, all prep-stmt must be deallocated.
---let $assert_cond= [SHOW GLOBAL STATUS LIKE "Com_stmt_prepare", Value, 1] = 11
+--let $assert_cond= [SHOW GLOBAL STATUS LIKE "Com_stmt_prepare", Value, 1] = $Com_stmt_prepare_expected
 --source include/assert.inc
 
 --let $assert_text= Global system status Com_stmt_execute must be set to zero, all prep-stmt must be deallocated.
---let $assert_cond= [SHOW GLOBAL STATUS LIKE "Com_stmt_execute", Value, 1] = 6
+--let $assert_cond= [SHOW GLOBAL STATUS LIKE "Com_stmt_execute", Value, 1] = $Com_stmt_execute_expected
 --source include/assert.inc
 
 --let $assert_text= Global system status Com_stmt_fetch must be set to zero, all prep-stmt must be deallocated.
@@ -492,7 +502,7 @@ source ../include/wait_for_status_variables.inc;
 --source include/assert.inc
 
 --let $assert_text= Global system status Com_stmt_close must be set to zero, all prep-stmt must be deallocated.
---let $assert_cond= [SHOW GLOBAL STATUS LIKE "Com_stmt_close", Value, 1] = 7
+--let $assert_cond= [SHOW GLOBAL STATUS LIKE "Com_stmt_close", Value, 1] = $Com_stmt_close_expected
 --source include/assert.inc
 
 ## Cleanup

--- a/mysql-test/suite/x/t/regression.test
+++ b/mysql-test/suite/x/t/regression.test
@@ -22,7 +22,7 @@ call mtr.add_suppression("Plugin mysqlx reported: .Setup of socket: '' failed, t
 SELECT id,user,command,state FROM information_schema.processlist ORDER BY id;
 -->endsql
 EOF
---replace_regex /localhost:[0-9]*/localhost/ /	[12]	/	0	/ /[0-9]+	root(.+)Sleep/$PROC_1_ID	root\1Sleep/ /[0-9]+	x_root(.+)Query/$PROC_2_ID	x_root\1Query/ /Execute/Query/ 
+--replace_regex /localhost:[0-9]*/localhost/ /	[12]	/	0	/ /[0-9]+	root(.+)Sleep/$PROC_1_ID	root\1Sleep/ /[0-9]+	x_root(.+)Query/$PROC_2_ID	x_root\1Query/ /Execute/Query/ /[0-9]+	event_scheduler/$PROC_ES_ID	event_scheduler/ 
 --exec $MYSQLXTEST -ux_root --password='' --file=$MYSQL_TMP_DIR/mysqlx-regression-ps.xpl 2>&1
 --remove_file $MYSQL_TMP_DIR/mysqlx-regression-ps.xpl
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9165

1. test_session_info.test duplicated with IDs recorded for the case when Percona Telemetry is built-in. It is better than masking IDs in output, because the test relies on real ID values

2. regression.test - ID masked in test output

3. prep_stmt_sundries.test - make assertion value dependant on Percona Telemetry being built-in