### PR TITLE
PS-9378: Backport PS-9302 (WRITESET perf improvements) to 8.0 (8.0)

### DIFF
--- a/sql/rpl_trx_tracking.h
+++ b/sql/rpl_trx_tracking.h
@@ -27,7 +27,7 @@
 #include <assert.h>
 #include <sys/types.h>
 #include <atomic>
-#include <map>
+#include <unordered_map>
 
 #include "libbinlogevents/include/binlog_event.h"
 
@@ -157,7 +157,7 @@ class Writeset_trx_dependency_tracker {
     Track the last transaction sequence number that changed each row
     in the database, using row hashes from the writeset as the index.
   */
-  typedef std::map<uint64, int64> Writeset_history;
+  typedef std::unordered_map<uint64, int64> Writeset_history;
   Writeset_history m_writeset_history;
 };
 


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9378

This patch was originally created for the 8.4 branch where the only
available binlog transaction dependency tracking mode is 'WRITESET'.
However, it also makes sense to backport this to 8.0 as the same
code paths are used when user explicitly set the
'binlog_transaction_dependency_tracking' system variable to 'WRITESET'
(by default in 8.0 series, this variable is set to 'COMMIT_ORDER').

Cherry-picked PS-9302
"Improve performance for binlog_transaction_dependency_tracking=WRITESET"
(https://perconadev.atlassian.net/browse/PS-9302) from 8.4.

Problem:
Comparing to 8.0 where the default value of
binlog_transaction_dependency_tracking was COMMIT_ORDER, 8.4 introduces a visible write performance drop.

Cause:
8.4 uses WRITESET dependency tracking. For this tracking we maintain a map of binlog_transaction_dependency_history_size for row_id to newest transaction sequence_number which modified a given row. Every new transaction needs to check its dependency by examining the map (find), which is done with logarithmic complexity.

Solution:
Change std::map to std::unordered_map. This allows us to find a row dependency in constant on average complexity.