### PR TITLE
clang-tidy check fixed

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - 5.7
       - 8.0
+      - 8.4
       - trunk
       - release-*
 
@@ -49,7 +50,7 @@ jobs:
       - name: Download boost
         if: steps.cache-boost.outputs.cache-hit != 'true'
         run: |
-          wget --progress=dot:giga -P ${BOOST_DIR} "https://boostorg.jfrog.io/artifactory/main/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
+          wget --progress=dot:giga -P ${BOOST_DIR} "https://archives.boost.io/release/${BOOST_VERSION//_/.}/source/boost_${BOOST_VERSION}.tar.gz"
           tar -xzf "${BOOST_DIR}/boost_${BOOST_VERSION}.tar.gz" -C "${BOOST_DIR}"
 
       - name: Prepare compile_commands.json


### PR DESCRIPTION
1. Updated Boost URL
2. Enabled check on branch 8.4