### PR TITLE
PS-9328: Fix valgrind errors in test_services.test_execute_prepared_s…

### DIFF
--- a/sql/statement/protocol_local_v2.cc
+++ b/sql/statement/protocol_local_v2.cc
@@ -290,13 +290,13 @@ void Protocol_local_v2::start_row() {
     /* Reuse row. */
     Row<value_t> *row = (*m_data_rows)[m_current_row_index];
     m_current_row = row->get_column_array();
-    memset((void *)m_current_row, 0, sizeof(value_t) * m_column_count);
+    for (size_t i = 0; i < m_column_count; ++i)
+      m_current_row[i] = std::monostate{};
     m_current_column = m_current_row;
 
   } else {
     /* Start a new row. */
-    m_current_row = static_cast<value_t *>(
-        m_result_set_mem_root.Alloc(sizeof(value_t) * m_column_count));
+    m_current_row = m_result_set_mem_root.ArrayAlloc<value_t>(m_column_count);
     m_current_column = m_current_row;
   }
 


### PR DESCRIPTION
…tatement test.

Implementation of "mysql_statement_service" service which allows to execute normal and prepared SQL statements from components, didn't initialize arrays of value_t objects which it used to represent rows produced by SQL statement.

As result valgrind errors were generated when test_execute_prepared_statement test used this service and the service code tried to store some values in such a uninitialized array. This was done using value_t's "operator =". And since value_t is a specialization of std::variant template, its "operator =" needs to read old data in object being assigned into to correctly handle disposal of old value stored in it (and this old data was uninitialized in this case).

This patch fixes the problem by ensuring that we call default value_t constructor for elements of array in question after its allocation. It also fixes code which resets such arrays before reuse, instead of filling it with zeros using memset() (which is not guaranteed to work in general case), we simply reset each element of array by assigning std::monostate to it.