### PR TITLE
PS-9704 (8.0) Fix auth_ldap bug with unescaped parentheses in user DN

### DIFF
--- a/plugin/auth_ldap/src/connection.cc
+++ b/plugin/auth_ldap/src/connection.cc
@@ -309,7 +309,7 @@ groups_t Connection::search_groups(const std::string &user_name,
   std::string filter = std::regex_replace(group_search_filter,
                                           std::regex("\\{UA\\}"), user_name);
   std::string escaped_user_dn =
-      std::regex_replace(user_dn, std::regex("\\\\\""), "\\\\\"");
+      std::regex_replace(user_dn, std::regex(R"(\\\"|[\(\)])"), R"(\$&)");
   filter = std::regex_replace(filter, std::regex("\\{UD\\}"), escaped_user_dn);
 
   LDAPMessage *l_result;


### PR DESCRIPTION
Fixing issue with parentheses in the user's DN. Now the plugin is failing when user's DN contains parentheses ( ).