### PR TITLE
PS-9293, PS-9328: Revert of fix for PS-7221: Bug #100402 (crash on se… (8.0 version).

### DIFF
--- a/sql/tztime.cc
+++ b/sql/tztime.cc
@@ -557,7 +557,6 @@ static my_time_t TIME_to_gmt_sec(const MYSQL_TIME *t, const TIME_ZONE_INFO *sp,
   String with names of SYSTEM time zone.
 */
 static const String tz_SYSTEM_name("SYSTEM", 6, &my_charset_latin1);
-static const String tz_UTC_name("UTC", 3, &my_charset_latin1);
 
 Time_zone *my_tz_find(const int64 displacement);
 
@@ -819,10 +818,19 @@ void Time_zone_utc::gmt_sec_to_TIME(MYSQL_TIME *tmp, my_time_t t) const {
   SYNOPSIS
     get_name()
 
+  DESCRIPTION
+    Since Time_zone_utc is used only internally by SQL's UTC_* functions it
+    is not accessible directly, and hence this function of Time_zone
+    interface is not implemented for this class and should not be called.
+
   RETURN VALUE
-    Name of time zone as String
+    0
 */
-const String *Time_zone_utc::get_name() const { return &tz_UTC_name; }
+const String *Time_zone_utc::get_name() const {
+  /* Should be never called */
+  assert(0);
+  return nullptr;
+}
 
 /*
   Instance of this class represents some time zone which is


### PR DESCRIPTION
…lect Sys_var_tz::session_value_ptr)

Reverting Percona Server's version of the fix which is no longer necessary. Upstream fixed this issue in a different, more complex, but also probably more clean way in their fix for bug#31168097 "SIG 6 ASSERTION `0' IN TIME_ZONE_UTC::GET_NAME AT TZTIME.CC:1182".

See: https://github.com/mysql/mysql-server/commit/1f8c02ec0cf40bc70ba074a1b83882e11228b9f6

The test case for this issue is kept around.