### PR TITLE
PS-9328: Fix sporadic rpl.rpl_backup_locked_by_applier test failures (8.0 version)

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_backup_locked_by_applier.result
+++ b/mysql-test/suite/rpl/r/rpl_backup_locked_by_applier.result
@@ -23,8 +23,8 @@ ERROR HY000: Lock wait timeout exceeded; try restarting transaction
 #
 # Unblock applier
 #
-SET DEBUG_SYNC = 'now SIGNAL continue_purge_applied_logs_after_backup_lock';
 # Removing debug point 'syncpoint_purge_applied_logs_after_backup_lock' from @@GLOBAL.debug
+SET DEBUG_SYNC = 'now SIGNAL continue_purge_applied_logs_after_backup_lock';
 #
 # Wait for replica to process the rest of the binlog
 #

--- a/mysql-test/suite/rpl/t/rpl_backup_locked_by_applier.test
+++ b/mysql-test/suite/rpl/t/rpl_backup_locked_by_applier.test
@@ -51,10 +51,10 @@ LOCK INSTANCE FOR BACKUP;
 --echo # Unblock applier
 --echo #
 
-SET DEBUG_SYNC = 'now SIGNAL continue_purge_applied_logs_after_backup_lock';
-
 --let $debug_point = syncpoint_purge_applied_logs_after_backup_lock
 --source include/remove_debug_point.inc
+
+SET DEBUG_SYNC = 'now SIGNAL continue_purge_applied_logs_after_backup_lock';
 
 --echo #
 --echo # Wait for replica to process the rest of the binlog


### PR DESCRIPTION
Fixed sporadic rpl.rpl_backup_locked_by_applier test failures which were caused by race condition in the test case.

Logic of the test assumes that conditional debug sync point in Rpl_applier_reader::purge_applied_logs(), which is used in this test, is supposed to be activated only once, when replication thread reaches it for the first time. The test case waits for this event, runs some commands to check that backup lock can't be taken, and then resumes execution of replication thread. After that it disables this conditional sync point.

However, if replication thread manages to reach this sync point for the second time, after test has resumed its execution and right before conditional sync point is disabled, it will wait on sync point until timeout is reached. As result the fact that debug sync point was reached but not handled will be detected during post test case check and cause its failure.

We fix this problem by moving disabling conditional sync point before we resume replication thread execution when sync point is reached for the first time.

The fix is applied to both 8.0 and 8.4 trees, since they are both affected.