### PR TITLE
PS-9614 Pool-of-Threads' timer thread fails to start if mysqld is sta…

### DIFF
--- a/sql/conn_handler/connection_handler.h
+++ b/sql/conn_handler/connection_handler.h
@@ -59,6 +59,12 @@ class Connection_handler {
             by this connection handler.
   */
   virtual uint get_max_threads() const = 0;
+
+  /**
+    Performs required initializations after the daemonization of the mysqld
+    process.
+  */
+  virtual void post_daemonize_init() {}
 };
 
 #endif  // CONNECTION_HANDLER_INCLUDED

--- a/sql/conn_handler/connection_handler_impl.h
+++ b/sql/conn_handler/connection_handler_impl.h
@@ -135,7 +135,7 @@ class Thread_pool_connection_handler : public Connection_handler {
 
   uint get_max_threads() const override { return threadpool_max_threads; }
 
-  void post_daemonize_init() override { start_timer_thread(); }
+  void post_daemonize_init() override { tp_start_timer_thread(); }
 };
 
 #endif  // CONNECTION_HANDLER_IMPL_INCLUDED

--- a/sql/conn_handler/connection_handler_impl.h
+++ b/sql/conn_handler/connection_handler_impl.h
@@ -134,6 +134,8 @@ class Thread_pool_connection_handler : public Connection_handler {
   bool add_connection(Channel_info *channel_info) override;
 
   uint get_max_threads() const override { return threadpool_max_threads; }
+
+  void post_daemonize_init() override { start_timer_thread(); }
 };
 
 #endif  // CONNECTION_HANDLER_IMPL_INCLUDED

--- a/sql/conn_handler/connection_handler_manager.cc
+++ b/sql/conn_handler/connection_handler_manager.cc
@@ -229,6 +229,10 @@ void Connection_handler_manager::wait_till_no_connection() {
   mysql_mutex_unlock(&LOCK_connection_count);
 }
 
+void Connection_handler_manager::post_daemonize_init() {
+  m_connection_handler->post_daemonize_init();
+}
+
 void Connection_handler_manager::destroy_instance() {
   Per_thread_connection_handler::destroy();
 

--- a/sql/conn_handler/connection_handler_manager.h
+++ b/sql/conn_handler/connection_handler_manager.h
@@ -234,5 +234,11 @@ class Connection_handler_manager {
     wat till connection_count to become zero.
   */
   static void wait_till_no_connection();
+
+  /**
+    Performs required initializations after the daemonization of the mysqld
+    process.
+  */
+  void post_daemonize_init();
 };
 #endif  // CONNECTION_HANDLER_MANAGER_INCLUDED.

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8158,13 +8158,10 @@ int mysqld_main(int argc, char **argv)
   }
 #endif
 
-  if (Connection_handler_manager::thread_handling ==
-      Connection_handler_manager::SCHEDULER_THREAD_POOL) {
-    // If --thread-handling=pool-of-threads is specified,
-    // the timer thread should start only after the daemon process has begun,
-    // provided that --daemonize was also specified.
-    Connection_handler_manager::get_instance()->post_daemonize_init();
-  }
+  // Post daemonization operations performed
+  // such as initializing the timer_thread when using
+  // --thread-handling=pool-of-threads
+  Connection_handler_manager::get_instance()->post_daemonize_init();
 
 #ifndef _WIN32
   user_info = check_user(mysqld_user);

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8158,6 +8158,14 @@ int mysqld_main(int argc, char **argv)
   }
 #endif
 
+  if (Connection_handler_manager::thread_handling ==
+      Connection_handler_manager::SCHEDULER_THREAD_POOL) {
+    // If --thread-handling=pool-of-threads is specified,
+    // the timer thread should start only after the daemon process has begun,
+    // provided that --daemonize was also specified.
+    Connection_handler_manager::get_instance()->post_daemonize_init();
+  }
+
 #ifndef _WIN32
   user_info = check_user(mysqld_user);
   if (!user_info.IsVoid()) {

--- a/sql/threadpool.h
+++ b/sql/threadpool.h
@@ -81,6 +81,6 @@ extern void tp_set_threadpool_size(uint val) noexcept;
 extern void tp_set_threadpool_stall_limit(uint val) noexcept;
 
 /* Function to start the timer thread */
-extern void start_timer_thread() noexcept;
+extern void tp_start_timer_thread() noexcept;
 
 #endif /* THREADPOOL_INCLUDED */

--- a/sql/threadpool.h
+++ b/sql/threadpool.h
@@ -80,4 +80,7 @@ extern void tp_set_max_threads(uint val);
 extern void tp_set_threadpool_size(uint val) noexcept;
 extern void tp_set_threadpool_stall_limit(uint val) noexcept;
 
+/* Function to start the timer thread */
+extern void start_timer_thread() noexcept;
+
 #endif /* THREADPOOL_INCLUDED */

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -612,7 +612,7 @@ static void start_timer(pool_timer_t *timer) noexcept {
   DBUG_VOID_RETURN;
 }
 
-void start_timer_thread() noexcept {
+void tp_start_timer_thread() noexcept {
   pool_timer.tick_interval = threadpool_stall_limit;
   start_timer(&pool_timer);
 }

--- a/sql/threadpool_unix.cc
+++ b/sql/threadpool_unix.cc
@@ -59,6 +59,8 @@ const char *threadpool_high_prio_mode_names[] = {"transactions", "statements",
 
 /** Indicates that threadpool was initialized*/
 static bool threadpool_started = false;
+/** Indicates that timer thread was started*/
+static bool timer_thread_started = false;
 
 /*
   Define PSI Keys for performance schema.
@@ -602,6 +604,7 @@ static void check_stall(thread_group_t *thread_group) {
 static void start_timer(pool_timer_t *timer) noexcept {
   my_thread_handle thread_id;
   DBUG_ENTER("start_timer");
+  timer_thread_started = true;
   mysql_mutex_init(key_timer_mutex, &timer->mutex, NULL);
   mysql_cond_init(key_timer_cond, &timer->cond);
   timer->shutdown = false;
@@ -609,10 +612,16 @@ static void start_timer(pool_timer_t *timer) noexcept {
   DBUG_VOID_RETURN;
 }
 
+void start_timer_thread() noexcept {
+  pool_timer.tick_interval = threadpool_stall_limit;
+  start_timer(&pool_timer);
+}
+
 static void stop_timer(pool_timer_t *timer) noexcept {
   DBUG_ENTER("stop_timer");
   mysql_mutex_lock(&timer->mutex);
   timer->shutdown = true;
+  timer_thread_started = false;
   mysql_cond_signal(&timer->cond);
   mysql_mutex_unlock(&timer->mutex);
   DBUG_VOID_RETURN;
@@ -1488,8 +1497,6 @@ bool tp_init() {
   mysql_thread_register("threadpool", thread_list, array_elements(thread_list));
 #endif
 
-  pool_timer.tick_interval = threadpool_stall_limit;
-  start_timer(&pool_timer);
   DBUG_RETURN(false);
 }
 
@@ -1497,8 +1504,7 @@ void tp_end() noexcept {
   DBUG_ENTER("tp_end");
 
   if (!threadpool_started) DBUG_VOID_RETURN;
-
-  stop_timer(&pool_timer);
+  if (timer_thread_started) stop_timer(&pool_timer);
   for (uint i = 0; i < array_elements(all_groups); i++) {
     thread_group_close(&all_groups[i]);
   }


### PR DESCRIPTION
…rted with --daemonize

Problem:
When pool-of-threads is enabled, a timer_thread should be created. However, if the process starts with --daemonize, the thread is missing. This occurs because during the execution of mysqld_daemonize(), the mysqld process forks, creating a child process that runs as a daemon. Since threads are not copied during a fork, and timer_thread is not reinitialized in the daemon process, it is lost.

Solution:
Move the timer_thread initialization to execute after the mysqld_daemonize() function.