### PR TITLE
PS-9470 : Code refresh for PS 8.4.3 - post merge MTR fix (rpl_gtids_t…

### DIFF
--- a/mysql-test/suite/rpl_gtid/r/rpl_gtids_table_disable_binlog_on_slave.result
+++ b/mysql-test/suite/rpl_gtid/r/rpl_gtids_table_disable_binlog_on_slave.result
@@ -69,15 +69,12 @@ include/assert.inc [committed gtids SOURCE_UUID:1-6:17-19]
 #
 # Verify that the gtid_executed table is compressed.
 #
-SET @debug_save= @@GLOBAL.DEBUG;
-SET @@GLOBAL.DEBUG= '+d,compress_gtid_table';
 SET @@SESSION.GTID_NEXT= 'SOURCE_UUID:20';
 COMMIT;
 SET GTID_NEXT='AUTOMATIC';
 # Trigger compression explicitly
 FLUSH LOGS;
-SET DEBUG_SYNC='now WAIT_FOR complete_compression';
-SET GLOBAL DEBUG= @debug_save;
+# Wait until compression completes
 SELECT * FROM mysql.gtid_executed;
 source_uuid	interval_start	interval_end	gtid_tag
 SOURCE_UUID	1	6	
@@ -146,6 +143,7 @@ FLUSH LOGS;
 # when writing gtid into table when binlog is disabled and
 # gtid_mode is enabled.
 #
+SET @debug_save= @@GLOBAL.DEBUG;
 SET @@GLOBAL.DEBUG= '+d,simulate_err_on_write_gtid_into_table';
 INSERT INTO t3 VALUES(1);
 include/rpl/wait_for_applier_error.inc [errno=1030]
@@ -159,15 +157,12 @@ include/assert.inc [Table t3 must not contain 1]
 #
 # Verify that the gtid_executed table is compressed.
 #
-SET @debug_save= @@GLOBAL.DEBUG;
-SET @@GLOBAL.DEBUG= '+d,compress_gtid_table';
 SET @@SESSION.GTID_NEXT= 'SOURCE_UUID:23';
 COMMIT;
 SET GTID_NEXT='AUTOMATIC';
 # Trigger compression explicitly
 FLUSH LOGS;
-SET DEBUG_SYNC='now WAIT_FOR complete_compression';
-SET GLOBAL DEBUG= @debug_save;
+# Wait until compression completes
 SELECT * FROM mysql.gtid_executed;
 source_uuid	interval_start	interval_end	gtid_tag
 SOURCE_UUID	1	15	

--- a/mysql-test/suite/rpl_gtid/t/rpl_gtids_table_disable_binlog_on_slave.test
+++ b/mysql-test/suite/rpl_gtid/t/rpl_gtids_table_disable_binlog_on_slave.test
@@ -130,8 +130,6 @@ COMMIT;
 --echo #
 --echo # Verify that the gtid_executed table is compressed.
 --echo #
-SET @debug_save= @@GLOBAL.DEBUG;
-SET @@GLOBAL.DEBUG= '+d,compress_gtid_table';
 --inc $gno_2
 --replace_result $master_uuid SOURCE_UUID
 --eval SET @@SESSION.GTID_NEXT= '$master_uuid:$gno_2'
@@ -140,8 +138,11 @@ COMMIT;
 
 --echo # Trigger compression explicitly
 FLUSH LOGS;
-SET DEBUG_SYNC='now WAIT_FOR complete_compression';
-SET GLOBAL DEBUG= @debug_save;
+
+--echo # Wait until compression completes
+--let $wait_condition = SELECT GROUP_CONCAT(CONCAT(interval_start, "-", interval_end) ORDER BY interval_start)  = "1-$gno_0,$gno_1-$gno_2" FROM mysql.gtid_executed
+--source include/wait_condition.inc
+
 --replace_result $master_uuid SOURCE_UUID
 SELECT * FROM mysql.gtid_executed;
 
@@ -216,6 +217,7 @@ FLUSH LOGS;
 --echo # when writing gtid into table when binlog is disabled and
 --echo # gtid_mode is enabled.
 --echo #
+SET @debug_save= @@GLOBAL.DEBUG;
 SET @@GLOBAL.DEBUG= '+d,simulate_err_on_write_gtid_into_table';
 --connection master
 INSERT INTO t3 VALUES(1);
@@ -245,8 +247,6 @@ SET GLOBAL DEBUG= @debug_save;
 --echo #
 --echo # Verify that the gtid_executed table is compressed.
 --echo #
-SET @debug_save= @@GLOBAL.DEBUG;
-SET @@GLOBAL.DEBUG= '+d,compress_gtid_table';
 --inc $gno_2
 --replace_result $master_uuid SOURCE_UUID
 --eval SET @@SESSION.GTID_NEXT= '$master_uuid:$gno_2'
@@ -255,8 +255,11 @@ COMMIT;
 
 --echo # Trigger compression explicitly
 FLUSH LOGS;
-SET DEBUG_SYNC='now WAIT_FOR complete_compression';
-SET GLOBAL DEBUG= @debug_save;
+
+--echo # Wait until compression completes
+--let $wait_condition = SELECT GROUP_CONCAT(CONCAT(interval_start, "-", interval_end) ORDER BY interval_start)  = "1-$gno_0,$gno_1-$gno_2" FROM mysql.gtid_executed
+--source include/wait_condition.inc
+
 --replace_result $master_uuid SOURCE_UUID
 SELECT * FROM mysql.gtid_executed;
 


### PR DESCRIPTION
…able_disable_binlog_on_slave test improvement).

Greately reduced probability of sporadic failures in rpl_gtid.rpl_gtids_table_disable_binlog_on_slave test.

rpl_gtid.rpl_gtids_table_disable_binlog_on_slave test needs to wait for GTID sets in mysql.gtid_executed table being compressed in a few places. Since this compression happens asynchronously in a compressor or persister threads the test at those points set a global debug flag requesting notification about compression event through debug sync signals, then initiated operation which triggered compression, and then waited for a debug sync point signal indicating that compression has been done. However, sometimes it got this signal too early, because thread performing compression was busy with previous iteration, when the global debug flag requesting notification was set and so we got notified about the end of previous compression iteration. As result mysql.gtid_executed state was different from expected.

This patch solves this problem by replacing this waiting for a signal about compression completion with waiting for expected mysql.gtid_executed state using wait_condition.inc helper script.

Note that the test still can fail occasionally after this patch, but this happens more rarely. This looks like a different problem - a race in GTID code which causes mysql.gtid_executed contents with intersecting GTID sets, which cannot be compressed correctly by current compressor, and which needs to be fixed separately.