### PR TITLE
PS-9328: Disabled rocksdb.non_blocking_manual_compaction test (8.4 version)

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -86,6 +86,12 @@ perfschema.idx_compare_ews_by_thread_by_event_name : BUG#31041671
 perfschema.idx_compare_ews_by_instance : BUG#31791537
 perfschema.idx_compare_rwlock_instances : BUG#31791537
 
+# rocksdb suite tests
+rocksdb.non_blocking_manual_compaction : BUG#0000 PS-9381 Often fails in Jenkins due to races.
+
+# rocksdb_stress suite tests
+rocksdb_stress.drop_cf_stress : BUG#0000 PS-9381 Often fails in Jenkins due to races.
+
 # rpl_gtid suite tests
 rpl_gtid.rpl_async_conn_failover_restart @windows : BUG#34132168 Disabled until bug is fixed
 rpl_gtid.rpl_gtid_truncate_memory_table_after_start_server : BUG#24351040


### PR DESCRIPTION
Disabled rocksdb.non_blocking_manual_compaction test which often fails in Jenkins due to race in it and which turned out is non-trivial to fix.