### PR TITLE
PS-9470 : Code refresh for PS 8.4.3 - post merge MTR fix (fixed auth_…

### DIFF
--- a/mysql-test/suite/auth_sec/r/acl_tables_row_locking.result
+++ b/mysql-test/suite/auth_sec/r/acl_tables_row_locking.result
@@ -128,6 +128,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -139,7 +140,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -158,6 +160,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -169,7 +172,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -185,6 +189,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -196,7 +201,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -215,6 +221,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -226,7 +233,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -242,6 +250,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -253,7 +262,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -272,6 +282,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -283,7 +294,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -299,6 +311,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -310,7 +323,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -329,6 +343,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.user
@@ -340,7 +355,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -359,6 +375,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -370,10 +387,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X	Acquired row lock on u2/u2x
 COMMIT;
 "Case 1.1: Using SERIALIZABLE with SELECT LOCK IN SHARE MODE"
 SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -390,6 +408,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -401,10 +420,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X	Acquired row lock on u2/u2x
 COMMIT;
 "Case 1.2: Start a transaction in REPEATABLE READ"
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
@@ -418,6 +438,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -429,10 +450,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X	Acquired row lock on u2/u2x
 COMMIT;
 "Case 1.2: Using REPEATABLE READ with SELECT LOCK IN SHARE MODE"
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ;
@@ -449,6 +471,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -460,10 +483,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X	Acquired row lock on u2/u2x
 COMMIT;
 "Case 1.3: Start a transaction in READ COMMITTED"
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
@@ -477,6 +501,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -488,10 +513,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
 "Case 1.3: Using READ COMMITTED with SELECT LOCK IN SHARE MODE"
 SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
@@ -508,6 +534,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -519,10 +546,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
 "Case 1.4: Start a transaction in READ UNCOMMITTED"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -536,6 +564,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -547,10 +576,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
 "Case 1.4: Using READ UNCOMMITTED with SELECT LOCK IN SHARE MODE"
 SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
@@ -567,6 +597,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.db
@@ -578,10 +609,11 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
-mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.db	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
+mysql.db	User	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
 # Run the test for all isolation level for table mysql.tables_priv
 "Case 1.1: Start a transaction in SERIALIZABLE"
@@ -598,6 +630,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -609,7 +642,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -629,6 +663,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -640,7 +675,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -657,6 +693,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -668,7 +705,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -688,6 +726,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -699,7 +738,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -716,6 +756,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -727,7 +768,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -747,6 +789,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -758,7 +801,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -775,6 +819,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -786,7 +831,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -806,6 +852,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.tables_priv
@@ -817,7 +864,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.tables_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.tables_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -837,6 +885,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -848,7 +897,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -867,6 +917,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -878,7 +929,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -894,6 +946,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -905,7 +958,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -924,6 +978,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -935,7 +990,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -951,6 +1007,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -962,7 +1019,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -981,6 +1039,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -992,7 +1051,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1008,6 +1068,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -1019,7 +1080,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1038,6 +1100,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.columns_priv
@@ -1049,7 +1112,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.columns_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1068,6 +1132,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1079,7 +1144,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1099,6 +1165,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1110,7 +1177,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1127,6 +1195,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1138,7 +1207,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1158,6 +1228,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1169,7 +1240,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1186,6 +1258,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1197,7 +1270,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1217,6 +1291,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1228,7 +1303,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1245,6 +1321,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1256,7 +1333,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1276,6 +1354,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.procs_priv
@@ -1287,7 +1366,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.procs_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.procs_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1307,6 +1387,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1318,7 +1399,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1338,6 +1420,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1349,7 +1432,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1366,6 +1450,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1377,7 +1462,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1397,6 +1483,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1408,7 +1495,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1425,6 +1513,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1436,7 +1525,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1456,6 +1546,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1467,7 +1558,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1484,6 +1576,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1495,7 +1588,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1515,6 +1609,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.proxies_priv
@@ -1526,7 +1621,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.proxies_priv	Grantor	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 mysql.proxies_priv	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
@@ -1546,6 +1642,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1557,7 +1654,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1576,6 +1674,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1587,7 +1686,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1603,6 +1703,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1614,7 +1715,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1633,6 +1735,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1644,7 +1747,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1660,6 +1764,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1671,7 +1776,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1690,6 +1796,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1701,7 +1808,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1717,6 +1825,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1728,7 +1837,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1747,6 +1857,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.global_grants
@@ -1758,7 +1869,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.global_grants	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1777,6 +1889,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1788,7 +1901,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1807,6 +1921,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1818,7 +1933,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1834,6 +1950,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1845,7 +1962,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1864,6 +1982,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1875,7 +1994,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -1891,6 +2011,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1902,7 +2023,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1921,6 +2043,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1932,7 +2055,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1948,6 +2072,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1959,7 +2084,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -1978,6 +2104,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.password_history
@@ -1989,7 +2116,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.password_history	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2008,6 +2136,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2019,7 +2148,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2038,6 +2168,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2049,7 +2180,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2065,6 +2197,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2076,7 +2209,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2095,6 +2229,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2106,7 +2241,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2122,6 +2258,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2133,7 +2270,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2152,6 +2290,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2163,7 +2302,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2179,6 +2319,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2190,7 +2331,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2209,6 +2351,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT User FROM mysql.default_roles
@@ -2220,7 +2363,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.default_roles	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2239,6 +2383,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2250,7 +2395,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2269,6 +2415,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2280,7 +2427,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2296,6 +2444,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2307,7 +2456,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2326,6 +2476,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2337,7 +2488,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X	Acquired row lock on u2/u2x
 COMMIT;
@@ -2353,6 +2505,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2364,7 +2517,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2383,6 +2537,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2394,7 +2549,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2410,6 +2566,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2421,7 +2578,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2440,6 +2598,7 @@ tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
 (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE
 "Allow the same row to be read for update by SELECT FOR UPDATE"
   connection update_con
 SELECT To_user FROM mysql.role_edges
@@ -2451,7 +2610,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.role_edges	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 COMMIT;
@@ -2473,7 +2633,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2503,7 +2664,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2533,7 +2695,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2561,7 +2724,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2588,7 +2752,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2613,7 +2778,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2641,7 +2807,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2669,7 +2836,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2697,7 +2865,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2726,7 +2895,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2752,7 +2922,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2824,7 +2995,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 mysql.user	PRIMARY	X,GAP	Acquired row lock on u2/u2x
@@ -2854,7 +3026,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -2891,7 +3064,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -2923,7 +3097,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 mysql.user	PRIMARY	X,GAP	Acquired row lock on u2/u2x
@@ -2953,7 +3128,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -2985,7 +3161,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.
@@ -3014,14 +3191,16 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 # Make sure no record locks are held on ACL table.
 SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3062,7 +3241,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3080,7 +3260,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 mysql.user	PRIMARY	X,GAP	Acquired row lock on u2/u2x
@@ -3116,7 +3297,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3142,7 +3324,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3168,7 +3351,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3192,7 +3376,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3215,7 +3400,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3240,7 +3426,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3264,7 +3451,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3288,7 +3476,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3312,7 +3501,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3337,7 +3527,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3361,7 +3552,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3425,7 +3617,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 mysql.user	PRIMARY	X,GAP	Acquired row lock on u2/u2x
@@ -3451,7 +3644,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3486,7 +3680,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -3516,7 +3711,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 mysql.user	PRIMARY	X,GAP	Acquired row lock on u2/u2x
@@ -3544,7 +3740,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -3574,7 +3771,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.
@@ -3599,14 +3797,16 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 # Make sure no record locks are held on ACL table.
 SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3641,7 +3841,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3659,7 +3860,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X	Acquired row lock on u2/u2x
 mysql.user	PRIMARY	X,GAP	Acquired row lock on u2/u2x
@@ -3693,7 +3895,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3719,7 +3922,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3745,7 +3949,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3769,7 +3974,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3792,7 +3998,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3815,7 +4022,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3839,7 +4047,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3863,7 +4072,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3887,7 +4097,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3912,7 +4123,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -3936,7 +4148,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4000,7 +4213,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.
@@ -4025,7 +4239,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4060,7 +4275,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -4090,7 +4306,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -4117,7 +4334,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -4147,7 +4365,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.
@@ -4172,14 +4391,16 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 # Make sure no record locks are held on ACL table.
 SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4214,7 +4435,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4232,7 +4454,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.
@@ -4265,7 +4488,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4291,7 +4515,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4317,7 +4542,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4341,7 +4567,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4364,7 +4591,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4387,7 +4615,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4411,7 +4640,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4435,7 +4665,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4459,7 +4690,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4484,7 +4716,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4508,7 +4741,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4572,7 +4806,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.
@@ -4597,7 +4832,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4632,7 +4868,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -4662,7 +4899,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -4689,7 +4927,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	S,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL tables.
@@ -4719,7 +4958,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.
@@ -4744,14 +4984,16 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 # Make sure no record locks are held on ACL table.
 SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4786,7 +5028,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 DELETE FROM mysql.user WHERE User='u2';
 INSERT INTO mysql.user SELECT * FROM user_bk;
@@ -4804,7 +5047,8 @@ SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
 tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
 FROM performance_schema.data_locks
 WHERE LOCK_TYPE='RECORD' AND
-(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+(LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+ORDER BY tab,INDEX_NAME,LOCK_MODE;
 tab	INDEX_NAME	LOCK_MODE	Has_lock
 mysql.user	PRIMARY	X,REC_NOT_GAP	Acquired row lock on u2/u2x
 # Make sure that we do not allow updating ACL table.

--- a/mysql-test/suite/auth_sec/t/acl_tables_row_locking.test
+++ b/mysql-test/suite/auth_sec/t/acl_tables_row_locking.test
@@ -86,7 +86,8 @@ let query_row_locks= SELECT CONCAT(OBJECT_SCHEMA,'.',OBJECT_NAME)
   tab,INDEX_NAME,LOCK_MODE, 'Acquired row lock on u2/u2x' AS Has_lock
   FROM performance_schema.data_locks
   WHERE LOCK_TYPE='RECORD' AND
-  (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0);
+  (LOCATE('u2',LOCK_DATA)>0 OR LOCATE('u2x',LOCK_DATA)>0)
+  ORDER BY tab,INDEX_NAME,LOCK_MODE;
 
 # Variables to loop through isolation levels.
 let $c=1;


### PR DESCRIPTION
…sec.acl_tables_row_locking test).

auth_sec.acl_tables_row_locking test failed due to different order of rows returned by queries on P_S.data_locks, which was caused by Upstream's change to P_S.data_locks implementation as part of fix for Bug#36302624 "performance_schema.data_lock_waits is generated with O(N^3) complexity".

See: https://github.com/mysql/mysql-server/commit/96ccd8dc9f9795ff4a671ef0cbf952732461b8a7

The probelm is not specific to PS and affects Upstream as well.

This patch fixes the problem by adding ORDER BY clause to query on P_S.data_locks run by this test, ensuring stable order of result rows, similarly how it is done in some other tests querying this P_S table.