### PR TITLE
PS-9470 : Code refresh for PS 8.4.3 - post merge MTR fix (disabled pe…

### DIFF
--- a/mysql-test/collections/disabled.def
+++ b/mysql-test/collections/disabled.def
@@ -82,6 +82,7 @@ max_parts.innodb_partition_open_files_limit                 : BUG#27423163 Test 
 
 # percona suite test
 percona.bug100352 : BUG#100352 https://bugs.mysql.com/bug.php?id=100352
+percona.backup_safe_binlog_info : BUG#0000 - PS-8897 Test for broken and unused functionality.
 
 # perfschema suite test
 perfschema.threads_history      : BUG#27712231


### PR DESCRIPTION
…rcona.backup_safe_binlog_info test)

Disabled percona.backup_safe_binlog_info test which failed sporadically in Jenkins.

This test provides coverage for storing current binlog position in InnoDB redo log by LOCK TABLES FOR BACKUP. Investigation has shown that code responsible for storing binlog position in InnoDB redo log no longer works correctly in general case in modern InnoDB. OTOH our backup tools no longer rely on it.

See: https://perconadev.atlassian.net/browse/PS-8897