### PR TITLE
PS-9165 postfix: Product Usage Tracking - phase 1 (MTR KV fixes)

### DIFF
--- a/plugin/keyring_vault/tests/mtr/keyring_udf-master.opt
+++ b/plugin/keyring_vault/tests/mtr/keyring_udf-master.opt
@@ -1,0 +1,1 @@
+--loose-percona-telemetry-disable=ON


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9165

'keyring_vault.keyring_udf' MTR test case modified so that it could be run on a server built both with and without telemetry component ('-DWITH_PERCONA_TELEMETRY=ON' CMake option).