### PR TITLE
PS-9328: Fix for sporadic index_merge_innodb test failures.

### DIFF
--- a/mysql-test/include/index_merge1.inc
+++ b/mysql-test/include/index_merge1.inc
@@ -516,7 +516,11 @@ if ($eval_before_analyze)
 {
   eval $eval_before_analyze;
 }
-analyze table t0;
+# We use OPTIMIZE instead of ANALYZE here to handle the case when InnoDB
+# purge threads do not manage to keep up and completely remove records which
+# were marked for deletion earlier, which affects row count estimations in
+# EXPLAIN below.
+optimize table t0;
 -- enable_result_log
 -- enable_query_log
 


### PR DESCRIPTION
Sporadic index_merge_innodb test failures occurred when InnoDB purge threads were unable to keep up with removing rows which were marked for deletion. The presence of these rows affected row count estimations making EXPLAIN output differ.

Fixed by running OPTIMIZE TABLE to ensure delete-marked rows removal prior to running EXPLAIN that failed.