### PR TITLE
PS-9218 merge: Merge MySQL 8.4.0 (partition_names fixes)

### DIFF
--- a/mysql-test/suite/rocksdb/t/partition.test
+++ b/mysql-test/suite/rocksdb/t/partition.test
@@ -35,6 +35,7 @@ SELECT PARTITION_NAME FROM information_schema.rocksdb_ddl WHERE TABLE_NAME="VAR_
 
 --enable_query_log
 
+--sorted_result
 SHOW TABLES;
 
 SELECT * FROM t1 ORDER BY i LIMIT 10;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9218

Reworked  "table_list->partition_names = &alter_info->partition_names;"
part from the WL#15517
"[5] HeatWave Support for InnoDB Partitions - Support for Loading Partitions"
patch introduced in https://github.com/mysql/mysql-server/commit/951ffba.

It turned out that changing this 'partition_names' affects
"ALTER TABLE ... ALGORITHM=INPLACE, DROP PARTITION ..." logic
under '--rocksdb-allow-unsafe-alter=ON'.
In particular, in the following call stack

1. 'mysql_inplace_alter_table()'
2. 'open_table()' from the
/*
  Tell the SE that the changed table in the data-dictionary.
  For engines which don't support atomic DDL this needs to be
  done before trying to rename the table.
*/
3. 'table->part_info->set_partition_bitmaps()' from the
/*
  Position for each partition in the bitmap is read from the Handler_share
  instance of the table. In MYSQL_OPEN_NO_NEW_TABLE_IN_SE mode, table is not
  opened in the SE and Handler_share instance for it is not created. Hence
  skipping partitions bitmap setting in the MYSQL_OPEN_NO_NEW_TABLE_IN_SE
  mode.
*/
4. 'set_read_partitions()'
5. 'add_named_partition()'

if the "table_list->partition_names = &alter_info->partition_names;" assignment
is made, we will get directly into
'my_error(ER_UNKNOWN_PARTITION, MYF(0), part_name, table->alias);'
as 'partition_names' will include the list of partitions mentioned in the
"DROP PARTITION ..." clause and 'find_or_nullptr()' will not be able to find
already dropped partition in the 'partition_name_hash'.

Fixed by saving the old value of 'partition_names' before calling
'secondary_engine_unload_table()' and restoring it afterwards.

Stabilized 'rocksdb.partition' MTR test case by adding '--sorted_result' to
'SHOW TABLES".