### PR TITLE
PS-9286 KMIP key activation implementation (8.4)

### DIFF
--- a/components/keyrings/keyring_kmip/backend/backend.cc
+++ b/components/keyrings/keyring_kmip/backend/backend.cc
@@ -110,6 +110,9 @@ bool Keyring_kmip_backend::store(const Metadata &metadata,
     if (id.empty()) {
       return true;
     }
+    if (!ctx.op_activate(id)) {
+      return true;
+    }
     data.set_extension({id});
   } catch (...) {
     mysql_components_handle_std_exception(__func__);


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9286

extra/libkmip head is at baf6832 with activate operation implementation. keyring_kmip/backend/backend.cc updateed to execute op_activate after key registration.