### PR TITLE
PS-9470 : Code refresh for PS 8.4.3 - post merge MTR fix (main.mysqlt…

### DIFF
--- a/mysql-test/t/mysqltest.test
+++ b/mysql-test/t/mysqltest.test
@@ -3044,7 +3044,7 @@ connection default;
 --echo #
 --echo # Test that a query failed with ER_NO_SUCH_THREAD causes mysqltest to dump the processlist before dying
 --echo #
---replace_regex /Id[[:space:]]+[0-9]+/Id MASKED/ /Time[[:space:]]+[0-9]+/Time MASKED/ /Time_ms[[:space:]]+[0-9]+/Time_ms MASKED/
+--replace_regex /Id[[:space:]]+[0-9]+/Id MASKED/ /Time[[:space:]]+[0-9]+/Time MASKED/ /Time_ms[[:space:]]+[0-9]+/Time_ms MASKED/ /Waiting for next activation/Waiting on empty queue/
 --error 1
 --exec echo "KILL QUERY 276447231;" | $MYSQL_TEST 2>&1
 
@@ -3052,7 +3052,7 @@ connection default;
 --exec echo "error ER_NO_SUCH_THREAD; KILL QUERY 276447231;" | $MYSQL_TEST 2>&1
 
 --echo # PROCESSLIST should be dumped if a different error was expected
---replace_regex /Id[[:space:]]+[0-9]+/Id MASKED/ /Time[[:space:]]+[0-9]+/Time MASKED/ /Time_ms[[:space:]]+[0-9]+/Time_ms MASKED/
+--replace_regex /Id[[:space:]]+[0-9]+/Id MASKED/ /Time[[:space:]]+[0-9]+/Time MASKED/ /Time_ms[[:space:]]+[0-9]+/Time_ms MASKED/ /Waiting for next activation/Waiting on empty queue/
 --error 1
 --exec echo "error ER_PARSE_ERROR; KILL QUERY 276447231;" | $MYSQL_TEST 2>&1
 


### PR DESCRIPTION
…est test).

Fixed sporadic failures of main.mysqltest test in Jenkins which occurred when it was executed after some test which created and then dropped events which might have been executed eventually (e.g. main.events_scheduling test).

The failures were caused by difference in processlist dump results which was performed by one of subtests in main.mysqltest test. The expected state of event scheduler thread in the processlist dump was "Waiting on empty queue", which is its normal state when event queue is empty/there are no events to be scheduled (e.g. it can be observed after event scheduler start up with empty mysql.events table). However, in some cases when event queue and mysql.events table are empty the state of event scheduler thread might also be "Waiting for next activation". This happens when event queue was initially non-empty, so event scheduler managed to enter waiting-for-event-activation state, but later became empty due to events from it being dropped. The reason, why this happens is that, unlike event creation or update, event deletion do not wake up event scheduler and cause change of its state.

This patch solves the problem with failures due to such difference by replacing "Waiting for next activation" state with a "Waiting on empty queue" state in processlist dump results.