### PR TITLE
PS-9504 [8.0]: Replace `MY_NODISCARD` with `[[nodiscard]]`

### DIFF
--- a/include/my_compiler.h
+++ b/include/my_compiler.h
@@ -91,16 +91,6 @@ constexpr bool unlikely(bool expr) { return expr; }
 #define __func__ __FUNCTION__
 #endif
 
-#if defined(__cplusplus) && defined(__cpp_attributes) && \
-    defined(__has_cpp_attribute)
-#if __has_cpp_attribute(nodiscard)
-#define MY_NODISCARD [[nodiscard]]
-#elif __has_cpp_attribute(gnu::warn_unused_result)
-#define MY_NODISCARD [[gnu::warn_unused_result]]
-#endif /* __has_cpp_attribute(gnu::warn_unused_result) */
-#endif /* defined(__cplusplus) && defined(__cpp_attributes) && \
-          defined(__has_cpp_attribute) */
-
 /*
   Disable MY_ATTRIBUTE for Sun Studio and Visual Studio.
   Note that Sun Studio supports some __attribute__ variants,
@@ -119,10 +109,6 @@ constexpr bool unlikely(bool expr) { return expr; }
 #else
 #define ALWAYS_INLINE __attribute__((always_inline)) inline
 #endif
-
-#ifndef MY_NODISCARD
-#define MY_NODISCARD MY_ATTRIBUTE((warn_unused_result))
-#endif /* MY_NODISCARD */
 
 #if defined(_MSC_VER)
 #define NO_INLINE __declspec(noinline)

--- a/include/my_sys.h
+++ b/include/my_sys.h
@@ -521,22 +521,22 @@ inline int my_b_get(IO_CACHE *info) {
   return _my_b_get(info);
 }
 
-MY_NODISCARD
+[[nodiscard]]
 inline my_off_t my_b_tell(const IO_CACHE *info) {
   return info->pos_in_file + *info->current_pos - info->request_pos;
 }
 
-MY_NODISCARD
+[[nodiscard]]
 inline uchar *my_b_get_buffer_start(const IO_CACHE *info) {
   return info->request_pos;
 }
 
-MY_NODISCARD
+[[nodiscard]]
 inline size_t my_b_get_bytes_in_buffer(const IO_CACHE *info) {
   return info->read_end - my_b_get_buffer_start(info);
 }
 
-MY_NODISCARD
+[[nodiscard]]
 inline my_off_t my_b_get_pos_in_file(const IO_CACHE *info) {
   return info->pos_in_file;
 }
@@ -544,7 +544,7 @@ inline my_off_t my_b_get_pos_in_file(const IO_CACHE *info) {
 /* tell write offset in the SEQ_APPEND cache */
 int my_b_copy_to_file(IO_CACHE *cache, FILE *file);
 
-MY_NODISCARD
+[[nodiscard]]
 inline size_t my_b_bytes_in_cache(const IO_CACHE *info) {
   return *info->current_end - *info->current_pos;
 }
@@ -740,31 +740,31 @@ extern bool array_append_string_unique(const char *str, const char **array,
 
 void my_store_ptr(uchar *buff, size_t pack_length, my_off_t pos);
 my_off_t my_get_ptr(uchar *ptr, size_t pack_length);
-MY_NODISCARD
+[[nodiscard]]
 extern int init_io_cache_ext(IO_CACHE *info, File file, size_t cachesize,
                              enum cache_type type, my_off_t seek_offset,
                              bool use_async_io, myf cache_myflags,
                              PSI_file_key file_key);
-MY_NODISCARD
+[[nodiscard]]
 extern int init_io_cache(IO_CACHE *info, File file, size_t cachesize,
                          enum cache_type type, my_off_t seek_offset,
                          bool use_async_io, myf cache_myflags);
-MY_NODISCARD
+[[nodiscard]]
 extern bool reinit_io_cache(IO_CACHE *info, enum cache_type type,
                             my_off_t seek_offset, bool use_async_io,
                             bool clear_cache);
 extern void setup_io_cache(IO_CACHE *info);
-MY_NODISCARD
+[[nodiscard]]
 extern int _my_b_read(IO_CACHE *info, uchar *Buffer, size_t Count);
-MY_NODISCARD
+[[nodiscard]]
 extern int _my_b_read_r(IO_CACHE *info, uchar *Buffer, size_t Count);
 extern void init_io_cache_share(IO_CACHE *read_cache, IO_CACHE_SHARE *cshare,
                                 IO_CACHE *write_cache, uint num_threads);
 extern void remove_io_thread(IO_CACHE *info);
-MY_NODISCARD
+[[nodiscard]]
 extern int _my_b_seq_read(IO_CACHE *info, uchar *Buffer, size_t Count);
 extern int _my_b_net_read(IO_CACHE *info, uchar *Buffer, size_t Count);
-MY_NODISCARD
+[[nodiscard]]
 extern int _my_b_write(IO_CACHE *info, const uchar *Buffer, size_t Count);
 extern int my_b_append(IO_CACHE *info, const uchar *Buffer, size_t Count);
 extern int my_b_safe_write(IO_CACHE *info, const uchar *Buffer, size_t Count);

--- a/sql/handler.h
+++ b/sql/handler.h
@@ -5334,7 +5334,7 @@ class handler {
   */
 
   virtual bool is_ignorable_error(int error);
-  MY_NODISCARD virtual bool continue_partition_copying_on_error(
+  [[nodiscard]] virtual bool continue_partition_copying_on_error(
       int error [[maybe_unused]]) {
     return false;
   }
@@ -6558,7 +6558,7 @@ class handler {
     @brief Offload an update to the storage engine. See handler::fast_update()
     for details.
   */
-  MY_NODISCARD int ha_fast_update(THD *thd,
+  [[nodiscard]] int ha_fast_update(THD *thd,
                                   mem_root_deque<Item *> &update_fields,
                                   mem_root_deque<Item *> &update_values,
                                   Item *conds);
@@ -6567,7 +6567,7 @@ class handler {
     @brief Offload an upsert to the storage engine. See handler::upsert()
     for details.
   */
-  MY_NODISCARD int ha_upsert(THD *thd, mem_root_deque<Item *> &update_fields,
+  [[nodiscard]] int ha_upsert(THD *thd, mem_root_deque<Item *> &update_fields,
                              mem_root_deque<Item *> &update_values);
 
  private:
@@ -6590,7 +6590,7 @@ class handler {
     @note HA_READ_BEFORE_WRITE_REMOVAL flag doesn not fit there because
     handler::ha_update_row(...) does not accept conditions.
   */
-  MY_NODISCARD virtual int fast_update(THD *, mem_root_deque<Item *> &,
+  [[nodiscard]] virtual int fast_update(THD *, mem_root_deque<Item *> &,
                                        mem_root_deque<Item *> &, Item *) {
     return ENOTSUP;
   }
@@ -6611,7 +6611,7 @@ class handler {
 
     @return an error if the insert should be terminated.
   */
-  MY_NODISCARD virtual int upsert(THD *, mem_root_deque<Item *> &,
+  [[nodiscard]] virtual int upsert(THD *, mem_root_deque<Item *> &,
                                   mem_root_deque<Item *> &) {
     return ENOTSUP;
   }

--- a/sql/partition_info.h
+++ b/sql/partition_info.h
@@ -604,7 +604,7 @@ static inline void init_all_partitions_iterator(partition_info *part_info,
    @return true - On failure.
    @return false - On success.
 */
-MY_NODISCARD
+[[nodiscard]]
 bool fill_first_partition_name(const partition_info *part_info,
                                const char *normalized_path, char *first_name);
 

--- a/sql/set_var.h
+++ b/sql/set_var.h
@@ -1119,7 +1119,7 @@ collation_unordered_map<std::string, sys_var *>
 extern bool get_sysvar_source(const char *name, uint length,
                               enum enum_variable_source *source);
 
-MY_NODISCARD
+[[nodiscard]]
 int sql_set_variables(THD *thd, List<set_var_base> *var_list, bool opened);
 bool keyring_access_test();
 bool fix_delay_key_write(sys_var *self, THD *thd, enum_var_type type);

--- a/sql/sql_partition.cc
+++ b/sql/sql_partition.cc
@@ -262,7 +262,7 @@ static bool is_name_in_list(const char *name, List<String> list_names) {
     false                         Success
 */
 
-MY_NODISCARD
+[[nodiscard]]
 static bool partition_default_handling(Partition_handler *part_handler,
                                        partition_info *part_info,
                                        bool is_create_table_ind,

--- a/sql/sql_partition.h
+++ b/sql/sql_partition.h
@@ -127,7 +127,7 @@ void get_full_part_id_from_key(const TABLE *table, uchar *buf, KEY *key_info,
    @retval true  - On failure.
    @retval false - On success.
 */
-MY_NODISCARD
+[[nodiscard]]
 bool get_first_partition_name(THD *thd, Partition_handler *part_handler,
                               const char *normalized_path,
                               const char *partition_info_str,

--- a/storage/innobase/handler/ha_innodb.h
+++ b/storage/innobase/handler/ha_innodb.h
@@ -1364,7 +1364,7 @@ will be closed before the index creation/drop.
 @param[in,out]	share		share structure where index translation table
                                 will be constructed in.
 @return true if index translation table built successfully */
-MY_NODISCARD
+[[nodiscard]]
 bool innobase_build_index_translation(const TABLE *table,
                                       dict_table_t *ib_table,
                                       INNOBASE_SHARE *share);

--- a/storage/innobase/include/buf0flu.h
+++ b/storage/innobase/include/buf0flu.h
@@ -43,7 +43,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 bool buf_flush_page_cleaner_is_active();
 
 /** Returns the count of currently active LRU manager threads. */
-MY_NODISCARD size_t buf_flush_active_lru_managers() noexcept;
+[[nodiscard]] size_t buf_flush_active_lru_managers() noexcept;
 
 #ifdef UNIV_DEBUG
 

--- a/storage/innobase/include/data0data.h
+++ b/storage/innobase/include/data0data.h
@@ -284,7 +284,7 @@ occupied by the field structs or the tuple struct is not counted.
 @param[in]      tuple   typed data tuple
 @param[in]      comp    nonzero=ROW_FORMAT=COMPACT
 @return sum of data lens */
-MY_NODISCARD
+[[nodiscard]]
 static inline ulint dtuple_get_data_size(const dtuple_t *tuple, ulint comp);
 /** Compare two data tuples.
 @param[in] tuple1 first data tuple

--- a/storage/innobase/include/dict0crea.h
+++ b/storage/innobase/include/dict0crea.h
@@ -119,7 +119,7 @@ static const constexpr auto ZIP_DICT_MAX_DATA_LENGTH = 32506;
 @param[out]	dict_id		dict id
 @param[in,out]	trx		transaction
 @return	error code or DB_SUCCESS */
-MY_NODISCARD
+[[nodiscard]]
 dberr_t dict_create_get_zip_dict_id_by_reference(table_id_t table_id,
                                                  ulint column_pos,
                                                  ulint *dict_id, trx_t *trx);
@@ -134,7 +134,7 @@ Must be freed with my_free().
 @param[out]	data_len	dict data length
 @param[in,out]	trx		transaction
 @return	error code or DB_SUCCESS */
-MY_NODISCARD
+[[nodiscard]]
 dberr_t dict_create_get_zip_dict_info_by_id(ulint dict_id, char **name,
                                             ulint *name_len, char **data,
                                             ulint *data_len, trx_t *trx);

--- a/storage/innobase/include/dict0dict.h
+++ b/storage/innobase/include/dict0dict.h
@@ -1682,7 +1682,7 @@ extern bool dict_upgrade_zip_dict_missing;
 @param[out]	dict_id		zip_dict id
 @retval	DB_SUCCESS		if OK
 @retval	DB_RECORD_NOT_FOUND	if not found */
-MY_NODISCARD
+[[nodiscard]]
 dberr_t dict_get_dictionary_id_by_key(table_id_t table_id, ulint column_pos,
                                       ulint *dict_id);
 
@@ -1696,7 +1696,7 @@ Must be freed with mem_free().
 @param[out]	data_len	dictionary data length
 @retval	DB_SUCCESS		if OK
 @retval	DB_RECORD_NOT_FOUND	if not found */
-MY_NODISCARD
+[[nodiscard]]
 dberr_t dict_get_dictionary_info_by_id(ulint dict_id, char **name,
                                        ulint *name_len, char **data,
                                        ulint *data_len);

--- a/storage/innobase/include/dict0load.h
+++ b/storage/innobase/include/dict0load.h
@@ -213,7 +213,7 @@ information from the record and returns to caller.
 @param[out]	data		dict data
 @param[out]	data_len	dict data length
 @return error message, or NULL on success */
-MY_NODISCARD
+[[nodiscard]]
 const char *dict_process_sys_zip_dict(mem_heap_t *heap,
                                       const dict_index_t &index,
                                       const rec_t *rec, ulint *id,

--- a/storage/innobase/include/fil0fil.h
+++ b/storage/innobase/include/fil0fil.h
@@ -2016,7 +2016,7 @@ inline void fil_space_open_if_needed(fil_space_t *space) {
 /** Enable encryption of temporary tablespace
 @param[in,out]	space	tablespace object
 @return DB_SUCCESS on success, DB_ERROR on failure */
-MY_NODISCARD
+[[nodiscard]]
 dberr_t fil_temp_update_encryption(fil_space_t *space);
 
 #if !defined(NO_FALLOCATE) && defined(UNIV_LINUX)

--- a/storage/innobase/include/fsp0fsp.h
+++ b/storage/innobase/include/fsp0fsp.h
@@ -765,7 +765,7 @@ uint32_t fsp_flags_to_dict_tf(uint32_t fsp_flags, bool compact);
 /** Enable encryption for already existing tablespace.
 @param[in,out]	space	tablespace object
 @return true if success, else false */
-MY_NODISCARD
+[[nodiscard]]
 bool fsp_enable_encryption(fil_space_t *space);
 
 /** Calculates the descriptor index within a descriptor page.

--- a/storage/innobase/include/ha_prototypes.h
+++ b/storage/innobase/include/ha_prototypes.h
@@ -227,7 +227,7 @@ void thd_set_lock_wait_time(THD *thd,
 /** Is FT ignore stopwords variable set.
 @param thd Thread object
 @return true if ft_ignore_stopwords is set, false otherwise. */
-MY_NODISCARD
+[[nodiscard]]
 bool thd_has_ft_ignore_stopwords(THD *thd) noexcept;
 
 /** Get the value of innodb_tmpdir.
@@ -448,13 +448,13 @@ void innobase_commit_low(trx_t *trx);
 
 /** Get the transaction of the current connection handle, if either exists.
 @return transaction of the current connection handle or NULL. */
-MY_NODISCARD
+[[nodiscard]]
 trx_t *innobase_get_trx(void);
 
 /** Get the transaction of the current connection handle if slow query log
 InnoDB extended statistics should be collected.
 @return transaction object if statistics should be collected, or NULL. */
-MY_NODISCARD
+[[nodiscard]]
 trx_t *innobase_get_trx_for_slow_log(void) noexcept;
 
 extern bool innodb_inited;

--- a/storage/innobase/include/os0enc.h
+++ b/storage/innobase/include/os0enc.h
@@ -211,7 +211,7 @@ class Encryption {
                   specified explicitly
   @param[in]      algorithm       Encryption algorithm to check
   @return true if no algorithm explicitly requested */
-  MY_NODISCARD static bool none_explicitly_specified(
+  [[nodiscard]] static bool none_explicitly_specified(
       bool explicit_encryption, const char *algorithm) noexcept;
 
   /** Generate random encryption value for key and iv.
@@ -379,7 +379,7 @@ class Encryption {
                                 byte *tmp, ulint tmp_len) const noexcept;
 
   /** Check if keyring plugin loaded. */
-  MY_NODISCARD static bool check_keyring() noexcept;
+  [[nodiscard]] static bool check_keyring() noexcept;
 
   /** Get encryption type
   @return encryption type **/

--- a/storage/innobase/include/os0file.h
+++ b/storage/innobase/include/os0file.h
@@ -521,7 +521,7 @@ class IORequest {
   }
 
   /** @return true if the page write should not be encrypted */
-  MY_NODISCARD bool is_encryption_disabled() const noexcept {
+  [[nodiscard]] bool is_encryption_disabled() const noexcept {
     return ((m_type & NO_ENCRYPTION) != 0);
   }
 

--- a/storage/innobase/include/os0thread.h
+++ b/storage/innobase/include/os0thread.h
@@ -194,14 +194,14 @@ using Atomic_xor_of_thread_id =
 thread. On Linux, returns tid. On other systems currently returns
 os_thread_get_curr_id().
 @return current thread identifier */
-MY_NODISCARD os_tid_t os_thread_get_tid() noexcept;
+[[nodiscard]] os_tid_t os_thread_get_tid() noexcept;
 
 /** Set relative scheduling priority for a given thread on
 Linux. Currently a no-op on other systems.
 @param[in]	thread_id	thread id
 @param[in]	relative_priority	system-specific priority value
 @return An actual thread priority after the update  */
-MY_NODISCARD
+[[nodiscard]]
 unsigned long int os_thread_set_priority(
     os_tid_t thread_id, unsigned long int relative_priority) noexcept;
 

--- a/storage/innobase/include/row0log.h
+++ b/storage/innobase/include/row0log.h
@@ -212,7 +212,7 @@ ulint row_log_estimate_work(const dict_index_t *index);
 
 /** Find out if temporary log files encrypted.
 @return true if temporary log file should be encrypted, false if not */
-MY_NODISCARD
+[[nodiscard]]
 bool log_tmp_is_encrypted() noexcept;
 
 /** Check the row log encryption is enabled or not.
@@ -226,7 +226,7 @@ void log_tmp_enable_encryption_if_set();
 @param[in]	offs		offset to block
 @param[in]	space_id	tablespace id
 @return whether the operation succeeded */
-MY_NODISCARD
+[[nodiscard]]
 bool log_tmp_block_encrypt(const byte *src_block, ulint size, byte *dst_block,
                            os_offset_t offs, space_id_t space_id);
 
@@ -237,7 +237,7 @@ bool log_tmp_block_encrypt(const byte *src_block, ulint size, byte *dst_block,
 @param[in]	offs		offset to block
 @param[in]	space_id	tablespace id
 @return whether the operation succeeded */
-MY_NODISCARD
+[[nodiscard]]
 bool log_tmp_block_decrypt(const byte *src_block, ulint size, byte *dst_block,
                            os_offset_t offs, space_id_t space_id);
 

--- a/storage/innobase/include/row0mysql.h
+++ b/storage/innobase/include/row0mysql.h
@@ -113,7 +113,7 @@ void row_mysql_prebuilt_free_compress_heap(row_prebuilt_t *prebuilt) noexcept;
 @param[in]	dict_data_len	optional dictionary data length
 @param[in]	compress_heap
 @return pointer to the uncompressed data */
-MY_NODISCARD
+[[nodiscard]]
 const byte *row_decompress_column(const byte *data, ulint *len,
                                   const byte *dict_data, ulint dict_data_len,
                                   mem_heap_t **compress_heap);
@@ -126,7 +126,7 @@ const byte *row_decompress_column(const byte *data, ulint *len,
 @param[in]	dict_data_len	optional dictionary data length
 @param[in]	compress_heap
 @return pointer to the compressed data */
-MY_NODISCARD
+[[nodiscard]]
 byte *row_compress_column(const byte *data, ulint *len, ulint lenlen,
                           const byte *dict_data, ulint dict_data_len,
                           mem_heap_t **compress_heap);

--- a/storage/innobase/include/srv0srv.h
+++ b/storage/innobase/include/srv0srv.h
@@ -1253,7 +1253,7 @@ void srv_master_thread_disabled_debug_update(THD *thd, SYS_VAR *var,
 innodb_temp_tablespace_encrypt is TRUE
 @param[in]	enable	true to enable encryption, false to disable
 @return DB_SUCCESS on success, DB_ERROR on failure */
-MY_NODISCARD
+[[nodiscard]]
 dberr_t srv_temp_encryption_update(bool enable);
 
 /** Status variables to be passed to MySQL */

--- a/storage/innobase/include/trx0trx.h
+++ b/storage/innobase/include/trx0trx.h
@@ -227,7 +227,7 @@ transaction.
 @param[in]	trx	receiver transaction
 @param[in]	from_trx	donor transaction
 @return read view clone */
-MY_NODISCARD
+[[nodiscard]]
 ReadView *trx_clone_read_view(trx_t *trx, trx_t *from_trx);
 
 /** Prepares a transaction for commit/rollback. */
@@ -718,7 +718,7 @@ class trx_stats final {
    already posted read in progress
   @return value to be passed to end_io_read
   */
-  MY_NODISCARD
+  [[nodiscard]]
   static std::chrono::steady_clock::time_point start_io_read(
       trx_t *trx, ulint bytes) noexcept;
 
@@ -730,7 +730,7 @@ class trx_stats final {
    already posted read in progress
   @return value to be passed to end_io_read
   */
-  MY_NODISCARD
+  [[nodiscard]]
   static std::chrono::steady_clock::time_point start_io_read(
       const trx_t &trx, ulint bytes) noexcept;
 
@@ -809,7 +809,7 @@ class trx_stats final {
   @param	page_id_fold	result of page_id_t::fold */
   static void inc_page_get(const trx_t &trx, ulint page_id_fold) noexcept;
 
-  MY_NODISCARD
+  [[nodiscard]]
   bool enabled() const noexcept { return take_stats; }
 
   void set(bool take) noexcept { take_stats = take; }

--- a/storage/innobase/lock/lock0lock.cc
+++ b/storage/innobase/lock/lock0lock.cc
@@ -877,7 +877,7 @@ bool Trx_locks_cache::has_granted_blocker(const trx_t *trx,
 #ifdef UNIV_DEBUG
 /** Checks if some other transaction has a lock request in the queue.
  @return lock or NULL */
-MY_NODISCARD static const lock_t *lock_rec_other_has_expl_req(
+[[nodiscard]] static const lock_t *lock_rec_other_has_expl_req(
     lock_mode mode,           /*!< in: LOCK_S or LOCK_X */
     const buf_block_t *block, /*!< in: buffer block containing
                               the record */

--- a/storage/innobase/os/os0thread.cc
+++ b/storage/innobase/os/os0thread.cc
@@ -144,7 +144,7 @@ no-op on other systems.
 @param[in]      relative_priority       system-specific priority value
 
 @return An actual thread priority after the update */
-MY_NODISCARD
+[[nodiscard]]
 ulint os_thread_set_priority(os_tid_t thread_id,
                              ulint relative_priority) noexcept {
 #ifdef UNIV_LINUX

--- a/storage/rocksdb/rdb_cf_options.h
+++ b/storage/rocksdb/rdb_cf_options.h
@@ -50,7 +50,7 @@ class Rdb_cf_options {
   Rdb_cf_options() = default;
 
   /* bool true return indicates cf_name was found */
-  MY_NODISCARD bool get(const std::string &cf_name,
+  [[nodiscard]] bool get(const std::string &cf_name,
                         rocksdb::ColumnFamilyOptions *const opts);
 
   void update(const std::string &cf_name, const std::string &cf_options);

--- a/storage/tokudb/ha_tokudb.h
+++ b/storage/tokudb/ha_tokudb.h
@@ -930,19 +930,19 @@ class ha_tokudb : public handler {
 
  private:
 #if defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
-  MY_NODISCARD int fast_update(THD *thd, mem_root_deque<Item *> &update_fields,
+  [[nodiscard]] int fast_update(THD *thd, mem_root_deque<Item *> &update_fields,
                                mem_root_deque<Item *> &update_values,
                                Item *conds);
-  MY_NODISCARD bool check_fast_update(THD *thd, List<Item> &update_fields,
+  [[nodiscard]] bool check_fast_update(THD *thd, List<Item> &update_fields,
                                       List<Item> &update_values, Item *conds);
-  MY_NODISCARD int send_update_message(List<Item> &update_fields,
+  [[nodiscard]] int send_update_message(List<Item> &update_fields,
                                        List<Item> &update_values, Item *conds,
                                        DB_TXN *txn);
-  MY_NODISCARD int upsert(THD *thd, mem_root_deque<Item *> &update_fields,
+  [[nodiscard]] int upsert(THD *thd, mem_root_deque<Item *> &update_fields,
                           mem_root_deque<Item *> &update_values);
-  MY_NODISCARD bool check_upsert(THD *thd, List<Item> &update_fields,
+  [[nodiscard]] bool check_upsert(THD *thd, List<Item> &update_fields,
                                  List<Item> &update_values);
-  MY_NODISCARD int send_upsert_message(List<Item> &update_fields,
+  [[nodiscard]] int send_upsert_message(List<Item> &update_fields,
                                        List<Item> &update_values, DB_TXN *txn);
 #endif  // defined(TOKU_INCLUDE_UPSERT) && TOKU_INCLUDE_UPSERT
  public:

--- a/storage/tokudb/hatoku_cmp.h
+++ b/storage/tokudb/hatoku_cmp.h
@@ -107,42 +107,42 @@ class KEY_AND_COL_INFO {
   KEY_AND_COL_INFO &operator=(const KEY_AND_COL_INFO &) = delete;
   ~KEY_AND_COL_INFO();
 
-  MY_NODISCARD int32_t allocate(const TABLE_SHARE &table_share);
+  [[nodiscard]] int32_t allocate(const TABLE_SHARE &table_share);
 
-  MY_NODISCARD int32_t initialize(const TABLE_SHARE &table_share,
+  [[nodiscard]] int32_t initialize(const TABLE_SHARE &table_share,
                                   const TABLE &table,
                                   uint32_t hidden_primary_key,
                                   uint32_t primary_key);
 
-  MY_NODISCARD int32_t initialize_col_pack_info(const TABLE_SHARE &table_share,
+  [[nodiscard]] int32_t initialize_col_pack_info(const TABLE_SHARE &table_share,
                                                 uint32_t keynr);
   void free();
 
   // reset the kc_info state at keynr
   void reset(uint32_t keynr);
 
-  MY_NODISCARD inline bool is_fixed_field(uint32_t field_num) const {
+  [[nodiscard]] inline bool is_fixed_field(uint32_t field_num) const {
     return field_types[field_num] == KEY_AND_COL_INFO::TOKUDB_FIXED_FIELD;
   }
 
-  MY_NODISCARD inline bool is_variable_field(uint32_t field_num) const {
+  [[nodiscard]] inline bool is_variable_field(uint32_t field_num) const {
     return field_types[field_num] == KEY_AND_COL_INFO::TOKUDB_VARIABLE_FIELD;
   }
 
-  MY_NODISCARD inline bool is_blob_field(uint32_t field_num) const {
+  [[nodiscard]] inline bool is_blob_field(uint32_t field_num) const {
     return field_types[field_num] == KEY_AND_COL_INFO::TOKUDB_BLOB_FIELD;
   }
 
   //
   // This offset is calculated starting from AFTER the NULL bytes
   //
-  MY_NODISCARD uint32_t get_fixed_field_size(const TABLE_SHARE &table_share,
+  [[nodiscard]] uint32_t get_fixed_field_size(const TABLE_SHARE &table_share,
                                              uint32_t keynr) const;
 
-  MY_NODISCARD uint32_t get_len_of_offsets(const TABLE_SHARE &table_share,
+  [[nodiscard]] uint32_t get_len_of_offsets(const TABLE_SHARE &table_share,
                                            uint32_t keynr) const;
 
-  MY_NODISCARD inline uint32_t get_max_desc_size(const TABLE &form) const
+  [[nodiscard]] inline uint32_t get_max_desc_size(const TABLE &form) const
       noexcept {
     uint32_t max_row_desc_buff_size;
     // upper bound of key comparison descriptor
@@ -154,7 +154,7 @@ class KEY_AND_COL_INFO {
     return max_row_desc_buff_size;
   }
 
-  MY_NODISCARD inline uint32_t get_max_secondary_key_pack_desc_size() const
+  [[nodiscard]] inline uint32_t get_max_secondary_key_pack_desc_size() const
       noexcept {
     uint32_t ret_val = 0;
     //
@@ -192,7 +192,7 @@ class KEY_AND_COL_INFO {
     return ret_val;
   }
 
-  MY_NODISCARD static inline uint32_t get_max_clustering_val_pack_desc_size(
+  [[nodiscard]] static inline uint32_t get_max_clustering_val_pack_desc_size(
       const TABLE_SHARE &table_share) {
     uint32_t ret_val = 0;
     //

--- a/utilities/innochecksum.cc
+++ b/utilities/innochecksum.cc
@@ -1394,7 +1394,7 @@ Extract the zip size from tablespace flags.
 @param[in] flags        tablespace flags
 @return	compressed page size of the file-per-table tablespace in bytes, or zero
 if the table is not compressed. */
-MY_NODISCARD
+[[nodiscard]]
 static ulint fsp_flags_get_zip_size(ulint flags) noexcept {
   ulint zip_size = 0;
   const ulint ssize = FSP_FLAGS_GET_ZIP_SSIZE(flags);


### PR DESCRIPTION
We require at least gcc 7.1 or clang 5 for compilation which both support `[[nodiscard]]`. `MY_NODISCARD` is no longer needed.