### PR TITLE
PS-9328: Merge 8.4.2 - Revert fix for PS-9125 Fix gtid_next formattin…

### DIFF
--- a/sql/rpl_gtid_specification.cc
+++ b/sql/rpl_gtid_specification.cc
@@ -143,7 +143,6 @@ std::size_t Gtid_specification::automatic_to_string(char *buf) const {
     pos += automatic_tag.to_string(buf + pos);
     buf[pos++] = '\0';
   }
-  buf[pos] = '\0';
   return pos;
 }
 


### PR DESCRIPTION
…g in Gtid_specification::automatic_to_string()

Reverting Percona Server version of the fix for PS-9125 as it became unnecessary after Upstream's fix for bug#36308318 "GTID_NEXT accepts Invalid value and also select shows wrong value".

For details see:
https://github.com/mysql/mysql-server/commit/a8c7f9bc16e16cb8095249ccf01a7e5641b4aa87 https://github.com/mysql/mysql-server/commit/2bb7af153b0e0603f939240be4d0cad01c89bd89