### PR TITLE
PS-9455 [trunk]: Add gcc-14 to Azure Pipelines + remove gcc-14 from Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -108,7 +108,7 @@ script_template: &SCRIPT_TEMPLATE
     NPROC=`nproc --all`
     NTHREADS=$(( $NPROC > 16 ? 16 : $NPROC ))
     if [[ "$BUILD_TYPE" == "RelWithDebInfo" ]]; then
-      MTR_TESTS="--suite=main"
+      MTR_TESTS="--suite=binlog_nogtid"
     else
       MTR_TESTS="main.1st"
     fi
@@ -166,7 +166,8 @@ task:
 task:
   << : *FILTER_TEMPLATE
   # run only on "percona/percona-server" but not on "8.0" as we have nightly cron builds for "8.0" branch
-  only_if: "$CIRRUS_CRON != '' || $CIRRUS_REPO_FULL_NAME == 'percona/percona-server' && $CIRRUS_BRANCH != '8.0' && !changesIncludeOnly('doc/*', 'build-ps/*', 'man/*', 'mysql-test/*', 'packaging/*', 'policy/*', 'scripts/*', 'support-files/*')"
+  # only_if: "$CIRRUS_CRON != '' || $CIRRUS_REPO_FULL_NAME == 'percona/percona-server' && $CIRRUS_BRANCH != '8.0' && !changesIncludeOnly('doc/*', 'build-ps/*', 'man/*', 'mysql-test/*', 'packaging/*', 'policy/*', 'scripts/*', 'support-files/*')"
+  only_if: false   # DISABLED
   aws_credentials: ENCRYPTED[!f57794979d3ed96943cd39073b66a4fffbdc3ee6366b265e68c5aae890961d171bddca50bf169cc07db56c8c68172b84!]
   ec2_instance:
     # aws ec2 describe-images --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-2024061*"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -291,11 +291,24 @@ jobs:
 
 
       # gcc-7 and newer compilers
-      gcc-13 RelWithDebInfo [Ubuntu 22.04 Jammy]:
-        imageName: 'ubuntu-22.04'
+      gcc-14 RelWithDebInfo [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
         Compiler: gcc
-        CompilerVer: 13
+        CompilerVer: 14
         BuildType: RelWithDebInfo
+
+      gcc-14 Debug [Ubuntu 24.04 Noble]:
+        imageName: 'ubuntu-24.04'
+        Compiler: gcc
+        CompilerVer: 14
+        BuildType: Debug
+
+      ${{ if or(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['Build.SourceBranchName'], 'fullci')) }}:
+        gcc-13 RelWithDebInfo [Ubuntu 22.04 Jammy]:
+          imageName: 'ubuntu-22.04'
+          Compiler: gcc
+          CompilerVer: 13
+          BuildType: RelWithDebInfo
 
       gcc-13 Debug [Ubuntu 22.04 Jammy]:
         imageName: 'ubuntu-22.04'
@@ -419,7 +432,7 @@ jobs:
         sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
         sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1
 
-        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES cmake cmake-curses-gui ccache bison libudev-dev libaio-dev libmecab-dev libnuma-dev libssl-dev libreadline-dev libedit-dev libpam-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev libsasl2-modules-gssapi-mit || exit 1;
+        sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install $PACKAGES cmake cmake-curses-gui ccache bison libtirpc-dev libudev-dev libaio-dev libmecab-dev libnuma-dev libssl-dev libreadline-dev libedit-dev libpam-dev libcurl4-openssl-dev libldap2-dev libkrb5-dev libsasl2-dev libsasl2-modules-gssapi-mit || exit 1;
         `# SYSTEM_LIBRARIES = CURL EDITLINE ICU LIBEVENT LZ4 PROTOBUF SSL ZSTD FIDO (Ubuntu 21.04+)`
         if [[ "$(BUILD_PARAMS_TYPE)" != "inverted" ]]; then
           sudo -E apt-get -yq --no-install-suggests --no-install-recommends --allow-unauthenticated install libicu-dev libevent-dev liblz4-dev zlib1g-dev protobuf-compiler libprotobuf-dev libprotoc-dev libzstd-dev libfido2-dev || exit 1;


### PR DESCRIPTION
1. Add `gcc-14` to Azure Pipelines
2. Dsiable `gcc-14` from Cirrus CI
3. Test `--suite=binlog_nogtid` for `RelWithDebInfo` in Cirrus CI as  we had timeouts with `--suite=main`.