### PR TITLE
PS-9453: percona_telemetry causes a long wait on COND_thd_list due to the absence of the root user

### DIFF
--- a/mysql-test/r/grant.result
+++ b/mysql-test/r/grant.result
@@ -831,7 +831,9 @@ show grants for mysqltest_8;
 Grants for mysqltest_8@%
 GRANT USAGE ON *.* TO `mysqltest_8`@`%`
 GRANT UPDATE ON `test`.`t1` TO `mysqltest_8`@`%`
-select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
+select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql')
+and not (grantee = "'mysql.session'@'localhost'"
+and table_name in ('component', 'replication_group_members'));
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
 'mysqltest_8'@'%'	def	test	t1	UPDATE	NO
 'mysqltest_8'@''	def	test	t1	UPDATE	NO
@@ -845,7 +847,9 @@ GRANT USAGE ON *.* TO `mysqltest_8`@``
 show grants for mysqltest_8;
 Grants for mysqltest_8@%
 GRANT USAGE ON *.* TO `mysqltest_8`@`%`
-select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
+select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql')
+and not (grantee = "'mysql.session'@'localhost'"
+and table_name in ('component', 'replication_group_members'));
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
 flush privileges;
 show grants for mysqltest_8@'';

--- a/mysql-test/r/information_schema_ci.result
+++ b/mysql-test/r/information_schema_ci.result
@@ -544,7 +544,9 @@ grant select (a) on test.t1 to joe@localhost with grant option;
 select * from INFORMATION_SCHEMA.COLUMN_PRIVILEGES WHERE table_schema != 'sys';
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	COLUMN_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
 'joe'@'localhost'	def	test	t1	a	SELECT	YES
-select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql');
+select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql')
+and not (grantee = "'mysql.session'@'localhost'"
+and table_name in ('component', 'replication_group_members'));
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
 drop view v1, v2, v3;
 drop table t1;

--- a/mysql-test/r/information_schema_cs.result
+++ b/mysql-test/r/information_schema_cs.result
@@ -544,7 +544,9 @@ grant select (a) on test.t1 to joe@localhost with grant option;
 select * from INFORMATION_SCHEMA.COLUMN_PRIVILEGES WHERE table_schema != 'sys';
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	COLUMN_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
 'joe'@'localhost'	def	test	t1	a	SELECT	YES
-select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql');
+select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql')
+and not (grantee = "'mysql.session'@'localhost'"
+and table_name in ('component', 'replication_group_members'));
 GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
 drop view v1, v2, v3;
 drop table t1;

--- a/mysql-test/r/transactional_acl_tables.result
+++ b/mysql-test/r/transactional_acl_tables.result
@@ -1342,7 +1342,9 @@ SELECT host, db, user, table_name, column_name, column_priv FROM mysql.columns_p
 host	db	user	table_name	column_name	column_priv
 h	test	u1	t1	a	Select,Insert,Update,References
 h	test	u1	t2	a	Insert
-SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv;
+SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv
+WHERE NOT (user = 'mysql.session'
+AND table_name IN ('component', 'replication_group_members'));
 host	db	user	table_name	grantor	table_priv	column_priv
 h	test	u1	t1	root@localhost		Select,Insert,Update,References
 h	test	u1	t2	root@localhost		Insert
@@ -1354,7 +1356,9 @@ COMMIT;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM u1@h;
 SELECT host, db, user, table_name, column_name, column_priv FROM mysql.columns_priv;
 host	db	user	table_name	column_name	column_priv
-SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv;
+SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv
+WHERE NOT (user = 'mysql.session'
+AND table_name IN ('component', 'replication_group_members'));
 host	db	user	table_name	grantor	table_priv	column_priv
 localhost	mysql	mysql.session	user	root@localhost	Select	
 localhost	sys	mysql.sys	sys_config	root@localhost	Select	

--- a/mysql-test/suite/component_percona_telemetry/r/no_user.result
+++ b/mysql-test/suite/component_percona_telemetry/r/no_user.result
@@ -1,0 +1,31 @@
+SELECT * FROM information_schema.table_privileges WHERE grantee = "'mysql.session'@'localhost'" ORDER BY table_schema, table_name;
+GRANTEE	TABLE_CATALOG	TABLE_SCHEMA	TABLE_NAME	PRIVILEGE_TYPE	IS_GRANTABLE
+'mysql.session'@'localhost'	def	mysql	component	SELECT	NO
+'mysql.session'@'localhost'	def	mysql	user	SELECT	NO
+'mysql.session'@'localhost'	def	performance_schema	replication_group_members	SELECT	NO
+SHOW GRANTS FOR 'mysql.session'@'localhost';
+Grants for mysql.session@localhost
+GRANT SHUTDOWN, SUPER, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO `mysql.session`@`localhost`
+GRANT AUDIT_ABORT_EXEMPT,AUTHENTICATION_POLICY_ADMIN,BACKUP_ADMIN,CLONE_ADMIN,CONNECTION_ADMIN,FIREWALL_EXEMPT,PERSIST_RO_VARIABLES_ADMIN,SESSION_VARIABLES_ADMIN,SYSTEM_USER,SYSTEM_VARIABLES_ADMIN ON *.* TO `mysql.session`@`localhost`
+GRANT SELECT ON `performance_schema`.* TO `mysql.session`@`localhost`
+GRANT SELECT ON `mysql`.`component` TO `mysql.session`@`localhost`
+GRANT SELECT ON `mysql`.`user` TO `mysql.session`@`localhost`
+GRANT SELECT ON `performance_schema`.`replication_group_members` TO `mysql.session`@`localhost`
+# restart:--percona_telemetry.grace_interval=30 --percona_telemetry.scrape_interval=30 --percona_telemetry.telemetry_root_dir=<telemetry_root_dir>
+RENAME USER 'root'@'localhost' to 'root.tmp'@'localhost';
+Warnings:
+Warning	4005	User 'root'@'localhost' is referenced as a definer account in a stored routine.
+Warning	4005	User 'root'@'localhost' is referenced as a definer account in a trigger.
+'root' user used by component's 1st verison does not exist. Telemetry dir should contain 1 file.
+1
+RENAME USER 'root.tmp'@'localhost' to 'root'@'localhost';
+Warnings:
+Warning	4005	User 'root'@'localhost' is referenced as a definer account in a stored routine.
+Warning	4005	User 'root'@'localhost' is referenced as a definer account in a trigger.
+# restart:--percona_telemetry.grace_interval=30 --percona_telemetry.scrape_interval=30 --percona_telemetry.telemetry_root_dir=<telemetry_root_dir>
+RENAME USER 'mysql.session'@'localhost' to 'mysql.session.tmp'@'localhost';
+include/assert.inc [No orphaned sessions expected in processlist]
+'mysql.session' user used by component does not exist. Telemetry dir should still contain 1 file.
+1
+RENAME USER 'mysql.session.tmp'@'localhost' to 'mysql.session'@'localhost';
+# restart:--percona_telemetry.grace_interval=30 --percona_telemetry.scrape_interval=30 --percona_telemetry.telemetry_root_dir=<telemetry_root_dir>

--- a/mysql-test/suite/component_percona_telemetry/t/no_user.test
+++ b/mysql-test/suite/component_percona_telemetry/t/no_user.test
@@ -1,0 +1,70 @@
+# Test that lack of the user used by Percona Telemetry Component
+# doesn't cause hangs during server restart and no orphaned sessions are created.
+
+--source include/have_percona_telemetry.inc
+
+--let $telemetry_root_dir = $MYSQL_TMP_DIR/telemetry_dir
+--let $grace_interval = 30
+--let $scrape_interval = 30
+
+--mkdir $telemetry_root_dir
+
+# Record mysql.session user privileges
+SELECT * FROM information_schema.table_privileges WHERE grantee = "'mysql.session'@'localhost'" ORDER BY table_schema, table_name;
+SHOW GRANTS FOR 'mysql.session'@'localhost';
+
+# restart the server with custom telemetry file path and timeouts
+--let $restart_parameters = "restart:--percona_telemetry.grace_interval=$grace_interval --percona_telemetry.scrape_interval=$scrape_interval --percona_telemetry.telemetry_root_dir=$telemetry_root_dir"
+--replace_regex /telemetry_root_dir=.*telemetry_dir/telemetry_root_dir=<telemetry_root_dir>/
+--source include/restart_mysqld.inc
+
+# Rename 'root' user (1st version of Percona Telemetry Component used 'root' user)
+# 1st version will not collect any data and will not create telemetry file and the restart will hang.
+# Fixed version will work properly as it doesn't use 'root' user.
+RENAME USER 'root'@'localhost' to 'root.tmp'@'localhost';
+
+# sleep more than grace_interval and check that telemetry file was created
+--let $timeout = `select $grace_interval + 10`
+--sleep $timeout
+
+--echo 'root' user used by component's 1st verison does not exist. Telemetry dir should contain 1 file.
+--exec ls -1 $telemetry_root_dir | wc -l
+
+#
+# It should be possible to restart the server.
+#
+RENAME USER 'root.tmp'@'localhost' to 'root'@'localhost';
+--let $restart_parameters = "restart:--percona_telemetry.grace_interval=$grace_interval --percona_telemetry.scrape_interval=$scrape_interval --percona_telemetry.telemetry_root_dir=$telemetry_root_dir"
+--replace_regex /telemetry_root_dir=.*telemetry_dir/telemetry_root_dir=<telemetry_root_dir>/
+--source include/restart_mysqld.inc
+
+
+#
+# Now rename the user used by component
+#
+RENAME USER 'mysql.session'@'localhost' to 'mysql.session.tmp'@'localhost';
+
+# Wait a few cycles and ensure that SHOW PROCESSLIST does not contain rows related to orphaned sessions.
+--let $timeout = `select $grace_interval + 3 * $scrape_interval`
+--sleep $timeout
+
+--let $assert_text = No orphaned sessions expected in processlist
+--let $assert_cond = [SELECT COUNT(*) as Result FROM performance_schema.processlist WHERE user = "mysql.session";, Result, 1] = 0
+--source include/assert.inc
+
+# Check that no new telemetry file was created
+--echo 'mysql.session' user used by component does not exist. Telemetry dir should still contain 1 file.
+--exec ls -1 $telemetry_root_dir | wc -l
+
+
+#
+# It should be still possible to restart the server.
+#
+RENAME USER 'mysql.session.tmp'@'localhost' to 'mysql.session'@'localhost';
+--let $restart_parameters = "restart:--percona_telemetry.grace_interval=$grace_interval --percona_telemetry.scrape_interval=$scrape_interval --percona_telemetry.telemetry_root_dir=$telemetry_root_dir"
+--replace_regex /telemetry_root_dir=.*telemetry_dir/telemetry_root_dir=<telemetry_root_dir>/
+--source include/restart_mysqld.inc
+
+# cleanup
+--force-rmdir $telemetry_root_dir
+

--- a/mysql-test/suite/funcs_1/r/is_table_privileges.result
+++ b/mysql-test/suite/funcs_1/r/is_table_privileges.result
@@ -53,7 +53,9 @@ TABLE_NAME	varchar(64)	NO
 PRIVILEGE_TYPE	varchar(64)	NO			
 IS_GRANTABLE	varchar(3)	NO			
 SELECT table_catalog, table_schema, table_name, privilege_type
-FROM information_schema.table_privileges WHERE table_catalog IS NOT NULL;
+FROM information_schema.table_privileges WHERE table_catalog IS NOT NULL
+AND NOT (grantee = "'mysql.session'@'localhost'"
+AND table_name IN ('component', 'replication_group_members'));
 table_catalog	table_schema	table_name	privilege_type
 def	mysql	user	SELECT
 def	sys	sys_config	SELECT

--- a/mysql-test/suite/funcs_1/t/is_table_privileges.test
+++ b/mysql-test/suite/funcs_1/t/is_table_privileges.test
@@ -64,7 +64,9 @@ eval SHOW COLUMNS FROM information_schema.$is_table;
 # Show that TABLE_CATALOG is always NULL.
 --sorted_result
 SELECT table_catalog, table_schema, table_name, privilege_type
-FROM information_schema.table_privileges WHERE table_catalog IS NOT NULL;
+FROM information_schema.table_privileges WHERE table_catalog IS NOT NULL
+AND NOT (grantee = "'mysql.session'@'localhost'"
+AND table_name IN ('component', 'replication_group_members'));
 
 --echo ######################################################################
 --echo # Testcase 3.2.11.2+3.2.11.3+3.2.11.4:

--- a/mysql-test/suite/innodb/r/log_first_rec_group.result
+++ b/mysql-test/suite/innodb/r/log_first_rec_group.result
@@ -17,15 +17,16 @@ include/assert.inc [All must happen within the single log block (this was requir
 #    value of 5 in first pass, 4 in second).
 SELECT * FROM t;
 a	b
-98	1
-99	2
-100	3
-101	4
-102	5
-103	6
+97	1
+98	2
+99	3
+100	4
+101	5
+102	6
+103	7
 SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't';
 AUTO_INCREMENT
-7
+8
 Pass: 1
 # Initialization - create table, resets autoincrement value.
 # 0. Move to the next log block.
@@ -42,14 +43,15 @@ include/assert.inc [All must happen within the single log block (this was requir
 #    value of 5 in first pass, 4 in second).
 SELECT * FROM t;
 a	b
-98	1
-99	2
-100	3
-101	4
-103	5
+97	1
+98	2
+99	3
+100	4
+101	5
+103	6
 SELECT AUTO_INCREMENT FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = 't';
 AUTO_INCREMENT
-6
+7
 #
 # Scenario 2. Restart after writing full log block with record ending at boundary,
 #             recovery should start in middle of the last written block (pass 0, 2)

--- a/mysql-test/suite/innodb/t/log_first_rec_group.test
+++ b/mysql-test/suite/innodb/t/log_first_rec_group.test
@@ -27,6 +27,7 @@ while ($pass != 2) {
 
   --echo # Initialization - create table, resets autoincrement value.
   CREATE TABLE t (a INT NOT NULL, b INT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE = InnoDB;
+  INSERT INTO t (a) VALUES (97);
   INSERT INTO t (a) VALUES (98);
   INSERT INTO t (a) VALUES (99);
   INSERT INTO t (a) VALUES (100);

--- a/mysql-test/suite/perfschema/t/privilege_table_io-master.opt
+++ b/mysql-test/suite/perfschema/t/privilege_table_io-master.opt
@@ -1,0 +1,1 @@
+--loose-percona-telemetry-disable=ON

--- a/mysql-test/t/grant.test
+++ b/mysql-test/t/grant.test
@@ -655,7 +655,9 @@ flush privileges;
 show grants for mysqltest_8@'';
 show grants for mysqltest_8;
 --sorted_result
-select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
+select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql')
+and not (grantee = "'mysql.session'@'localhost'"
+and table_name in ('component', 'replication_group_members'));
 connect (conn5,localhost,mysqltest_8,,);
 select * from t1;
 disconnect conn5;
@@ -665,7 +667,9 @@ revoke update on t1 from mysqltest_8;
 show grants for mysqltest_8@'';
 show grants for mysqltest_8;
 --sorted_result
-select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql');
+select * from  information_schema.table_privileges where table_schema NOT IN ('sys','mysql')
+and not (grantee = "'mysql.session'@'localhost'"
+and table_name in ('component', 'replication_group_members'));
 flush privileges;
 show grants for mysqltest_8@'';
 show grants for mysqltest_8;

--- a/mysql-test/t/grant_dynamic_session_variables_admin-master.opt
+++ b/mysql-test/t/grant_dynamic_session_variables_admin-master.opt
@@ -1,0 +1,1 @@
+--loose-percona-telemetry-disable=ON

--- a/mysql-test/t/information_schema_cs.test
+++ b/mysql-test/t/information_schema_cs.test
@@ -292,7 +292,10 @@ select * from information_schema.views where table_schema !=
 'sys' order by table_name;
 grant select (a) on test.t1 to joe@localhost with grant option;
 select * from INFORMATION_SCHEMA.COLUMN_PRIVILEGES WHERE table_schema != 'sys';
-select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql');
+select * from INFORMATION_SCHEMA.TABLE_PRIVILEGES WHERE table_schema NOT IN ('sys','mysql')
+and not (grantee = "'mysql.session'@'localhost'"
+and table_name in ('component', 'replication_group_members'));
+
 drop view v1, v2, v3;
 drop table t1;
 delete from mysql.user where user='joe';

--- a/mysql-test/t/mysql_upgrade-master.opt
+++ b/mysql-test/t/mysql_upgrade-master.opt
@@ -1,0 +1,1 @@
+--loose-percona-telemetry-disable=ON

--- a/mysql-test/t/transactional_acl_tables.test
+++ b/mysql-test/t/transactional_acl_tables.test
@@ -1829,14 +1829,18 @@ CREATE TABLE t2 (a INT);
 GRANT SELECT(a), UPDATE(a), INSERT(a), REFERENCES(a) ON t1 TO u1@h;
 GRANT INSERT(a) ON t2 TO u1@h;
 SELECT host, db, user, table_name, column_name, column_priv FROM mysql.columns_priv;
-SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv;
+SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv
+WHERE NOT (user = 'mysql.session'
+AND table_name IN ('component', 'replication_group_members'));
 DELETE FROM mysql.columns_priv WHERE host = 'h' AND user = 'u1'
 AND table_name = 't1';
 COMMIT;
 REVOKE ALL PRIVILEGES, GRANT OPTION FROM u1@h;
 
 SELECT host, db, user, table_name, column_name, column_priv FROM mysql.columns_priv;
-SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv;
+SELECT host, db, user, table_name, grantor, table_priv, column_priv FROM mysql.tables_priv
+WHERE NOT (user = 'mysql.session'
+AND table_name IN ('component', 'replication_group_members'));
 SHOW GRANTS FOR u1@h;
 
 # Check whether on FLUSH PRIVILEGES the GRANT_TABLE::init handles OUT OF MEMORY

--- a/sql/dd/impl/upgrade/server.cc
+++ b/sql/dd/impl/upgrade/server.cc
@@ -959,6 +959,15 @@ bool upgrade_system_schemas(THD *thd) {
 /* 1. We INSERT INTO, because prepared statements do not support
       INSTALL COMPONENT
    2. We use stored procedure to be able to do conditional action.
+   3. Percona Telemetry Component uses mysql.session user. For the component to
+      be fully functional, mysql.session user lacks the following privileges:
+        1. REPLICATION SLAVE
+        2. REPLICATION CLIENT
+        3. SELECT on mysql.component
+        4. SELECT on performance_schema.replication_group_members
+      GRANT does not work yet as ACL is not initialized yet. Use UPDATES.
+      For 3 and 4 we could set Select_priv = 'Y' in mysql.user table for
+      mysql.session user, but let's allow only minimal required privileges.
 */
 static const char *percona_telemetry_install[] = {
     "USE mysql;\n",
@@ -977,6 +986,15 @@ static const char *percona_telemetry_install[] = {
     "PREPARE stmt FROM @str;\n",
     "EXECUTE stmt;\n",
     "DROP PREPARE stmt;\n",
+    "UPDATE mysql.user SET Repl_slave_priv = 'Y' WHERE User = 'mysql.session' "
+    "AND Host = 'localhost';\n",
+    "UPDATE mysql.user SET Repl_client_priv = 'Y' WHERE User = 'mysql.session' "
+    "AND Host = 'localhost';\n",
+    "INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', 'mysql', "
+    "'mysql.session', 'component', 'root@localhost', NOW(), 'Select', '');\n",
+    "INSERT IGNORE INTO mysql.tables_priv VALUES ('localhost', "
+    "'performance_schema', 'mysql.session', 'replication_group_members', "
+    "'root@localhost', NOW(), 'Select', '');\n",
     NULL};
 
 static const char *percona_telemetry_uninstall[] = {

--- a/unittest/gunit/components/percona_telemetry/data_provider-t.cc
+++ b/unittest/gunit/components/percona_telemetry/data_provider-t.cc
@@ -287,7 +287,7 @@ TEST_F(DataProviderTest, collect_se_usage_info_test) {
   const std::string query(
       std::string("SELECT DISTINCT ENGINE FROM information_schema.tables WHERE "
                   "table_schema NOT IN('mysql', 'information_schema', "
-                  "'performance_schema', 'sys');"));
+                  "'performance_schema', 'sys')"));
   const std::string expected_json_key("se_engines_in_use");
   collect_array_info_common(query, expected_json_key,
                             &MockDataProvider::collect_se_usage_info);


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9453

Problem:
If there is no 'root' user (it was renamed) and Percona Telemetry is
enabled, server shutdown stuck.
Additionally SHOW PROCESSLIST reports increasing number of processes
with root user in state 'login'.

Cause:
Percona Telemetry component used hard codded 'root' user used for
querying the server for metrics. If the user is not present,
mysql_command_factory service connect() method fails, however it leaves
opened/orphaned internal MYSQL_SESSION. It is because after opening
MYSQL_SESSION we check if the user exists. It doesn't exist, so the
method returns with STATE_MACHINE_FAILED error.
Caller does not know anything about underlying session, does cleanup,
frees memory. Moreover, the same problem potentially exists even if
the user exists, but cssm_begin_connect() exits with error for any
reason.
Creation of session registers THD object in Global_THD_manager. That's
why increasing number of processes is visible in SHOW PROCESSLIST.

Why it hangs during shutdown:
During shutdown, the server waits for signal handler thread
(signal_hand()) to join the main thread. Then the component
infrastructure is deinitialized. At the same time signal_hand() waits
for all threads to finish Global_THD_manager::wait_till_no_thd().

The above described bug related to orphaned mysql sessions cause that
there are orphaned THDs that never end. This causes server to wait
infinitively.

Solution:
1. Handle the error in cssm_begin_connect() and close opened
MYSQL_SESSION. This part fixes hangs caused by nonexistent user.
2. Percona Telemetry Component uses mysql.session user. When Percona
Telemetry Component is enabled, the user is granted a few more
permissions during the server startup. Note that even without this
permissions, the component is able to work, but not able to report some
metrics.

Additionally fixed potential memory leak if connection setup in Percona
Telemetry Component fails.