### PR TITLE
PS-9293 Fixes of tests for release-8.0.39-30

### DIFF
--- a/mysql-test/r/resource_group_bugs.result
+++ b/mysql-test/r/resource_group_bugs.result
@@ -37,11 +37,11 @@ PREPARE stmt1 FROM 'SELECT /*+ RESOURCE_GROUP(r1) */ processlist_info, resource_
 # as well (it didn't before the fix).
 EXECUTE stmt1;
 processlist_info	resource_group
-EXECUTE stmt1	r1
+SELECT /*+ RESOURCE_GROUP(r1) */ processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	r1
 # Check that hint applies in case of re-execution.
 EXECUTE stmt1;
 processlist_info	resource_group
-EXECUTE stmt1	r1
+SELECT /*+ RESOURCE_GROUP(r1) */ processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	r1
 # Check that further statements in the connection are not affected.
 SELECT processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id();
 processlist_info	resource_group
@@ -53,25 +53,25 @@ PREPARE stmt3 FROM 'SELECT processlist_info, resource_group FROM performance_sch
 # The first statement should still use 'r1',
 EXECUTE stmt1;
 processlist_info	resource_group
-EXECUTE stmt1	r1
+SELECT /*+ RESOURCE_GROUP(r1) */ processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	r1
 # The second statement should use 'r2',
 EXECUTE stmt2;
 processlist_info	resource_group
-EXECUTE stmt2	r2
+SELECT /*+ RESOURCE_GROUP(r2) */ processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	r2
 # The third one should used default group.
 EXECUTE stmt3;
 processlist_info	resource_group
-EXECUTE stmt3	USR_default
+SELECT processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	USR_default
 # Ditto for case of re-execution.
 EXECUTE stmt1;
 processlist_info	resource_group
-EXECUTE stmt1	r1
+SELECT /*+ RESOURCE_GROUP(r1) */ processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	r1
 EXECUTE stmt2;
 processlist_info	resource_group
-EXECUTE stmt2	r2
+SELECT /*+ RESOURCE_GROUP(r2) */ processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	r2
 EXECUTE stmt3;
 processlist_info	resource_group
-EXECUTE stmt3	USR_default
+SELECT processlist_info, resource_group FROM performance_schema.threads WHERE processlist_id = connection_id()	USR_default
 # Clean-up.
 DEALLOCATE PREPARE stmt1;
 DEALLOCATE PREPARE stmt2;

--- a/mysql-test/suite/auth_sec/r/grant_as_ddl.result
+++ b/mysql-test/suite/auth_sec/r/grant_as_ddl.result
@@ -1,5 +1,6 @@
 SET @start_partial_revokes = @@global.partial_revokes;
 SET @@global.partial_revokes=ON;
+RESET MASTER;
 SET @@global.partial_revokes = ON;
 SELECT @@global.partial_revokes;
 @@global.partial_revokes

--- a/mysql-test/suite/auth_sec/t/grant_as_ddl.test
+++ b/mysql-test/suite/auth_sec/t/grant_as_ddl.test
@@ -14,6 +14,7 @@
 # Set partial revokes to ON
 SET @start_partial_revokes = @@global.partial_revokes;
 SET @@global.partial_revokes=ON;
+RESET MASTER;
 
 --disable_query_log
 CALL mtr.add_suppression("one or more privileges granted through");


### PR DESCRIPTION
Following fixes added

https://perconadev.atlassian.net/browse/PS-9293

***

Proper reset before test added.
To reproduce the test failure on prev. code, run
./mtr auth_sec.system_user_priv auth_sec.grant_as_ddl --no-reorder
(Solution by Venkatesh Prasad)

***
New release just added SQL echo of prepared statement. Test results
re-recorded for the "resource_group_bugs" test

