### PR TITLE
PS-9192: JS Stored Routines: advanced error reporting

### DIFF
--- a/components/js_lang/CMakeLists.txt
+++ b/components/js_lang/CMakeLists.txt
@@ -33,6 +33,7 @@ MYSQL_ADD_COMPONENT(js_lang
   component.cc
   js_lang_core.cc
   js_lang_param.cc
+  js_lang_udf.cc
   LINK_LIBRARIES ext::v8
   MODULE_ONLY
 )

--- a/components/js_lang/README.md
+++ b/components/js_lang/README.md
@@ -89,7 +89,6 @@ TODO/Future work:
 Short-term
 ----------
 
-- Better error reporting (stacktraces!)
 - Console support
 - Handling of KILL/timeouts.
 - Memory tracking/limiting?

--- a/components/js_lang/js_lang_common.h
+++ b/components/js_lang/js_lang_common.h
@@ -37,6 +37,8 @@
 #include <mysql/components/services/mysql_thd_attributes.h>
 #include <mysql/components/services/mysql_thd_store_service.h>
 #include <mysql/components/services/security_context.h>
+#include <mysql/components/services/udf_metadata.h>
+#include <mysql/components/services/udf_registration.h>
 #include <mysql/mysql_lex_string.h>
 #include <mysqld_error.h>
 
@@ -74,6 +76,8 @@ extern REQUIRES_SERVICE_PLACEHOLDER(mysql_string_get_data_in_charset);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_attributes);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_security_context);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_store);
+extern REQUIRES_SERVICE_PLACEHOLDER(mysql_udf_metadata);
+extern REQUIRES_SERVICE_PLACEHOLDER(udf_registration);
 
 /**
   Helper function which is used to absorb results of service calls

--- a/components/js_lang/js_lang_udf.cc
+++ b/components/js_lang/js_lang_udf.cc
@@ -1,0 +1,197 @@
+/* Copyright (c) 2023, 2024 Percona LLC and/or its affiliates. All rights
+   reserved.
+
+   This program is free software; you can redistribute it and/or
+   modify it under the terms of the GNU General Public License
+   as published by the Free Software Foundation; version 2 of
+   the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA */
+
+/*
+  This file contains implementation of auxiliary UDF functions which give
+  users access to various information about connection and user JS context,
+  and JS component as a whole.
+*/
+
+#include <mysqlpp/udf_context_charset_extension.hpp>
+#include <mysqlpp/udf_registration.hpp>
+#include <mysqlpp/udf_wrappers.hpp>
+
+#include "js_lang_common.h"
+#include "js_lang_core.h"
+
+/** Collation to be used for return value for UDFs which return strings. */
+static constexpr char UTF8_DEFAULT_COLLATION_NAME[] = "utf8mb4_0900_ai_ci";
+
+/**
+  Max result length for UDFs which return string values and for which we
+  decided to return results of TEXT type (as opposed to TINYTEXT or
+  MEDIUMTEXT). It's 2^16-1 (max TEXT length in bytes) divided by 4
+  (max number of bytes per utf8mb4_* character).
+
+  In practice, the returned value can exceed this length. Doing so should
+  only cause problems when a table is created with column types based on
+  UDF return type and then too long return value is stored in this table
+  (including implicit temporary table case).
+*/
+static constexpr std::size_t MAX_TEXT_RESULT_LENGTH = ((1 << 16) - 1) / 4;
+
+/**
+  Implementation of JS_GET_LAST_ERROR() UDF for getting error message for the
+  last JS error in the connection for the current user.
+*/
+class js_get_last_error_impl {
+ public:
+  js_get_last_error_impl(mysqlpp::udf_context &ctx) {
+    /*
+      TODO: Consider supporting retrieval of error info for different users/
+            contexts. It might be a separate UDF. It also must do privilege
+            checking (might require a new privilege for this).
+    */
+    if (ctx.get_number_of_args() != 0)
+      throw std::invalid_argument{"Wrong argument list: should be ()"};
+
+    ctx.mark_result_nullable(true);
+    ctx.mark_result_const(false);
+
+    /*
+      Any reasonable error message should fit into TEXT field/64K bytes.
+      While TINYTEXT with its 255-byte limit is probably too small for
+      this purpose (e.g. MySQL error messages are limited to 512 bytes).
+
+      In practice, UDF can return values exceeding this limit. Doing so,
+      should only cause problems in scenarios when one table is created
+      with column tyoes based on the type of UDF return value (including
+      implicit temporary tables case).
+    */
+    ctx.set_result_max_length(MAX_TEXT_RESULT_LENGTH);
+
+    mysqlpp::udf_context_charset_extension charset_ext{
+        mysql_service_mysql_udf_metadata};
+    charset_ext.set_return_value_collation(ctx, UTF8_DEFAULT_COLLATION_NAME);
+  }
+  mysqlpp::udf_result_t<STRING_RESULT> calculate(const mysqlpp::udf_context &) {
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    // Handle the case when JS was never run for in this connection or
+    // for the current user in this connection.
+    if (auth_id_ctx == nullptr) return std::nullopt;
+
+    return auth_id_ctx->get_last_error();
+  }
+};
+
+/**
+  Implementation of JS_GET_LAST_ERROR_INFO() UDF for getting extended
+  information about the last JS error in the connection for the current user.
+*/
+class js_get_last_error_info_impl {
+ public:
+  js_get_last_error_info_impl(mysqlpp::udf_context &ctx) {
+    // TODO: Consider supporting retrieval of error info for different users/
+    //       contexts for this function as well.
+    if (ctx.get_number_of_args() != 0)
+      throw std::invalid_argument{"Wrong argument list: should be ()"};
+
+    ctx.mark_result_nullable(true);
+    ctx.mark_result_const(false);
+
+    /*
+      Extended information about error consists of error message, information
+      about problematic code line and possibly stacktrace (up to 10 frames
+      by default). So it is very unlikely that it won't fit into TEXT field/
+      64K bytes.
+
+      In practice, returning value exceeding this limit from the UDF should
+      work fine in most cases. The only problematic scenarios involve creation
+      of table with column types based on UDF return type and trying to store
+      the result in it.
+    */
+    ctx.set_result_max_length(MAX_TEXT_RESULT_LENGTH);
+
+    mysqlpp::udf_context_charset_extension charset_ext{
+        mysql_service_mysql_udf_metadata};
+    charset_ext.set_return_value_collation(ctx, UTF8_DEFAULT_COLLATION_NAME);
+  }
+  mysqlpp::udf_result_t<STRING_RESULT> calculate(const mysqlpp::udf_context &) {
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    // Handle the case when JS was never run for in this connection or
+    // for the current user in this connection.
+    if (auth_id_ctx == nullptr) return std::nullopt;
+
+    return auth_id_ctx->get_last_error_info();
+  }
+};
+
+/**
+  Implementation of JS_CLEAR_LAST_ERROR() UDF for clearing information about
+  last JS error for the connection and the current user pair (resets it to a
+  state as if no error has happened).
+*/
+class js_clear_last_error_impl {
+ public:
+  js_clear_last_error_impl(mysqlpp::udf_context &ctx) {
+    // TODO: Consider supporting clearing of error info for different users/
+    //       contexts for this function as well.
+    if (ctx.get_number_of_args() != 0)
+      throw std::invalid_argument{"Wrong argument list: should be ()"};
+
+    ctx.mark_result_nullable(false);
+    ctx.mark_result_const(false);
+  }
+  mysqlpp::udf_result_t<INT_RESULT> calculate(const mysqlpp::udf_context &) {
+    auto auth_id_ctx = Js_thd::get_current_auth_id_context();
+
+    // Handle the case when JS was never run for in this connection or
+    // for the current user in this connection.
+    if (auth_id_ctx == nullptr) return 0;
+
+    return auth_id_ctx->clear_last_error();
+  }
+};
+
+DECLARE_STRING_UDF_AUTO(js_get_last_error)
+DECLARE_STRING_UDF_AUTO(js_get_last_error_info)
+DECLARE_INT_UDF_AUTO(js_clear_last_error)
+
+static std::array udfs{DECLARE_UDF_INFO_AUTO(js_get_last_error),
+                       DECLARE_UDF_INFO_AUTO(js_get_last_error_info),
+                       DECLARE_UDF_INFO_AUTO(js_clear_last_error)};
+using udf_bitset_type = mysqlpp::udf_bitset<std::tuple_size_v<decltype(udfs)>>;
+static udf_bitset_type registered_udfs;
+
+bool register_udfs() {
+  mysqlpp::register_udfs(mysql_service_udf_registration, udfs, registered_udfs);
+
+  if (!registered_udfs.all()) {
+    my_error(ER_LANGUAGE_COMPONENT, MYF(0),
+             "Can't register auxiliary UDFs for " CURRENT_COMPONENT_NAME_STR
+             "component.");
+    return true;
+  }
+
+  return false;
+}
+
+bool unregister_udfs() {
+  mysqlpp::unregister_udfs(mysql_service_udf_registration, udfs,
+                           registered_udfs);
+
+  if (!registered_udfs.none()) {
+    my_error(ER_LANGUAGE_COMPONENT, MYF(0),
+             "Can't unregister auxiliary UDFs for " CURRENT_COMPONENT_NAME_STR
+             "component.");
+    return true;
+  }
+
+  return false;
+}

--- a/mysql-test/suite/component_js_lang/r/js_lang_basic.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_basic.result
@@ -7913,6 +7913,337 @@ DROP USER u_creator@localhost;
 DROP USER u_caller@localhost;
 DROP USER u_dropper@localhost;
 DROP DATABASE mysqltest;
+
+#
+# Tests for advanced error reporting, JS_GET_LAST_ERROR() and other
+# related UDFs.
+#
+CREATE FUNCTION f_error() RETURNS VARCHAR(100) LANGUAGE JS AS $$
+function l0() {
+return "Ooops!"();
+}
+function l1() {
+return l0();
+}
+let l2 = (() => { return l1(); });
+return l2();
+$$|
+CREATE PROCEDURE p_error() LANGUAGE JS AS $$
+function l0() {
+return "Ooops!"();
+}
+function l1() {
+return l0();
+}
+(() => { return l1(); })();
+$$|
+CREATE FUNCTION f_error_no_stack() RETURNS VARCHAR(100) LANGUAGE JS AS $$
+function l0() {
+throw "Ooops!";
+}
+function l1() {
+return l0();
+}
+let l2 = (() => { return l1(); });
+return l2();
+$$|
+CREATE FUNCTION f_error_oneline() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return "Ooops"() $$;
+CREATE FUNCTION f_fine() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return 42; $$|
+#
+# Basic tests for both JS_GET_LAST_ERROR() and JS_GET_LAST_ERROR_INFO().
+#
+SELECT f_error();
+ERROR HY000: TypeError: "Ooops!" is not a function
+SELECT js_get_last_error();
+js_get_last_error()
+TypeError: "Ooops!" is not a function
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+Error: TypeError: "Ooops!" is not a function
+At: SQL FUNCTION test.f_error:3:15
+Line: return "Ooops!"();
+                     ^
+Stack:
+TypeError: "Ooops!" is not a function
+    at l0 (SQL FUNCTION test.f_error:3:16)
+    at l1 (SQL FUNCTION test.f_error:6:8)
+    at l2 (SQL FUNCTION test.f_error:8:26)
+    at SQL FUNCTION test.f_error:9:8
+CALL p_error();
+ERROR HY000: TypeError: "Ooops!" is not a function
+SELECT js_get_last_error();
+js_get_last_error()
+TypeError: "Ooops!" is not a function
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+Error: TypeError: "Ooops!" is not a function
+At: SQL PROCEDURE test.p_error:3:15
+Line: return "Ooops!"();
+                     ^
+Stack:
+TypeError: "Ooops!" is not a function
+    at l0 (SQL PROCEDURE test.p_error:3:16)
+    at l1 (SQL PROCEDURE test.p_error:6:8)
+    at SQL PROCEDURE test.p_error:8:17
+    at SQL PROCEDURE test.p_error:8:25
+    at SQL PROCEDURE test.p_error:10:3
+#
+# Case when no stacktrace is available.
+SELECT f_error_no_stack();
+ERROR HY000: Ooops!
+SELECT js_get_last_error();
+js_get_last_error()
+Ooops!
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+Error: Ooops!
+At: SQL FUNCTION test.f_error_no_stack:3:0
+Line: throw "Ooops!";
+      ^
+#
+# Case with single line function is interesting because it
+# exposed wrapper code in initial implementation of extended
+# error info reporting code.
+SELECT f_error_oneline();
+ERROR HY000: TypeError: "Ooops" is not a function
+SELECT js_get_last_error();
+js_get_last_error()
+TypeError: "Ooops" is not a function
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+Error: TypeError: "Ooops" is not a function
+At: SQL FUNCTION test.f_error_oneline:1:15
+Line:  return "Ooops"() 
+                     ^
+Stack:
+TypeError: "Ooops" is not a function
+    at SQL FUNCTION test.f_error_oneline:1:16
+#
+# Note that successfull execution of JS routine doesn't reset error
+# info. This can be useful in case when several JS routines are called
+# in a row.
+SELECT f_fine();
+f_fine()
+42
+SELECT js_get_last_error();
+js_get_last_error()
+TypeError: "Ooops" is not a function
+#
+# Test JS_CLEAR_LAST_ERROR() UDF (which clears last error state).
+#
+SELECT js_clear_last_error();
+js_clear_last_error()
+1
+# Note that we return NULL when the last error state was reset, or
+# if no JS error has happened so far.
+SELECT js_get_last_error();
+js_get_last_error()
+NULL
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+NULL
+#
+# When there is no error state to clear 0 should be returned by
+# JS_CLEAR_LAST_ERROR().
+#
+SELECT js_clear_last_error();
+js_clear_last_error()
+0
+SELECT js_get_last_error();
+js_get_last_error()
+NULL
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+NULL
+#
+# Now test how these UDF work for cases when there wasn't any JS
+# run for connection or/and user, or when there was no error in it.
+#
+connect  con_root, localhost, root,,;
+#
+# Case when no JS was run in the connection.
+# (User run JS but in another connection).
+SELECT js_get_last_error();
+js_get_last_error()
+NULL
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+NULL
+#
+# Let us also check what JS_CLEAR_LAST_ERROR() does in this case.
+SELECT js_clear_last_error();
+js_clear_last_error()
+0
+#
+# Case when user run JS in connection, but there were no error.
+SELECT f_fine();
+f_fine()
+42
+SELECT js_get_last_error();
+js_get_last_error()
+NULL
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+NULL
+SELECT js_clear_last_error();
+js_clear_last_error()
+0
+disconnect con_root;
+connection default;
+CREATE USER u_other@localhost;
+GRANT EXECUTE ON test.* TO u_other@localhost;
+CREATE FUNCTION f_invoker() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return 42 $$;
+CREATE FUNCTION f_invoker_error() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return "Not-a-function"() $$;
+connect  con_other, localhost, u_other,,;
+#
+# Case when user never run any JS at all.
+SELECT js_get_last_error();
+js_get_last_error()
+NULL
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+NULL
+SELECT js_clear_last_error();
+js_clear_last_error()
+0
+#
+# Failed execution of SQL SECURITY DEFINER routine with different
+# creator doesn't affect current user's JS error state.
+SELECT f_error();
+ERROR HY000: TypeError: "Ooops!" is not a function
+SELECT js_get_last_error();
+js_get_last_error()
+NULL
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+NULL
+SELECT js_clear_last_error();
+js_clear_last_error()
+0
+#
+# Successful execution of SQL SECURITY INVOKER routine does not
+# affect current user's JS error state either.
+SELECT f_invoker();
+f_invoker()
+42
+SELECT js_get_last_error();
+js_get_last_error()
+NULL
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+NULL
+SELECT js_clear_last_error();
+js_clear_last_error()
+0
+#
+# OTOH failed execution of SQL SECURITY INVOKER routine does.
+SELECT f_invoker_error();
+ERROR HY000: TypeError: "Not-a-function" is not a function
+SELECT js_get_last_error();
+js_get_last_error()
+TypeError: "Not-a-function" is not a function
+SELECT js_get_last_error_info();
+js_get_last_error_info()
+Error: TypeError: "Not-a-function" is not a function
+At: SQL FUNCTION test.f_invoker_error:1:24
+Line:  return "Not-a-function"() 
+                              ^
+Stack:
+TypeError: "Not-a-function" is not a function
+    at SQL FUNCTION test.f_invoker_error:1:25
+SELECT js_clear_last_error();
+js_clear_last_error()
+1
+disconnect con_other;
+connection default;
+#
+# Check types, charset and nullability of return values for
+# JS_GET_LAST_ERROR() and friends.
+#
+SELECT f_error();
+ERROR HY000: TypeError: "Ooops!" is not a function
+CREATE TABLE t_e AS SELECT JS_GET_LAST_ERROR();
+CREATE TABLE t_i AS SELECT JS_GET_LAST_ERROR_INFO();
+CREATE TABLE t_c AS SELECT JS_CLEAR_LAST_ERROR();
+SHOW CREATE TABLE t_e;
+Table	Create Table
+t_e	CREATE TABLE `t_e` (
+  `JS_GET_LAST_ERROR()` text
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t_e;
+JS_GET_LAST_ERROR()
+TypeError: "Ooops!" is not a function
+SHOW CREATE TABLE t_i;
+Table	Create Table
+t_i	CREATE TABLE `t_i` (
+  `JS_GET_LAST_ERROR_INFO()` text
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t_i;
+JS_GET_LAST_ERROR_INFO()
+Error: TypeError: "Ooops!" is not a function
+At: SQL FUNCTION test.f_error:3:15
+Line: return "Ooops!"();
+                     ^
+Stack:
+TypeError: "Ooops!" is not a function
+    at l0 (SQL FUNCTION test.f_error:3:16)
+    at l1 (SQL FUNCTION test.f_error:6:8)
+    at l2 (SQL FUNCTION test.f_error:8:26)
+    at SQL FUNCTION test.f_error:9:8
+SHOW CREATE TABLE t_c;
+Table	Create Table
+t_c	CREATE TABLE `t_c` (
+  `JS_CLEAR_LAST_ERROR()` bigint NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+SELECT * FROM t_c;
+JS_CLEAR_LAST_ERROR()
+1
+DROP TABLES t_e, t_i, t_c;
+#
+# Also test what will happen when UDFs return values with length
+# exceeding their return value type length.
+#
+# CREATE FUNCTION f_huge_error() RETURNS INT LANGUAGE JS AS $$ return "Make-the-error-message-big-enough-<70000-a-here>"(); $$
+SELECT f_huge_error();
+ERROR HY000: TypeError: "Make-the-error-message-big-enough-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+#
+# Should still work fine except CREATE TABLE ... SELECT UDF() case.
+SELECT JS_GET_LAST_ERROR();
+JS_GET_LAST_ERROR()
+TypeError: "Make-the-error-message-big-enough-<70000-of-a-here>" is not a function
+SELECT LENGTH(JS_GET_LAST_ERROR());
+LENGTH(JS_GET_LAST_ERROR())
+70065
+CREATE TABLE t AS SELECT JS_GET_LAST_ERROR();
+ERROR 22001: Data too long for column 'JS_GET_LAST_ERROR()' at row 1
+SELECT JS_GET_LAST_ERROR_INFO();
+JS_GET_LAST_ERROR_INFO()
+Error: TypeError: "Make-the-error-message-big-enough-<70000-of-a-here>" is not a function
+At: SQL FUNCTION test.f_huge_error:1:70044
+Line:  return "Make-the-error-message-big-enough-<70000-of-a-here>"(); 
+<70000-of-_-here>                                                  ^
+Stack:
+TypeError: "Make-the-error-message-big-enough-<70000-of-a-here>" is not a function
+    at SQL FUNCTION test.f_huge_error:1:70045
+SELECT LENGTH(JS_GET_LAST_ERROR_INFO());
+LENGTH(JS_GET_LAST_ERROR_INFO())
+280341
+CREATE TABLE t AS SELECT JS_GET_LAST_ERROR_INFO();
+ERROR 22001: Data too long for column 'JS_GET_LAST_ERROR_INFO()' at row 1
+SELECT JS_CLEAR_LAST_ERROR();
+JS_CLEAR_LAST_ERROR()
+1
+#
+# Clean-up
+DROP FUNCTION f_huge_error;
+DROP FUNCTION f_error;
+DROP PROCEDURE p_error;
+DROP FUNCTION f_error_no_stack;
+DROP FUNCTION f_error_oneline;
+DROP FUNCTION f_fine;
+DROP FUNCTION f_invoker;
+DROP FUNCTION f_invoker_error;
+DROP USER u_other@localhost;
 REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
 #
 # Test of component uninstallation while having outstanding per

--- a/mysql-test/suite/component_js_lang/t/js_lang_basic.test
+++ b/mysql-test/suite/component_js_lang/t/js_lang_basic.test
@@ -3330,6 +3330,222 @@ DROP USER u_dropper@localhost;
 DROP DATABASE mysqltest;
 
 
+--echo
+--echo #
+--echo # Tests for advanced error reporting, JS_GET_LAST_ERROR() and other
+--echo # related UDFs.
+--echo #
+
+DELIMITER |;
+CREATE FUNCTION f_error() RETURNS VARCHAR(100) LANGUAGE JS AS $$
+  function l0() {
+    return "Ooops!"();
+  }
+  function l1() {
+    return l0();
+  }
+  let l2 = (() => { return l1(); });
+  return l2();
+$$|
+CREATE PROCEDURE p_error() LANGUAGE JS AS $$
+  function l0() {
+    return "Ooops!"();
+  }
+  function l1() {
+    return l0();
+  }
+  (() => { return l1(); })();
+$$|
+CREATE FUNCTION f_error_no_stack() RETURNS VARCHAR(100) LANGUAGE JS AS $$
+  function l0() {
+    throw "Ooops!";
+  }
+  function l1() {
+    return l0();
+  }
+  let l2 = (() => { return l1(); });
+  return l2();
+$$|
+CREATE FUNCTION f_error_oneline() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return "Ooops"() $$;
+CREATE FUNCTION f_fine() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return 42; $$|
+DELIMITER ;|
+
+--echo #
+--echo # Basic tests for both JS_GET_LAST_ERROR() and JS_GET_LAST_ERROR_INFO().
+--echo #
+--error ER_LANGUAGE_COMPONENT
+SELECT f_error();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+
+--error ER_LANGUAGE_COMPONENT
+CALL p_error();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+
+--echo #
+--echo # Case when no stacktrace is available.
+--error ER_LANGUAGE_COMPONENT
+SELECT f_error_no_stack();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+
+--echo #
+--echo # Case with single line function is interesting because it
+--echo # exposed wrapper code in initial implementation of extended
+--echo # error info reporting code.
+--error ER_LANGUAGE_COMPONENT
+SELECT f_error_oneline();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+
+--echo #
+--echo # Note that successfull execution of JS routine doesn't reset error
+--echo # info. This can be useful in case when several JS routines are called
+--echo # in a row.
+SELECT f_fine();
+SELECT js_get_last_error();
+
+--echo #
+--echo # Test JS_CLEAR_LAST_ERROR() UDF (which clears last error state).
+--echo #
+SELECT js_clear_last_error();
+--echo # Note that we return NULL when the last error state was reset, or
+--echo # if no JS error has happened so far.
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+
+--echo #
+--echo # When there is no error state to clear 0 should be returned by
+--echo # JS_CLEAR_LAST_ERROR().
+--echo #
+SELECT js_clear_last_error();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+
+--echo #
+--echo # Now test how these UDF work for cases when there wasn't any JS
+--echo # run for connection or/and user, or when there was no error in it.
+--echo #
+
+--connect (con_root, localhost, root,,)
+--echo #
+--echo # Case when no JS was run in the connection.
+--echo # (User run JS but in another connection).
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+--echo #
+--echo # Let us also check what JS_CLEAR_LAST_ERROR() does in this case.
+SELECT js_clear_last_error();
+
+--echo #
+--echo # Case when user run JS in connection, but there were no error.
+SELECT f_fine();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+SELECT js_clear_last_error();
+
+--disconnect con_root
+--source include/wait_until_disconnected.inc
+--connection default
+
+CREATE USER u_other@localhost;
+GRANT EXECUTE ON test.* TO u_other@localhost;
+CREATE FUNCTION f_invoker() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return 42 $$;
+CREATE FUNCTION f_invoker_error() RETURNS INT SQL SECURITY INVOKER LANGUAGE JS AS $$ return "Not-a-function"() $$;
+--connect (con_other, localhost, u_other,,)
+--echo #
+--echo # Case when user never run any JS at all.
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+SELECT js_clear_last_error();
+
+--echo #
+--echo # Failed execution of SQL SECURITY DEFINER routine with different
+--echo # creator doesn't affect current user's JS error state.
+--error ER_LANGUAGE_COMPONENT
+SELECT f_error();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+SELECT js_clear_last_error();
+
+--echo #
+--echo # Successful execution of SQL SECURITY INVOKER routine does not
+--echo # affect current user's JS error state either.
+SELECT f_invoker();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+SELECT js_clear_last_error();
+
+--echo #
+--echo # OTOH failed execution of SQL SECURITY INVOKER routine does.
+--error ER_LANGUAGE_COMPONENT
+SELECT f_invoker_error();
+SELECT js_get_last_error();
+SELECT js_get_last_error_info();
+SELECT js_clear_last_error();
+
+--disconnect con_other
+--source include/wait_until_disconnected.inc
+--connection default
+
+--echo #
+--echo # Check types, charset and nullability of return values for
+--echo # JS_GET_LAST_ERROR() and friends.
+--echo #
+--error ER_LANGUAGE_COMPONENT
+SELECT f_error();
+CREATE TABLE t_e AS SELECT JS_GET_LAST_ERROR();
+CREATE TABLE t_i AS SELECT JS_GET_LAST_ERROR_INFO();
+CREATE TABLE t_c AS SELECT JS_CLEAR_LAST_ERROR();
+SHOW CREATE TABLE t_e;
+SELECT * FROM t_e;
+SHOW CREATE TABLE t_i;
+SELECT * FROM t_i;
+SHOW CREATE TABLE t_c;
+SELECT * FROM t_c;
+DROP TABLES t_e, t_i, t_c;
+
+--echo #
+--echo # Also test what will happen when UDFs return values with length
+--echo # exceeding their return value type length.
+--echo #
+--let $a70k = `SELECT REPEAT('a', 70000)`
+--echo # CREATE FUNCTION f_huge_error() RETURNS INT LANGUAGE JS AS \$\$ return "Make-the-error-message-big-enough-<70000-a-here>"(); \$\$
+--disable_query_log
+--eval CREATE FUNCTION f_huge_error() RETURNS INT LANGUAGE JS AS \$\$ return "Make-the-error-message-big-enough-$a70k"(); \$\$
+--enable_query_log
+--error ER_LANGUAGE_COMPONENT
+SELECT f_huge_error();
+
+--echo #
+--echo # Should still work fine except CREATE TABLE ... SELECT UDF() case.
+--replace_regex /a{70000}/\<70000-of-a-here\>/ / {70000}/\<70000-of-_-here\>/
+SELECT JS_GET_LAST_ERROR();
+SELECT LENGTH(JS_GET_LAST_ERROR());
+--error ER_DATA_TOO_LONG
+CREATE TABLE t AS SELECT JS_GET_LAST_ERROR();
+
+--replace_regex /a{70000}/\<70000-of-a-here\>/ / {70000}/\<70000-of-_-here\>/
+SELECT JS_GET_LAST_ERROR_INFO();
+SELECT LENGTH(JS_GET_LAST_ERROR_INFO());
+--error ER_DATA_TOO_LONG
+CREATE TABLE t AS SELECT JS_GET_LAST_ERROR_INFO();
+
+SELECT JS_CLEAR_LAST_ERROR();
+
+--echo #
+--echo # Clean-up
+DROP FUNCTION f_huge_error;
+DROP FUNCTION f_error;
+DROP PROCEDURE p_error;
+DROP FUNCTION f_error_no_stack;
+DROP FUNCTION f_error_oneline;
+DROP FUNCTION f_fine;
+DROP FUNCTION f_invoker;
+DROP FUNCTION f_invoker_error;
+DROP USER u_other@localhost;
+
 REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
 
 --echo #


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9192

Added a few UDFs which allow to get basic and extended information about last JS error that was reported for the current connection and user. The idea is that these UDFs should simplify debugging of JS stored routines.

They are:

- JS_GET_LAST_ERROR() returns error message for last JS error for the current connection and user.
- JS_GET_LAST_ERROR_INFO() returns an extended information about last JS error such as stored program and line where error was emitted, as well as stack trace if it is available.
- JS_CLEAR_LAST_ERROR() clears last JS error state for the connection/user.

Added test coverage for these UDFs.