### PR TITLE
PS-9591 Fixed rpl_nogtid.rpl_server_uuid testafter upstream 8.4.4 merge.

### DIFF
--- a/mysql-test/suite/rpl_nogtid/t/rpl_server_uuid.test
+++ b/mysql-test/suite/rpl_nogtid/t/rpl_server_uuid.test
@@ -268,7 +268,7 @@ eval CHANGE REPLICATION SOURCE TO
 --let $assert_file=$MYSQLTEST_VARDIR/log/mysqld.1.err
 # Grep only after the message that the server_2 has connected to the master
 --let $assert_only_after=Start binlog_dump to source_thread_id\($replica_thread_id\)
---let $assert_select=found a zombie dump thread with the same UUID
+--let $assert_select=an existing dump thread with the same UUID was detected
 --let $assert_match= ($assert_select)+
 --let $assert_text= Found the expected line in master's error log for server 2 disconnection
 --source include/assert_grep.inc


### PR DESCRIPTION
https://perconadev.atlassian.net/browse/PS-9591

Upstream has changed error message which is emitted to error log when a zombie dump thread is aborted in its fix for bug#25330090 "SLIGHTLY CONFUSING 'NOTE' REPORTED IN MASTER SERVER'S LOG WHEN SLAVE RECONNECTS" (https://github.com/mysql/mysql-server/commit/5300d99). However, they didn't adjust rpl_server_uuid test which checks for presence of this message in error log in such cases. As result rpl_server_uuid started to fail on some platforms - e.g. on Ubuntu Jammy in our Jenkins.

It didn't fail in all cases though, due to fact the helper include/assert_grep.inc script, which is used in this test to check presence of message in error log, was broken by an earlier change -- fix for bug#36507020 "relay_log_space_limit GTID and large txns may lead to no channel progress"
(https://github.com/mysql/mysql-server/commit/9d363db).

This patch fixes the first issue mentioned above by updating check in the test to search for new version of error message.

Fixing the second issue might break some test cases, so it is better to be addressed separately.