### PR TITLE
PS-9328 merge: Merge 8.4.2 - Fixed gcc-12 RelWithDebInfo compilation warnings

### DIFF
--- a/router/src/routing/tests/CMakeLists.txt
+++ b/router/src/routing/tests/CMakeLists.txt
@@ -27,6 +27,10 @@ IF(MY_COMPILER_IS_CLANG)
   STRING_APPEND(CMAKE_CXX_FLAGS " -Wno-deprecated")
 ENDIF()
 
+IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
+  ADD_COMPILE_FLAGS(test_next_available.cc COMPILE_FLAGS "-Wno-restrict")
+ENDIF()
+
 # routing-library as object-lib for testing
 STATICLIB_FROM_TARGET(routing_export_all routing)
 TARGET_COMPILE_DEFINITIONS(routing_export_all

--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -312,7 +312,15 @@ IF(LINUX_ALPINE)
 ENDIF()
 
 IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 12)
-  ADD_COMPILE_FLAGS(regexp_engine-t.cc COMPILE_FLAGS "-Wno-restrict")
+  ADD_COMPILE_FLAGS(
+    regexp_engine-t.cc
+    gis_area-t.cc
+    gis_is_simple-t.cc
+    gis_isvalid-t.cc
+    gis_relops-t.cc
+    gis_setops-t.cc
+    COMPILE_FLAGS "-Wno-restrict"
+  )
 ENDIF()
 
 IF(WIN32)


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9328

Suppressed '-Wrestrict' warnings in selected GIS and Router unit tests.

/usr/include/c++/12/bits/char_traits.h:435:56: error: ‘void* __builtin_memcpy(void*, const void*, long unsigned int)’ accessing 9223372036854775810 or more bytes at offsets [2, 9223372036854775807] and 1 may overlap up to 9223372036854775813 bytes at offset -3 [-Werror=restrict]
  435 |         return static_cast<char_type*>(__builtin_memcpy(__s1, __s2, __n));
      |                                        ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~