### PR TITLE
PS-9222 Include reordered fields when calculating mlog buffer size

### DIFF
--- a/mysql-test/suite/percona_innodb/r/instant_alter_index_prefix.result
+++ b/mysql-test/suite/percona_innodb/r/instant_alter_index_prefix.result
@@ -1,0 +1,38 @@
+without prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, UNIQUE KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+ALTER TABLE t1 ADD COLUMN c4 VARCHAR(18) NOT NULL, ALGORITHM=INSTANT;
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+# Restart the server and reload the table to see if tables are corrupted.
+# Kill and restart
+# Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+c1	c2	c3	c4
+k1	2021-12-21 00:00:00.000	something	value
+k3	2021-12-21 00:00:00.000	something else	
+DROP TABLE t1;
+with prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, PRIMARY KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+ALTER TABLE t1 ADD COLUMN c4 VARCHAR(18) NOT NULL, ALGORITHM=INSTANT;
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+# Restart the server and reload the table to see if tables are corrupted.
+# Kill and restart
+# Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+c1	c2	c3	c4
+k1	2021-12-21 00:00:00.000	something	value
+k3	2021-12-21 00:00:00.000	something else	
+DROP TABLE t1;

--- a/mysql-test/suite/percona_innodb/r/instant_alter_stored_column_order.result
+++ b/mysql-test/suite/percona_innodb/r/instant_alter_stored_column_order.result
@@ -1,0 +1,44 @@
+without prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, UNIQUE KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+ALTER TABLE t1
+CHANGE c2 c2 DATETIME(3) NOT NULL AFTER c3,
+ADD COLUMN c4 VARCHAR(18) NOT NULL,
+ALGORITHM=INSTANT;
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+# Restart the server and reload the table to see if tables are corrupted.
+# Kill and restart
+# Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+c1	c3	c2	c4
+k1	something	2021-12-21 00:00:00.000	value
+k3	something else	2021-12-21 00:00:00.000	
+DROP TABLE t1;
+with prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, PRIMARY KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+ALTER TABLE t1
+CHANGE c2 c2 DATETIME(3) NOT NULL AFTER c3,
+ADD COLUMN c4 VARCHAR(18) NOT NULL,
+ALGORITHM=INSTANT;
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+# Restart the server and reload the table to see if tables are corrupted.
+# Kill and restart
+# Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+c1	c3	c2	c4
+k1	something	2021-12-21 00:00:00.000	value
+k3	something else	2021-12-21 00:00:00.000	
+DROP TABLE t1;

--- a/mysql-test/suite/percona_innodb/t/instant_alter_index_prefix.test
+++ b/mysql-test/suite/percona_innodb/t/instant_alter_index_prefix.test
@@ -1,0 +1,50 @@
+# PS-9222 Testing if ALGORITHM=INSTANT crashes server
+source include/have_debug.inc;
+
+--echo without prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, UNIQUE KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+
+ALTER TABLE t1 ADD COLUMN c4 VARCHAR(18) NOT NULL, ALGORITHM=INSTANT;
+
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+
+--echo # Restart the server and reload the table to see if tables are corrupted.
+--source include/kill_and_restart_mysqld.inc
+
+-- echo # Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+
+# cleanup
+DROP TABLE t1;
+
+--echo with prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, PRIMARY KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+
+ALTER TABLE t1 ADD COLUMN c4 VARCHAR(18) NOT NULL, ALGORITHM=INSTANT;
+
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+
+--echo # Restart the server and reload the table to see if tables are corrupted.
+--source include/kill_and_restart_mysqld.inc
+
+-- echo # Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+
+# cleanup
+DROP TABLE t1;

--- a/mysql-test/suite/percona_innodb/t/instant_alter_stored_column_order.test
+++ b/mysql-test/suite/percona_innodb/t/instant_alter_stored_column_order.test
@@ -1,0 +1,56 @@
+# PS-9222 Testing if ALGORITHM=INSTANT crashes server
+source include/have_debug.inc;
+
+--echo without prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, UNIQUE KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+
+ALTER TABLE t1
+CHANGE c2 c2 DATETIME(3) NOT NULL AFTER c3,
+ADD COLUMN c4 VARCHAR(18) NOT NULL,
+ALGORITHM=INSTANT;
+
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+
+--echo # Restart the server and reload the table to see if tables are corrupted.
+--source include/kill_and_restart_mysqld.inc
+
+-- echo # Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+
+# cleanup
+DROP TABLE t1;
+
+--echo with prefix field in the index
+CREATE TABLE t1 (c1 TINYTEXT COLLATE ascii_bin NOT NULL, c2 DATETIME(3) NOT NULL, c3 TEXT, PRIMARY KEY (c1(30)));
+INSERT INTO t1 (c1, c2, c3) VALUE ('k1','2021-12-21','something');
+INSERT INTO t1 (c1, c2, c3) VALUE ('k3','2021-12-21','something else');
+
+ALTER TABLE t1
+CHANGE c2 c2 DATETIME(3) NOT NULL AFTER c3,
+ADD COLUMN c4 VARCHAR(18) NOT NULL,
+ALGORITHM=INSTANT;
+
+SET GLOBAL innodb_log_checkpoint_now = ON;
+SET GLOBAL innodb_page_cleaner_disabled_debug = 1;
+SET GLOBAL innodb_dict_stats_disabled_debug = 1;
+SET GLOBAL innodb_master_thread_disabled_debug = 1;
+SET GLOBAL innodb_checkpoint_disabled = ON;
+
+UPDATE t1 SET c4 = 'value' WHERE c1 = 'k1';
+
+--echo # Restart the server and reload the table to see if tables are corrupted.
+--source include/kill_and_restart_mysqld.inc
+
+-- echo # Run a select to confirm that the database started up successfully
+SELECT * FROM t1;
+
+# cleanup
+DROP TABLE t1;

--- a/storage/innobase/mtr/mtr0log.cc
+++ b/storage/innobase/mtr/mtr0log.cc
@@ -867,8 +867,8 @@ bool mlog_open_and_write_index(mtr_t *mtr, const byte *rec,
 
       if (col->is_instant_added() || col->is_instant_dropped()) {
         continue;
-      } else if (col->get_phy_pos() >= phy_pos) {
-        phy_pos = col->get_phy_pos();
+      } else if (field->get_phy_pos() >= phy_pos) {
+        phy_pos = field->get_phy_pos();
       } else {
         fields_with_changed_order[i] = true;
       }

--- a/storage/innobase/mtr/mtr0log.cc
+++ b/storage/innobase/mtr/mtr0log.cc
@@ -851,6 +851,9 @@ bool mlog_open_and_write_index(mtr_t *mtr, const byte *rec,
   }
 
   if (!mlog_open(mtr, alloc, log_ptr)) {
+    if (is_versioned) {
+      delete[] fields_with_changed_order;
+    }
     /* logging is disabled */
     return (false);
   }


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9222

Problem
=======
Upstream commit e6e13a8f tries to fix an issue that doesn't log the fields that changes orders when using ALGORITHM=instant, by checking if the fields is also reordered, then adding the columns into the list. However when calculating the size of the buffer this fix doesn't take account the extra fields that may be logged, and causing the assertion on the buffer size failed eventually.

Solution
========
To calculate the buffer size correctly, we move the logic of finding reordered fiedls before buffer size calculation, then count the number of fields with the same logic when deciding if a field needs to be logged.