### PR TITLE
PS-9612 [8.0]: Percona Server build fails on 128+ threads machines

### DIFF
--- a/sql/threadpool.h
+++ b/sql/threadpool.h
@@ -22,7 +22,7 @@
 
 struct SHOW_VAR;
 
-#define MAX_THREAD_GROUPS 128
+#define MAX_THREAD_GROUPS 1024
 
 enum tp_high_prio_mode_t {
   TP_HIGH_PRIO_MODE_TRANSACTIONS,


### PR DESCRIPTION
Change `MAX_THREAD_GROUPS` from 128 to 1024 to support recent CPUs in thread pool.