### PR TITLE
PS-9328: Fix for failures to shutdown server after execution of threadpool_debug test (8.0 version)

### DIFF
--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -1197,6 +1197,7 @@ bool Thread_pool_connection_handler::add_connection(
 
   if (unlikely(!thd)) {
     channel_info->send_error_and_close_channel(ER_OUT_OF_RESOURCES, 0, false);
+    Connection_handler_manager::dec_connection_count();
     DBUG_RETURN(true);
   }
 
@@ -1206,6 +1207,7 @@ bool Thread_pool_connection_handler::add_connection(
     thd->get_protocol_classic()->end_net();
     delete thd;
     channel_info->send_error_and_close_channel(ER_OUT_OF_RESOURCES, 0, false);
+    Connection_handler_manager::dec_connection_count();
     DBUG_RETURN(true);
   }
 


### PR DESCRIPTION
…dpool_debug test.

Problem:
========
MTR was unable to properly shutdown Percona Server after execution of threadpool_debug test and had to resort to killing it with SIGKILL.

Analysis:
=========
threadpool_debug test simulates OOM situation when creating new THD objects while processing new connections using threadpool plugin. This is done by injecting and error in Thread_pool_connection_handler::add_connection() method. The problem occurred because we failed to correctly decrement connections count before returning from this method in case of error, like it is done in add_connection() methods for other connection handlers. As result during server shutdown we tried to wait indefinitely until total number of connections will become 0, which never happened since the connections which we failed to create due to simulated OOM were counted as existing (even though they didn't really).

Note that the above means that failure to properly shutdown probably could have been observed on user systems which use threadpool plugin in cases when establishment of new connections failed due to OOM. OTOH Percona Server/MySQL is likely to hit more serious problems in case of OOM anyway.

Solution:
=========
Thread_pool_connection_handler::add_connection() now decrements connection count in case of its failure as implementations of add_connection() for other connection handlers do.

Fix is applied to both 8.0 and 8.4 as both branches are affected by this issue.