### PR TITLE
PS-9352 Avoid out of bounds access due to ulong bitmask

### DIFF
--- a/sql/auth/sql_authorization.cc
+++ b/sql/auth/sql_authorization.cc
@@ -2931,6 +2931,7 @@ void get_privilege_desc(char *to, uint max_length, ulong access)
     max_length--;                               // Reserve place for end-zero
     for (pos=0 ; access ; pos++, access>>=1)
     {
+      if (pos >= array_elements(command_lengths)) break;
       if ((access & 1) &&
           command_lengths[pos] + (uint) (to-start) < max_length)
       {


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9352

Bug#35507223 mysql/mysql-server@3a27636ac1b

In MySQL 8.0 there are cases in which ~NO_ACCESS bitmask is passed as "access" argument to get_privilege_desc() function. In the past, before Bug#35507223 was fixed, this could have caused crash due to out of bounds array access.

Since we can't totally exclude that the same thing is possible in 5.7 branch we have decided to fix potential problem there as well, by adding simple check for out of bounds array access.