### PR TITLE
[compilation] PS-9542 (trunk): Fix clang-19 compilation issues

### DIFF
--- a/libs/mysql/serialization/archive.h
+++ b/libs/mysql/serialization/archive.h
@@ -81,14 +81,14 @@ class Archive {
   /// @note To be implemented in Archive_derived_type
   template <typename Type>
   static std::size_t get_size(Type &&arg) {
-    return Archive_derived_type::template get_size(std::forward<Type>(arg));
+    return Archive_derived_type::get_size(std::forward<Type>(arg));
   }
 
   /// @brief Returns archive size - size of data written to the archive
   /// @return archive size - size of data written to the archive
   /// @note To be implemented in Archive_derived_type
   inline std::size_t get_size_written() const {
-    return Archive_derived_type::template get_size_written();
+    return Archive_derived_type::get_size_written();
   }
 
   /// @brief Function returns maximum size of the Type

--- a/libs/mysql/serialization/serializer_default_impl.hpp
+++ b/libs/mysql/serialization/serializer_default_impl.hpp
@@ -233,7 +233,7 @@ template <class Archive_concrete_type>
 template <class Field_type, Field_size field_size_defined, typename Enabler>
 std::size_t Serializer_default<Archive_concrete_type>::get_field_size(
     const Field_type &field) {
-  return Archive_concrete_type::template get_size(
+  return Archive_concrete_type::get_size(
       Field_wrapper<const Field_type, field_size_defined>(field));
 }
 
@@ -473,8 +473,8 @@ std::size_t Serializer_default<Archive_concrete_type>::get_size_field_def(
   std::size_t calculated_size = 0;
   bool is_provided = field_definition.run_encode_predicate();
   if (is_provided) {
-    auto size_id_type = Archive_concrete_type::template get_size(
-        create_varlen_field_wrapper(field_id));
+    auto size_id_type =
+        Archive_concrete_type::get_size(create_varlen_field_wrapper(field_id));
     calculated_size = get_field_size<Field_type, field_size_defined>(
                           field_definition.get_ref()) +
                       size_id_type;
@@ -489,18 +489,18 @@ std::size_t Serializer_default<Archive_concrete_type>::get_size_serializable(
     bool skip_id) {
   std::size_t serializable_overhead_type = 0;
   if (skip_id == false) {
-    serializable_overhead_type = Archive_concrete_type::template get_size(
-        create_varlen_field_wrapper(field_id));
+    serializable_overhead_type =
+        Archive_concrete_type::get_size(create_varlen_field_wrapper(field_id));
   }
   auto serializable_size = serializable.template get_size_internal<Base_type>();
-  auto serializable_overhead_size = Archive_concrete_type::template get_size(
+  auto serializable_overhead_size = Archive_concrete_type::get_size(
       create_varlen_field_wrapper(serializable_size));
 
   Field_id_type last_non_ignorable_field_id =
       find_last_non_ignorable_field_id(serializable);
 
   auto serializable_overhead_last_non_ignorable_field_id =
-      Archive_concrete_type::template get_size(
+      Archive_concrete_type::get_size(
           create_varlen_field_wrapper(last_non_ignorable_field_id));
   return serializable_overhead_type + serializable_overhead_size +
          serializable_overhead_last_non_ignorable_field_id + serializable_size;

--- a/libs/mysql/serialization/serializer_impl.hpp
+++ b/libs/mysql/serialization/serializer_impl.hpp
@@ -51,8 +51,8 @@ std::size_t
 Serializer<Serializer_derived_type, Archive_type>::get_size_field_def(
     Field_id_type field_id,
     const Field_definition<Field_type, field_size_defined> &field_definition) {
-  return Serializer_derived_type::template get_size_field_def(field_id,
-                                                              field_definition);
+  return Serializer_derived_type::get_size_field_def(field_id,
+                                                     field_definition);
 }
 
 template <class Serializer_derived_type, class Archive_type>
@@ -61,8 +61,8 @@ std::size_t
 Serializer<Serializer_derived_type, Archive_type>::get_size_serializable(
     Field_id_type field_id, const Serializable_concrete_type &serializable,
     bool skip_id) {
-  return Serializer_derived_type::template get_size_serializable(
-      field_id, serializable, skip_id);
+  return Serializer_derived_type::get_size_serializable(field_id, serializable,
+                                                        skip_id);
 }
 
 template <class Serializer_derived_type, class Archive_type>

--- a/router/src/harness/include/mysql/harness/filesystem.h
+++ b/router/src/harness/include/mysql/harness/filesystem.h
@@ -118,7 +118,7 @@ class HARNESS_EXPORT Path {
    * Construct a path
    *
    * @param path Non-empty string denoting the path.
-   * @throws std::invalid_argument
+   * @throws std::invalid_argument if there is an error
    */
   Path(std::string path);
 

--- a/router/src/harness/include/mysql/harness/logging/logger_plugin.h
+++ b/router/src/harness/include/mysql/harness/logging/logger_plugin.h
@@ -47,7 +47,7 @@ extern mysql_harness::Plugin HARNESS_EXPORT harness_plugin_logger;
  * created
  * @param level     logging level for the newly create logging handlers
  *
- * @throws std::logic_error
+ * @throws std::logic_error if there is an error
  */
 void HARNESS_EXPORT
 create_plugin_loggers(const mysql_harness::LoaderConfig &config,

--- a/router/src/harness/include/mysql/harness/logging/registry.h
+++ b/router/src/harness/include/mysql/harness/logging/registry.h
@@ -336,7 +336,7 @@ void clear_registry(Registry &registry);
  * @param main_app_log_domain Log domain (logger id) to be used as the main
  *                            program logger. This logger must exist, because
  *                            log_*() functions might fail
- * @throws std::logic_error
+ * @throws std::logic_error if there is an error
  */
 HARNESS_EXPORT
 void create_module_loggers(Registry &registry, const LogLevel level,
@@ -352,7 +352,7 @@ void create_module_loggers(Registry &registry, const LogLevel level,
  * @param log_level The log level of the logger
  * @param logger_name The name under which the logger is registered
  *
- * @throws std::logic_error
+ * @throws std::logic_error if there is an error
  */
 HARNESS_EXPORT
 void create_logger(Registry &registry, const LogLevel level,

--- a/router/src/harness/include/mysql/harness/tls_context.h
+++ b/router/src/harness/include/mysql/harness/tls_context.h
@@ -177,7 +177,7 @@ class HARNESS_TLS_EXPORT TlsContext {
    * @see has_curves()
    *
    * @param curves colon-separated names of curves
-   * @throws TlsError
+   * @throws TlsError in case of TLS error
    * @throws std::invalid_argument if API isn't supported
    * @see has_set_curves_list()
    */

--- a/router/src/http/src/rest_cli.cc
+++ b/router/src/http/src/rest_cli.cc
@@ -93,7 +93,7 @@ class RestClientFrontend {
    * @returns exit-code
    * @retval EXIT_SUCESS success
    * @retval EXIT_FAILURE on error
-   * @throws FrontendError
+   * @throws FrontendError if there is an error
    */
   int run();
 

--- a/router/src/metadata_cache/src/cluster_metadata_ar.h
+++ b/router/src/metadata_cache/src/cluster_metadata_ar.h
@@ -74,7 +74,7 @@ class METADATA_CACHE_EXPORT ARClusterMetadata : public ClusterMetadata {
    * @param [out] instance_id id of the server the metadata was fetched from
    * @return object containing cluster topology information in case of success,
    * or error code in case of failure
-   * @throws metadata_cache::metadata_error
+   * @throws metadata_cache::metadata_error on failure
    */
   stdx::expected<metadata_cache::ClusterTopology, std::error_code>
   fetch_cluster_topology(

--- a/router/src/metadata_cache/src/cluster_metadata_gr.cc
+++ b/router/src/metadata_cache/src/cluster_metadata_gr.cc
@@ -157,7 +157,7 @@ class GRClusterSetMetadataBackend : public GRMetadataBackendV2 {
    * filters or policies (like target_cluster etc.)
    * @return object containing cluster topology information in case of success,
    * or error code in case of failure
-   * @throws metadata_cache::metadata_error
+   * @throws metadata_cache::metadata_error on failure
    */
   stdx::expected<metadata_cache::ClusterTopology, std::error_code>
   fetch_cluster_topology(

--- a/router/src/metadata_cache/src/cluster_metadata_gr.h
+++ b/router/src/metadata_cache/src/cluster_metadata_gr.h
@@ -84,7 +84,7 @@ class METADATA_CACHE_EXPORT GRClusterMetadata : public ClusterMetadata {
    * @param [out] instance_id of the server the metadata was fetched from
    * @return object containing cluster topology information in case of success,
    * or error code in case of failure
-   * @throws metadata_cache::metadata_error
+   * @throws metadata_cache::metadata_error on failure
    */
   stdx::expected<metadata_cache::ClusterTopology, std::error_code>
   fetch_cluster_topology(

--- a/router/src/router/src/cluster_metadata.h
+++ b/router/src/router/src/cluster_metadata.h
@@ -115,10 +115,10 @@ class ClusterMetadata {
   /** @brief Verify that host is a valid metadata server
    *
    *
-   * @throws MySQLSession::Error
-   * @throws std::runtime_error
-   * @throws std::out_of_range
-   * @throws std::logic_error
+   * @throws MySQLSession::Error on failure
+   * @throws std::runtime_error on failure
+   * @throws std::out_of_range on failure
+   * @throws std::logic_error on failure
    *
    * checks that the server
    *
@@ -131,10 +131,10 @@ class ClusterMetadata {
   /** @brief Verify that host is a valid cluster member (either Group
    * Replication or ReplicaSet cluster)
    *
-   * @throws MySQLSession::Error
-   * @throws std::runtime_error
-   * @throws std::out_of_range
-   * @throws std::logic_error
+   * @throws MySQLSession::Error on failure
+   * @throws std::runtime_error on failure
+   * @throws std::out_of_range on failure
+   * @throws std::logic_error on failure
    */
   virtual void require_cluster_is_ok() = 0;
 

--- a/router/src/router/src/config_generator.h
+++ b/router/src/router/src/config_generator.h
@@ -77,7 +77,7 @@ class ConfigGenerator {
    * @param server_url server to bootstrap from
    * @param bootstrap_options bootstrap options
    *
-   * @throws std::runtime_error
+   * @throws std::runtime_error on failure
    */
   void init(const std::string &server_url,
             const std::map<std::string, std::string> &bootstrap_options);
@@ -90,7 +90,7 @@ class ConfigGenerator {
    * @returns false if SSL mode is set to PREFERRED and SSL is not being used,
    *          true otherwise
    *
-   * @throws std::runtime_error
+   * @throws std::runtime_error on failure
    */
   bool warn_on_no_ssl(const std::map<std::string, std::string> &options);
 
@@ -218,8 +218,8 @@ class ConfigGenerator {
    * argumenent)
    * @param bootstrap_options bootstrap command-line options
    *
-   * @throws std::runtime_error
-   * @throws std::logic_error
+   * @throws std::runtime_error on failure
+   * @throws std::logic_error on failure
    */
   void connect_to_metadata_server(
       const URI &u, const std::string &bootstrap_socket,
@@ -232,7 +232,7 @@ class ConfigGenerator {
    * @param bootstrap_socket bootstrap (unix) socket (--bootstrap-socket
    * argumenent)
    *
-   * @throws TODO
+   * @throws TODO on failure
    */
   void init_gr_data(const URI &u, const std::string &bootstrap_socket);
 

--- a/router/src/router/src/router_app.h
+++ b/router/src/router/src/router_app.h
@@ -471,21 +471,21 @@ class MySQLRouter {
   /**
    * @brief Initializes keyring using master-key-reader and master-key-writer.
    *
-   * @throw MasterKeyReadError
+   * @throw MasterKeyReadError on failure
    */
   void init_keyring_using_external_facility(mysql_harness::Config &config);
 
   /**
    * @brief Initializes keyring using master key file.
    *
-   * @throw std::runtime_error
+   * @throw std::runtime_error on failure
    */
   void init_keyring_using_master_key_file();
 
   /**
    * @brief Initializes keyring using password read from STDIN.
    *
-   * @throw std::runtime_error
+   * @throw std::runtime_error on failure
    */
   void init_keyring_using_prompted_password();
 

--- a/sql-common/json_binary.cc
+++ b/sql-common/json_binary.cc
@@ -1618,7 +1618,6 @@ bool space_needed(const Json_wrapper *value, bool large, size_t *needed) {
   @return false on success, true if an error occurred
 
   @par Example of partial update
-
   Given the JSON document [ "abc", "def" ], which is serialized like this in a
   JSON column:
 
@@ -1844,7 +1843,6 @@ bool Value::update_in_shadow(const Field_json *field, size_t pos,
   @return false on success, true if an error occurred
 
   @par Example of partial update
-
   Take the JSON document { "a": "x", "b": "y", "c": "z" }, whose serialized
   representation looks like the following:
 

--- a/sql/sql_select.cc
+++ b/sql/sql_select.cc
@@ -1414,7 +1414,7 @@ SJ_TMP_TABLE *create_sj_tmp_table(THD *thd, JOIN *join,
   return sjtbl;
 }
 
-/**
+/*
   Setup the strategies to eliminate semi-join duplicates.
 
   @param join           Join to process


### PR DESCRIPTION
Fix 2 types of warnings:
1.
```
/data/mysql-server/percona-8.4/libs/mysql/serialization/serializer_default_impl.hpp:476:57: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  476 |     auto size_id_type = Archive_concrete_type::template get_size(
```
2.
```
/data/mysql-server/percona-8.4/router/src/metadata_cache/src/cluster_metadata_ar.h:77:43: error: empty paragraph passed to '@throws' command [-Werror,-Wdocumentation]
   77 |    * @throws metadata_cache::metadata_error
      |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
   78 |    */
```