### PR TITLE
PS-9470 : Code refresh for PS 8.4.3 - post merge MTR fix (routertest_…

### DIFF
--- a/router/tests/integration/test_routing_direct.cc
+++ b/router/tests/integration/test_routing_direct.cc
@@ -3570,7 +3570,7 @@ TEST_P(ConnectionTest, classic_protocol_replay_session_trackers) {
     }
 
     std::ostringstream oss;
-    oss << "SET @@SESSION." << std::quoted(var[0], '`') << "=";
+    oss << "SET @@SESSION." << var[0] << "=";
 
     if (var[1].empty()) {
       if (var[0] == "innodb_ft_user_stopword_table") {
@@ -3658,7 +3658,7 @@ TEST_P(ConnectionTest, classic_protocol_session_vars_nullable) {
 
   for (auto var : session_vars) {
     std::ostringstream oss;
-    oss << "SET @@SESSION." << std::quoted(var[0], '`') << "="
+    oss << "SET @@SESSION." << var[0] << "="
         << "NULL";
 
     SCOPED_TRACE("// " + oss.str());


### PR DESCRIPTION
…integration_routing_direct issue)

Fixed failure of routertest_integration_routing_direct unit test which were caused by server failing on assert while trying to set component system variable (i.e. percona_telemetry.grace_interval) using quoting which is wrong for a component variable name
(i.e. set @@SESSION.\`percona_telemetry.grace_interval\`=100;)

This issue affects PS 8.4.2-2 as well but was not noticed during its release process.

The real cause of the issue is a problem in the server code. On the one hand, server code interprets \`percona_telemetry.grace_interval\` as a single quoted identifier, and therefore plugin variable name in SET statement, but on the other hand, attempt to find a plugin variable using find_dynamic_system_variable() with such a name doesn't fail, and returns corresponding component variable instead, breaking asserts in the code.

This issue probably also affects Upstream, but is likely not to get much attention there since there are no components loaded by default there (unlike in Percona Server where we have Telemetry component).

The problem affects debug builds of server only and doesn't affect release builds. OTOH fixing it correctly is likely to require fairly intrusive code change.

Taking into the account the above and since, as far as I can see, there is no good reason for router unit test to use quoting for system variable names, this patch choses not to fix the problem in server code, but instead, workarounds it by changing unit test not to use quoting for system variable names.