### PR TITLE
PS-9328: Fix for sporadic rpl.rpl_json test failures.

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_json.result
+++ b/mysql-test/suite/rpl/r/rpl_json.result
@@ -1207,7 +1207,7 @@ nkey	jcol
 4	{"12": "uciov", "13": "ierdna", "14": "elisav", "15": "namor", "16": "jugcvb"}
 5	{"1": "ailemac", "2": "nielk", "3": "nuicarc", "4": "ihcseruj", "5": "qweasdas"}
 6	[1, 2, 3, 4, 5]
-SELECT JSON_OBJECTAGG(t1.pkey, t2.jcol) FROM data_table AS t1, json_data AS t2;
+SELECT /*+ JOIN_ORDER(t1, t2) */ JSON_OBJECTAGG(t1.pkey, t2.jcol) FROM data_table AS t1, json_data AS t2;
 JSON_OBJECTAGG(t1.pkey, t2.jcol)
 {"1": [1, 2, 3, 4, 5], "2": [1, 2, 3, 4, 5], "3": [1, 2, 3, 4, 5], "4": [1, 2, 3, 4, 5], "5": [1, 2, 3, 4, 5]}
 SELECT JSON_ARRAYAGG(jcol) FROM json_data;

--- a/mysql-test/suite/rpl/t/rpl_json.test
+++ b/mysql-test/suite/rpl/t/rpl_json.test
@@ -271,7 +271,7 @@ INSERT INTO json_data(jcol) SELECT JSON_ARRAYAGG(pkey) FROM data_table;
 --echo # Check whether tables were created on the slave
 
 SELECT * FROM json_data;
-SELECT JSON_OBJECTAGG(t1.pkey, t2.jcol) FROM data_table AS t1, json_data AS t2;
+SELECT /*+ JOIN_ORDER(t1, t2) */ JSON_OBJECTAGG(t1.pkey, t2.jcol) FROM data_table AS t1, json_data AS t2;
 SELECT JSON_ARRAYAGG(jcol) FROM json_data;
 
 --let $diff_tables = master:json_data, slave:json_data


### PR DESCRIPTION
Results from JSON_OBJECTAGG aggregate function can depend on the order in which rows are returned by SELECT clause, in cases when it can get duplicate values as its "key" argument. However, such order is not guaranteed in general case and can, for example, depend on the order in which tables are joined.

rpl.rpl_json test has failed sporadically, when one of its queries that uses JSON_OBJECTAGG in such an ambigous context, was executed using different join order.

This fix solves the problem by enforcing fixed join order for this query.