### PR TITLE
PS-9193: JS Routines: killability/max_statement_time support.

### DIFF
--- a/components/js_lang/README.md
+++ b/components/js_lang/README.md
@@ -90,7 +90,6 @@ Short-term
 ----------
 
 - Console support
-- Handling of KILL/timeouts.
 - Memory tracking/limiting?
 - Handling of async JS features
 - Execution of SQL

--- a/components/js_lang/component.cc
+++ b/components/js_lang/component.cc
@@ -64,6 +64,7 @@ REQUIRES_SERVICE_PLACEHOLDER(mysql_string_copy_converter);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_string_factory);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_string_get_data_in_charset);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_attributes);
+REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_kill_handler);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_security_context);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_store);
 REQUIRES_SERVICE_PLACEHOLDER(mysql_udf_metadata);
@@ -328,6 +329,7 @@ BEGIN_COMPONENT_REQUIRES(js_lang)
   REQUIRES_SERVICE(mysql_string_factory),
   REQUIRES_SERVICE(mysql_string_get_data_in_charset),
   REQUIRES_SERVICE(mysql_thd_attributes),
+  REQUIRES_SERVICE(mysql_thd_kill_handler),
   REQUIRES_SERVICE(mysql_thd_security_context),
   REQUIRES_SERVICE(mysql_thd_store),
   REQUIRES_SERVICE(mysql_udf_metadata),

--- a/components/js_lang/js_lang_common.h
+++ b/components/js_lang/js_lang_common.h
@@ -35,6 +35,7 @@
 #include <mysql/components/services/mysql_stored_program.h>
 #include <mysql/components/services/mysql_string.h>
 #include <mysql/components/services/mysql_thd_attributes.h>
+#include <mysql/components/services/mysql_thd_kill_handler.h>
 #include <mysql/components/services/mysql_thd_store_service.h>
 #include <mysql/components/services/security_context.h>
 #include <mysql/components/services/udf_metadata.h>
@@ -74,6 +75,7 @@ extern REQUIRES_SERVICE_PLACEHOLDER(mysql_string_copy_converter);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_string_factory);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_string_get_data_in_charset);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_attributes);
+extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_kill_handler);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_security_context);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_thd_store);
 extern REQUIRES_SERVICE_PLACEHOLDER(mysql_udf_metadata);

--- a/include/mysql/components/services/bits/mysql_thd_kill_handler_bits.h
+++ b/include/mysql/components/services/bits/mysql_thd_kill_handler_bits.h
@@ -1,0 +1,11 @@
+#ifndef COMPONENTS_SERVICES_MYSQL_THD_KILL_HANDLER_BITS_H
+#define COMPONENTS_SERVICES_MYSQL_THD_KILL_HANDLER_BITS_H
+
+#include <cstdint>  // int16_t
+
+#include "mysql/components/services/bits/mysql_thd_attributes_bits.h"  // STATUS_SESSION_KILLED,...
+#include "mysql/components/services/bits/thd.h"  // MYSQL_THD
+
+typedef void (*kill_handler_fn)(MYSQL_THD thd, uint16_t state, void *data);
+
+#endif /* COMPONENTS_SERVICES_MYSQL_THD_KILL_HANDLER_BITS_H */

--- a/include/mysql/components/services/mysql_thd_kill_handler.h
+++ b/include/mysql/components/services/mysql_thd_kill_handler.h
@@ -1,0 +1,41 @@
+#ifndef COMPONENTS_SERVICES_MYSQL_THD_KILL_HANDLER_H
+#define COMPONENTS_SERVICES_MYSQL_THD_KILL_HANDLER_H
+
+#include "mysql/components/services/bits/mysql_thd_kill_handler_bits.h"  // MYSQL_THD, kill_handler_fn
+
+/**
+  Service enabling components to install/remove handler for connection/
+  statement being killed.
+*/
+
+BEGIN_SERVICE_DEFINITION(mysql_thd_kill_handler)
+
+/**
+  Install/remove a handler to be invoked when connection or statement being
+  executed in it are killed or reach MAX_EXECUTION_TIME limit.
+  The idea is that component might want to abort some long running or
+  blocking operation it executes in this case.
+
+  @param thd    MYSQL_THD representing the connection.
+  @param fn     Handler function to be invoked when connection or statement
+                in it is killed. This function will be passed MYSQL_THD for
+                the connection affected, type of KILL operation and value
+                of 'data' parameter.
+                NULL indicates that already installed handler should be
+                removed.
+  @param data   Pointer to auxiliary data to be passed to the handler
+                function.
+
+  @retval False - success.
+  @retval True -  failure (callback already installed).
+
+  @note The handler is invoked from a thread other than one handling
+        connection/statement being killed. Hence one needs to ensure
+        handler's thread-safety.
+*/
+
+DECLARE_BOOL_METHOD(set, (MYSQL_THD thd, kill_handler_fn fn, void *data));
+
+END_SERVICE_DEFINITION(mysql_thd_kill_handler)
+
+#endif  // !COMPONENTS_SERVICES_MYSQL_THD_KILL_HANDLER_H

--- a/mysql-test/suite/component_js_lang/r/js_lang_kill.result
+++ b/mysql-test/suite/component_js_lang/r/js_lang_kill.result
@@ -1,0 +1,71 @@
+INSTALL COMPONENT 'file://component_js_lang';
+GRANT CREATE_JS_ROUTINE ON *.* TO root@localhost;
+connect  con_killer, localhost, root,,;
+CREATE FUNCTION run_forever() RETURNS INT LANGUAGE JS AS $$ while (true) { } $$;
+CREATE FUNCTION f(i INT) RETURNS INT LANGUAGE JS AS $$ return i * 42 $$;
+#
+# Let us start by testing KILL QUERY handling.
+#
+connect  con_victim, localhost, root,,;
+# Get con_victim's connection_id.
+#
+# Call function which will run forever and try to kill the query.
+SELECT run_forever();;
+connection con_killer;
+# Wait until SELECT query starts to run.
+#
+# We don't have a good 'state' value to ensure that its execution
+# reached the stage of JS code execution. But it is sufficient
+# for the test if it happens occasionally.
+KILL QUERY ID;
+connection con_victim;
+# Reap the SELECT.
+ERROR 70100: Query execution was interrupted
+# Run another function to show that we still can execute JS
+# in connection after it.
+SELECT f(1);
+f(1)
+42
+# Rinse and repeat, to show how it works when functions are cached.
+SELECT run_forever();;
+connection con_killer;
+# Wait until SELECT query starts to run.
+KILL QUERY ID;
+connection con_victim;
+# Reap the SELECT.
+ERROR 70100: Query execution was interrupted
+SELECT f(2);
+f(2)
+84
+#
+# Now, let us test handling of statement timeouts (implemented as a
+# variant of KILL internally).
+#
+SELECT /*+ MAX_EXECUTION_TIME(1000) */ run_forever();
+ERROR HY000: Query execution was interrupted, maximum statement execution time exceeded
+SELECT f(3);
+f(3)
+126
+#
+# Then, test KILL also known as KILL CONNECTION.
+#
+SELECT run_forever();;
+connection con_killer;
+# Wait until SELECT query starts to run.
+KILL ID;
+# Try to reap SELECT and see that 'con_victim' connection is closed.
+connection con_victim;
+ERROR HY000: Lost connection to MySQL server during query
+#
+# Clean-up.
+#
+connection con_killer;
+disconnect con_killer;
+connection default;
+DROP FUNCTION f;
+DROP FUNCTION run_forever;
+connection default;
+REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
+UNINSTALL COMPONENT 'file://component_js_lang';
+# Restart server to let subsequent tests to do INSTALL COMPONENT freely.
+# restart

--- a/mysql-test/suite/component_js_lang/t/js_lang_kill.test
+++ b/mysql-test/suite/component_js_lang/t/js_lang_kill.test
@@ -1,0 +1,107 @@
+#
+# Test coverage for KILLability and timeout handling in JS routines.
+#
+--source include/have_js_lang_component.inc
+INSTALL COMPONENT 'file://component_js_lang';
+
+GRANT CREATE_JS_ROUTINE ON *.* TO root@localhost;
+
+--enable_connect_log
+--connect (con_killer, localhost, root,,)
+CREATE FUNCTION run_forever() RETURNS INT LANGUAGE JS AS $$ while (true) { } $$;
+CREATE FUNCTION f(i INT) RETURNS INT LANGUAGE JS AS $$ return i * 42 $$;
+
+--echo #
+--echo # Let us start by testing KILL QUERY handling.
+--echo #
+--connect (con_victim, localhost, root,,)
+--echo # Get con_victim's connection_id.
+--let $id = `SELECT connection_id();`
+
+--echo #
+--echo # Call function which will run forever and try to kill the query.
+--send SELECT run_forever();
+
+--connection con_killer
+--echo # Wait until SELECT query starts to run.
+--echo #
+--echo # We don't have a good 'state' value to ensure that its execution
+--echo # reached the stage of JS code execution. But it is sufficient
+--echo # for the test if it happens occasionally.
+--let $wait_condition= SELECT COUNT(*) > 0 FROM information_schema.processlist WHERE info = 'SELECT run_forever()' AND state = 'executing'
+--source include/wait_condition.inc
+--replace_result $ID ID
+--eval KILL QUERY $id
+
+--connection con_victim
+--echo # Reap the SELECT.
+--error ER_QUERY_INTERRUPTED
+--reap
+
+--echo # Run another function to show that we still can execute JS
+--echo # in connection after it.
+SELECT f(1);
+
+--echo # Rinse and repeat, to show how it works when functions are cached.
+--send SELECT run_forever();
+--connection con_killer
+--echo # Wait until SELECT query starts to run.
+--let $wait_condition= SELECT COUNT(*) > 0 FROM information_schema.processlist WHERE info = 'SELECT run_forever()' AND state = 'executing'
+--source include/wait_condition.inc
+--replace_result $ID ID
+--eval KILL QUERY $id
+
+--connection con_victim
+--echo # Reap the SELECT.
+--error ER_QUERY_INTERRUPTED
+--reap
+SELECT f(2);
+
+--echo #
+--echo # Now, let us test handling of statement timeouts (implemented as a
+--echo # variant of KILL internally).
+--echo #
+--error ER_QUERY_TIMEOUT
+SELECT /*+ MAX_EXECUTION_TIME(1000) */ run_forever();
+
+SELECT f(3);
+
+--echo #
+--echo # Then, test KILL also known as KILL CONNECTION.
+--echo #
+--send SELECT run_forever();
+
+--connection con_killer
+--echo # Wait until SELECT query starts to run.
+--let $wait_condition= SELECT COUNT(*) > 0 FROM information_schema.processlist WHERE info = 'SELECT run_forever()' AND state = 'executing'
+--source include/wait_condition.inc
+--replace_result $ID ID
+--eval KILL $id
+
+--echo # Try to reap SELECT and see that 'con_victim' connection is closed.
+--connection con_victim
+--error CR_SERVER_LOST
+--reap
+--source include/wait_until_disconnected.inc
+
+--echo #
+--echo # Clean-up.
+--echo #
+
+--connection con_killer
+--disconnect con_killer
+--source include/wait_until_disconnected.inc
+--connection default
+
+DROP FUNCTION f;
+DROP FUNCTION run_forever;
+
+--connection default
+--disable_connect_log
+
+REVOKE CREATE_JS_ROUTINE ON *.* FROM root@localhost;
+
+UNINSTALL COMPONENT 'file://component_js_lang';
+
+--echo # Restart server to let subsequent tests to do INSTALL COMPONENT freely.
+--source include/restart_mysqld.inc

--- a/sql/server_component/CMakeLists.txt
+++ b/sql/server_component/CMakeLists.txt
@@ -82,6 +82,7 @@ SET(MYSQL_SERVER_COMPONENT_SOURCES
   mysql_simple_error_log_imp.cc
   mysql_statement_service_imp.cc
   mysql_signal_handler_imp.cc
+  mysql_thd_kill_handler_imp.cc
   )
 
 # This static library is used to build mysqld binary and in some unit test cases

--- a/sql/server_component/mysql_thd_kill_handler_imp.cc
+++ b/sql/server_component/mysql_thd_kill_handler_imp.cc
@@ -1,0 +1,35 @@
+#include "sql/server_component/mysql_thd_kill_handler_imp.h"
+
+#include <mysql/components/minimal_chassis.h>
+#include <mysql/components/service_implementation.h>
+
+#include "sql/sql_class.h"
+
+DEFINE_BOOL_METHOD(Mysql_thd_kill_handler_imp::set,
+                   (MYSQL_THD thd_arg, kill_handler_fn fn, void *data)) {
+  THD *thd = static_cast<THD *>(thd_arg);
+  if (thd == nullptr) thd = current_thd;
+  return thd->set_kill_handler(fn, data);
+}
+
+void Mysql_thd_kill_handler_imp::call_handler(THD *thd, kill_handler_fn fn,
+                                              void *data) {
+  uint16_t int_state = [](auto state) {
+    switch (state) {
+      case THD::killed_state::NOT_KILLED:
+        return STATUS_SESSION_OK;
+      case THD::killed_state::KILL_CONNECTION:
+        return STATUS_SESSION_KILLED;
+      case THD::killed_state::KILL_QUERY:
+        return STATUS_QUERY_KILLED;
+      case THD::killed_state::KILL_TIMEOUT:
+        return STATUS_QUERY_TIMEOUT;
+      case THD::killed_state::KILLED_NO_VALUE:
+        return STATUS_SESSION_OK;
+      default:
+        return STATUS_SESSION_OK;
+    }
+  }(thd->is_killed());
+
+  fn(thd, int_state, data);
+}

--- a/sql/server_component/mysql_thd_kill_handler_imp.h
+++ b/sql/server_component/mysql_thd_kill_handler_imp.h
@@ -1,0 +1,26 @@
+#ifndef SQL_SERVER_COMPONENT_MYSQL_THD_KILL_HANDLER_IMP_H
+#define SQL_SERVER_COMPONENT_MYSQL_THD_KILL_HANDLER_IMP_H
+
+#include "mysql/components/service_implementation.h"
+#include "mysql/components/services/mysql_thd_kill_handler.h"
+
+/**
+  Implementation of service enabling components to install/remove handler
+  for connection/statement being killed.
+*/
+class Mysql_thd_kill_handler_imp {
+ public:
+  static DEFINE_BOOL_METHOD(set,
+                            (MYSQL_THD thd, kill_handler_fn fn, void *data));
+
+ private:
+  /**
+    Invoke kill handler and pass THD, kill type and pointer to auxiliary
+     data to it as parameters.
+  */
+  static void call_handler(THD *thd, kill_handler_fn fn, void *data);
+
+  friend class THD;
+};
+
+#endif  // !SQL_SERVER_COMPONENT_MYSQL_THD_KILL_HANDLER_IMP_H

--- a/sql/server_component/server_component.cc
+++ b/sql/server_component/server_component.cc
@@ -93,6 +93,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 #include "mysql_string_service_imp.h"
 #include "mysql_system_variable_update_imp.h"
 #include "mysql_thd_attributes_imp.h"
+#include "mysql_thd_kill_handler_imp.h"
 #include "mysql_thd_store_imp.h"
 #include "mysql_transaction_delegate_control_imp.h"
 #include "mysqld_error.h"
@@ -586,6 +587,9 @@ END_SERVICE_IMPLEMENTATION();
 BEGIN_SERVICE_IMPLEMENTATION(mysql_server, mysql_status_variable_string)
 mysql_status_variable_reader_imp::get END_SERVICE_IMPLEMENTATION();
 
+BEGIN_SERVICE_IMPLEMENTATION(mysql_server, mysql_thd_kill_handler)
+Mysql_thd_kill_handler_imp::set END_SERVICE_IMPLEMENTATION();
+
 BEGIN_SERVICE_IMPLEMENTATION(mysql_server, mysql_thd_store)
 Mysql_thd_store_service_imp::register_slot,
     Mysql_thd_store_service_imp::unregister_slot,
@@ -1047,6 +1051,7 @@ PROVIDES_SERVICE(mysql_server_path_filter, dynamic_loader_scheme_file),
     PROVIDES_SERVICE(mysql_server, mysql_text_consumer_get_string_v1),
     PROVIDES_SERVICE(mysql_server, mysql_text_consumer_client_capabilities_v1),
     PROVIDES_SERVICE(mysql_server, mysql_status_variable_string),
+    PROVIDES_SERVICE(mysql_server, mysql_thd_kill_handler),
     PROVIDES_SERVICE(mysql_server, mysql_thd_store),
     PROVIDES_SERVICE(mysql_server, mysql_command_field_metadata),
     PROVIDES_SERVICE(mysql_server, dynamic_loader_services_loaded_notification),

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -70,6 +70,7 @@
 #include "mysql/components/services/bits/my_thread_bits.h"
 #include "mysql/components/services/bits/mysql_cond_bits.h"
 #include "mysql/components/services/bits/mysql_mutex_bits.h"
+#include "mysql/components/services/bits/mysql_thd_kill_handler_bits.h"
 #include "mysql/components/services/bits/psi_bits.h"
 #include "mysql/components/services/bits/psi_idle_bits.h"
 #include "mysql/components/services/bits/psi_stage_bits.h"
@@ -5169,6 +5170,44 @@ class THD : public MDL_context_owner,
   /// Flag indicating whether this session incremented the number of sessions
   /// with GTID_NEXT set to AUTOMATIC:tag
   bool has_incremented_gtid_automatic_count;
+
+ public:
+  /**
+    Install/remove handler to be invoked then this connection or statement
+    in it is killed.
+
+    @param fn     Pointer to handler function to install. Use NULL to remove
+                  installed handler.
+    @param data   Pointer to an auxiliary data to be passed to the handler.
+
+    @note The handler will be executed by a thread other than one handling
+          the connection/statement, so needs to be thread-safe.
+
+    @retval False - success.
+    @retval True -  failure (handler already installed).
+  */
+  bool set_kill_handler(kill_handler_fn fn, void *data) {
+    MUTEX_LOCK(lock, &LOCK_thd_data);
+    // Replacing one non-null handler with another is likely to be bug.
+    if (m_kill_handler_fn != nullptr && fn != nullptr) return true;
+    m_kill_handler_fn = fn;
+    m_kill_handler_data = data;
+    return false;
+  }
+
+ private:
+  /**
+    Handler to be invoked then this connection or statement in it is killed
+    (including timeout case). Components can use this functionality to allow
+    kill to abort some long running or blocking operation in them.
+    'nullptr' when no such callback is present/active for this connection.
+
+    We also store pointer to auxiliary data to be passed to the handler.
+
+    Protected by THD::LOCK_thd_data lock.
+  */
+  kill_handler_fn m_kill_handler_fn{nullptr};
+  void *m_kill_handler_data{nullptr};
 };
 
 /**


### PR DESCRIPTION
Improved handling of KILL and MAX_EXECUTION_TIME timeouts in connections running JS code.

JS language component now gets notified when connection (or statement)
executing JS code gets killed (due to KILL statement or due to reaching
MAX_EXECUTION_TIME timeout). The component calls V8 method aborting
execution of JS code, allowing to terminate connection/statement without
delays.