### PR TITLE
PS-9033 - minimum fix

### DIFF
--- a/components/audit_log_filter/audit_log_filter.cc
+++ b/components/audit_log_filter/audit_log_filter.cc
@@ -659,13 +659,13 @@ bool AuditLogFilter::get_connection_user(Security_context_handle &ctx,
   MYSQL_LEX_CSTRING user{"", 0};
   MYSQL_LEX_CSTRING host{"", 0};
 
-  if (m_security_context_opts_srv->get(ctx, "user", &user) == 1) {
+  if (m_security_context_opts_srv->get(ctx, "priv_user", &user) == 1) {
     LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
                     "Can not get user name from security context");
     return false;
   }
 
-  if (m_security_context_opts_srv->get(ctx, "host", &host) == 1) {
+  if (m_security_context_opts_srv->get(ctx, "priv_host", &host) == 1) {
     LogComponentErr(ERROR_LEVEL, ER_LOG_PRINTF_MSG,
                     "Can not get user host from security context");
     return false;


### PR DESCRIPTION
Audit should use CURRENT_USER values to compare the connected user, otherwise only exact matches will be audited.

ie.
User defined in DB: test@%
User connected viewed as USER(): test@X.X.X.X
User connected viewed as CURRENT_USER(): test@%