### PR TITLE
PS-8057: Fix initialization of general and slow log file names (8.0.39)

### DIFF
--- a/mysql-test/r/percona_slow_general_log_names.result
+++ b/mysql-test/r/percona_slow_general_log_names.result
@@ -1,0 +1,6 @@
+select @@global.slow_query_log_file;
+@@global.slow_query_log_file
+mysqld.slowlog
+select @@global.general_log_file;
+@@global.general_log_file
+mysqld.general

--- a/mysql-test/t/percona_slow_general_log_names-master.opt
+++ b/mysql-test/t/percona_slow_general_log_names-master.opt
@@ -1,0 +1,6 @@
+--slow_query_log=ON
+--general_log=ON
+--slow_query_log_file=mysqld.slowlog
+--general_log_file=mysqld.general
+--max_slowlog_files=10
+--max_slowlog_size=5000

--- a/mysql-test/t/percona_slow_general_log_names.test
+++ b/mysql-test/t/percona_slow_general_log_names.test
@@ -1,0 +1,3 @@
+--replace_regex /\.\d+//
+select @@global.slow_query_log_file;
+select @@global.general_log_file;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-8057

In case general and slow log file names are provided in config and slow log rotation is enabled, slow_query_log_file system variable gets initialized with general log name.

The reason of the issue is that code responsible for slow and general logs handling have many in common and during initial log names initialization code responsible for slow log rotation was ivoked while initializing general log name.

To fix the issue there was a checkup added to make sure code related to slow log rotation is not invoked while general log file name is being processed.