### PR TITLE
PS-9314 fix: Signal 11 when using JSON_TABLE (8.0)

### DIFF
--- a/mysql-test/r/func_str.result
+++ b/mysql-test/r/func_str.result
@@ -5299,6 +5299,11 @@ is null
 DROP PROCEDURE p1;
 DROP TABLE t1;
 #
+# PS-9314: Signal 11 when using JSON_TABLE
+# (https://perconadev.atlassian.net/browse/PS-9314)
+SELECT ele AS domain FROM JSON_TABLE('["TEST' + (SELECT LOAD_FILE('test')) + '"]', "$[*]" COLUMNS (ele VARCHAR(70) PATH "$" )) AS json_elements;
+ERROR 22032: Invalid data type for JSON data in argument 1 to function json_table; a JSON string or JSON type is required.
+#
 # Bug #32163391 ASSERTION `CRC32_Z(CRC, POS, LENGTH)
 #               < STD::NUMERIC_LIMITS<HA_CHECKSUM>::MAX()' FAILED.
 do crc32(char(1.134475e+308));

--- a/mysql-test/t/func_str.test
+++ b/mysql-test/t/func_str.test
@@ -2182,6 +2182,12 @@ DROP TABLE t1;
 remove_file $file;
 
 --echo #
+--echo # PS-9314: Signal 11 when using JSON_TABLE
+--echo # (https://perconadev.atlassian.net/browse/PS-9314)
+--error ER_INVALID_TYPE_FOR_JSON
+SELECT ele AS domain FROM JSON_TABLE('["TEST' + (SELECT LOAD_FILE('test')) + '"]', "$[*]" COLUMNS (ele VARCHAR(70) PATH "$" )) AS json_elements;
+
+--echo #
 --echo # Bug #32163391 ASSERTION `CRC32_Z(CRC, POS, LENGTH)
 --echo #               < STD::NUMERIC_LIMITS<HA_CHECKSUM>::MAX()' FAILED.
 

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -1043,9 +1043,6 @@ class Item_load_file final : public Item_str_func {
     func_arg->banned_function_name = func_name();
     return true;
   }
-
-  // prevent caching of the item value in Item_func_isnull
-  table_map used_tables() const override { return (table_map)1L; }
 };
 
 class Item_func_export_set final : public Item_str_func {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9314

As part of the 8.0.22 merge we added our fix (commit e29ddfe) for Oracle's Bug #101401
"ISNULL continously returns the same value for LOAD_FILE" (https://bugs.mysql.com/bug.php?id=101401)
However, when Oracle fixed the same issue in 8.0.23, Bug #32096341
"ISNULL continuously returns the same value for LOAD_FILE" (commit mysql/mysql-server@de4b3f7), ou fix never got reverted, which introduced this regression.

Fixed by reverting our patch.

Extended 'main.func_str' MTR test case with additional checks for this particular regression.