### PR TITLE
(8.0) PS-9621: Initialization of std::atomic_flag caller_active_ in Percona Telemetry component is not compliant with the standard

### DIFF
--- a/components/percona_telemetry/worker.cc
+++ b/components/percona_telemetry/worker.cc
@@ -25,8 +25,7 @@ Worker::Worker(Config &config, Storage &storage, DataProvider &data_provider,
       storage_(storage),
       data_provider_(data_provider),
       logger_(logger),
-      stop_worker_thd_(false),
-      caller_active_(ATOMIC_FLAG_INIT) {}
+      stop_worker_thd_(false) {}
 
 bool Worker::start() {
   std::thread thd(&Worker::worker_thd_fn, this);

--- a/components/percona_telemetry/worker.h
+++ b/components/percona_telemetry/worker.h
@@ -44,7 +44,7 @@ class Worker {
   DataProvider &data_provider_;
   Logger &logger_;
   std::atomic_bool stop_worker_thd_;
-  std::atomic_flag caller_active_;
+  std::atomic_flag caller_active_ = ATOMIC_FLAG_INIT;
   std::condition_variable cv_;
 
   std::thread thd_;


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9621

Initialization of std::atomic_flag in the constructor's initializer list is not compliant with the standard. Gcc allows it, however clang issues a compilation warning which turns into error in maintainer mode build.
(error: braces around scalar initializer [-Werror,-Wbraced-scalar-init])